### PR TITLE
Fix status conversion in Couchdb Error

### DIFF
--- a/couchdb/errors.go
+++ b/couchdb/errors.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 )
 
 // This file contains error handling code for couchdb request
@@ -69,7 +70,7 @@ func (e *Error) Error() string {
 // JSON returns the json representation of this error
 func (e *Error) JSON() map[string]interface{} {
 	jsonMap := map[string]interface{}{
-		"status": string(e.StatusCode),
+		"status": strconv.Itoa(e.StatusCode),
 		"error":  e.Name,
 		"reason": e.Reason,
 	}
@@ -83,8 +84,8 @@ func isNoDatabaseError(err error) bool {
 	if err == nil {
 		return false
 	}
-	coucherr, iscoucherr := err.(*Error)
-	return iscoucherr && coucherr.Reason == "no_db_file"
+	couchErr, isCouchErr := err.(*Error)
+	return isCouchErr && couchErr.Reason == "no_db_file"
 }
 
 func newRequestError(originalError error) error {

--- a/couchdb/errors.go
+++ b/couchdb/errors.go
@@ -50,8 +50,6 @@ import (
 // 		supplied JSON was invalid, or invalid information was supplied as part
 // 		of the request.
 
-const ()
-
 // Error represent an error from couchdb
 type Error struct {
 	StatusCode  int

--- a/couchdb/errors.go
+++ b/couchdb/errors.go
@@ -66,17 +66,17 @@ func (e *Error) Error() string {
 	return fmt.Sprintf("CouchdbError %d : %s(%s)", e.StatusCode, e.Name, e.Reason)
 }
 
-// JSON returns the hash to ouput in HTTP for a given error
+// JSON returns the hash to output in HTTP for a given error
 func (e *Error) JSON() map[string]interface{} {
-	json := map[string]interface{}{
+	jsonMap := map[string]interface{}{
 		"status": string(e.StatusCode),
 		"error":  e.Name,
 		"reason": e.Reason,
 	}
 	if e.Original != nil {
-		json["original"] = e.Original.Error()
+		jsonMap["original"] = e.Original.Error()
 	}
-	return json
+	return jsonMap
 }
 
 func isNoDatabaseError(err error) bool {

--- a/couchdb/errors.go
+++ b/couchdb/errors.go
@@ -66,7 +66,7 @@ func (e *Error) Error() string {
 	return fmt.Sprintf("CouchdbError %d : %s(%s)", e.StatusCode, e.Name, e.Reason)
 }
 
-// JSON returns the hash to output in HTTP for a given error
+// JSON returns the json representation of this error
 func (e *Error) JSON() map[string]interface{} {
 	jsonMap := map[string]interface{}{
 		"status": string(e.StatusCode),

--- a/couchdb/errors_test.go
+++ b/couchdb/errors_test.go
@@ -1,0 +1,30 @@
+package couchdb
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestError_JSON(t *testing.T) {
+	couchError := Error{
+		StatusCode: 200,
+		CouchdbJSON: []byte(`{
+			"hello": "couchdb"
+		}`),
+		Name:     "a name",
+		Reason:   "a reason",
+		Original: fmt.Errorf("universe %d", 42),
+	}
+
+	asJson := couchError.JSON()
+
+	expectedMap := map[string]interface{}{
+		"status":   "200",
+		"error":    "a name",
+		"reason":   "a reason",
+		"original": "universe 42",
+	}
+
+	assert.EqualValues(t, expectedMap, asJson)
+}


### PR DESCRIPTION
* Converting the status code from `int` to `string` was done using `string()` instead of `strconv.ItoA()`.
* Test case created.
* Minor fixes/cleanup