### PR TITLE
Upload with integrity check

### DIFF
--- a/web/files/files.go
+++ b/web/files/files.go
@@ -6,11 +6,9 @@
 package files
 
 import (
-	"crypto/md5"
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"hash"
 	"net/http"
 	"strings"
 
@@ -52,10 +50,6 @@ type DocMetadata struct {
 	Executable bool
 	Tags       []string
 	GivenMD5   []byte
-
-	md5H   hash.Hash
-	doneCh chan bool
-	errsCh chan error
 }
 
 func (m *DocMetadata) path() string {
@@ -99,10 +93,6 @@ func NewDocMetadata(docTypeStr, name, folderID, tagsStr, md5Str string, executab
 		Tags:       tags,
 		Executable: executable,
 		GivenMD5:   givenMD5,
-
-		md5H:   md5.New(),
-		doneCh: make(chan bool),
-		errsCh: make(chan error),
 	}
 
 	return

--- a/web/files/upload.go
+++ b/web/files/upload.go
@@ -1,0 +1,94 @@
+// Package files is for storing files on the cozy, including binary ones like
+// photos and movies. The range of possible operations with this endpoint goes
+// from simple ones, like uploading a file, to more complex ones, like renaming
+// a folder. It also ensure that an instance is not exceeding its quota, and
+// keeps a trash to recover files recently deleted.
+package files
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/spf13/afero"
+)
+
+// Upload is the method for uploading a file
+func Upload(m *DocMetadata, fs afero.Fs, body io.ReadCloser) (err error) {
+	if m.Type != FileDocType {
+		return errDocTypeInvalid
+	}
+
+	path := m.path()
+
+	// Existence of FolderID is mandatory
+	exists, err := afero.Exists(fs, path)
+	if err != nil {
+		return
+	}
+	if exists {
+		return errDocAlreadyExists
+	}
+
+	defer body.Close()
+	return copyOnFsAndCheck(m, fs, path, body)
+}
+
+func copyOnFsAndCheck(m *DocMetadata, fs afero.Fs, path string, r io.Reader) (err error) {
+	file, err := fs.Create(path)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+
+	md5H := m.md5H
+	done := m.doneCh
+	errs := m.errsCh
+	defer close(done)
+	defer close(errs)
+
+	docR, docW := io.Pipe()
+	md5R, md5W := io.Pipe()
+
+	go doCopy(file, docR, done, errs)
+	go doCopy(md5H, md5R, done, errs)
+
+	go func() {
+		defer docW.Close()
+		defer md5W.Close()
+
+		mw := io.MultiWriter(docW, md5W)
+
+		_, err = io.Copy(mw, r)
+		if err != nil {
+			errs <- err
+		}
+	}()
+
+	for c := 0; c < 2; c++ {
+		select {
+		case <-done:
+		case err = <-errs:
+			return
+		}
+	}
+
+	calcMD5 := md5H.Sum(nil)
+	if !bytes.Equal(m.GivenMD5, calcMD5) {
+		err = fs.Remove(path)
+		if err == nil {
+			err = errInvalidHash
+		}
+		return
+	}
+
+	return
+}
+
+func doCopy(dst io.Writer, src io.Reader, done chan bool, errs chan error) {
+	_, err := io.Copy(dst, src)
+	if err != nil {
+		errs <- err
+	} else {
+		done <- true
+	}
+}

--- a/web/files/upload.go
+++ b/web/files/upload.go
@@ -41,7 +41,7 @@ func copyOnFsAndCheckIntegrity(m *DocMetadata, fs afero.Fs, path string, r io.Re
 	}
 	defer file.Close()
 
-	md5H := md5.New()
+	md5H := md5.New() // #nosec
 	_, err = io.Copy(file, io.TeeReader(r, md5H))
 
 	calcMD5 := md5H.Sum(nil)

--- a/web/files/upload.go
+++ b/web/files/upload.go
@@ -7,7 +7,7 @@ package files
 
 import (
 	"bytes"
-	"crypto/md5"
+	"crypto/md5" // #nosec
 	"io"
 
 	"github.com/spf13/afero"


### PR DESCRIPTION
Adds MD5 checksum on uploaded content.

In 6fbe3ce40d2e57268aeb8463166c1aaa87628ed2 I tested a concurrent approach which is a little faster but with added complexities. I came to a simpler (and a little slower) solution finally...