### PR TITLE
Add documentation for next sprint CRUD API

### DIFF
--- a/docs/crud.md
+++ b/docs/crud.md
@@ -2,9 +2,15 @@
 
 ### Typing
 
-The notion of document type does not exist in couchdb.
-Cozy-stack introduce this notion with a special `_type` field. This type cannot contain "/", it should be unique among all developers, it is recommend to use the Java naming convention with a domain you own.
-All CozyCloud types will be prefixed by io.cozy
+The notion of document type does not exist in Couchdb.
+
+Cozy-stack introduce this notion by prefixing each document's `_id` with a fully qualified type name followed by `/`.
+
+This type name cannot contain `/`, and it should be unique among all developers, it is recommended to use the Java naming convention with a domain you own.
+
+All CozyCloud types will be prefixed by io.cozy and be pluralized.
+Example ID : `io.cozy.events/6494e0ac-dfcb-11e5-88c1-472e84a9cbee`
+Where, `io.cozy.` is the developer specific prefix, `events` the actual type, and `6494e0ac-dfcb-11e5-88c1-472e84a9cbee` the document's unique (within a type) id .
 
 ------------------------------------------------------------------------------
 
@@ -30,7 +36,6 @@ Etag: "3-6494e0ac6494e0ac"
 {
     "_id": "io.cozy.events/6494e0ac-dfcb-11e5-88c1-472e84a9cbee",
     "_rev": "3-6494e0ac6494e0ac",
-    "_type": "io.cozy.events",
     "startdate": "20160823T150000Z",
     "enddate": "20160923T160000Z",
     "summary": "A long month",
@@ -79,7 +84,6 @@ Accept: application/json
 ```
 ```json
 {
-    "_type": "io.cozy.events",
     "startdate": "20160712T150000",
     "enddate": "20160712T150000",
 }
@@ -99,7 +103,6 @@ Content-Type: application/json
   "data": {
     "_id": "io.cozy.events/6494e0ac-dfcb-11e5-88c1-472e84a9cbee",
     "_rev": "1-6494e0ac6494e0ac",
-    "_type": "io.cozy.events",
     "startdate": "20160712T150000",
     "enddate": "20160712T150000"
   }
@@ -115,7 +118,6 @@ Content-Type: application/json
 ### Details
 
 - A doc cannot contain an `_id` field, if so an error 400 is returned
-- A doc cannot contain a `_type` different from the URL one, if so an error 400 is returned
 - A doc cannot contain any field starting with `_`, those are reserved for future cozy & couchdb api evolution
 
 

--- a/docs/crud.md
+++ b/docs/crud.md
@@ -106,3 +106,62 @@ Content-Type: application/json
 - A doc cannot contain an `_id` field, if so an error 400 is returned
 - A doc cannot contain a `_type` different from the URL one, if so an error 400 is returned
 - A doc cannot contain any field starting with `_`, those are reserved for future cozy & couchdb api evolution
+
+
+--------------------------------------------------------------------------------
+
+# Delete a document
+
+### Request
+```http
+DELETE /data/:type/:id
+```
+```http
+DELETE /data/types.cozy.io/events/6494e0ac-dfcb-11e5-88c1-472e84a9cbee
+Accept: application/json
+
+```
+
+### Response OK
+```http
+200 OK
+Content-Length: ...
+Content-Type: application/json
+```
+```json
+{
+    "id": "types.cozy.io/events/6494e0ac-dfcb-11e5-88c1-472e84a9cbee",
+    "ok": true,
+    "rev": "2-056f5f44046ecafc08a2bc2b9c229e20",
+    "_deleted": true
+}
+```
+### Possible errors :
+- 400 bad request
+- 403 unauthenticated
+- 401 unauthorized
+- 404 not_found
+  - reason: missing
+  - reason: deleted
+- 500 unkown
+
+### Conflict prevention
+
+It is possible to use either a `rev` query string parameter or a HTTP `If-Match` header to prevent conflict on deletion:
+- If both are passed and are different, an error 400 is returned
+- If only one is passed or they are equals, the document will only be deleted if its `_rev` match the passed one. Otherwise, an error 412  is returned.
+- If none is passed, the document will be force-deleted.
+
+**Why shouldn't you force delete** (contrieved example) the user is syncing contacts from his mobile, a contact is created with name but no number, the user see it in the contact app. In parallel, the number is added by sync and the user click "delete" because a contact with no number is useless. The decision to delete is based on outdated data state and should therefore be aborted.
+Couchdb will prevent this, the stack API allow it for fast prototyping but it should be avoided for serious applications.
+
+### Binary attachments
+
+When a document is deleted and it was the last reference to a binary, said binary is deleted as well.
+
+If you are moving binary from one document to another, you will need to create the new document with binary link first, and only afterward delete the previous document.
+
+### Details
+
+- If no id is provided in URL, an error 400 is returned
+-

--- a/docs/crud.md
+++ b/docs/crud.md
@@ -56,12 +56,12 @@ Content-Type: application/json
 ```
 
 ### possible errors :
-- 403 unauthenticated
-- 401 unauthorized
+- 401 unauthorized (no authentication has been provided)
+- 403 forbidden (the authentication does not provide permissions for this action)
 - 404 not_found
   - reason: missing
   - reason: deleted
-- 500 unkown
+- 500 internal server error
 
 --------------------------------------------------------------------------------
 
@@ -107,9 +107,10 @@ Content-Type: application/json
 ```
 
 ### possible errors :
-- 403 unauthenticated
-- 401 unauthorized
-- 500 unkown
+- 400 bad request
+- 401 unauthorized (no authentication has been provided)
+- 403 forbidden (the authentication does not provide permissions for this action)
+- 500 internal server error
 
 ### Details
 
@@ -148,12 +149,13 @@ Content-Type: application/json
 ```
 ### Possible errors :
 - 400 bad request
-- 403 unauthenticated
-- 401 unauthorized
+- 401 unauthorized (no authentication has been provided)
+- 403 forbidden (the authentication does not provide permissions for this action)
 - 404 not_found
   - reason: missing
   - reason: deleted
-- 500 unkown
+- 412 Conflict (see Conflict prevention section below)
+- 500 internal server error
 
 ### Conflict prevention
 
@@ -165,13 +167,6 @@ It is possible to use either a `rev` query string parameter or a HTTP `If-Match`
 **Why shouldn't you force delete** (contrieved example) the user is syncing contacts from his mobile, a contact is created with name but no number, the user see it in the contact app. In parallel, the number is added by sync and the user click "delete" because a contact with no number is useless. The decision to delete is based on outdated data state and should therefore be aborted.
 Couchdb will prevent this, the stack API allow it for fast prototyping but it should be avoided for serious applications.
 
-### Binary attachments
-
-When a document is deleted and it was the last reference to a binary, said binary is deleted as well.
-
-If you are moving binary from one document to another, you will need to create the new document with binary link first, and only afterward delete the previous document.
-
 ### Details
 
 - If no id is provided in URL, an error 400 is returned
--

--- a/docs/crud.md
+++ b/docs/crud.md
@@ -1,0 +1,108 @@
+# Access a document
+
+#### Request
+```http
+GET /data/:type/:id
+```
+```http
+GET /data/types.cozy.io/events/6494e0ac-dfcb-11e5-88c1-472e84a9cbee
+```
+
+#### Response OK
+```http
+HTTP/1.1 200 OK
+Date: Mon, 27 Sept 2016 12:28:53 GMT
+Content-Length: ...
+Content-Type: application/json
+Etag: "3-6494e0ac6494e0ac"
+```
+```json
+{
+    "_id": "types.cozy.io/events/6494e0ac-dfcb-11e5-88c1-472e84a9cbee",
+    "_rev": "3-6494e0ac6494e0ac",
+    "_type": "types.cozy.io/events",
+    "startdate": "20160823T150000Z",
+    "enddate": "20160923T160000Z",
+    "summary": "A long month",
+    "description": "I could go on and on and on ....",
+}
+```
+
+### Response Error
+```http
+HTTP/1.1 404 Not Found
+Content-Length: ...
+Content-Type: application/json
+```
+```json
+{
+  "status": 404,
+  "error": "not_found",
+  "reason": "deleted",
+  "title": "Event deleted",
+  "details": "Event 6494e0ac-dfcb-11e5-88c1-472e84a9cbee was deleted",
+  "links": {"about": "https://cozy.github.io/cozy-stack/errors.md#deleted"}
+}
+```
+
+### possible errors :
+- 403 unauthenticated
+- 401 unauthorized
+- 404 not_found
+  - reason: missing
+  - reason: deleted
+- 500 unkown
+
+--------------------------------------------------------------------------------
+
+# Create a document
+
+### Request
+```http
+POST /data/:type/
+```
+```http
+POST /data/types.cozy.io/events/
+Content-Length: ...
+Content-Type: application/json
+Accept: application/json
+```
+```json
+{
+    "_type": "types.cozy.io/events",
+    "startdate": "20160712T150000",
+    "enddate": "20160712T150000",
+}
+```
+
+### Response OK
+```http
+201 Created
+Content-Length: ...
+Content-Type: application/json
+```
+```json
+{
+  "id": "types.cozy.io/events/6494e0ac-dfcb-11e5-88c1-472e84a9cbee",
+  "ok": true,
+  "rev": "1-6494e0ac6494e0ac",
+  "data": {
+    "_id": "types.cozy.io/events/6494e0ac-dfcb-11e5-88c1-472e84a9cbee",
+    "_rev": "1-6494e0ac6494e0ac",
+    "_type": "types.cozy.io/events",
+    "startdate": "20160712T150000",
+    "enddate": "20160712T150000"
+  }
+}
+```
+
+### possible errors :
+- 403 unauthenticated
+- 401 unauthorized
+- 500 unkown
+
+### Details
+
+- A doc cannot contain an `_id` field, if so an error 400 is returned
+- A doc cannot contain a `_type` different from the URL one, if so an error 400 is returned
+- A doc cannot contain any field starting with `_`, those are reserved for future cozy & couchdb api evolution

--- a/docs/crud.md
+++ b/docs/crud.md
@@ -1,3 +1,13 @@
+# General
+
+### Typing
+
+The notion of document type does not exist in couchdb.
+Cozy-stack introduce this notion with a special `_type` field. This type cannot contain "/", it should be unique among all developers, it is recommend to use the Java naming convention with a domain you own.
+All CozyCloud types will be prefixed by io.cozy
+
+------------------------------------------------------------------------------
+
 # Access a document
 
 #### Request
@@ -5,7 +15,7 @@
 GET /data/:type/:id
 ```
 ```http
-GET /data/types.cozy.io/events/6494e0ac-dfcb-11e5-88c1-472e84a9cbee
+GET /data/io.cozy.events/6494e0ac-dfcb-11e5-88c1-472e84a9cbee
 ```
 
 #### Response OK
@@ -18,9 +28,9 @@ Etag: "3-6494e0ac6494e0ac"
 ```
 ```json
 {
-    "_id": "types.cozy.io/events/6494e0ac-dfcb-11e5-88c1-472e84a9cbee",
+    "_id": "io.cozy.events/6494e0ac-dfcb-11e5-88c1-472e84a9cbee",
     "_rev": "3-6494e0ac6494e0ac",
-    "_type": "types.cozy.io/events",
+    "_type": "io.cozy.events",
     "startdate": "20160823T150000Z",
     "enddate": "20160923T160000Z",
     "summary": "A long month",
@@ -62,14 +72,14 @@ Content-Type: application/json
 POST /data/:type/
 ```
 ```http
-POST /data/types.cozy.io/events/
+POST /data/io.cozy.events/
 Content-Length: ...
 Content-Type: application/json
 Accept: application/json
 ```
 ```json
 {
-    "_type": "types.cozy.io/events",
+    "_type": "io.cozy.events",
     "startdate": "20160712T150000",
     "enddate": "20160712T150000",
 }
@@ -83,13 +93,13 @@ Content-Type: application/json
 ```
 ```json
 {
-  "id": "types.cozy.io/events/6494e0ac-dfcb-11e5-88c1-472e84a9cbee",
+  "id": "io.cozy.events/6494e0ac-dfcb-11e5-88c1-472e84a9cbee",
   "ok": true,
   "rev": "1-6494e0ac6494e0ac",
   "data": {
-    "_id": "types.cozy.io/events/6494e0ac-dfcb-11e5-88c1-472e84a9cbee",
+    "_id": "io.cozy.events/6494e0ac-dfcb-11e5-88c1-472e84a9cbee",
     "_rev": "1-6494e0ac6494e0ac",
-    "_type": "types.cozy.io/events",
+    "_type": "io.cozy.events",
     "startdate": "20160712T150000",
     "enddate": "20160712T150000"
   }
@@ -117,7 +127,7 @@ Content-Type: application/json
 DELETE /data/:type/:id
 ```
 ```http
-DELETE /data/types.cozy.io/events/6494e0ac-dfcb-11e5-88c1-472e84a9cbee
+DELETE /data/io.cozy.events/6494e0ac-dfcb-11e5-88c1-472e84a9cbee
 Accept: application/json
 
 ```
@@ -130,7 +140,7 @@ Content-Type: application/json
 ```
 ```json
 {
-    "id": "types.cozy.io/events/6494e0ac-dfcb-11e5-88c1-472e84a9cbee",
+    "id": "io.cozy.events/6494e0ac-dfcb-11e5-88c1-472e84a9cbee",
     "ok": true,
     "rev": "2-056f5f44046ecafc08a2bc2b9c229e20",
     "_deleted": true


### PR DESCRIPTION
RFC @nono

First shot at documenting the API for data manipulation.

Basically just a JSONAPI wrapper to Couchdb

Decision to be discussed : 
- Do we really want JSON-API for these route too or should we consider them lower level.
- The former DS hided `_rev` from the client, I believe this was unwise as we ended up reimplementing it in places for synchronisation with other sources (*dav and imap)
- Should we really allow the creation of a doc with a given `_id` ? The only proper way to use this API is to wrap it in a trycatch and do a `PUT` instead if the doc already exists. It seems we should push devs to always do a `PUT`, or eventually a `PATCH` if only changing some fields.
- keeping the type (formerly `docType`) in the document seems convenient, however, it should be marked as a special field with `_`. 
- I added the `type` to the URL, it is not a big effort on developper part but will allow some optimisations later.
- Is the error format lacking something ? One of the issue we had in previous stack was the lack of uniformity and lost of information in error reporting.