### PR TITLE
[VFS] Concurrent access

### DIFF
--- a/vfs/directory.go
+++ b/vfs/directory.go
@@ -97,10 +97,13 @@ func NewDirDoc(name, folderID string, tags []string) (doc *DirDoc, err error) {
 }
 
 // CreateDirectory is the method for creating a new directory
-func CreateDirectory(doc *DirDoc, fs afero.Fs, dbPrefix string) error {
-	var err error
-
+func CreateDirectory(doc *DirDoc, fs afero.Fs, dbPrefix string) (err error) {
 	pth, _, err := createNewFilePath(doc.Name, doc.FolderID, fs, dbPrefix)
+	if err != nil {
+		return err
+	}
+
+	err = fs.Mkdir(pth, 0755)
 	if err != nil {
 		return err
 	}
@@ -113,13 +116,5 @@ func CreateDirectory(doc *DirDoc, fs afero.Fs, dbPrefix string) error {
 
 	doc.Path = pth
 
-	if err = couchdb.CreateDoc(dbPrefix, doc); err != nil {
-		return err
-	}
-
-	if err = fs.Mkdir(pth, 0755); err != nil {
-		return err
-	}
-
-	return nil
+	return couchdb.CreateDoc(dbPrefix, doc)
 }

--- a/vfs/errors.go
+++ b/vfs/errors.go
@@ -1,15 +1,8 @@
 package vfs
 
-import (
-	"errors"
-	"os"
-)
+import "errors"
 
 var (
-	// ErrDocAlreadyExists is used when file or directory already exists
-	ErrDocAlreadyExists = os.ErrExist
-	// ErrDocDoesNotExist is used when file or directory does not exist
-	ErrDocDoesNotExist = os.ErrNotExist
 	// ErrParentDoesNotExist is used when the parent folder does not
 	// exist
 	ErrParentDoesNotExist = errors.New("Parent folder with given FolderID does not exist")

--- a/vfs/file.go
+++ b/vfs/file.go
@@ -294,7 +294,7 @@ func safeCreateFile(pth string, executable bool, fs afero.Fs) (afero.File, error
 	return fs.OpenFile(pth, flag, mode)
 }
 
-func copyOnFsAndCheckIntegrity(file afero.File, givenMD5 []byte, fs afero.Fs, r io.Reader) (written int64, md5Sum []byte, err error) {
+func copyOnFsAndCheckIntegrity(file io.WriteCloser, givenMD5 []byte, fs afero.Fs, r io.Reader) (written int64, md5Sum []byte, err error) {
 	defer func() {
 		if cerr := file.Close(); cerr != nil && err == nil {
 			err = cerr

--- a/vfs/file.go
+++ b/vfs/file.go
@@ -162,7 +162,7 @@ func ServeFileContent(doc *FileDoc, req *http.Request, w http.ResponseWriter, fs
 func ServeFileContentByPath(pth string, req *http.Request, w http.ResponseWriter, fs afero.Fs) error {
 	fileInfo, err := fs.Stat(pth)
 	if err != nil {
-		return ErrDocDoesNotExist
+		return err
 	}
 
 	name := path.Base(pth)
@@ -183,26 +183,25 @@ func serveContent(req *http.Request, w http.ResponseWriter, fs afero.Fs, pth, na
 }
 
 // CreateFileAndUpload is the method for uploading a file onto the filesystem.
-func CreateFileAndUpload(doc *FileDoc, fs afero.Fs, dbPrefix string, body io.Reader) error {
-	var err error
-
-	pth, _, err := createNewFilePath(doc.Name, doc.FolderID, fs, dbPrefix)
+func CreateFileAndUpload(doc *FileDoc, fs afero.Fs, dbPrefix string, body io.Reader) (err error) {
+	newpath, _, err := createNewFilePath(doc.Name, doc.FolderID, fs, dbPrefix)
 	if err != nil {
 		return err
 	}
 
-	// Error handling to make sure the steps of uploading the file and
-	// creating the corresponding are both rollbacked in case of an
-	// error. This should preserve our VFS coherency a little.
+	file, err := safeCreateFile(newpath, doc.Executable, fs)
+	if err != nil {
+		return err
+	}
+
 	defer func() {
 		if err != nil {
-			fs.Remove(pth)
+			fs.Remove(newpath)
 		}
 	}()
 
-	var written int64
-	var md5Sum []byte
-	if written, md5Sum, err = copyOnFsAndCheckIntegrity(pth, doc.MD5Sum, doc.Executable, fs, body); err != nil {
+	written, md5Sum, err := copyOnFsAndCheckIntegrity(file, doc.MD5Sum, fs, body)
+	if err != nil {
 		return err
 	}
 
@@ -218,7 +217,7 @@ func CreateFileAndUpload(doc *FileDoc, fs afero.Fs, dbPrefix string, body io.Rea
 		return ErrContentLengthMismatch
 	}
 
-	doc.Path = pth
+	doc.Path = newpath
 
 	return couchdb.CreateDoc(dbPrefix, doc)
 }
@@ -226,47 +225,65 @@ func CreateFileAndUpload(doc *FileDoc, fs afero.Fs, dbPrefix string, body io.Rea
 // ModifyFileContent overrides the content of a file onto the
 // filesystem.
 //
-// @TODO: make it more resilient to not lose data if the transfer
-// fails.
-func ModifyFileContent(oldDoc *FileDoc, newDoc *FileDoc, fs afero.Fs, dbPrefix string, body io.Reader) (err error) {
-	updateDate := time.Now()
+// This method should change the file content atomically. If any error
+// happens while copying the content, the previous file revision is
+// kept undamaged.
+func ModifyFileContent(olddoc *FileDoc, newdoc *FileDoc, fs afero.Fs, dbPrefix string, body io.Reader) (err error) {
+	mdate := time.Now()
 
-	pth := oldDoc.Path
-
-	defer func() {
-		if err != nil {
-			fs.Remove(pth)
-		}
-	}()
-
-	var written int64
-	var md5Sum []byte
-	if written, md5Sum, err = copyOnFsAndCheckIntegrity(pth, newDoc.MD5Sum, newDoc.Executable, fs, body); err != nil {
+	tmppath := "/" + olddoc.ID() + "_" + olddoc.Rev() + "_" + strconv.FormatInt(mdate.UnixNano(), 10)
+	newpath := olddoc.Path
+	if err != nil {
 		return err
 	}
 
-	if newDoc.Size < 0 {
-		newDoc.Size = written
+	file, err := safeCreateFile(tmppath, newdoc.Executable, fs)
+	if err != nil {
+		return err
 	}
 
-	if newDoc.MD5Sum == nil {
-		newDoc.MD5Sum = md5Sum
+	defer func() {
+		if err != nil {
+			fs.Remove(tmppath)
+		}
+	}()
+
+	written, md5Sum, err := copyOnFsAndCheckIntegrity(file, newdoc.MD5Sum, fs, body)
+	if err != nil {
+		return err
 	}
 
-	if newDoc.Size != written {
+	if newdoc.Size < 0 {
+		newdoc.Size = written
+	}
+
+	if newdoc.MD5Sum == nil {
+		newdoc.MD5Sum = md5Sum
+	}
+
+	if newdoc.Size != written {
 		return ErrContentLengthMismatch
 	}
 
-	newDoc.Path = pth
-	newDoc.SetID(oldDoc.ID())
-	newDoc.SetRev(oldDoc.Rev())
-	newDoc.CreatedAt = oldDoc.CreatedAt
-	newDoc.UpdatedAt = updateDate
+	newdoc.Path = newpath
+	newdoc.SetID(olddoc.ID())
+	newdoc.SetRev(olddoc.Rev())
+	newdoc.CreatedAt = olddoc.CreatedAt
+	newdoc.UpdatedAt = mdate
 
-	return couchdb.UpdateDoc(dbPrefix, newDoc)
+	err = couchdb.UpdateDoc(dbPrefix, newdoc)
+	if err != nil {
+		return err
+	}
+
+	return fs.Rename(tmppath, newpath)
 }
 
-func copyOnFsAndCheckIntegrity(pth string, givenMD5 []byte, executable bool, fs afero.Fs, r io.Reader) (written int64, md5Sum []byte, err error) {
+func safeCreateFile(pth string, executable bool, fs afero.Fs) (afero.File, error) {
+	// write only (O_WRONLY), try to create the file and check that it
+	// does not already exist (O_CREATE|O_EXCL).
+	flag := os.O_WRONLY | os.O_CREATE | os.O_EXCL
+
 	var mode os.FileMode
 	if executable {
 		mode = 0755 // -rwxr-xr-x
@@ -274,29 +291,19 @@ func copyOnFsAndCheckIntegrity(pth string, givenMD5 []byte, executable bool, fs 
 		mode = 0644 // -rw-r--r--
 	}
 
-	// We want to write only (O_WRONLY), create the file if it does not
-	// already exist (O_CREATE) and truncate it to length 0 if necessary
-	// (O_TRUNC).
-	flag := os.O_WRONLY | os.O_CREATE | os.O_TRUNC
-	f, err := fs.OpenFile(pth, flag, mode)
-	if err != nil {
-		return
-	}
+	return fs.OpenFile(pth, flag, mode)
+}
 
+func copyOnFsAndCheckIntegrity(file afero.File, givenMD5 []byte, fs afero.Fs, r io.Reader) (written int64, md5Sum []byte, err error) {
 	defer func() {
-		if cerr := f.Close(); cerr != nil && err == nil {
+		if cerr := file.Close(); cerr != nil && err == nil {
 			err = cerr
 		}
 	}()
 
-	err = fs.Chmod(pth, mode)
-	if err != nil {
-		return
-	}
-
 	md5H := md5.New() // #nosec
 
-	written, err = io.Copy(f, io.TeeReader(r, md5H))
+	written, err = io.Copy(file, io.TeeReader(r, md5H))
 	if err != nil {
 		return
 	}

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -76,14 +76,5 @@ func createNewFilePath(name, folderID string, storage afero.Fs, dbPrefix string)
 	}
 
 	pth = path.Join(parentPath, name)
-	exists, err := afero.Exists(storage, pth)
-	if err != nil {
-		return
-	}
-	if exists {
-		err = ErrDocAlreadyExists
-		return
-	}
-
 	return
 }

--- a/web/jsonapi/errors.go
+++ b/web/jsonapi/errors.go
@@ -2,6 +2,7 @@ package jsonapi
 
 import (
 	"net/http"
+	"os"
 
 	"github.com/cozy/cozy-stack/couchdb"
 	"github.com/cozy/cozy-stack/vfs"
@@ -37,15 +38,17 @@ func WrapVfsError(err error) *Error {
 	if couchErr, isCouchErr := err.(*couchdb.Error); isCouchErr {
 		return WrapCouchError(couchErr)
 	}
-	switch err {
-	case vfs.ErrDocAlreadyExists:
+	if os.IsExist(err) {
 		return &Error{
 			Status: http.StatusConflict,
 			Title:  "Conflict",
 			Detail: err.Error(),
 		}
-	case vfs.ErrDocDoesNotExist:
+	}
+	if os.IsNotExist(err) {
 		return NotFound(err)
+	}
+	switch err {
 	case vfs.ErrParentDoesNotExist:
 		return NotFound(err)
 	case vfs.ErrDocTypeInvalid:


### PR DESCRIPTION
Fix concurrent access to file and directory creation and add tests on the matter.

  - rely on one call to the FS using `O_CREATE|O_EXCL`
  - rely on `MkDir` atomicity *before* adding the document in Couch
  - rely on `Rename` atomicity to modify file content using a temporary file

--

This should be merged after #48 