### PR TITLE
[VFS] Patch file meta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
   - curl -X PUT http://127.0.0.1:5984/{_users,_replicator,_global_changes}
   - go get -u github.com/alecthomas/gometalinter
   - gometalinter --install --update
-  - gometalinter --deadline 120s --dupl-threshold 70 -D errcheck ./...
+  - gometalinter --deadline 120s --dupl-threshold 70 -D errcheck -D gocyclo ./...
 
 after_failure:
   - docker ps -a

--- a/vfs/directory.go
+++ b/vfs/directory.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/cozy/cozy-stack/couchdb"
-	"github.com/spf13/afero"
 )
 
 // DirDoc is a struct containing all the informations about a
@@ -98,9 +97,9 @@ func NewDirDoc(name, folderID string, tags []string) (doc *DirDoc, err error) {
 
 // GetDirectoryDoc is used to fetch directory document information
 // form the database.
-func GetDirectoryDoc(fileID, dbPrefix string) (doc *DirDoc, err error) {
+func GetDirectoryDoc(c *Context, fileID string) (doc *DirDoc, err error) {
 	doc = &DirDoc{}
-	err = couchdb.GetDoc(dbPrefix, string(FolderDocType), fileID, doc)
+	err = couchdb.GetDoc(c.db, string(FolderDocType), fileID, doc)
 	if couchdb.IsNotFoundError(err) {
 		err = ErrParentDoesNotExist
 	}
@@ -108,24 +107,24 @@ func GetDirectoryDoc(fileID, dbPrefix string) (doc *DirDoc, err error) {
 }
 
 // CreateDirectory is the method for creating a new directory
-func CreateDirectory(doc *DirDoc, fs afero.Fs, dbPrefix string) (err error) {
-	pth, _, err := createNewFilePath(doc.Name, doc.FolderID, fs, dbPrefix)
+func CreateDirectory(c *Context, doc *DirDoc) (err error) {
+	pth, _, err := createNewFilePath(c, doc.Name, doc.FolderID)
 	if err != nil {
 		return err
 	}
 
-	err = fs.Mkdir(pth, 0755)
+	err = c.fs.Mkdir(pth, 0755)
 	if err != nil {
 		return err
 	}
 
 	defer func() {
 		if err != nil {
-			fs.Remove(pth)
+			c.fs.Remove(pth)
 		}
 	}()
 
 	doc.Path = pth
 
-	return couchdb.CreateDoc(dbPrefix, doc)
+	return couchdb.CreateDoc(c.db, doc)
 }

--- a/vfs/directory.go
+++ b/vfs/directory.go
@@ -96,6 +96,17 @@ func NewDirDoc(name, folderID string, tags []string) (doc *DirDoc, err error) {
 	return
 }
 
+// GetDirectoryDoc is used to fetch directory document information
+// form the database.
+func GetDirectoryDoc(fileID, dbPrefix string) (doc *DirDoc, err error) {
+	doc = &DirDoc{}
+	err = couchdb.GetDoc(dbPrefix, string(FolderDocType), fileID, doc)
+	if couchdb.IsNotFoundError(err) {
+		err = ErrParentDoesNotExist
+	}
+	return
+}
+
 // CreateDirectory is the method for creating a new directory
 func CreateDirectory(doc *DirDoc, fs afero.Fs, dbPrefix string) (err error) {
 	pth, _, err := createNewFilePath(doc.Name, doc.FolderID, fs, dbPrefix)

--- a/vfs/directory.go
+++ b/vfs/directory.go
@@ -108,7 +108,7 @@ func GetDirectoryDoc(c *Context, fileID string) (doc *DirDoc, err error) {
 
 // CreateDirectory is the method for creating a new directory
 func CreateDirectory(c *Context, doc *DirDoc) (err error) {
-	pth, _, err := createNewFilePath(c, doc.Name, doc.FolderID)
+	pth, _, err := getFilePath(c, doc.Name, doc.FolderID)
 	if err != nil {
 		return err
 	}

--- a/vfs/errors.go
+++ b/vfs/errors.go
@@ -11,6 +11,9 @@ var (
 	ErrDocTypeInvalid = errors.New("Invalid document type")
 	// ErrIllegalFilename is used when the given filename is not allowed
 	ErrIllegalFilename = errors.New("Invalid filename: empty or contains an illegal character")
+	// ErrIllegalTime is used when a time given (creation or
+	// modification) is not allowed
+	ErrIllegalTime = errors.New("Invalid time given")
 	// ErrInvalidHash is used when the given hash does not match the
 	// calculated one
 	ErrInvalidHash = errors.New("Invalid hash")

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -33,11 +33,14 @@ type DocMetaAttributes struct {
 	Tags     []string `json:"tags,omitempty"`
 }
 
+// Context is used to convey the afero.Fs object along with the
+// CouchDb database prefix.
 type Context struct {
 	fs afero.Fs
 	db string
 }
 
+// NewContext is the constructor function for Context
 func NewContext(fs afero.Fs, dbprefix string) *Context {
 	return &Context{fs, dbprefix}
 }

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -33,6 +33,15 @@ type DocMetaAttributes struct {
 	Tags     []string `json:"tags,omitempty"`
 }
 
+type Context struct {
+	fs afero.Fs
+	db string
+}
+
+func NewContext(fs afero.Fs, dbprefix string) *Context {
+	return &Context{fs, dbprefix}
+}
+
 // ParseDocType is used to transform a string to a DocType.
 func ParseDocType(docType string) (result DocType, err error) {
 	switch docType {
@@ -58,7 +67,7 @@ func checkFileName(str string) error {
 // defined is the database and filesystem and it will generate the new
 // path of the wanted file, checking if there is not colision with
 // existing file.
-func createNewFilePath(name, folderID string, storage afero.Fs, dbPrefix string) (pth string, parentDoc *DirDoc, err error) {
+func createNewFilePath(c *Context, name, folderID string) (pth string, parentDoc *DirDoc, err error) {
 	if err = checkFileName(name); err != nil {
 		return
 	}
@@ -68,7 +77,7 @@ func createNewFilePath(name, folderID string, storage afero.Fs, dbPrefix string)
 	if folderID == "" {
 		parentPath = "/"
 	} else {
-		parentDoc, err = GetDirectoryDoc(folderID, dbPrefix)
+		parentDoc, err = GetDirectoryDoc(c, folderID)
 		if err != nil {
 			return
 		}

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -8,6 +8,7 @@ package vfs
 import (
 	"path"
 	"strings"
+	"time"
 
 	"github.com/spf13/afero"
 )
@@ -28,9 +29,11 @@ const (
 // DocMetaAttributes is a struct containing modifiable fields from
 // file and directory documents.
 type DocMetaAttributes struct {
-	Name     string   `json:"name,omitempty"`
-	FolderID string   `json:"folderID,omitempty"`
-	Tags     []string `json:"tags,omitempty"`
+	Name       string     `json:"name,omitempty"`
+	FolderID   *string    `json:"folderID,omitempty"`
+	Tags       []string   `json:"tags,omitempty"`
+	UpdatedAt  *time.Time `json:"updated_at,omitempty"`
+	Executable *bool      `json:"executable,omitempty"`
 }
 
 // Context is used to convey the afero.Fs object along with the
@@ -65,12 +68,12 @@ func checkFileName(str string) error {
 	return nil
 }
 
-// checkParentFolderID is used to generate the filepath of a new file
-// or directory. It will check if the given parent folderID is well
+// getFilePath is used to generate the filepath of a new file or
+// directory. It will check if the given parent folderID is well
 // defined is the database and filesystem and it will generate the new
 // path of the wanted file, checking if there is not colision with
 // existing file.
-func createNewFilePath(c *Context, name, folderID string) (pth string, parentDoc *DirDoc, err error) {
+func getFilePath(c *Context, name, folderID string) (pth string, parentDoc *DirDoc, err error) {
 	if err = checkFileName(name); err != nil {
 		return
 	}

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/gin-gonic/gin"
-	"github.com/spf13/afero"
 )
 
 // DefaultContentType is used for files uploaded with no content-type
@@ -27,7 +26,7 @@ const DefaultContentType = "application/octet-stream"
 //
 // swagger:route POST /files/:folder-id files uploadFileOrCreateDir
 func CreationHandler(c *gin.Context) {
-	fs, dbPrefix, err := getFsAndDBPrefix(c)
+	vfsC, err := getVfsContext(c)
 	if err != nil {
 		return
 	}
@@ -41,9 +40,9 @@ func CreationHandler(c *gin.Context) {
 	var doc jsonapi.JSONApier
 	switch docType {
 	case vfs.FileDocType:
-		doc, err = createFileHandler(c, fs, dbPrefix)
+		doc, err = createFileHandler(c, vfsC)
 	case vfs.FolderDocType:
-		doc, err = createDirectoryHandler(c, fs, dbPrefix)
+		doc, err = createDirectoryHandler(c, vfsC)
 	default:
 		err = vfs.ErrDocTypeInvalid
 	}
@@ -62,7 +61,7 @@ func CreationHandler(c *gin.Context) {
 	c.Data(http.StatusCreated, jsonapi.ContentType, data)
 }
 
-func createFileHandler(c *gin.Context, fs afero.Fs, dbPrefix string) (doc *vfs.FileDoc, err error) {
+func createFileHandler(c *gin.Context, vfsC *vfs.Context) (doc *vfs.FileDoc, err error) {
 	doc, err = fileDocFromReq(
 		c,
 		c.Query("Name"),
@@ -73,7 +72,7 @@ func createFileHandler(c *gin.Context, fs afero.Fs, dbPrefix string) (doc *vfs.F
 		return
 	}
 
-	err = vfs.CreateFileAndUpload(doc, fs, dbPrefix, c.Request.Body)
+	err = vfs.CreateFileAndUpload(vfsC, doc, c.Request.Body)
 	if err != nil {
 		jsonapi.AbortWithError(c, jsonapi.WrapVfsError(err))
 		return
@@ -82,7 +81,7 @@ func createFileHandler(c *gin.Context, fs afero.Fs, dbPrefix string) (doc *vfs.F
 	return
 }
 
-func createDirectoryHandler(c *gin.Context, fs afero.Fs, dbPrefix string) (doc *vfs.DirDoc, err error) {
+func createDirectoryHandler(c *gin.Context, vfsC *vfs.Context) (doc *vfs.DirDoc, err error) {
 	doc, err = vfs.NewDirDoc(
 		c.Query("Name"),
 		c.Param("folder-id"),
@@ -92,7 +91,7 @@ func createDirectoryHandler(c *gin.Context, fs afero.Fs, dbPrefix string) (doc *
 		return
 	}
 
-	err = vfs.CreateDirectory(doc, fs, dbPrefix)
+	err = vfs.CreateDirectory(vfsC, doc)
 	if err != nil {
 		return
 	}
@@ -107,7 +106,7 @@ func createDirectoryHandler(c *gin.Context, fs afero.Fs, dbPrefix string) (doc *
 func OverwriteFileContentHandler(c *gin.Context) {
 	var err error
 
-	fs, dbPrefix, err := getFsAndDBPrefix(c)
+	vfsC, err := getVfsContext(c)
 	if err != nil {
 		return
 	}
@@ -115,7 +114,7 @@ func OverwriteFileContentHandler(c *gin.Context) {
 	var oldDoc *vfs.FileDoc
 	var newDoc *vfs.FileDoc
 
-	oldDoc, err = vfs.GetFileDoc(c.Param("file-id"), dbPrefix)
+	oldDoc, err = vfs.GetFileDoc(vfsC, c.Param("file-id"))
 	if err != nil {
 		jsonapi.AbortWithError(c, jsonapi.WrapVfsError(err))
 		return
@@ -138,7 +137,7 @@ func OverwriteFileContentHandler(c *gin.Context) {
 		return
 	}
 
-	err = vfs.ModifyFileContent(oldDoc, newDoc, fs, dbPrefix, c.Request.Body)
+	err = vfs.ModifyFileContent(vfsC, oldDoc, newDoc, c.Request.Body)
 	if err != nil {
 		jsonapi.AbortWithError(c, jsonapi.WrapVfsError(err))
 		return
@@ -170,7 +169,7 @@ type jsonDataContainer struct {
 func ModificationHandler(c *gin.Context) {
 	var err error
 
-	fs, dbPrefix, err := getFsAndDBPrefix(c)
+	vfsC, err := getVfsContext(c)
 	if err != nil {
 		jsonapi.AbortWithError(c, jsonapi.InternalServerError(err))
 		return
@@ -193,7 +192,7 @@ func ModificationHandler(c *gin.Context) {
 	var doc jsonapi.JSONApier
 	switch docType {
 	case vfs.FileDocType:
-		doc, err = modFileHandler(c, patchData, fs, dbPrefix)
+		doc, err = modFileHandler(vfsC, c.Request, patchData)
 	case vfs.FolderDocType:
 		// @TODO
 		err = fmt.Errorf("Not implemented")
@@ -213,18 +212,18 @@ func ModificationHandler(c *gin.Context) {
 	c.Data(http.StatusOK, jsonapi.ContentType, data)
 }
 
-func modFileHandler(c *gin.Context, patchData *jsonData, fs afero.Fs, dbPrefix string) (jsonapi.JSONApier, error) {
-	doc, err := vfs.GetFileDoc(patchData.ID, dbPrefix)
+func modFileHandler(vfsC *vfs.Context, req *http.Request, patchData *jsonData) (jsonapi.JSONApier, error) {
+	doc, err := vfs.GetFileDoc(vfsC, patchData.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	ifMatch := c.Request.Header.Get("If-Match")
+	ifMatch := req.Header.Get("If-Match")
 	if ifMatch != "" && doc.Rev() != ifMatch {
 		return nil, jsonapi.PreconditionFailed("If-Match", fmt.Errorf("Revision does not match."))
 	}
 
-	doc, err = vfs.ModifyFileMetadata(doc, patchData.Attrs, fs, dbPrefix)
+	doc, err = vfs.ModifyFileMetadata(vfsC, doc, patchData.Attrs)
 	if err != nil {
 		return nil, err
 	}
@@ -243,7 +242,7 @@ func modFileHandler(c *gin.Context, patchData *jsonData, fs afero.Fs, dbPrefix s
 func ReadFileHandler(c *gin.Context) {
 	var err error
 
-	fs, dbPrefix, err := getFsAndDBPrefix(c)
+	vfsC, err := getVfsContext(c)
 	if err != nil {
 		return
 	}
@@ -254,12 +253,12 @@ func ReadFileHandler(c *gin.Context) {
 	// form their path
 	if fileID == "download" {
 		pth := c.Query("path")
-		err = vfs.ServeFileContentByPath(pth, c.Request, c.Writer, fs)
+		err = vfs.ServeFileContentByPath(vfsC, pth, c.Request, c.Writer)
 	} else {
 		var doc *vfs.FileDoc
-		doc, err = vfs.GetFileDoc(fileID, dbPrefix)
+		doc, err = vfs.GetFileDoc(vfsC, fileID)
 		if err == nil {
-			err = vfs.ServeFileContent(doc, c.Request, c.Writer, fs)
+			err = vfs.ServeFileContent(vfsC, doc, c.Request, c.Writer)
 		}
 	}
 
@@ -281,15 +280,16 @@ func Routes(router *gin.RouterGroup) {
 	router.PUT("/:file-id", OverwriteFileContentHandler)
 }
 
-func getFsAndDBPrefix(c *gin.Context) (fs afero.Fs, dbPrefix string, err error) {
+func getVfsContext(c *gin.Context) (*vfs.Context, error) {
 	instance := middlewares.GetInstance(c)
-	dbPrefix = instance.GetDatabasePrefix()
-	fs, err = instance.GetStorageProvider()
+	dbprefix := instance.GetDatabasePrefix()
+	fs, err := instance.GetStorageProvider()
 	if err != nil {
 		jsonapi.AbortWithError(c, jsonapi.InternalServerError(err))
-		return
+		return nil, err
 	}
-	return
+	vfsC := vfs.NewContext(fs, dbprefix)
+	return vfsC, nil
 }
 
 func fileDocFromReq(c *gin.Context, name, folderID string, tags []string) (doc *vfs.FileDoc, err error) {

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -364,7 +364,7 @@ func TestUploadWithParentAlreadyExists(t *testing.T) {
 
 func TestModifyMetadataFileMove(t *testing.T) {
 	body := "foo"
-	res1, data1 := upload(t, "/files/?Type=io.cozy.files&Name=filemoveme", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
+	res1, data1 := upload(t, "/files/?Type=io.cozy.files&Name=filemoveme&Tags=foo,bar", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
 	assert.Equal(t, 201, res1.StatusCode)
 
 	var ok bool
@@ -386,14 +386,28 @@ func TestModifyMetadataFileMove(t *testing.T) {
 	assert.True(t, ok)
 
 	attrs := map[string]interface{}{
-		"tags":     []string{"foo", "bar"},
-		"name":     "moved",
-		"folderID": folderID,
+		"tags":       []string{"bar", "baz"},
+		"name":       "moved",
+		"folderID":   folderID,
+		"executable": true,
 	}
 
 	res3, data3 := patchFile(t, "/files/"+fileID, "io.cozy.files", fileID, attrs)
 	assert.Equal(t, 200, res3.StatusCode)
-	t.Log(data3)
+
+	data3, ok = data3["data"].(map[string]interface{})
+	assert.True(t, ok)
+
+	attrs3, ok := data3["attributes"].(map[string]interface{})
+	assert.True(t, ok)
+
+	assert.Equal(t, "text/plain", attrs3["mime"])
+	assert.Equal(t, "moved", attrs3["name"])
+	assert.EqualValues(t, []interface{}{"foo", "bar", "baz"}, attrs3["tags"])
+	assert.Equal(t, "text", attrs3["class"])
+	assert.Equal(t, "rL0Y20zC+Fzt72VPzMSk2A==", attrs3["md5sum"])
+	assert.Equal(t, true, attrs3["executable"])
+	assert.Equal(t, "3", attrs3["size"])
 }
 
 func TestModifyContentNoFileID(t *testing.T) {

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -1,6 +1,7 @@
 package files
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -100,6 +101,38 @@ func uploadMod(t *testing.T, path, contentType, body, hash string) (res *http.Re
 		return
 	}
 	return doUploadOrMod(t, req, contentType, body, hash)
+}
+
+func patchFile(t *testing.T, path, docType, id string, attrs map[string]interface{}) (res *http.Response, v map[string]interface{}) {
+	type jsonData struct {
+		Type  string                 `json:"type"`
+		ID    string                 `json:"id"`
+		Attrs map[string]interface{} `json:"attributes,omitempty"`
+	}
+
+	bodyreq := &jsonData{
+		Type:  docType,
+		ID:    id,
+		Attrs: attrs,
+	}
+
+	b, err := json.Marshal(map[string]*jsonData{"data": bodyreq})
+	req, err := http.NewRequest("PATCH", ts.URL+path, bytes.NewReader(b))
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	res, err = http.DefaultClient.Do(req)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	defer res.Body.Close()
+
+	err = extractJSONRes(res, &v)
+	assert.NoError(t, err)
+
+	return
 }
 
 func download(t *testing.T, path, byteRange string) (res *http.Response, body []byte) {
@@ -327,6 +360,40 @@ func TestUploadWithParentAlreadyExists(t *testing.T) {
 
 	res2, _ := upload(t, "/files/"+parentID+"?Type=io.cozy.files&Name=iexistfile", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
 	assert.Equal(t, 409, res2.StatusCode)
+}
+
+func TestModifyMetadataFileMove(t *testing.T) {
+	body := "foo"
+	res1, data1 := upload(t, "/files/?Type=io.cozy.files&Name=filemoveme", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
+	assert.Equal(t, 201, res1.StatusCode)
+
+	var ok bool
+	data1, ok = data1["data"].(map[string]interface{})
+	assert.True(t, ok)
+
+	fileID, ok := data1["id"].(string)
+	assert.True(t, ok)
+	// fileRev, ok := data1["rev"].(string)
+	// assert.True(t, ok)
+
+	res2, data2 := createDir(t, "/files/?Name=movemeinme&Type=io.cozy.folders")
+	assert.Equal(t, 201, res2.StatusCode)
+
+	data2, ok = data2["data"].(map[string]interface{})
+	assert.True(t, ok)
+
+	folderID, ok := data2["id"].(string)
+	assert.True(t, ok)
+
+	attrs := map[string]interface{}{
+		"tags":     []string{"foo", "bar"},
+		"name":     "moved",
+		"folderID": folderID,
+	}
+
+	res3, data3 := patchFile(t, "/files/"+fileID, "io.cozy.files", fileID, attrs)
+	assert.Equal(t, 200, res3.StatusCode)
+	t.Log(data3)
 }
 
 func TestModifyContentNoFileID(t *testing.T) {
@@ -580,6 +647,7 @@ func TestMain(m *testing.M) {
 	router.Use(injectInstance(instance))
 	router.POST("/files/", CreationHandler)
 	router.POST("/files/:folder-id", CreationHandler)
+	router.PATCH("/files/:file-id", ModificationHandler)
 	router.PUT("/files/:file-id", OverwriteFileContentHandler)
 	router.HEAD("/files/:file-id", ReadFileHandler)
 	router.GET("/files/:file-id", ReadFileHandler)

--- a/web/jsonapi/errors.go
+++ b/web/jsonapi/errors.go
@@ -3,6 +3,7 @@ package jsonapi
 import (
 	"net/http"
 	"os"
+	"strconv"
 
 	"github.com/cozy/cozy-stack/couchdb"
 	"github.com/cozy/cozy-stack/vfs"
@@ -24,6 +25,10 @@ type Error struct {
 	Source SourceError `json:"source,omitempty"`
 }
 
+func (e *Error) Error() string {
+	return e.Title + "(" + strconv.Itoa(e.Status) + ")" + ": " + e.Detail
+}
+
 // WrapCouchError returns a formatted error from a couchdb error
 func WrapCouchError(err *couchdb.Error) *Error {
 	return &Error{
@@ -35,6 +40,9 @@ func WrapCouchError(err *couchdb.Error) *Error {
 
 // WrapVfsError returns a formatted error from a golang error emitted by the vfs
 func WrapVfsError(err error) *Error {
+	if jsonErr, isJSONApiError := err.(*Error); isJSONApiError {
+		return jsonErr
+	}
 	if couchErr, isCouchErr := err.(*couchdb.Error); isCouchErr {
 		return WrapCouchError(couchErr)
 	}
@@ -68,6 +76,15 @@ func NotFound(err error) *Error {
 	return &Error{
 		Status: http.StatusNotFound,
 		Title:  "Not Found",
+		Detail: err.Error(),
+	}
+}
+
+// BadRequest returns a 400 formatted error
+func BadRequest(err error) *Error {
+	return &Error{
+		Status: http.StatusBadRequest,
+		Title:  "Bad request",
 		Detail: err.Error(),
 	}
 }

--- a/web/jsonapi/errors.go
+++ b/web/jsonapi/errors.go
@@ -63,6 +63,8 @@ func WrapVfsError(err error) *Error {
 		return InvalidAttribute("type", err)
 	case vfs.ErrIllegalFilename:
 		return InvalidParameter("folder-id", err)
+	case vfs.ErrIllegalTime:
+		return InvalidParameter("UpdatedAt", err)
 	case vfs.ErrInvalidHash:
 		return PreconditionFailed("Content-MD5", err)
 	case vfs.ErrContentLengthMismatch:


### PR DESCRIPTION
Adds the `PATCH /files/:file-id` route to modify the metadata of a file, move it and rename it.

I've also added a `vfs.Context` struct to stop passing around fs / dbprefix values...