### PR TITLE
Serve help message

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,8 +36,8 @@ func init() {
 	RootCmd.PersistentFlags().StringP("mode", "m", "development", "server mode: development or production")
 	viper.BindPFlag("mode", RootCmd.PersistentFlags().Lookup("mode"))
 
-	RootCmd.PersistentFlags().StringP("address", "a", "localhost", "server host")
-	viper.BindPFlag("address", RootCmd.PersistentFlags().Lookup("address"))
+	RootCmd.PersistentFlags().StringP("host", "", "localhost", "server host")
+	viper.BindPFlag("host", RootCmd.PersistentFlags().Lookup("host"))
 
 	RootCmd.PersistentFlags().IntP("port", "p", 8080, "server port")
 	viper.BindPFlag("port", RootCmd.PersistentFlags().Lookup("port"))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,18 +31,18 @@ profiles you.`,
 var cfgFile string
 
 func init() {
-	RootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file (default is $HOME/.cozy.yaml)")
+	RootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "configuration file (default \"$HOME/.cozy.yaml\")")
 
 	RootCmd.PersistentFlags().StringP("mode", "m", "development", "server mode: development or production")
 	viper.BindPFlag("mode", RootCmd.PersistentFlags().Lookup("mode"))
 
-	RootCmd.PersistentFlags().StringP("address", "a", "localhost", "Address on which the server will listen")
+	RootCmd.PersistentFlags().StringP("address", "a", "localhost", "server host")
 	viper.BindPFlag("address", RootCmd.PersistentFlags().Lookup("address"))
 
-	RootCmd.PersistentFlags().IntP("port", "p", 8080, "Port on which the server will listen")
+	RootCmd.PersistentFlags().IntP("port", "p", 8080, "server port")
 	viper.BindPFlag("port", RootCmd.PersistentFlags().Lookup("port"))
 
-	RootCmd.PersistentFlags().StringP("databaseUrl", "d", "http://localhost:5984", "Database to connect to")
+	RootCmd.PersistentFlags().StringP("databaseUrl", "d", "http://localhost:5984", "couchdb database address")
 	viper.BindPFlag("databaseUrl", RootCmd.PersistentFlags().Lookup("databaseUrl"))
 }
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -16,7 +16,7 @@ var serveCmd = &cobra.Command{
 	Short: "Starts the stack and listens for HTTP calls",
 	Long: `Starts the stack and listens for HTTP calls
 It will accept HTTP requests on localhost:8080 by default.
-Use the --port and --address flags to change the listening option.`,
+Use the --port and --host flags to change the listening option.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := Configure(); err != nil {
 			return err
@@ -25,8 +25,8 @@ Use the --port and --address flags to change the listening option.`,
 		router := getGin()
 		web.SetupRoutes(router)
 
-		address := config.GetConfig().Address + ":" + strconv.Itoa(config.GetConfig().Port)
-		return router.Run(address)
+		addr := config.GetConfig().Host + ":" + strconv.Itoa(config.GetConfig().Port)
+		return router.Run(addr)
 	},
 }
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -13,10 +13,10 @@ import (
 // serveCmd represents the serve command
 var serveCmd = &cobra.Command{
 	Use:   "serve",
-	Short: "Start the stack and listens for HTTP calls",
-	Long: `Start the HTTP server for the server.
-It will accept HTTP request on port 8080 by default.
-If you want to use another port, on you can use the PORT env variable.`,
+	Short: "Starts the stack and listens for HTTP calls",
+	Long: `Starts the stack and listens for HTTP calls
+It will accept HTTP requests on localhost:8080 by default.
+Use the --port and --address flags to change the listening option.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := Configure(); err != nil {
 			return err

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -20,8 +20,8 @@ var statusCmd = &cobra.Command{
 			return err
 		}
 
-		address := "http://" + config.GetConfig().Address + ":" + strconv.Itoa(config.GetConfig().Port) + "/status"
-		resp, err := http.Get(address)
+		url := "http://" + config.GetConfig().Host + ":" + strconv.Itoa(config.GetConfig().Port) + "/status"
+		resp, err := http.Get(url)
 		if err != nil {
 			fmt.Println("Error the HTTP server is not running:", err)
 			os.Exit(1)

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 
 	"github.com/cozy/cozy-stack/config"
@@ -20,8 +21,12 @@ var statusCmd = &cobra.Command{
 			return err
 		}
 
-		url := "http://" + config.GetConfig().Host + ":" + strconv.Itoa(config.GetConfig().Port) + "/status"
-		resp, err := http.Get(url)
+		url := &url.URL{
+			Scheme: "http",
+			Host:   config.GetConfig().Host + ":" + strconv.Itoa(config.GetConfig().Port),
+			Path:   "/status",
+		}
+		resp, err := http.Get(url.String())
 		if err != nil {
 			fmt.Println("Error the HTTP server is not running:", err)
 			os.Exit(1)

--- a/config/config.go
+++ b/config/config.go
@@ -9,7 +9,7 @@ var config *Config
 // Config contains the configuration values of the application
 type Config struct {
 	Mode     Mode
-	Address  string
+	Host     string
 	Port     int
 	Database Database
 }
@@ -37,9 +37,9 @@ func GetConfig() *Config {
 // UseViper sets the configured instance of Config
 func UseViper(viper *viper.Viper) {
 	config = &Config{
-		Mode:    parseMode(viper.GetString("mode")),
-		Address: viper.GetString("address"),
-		Port:    viper.GetInt("port"),
+		Mode: parseMode(viper.GetString("mode")),
+		Host: viper.GetString("host"),
+		Port: viper.GetInt("port"),
 		Database: Database{
 			URL: viper.GetString("databaseUrl"),
 		},


### PR DESCRIPTION
Little *morning nitpicking* PR on naming and help messages:

  - rephrased the outdated `help serve` message
  - renamed the `Address` config param to `Host`, which I think is more correct..
  - more consistent help messages for flags