### PR TITLE
Delete unused `Execute`

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -18,15 +17,6 @@ var RootCmd = &cobra.Command{
 With it, your web apps and your devices can share data easily, providing you
 with a new experience. You can install Cozy on your own hardware where no one
 profiles you.`,
-}
-
-// Execute adds all child commands to the root command sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	if err := RootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(-1)
-	}
 }
 
 func init() {


### PR DESCRIPTION
Not needed because `RootCmd.Execute` is run by `main.go`