### PR TITLE
Improve http tests

### DIFF
--- a/couchdb/couchdb.go
+++ b/couchdb/couchdb.go
@@ -97,6 +97,11 @@ func (j *JSONDoc) ToMapWithType() map[string]interface{} {
 	return j.M
 }
 
+// Get returns the value of one of the db fields
+func (j JSONDoc) Get(key string) interface{} {
+	return j.M[key]
+}
+
 // CouchURL is the URL where to check if CouchDB is up
 func CouchURL() string {
 	return "http://localhost:5984/"
@@ -165,13 +170,17 @@ func makeRequest(method, path string, reqbody interface{}, resbody interface{}) 
 	return err
 }
 
+func fixErrorNoDatabaseIsWrongDoctype(err error) {
+	if IsNoDatabaseError(err) {
+		err.(*Error).Reason = "wrong_doctype"
+	}
+}
+
 // GetDoc fetch a document by its docType and ID, out is filled with
 // the document by json.Unmarshal-ing
 func GetDoc(dbprefix, doctype, id string, out Doc) error {
 	err := makeRequest("GET", docURL(dbprefix, doctype, id), nil, out)
-	if IsNoDatabaseError(err) {
-		err.(*Error).Reason = "wrong_doctype"
-	}
+	fixErrorNoDatabaseIsWrongDoctype(err)
 	return err
 }
 
