### PR TITLE
Add mango index & queries to couchdb package

### DIFF
--- a/couchdb/couchdb.go
+++ b/couchdb/couchdb.go
@@ -322,7 +322,7 @@ func DefineIndex(dbprefix, doctype string, index mango.IndexDefinitionRequest) e
 func FindDocs(dbprefix, doctype string, req *FindRequest, results interface{}) error {
 	url := makeDBName(dbprefix, doctype) + "/_find"
 	// prepare a structure to receive the results
-	var response = findResponse{}
+	var response findResponse
 	err := makeRequest("POST", url, &req, &response)
 	if err != nil {
 		return err

--- a/couchdb/couchdb_test.go
+++ b/couchdb/couchdb_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cozy/cozy-stack/couchdb/mango"
 	"github.com/sourcegraph/checkup"
 	"github.com/stretchr/testify/assert"
 )
@@ -17,10 +18,15 @@ func TestErrors(t *testing.T) {
 	assert.Contains(t, err.Error(), "missing")
 }
 
+const TestDoctype = "io.cozy.testobject"
+const TestPrefix = "dev/"
+
 type testDoc struct {
 	TestID  string `json:"_id,omitempty"`
 	TestRev string `json:"_rev,omitempty"`
 	Test    string `json:"test"`
+	FieldA  string `json:"fieldA,omitempty"`
+	FieldB  int    `json:"fieldB,omitempty"`
 }
 
 func (t *testDoc) ID() string {
@@ -32,7 +38,7 @@ func (t *testDoc) Rev() string {
 }
 
 func (t *testDoc) DocType() string {
-	return "io.cozy.testobject"
+	return TestDoctype
 }
 
 func (t *testDoc) SetID(id string) {
@@ -52,12 +58,11 @@ func makeTestDoc() Doc {
 func TestCreateDoc(t *testing.T) {
 	var err error
 
-	var TESTPREFIX = "dev/"
 	var doc = makeTestDoc()
 	assert.Empty(t, doc.Rev(), doc.ID())
 
 	// Create the document
-	err = CreateDoc(TESTPREFIX, doc)
+	err = CreateDoc(TestPrefix, doc)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, doc.Rev(), doc.ID())
 
@@ -65,7 +70,7 @@ func TestCreateDoc(t *testing.T) {
 
 	// Fetch it and see if its match
 	fetched := &testDoc{}
-	err = GetDoc(TESTPREFIX, docType, id, fetched)
+	err = GetDoc(TestPrefix, docType, id, fetched)
 	assert.NoError(t, err)
 	assert.Equal(t, doc.ID(), fetched.ID())
 	assert.Equal(t, doc.Rev(), fetched.Rev())
@@ -76,25 +81,25 @@ func TestCreateDoc(t *testing.T) {
 	// Update it
 	updated := fetched
 	updated.Test = "changedvalue"
-	err = UpdateDoc(TESTPREFIX, updated)
+	err = UpdateDoc(TestPrefix, updated)
 	assert.NoError(t, err)
 	assert.NotEqual(t, revBackup, updated.Rev())
 	assert.Equal(t, "changedvalue", updated.Test)
 
 	// Refetch it and see if its match
 	fetched2 := &testDoc{}
-	err = GetDoc(TESTPREFIX, docType, id, fetched2)
+	err = GetDoc(TestPrefix, docType, id, fetched2)
 	assert.NoError(t, err)
 	assert.Equal(t, doc.ID(), fetched2.ID())
 	assert.Equal(t, updated.Rev(), fetched2.Rev())
 	assert.Equal(t, "changedvalue", fetched2.Test)
 
 	// Delete it
-	err = DeleteDoc(TESTPREFIX, updated)
+	err = DeleteDoc(TestPrefix, updated)
 	assert.NoError(t, err)
 
 	fetched3 := &testDoc{}
-	err = GetDoc(TESTPREFIX, docType, id, fetched3)
+	err = GetDoc(TestPrefix, docType, id, fetched3)
 	assert.Error(t, err)
 	coucherr, iscoucherr := err.(*Error)
 	if assert.True(t, iscoucherr) {
@@ -103,11 +108,71 @@ func TestCreateDoc(t *testing.T) {
 
 }
 
+func TestDefineIndex(t *testing.T) {
+	err := DefineIndex(TestPrefix, TestDoctype, mango.IndexOnFields("fieldA", "fieldB"))
+	assert.NoError(t, err)
+
+	// if I try to define the same index several time
+	err2 := DefineIndex(TestPrefix, TestDoctype, mango.IndexOnFields("fieldA", "fieldB"))
+	assert.NoError(t, err2)
+}
+
+func TestQuery(t *testing.T) {
+
+	// create a few docs for testing
+	doc1 := testDoc{FieldA: "value1", FieldB: 100}
+	doc2 := testDoc{FieldA: "value2", FieldB: 1000}
+	doc3 := testDoc{FieldA: "value2", FieldB: 300}
+	doc4 := testDoc{FieldA: "value13", FieldB: 1500}
+	docs := []*testDoc{&doc1, &doc2, &doc3, &doc4}
+	for _, doc := range docs {
+		err := CreateDoc(TestPrefix, doc)
+		if !assert.NoError(t, err) || doc.ID() == "" {
+			t.FailNow()
+			return
+		}
+	}
+
+	err := DefineIndex(TestPrefix, TestDoctype, mango.IndexOnFields("fieldA", "fieldB"))
+	if !assert.NoError(t, err) {
+		t.FailNow()
+		return
+	}
+	var out []testDoc
+	req := &FindRequest{Selector: mango.Equal("fieldA", "value2")}
+	err = FindDocs(TestPrefix, TestDoctype, req, &out)
+	if assert.NoError(t, err) {
+		assert.Len(t, out, 2, "should get 2 results")
+		// if fieldA are equaly, docs will be ordered by fieldB
+		assert.Equal(t, doc3.ID(), out[0].ID())
+		assert.Equal(t, "value2", out[0].FieldA)
+		assert.Equal(t, doc2.ID(), out[1].ID())
+		assert.Equal(t, "value2", out[1].FieldA)
+	}
+
+	var out2 []testDoc
+	req2 := &FindRequest{Selector: mango.StartWith("fieldA", "value1")}
+	err = FindDocs(TestPrefix, TestDoctype, req2, &out2)
+	if assert.NoError(t, err) {
+		assert.Len(t, out, 2, "should get 2 results")
+		// if we do as startWith, docs will be ordered by the rest of fieldA
+		assert.Equal(t, doc1.ID(), out2[0].ID())
+		assert.Equal(t, doc4.ID(), out2[1].ID())
+	}
+
+	fmt.Println("results", out)
+}
+
 func TestMain(m *testing.M) {
 	// First we make sure couchdb is started
 	couchdb, err := checkup.HTTPChecker{URL: CouchDBURL}.Check()
 	if err != nil || couchdb.Status() != checkup.Healthy {
 		fmt.Println("This test need couchdb to run.")
+		os.Exit(1)
+	}
+	err = ResetDB(TestPrefix, TestDoctype)
+	if err != nil {
+		fmt.Printf("Cant reset db (%s, %s) %s\n", TestPrefix, TestDoctype, err.Error())
 		os.Exit(1)
 	}
 

--- a/couchdb/mango/index.go
+++ b/couchdb/mango/index.go
@@ -1,0 +1,27 @@
+package mango
+
+import "encoding/json"
+
+// An IndexDefinition is just a list of fields to be indexed.
+type IndexDefinition []string
+
+// MarshalJSON implements the json.Marshaller interface on IndexDefinition
+// by wrapping it in a {"fields": ...}
+func (def IndexDefinition) MarshalJSON() ([]byte, error) {
+	return json.Marshal(makeMap("fields", []string(def)))
+}
+
+// An IndexDefinitionRequest is a request to be POSTED to create the index
+type IndexDefinitionRequest struct {
+	Name  string          `json:"name,omitempty"`
+	DDoc  string          `json:"ddoc,omitempty"`
+	Index IndexDefinition `json:"index"`
+}
+
+// IndexOnFields constructs a new IndexDefinitionRequest
+// it lets couchdb defaults for index & designdoc names.
+func IndexOnFields(fields ...string) IndexDefinitionRequest {
+	return IndexDefinitionRequest{
+		Index: IndexDefinition(fields),
+	}
+}

--- a/couchdb/mango/index_test.go
+++ b/couchdb/mango/index_test.go
@@ -1,0 +1,15 @@
+package mango
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIndexMarshaling(t *testing.T) {
+	def := IndexOnFields("folderID", "name")
+	jsonbytes, _ := json.Marshal(def)
+	expected := `{"index":{"fields":["folderID","name"]}}`
+	assert.Equal(t, expected, string(jsonbytes), "index should MarshalJSON properly")
+}

--- a/couchdb/mango/query.go
+++ b/couchdb/mango/query.go
@@ -49,8 +49,8 @@ const nor LogicOperator = "$nor"
 // In the future, we might add go-side validation
 // but we will need to duplicate the couchdb UCA algorithm
 type Filter interface {
+	json.Marshaler
 	ToMango() map[string]interface{}
-	MarshalJSON() ([]byte, error)
 }
 
 // valueFilter is a filter on a single field

--- a/couchdb/mango/query.go
+++ b/couchdb/mango/query.go
@@ -1,0 +1,190 @@
+package mango
+
+import (
+	"encoding/json"
+	"unicode"
+)
+
+// This package provides utility structures to build mango queries
+
+////////////////////////////////////////////////////////////////
+// Filter
+///////////////////////////////////////////////////////////////
+
+// ValueOperator is an operator between a field and a value
+type ValueOperator string
+
+// Eq ($eq) checks that field == value
+const eq ValueOperator = "$eq"
+
+// Gt ($gt) checks that field > value
+const gt ValueOperator = "$gt"
+
+// Gte ($gte) checks that field >= value
+const gte ValueOperator = "$gte"
+
+// Lt ($lt) checks that field < value
+const lt ValueOperator = "$lt"
+
+// Lte ($lte) checks that field <= value
+const lte ValueOperator = "$lte"
+
+// LogicOperator is an operator between two filters
+type LogicOperator string
+
+// And ($and) checks that filter && filter2
+const and LogicOperator = "$and"
+
+// Not ($not) checks that !filter
+const not LogicOperator = "$not"
+
+// Or ($or) checks that filter1 || filter2 || ...
+const or LogicOperator = "$or"
+
+// Nor ($nor) checks that !(filter1 || filter2 || ...)
+const nor LogicOperator = "$nor"
+
+// A Filter is a filter on documents, to be passed
+// as the selector of a couchdb.FindRequest
+// In the future, we might add go-side validation
+// but we will need to duplicate the couchdb UCA algorithm
+type Filter interface {
+	ToMango() map[string]interface{}
+	MarshalJSON() ([]byte, error)
+}
+
+// valueFilter is a filter on a single field
+type valueFilter struct {
+	field string
+	op    ValueOperator
+	value interface{}
+}
+
+// ToMango implements the Filter interface on valueFilter
+// it returns a map, either `{field: value}` or `{field: {$op: value}}`
+func (vf *valueFilter) ToMango() map[string]interface{} {
+	var value interface{}
+	if vf.op == eq {
+		value = vf.value
+	} else {
+		value = makeMap(string(vf.op), vf.value)
+	}
+	return makeMap(vf.field, value)
+}
+
+func (vf valueFilter) MarshalJSON() ([]byte, error) {
+	return json.Marshal(vf.ToMango())
+}
+
+// logicFilter is a combination of filters with logic operator
+type logicFilter struct {
+	op      LogicOperator
+	filters []Filter
+}
+
+// ToMango implements the Filter interface on logicFilter
+// We could add some logic to make $and queries more readable
+// For instance
+// {"$and": [{"field": {"$lt":6}}, {"field": {"$gt":3}}]
+// ---> {"field": {"$lt":6, "$gt":3}
+// but it doesnt improve performances.
+func (lf logicFilter) ToMango() map[string]interface{} {
+
+	// special case, $not has an arity of one
+	if lf.op == not {
+		return makeMap(string(lf.op), lf.filters[0].ToMango())
+	}
+
+	// all other LogicOperator works on arrays
+	filters := make([]map[string]interface{}, len(lf.filters))
+	for i, v := range lf.filters {
+		filters[i] = v.ToMango()
+	}
+	return makeMap(string(lf.op), filters)
+}
+
+func (lf logicFilter) MarshalJSON() ([]byte, error) {
+	return json.Marshal(lf.ToMango())
+}
+
+// ensure ValueFilter & LogicFilter match FilterInterface
+var _ Filter = (*valueFilter)(nil)
+var _ Filter = (*logicFilter)(nil)
+
+// Some Filter creation function
+
+// And returns a filter combining several filters
+func And(filters ...Filter) Filter { return logicFilter{and, filters} }
+
+// Or returns a filter combining several filters
+func Or(filters ...Filter) Filter { return logicFilter{or, filters} }
+
+// Nor returns a filter combining several filters
+func Nor(filters ...Filter) Filter { return logicFilter{nor, filters} }
+
+// Not returns a filter inversing another filter
+func Not(filter Filter) Filter { return logicFilter{not, []Filter{filter}} }
+
+// Equal returns a filter that check if a field == value
+func Equal(field string, value interface{}) Filter { return &valueFilter{field, eq, value} }
+
+// Gt returns a filter that check if a field > value
+func Gt(field string, value interface{}) Filter { return &valueFilter{field, gt, value} }
+
+// Gte returns a filter that check if a field >= value
+func Gte(field string, value interface{}) Filter { return &valueFilter{field, gte, value} }
+
+// Lt returns a filter that check if a field < value
+func Lt(field string, value interface{}) Filter { return &valueFilter{field, lt, value} }
+
+// Lte returns a filter that check if a field <= value
+func Lte(field string, value interface{}) Filter { return &valueFilter{field, lte, value} }
+
+// Between returns a filter that check if v1 <= field < v2
+func Between(field string, v1 interface{}, v2 interface{}) Filter {
+	return &logicFilter{op: and, filters: []Filter{
+		&valueFilter{field, gte, v1},
+		&valueFilter{field, lt, v2},
+	}}
+}
+
+const uFFFF = string(unicode.MaxRune)
+
+// StartWith returns a filter that check if field's string value start with prefix
+func StartWith(field string, prefix string) Filter {
+	return Between(field, prefix, prefix+uFFFF)
+}
+
+////////////////////////////////////////////////////////////////
+// Sort
+///////////////////////////////////////////////////////////////
+
+// SortDirection can be either ASC or DESC
+type SortDirection string
+
+// Asc is the ascending sorting order
+const Asc SortDirection = "asc"
+
+// Desc is the descending sorting order
+const Desc SortDirection = "desc"
+
+// SortBy is a sorting rule to be used as the sort of a couchdb.FindRequest
+// a (field, direction) combination.
+type SortBy struct {
+	Field     string
+	Direction SortDirection
+}
+
+// MarshalJSON implements json.Marshaller on SortBy
+// it will returns a json array [field, direction]
+func (s SortBy) MarshalJSON() ([]byte, error) {
+	asSlice := []string{s.Field, string(s.Direction)}
+	return json.Marshal(asSlice)
+}
+
+// utility function to create a map with a single key
+func makeMap(key string, value interface{}) map[string]interface{} {
+	out := make(map[string]interface{})
+	out[key] = value
+	return out
+}

--- a/couchdb/mango/query_test.go
+++ b/couchdb/mango/query_test.go
@@ -1,0 +1,44 @@
+package mango
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type M map[string]interface{}
+type S []interface{}
+
+func DeepEqual(t *testing.T, map1, map2 interface{}) bool {
+	j1, err1 := json.Marshal(map1)
+	j2, err2 := json.Marshal(map2)
+	if assert.NoError(t, err1) && assert.NoError(t, err2) {
+		assert.Equal(t, string(j1), string(j2))
+	}
+	return false
+}
+
+func TestQueryMarshaling(t *testing.T) {
+	q1 := Equal("FolderID", "ab123")
+	DeepEqual(t, q1.ToMango(), M{"FolderID": "ab123"})
+	q2 := Gt("Size", 1000)
+	DeepEqual(t, q2.ToMango(), M{"Size": M{"$gt": 1000}})
+	q3 := And(q1, q2)
+	DeepEqual(t, q3.ToMango(),
+		M{"$and": S{
+			M{"FolderID": "ab123"},
+			M{"Size": M{"$gt": 1000}},
+		}})
+
+	q4 := Not(Equal("FolderID", "ab123"))
+	DeepEqual(t, q4.ToMango(), M{"$not": M{"FolderID": "ab123"}})
+}
+
+func TestSortMarshaling(t *testing.T) {
+	s1 := &SortBy{"folderID", Asc}
+	j1, err := json.Marshal(s1)
+	if assert.NoError(t, err) {
+		assert.Equal(t, j1, []byte(`["folderID","asc"]`))
+	}
+}


### PR DESCRIPTION
This PR introduces mango queries to the couchdb package.

The API is as follow 
```go
index := mango.IndexOnFields('folderID', 'modificationDate')
couchdb.DefineIndex(prefix, doctype, index);

query := couchdb.FindRequest{
Filter: mango.Equal('folderID', myID), 
Sort: mango.SortBy{'modificationDate', mango.Asc}
}
var out []Files
couchdb.FindDocs(prefix, doctype, &query, &out)
```