### PR TITLE
[VFS] Update file content

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
   - curl -X PUT http://127.0.0.1:5984/{_users,_replicator,_global_changes}
   - go get -u github.com/alecthomas/gometalinter
   - gometalinter --install --update
-  - gometalinter --deadline 120s -D errcheck ./...
+  - gometalinter --deadline 120s --dupl-threshold 70 -D errcheck ./...
 
 after_failure:
   - docker ps -a

--- a/vfs/file.go
+++ b/vfs/file.go
@@ -267,15 +267,16 @@ func ModifyFileContent(oldDoc *FileDoc, newDoc *FileDoc, fs afero.Fs, dbPrefix s
 }
 
 func copyOnFsAndCheckIntegrity(pth string, givenMD5 []byte, executable bool, fs afero.Fs, r io.Reader) (written int64, md5Sum []byte, err error) {
+	var mode os.FileMode
+	if executable {
+		mode = 0755 // -rwxr-xr-x
+	} else {
+		mode = 0644 // -rw-r--r--
+	}
+
 	// We want to write only (O_WRONLY), create the file if it does not
 	// already exist (O_CREATE) and truncate it to length 0 if necessary
 	// (O_TRUNC).
-	var mode os.FileMode
-	if executable {
-		mode = 0755
-	} else {
-		mode = 0644
-	}
 	flag := os.O_WRONLY | os.O_CREATE | os.O_TRUNC
 	f, err := fs.OpenFile(pth, flag, mode)
 	if err != nil {

--- a/vfs/file.go
+++ b/vfs/file.go
@@ -282,16 +282,16 @@ func copyOnFsAndCheckIntegrity(pth string, givenMD5 []byte, executable bool, fs 
 		return
 	}
 
-	err = fs.Chmod(pth, mode)
-	if err != nil {
-		return
-	}
-
 	defer func() {
 		if cerr := f.Close(); cerr != nil && err == nil {
 			err = cerr
 		}
 	}()
+
+	err = fs.Chmod(pth, mode)
+	if err != nil {
+		return
+	}
 
 	md5H := md5.New() // #nosec
 

--- a/vfs/file.go
+++ b/vfs/file.go
@@ -7,25 +7,14 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"os"
 	"path"
+	"strconv"
 	"time"
 
 	"github.com/cozy/cozy-stack/couchdb"
 	"github.com/spf13/afero"
 )
-
-// FileAttributes is a struct with the attributes of a file
-type FileAttributes struct {
-	Name       string    `json:"name"`
-	CreatedAt  time.Time `json:"created_at"`
-	UpdatedAt  time.Time `json:"updated_at"`
-	Size       int64     `json:"size,string"`
-	Tags       []string  `json:"tags"`
-	MD5Sum     []byte    `json:"md5sum"`
-	Executable bool      `json:"executable"`
-	Class      string    `json:"class"`
-	Mime       string    `json:"mime"`
-}
 
 // FileDoc is a struct containing all the informations about a file.
 // It implements the couchdb.Doc and jsonapi.JSONApier interfaces.
@@ -34,12 +23,21 @@ type FileDoc struct {
 	FID string `json:"_id,omitempty"`
 	// File revision
 	FRev string `json:"_rev,omitempty"`
-	// File attributes
-	Attrs *FileAttributes `json:"attributes"`
+	// File name
+	Name string `json:"name"`
 	// Parent folder identifier
 	FolderID string `json:"folderID"`
 	// File path on VFS
 	Path string `json:"path"`
+
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+	Size       int64     `json:"size,string"`
+	Tags       []string  `json:"tags"`
+	MD5Sum     []byte    `json:"md5sum"`
+	Executable bool      `json:"executable"`
+	Class      string    `json:"class"`
+	Mime       string    `json:"mime"`
 }
 
 // ID returns the file qualified identifier (part of couchdb.Doc
@@ -75,16 +73,51 @@ func (f *FileDoc) SetRev(rev string) {
 // the file document
 func (f *FileDoc) ToJSONApi() ([]byte, error) {
 	id := f.FID
+	attrs := map[string]interface{}{
+		"name":       f.Name,
+		"created_at": f.CreatedAt,
+		"updated_at": f.UpdatedAt,
+		"size":       strconv.FormatInt(f.Size, 10),
+		"tags":       f.Tags,
+		"md5sum":     f.MD5Sum,
+		"executable": f.Executable,
+		"class":      f.Class,
+		"mime":       f.Mime,
+	}
 	data := map[string]interface{}{
 		"id":         id,
 		"type":       f.DocType(),
 		"rev":        f.Rev(),
-		"attributes": f.Attrs,
+		"attributes": attrs,
 	}
 	m := map[string]interface{}{
 		"data": data,
 	}
 	return json.Marshal(m)
+}
+
+// NewFileDoc is the FileDoc constructor. The given name is validated.
+func NewFileDoc(name, folderID string, size int64, md5Sum []byte, mime, class string, executable bool, tags []string) (doc *FileDoc, err error) {
+	if err = checkFileName(name); err != nil {
+		return
+	}
+
+	createDate := time.Now()
+	doc = &FileDoc{
+		Name:     name,
+		FolderID: folderID,
+
+		CreatedAt:  createDate,
+		UpdatedAt:  createDate,
+		Size:       size,
+		MD5Sum:     md5Sum,
+		Mime:       mime,
+		Class:      class,
+		Executable: executable,
+		Tags:       tags,
+	}
+
+	return
 }
 
 // GetFileDoc is used to fetch file document information form our
@@ -104,18 +137,17 @@ func GetFileDoc(fileID, dbPrefix string) (doc *FileDoc, err error) {
 // non-ranged requests
 //
 // The content disposition is inlined.
-func ServeFileContent(fileDoc *FileDoc, req *http.Request, w http.ResponseWriter, fs afero.Fs) (err error) {
-	attrs := fileDoc.Attrs
+func ServeFileContent(doc *FileDoc, req *http.Request, w http.ResponseWriter, fs afero.Fs) (err error) {
 	header := w.Header()
-	header.Set("Content-Type", attrs.Mime)
-	header.Set("Content-Disposition", "inline; filename="+attrs.Name)
+	header.Set("Content-Type", doc.Mime)
+	header.Set("Content-Disposition", "inline; filename="+doc.Name)
 
 	if header.Get("Range") == "" {
-		eTag := base64.StdEncoding.EncodeToString(fileDoc.Attrs.MD5Sum)
+		eTag := base64.StdEncoding.EncodeToString(doc.MD5Sum)
 		header.Set("Etag", eTag)
 	}
 
-	return serveContent(req, w, fs, fileDoc.Path, attrs.Name, attrs.UpdatedAt)
+	return serveContent(req, w, fs, doc.Path, doc.Name, doc.UpdatedAt)
 }
 
 // ServeFileContentByPath replies to a http request using the content
@@ -151,34 +183,12 @@ func serveContent(req *http.Request, w http.ResponseWriter, fs afero.Fs, pth, na
 }
 
 // CreateFileAndUpload is the method for uploading a file onto the filesystem.
-func CreateFileAndUpload(m *DocAttributes, fs afero.Fs, dbPrefix string, body io.ReadCloser) (doc *FileDoc, err error) {
-	if m.docType != FileDocType {
-		err = ErrDocTypeInvalid
-		return
-	}
+func CreateFileAndUpload(doc *FileDoc, fs afero.Fs, dbPrefix string, body io.Reader) error {
+	var err error
 
-	pth, _, err := createNewFilePath(m, fs, dbPrefix)
+	pth, _, err := createNewFilePath(doc.Name, doc.FolderID, fs, dbPrefix)
 	if err != nil {
-		return
-	}
-
-	createDate := time.Now()
-	attrs := &FileAttributes{
-		Name:       m.name,
-		CreatedAt:  createDate,
-		UpdatedAt:  createDate,
-		Size:       m.size,
-		Tags:       m.tags,
-		MD5Sum:     m.givenMD5,
-		Executable: m.executable,
-		Class:      m.class,
-		Mime:       m.mime,
-	}
-
-	doc = &FileDoc{
-		Attrs:    attrs,
-		FolderID: m.folderID,
-		Path:     pth,
+		return err
 	}
 
 	// Error handling to make sure the steps of uploading the file and
@@ -192,38 +202,96 @@ func CreateFileAndUpload(m *DocAttributes, fs afero.Fs, dbPrefix string, body io
 
 	var written int64
 	var md5Sum []byte
-	if written, md5Sum, err = copyOnFsAndCheckIntegrity(m, fs, pth, body); err != nil {
-		return
+	if written, md5Sum, err = copyOnFsAndCheckIntegrity(pth, doc.MD5Sum, doc.Executable, fs, body); err != nil {
+		return err
 	}
 
-	if attrs.Size < 0 {
-		attrs.Size = written
+	if doc.Size < 0 {
+		doc.Size = written
 	}
 
-	if attrs.MD5Sum == nil {
-		attrs.MD5Sum = md5Sum
+	if doc.MD5Sum == nil {
+		doc.MD5Sum = md5Sum
 	}
 
-	if attrs.Size != written {
-		err = ErrContentLengthMismatch
-		return
+	if doc.Size != written {
+		return ErrContentLengthMismatch
 	}
 
-	if err = couchdb.CreateDoc(dbPrefix, doc); err != nil {
-		return
-	}
+	doc.Path = pth
 
-	return
+	return couchdb.CreateDoc(dbPrefix, doc)
 }
 
-func copyOnFsAndCheckIntegrity(m *DocAttributes, fs afero.Fs, pth string, r io.ReadCloser) (written int64, md5Sum []byte, err error) {
-	f, err := fs.Create(pth)
+// ModifyFileContent overrides the content of a file onto the
+// filesystem.
+//
+// @TODO: make it more resilient to not lose data if the transfer
+// fails.
+func ModifyFileContent(oldDoc *FileDoc, newDoc *FileDoc, fs afero.Fs, dbPrefix string, body io.Reader) (err error) {
+	updateDate := time.Now()
+
+	pth := oldDoc.Path
+
+	defer func() {
+		if err != nil {
+			fs.Remove(pth)
+		}
+	}()
+
+	var written int64
+	var md5Sum []byte
+	if written, md5Sum, err = copyOnFsAndCheckIntegrity(pth, newDoc.MD5Sum, newDoc.Executable, fs, body); err != nil {
+		return err
+	}
+
+	if newDoc.Size < 0 {
+		newDoc.Size = written
+	}
+
+	if newDoc.MD5Sum == nil {
+		newDoc.MD5Sum = md5Sum
+	}
+
+	if newDoc.Size != written {
+		return ErrContentLengthMismatch
+	}
+
+	newDoc.Path = pth
+	newDoc.SetID(oldDoc.ID())
+	newDoc.SetRev(oldDoc.Rev())
+	newDoc.CreatedAt = oldDoc.CreatedAt
+	newDoc.UpdatedAt = updateDate
+
+	return couchdb.UpdateDoc(dbPrefix, newDoc)
+}
+
+func copyOnFsAndCheckIntegrity(pth string, givenMD5 []byte, executable bool, fs afero.Fs, r io.Reader) (written int64, md5Sum []byte, err error) {
+	// We want to write only (O_WRONLY), create the file if it does not
+	// already exist (O_CREATE) and truncate it to length 0 if necessary
+	// (O_TRUNC).
+	var mode os.FileMode
+	if executable {
+		mode = 0755
+	} else {
+		mode = 0644
+	}
+	flag := os.O_WRONLY | os.O_CREATE | os.O_TRUNC
+	f, err := fs.OpenFile(pth, flag, mode)
 	if err != nil {
 		return
 	}
 
-	defer f.Close()
-	defer r.Close()
+	err = fs.Chmod(pth, mode)
+	if err != nil {
+		return
+	}
+
+	defer func() {
+		if cerr := f.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
 
 	md5H := md5.New() // #nosec
 
@@ -232,9 +300,9 @@ func copyOnFsAndCheckIntegrity(m *DocAttributes, fs afero.Fs, pth string, r io.R
 		return
 	}
 
-	doCheck := m.givenMD5 != nil
+	doCheck := givenMD5 != nil
 	md5Sum = md5H.Sum(nil)
-	if doCheck && !bytes.Equal(m.givenMD5, md5Sum) {
+	if doCheck && !bytes.Equal(givenMD5, md5Sum) {
 		err = ErrInvalidHash
 		return
 	}

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -132,6 +132,12 @@ func OverwriteFileContentHandler(c *gin.Context) {
 		return
 	}
 
+	ifMatch := c.Request.Header.Get("If-Match")
+	if ifMatch != "" && oldDoc.Rev() != ifMatch {
+		jsonapi.AbortWithError(c, jsonapi.PreconditionFailed("If-Match", fmt.Errorf("Revision does not match.")))
+		return
+	}
+
 	err = vfs.ModifyFileContent(oldDoc, newDoc, fs, dbPrefix, c.Request.Body)
 	if err != nil {
 		jsonapi.AbortWithError(c, jsonapi.WrapVfsError(err))

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -58,9 +59,9 @@ func createDir(t *testing.T, path string) (res *http.Response, v map[string]inte
 	return
 }
 
-func upload(t *testing.T, path, contentType, body, hash string) (res *http.Response, v map[string]interface{}) {
+func doUploadOrMod(t *testing.T, method, path, contentType, body, hash string) (res *http.Response, v map[string]interface{}) {
 	buf := strings.NewReader(body)
-	req, err := http.NewRequest("POST", ts.URL+path, buf)
+	req, err := http.NewRequest(method, ts.URL+path, buf)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -84,6 +85,14 @@ func upload(t *testing.T, path, contentType, body, hash string) (res *http.Respo
 	assert.NoError(t, err)
 
 	return
+}
+
+func upload(t *testing.T, path, contentType, body, hash string) (res *http.Response, v map[string]interface{}) {
+	return doUploadOrMod(t, "POST", path, contentType, body, hash)
+}
+
+func uploadMod(t *testing.T, path, contentType, body, hash string) (res *http.Response, v map[string]interface{}) {
+	return doUploadOrMod(t, "PUT", path, contentType, body, hash)
 }
 
 func download(t *testing.T, path, byteRange string) (res *http.Response, body []byte) {
@@ -249,6 +258,72 @@ func TestUploadWithParentAlreadyExists(t *testing.T) {
 	assert.Equal(t, 409, res2.StatusCode)
 }
 
+func TestModifyContentNoFileID(t *testing.T) {
+	res, _ := uploadMod(t, "/files/badid", "text/plain", "nil", "")
+	assert.Equal(t, 404, res.StatusCode)
+}
+
+func TestModifyContentSuccess(t *testing.T) {
+	var err error
+	var buf []byte
+	var fileInfo os.FileInfo
+
+	storage, _ := instance.GetStorageProvider()
+	res1, data1 := upload(t, "/files/?Type=io.cozy.files&Name=willbemodified&Executable=true", "text/plain", "foo", "")
+	assert.Equal(t, 201, res1.StatusCode)
+
+	buf, err = afero.ReadFile(storage, "/willbemodified")
+	assert.Equal(t, "foo", string(buf))
+	fileInfo, err = storage.Stat("/willbemodified")
+	assert.NoError(t, err)
+	assert.Equal(t, fileInfo.Mode().String(), "-rwxr-xr-x")
+
+	var ok bool
+	data1, ok = data1["data"].(map[string]interface{})
+	assert.True(t, ok)
+
+	attrs1, ok := data1["attributes"].(map[string]interface{})
+	assert.True(t, ok)
+
+	fileID, ok := data1["id"].(string)
+	assert.True(t, ok)
+
+	newcontent := "newcontent :)"
+	res2, data2 := uploadMod(t, "/files/"+fileID+"?Executable=false", "audio/mp3", newcontent, "")
+	assert.Equal(t, 200, res2.StatusCode)
+
+	data2, ok = data2["data"].(map[string]interface{})
+	assert.True(t, ok)
+
+	attrs2, ok := data2["attributes"].(map[string]interface{})
+	assert.True(t, ok)
+
+	assert.Equal(t, data2["id"], data1["id"], "same id")
+	assert.Equal(t, data2["path"], data1["path"], "same path")
+	assert.NotEqual(t, data2["rev"], data1["res"], "different rev")
+
+	assert.Equal(t, attrs2["name"], attrs1["name"])
+	assert.Equal(t, attrs2["created_at"], attrs1["created_at"])
+	assert.NotEqual(t, attrs2["updated_at"], attrs1["updated_at"])
+	assert.NotEqual(t, attrs2["size"], attrs1["size"])
+
+	assert.Equal(t, attrs2["size"], strconv.Itoa(len(newcontent)))
+	assert.NotEqual(t, attrs2["md5sum"], attrs1["md5sum"])
+	assert.NotEqual(t, attrs2["class"], attrs1["class"])
+	assert.NotEqual(t, attrs2["mime"], attrs1["mime"])
+	assert.NotEqual(t, attrs2["executable"], attrs1["executable"])
+	assert.Equal(t, attrs2["class"], "audio")
+	assert.Equal(t, attrs2["mime"], "audio/mp3")
+	assert.Equal(t, attrs2["executable"], false)
+
+	buf, err = afero.ReadFile(storage, "/willbemodified")
+	assert.NoError(t, err)
+	assert.Equal(t, newcontent, string(buf))
+	fileInfo, err = storage.Stat("/willbemodified")
+	assert.NoError(t, err)
+	assert.Equal(t, fileInfo.Mode().String(), "-rw-r--r--")
+}
+
 func TestDownloadFileBadID(t *testing.T) {
 	res, _ := download(t, "/files/badid", "")
 	assert.Equal(t, 404, res.StatusCode)
@@ -332,7 +407,9 @@ func TestMain(m *testing.M) {
 	router.Use(injectInstance(instance))
 	router.POST("/files/", CreationHandler)
 	router.POST("/files/:folder-id", CreationHandler)
-	router.GET("/files/:file-id", ReadHandler)
+	router.PUT("/files/:file-id", OverwriteFileContentHandler)
+	router.HEAD("/files/:file-id", ReadFileHandler)
+	router.GET("/files/:file-id", ReadFileHandler)
 	ts = httptest.NewServer(router)
 	defer ts.Close()
 	os.Exit(m.Run())


### PR DESCRIPTION
This PR introduce the new route `PUT /files/:files-id` along with a new method `vfs.ModifyFileContent`.

==

*Some notes*:

In order to add this feature, I also removed the intermediary (and awkward) struct `vfs.DirAttributes` that was used to stack all the contents of a creation request for files *and* directories. Now, `web/file` can use `vfs.NewFileDoc` or `vfs.NewDirDoc` directly and appropriately.

I also increased the gometalinter dupl-threshold, because it annoyed me on some trivial code (in test)...