@@ -203,6 +212,7 @@ func Delete(dbprefix, doctype, id, rev string) (tombrev string, err error) {
 	qs := url.Values{"rev": []string{rev}}
 	url := docURL(dbprefix, doctype, id) + "?" + qs.Encode()
 	err = makeRequest("DELETE", url, nil, &res)
+	fixErrorNoDatabaseIsWrongDoctype(err)
 	if err == nil {
 		tombrev = res.Rev
 	}
@@ -229,12 +239,35 @@ func UpdateDoc(dbprefix string, doc Doc) (err error) {
 	id := doc.ID()
 	rev := doc.Rev()
 	if id == "" || rev == "" || doctype == "" {
-		return fmt.Errorf("UpdateDoc argument should have doctype, id and rev ")
+		return fmt.Errorf("UpdateDoc doc argument should have doctype, id and rev")
 	}
 
 	url := docURL(dbprefix, doctype, id)
 	var res updateResponse
 	err = makeRequest("PUT", url, doc, &res)
+	fixErrorNoDatabaseIsWrongDoctype(err)
+	if err == nil {
+		doc.SetRev(res.Rev)
+	}
+	return err
+}
+
+// CreateNamedDoc persist a document with an ID.
+// if the document already exist, it will return a 409 error.
+// The document ID should be fillled.
+// The doc SetRev function will be called with the new rev.
+func CreateNamedDoc(dbprefix string, doc Doc) (err error) {
+	doctype := doc.DocType()
+	id := doc.ID()
+
+	if doc.Rev() != "" || doc.ID() == "" || doctype == "" {
+		return fmt.Errorf("CreateNamedDoc should have type and id but no rev")
+	}
+
+	url := docURL(dbprefix, doctype, id)
+	var res updateResponse
+	err = makeRequest("PUT", url, doc, &res)
+	fixErrorNoDatabaseIsWrongDoctype(err)
 	if err == nil {
 		doc.SetRev(res.Rev)
 	}

--- a/couchdb/couchdb.go
+++ b/couchdb/couchdb.go
@@ -78,7 +78,16 @@ func (j JSONDoc) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements json.Unmarshaller by proxying to internal map
 func (j *JSONDoc) UnmarshalJSON(bytes []byte) error {
-	return json.Unmarshal(bytes, &j.M)
+	err := json.Unmarshal(bytes, &j.M)
+	if err != nil {
+		return err
+	}
+	doctype, ok := j.M["_type"].(string)
+	if ok {
+		j.Type = doctype
+	}
+	delete(j.M, "_type")
+	return nil
 }
 
 // ToMapWithType returns the JSONDoc internal map including its DocType

--- a/couchdb/errors.go
+++ b/couchdb/errors.go
@@ -70,6 +70,7 @@ func (e *Error) Error() string {
 // JSON returns the json representation of this error
 func (e *Error) JSON() map[string]interface{} {
 	jsonMap := map[string]interface{}{
+		"ok":     false,
 		"status": strconv.Itoa(e.StatusCode),
 		"error":  e.Name,
 		"reason": e.Reason,

--- a/couchdb/errors_test.go
+++ b/couchdb/errors_test.go
@@ -2,8 +2,9 @@ package couchdb
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestError_JSON(t *testing.T) {
@@ -20,6 +21,7 @@ func TestError_JSON(t *testing.T) {
 	asJSON := couchError.JSON()
 
 	expectedMap := map[string]interface{}{
+		"ok":       false,
 		"status":   "200",
 		"error":    "a name",
 		"reason":   "a reason",

--- a/docs/crud.md
+++ b/docs/crud.md
@@ -126,6 +126,129 @@ Content-Type: application/json
 
 --------------------------------------------------------------------------------
 
+# Update an existing document
+
+### Request
+```http
+PUT /data/:type/:id
+```
+```http
+PUT /data/io.cozy.events/6494e0ac-dfcb-11e5-88c1-472e84a9cbee
+Content-Length: ...
+Content-Type: application/json
+Accept: application/json
+```
+```json
+{
+    "_id": "6494e0ac-dfcb-11e5-88c1-472e84a9cbee",
+    "_type": "io.cozy.events",
+    "_rev": "1-6494e0ac6494e0ac",
+    "startdate": "20160712T150000",
+    "enddate": "20160712T200000",
+}
+```
+
+### Response OK
+```http
+200 OK
+Content-Length: ...
+Content-Type: application/json
+```
+```json
+{
+    "id": "6494e0ac-dfcb-11e5-88c1-472e84a9cbee",
+    "type": "io.cozy.events",
+    "ok": true,
+    "rev": "2-056f5f44046ecafc08a2bc2b9c229e20",
+    "data": {
+        "_id": "6494e0ac-dfcb-11e5-88c1-472e84a9cbee",
+        "_type": "io.cozy.events",
+        "_rev": "2-056f5f44046ecafc08a2bc2b9c229e20",
+        "startdate": "20160712T150000",
+        "enddate": "20160712T200000",
+    }
+}
+```
+
+### Possible errors :
+- 400 bad request
+- 401 unauthorized (no authentication has been provided)
+- 403 forbidden (the authentication does not provide permissions for this action)
+- 404 not_found
+  - reason: missing
+  - reason: deleted
+- 409 Conflict (see Conflict prevention section below)
+- 500 internal server error
+
+### Conflict prevention
+
+The client MUST give a `_rev` field in the document. If this field is different from the one in the current version of the document, an error 409 Conflict will be returned.
+
+### Details
+
+- If no id is provided in URL, an error 400 is returned
+- If the id provided in URL is not the same than the one in document, an error 400 is returned.
+
+--------------------------------------------------------------------------
+
+
+# Create a document with a fixed id
+
+### Request
+```http
+PUT /data/:type/:id
+```
+```http
+PUT /data/io.cozy.events/6494e0ac-dfcb-11e5-88c1-472e84a9cbee
+Content-Length: ...
+Content-Type: application/json
+Accept: application/json
+```
+```json
+{
+    "startdate": "20160712T150000",
+    "enddate": "20160712T200000",
+}
+```
+
+### Response OK
+```http
+200 OK
+Content-Length: ...
+Content-Type: application/json
+```
+```json
+{
+    "id": "6494e0ac-dfcb-11e5-88c1-472e84a9cbee",
+    "type": "io.cozy.events",
+    "ok": true,
+    "rev": "1-056f5f44046ecafc08a2bc2b9c229e20",
+    "data": {
+        "_id": "6494e0ac-dfcb-11e5-88c1-472e84a9cbee",
+        "_type": "io.cozy.events",
+        "_rev": "1-056f5f44046ecafc08a2bc2b9c229e20",
+        "startdate": "20160712T150000",
+        "enddate": "20160712T200000",
+    }
+}
+```
+
+### Possible errors :
+- 400 bad request
+- 401 unauthorized (no authentication has been provided)
+- 403 forbidden (the authentication does not provide permissions for this action)
+- 404 not_found
+  - reason: missing
+  - reason: deleted
+- 409 Conflict (see Conflict prevention section below)
+- 500 internal server error
+
+### Details
+
+- No id should be provide in the document itself
+
+--------------------------------------------------------------------------------
+
 # Delete a document
 
 ### Request
@@ -160,18 +283,14 @@ Content-Type: application/json
 - 404 not_found
   - reason: missing
   - reason: deleted
-- 412 Conflict (see Conflict prevention section below)
+- 409 Conflict (see Conflict prevention section below)
 - 500 internal server error
 
 ### Conflict prevention
 
 It is possible to use either a `rev` query string parameter or a HTTP `If-Match` header to prevent conflict on deletion:
-- If both are passed and are different, an error 400 is returned
-- If only one is passed or they are equals, the document will only be deleted if its `_rev` match the passed one. Otherwise, an error 412  is returned.
-- If none is passed, the document will be force-deleted.
-
-**Why shouldn't you force delete** (contrieved example) the user is syncing contacts from his mobile, a contact is created with name but no number, the user see it in the contact app. In parallel, the number is added by sync and the user click "delete" because a contact with no number is useless. The decision to delete is based on outdated data state and should therefore be aborted.
-Couchdb will prevent this, the stack API allow it for fast prototyping but it should be avoided for serious applications.
+- If none is passed or they are different, an error 400 is returned
+- If only one is passed or they are equals, the document will only be deleted if its `_rev` match the passed one. Otherwise, an error 409  is returned.
 
 ### Details
 

--- a/web/data/data.go
+++ b/web/data/data.go
@@ -51,6 +51,12 @@ func createDoc(c *gin.Context) {
 		return
 	}
 
+	if doc.ID() != "" {
+		err := fmt.Errorf("Cannot create a document with _id")
+		c.AbortWithError(http.StatusBadRequest, err)
+		return
+	}
+
 	err := couchdb.CreateDoc(prefix, doc)
 	if err != nil {
 		c.AbortWithError(errors.HTTPStatus(err), err)
@@ -78,18 +84,26 @@ func updateDoc(c *gin.Context) {
 
 	doc.Type = c.Param("doctype")
 
-	if doc.ID() != "" && doc.ID() != c.Param("docid") {
-		err := fmt.Errorf("_id in document doesnt match url")
+	if (doc.ID() == "") != (doc.Rev() == "") {
+		err := fmt.Errorf("You must either provide an _id and _rev in document (update) or neither (create with  fixed id).")
 		c.AbortWithError(http.StatusBadRequest, err)
 		return
 	}
 
-	rev := c.Request.Header.Get("If-Match")
-	if rev != "" {
-		doc.SetRev(rev)
+	if doc.ID() != "" && doc.ID() != c.Param("docid") {
+		err := fmt.Errorf("document _id doesnt match url")
+		c.AbortWithError(http.StatusBadRequest, err)
+		return
 	}
 
-	err := couchdb.UpdateDoc(prefix, doc)
+	var err error
+	if doc.ID() == "" {
+		doc.SetID(c.Param("docid"))
+		err = couchdb.CreateNamedDoc(prefix, doc)
+	} else {
+		err = couchdb.UpdateDoc(prefix, doc)
+	}
+
 	if err != nil {
 		c.AbortWithError(errors.HTTPStatus(err), err)
 		return
@@ -109,11 +123,21 @@ func deleteDoc(c *gin.Context) {
 	doctype := c.MustGet("doctype").(string)
 	docid := c.Param("docid")
 	prefix := instance.GetDatabasePrefix()
-	rev := c.Request.Header.Get("If-Match")
+	revHeader := c.Request.Header.Get("If-Match")
+	revQuery := c.Query("rev")
+	rev := ""
 
-	if rev == "" {
-		err := fmt.Errorf("NotImplemented : delete without If-Match")
-		c.AbortWithError(http.StatusNotImplemented, err)
+	if revHeader != "" && revQuery != "" && revQuery != revHeader {
+		err := fmt.Errorf("If-Match Header and rev query parameters mismatch")
+		c.AbortWithError(http.StatusBadRequest, err)
+		return
+	} else if revHeader != "" {
+		rev = revHeader
+	} else if revQuery != "" {
+		rev = revQuery
+	} else {
+		err := fmt.Errorf("delete without revision")
+		c.AbortWithError(http.StatusBadRequest, err)
 		return
 	}
 

--- a/web/data/data_test.go
+++ b/web/data/data_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cozy/cozy-stack/couchdb"
 	"github.com/cozy/cozy-stack/web/errors"
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/gin-gonic/gin"
@@ -25,6 +26,7 @@ const Host = "example.com"
 const Type = "io.cozy.events"
 const ID = "4521C325F6478E45"
 const ExpectedDBName = "example-com%2Fio-cozy-events"
+const TestPrefix = "example-com/"
 
 var DOCUMENT = []byte(`{
 	"test": "testvalue"
@@ -48,12 +50,27 @@ func couchReq(method, path string, body io.Reader) (*http.Response, error) {
 	return res, nil
 }
 
+type stackUpdateResponse struct {
+	ID      string          `json:"id"`
+	Rev     string          `json:"rev"`
+	Type    string          `json:"type"`
+	Ok      bool            `json:"ok"`
+	Deleted bool            `json:"deleted"`
+	Error   string          `json:"error"`
+	Reason  string          `json:"reason"`
+	Data    couchdb.JSONDoc `json:"data"`
+}
+
 func jsonReader(data *map[string]interface{}) io.Reader {
 	bs, _ := json.Marshal(&data)
 	return bytes.NewReader(bs)
 }
 
-func doRequest(req *http.Request) (jsonres map[string]interface{}, res *http.Response, err error) {
+func docURL(ts *httptest.Server, doc couchdb.JSONDoc) string {
+	return ts.URL + "/data/" + doc.DocType() + "/" + doc.ID()
+}
+
+func doRequest(req *http.Request, out interface{}) (jsonres map[string]interface{}, res *http.Response, err error) {
 
 	res, err = client.Do(req)
 	if err != nil {
@@ -64,18 +81,33 @@ func doRequest(req *http.Request) (jsonres map[string]interface{}, res *http.Res
 	if err != nil {
 		return
 	}
-	var out map[string]interface{}
+	if out == nil {
+		var out map[string]interface{}
+		err = json.Unmarshal(body, &out)
+		if err != nil {
+			return
+		}
+		return out, res, err
+	}
+
 	err = json.Unmarshal(body, &out)
 	if err != nil {
 		return
 	}
-	return out, res, err
+	return nil, res, err
+
 }
 
 func injectInstance(instance *middlewares.Instance) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		c.Set("instance", instance)
 	}
+}
+
+func getDocForTest() couchdb.JSONDoc {
+	doc := couchdb.JSONDoc{Type: Type, M: map[string]interface{}{"test": "value"}}
+	couchdb.CreateDoc(TestPrefix, &doc)
+	return doc
 }
 
 func TestMain(m *testing.M) {
@@ -107,7 +139,7 @@ func TestMain(m *testing.M) {
 func TestSuccessGet(t *testing.T) {
 	req, _ := http.NewRequest("GET", ts.URL+"/data/"+Type+"/"+ID, nil)
 	req.Header.Add("Host", Host)
-	out, res, err := doRequest(req)
+	out, res, err := doRequest(req, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "200 OK", res.Status, "should get a 200")
 	if assert.Contains(t, out, "test") {
@@ -118,7 +150,7 @@ func TestSuccessGet(t *testing.T) {
 func TestWrongDoctype(t *testing.T) {
 	req, _ := http.NewRequest("GET", ts.URL+"/data/nottype/"+ID, nil)
 	req.Header.Add("Host", Host)
-	out, res, err := doRequest(req)
+	out, res, err := doRequest(req, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "404 Not Found", res.Status, "should get a 404")
 	if assert.Contains(t, out, "error") {
@@ -133,7 +165,7 @@ func TestWrongDoctype(t *testing.T) {
 func TestWrongID(t *testing.T) {
 	req, _ := http.NewRequest("GET", ts.URL+"/data/"+Type+"/NOTID", nil)
 	req.Header.Add("Host", Host)
-	out, res, err := doRequest(req)
+	out, res, err := doRequest(req, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "404 Not Found", res.Status, "should get a 404")
 	if assert.Contains(t, out, "error") {
@@ -148,7 +180,7 @@ func TestWrongHost(t *testing.T) {
 	t.Skip("unskip me when we stop falling back to Host = dev")
 	req, _ := http.NewRequest("GET", ts.URL+"/data/"+Type+"/"+ID, nil)
 	req.Header.Add("Host", "NOTHOST")
-	out, res, err := doRequest(req)
+	out, res, err := doRequest(req, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "404 Not Found", res.Status, "should get a 404")
 	if assert.Contains(t, out, "error") {
@@ -159,83 +191,241 @@ func TestWrongHost(t *testing.T) {
 	}
 }
 
-func TestSuccessCreate(t *testing.T) {
+func TestSuccessCreateKnownDoctype(t *testing.T) {
 	var in = jsonReader(&map[string]interface{}{
+		"somefield": "avalue",
+	})
+	var sur stackUpdateResponse
+	req, _ := http.NewRequest("POST", ts.URL+"/data/"+Type+"/", in)
+	req.Header.Add("Host", Host)
+	_, res, err := doRequest(req, &sur)
+	assert.NoError(t, err)
+	assert.Equal(t, "201 Created", res.Status, "should get a 201")
+	assert.Equal(t, sur.Ok, true, "ok is true")
+	assert.NotContains(t, sur.ID, "/", "id is simple uuid")
+	assert.Equal(t, sur.Type, Type, "type is correct")
+	assert.NotEmpty(t, sur.Rev, "rev at top level (couchdb compatibility)")
+	assert.Equal(t, sur.ID, sur.Data.ID(), "id is simple uuid")
+	assert.Equal(t, sur.Type, sur.Data.Type, "type is correct")
+	assert.Equal(t, sur.Rev, sur.Data.Rev(), "rev is correct")
+	assert.Equal(t, "avalue", sur.Data.Get("somefield"), "content is correct")
+}
+
+func TestSuccessCreateUnknownDoctype(t *testing.T) {
+	var in = jsonReader(&map[string]interface{}{
+		"somefield": "avalue",
+	})
+	var sur stackUpdateResponse
+	type2 := "io.cozy.anothertype"
+	req, _ := http.NewRequest("POST", ts.URL+"/data/"+type2+"/", in)
+	req.Header.Add("Host", Host)
+	_, res, err := doRequest(req, &sur)
+	assert.NoError(t, err)
+	assert.Equal(t, "201 Created", res.Status, "should get a 201")
+	assert.Equal(t, sur.Ok, true, "ok is true")
+	assert.NotContains(t, sur.ID, "/", "id is simple uuid")
+	assert.Equal(t, sur.Type, type2, "type is correct")
+	assert.NotEmpty(t, sur.Rev, "rev at top level (couchdb compatibility)")
+	assert.Equal(t, sur.ID, sur.Data.ID(), "in doc id is correct")
+	assert.Equal(t, sur.Type, sur.Data.Type, "in doc type is correct")
+	assert.Equal(t, sur.Rev, sur.Data.Rev(), "in doc rev is correct")
+	assert.Equal(t, "avalue", sur.Data.Get("somefield"), "content is correct")
+}
+
+func TestWrongCreateWithID(t *testing.T) {
+	var in = jsonReader(&map[string]interface{}{
+		"_id":       "this-should-not-be-an-id",
 		"somefield": "avalue",
 	})
 	req, _ := http.NewRequest("POST", ts.URL+"/data/"+Type+"/", in)
 	req.Header.Add("Host", Host)
-	out, res, err := doRequest(req)
+	_, res, err := doRequest(req, nil)
 	assert.NoError(t, err)
-	assert.Equal(t, "201 Created", res.Status, "should get a 201")
-	assert.Contains(t, out, "ok", "ok at top level (couchdb compatibility)")
-	assert.Equal(t, out["ok"], true, "ok is true")
-	assert.Contains(t, out, "id", "id at top level (couchdb compatibility)")
-	assert.Contains(t, out, "rev", "rev at top level (couchdb compatibility)")
-	if assert.Contains(t, out, "data", "document included") {
-		data, ismap := out["data"].(map[string]interface{})
-		if assert.True(t, ismap, "document is a json object") {
-			assert.Contains(t, out["data"], "_id", "document contains _id")
-			assert.Contains(t, out["data"], "_rev", "document contains _rev")
-			if assert.Contains(t, out["data"], "somefield") {
-				assert.Equal(t, data["somefield"], "avalue", "document contains fields")
-			}
-		}
-	}
+	assert.Equal(t, "400 Bad Request", res.Status, "should get a 400")
 }
 
 func TestSuccessUpdate(t *testing.T) {
 
 	// Get revision
-	get, _ := http.NewRequest("GET", ts.URL+"/data/"+Type+"/"+ID, nil)
-	doc, res, err := doRequest(get)
+	doc := getDocForTest()
+	url := ts.URL + "/data/" + doc.DocType() + "/" + doc.ID()
 
 	// update it
 	var in = jsonReader(&map[string]interface{}{
-		"_id":       doc["_id"],
-		"_rev":      doc["_rev"],
-		"test":      doc["test"],
+		"_id":       doc.ID(),
+		"_rev":      doc.Rev(),
+		"test":      doc.Get("test"),
 		"somefield": "anewvalue",
 	})
-	req, _ := http.NewRequest("PUT", ts.URL+"/data/"+Type+"/"+ID, in)
+	req, _ := http.NewRequest("PUT", url, in)
 	req.Header.Add("Host", Host)
-	out, res, err := doRequest(req)
+	var out stackUpdateResponse
+	_, res, err := doRequest(req, &out)
 	assert.NoError(t, err)
 	assert.Equal(t, "200 OK", res.Status, "should get a 201")
-	assert.Contains(t, out, "ok", "ok at top level (couchdb compatibility)")
-	assert.Equal(t, out["ok"], true, "ok is true")
-	assert.Contains(t, out, "id", "id at top level (couchdb compatibility)")
-	assert.Contains(t, out, "rev", "rev at top level (couchdb compatibility)")
-	if assert.Contains(t, out, "data", "document included") {
-		data, ismap := out["data"].(map[string]interface{})
-		if assert.True(t, ismap, "document is a json object") {
-			assert.Contains(t, data, "_id", "document contains _id")
-			assert.Contains(t, data, "_rev", "document contains _rev")
-			if assert.Contains(t, data, "test") {
-				assert.Equal(t, data["test"], "testvalue", "document contains old fields")
-			}
-			if assert.Contains(t, data, "somefield") {
-				assert.Equal(t, data["somefield"], "anewvalue", "document contains new fields")
-			}
-		}
-	}
+	assert.Empty(t, out.Error, "there is no error")
+	assert.Equal(t, out.ID, doc.ID(), "id has not changed")
+	assert.Equal(t, out.Ok, true, "ok is true")
+	assert.NotEmpty(t, out.Rev, "there is a rev")
+	assert.NotEqual(t, out.Rev, doc.Rev(), "rev has changed")
+	assert.Equal(t, out.ID, out.Data.ID(), "in doc id is simple uuid")
+	assert.Equal(t, out.Type, out.Data.Type, "in doc type is correct")
+	assert.Equal(t, out.Rev, out.Data.Rev(), "in doc rev is correct")
+	assert.Equal(t, "anewvalue", out.Data.Get("somefield"), "content has changed")
 }
 
-func TestSuccessDelete(t *testing.T) {
+// Test for having not the same ID in document and URL
+func TestWrongIDInDocUpdate(t *testing.T) {
 	// Get revision
-	get, _ := http.NewRequest("GET", ts.URL+"/data/"+Type+"/"+ID, nil)
-	doc, res, err := doRequest(get)
-	rev := doc["_rev"].(string)
-
-	// Do deletion
-	req, _ := http.NewRequest("DELETE", ts.URL+"/data/"+Type+"/"+ID, nil)
-	req.Header.Add("If-Match", rev)
+	doc := getDocForTest()
+	// update it
+	var in = jsonReader(&map[string]interface{}{
+		"_id":       "this is not the id in the URL",
+		"_rev":      doc.Rev(),
+		"test":      doc.M["test"],
+		"somefield": "anewvalue",
+	})
+	url := ts.URL + "/data/" + doc.DocType() + "/" + doc.ID()
+	req, _ := http.NewRequest("PUT", url, in)
 	req.Header.Add("Host", Host)
-	out, res, err := doRequest(req)
+	_, res, err := doRequest(req, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "400 Bad Request", res.Status, "should get a 404")
+}
+
+// Test for having an inexisting id at all
+func TestCreateDocWithAFixedID(t *testing.T) {
+	// update it
+	var in = jsonReader(&map[string]interface{}{
+		"test":      "value",
+		"somefield": "anewvalue",
+	})
+	url := ts.URL + "/data/" + Type + "/specific-id"
+	req, _ := http.NewRequest("PUT", url, in)
+	req.Header.Add("Host", Host)
+	var out stackUpdateResponse
+	_, res, err := doRequest(req, &out)
 	assert.NoError(t, err)
 	assert.Equal(t, "200 OK", res.Status, "should get a 201")
-	assert.Contains(t, out, "ok", "ok at top level (couchdb compatibility)")
-	assert.Equal(t, out["ok"], true, "ok is true")
-	assert.Contains(t, out, "id", "id at top level (couchdb compatibility)")
-	assert.Contains(t, out, "rev", "rev at top level (couchdb compatibility)")
+	assert.Empty(t, out.Error, "there is no error")
+	assert.Equal(t, out.ID, "specific-id", "id has not changed")
+	assert.Equal(t, out.Ok, true, "ok is true")
+	assert.NotEmpty(t, out.Rev, "there is a rev")
+	assert.Equal(t, out.ID, out.Data.ID(), "in doc id is simple uuid")
+	assert.Equal(t, out.Type, out.Data.Type, "in doc type is correct")
+	assert.Equal(t, out.Rev, out.Data.Rev(), "in doc rev is correct")
+	assert.Equal(t, "anewvalue", out.Data.Get("somefield"), "content has changed")
+
+}
+
+func TestNoRevInDocUpdate(t *testing.T) {
+	// Get revision
+	doc := getDocForTest()
+	// update it
+	var in = jsonReader(&map[string]interface{}{
+		"_id":       doc.ID(),
+		"test":      doc.M["test"],
+		"somefield": "anewvalue",
+	})
+	url := ts.URL + "/data/" + doc.DocType() + "/" + doc.ID()
+	req, _ := http.NewRequest("PUT", url, in)
+	req.Header.Add("Host", Host)
+	_, res, err := doRequest(req, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "400 Bad Request", res.Status, "should get a 400")
+}
+
+func TestPreviousRevInDocUpdate(t *testing.T) {
+	// Get revision
+	doc := getDocForTest()
+	firstRev := doc.Rev()
+	url := ts.URL + "/data/" + doc.DocType() + "/" + doc.ID()
+
+	// correcly update it
+	var in = jsonReader(&map[string]interface{}{
+		"_id":       doc.ID(),
+		"_rev":      doc.Rev(),
+		"somefield": "anewvalue",
+	})
+	req, _ := http.NewRequest("PUT", url, in)
+	req.Header.Add("Host", Host)
+	_, res, err := doRequest(req, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "200 OK", res.Status, "first update should work")
+
+	// update it
+	var in2 = jsonReader(&map[string]interface{}{
+		"_id":       doc.ID(),
+		"_rev":      firstRev,
+		"somefield": "anewvalue2",
+	})
+	req2, _ := http.NewRequest("PUT", url, in2)
+	req2.Header.Add("Host", Host)
+	_, res2, err := doRequest(req2, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "409 Conflict", res2.Status, "should get a 409")
+}
+
+func TestSuccessDeleteIfMatch(t *testing.T) {
+	// Get revision
+	doc := getDocForTest()
+	rev := doc.Rev()
+
+	// Do deletion
+	url := ts.URL + "/data/" + doc.DocType() + "/" + doc.ID()
+	req, _ := http.NewRequest("DELETE", url, nil)
+	req.Header.Add("If-Match", rev)
+	req.Header.Add("Host", Host)
+	var out stackUpdateResponse
+	_, res, err := doRequest(req, &out)
+	assert.NoError(t, err)
+	assert.Equal(t, "200 OK", res.Status, "should get a 201")
+	assert.Equal(t, out.Ok, true, "ok at top level (couchdb compatibility)")
+	assert.Equal(t, out.ID, doc.ID(), "id at top level (couchdb compatibility)")
+	assert.Equal(t, out.Deleted, true, "id at top level (couchdb compatibility)")
+	assert.NotEqual(t, out.Rev, doc.Rev(), "id at top level (couchdb compatibility)")
+}
+
+func TestFailDeleteIfNotMatch(t *testing.T) {
+	// Get revision
+	doc := getDocForTest()
+
+	// Do deletion
+	url := ts.URL + "/data/" + doc.DocType() + "/" + doc.ID()
+	req, _ := http.NewRequest("DELETE", url, nil)
+	req.Header.Add("If-Match", "1-238238232322121") // not correct rev
+	req.Header.Add("Host", Host)
+	var out stackUpdateResponse
+	_, res, err := doRequest(req, &out)
+	assert.NoError(t, err)
+	assert.Equal(t, "409 Conflict", res.Status, "should get a 409")
+}
+
+func TestFailDeleteIfHeaderAndRevMismatch(t *testing.T) {
+	// Get revision
+	doc := getDocForTest()
+
+	// Do deletion
+	url := ts.URL + "/data/" + doc.DocType() + "/" + doc.ID() + "?rev=1-238238232322121"
+	req, _ := http.NewRequest("DELETE", url, nil)
+	req.Header.Add("If-Match", "1-23823823231") // not same rev
+	req.Header.Add("Host", Host)
+	var out stackUpdateResponse
+	_, res, err := doRequest(req, &out)
+	assert.NoError(t, err)
+	assert.Equal(t, "400 Bad Request", res.Status, "should get a 400")
+}
+
+func TestFailDeleteIfNoRev(t *testing.T) {
+	// Get revision
+	doc := getDocForTest()
+
+	// Do deletion
+	url := ts.URL + "/data/" + doc.DocType() + "/" + doc.ID()
+	req, _ := http.NewRequest("DELETE", url, nil)
+	req.Header.Add("Host", Host)
+	var out stackUpdateResponse
+	_, res, err := doRequest(req, &out)
+	assert.NoError(t, err)
+	assert.Equal(t, "400 Bad Request", res.Status, "should get a 400")
 }


### PR DESCRIPTION
This add a lot of test on HTTP Update & Delete, and fix a few bug.

It reverts the proposal in API documentation to have the deletion works without revision provided, as it would force to make two couchdb request for every stack request.

This behaviour could later be reintroduced with a ?force=true query parameter.