### PR TITLE
[VFS] Add a vfs package

### DIFF
--- a/vfs/directory.go
+++ b/vfs/directory.go
@@ -1,4 +1,4 @@
-package files
+package vfs
 
 import (
 	"encoding/json"
@@ -76,9 +76,9 @@ func (d *DirDoc) ToJSONApi() ([]byte, error) {
 }
 
 // CreateDirectory is the method for creating a new directory
-func CreateDirectory(m *DocMetadata, fs afero.Fs, dbPrefix string) (doc *DirDoc, err error) {
+func CreateDirectory(m *DocAttributes, fs afero.Fs, dbPrefix string) (doc *DirDoc, err error) {
 	if m.Type != FolderDocType {
-		err = errDocTypeInvalid
+		err = ErrDocTypeInvalid
 		return
 	}
 

--- a/vfs/directory.go
+++ b/vfs/directory.go
@@ -77,7 +77,7 @@ func (d *DirDoc) ToJSONApi() ([]byte, error) {
 
 // CreateDirectory is the method for creating a new directory
 func CreateDirectory(m *DocAttributes, fs afero.Fs, dbPrefix string) (doc *DirDoc, err error) {
-	if m.Type != FolderDocType {
+	if m.docType != FolderDocType {
 		err = ErrDocTypeInvalid
 		return
 	}
@@ -89,15 +89,15 @@ func CreateDirectory(m *DocAttributes, fs afero.Fs, dbPrefix string) (doc *DirDo
 
 	createDate := time.Now()
 	attrs := &dirAttributes{
-		Name:      m.Name,
+		Name:      m.name,
 		CreatedAt: createDate,
 		UpdatedAt: createDate,
-		Tags:      m.Tags,
+		Tags:      m.tags,
 	}
 
 	doc = &DirDoc{
 		Attrs:    attrs,
-		FolderID: m.FolderID,
+		FolderID: m.folderID,
 		Path:     pth,
 	}
 

--- a/vfs/errors.go
+++ b/vfs/errors.go
@@ -22,9 +22,6 @@ var (
 	// ErrInvalidHash is used when the given hash does not match the
 	// calculated one
 	ErrInvalidHash = errors.New("Invalid hash")
-	// ErrContentLengthInvalid is used when the content-length is not
-	// valid
-	ErrContentLengthInvalid = errors.New("Invalid content length")
 	// ErrContentLengthMismatch is used when the content-length does not
 	// match the calculated one
 	ErrContentLengthMismatch = errors.New("Content length does not match")
@@ -42,13 +39,13 @@ func HTTPStatus(err error) (code int) {
 	case ErrParentDoesNotExist:
 		code = http.StatusNotFound
 	case ErrDocTypeInvalid:
+		code = http.StatusUnprocessableEntity
 	case ErrIllegalFilename:
+		code = http.StatusUnprocessableEntity
 	case ErrInvalidHash:
 		code = http.StatusPreconditionFailed
-	case ErrContentLengthInvalid:
-		code = http.StatusUnprocessableEntity
 	case ErrContentLengthMismatch:
-		code = http.StatusPreconditionFailed
+		code = http.StatusUnprocessableEntity
 	}
 	return
 }

--- a/vfs/errors.go
+++ b/vfs/errors.go
@@ -2,6 +2,7 @@ package vfs
 
 import (
 	"errors"
+	"net/http"
 	"os"
 )
 
@@ -15,3 +16,25 @@ var (
 	ErrContentLengthInvalid  = errors.New("Invalid content length")
 	ErrContentLengthMismatch = errors.New("Content length does not match")
 )
+
+// Return the HTTP status code associated to a given error. If the
+// error is not part of vfs errors, the code returned is 0.
+func HTTPStatus(err error) (code int) {
+	switch err {
+	case ErrDocAlreadyExists:
+		code = http.StatusConflict
+	case ErrDocDoesNotExist:
+		code = http.StatusNotFound
+	case ErrParentDoesNotExist:
+		code = http.StatusNotFound
+	case ErrDocTypeInvalid:
+	case ErrIllegalFilename:
+	case ErrInvalidHash:
+		code = http.StatusPreconditionFailed
+	case ErrContentLengthInvalid:
+		code = http.StatusUnprocessableEntity
+	case ErrContentLengthMismatch:
+		code = http.StatusPreconditionFailed
+	}
+	return
+}

--- a/vfs/errors.go
+++ b/vfs/errors.go
@@ -1,0 +1,17 @@
+package vfs
+
+import (
+	"errors"
+	"os"
+)
+
+var (
+	ErrDocAlreadyExists      = os.ErrExist
+	ErrDocDoesNotExist       = os.ErrNotExist
+	ErrParentDoesNotExist    = errors.New("Parent folder with given FolderID does not exist")
+	ErrDocTypeInvalid        = errors.New("Invalid document type")
+	ErrIllegalFilename       = errors.New("Invalid filename: empty or contains an illegal character")
+	ErrInvalidHash           = errors.New("Invalid hash")
+	ErrContentLengthInvalid  = errors.New("Invalid content length")
+	ErrContentLengthMismatch = errors.New("Content length does not match")
+)

--- a/vfs/errors.go
+++ b/vfs/errors.go
@@ -7,18 +7,32 @@ import (
 )
 
 var (
-	ErrDocAlreadyExists      = os.ErrExist
-	ErrDocDoesNotExist       = os.ErrNotExist
-	ErrParentDoesNotExist    = errors.New("Parent folder with given FolderID does not exist")
-	ErrDocTypeInvalid        = errors.New("Invalid document type")
-	ErrIllegalFilename       = errors.New("Invalid filename: empty or contains an illegal character")
-	ErrInvalidHash           = errors.New("Invalid hash")
-	ErrContentLengthInvalid  = errors.New("Invalid content length")
+	// ErrDocAlreadyExists is used when file or directory already exists
+	ErrDocAlreadyExists = os.ErrExist
+	// ErrDocDoesNotExist is used when file or directory does not exist
+	ErrDocDoesNotExist = os.ErrNotExist
+	// ErrParentDoesNotExist is used when the parent folder does not
+	// exist
+	ErrParentDoesNotExist = errors.New("Parent folder with given FolderID does not exist")
+	// ErrDocTypeInvalid is used when the document type sent is not
+	// recognized
+	ErrDocTypeInvalid = errors.New("Invalid document type")
+	// ErrIllegalFilename is used when the given filename is not allowed
+	ErrIllegalFilename = errors.New("Invalid filename: empty or contains an illegal character")
+	// ErrInvalidHash is used when the given hash does not match the
+	// calculated one
+	ErrInvalidHash = errors.New("Invalid hash")
+	// ErrContentLengthInvalid is used when the content-length is not
+	// valid
+	ErrContentLengthInvalid = errors.New("Invalid content length")
+	// ErrContentLengthMismatch is used when the content-length does not
+	// match the calculated one
 	ErrContentLengthMismatch = errors.New("Content length does not match")
 )
 
-// Return the HTTP status code associated to a given error. If the
-// error is not part of vfs errors, the code returned is 0.
+// HTTPStatus returns the HTTP status code associated to a given
+// error. If the error is not part of vfs errors, the code returned is
+// 0.
 func HTTPStatus(err error) (code int) {
 	switch err {
 	case ErrDocAlreadyExists:

--- a/vfs/file.go
+++ b/vfs/file.go
@@ -157,7 +157,7 @@ func serveContent(req *http.Request, w http.ResponseWriter, fs afero.Fs, pth, na
 
 // CreateFileAndUpload is the method for uploading a file onto the filesystem.
 func CreateFileAndUpload(m *DocAttributes, fs afero.Fs, dbPrefix string, body io.ReadCloser) (doc *FileDoc, err error) {
-	if m.Type != FileDocType {
+	if m.docType != FileDocType {
 		err = ErrDocTypeInvalid
 		return
 	}
@@ -169,20 +169,20 @@ func CreateFileAndUpload(m *DocAttributes, fs afero.Fs, dbPrefix string, body io
 
 	createDate := time.Now()
 	attrs := &fileAttributes{
-		Name:       m.Name,
+		Name:       m.name,
 		CreatedAt:  createDate,
 		UpdatedAt:  createDate,
-		Size:       m.Size,
-		Tags:       m.Tags,
-		MD5Sum:     m.GivenMD5,
-		Executable: m.Executable,
-		Class:      m.Class,
-		Mime:       m.Mime,
+		Size:       m.size,
+		Tags:       m.tags,
+		MD5Sum:     m.givenMD5,
+		Executable: m.executable,
+		Class:      m.class,
+		Mime:       m.mime,
 	}
 
 	doc = &FileDoc{
 		Attrs:    attrs,
-		FolderID: m.FolderID,
+		FolderID: m.folderID,
 		Path:     pth,
 	}
 
@@ -232,7 +232,7 @@ func copyOnFsAndCheckIntegrity(m *DocAttributes, fs afero.Fs, pth string, r io.R
 	}
 
 	calcMD5 := md5H.Sum(nil)
-	if !bytes.Equal(m.GivenMD5, calcMD5) {
+	if !bytes.Equal(m.givenMD5, calcMD5) {
 		err = ErrInvalidHash
 		return
 	}

--- a/vfs/file.go
+++ b/vfs/file.go
@@ -8,15 +8,11 @@ import (
 	"io"
 	"net/http"
 	"path"
-	"strings"
 	"time"
 
 	"github.com/cozy/cozy-stack/couchdb"
 	"github.com/spf13/afero"
 )
-
-// DefaultContentType is used for files uploaded with no content-type
-const DefaultContentType = "application/octet-stream"
 
 type fileAttributes struct {
 	Name       string    `json:"name"`
@@ -235,29 +231,6 @@ func copyOnFsAndCheckIntegrity(m *DocAttributes, fs afero.Fs, pth string, r io.R
 	if !bytes.Equal(m.givenMD5, calcMD5) {
 		err = ErrInvalidHash
 		return
-	}
-
-	return
-}
-
-func extractMimeAndClass(contentType string) (mime, class string) {
-	if contentType == "" {
-		contentType = DefaultContentType
-	}
-
-	charsetIndex := strings.Index(contentType, ";")
-	if charsetIndex >= 0 {
-		mime = contentType[:charsetIndex]
-	} else {
-		mime = contentType
-	}
-
-	// @TODO improve for specific mime types
-	slashIndex := strings.Index(contentType, "/")
-	if slashIndex >= 0 {
-		class = contentType[:slashIndex]
-	} else {
-		class = contentType
 	}
 
 	return

--- a/vfs/file.go
+++ b/vfs/file.go
@@ -1,4 +1,4 @@
-package files
+package vfs
 
 import (
 	"bytes"
@@ -156,9 +156,9 @@ func serveContent(req *http.Request, w http.ResponseWriter, fs afero.Fs, pth, na
 }
 
 // CreateFileAndUpload is the method for uploading a file onto the filesystem.
-func CreateFileAndUpload(m *DocMetadata, fs afero.Fs, contentType string, contentLength int64, dbPrefix string, body io.ReadCloser) (doc *FileDoc, err error) {
+func CreateFileAndUpload(m *DocAttributes, fs afero.Fs, contentType string, contentLength int64, dbPrefix string, body io.ReadCloser) (doc *FileDoc, err error) {
 	if m.Type != FileDocType {
-		err = errDocTypeInvalid
+		err = ErrDocTypeInvalid
 		return
 	}
 
@@ -202,7 +202,7 @@ func CreateFileAndUpload(m *DocMetadata, fs afero.Fs, contentType string, conten
 	}
 
 	if contentLength >= 0 && written != contentLength {
-		err = errContentLengthMismatch
+		err = ErrContentLengthMismatch
 		return
 	}
 
@@ -217,7 +217,7 @@ func CreateFileAndUpload(m *DocMetadata, fs afero.Fs, contentType string, conten
 	return
 }
 
-func copyOnFsAndCheckIntegrity(m *DocMetadata, fs afero.Fs, pth string, r io.ReadCloser) (written int64, err error) {
+func copyOnFsAndCheckIntegrity(m *DocAttributes, fs afero.Fs, pth string, r io.ReadCloser) (written int64, err error) {
 	f, err := fs.Create(pth)
 	if err != nil {
 		return
@@ -234,7 +234,7 @@ func copyOnFsAndCheckIntegrity(m *DocMetadata, fs afero.Fs, pth string, r io.Rea
 
 	calcMD5 := md5H.Sum(nil)
 	if !bytes.Equal(m.GivenMD5, calcMD5) {
-		err = errInvalidHash
+		err = ErrInvalidHash
 		return
 	}
 

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -1,0 +1,164 @@
+package vfs
+
+import (
+	"encoding/base64"
+	"path"
+	"strings"
+
+	"github.com/cozy/cozy-stack/couchdb"
+	"github.com/spf13/afero"
+)
+
+// DocType is the type of document, eg. file or folder
+type DocType string
+
+const (
+	// FileDocType is document type
+	FileDocType DocType = "io.cozy.files"
+	// FolderDocType is document type
+	FolderDocType = "io.cozy.folders"
+)
+
+// ForbiddenFilenameChars is the list of forbidden characters in a filename.
+const ForbiddenFilenameChars = "/\x00"
+
+// DocAttributes encapsulates the few metadata linked to a document
+// creation request.
+type DocAttributes struct {
+	Type       DocType
+	Name       string
+	FolderID   string
+	Executable bool
+	Tags       []string
+	GivenMD5   []byte
+}
+
+// NewDocAttributes is the DocAttributes constructor. All inputs are
+// validated and if wrong, an error is returned.
+func NewDocAttributes(docTypeStr, name, folderID, tagsStr, md5Str string, executable bool) (m *DocAttributes, err error) {
+	docType, err := parseDocType(docTypeStr)
+	if err != nil {
+		return
+	}
+
+	if err = checkFileName(name); err != nil {
+		return
+	}
+
+	// FolderID is not mandatory. If empty, the document is at the root
+	// of the FS
+	if folderID != "" {
+		if err = checkFileName(folderID); err != nil {
+			return
+		}
+	}
+
+	tags := parseTags(tagsStr)
+
+	var givenMD5 []byte
+	if md5Str != "" {
+		givenMD5, err = parseMD5Hash(md5Str)
+		if err != nil {
+			return
+		}
+	}
+
+	m = &DocAttributes{
+		Type:       docType,
+		Name:       name,
+		FolderID:   folderID,
+		Tags:       tags,
+		Executable: executable,
+		GivenMD5:   givenMD5,
+	}
+
+	return
+}
+
+func parseTags(str string) (tags []string) {
+	for _, tag := range strings.Split(str, ",") {
+		tag = strings.TrimSpace(tag)
+		if tag != "" {
+			tags = append(tags, tag)
+		}
+	}
+	return
+}
+
+func parseDocType(docType string) (result DocType, err error) {
+	switch docType {
+	case "io.cozy.files":
+		result = FileDocType
+	case "io.cozy.folders":
+		result = FolderDocType
+	default:
+		err = ErrDocTypeInvalid
+	}
+	return
+}
+
+func parseMD5Hash(md5B64 string) ([]byte, error) {
+	// Encoded md5 hash in base64 should at least have 22 caracters in
+	// base64: 16*3/4 = 21+1/3
+	//
+	// The padding may add up to 2 characters (non useful). If we are
+	// out of these boundaries we know we don't have a good hash and we
+	// can bail immediatly.
+	if len(md5B64) < 22 || len(md5B64) > 24 {
+		return nil, ErrInvalidHash
+	}
+
+	givenMD5, err := base64.StdEncoding.DecodeString(md5B64)
+	if err != nil || len(givenMD5) != 16 {
+		return nil, ErrInvalidHash
+	}
+
+	return givenMD5, nil
+}
+
+func checkFileName(str string) error {
+	if str == "" || strings.ContainsAny(str, ForbiddenFilenameChars) {
+		return ErrIllegalFilename
+	}
+	return nil
+}
+
+// checkParentFolderID is used to generate the filepath of a new file
+// or directory. It will check if the given parent folderID is well
+// defined is the database and filesystem and it will generate the new
+// path of the wanted file, checking if there is not colision with
+// existing file.
+func createNewFilePath(m *DocAttributes, storage afero.Fs, dbPrefix string) (pth string, parentDoc *DirDoc, err error) {
+	folderID := m.FolderID
+
+	var parentPath string
+
+	if folderID == "" {
+		parentPath = "/"
+	} else {
+		parentDoc = &DirDoc{}
+
+		// NOTE: we only check the existence of the folder on the db
+		err = couchdb.GetDoc(dbPrefix, string(FolderDocType), folderID, parentDoc)
+		if couchdb.IsNotFoundError(err) {
+			err = ErrParentDoesNotExist
+		}
+		if err != nil {
+			return
+		}
+
+		parentPath = parentDoc.Path
+	}
+
+	pth = path.Join(parentPath, m.Name)
+	exists, err := afero.Exists(storage, pth)
+	if err != nil {
+		return
+	}
+	if exists {
+		err = ErrDocAlreadyExists
+		return
+	}
+
+	return
+}

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -26,15 +26,19 @@ const ForbiddenFilenameChars = "/\x00"
 // DocAttributes encapsulates the few metadata linked to a document
 // creation request.
 type DocAttributes struct {
-	Type       DocType
-	Name       string
-	FolderID   string
-	Executable bool
-	Tags       []string
-	GivenMD5   []byte
-	Size       int64
-	Mime       string
-	Class      string
+	docType    DocType
+	name       string
+	folderID   string
+	executable bool
+	tags       []string
+	givenMD5   []byte
+	size       int64
+	mime       string
+	class      string
+}
+
+func (d *DocAttributes) DocType() DocType {
+	return d.docType
 }
 
 // NewDocAttributes is the DocAttributes constructor. All inputs are
@@ -75,15 +79,15 @@ func NewDocAttributes(docTypeStr, name, folderID, tagsStr, md5Str, contentType, 
 	mime, class := extractMimeAndClass(contentType)
 
 	m = &DocAttributes{
-		Type:       docType,
-		Name:       name,
-		FolderID:   folderID,
-		Tags:       tags,
-		Executable: executable,
-		GivenMD5:   givenMD5,
-		Size:       size,
-		Mime:       mime,
-		Class:      class,
+		docType:    docType,
+		name:       name,
+		folderID:   folderID,
+		tags:       tags,
+		executable: executable,
+		givenMD5:   givenMD5,
+		size:       size,
+		mime:       mime,
+		class:      class,
 	}
 
 	return
@@ -156,7 +160,7 @@ func checkFileName(str string) error {
 // path of the wanted file, checking if there is not colision with
 // existing file.
 func createNewFilePath(m *DocAttributes, storage afero.Fs, dbPrefix string) (pth string, parentDoc *DirDoc, err error) {
-	folderID := m.FolderID
+	folderID := m.folderID
 
 	var parentPath string
 
@@ -177,7 +181,7 @@ func createNewFilePath(m *DocAttributes, storage afero.Fs, dbPrefix string) (pth
 		parentPath = parentDoc.Path
 	}
 
-	pth = path.Join(parentPath, m.Name)
+	pth = path.Join(parentPath, m.name)
 	exists, err := afero.Exists(storage, pth)
 	if err != nil {
 		return

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -37,6 +37,7 @@ type DocAttributes struct {
 	class      string
 }
 
+// DocType returns the document type of the attributes.
 func (d *DocAttributes) DocType() DocType {
 	return d.docType
 }

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -1,3 +1,8 @@
+// Package vfs is for storing files on the cozy, including binary ones like
+// photos and movies. The range of possible operations with this endpoint goes
+// from simple ones, like uploading a file, to more complex ones, like renaming
+// a folder. It also ensure that an instance is not exceeding its quota, and
+// keeps a trash to recover files recently deleted.
 package vfs
 
 import (

--- a/web/errors/errors.go
+++ b/web/errors/errors.go
@@ -21,25 +21,6 @@ var NoInstance = &gin.Error{
 
 // HTTPStatus gives the http status for given error
 func HTTPStatus(err error) (code int) {
-	switch err {
-	case vfs.ErrDocAlreadyExists:
-		code = http.StatusConflict
-	case vfs.ErrParentDoesNotExist:
-		code = http.StatusNotFound
-	case vfs.ErrDocDoesNotExist:
-		code = http.StatusNotFound
-	case vfs.ErrContentLengthInvalid:
-		code = http.StatusUnprocessableEntity
-	case vfs.ErrInvalidHash:
-		code = http.StatusPreconditionFailed
-	case vfs.ErrContentLengthMismatch:
-		code = http.StatusPreconditionFailed
-	}
-
-	if code != 0 {
-		return
-	}
-
 	if os.IsNotExist(err) {
 		code = http.StatusNotFound
 	} else if os.IsExist(err) {
@@ -47,6 +28,10 @@ func HTTPStatus(err error) (code int) {
 	} else if couchErr, isCouchErr := err.(*couchdb.Error); isCouchErr {
 		code = couchErr.StatusCode
 	} else {
+		code = vfs.HTTPStatus(err)
+	}
+
+	if code == 0 {
 		code = http.StatusInternalServerError
 	}
 

--- a/web/errors/errors.go
+++ b/web/errors/errors.go
@@ -28,6 +28,8 @@ func HTTPStatus(err error) (code int) {
 		code = http.StatusNotFound
 	case vfs.ErrDocDoesNotExist:
 		code = http.StatusNotFound
+	case vfs.ErrContentLengthInvalid:
+		code = http.StatusUnprocessableEntity
 	case vfs.ErrInvalidHash:
 		code = http.StatusPreconditionFailed
 	case vfs.ErrContentLengthMismatch:

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -6,97 +6,15 @@
 package files
 
 import (
-	"encoding/base64"
-	"errors"
 	"net/http"
-	"os"
-	"path"
 	"strconv"
-	"strings"
 
-	"github.com/cozy/cozy-stack/couchdb"
+	"github.com/cozy/cozy-stack/vfs"
+	"github.com/cozy/cozy-stack/web/errors"
 	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/gin-gonic/gin"
-	"github.com/spf13/afero"
 )
-
-// DocType is the type of document, eg. file or folder
-type DocType string
-
-const (
-	// FileDocType is document type
-	FileDocType DocType = "io.cozy.files"
-	// FolderDocType is document type
-	FolderDocType = "io.cozy.folders"
-
-	// ForbiddenFilenameChars is the list of forbidden characters in a filename.
-	ForbiddenFilenameChars = "/\x00"
-)
-
-var (
-	errDocAlreadyExists      = os.ErrExist
-	errDocDoesNotExist       = os.ErrNotExist
-	errParentDoesNotExist    = errors.New("Parent folder with given FolderID does not exist")
-	errDocTypeInvalid        = errors.New("Invalid document type")
-	errIllegalFilename       = errors.New("Invalid filename: empty or contains an illegal character")
-	errInvalidHash           = errors.New("Invalid hash")
-	errContentLengthInvalid  = errors.New("Invalid content length")
-	errContentLengthMismatch = errors.New("Content length does not match")
-)
-
-// DocMetadata encapsulates the few metadata linked to a document
-// creation request.
-type DocMetadata struct {
-	Type       DocType
-	Name       string
-	FolderID   string
-	Executable bool
-	Tags       []string
-	GivenMD5   []byte
-}
-
-// NewDocMetadata is the DocMetadata constructor. All inputs are
-// validated and if wrong, an error is returned.
-func NewDocMetadata(docTypeStr, name, folderID, tagsStr, md5Str string, executable bool) (m *DocMetadata, err error) {
-	docType, err := parseDocType(docTypeStr)
-	if err != nil {
-		return
-	}
-
-	if err = checkFileName(name); err != nil {
-		return
-	}
-
-	// FolderID is not mandatory. If empty, the document is at the root
-	// of the FS
-	if folderID != "" {
-		if err = checkFileName(folderID); err != nil {
-			return
-		}
-	}
-
-	tags := parseTags(tagsStr)
-
-	var givenMD5 []byte
-	if md5Str != "" {
-		givenMD5, err = parseMD5Hash(md5Str)
-		if err != nil {
-			return
-		}
-	}
-
-	m = &DocMetadata{
-		Type:       docType,
-		Name:       name,
-		FolderID:   folderID,
-		Tags:       tags,
-		Executable: executable,
-		GivenMD5:   givenMD5,
-	}
-
-	return
-}
 
 // CreationHandler handle all POST requests on /files/:folder-id
 // aiming at creating a new document in the FS. Given the Type
@@ -115,7 +33,7 @@ func CreationHandler(c *gin.Context) {
 
 	header := c.Request.Header
 
-	m, err := NewDocMetadata(
+	m, err := vfs.NewDocAttributes(
 		c.Query("Type"),
 		c.Query("Name"),
 		c.Param("folder-id"),
@@ -138,20 +56,20 @@ func CreationHandler(c *gin.Context) {
 
 	var doc jsonapi.JSONApier
 	switch m.Type {
-	case FileDocType:
-		doc, err = CreateFileAndUpload(m, storage, contentType, contentLength, dbPrefix, c.Request.Body)
-	case FolderDocType:
-		doc, err = CreateDirectory(m, storage, dbPrefix)
+	case vfs.FileDocType:
+		doc, err = vfs.CreateFileAndUpload(m, storage, contentType, contentLength, dbPrefix, c.Request.Body)
+	case vfs.FolderDocType:
+		doc, err = vfs.CreateDirectory(m, storage, dbPrefix)
 	}
 
 	if err != nil {
-		c.AbortWithError(makeCode(err), err)
+		c.AbortWithError(errors.HTTPStatus(err), err)
 		return
 	}
 
 	data, err := doc.ToJSONApi()
 	if err != nil {
-		c.AbortWithError(makeCode(err), err)
+		c.AbortWithError(errors.HTTPStatus(err), err)
 		return
 	}
 
@@ -183,17 +101,17 @@ func ReadHandler(c *gin.Context) {
 	// form their path
 	if fileID == "download" {
 		pth := c.Query("path")
-		err = ServeFileContentByPath(pth, c.Request, c.Writer, storage)
+		err = vfs.ServeFileContentByPath(pth, c.Request, c.Writer, storage)
 	} else {
-		var doc *FileDoc
-		doc, err = GetFileDoc(fileID, dbPrefix)
+		var doc *vfs.FileDoc
+		doc, err = vfs.GetFileDoc(fileID, dbPrefix)
 		if err == nil {
-			err = ServeFileContent(doc, c.Request, c.Writer, storage)
+			err = vfs.ServeFileContent(doc, c.Request, c.Writer, storage)
 		}
 	}
 
 	if err != nil {
-		c.AbortWithError(makeCode(err), err)
+		c.AbortWithError(errors.HTTPStatus(err), err)
 		return
 	}
 }
@@ -207,59 +125,6 @@ func Routes(router *gin.RouterGroup) {
 	router.POST("/:folder-id", CreationHandler)
 }
 
-func makeCode(err error) (code int) {
-	switch err {
-	case errDocAlreadyExists:
-		code = http.StatusConflict
-	case errParentDoesNotExist:
-		code = http.StatusNotFound
-	case errDocDoesNotExist:
-		code = http.StatusNotFound
-	case errInvalidHash:
-		code = http.StatusPreconditionFailed
-	case errContentLengthMismatch:
-		code = http.StatusPreconditionFailed
-	}
-
-	if code != 0 {
-		return
-	}
-
-	if os.IsNotExist(err) {
-		code = http.StatusNotFound
-	} else if os.IsExist(err) {
-		code = http.StatusConflict
-	} else if couchErr, isCouchErr := err.(*couchdb.Error); isCouchErr {
-		code = couchErr.StatusCode
-	} else {
-		code = http.StatusInternalServerError
-	}
-
-	return
-}
-
-func parseTags(str string) (tags []string) {
-	for _, tag := range strings.Split(str, ",") {
-		tag = strings.TrimSpace(tag)
-		if tag != "" {
-			tags = append(tags, tag)
-		}
-	}
-	return
-}
-
-func parseDocType(docType string) (result DocType, err error) {
-	switch docType {
-	case "io.cozy.files":
-		result = FileDocType
-	case "io.cozy.folders":
-		result = FolderDocType
-	default:
-		err = errDocTypeInvalid
-	}
-	return
-}
-
 func parseContentLength(contentLength string) (size int64, err error) {
 	if contentLength == "" {
 		size = -1
@@ -268,73 +133,7 @@ func parseContentLength(contentLength string) (size int64, err error) {
 
 	size, err = strconv.ParseInt(contentLength, 10, 64)
 	if err != nil {
-		err = errContentLengthInvalid
+		err = vfs.ErrContentLengthInvalid
 	}
-	return
-}
-
-func parseMD5Hash(md5B64 string) ([]byte, error) {
-	// Encoded md5 hash in base64 should at least have 22 caracters in
-	// base64: 16*3/4 = 21+1/3
-	//
-	// The padding may add up to 2 characters (non useful). If we are
-	// out of these boundaries we know we don't have a good hash and we
-	// can bail immediatly.
-	if len(md5B64) < 22 || len(md5B64) > 24 {
-		return nil, errInvalidHash
-	}
-
-	givenMD5, err := base64.StdEncoding.DecodeString(md5B64)
-	if err != nil || len(givenMD5) != 16 {
-		return nil, errInvalidHash
-	}
-
-	return givenMD5, nil
-}
-
-func checkFileName(str string) error {
-	if str == "" || strings.ContainsAny(str, ForbiddenFilenameChars) {
-		return errIllegalFilename
-	}
-	return nil
-}
-
-// checkParentFolderID is used to generate the filepath of a new file
-// or directory. It will check if the given parent folderID is well
-// defined is the database and filesystem and it will generate the new
-// path of the wanted file, checking if there is not colision with
-// existing file.
-func createNewFilePath(m *DocMetadata, storage afero.Fs, dbPrefix string) (pth string, parentDoc *DirDoc, err error) {
-	folderID := m.FolderID
-
-	var parentPath string
-
-	if folderID == "" {
-		parentPath = "/"
-	} else {
-		parentDoc = &DirDoc{}
-
-		// NOTE: we only check the existence of the folder on the db
-		err = couchdb.GetDoc(dbPrefix, string(FolderDocType), folderID, parentDoc)
-		if couchdb.IsNotFoundError(err) {
-			err = errParentDoesNotExist
-		}
-		if err != nil {
-			return
-		}
-
-		parentPath = parentDoc.Path
-	}
-
-	pth = path.Join(parentPath, m.Name)
-	exists, err := afero.Exists(storage, pth)
-	if err != nil {
-		return
-	}
-	if exists {
-		err = errDocAlreadyExists
-		return
-	}
-
 	return
 }

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -1,8 +1,6 @@
-// Package files is for storing files on the cozy, including binary ones like
-// photos and movies. The range of possible operations with this endpoint goes
-// from simple ones, like uploading a file, to more complex ones, like renaming
-// a folder. It also ensure that an instance is not exceeding its quota, and
-// keeps a trash to recover files recently deleted.
+// Package files is the HTTP frontend of the vfs package. It exposes
+// an HTTP api to manipulate the filesystem and offer all the
+// possibilities given by the vfs.
 package files
 
 import (

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -4,7 +4,11 @@
 package files
 
 import (
+	"encoding/base64"
+	"fmt"
 	"net/http"
+	"strconv"
+	"strings"
 
 	"github.com/cozy/cozy-stack/vfs"
 	"github.com/cozy/cozy-stack/web/errors"
@@ -12,6 +16,9 @@ import (
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/gin-gonic/gin"
 )
+
+// DefaultContentType is used for files uploaded with no content-type
+const DefaultContentType = "application/octet-stream"
 
 // CreationHandler handle all POST requests on /files/:folder-id
 // aiming at creating a new document in the FS. Given the Type
@@ -29,31 +36,47 @@ func CreationHandler(c *gin.Context) {
 	}
 
 	header := c.Request.Header
-	contentType := c.ContentType()
-	contentLength := header.Get("Content-Length")
 
-	m, err := vfs.NewDocAttributes(
-		c.Query("Type"),
-		c.Query("Name"),
-		c.Param("folder-id"),
-		c.Query("Tags"),
-		header.Get("Content-MD5"),
-		contentType,
-		contentLength,
-		c.Query("Executable") == "true",
-	)
+	mime, class := extractMimeAndClass(c.ContentType())
 
+	var givenMD5 []byte
+	if md5Str := header.Get("Content-MD5"); md5Str != "" {
+		givenMD5, err = parseMD5Hash(md5Str)
+	}
 	if err != nil {
 		c.AbortWithError(http.StatusUnprocessableEntity, err)
 		return
 	}
 
+	size, err := parseContentLength(header.Get("Content-Length"))
+	if err != nil {
+		c.AbortWithError(http.StatusUnprocessableEntity, err)
+		return
+	}
+
+	d, err := vfs.NewDocAttributes(
+		c.Query("Type"),
+		c.Query("Name"),
+		c.Param("folder-id"),
+		mime,
+		class,
+		size,
+		givenMD5,
+		parseTags(c.Query("Tags")),
+		c.Query("Executable") == "true",
+	)
+
+	if err != nil {
+		c.AbortWithError(errors.HTTPStatus(err), err)
+		return
+	}
+
 	var doc jsonapi.JSONApier
-	switch m.DocType() {
+	switch d.DocType() {
 	case vfs.FileDocType:
-		doc, err = vfs.CreateFileAndUpload(m, storage, dbPrefix, c.Request.Body)
+		doc, err = vfs.CreateFileAndUpload(d, storage, dbPrefix, c.Request.Body)
 	case vfs.FolderDocType:
-		doc, err = vfs.CreateDirectory(m, storage, dbPrefix)
+		doc, err = vfs.CreateDirectory(d, storage, dbPrefix)
 	}
 
 	if err != nil {
@@ -117,4 +140,69 @@ func Routes(router *gin.RouterGroup) {
 
 	router.POST("/", CreationHandler)
 	router.POST("/:folder-id", CreationHandler)
+}
+
+func parseTags(str string) (tags []string) {
+	for _, tag := range strings.Split(str, ",") {
+		tag = strings.TrimSpace(tag)
+		if tag != "" {
+			tags = append(tags, tag)
+		}
+	}
+	return
+}
+
+func parseMD5Hash(md5B64 string) ([]byte, error) {
+	// Encoded md5 hash in base64 should at least have 22 caracters in
+	// base64: 16*3/4 = 21+1/3
+	//
+	// The padding may add up to 2 characters (non useful). If we are
+	// out of these boundaries we know we don't have a good hash and we
+	// can bail immediatly.
+	if len(md5B64) < 22 || len(md5B64) > 24 {
+		return nil, fmt.Errorf("Given Content-MD5 is invalid")
+	}
+
+	givenMD5, err := base64.StdEncoding.DecodeString(md5B64)
+	if err != nil || len(givenMD5) != 16 {
+		return nil, fmt.Errorf("Given Content-MD5 is invalid")
+	}
+
+	return givenMD5, nil
+}
+
+func parseContentLength(contentLength string) (size int64, err error) {
+	if contentLength == "" {
+		size = -1
+		return
+	}
+
+	size, err = strconv.ParseInt(contentLength, 10, 64)
+	if err != nil {
+		err = fmt.Errorf("Invalid content length")
+	}
+	return
+}
+
+func extractMimeAndClass(contentType string) (mime, class string) {
+	if contentType == "" {
+		contentType = DefaultContentType
+	}
+
+	charsetIndex := strings.Index(contentType, ";")
+	if charsetIndex >= 0 {
+		mime = contentType[:charsetIndex]
+	} else {
+		mime = contentType
+	}
+
+	// @TODO improve for specific mime types
+	slashIndex := strings.Index(contentType, "/")
+	if slashIndex >= 0 {
+		class = contentType[:slashIndex]
+	} else {
+		class = contentType
+	}
+
+	return
 }

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -51,7 +51,7 @@ func CreationHandler(c *gin.Context) {
 	}
 
 	var doc jsonapi.JSONApier
-	switch m.Type {
+	switch m.DocType() {
 	case vfs.FileDocType:
 		doc, err = vfs.CreateFileAndUpload(m, storage, dbPrefix, c.Request.Body)
 	case vfs.FolderDocType:


### PR DESCRIPTION
This PR is only refactorization. The main idea is to export the vfs parts in its own package to give us some space for what is coming next.

The diff may be hard to read so here exact list of what it does:

  - create a `package vfs` with all the code specific to vfs, file and directory handling (no gin)
  - add error handling in vfs/errors
  - renamed `vfs.DocMetadata` struct into `vfs.DocAttributes` and make its fields private
  - add `mime`, `class` and `size` fields to `vfs.DocAttributes` to be more consistent
  - use `web/errors` in `web/files` to be consistent with `web/data`
