### PR TITLE
couch.Doc interface

### DIFF
--- a/couchdb/couchdb.go
+++ b/couchdb/couchdb.go
@@ -162,9 +162,7 @@ func ResetDB(dbprefix, doctype string) error {
 	return CreateDB(dbprefix, doctype)
 }
 
-func createDocOrDb(dbprefix string, doc Doc, response interface{}) (err error) {
-	doctype := doc.DocType()
-
+func createDocOrDb(dbprefix, doctype string, doc Doc, response interface{}) (err error) {
 	db := makeDBName(dbprefix, doctype)
 	err = makeRequest("POST", db, doc, response)
 	if err == nil || !isNoDatabaseError(err) {
@@ -181,7 +179,9 @@ func createDocOrDb(dbprefix string, doc Doc, response interface{}) (err error) {
 // CreateDoc is used to persist the given document in the couchdb
 // database. It returns the revision of the added document and sets the
 // document id.
-func CreateDoc(dbprefix string, doc Doc) (err error) {
+//
+// @TODO: we still pass the doctype around to handle the /data api
+func CreateDoc(dbprefix, doctype string, doc Doc) (err error) {
 	var res *updateResponse
 
 	if doc.ID() != "" {
@@ -189,8 +189,8 @@ func CreateDoc(dbprefix string, doc Doc) (err error) {
 		return
 	}
 
-	doc.SetID(genDocID(doc.DocType()))
-	err = createDocOrDb(dbprefix, doc, &res)
+	doc.SetID(genDocID(doctype))
+	err = createDocOrDb(dbprefix, doctype, doc, &res)
 	if err != nil {
 		return
 	}

--- a/couchdb/couchdb.go
+++ b/couchdb/couchdb.go
@@ -76,7 +76,7 @@ func makeDBName(dbprefix, doctype string) string {
 }
 
 func docURL(dbprefix, doctype, id string) string {
-	return makeDBName(dbprefix, doctype) + "/" + url.QueryEscape(doctype+"/"+id)
+	return makeDBName(dbprefix, doctype) + "/" + url.QueryEscape(id)
 }
 
 func genDocID(doctype string) string {

--- a/couchdb/couchdb.go
+++ b/couchdb/couchdb.go
@@ -38,22 +38,27 @@ type JSONDoc struct {
 	Data map[string]interface{}
 }
 
+// ID returns the identifier field of the document
 func (j *JSONDoc) ID() string {
 	return j.Data["_id"].(string)
 }
 
+// Rev returns the revision field of the document
 func (j *JSONDoc) Rev() string {
 	return j.Data["_rev"].(string)
 }
 
+// DocType returns the document type
 func (j *JSONDoc) DocType() string {
 	return j.Type
 }
 
+// SetID is used to set the identifier of the document
 func (j *JSONDoc) SetID(id string) {
 	j.Data["_id"] = id
 }
 
+// SetRev is used to set the revision of the document
 func (j *JSONDoc) SetRev(rev string) {
 	j.Data["_rev"] = rev
 }
@@ -200,9 +205,4 @@ func CreateDoc(dbprefix string, doc Doc) (err error) {
 
 	doc.SetRev(res.Rev)
 	return
-}
-
-func GetDoctypeAndID(doc Doc) (string, string) {
-	parts := strings.Split(doc.ID(), "/")
-	return parts[0], parts[1]
 }

--- a/couchdb/couchdb.go
+++ b/couchdb/couchdb.go
@@ -33,34 +33,31 @@ type Doc interface {
 
 // JSONDoc is a map representing a simple json object that implements
 // the Doc interface.
-type JSONDoc struct {
-	Type string
-	Data map[string]interface{}
-}
+type JSONDoc map[string]interface{}
 
 // ID returns the identifier field of the document
-func (j *JSONDoc) ID() string {
-	return j.Data["_id"].(string)
+func (j JSONDoc) ID() string {
+	return j["_id"].(string)
 }
 
 // Rev returns the revision field of the document
-func (j *JSONDoc) Rev() string {
-	return j.Data["_rev"].(string)
+func (j JSONDoc) Rev() string {
+	return j["_rev"].(string)
 }
 
 // DocType returns the document type
-func (j *JSONDoc) DocType() string {
-	return j.Type
+func (j JSONDoc) DocType() string {
+	return j["doctype"].(string)
 }
 
 // SetID is used to set the identifier of the document
-func (j *JSONDoc) SetID(id string) {
-	j.Data["_id"] = id
+func (j JSONDoc) SetID(id string) {
+	j["_id"] = id
 }
 
 // SetRev is used to set the revision of the document
-func (j *JSONDoc) SetRev(rev string) {
-	j.Data["_rev"] = rev
+func (j JSONDoc) SetRev(rev string) {
+	j["_rev"] = rev
 }
 
 // CouchURL is the URL where to check if CouchDB is up

--- a/couchdb/couchdb.go
+++ b/couchdb/couchdb.go
@@ -19,13 +19,24 @@ type updateResponse struct {
 	Ok  bool   `json:"ok"`
 }
 
-// Doc : A couchdb Doc is just a json object
-type Doc map[string]interface{}
+// Doc is the interface that encapsulate a couchdb document, of any
+// serializable type. This interface defines method to set and get the
+// ID of the document.
+type Doc interface {
+	GetID() string
+	SetID(id string)
+}
 
-// GetDoctypeAndID returns the doctype and unqualified id of a document
-func (d Doc) GetDoctypeAndID() (string, string) {
-	parts := strings.Split(d["_id"].(string), "/")
-	return parts[0], parts[1]
+// JSONDoc is a map representing a simple json object that implements
+// the Doc interface.
+type JSONDoc map[string]interface{}
+
+func (j JSONDoc) GetID() string {
+	return j["_id"].(string)
+}
+
+func (j JSONDoc) SetID(id string) {
+	j["_id"] = id
 }
 
 // CouchURL is the URL where to check if CouchDB is up
@@ -43,17 +54,13 @@ func makeDBName(dbprefix, doctype string) string {
 	return url.QueryEscape(dbname)
 }
 
-func makeDocID(doctype string, id string) string {
-	return url.QueryEscape(doctype + "/" + id)
-}
-
 func docURL(dbprefix, doctype, id string) string {
-	return makeDBName(dbprefix, doctype) + "/" + makeDocID(doctype, id)
+	return makeDBName(dbprefix, doctype) + "/" + url.QueryEscape(doctype+"/"+id)
 }
 
-func makeUUID() string {
+func genDocID(doctype string) string {
 	u := uuid.NewV4()
-	return hex.EncodeToString(u[:])
+	return doctype + "/" + hex.EncodeToString(u[:])
 }
 
 func makeRequest(method, path string, reqbody interface{}, resbody interface{}) error {
@@ -107,7 +114,7 @@ func makeRequest(method, path string, reqbody interface{}, resbody interface{}) 
 
 // GetDoc fetch a document by its docType and ID, out is filled with
 // the document by json.Unmarshal-ing
-func GetDoc(dbprefix, doctype, id string, out *Doc) error {
+func GetDoc(dbprefix, doctype, id string, out Doc) error {
 	err := makeRequest("GET", docURL(dbprefix, doctype, id), nil, out)
 	if isNoDatabaseError(err) {
 		err.(*Error).Reason = "wrong_doctype"
@@ -134,34 +141,47 @@ func ResetDB(dbprefix, doctype string) error {
 	return CreateDB(dbprefix, doctype)
 }
 
-func attemptCreateDBAndDoc(dbprefix, doctype string, doc Doc) error {
-	createErr := CreateDB(dbprefix, doctype)
-	if createErr != nil {
-		return createErr
+func createDocOrDb(dbprefix, doctype string, doc Doc, response interface{}) (err error) {
+	db := makeDBName(dbprefix, doctype)
+	err = makeRequest("POST", db, doc, response)
+	if err == nil || !isNoDatabaseError(err) {
+		return
 	}
-	return CreateDoc(dbprefix, doctype, doc)
+
+	err = CreateDB(dbprefix, doctype)
+	if err == nil {
+		err = makeRequest("POST", db, doc, response)
+	}
+	return
 }
 
-// CreateDoc creates a document in couchdb. It modifies doc in place to add
-// _id and _rev.
-func CreateDoc(dbprefix, doctype string, doc Doc) error {
-	var response updateResponse
+// CreateDoc is used to persist the given document in the couchdb
+// database. It returns the revision of the added document and sets the
+// document id.
+func CreateDoc(dbprefix, doctype string, doc Doc) (rev string, err error) {
+	var res *updateResponse
 
-	doc["_id"] = doctype + "/" + makeUUID()
-
-	err := makeRequest("POST", makeDBName(dbprefix, doctype), &doc, &response)
-	if isNoDatabaseError(err) {
-		return attemptCreateDBAndDoc(dbprefix, doctype, doc)
+	if doc.GetID() != "" {
+		err = fmt.Errorf("Can not create document with a defined ID")
+		return
 	}
+
+	doc.SetID(genDocID(doctype))
+	err = createDocOrDb(dbprefix, doctype, doc, &res)
 	if err != nil {
-		return err
+		return
 	}
-	if !response.Ok {
-		return fmt.Errorf("couchdb replied with 200 ok=false")
+
+	if !res.Ok {
+		err = fmt.Errorf("CouchDB replied with 200 ok=false")
+		return
 	}
-	// assign extracted values to the given doc
-	// doubt : should we instead try to be more immutable and make a new map ?
-	doc["_id"] = response.ID
-	doc["_rev"] = response.Rev
-	return nil
+
+	rev = res.Rev
+	return
+}
+
+func GetDoctypeAndID(doc Doc) (string, string) {
+	parts := strings.Split(doc.GetID(), "/")
+	return parts[0], parts[1]
 }

--- a/couchdb/couchdb.go
+++ b/couchdb/couchdb.go
@@ -33,26 +33,29 @@ type Doc interface {
 
 // JSONDoc is a map representing a simple json object that implements
 // the Doc interface.
-type JSONDoc map[string]interface{}
-
-func (j JSONDoc) ID() string {
-	return j["_id"].(string)
+type JSONDoc struct {
+	Type string
+	Data map[string]interface{}
 }
 
-func (j JSONDoc) Rev() string {
-	return j["_rev"].(string)
+func (j *JSONDoc) ID() string {
+	return j.Data["_id"].(string)
 }
 
-func (j JSONDoc) DocType() string {
-	return j["doctype"].(string)
+func (j *JSONDoc) Rev() string {
+	return j.Data["_rev"].(string)
 }
 
-func (j JSONDoc) SetID(id string) {
-	j["_id"] = id
+func (j *JSONDoc) DocType() string {
+	return j.Type
 }
 
-func (j JSONDoc) SetRev(rev string) {
-	j["_rev"] = rev
+func (j *JSONDoc) SetID(id string) {
+	j.Data["_id"] = id
+}
+
+func (j *JSONDoc) SetRev(rev string) {
+	j.Data["_rev"] = rev
 }
 
 // CouchURL is the URL where to check if CouchDB is up

--- a/couchdb/couchdb_test.go
+++ b/couchdb/couchdb_test.go
@@ -17,9 +17,22 @@ func TestErrors(t *testing.T) {
 	assert.Contains(t, err.Error(), "missing")
 }
 
+type testDoc struct {
+	ID   string `json:"_id"`
+	Test string `json:"test"`
+}
+
+func (t *testDoc) GetID() string {
+	return t.ID
+}
+
+func (t *testDoc) SetID(id string) {
+	t.ID = id
+}
+
 func makeTestDoc() Doc {
-	return map[string]interface{}{
-		"test": "somevalue",
+	return &testDoc{
+		Test: "somevalue",
 	}
 }
 
@@ -27,15 +40,18 @@ func TestCreateDoc(t *testing.T) {
 	var TESTPREFIX = "dev/"
 	var TESTTYPE = "io.cozy.testobject"
 	var doc = makeTestDoc()
-	err := CreateDoc(TESTPREFIX, TESTTYPE, doc)
+	assert.Empty(t, doc.GetID())
+	rev, err := CreateDoc(TESTPREFIX, TESTTYPE, doc)
 	assert.NoError(t, err)
-	assert.NotEmpty(t, doc["_id"])
-	docType, id := doc.GetDoctypeAndID()
-	var out Doc
-	err = GetDoc(TESTPREFIX, docType, id, &out)
+	assert.NotEmpty(t, rev, doc.GetID())
+
+	docType, id := GetDoctypeAndID(doc)
+
+	out := &testDoc{}
+	err = GetDoc(TESTPREFIX, docType, id, out)
 	assert.NoError(t, err)
-	assert.Equal(t, out["_id"], doc["_id"])
-	assert.Equal(t, out["test"], "somevalue")
+	assert.Equal(t, out.GetID(), doc.GetID())
+	assert.Equal(t, out.Test, "somevalue")
 }
 
 func TestMain(m *testing.M) {

--- a/couchdb/couchdb_test.go
+++ b/couchdb/couchdb_test.go
@@ -18,17 +18,17 @@ func TestErrors(t *testing.T) {
 }
 
 type testDoc struct {
-	ID_  string `json:"_id"`
-	Rev_ string `json:"_rev,omitempty"`
-	Test string `json:"test"`
+	TestID  string `json:"_id"`
+	TestRev string `json:"_rev,omitempty"`
+	Test    string `json:"test"`
 }
 
 func (t *testDoc) ID() string {
-	return t.ID_
+	return t.TestID
 }
 
 func (t *testDoc) Rev() string {
-	return t.Rev_
+	return t.TestRev
 }
 
 func (t *testDoc) DocType() string {
@@ -36,11 +36,11 @@ func (t *testDoc) DocType() string {
 }
 
 func (t *testDoc) SetID(id string) {
-	t.ID_ = id
+	t.TestID = id
 }
 
 func (t *testDoc) SetRev(rev string) {
-	t.Rev_ = rev
+	t.TestRev = rev
 }
 
 func makeTestDoc() Doc {
@@ -59,7 +59,7 @@ func TestCreateDoc(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, doc.Rev(), doc.ID())
 
-	docType, id := GetDoctypeAndID(doc)
+	docType, id := doc.DocType(), doc.ID()
 
 	out := &testDoc{}
 	err = GetDoc(TESTPREFIX, docType, id, out)

--- a/couchdb/couchdb_test.go
+++ b/couchdb/couchdb_test.go
@@ -18,16 +18,29 @@ func TestErrors(t *testing.T) {
 }
 
 type testDoc struct {
-	ID   string `json:"_id"`
+	ID_  string `json:"_id"`
+	Rev_ string `json:"_rev,omitempty"`
 	Test string `json:"test"`
 }
 
-func (t *testDoc) GetID() string {
-	return t.ID
+func (t *testDoc) ID() string {
+	return t.ID_
+}
+
+func (t *testDoc) Rev() string {
+	return t.Rev_
+}
+
+func (t *testDoc) DocType() string {
+	return "io.cozy.testobject"
 }
 
 func (t *testDoc) SetID(id string) {
-	t.ID = id
+	t.ID_ = id
+}
+
+func (t *testDoc) SetRev(rev string) {
+	t.Rev_ = rev
 }
 
 func makeTestDoc() Doc {
@@ -37,20 +50,21 @@ func makeTestDoc() Doc {
 }
 
 func TestCreateDoc(t *testing.T) {
+	var err error
+
 	var TESTPREFIX = "dev/"
-	var TESTTYPE = "io.cozy.testobject"
 	var doc = makeTestDoc()
-	assert.Empty(t, doc.GetID())
-	rev, err := CreateDoc(TESTPREFIX, TESTTYPE, doc)
+	assert.Empty(t, doc.Rev(), doc.ID())
+	err = CreateDoc(TESTPREFIX, doc)
 	assert.NoError(t, err)
-	assert.NotEmpty(t, rev, doc.GetID())
+	assert.NotEmpty(t, doc.Rev(), doc.ID())
 
 	docType, id := GetDoctypeAndID(doc)
 
 	out := &testDoc{}
 	err = GetDoc(TESTPREFIX, docType, id, out)
 	assert.NoError(t, err)
-	assert.Equal(t, out.GetID(), doc.GetID())
+	assert.Equal(t, out.ID(), doc.ID())
 	assert.Equal(t, out.Test, "somevalue")
 }
 

--- a/couchdb/couchdb_test.go
+++ b/couchdb/couchdb_test.go
@@ -55,7 +55,7 @@ func TestCreateDoc(t *testing.T) {
 	var TESTPREFIX = "dev/"
 	var doc = makeTestDoc()
 	assert.Empty(t, doc.Rev(), doc.ID())
-	err = CreateDoc(TESTPREFIX, doc)
+	err = CreateDoc(TESTPREFIX, "io.cozy.testobject", doc)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, doc.Rev(), doc.ID())
 

--- a/web/data/data.go
+++ b/web/data/data.go
@@ -42,13 +42,13 @@ func createDoc(c *gin.Context) {
 	instance := middlewares.GetInstance(c)
 	prefix := instance.GetDatabasePrefix()
 
-	doc := &couchdb.JSONDoc{Type: doctype}
-
-	if err := c.BindJSON(doc.Data); err != nil {
+	var doc couchdb.JSONDoc
+	if err := c.BindJSON(&doc); err != nil {
 		c.AbortWithError(http.StatusBadRequest, err)
 		return
 	}
 
+	doc["doctype"] = doctype
 	err := couchdb.CreateDoc(prefix, doc)
 	if err != nil {
 		c.AbortWithError(errors.HTTPStatus(err), err)
@@ -59,7 +59,7 @@ func createDoc(c *gin.Context) {
 		"ok":   true,
 		"id":   doc.ID(),
 		"rev":  doc.Rev(),
-		"data": doc.Data,
+		"data": doc,
 	})
 }
 

--- a/web/data/data.go
+++ b/web/data/data.go
@@ -24,11 +24,12 @@ func validDoctype(c *gin.Context) {
 func getDoc(c *gin.Context) {
 	instance := c.MustGet("instance").(*middlewares.Instance)
 	doctype := c.MustGet("doctype").(string)
+	docid := doctype + "/" + c.Param("docid")
 
 	prefix := instance.GetDatabasePrefix()
 
 	var out couchdb.JSONDoc
-	err := couchdb.GetDoc(prefix, doctype, c.Param("docid"), &out)
+	err := couchdb.GetDoc(prefix, doctype, docid, &out)
 	if err != nil {
 		c.AbortWithError(errors.HTTPStatus(err), err)
 		return

--- a/web/data/data.go
+++ b/web/data/data.go
@@ -48,7 +48,8 @@ func createDoc(c *gin.Context) {
 		return
 	}
 
-	rev, err := couchdb.CreateDoc(prefix, doctype, doc)
+	doc["doctype"] = doctype
+	err := couchdb.CreateDoc(prefix, doc)
 	if err != nil {
 		c.AbortWithError(errors.HTTPStatus(err), err)
 		return
@@ -56,8 +57,8 @@ func createDoc(c *gin.Context) {
 
 	c.JSON(200, gin.H{
 		"ok":   true,
-		"id":   doc.GetID(),
-		"rev":  rev,
+		"id":   doc.ID(),
+		"rev":  doc.Rev(),
 		"data": doc,
 	})
 }

--- a/web/data/data.go
+++ b/web/data/data.go
@@ -42,13 +42,13 @@ func createDoc(c *gin.Context) {
 	instance := middlewares.GetInstance(c)
 	prefix := instance.GetDatabasePrefix()
 
-	var doc couchdb.JSONDoc
-	if err := c.BindJSON(&doc); err != nil {
+	doc := &couchdb.JSONDoc{Type: doctype}
+
+	if err := c.BindJSON(doc.Data); err != nil {
 		c.AbortWithError(http.StatusBadRequest, err)
 		return
 	}
 
-	doc["doctype"] = doctype
 	err := couchdb.CreateDoc(prefix, doc)
 	if err != nil {
 		c.AbortWithError(errors.HTTPStatus(err), err)
@@ -59,7 +59,7 @@ func createDoc(c *gin.Context) {
 		"ok":   true,
 		"id":   doc.ID(),
 		"rev":  doc.Rev(),
-		"data": doc,
+		"data": doc.Data,
 	})
 }
 

--- a/web/data/data.go
+++ b/web/data/data.go
@@ -48,8 +48,7 @@ func createDoc(c *gin.Context) {
 		return
 	}
 
-	doc["doctype"] = doctype
-	err := couchdb.CreateDoc(prefix, doc)
+	err := couchdb.CreateDoc(prefix, doctype, doc)
 	if err != nil {
 		c.AbortWithError(errors.HTTPStatus(err), err)
 		return

--- a/web/data/data_test.go
+++ b/web/data/data_test.go
@@ -48,10 +48,7 @@ func couchReq(method, path string, body io.Reader) (*http.Response, error) {
 	return res, nil
 }
 
-func testRoute(t *testing.T, url string, host string, jsonout interface{}) (
-	*http.Response, []byte, error) {
-
-	fmt.Println("test req", url)
+func testRoute(t *testing.T, url string, host string, jsonout interface{}) (*http.Response, []byte, error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, nil, err
@@ -65,10 +62,9 @@ func testRoute(t *testing.T, url string, host string, jsonout interface{}) (
 	defer res.Body.Close()
 	body, ioerr := ioutil.ReadAll(res.Body)
 	if ioerr != nil {
-		return res, nil, nil
+		return nil, nil, ioerr
 	}
 	return res, body, json.Unmarshal(body, jsonout)
-
 }
 
 func injectInstance(instance *middlewares.Instance) gin.HandlerFunc {


### PR DESCRIPTION
See #36.

The `doctype` on the JSONDoc felt weird and we may fallback on this one... This change will affect the crud api since it adds a explicit `doctype` field to documents.. while the `_id` field also contains it. I'm not really sure about that.

Other than that, I don't see many issue.