### PR TITLE
[VFS] Change directory metadata, move and rename them

### DIFF
--- a/vfs/directory.go
+++ b/vfs/directory.go
@@ -1,10 +1,16 @@
 package vfs
 
 import (
+	"fmt"
+	"os"
+	"path"
+	"strings"
 	"time"
 
 	"github.com/cozy/cozy-stack/couchdb"
+	"github.com/cozy/cozy-stack/couchdb/mango"
 	"github.com/cozy/cozy-stack/web/jsonapi"
+	"github.com/spf13/afero"
 )
 
 // DirDoc is a struct containing all the informations about a
@@ -18,7 +24,7 @@ type DirDoc struct {
 	// Directory name
 	Name string `json:"name"`
 	// Parent folder identifier
-	FolderID string `json:"folderID"`
+	FolderID string `json:"folder_id"`
 	// Directory path on VFS
 	Path string `json:"path"`
 
@@ -74,10 +80,21 @@ func (d *DirDoc) Included() []jsonapi.Object {
 	return []jsonapi.Object{}
 }
 
+func fetchChildren(c *Context, parent *DirDoc, doctype DocType, docs interface{}) error {
+	req := &couchdb.FindRequest{
+		Selector: mango.Equal("folder_id", parent.ID()),
+	}
+	return couchdb.FindDocs(c.db, string(doctype), req, docs)
+}
+
 // NewDirDoc is the DirDoc constructor. The given name is validated.
 func NewDirDoc(name, folderID string, tags []string) (doc *DirDoc, err error) {
 	if err = checkFileName(name); err != nil {
 		return
+	}
+
+	if folderID == "" {
+		folderID = RootFolderID
 	}
 
 	createDate := time.Now()
@@ -104,6 +121,24 @@ func GetDirectoryDoc(c *Context, fileID string) (doc *DirDoc, err error) {
 	return
 }
 
+// GetDirectoryDocFromPath is used to fetch directory document information from
+// the database from its path.
+func GetDirectoryDocFromPath(c *Context, pth string) (*DirDoc, error) {
+	var docs []*DirDoc
+	req := &couchdb.FindRequest{
+		Selector: mango.Equal("path", path.Clean(pth)),
+		Limit:    1,
+	}
+	err := couchdb.FindDocs(c.db, string(FolderDocType), req, &docs)
+	if err != nil {
+		return nil, err
+	}
+	if len(docs) == 0 {
+		return nil, os.ErrNotExist
+	}
+	return docs[0], nil
+}
+
 // CreateDirectory is the method for creating a new directory
 func CreateDirectory(c *Context, doc *DirDoc) (err error) {
 	pth, _, err := getFilePath(c, doc.Name, doc.FolderID)
@@ -125,4 +160,112 @@ func CreateDirectory(c *Context, doc *DirDoc) (err error) {
 	doc.Path = pth
 
 	return couchdb.CreateDoc(c.db, doc)
+}
+
+// ModifyDirectoryMetadata modify the metadata associated to a
+// directory. It can be used to rename or move the directory in the
+// VFS.
+func ModifyDirectoryMetadata(c *Context, olddoc *DirDoc, data *DocMetaAttributes) (newdoc *DirDoc, err error) {
+	pth := olddoc.Path
+	name := olddoc.Name
+	tags := olddoc.Tags
+	folderID := olddoc.FolderID
+	mdate := olddoc.UpdatedAt
+
+	if data.FolderID != nil && *data.FolderID != folderID {
+		folderID = *data.FolderID
+		pth, _, err = getFilePath(c, name, folderID)
+		if err != nil {
+			return
+		}
+	}
+
+	if data.Name != "" {
+		name = data.Name
+		pth = path.Join(path.Dir(pth), name)
+	}
+
+	if data.Tags != nil {
+		tags = appendTags(tags, data.Tags)
+	}
+
+	if data.UpdatedAt != nil {
+		mdate = *data.UpdatedAt
+	}
+
+	if mdate.Before(olddoc.CreatedAt) {
+		err = ErrIllegalTime
+		return
+	}
+
+	newdoc, err = NewDirDoc(name, folderID, tags)
+	if err != nil {
+		return
+	}
+
+	newdoc.SetID(olddoc.ID())
+	newdoc.SetRev(olddoc.Rev())
+	newdoc.CreatedAt = olddoc.CreatedAt
+	newdoc.UpdatedAt = mdate
+	newdoc.Path = pth
+
+	if pth != olddoc.Path {
+		err = renameDirectory(olddoc.Path, pth, c.fs)
+		if err != nil {
+			return
+		}
+	}
+
+	err = bulkUpdateDocsPath(c, olddoc, pth)
+	if err != nil {
+		return
+	}
+
+	err = couchdb.UpdateDoc(c.db, newdoc)
+	return
+}
+
+// @TODO remove this method and use couchdb bulk updates instead
+func bulkUpdateDocsPath(c *Context, olddoc *DirDoc, newpath string) error {
+	var children []*DirDoc
+	err := fetchChildren(c, olddoc, FolderDocType, &children)
+	if err != nil {
+		return err
+	}
+
+	if len(children) == 0 {
+		return nil
+	}
+
+	errc := make(chan error)
+
+	for _, child := range children {
+		go func(child *DirDoc) {
+			child.Path = path.Join(newpath, child.Name)
+			errc <- couchdb.UpdateDoc(c.db, child)
+		}(child)
+	}
+
+	for i := 0; i < len(children); i++ {
+		if e := <-errc; e != nil {
+			err = e
+		}
+	}
+
+	return err
+}
+
+func renameDirectory(oldpath, newpath string, fs afero.Fs) error {
+	newpath = path.Clean(newpath)
+	oldpath = path.Clean(oldpath)
+
+	if !path.IsAbs(newpath) || !path.IsAbs(oldpath) {
+		return fmt.Errorf("renameDirectory: paths should be absolute")
+	}
+
+	if strings.HasPrefix(newpath, oldpath+"/") {
+		return ErrForbiddenDocMove
+	}
+
+	return fs.Rename(oldpath, newpath)
 }

--- a/vfs/errors.go
+++ b/vfs/errors.go
@@ -6,6 +6,9 @@ var (
 	// ErrParentDoesNotExist is used when the parent folder does not
 	// exist
 	ErrParentDoesNotExist = errors.New("Parent folder with given FolderID does not exist")
+	// ErrForbiddenDocMove is used when trying to move a document in an
+	// illicit destination
+	ErrForbiddenDocMove = errors.New("Forbidden document move")
 	// ErrDocTypeInvalid is used when the document type sent is not
 	// recognized
 	ErrDocTypeInvalid = errors.New("Invalid document type")

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -282,6 +282,10 @@ func ModificationHandler(c *gin.Context) {
 // ReadFileHandler handles all GET requests on /files/:file-id,
 // /files/download and /files/metadata and dispatches to the right
 // handler. See ReadMetadataHandler and ReadFileContentHandler.
+//
+// @TODO: get rid of this handler which should be split in two
+// distinct handlers on the router level. This is not handled properly
+// by httprouter-v1.
 func ReadFileHandler(c *gin.Context) {
 	fileID := c.Param("file-id")
 

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -240,6 +240,8 @@ func ModificationHandler(c *gin.Context) {
 			doc, err = vfs.GetFileDocFromPath(vfsC, c.Query("path"))
 		case vfs.FolderDocType:
 			doc, err = vfs.GetDirectoryDocFromPath(vfsC, c.Query("path"))
+		default:
+			err = vfs.ErrDocTypeInvalid
 		}
 	} else {
 		switch docType {
@@ -247,6 +249,8 @@ func ModificationHandler(c *gin.Context) {
 			doc, err = vfs.GetFileDoc(vfsC, fileID)
 		case vfs.FolderDocType:
 			doc, err = vfs.GetDirectoryDoc(vfsC, fileID)
+		default:
+			err = vfs.ErrDocTypeInvalid
 		}
 	}
 

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -279,25 +279,6 @@ func ModificationHandler(c *gin.Context) {
 	jsonapi.Data(c, http.StatusOK, data, nil)
 }
 
-// ReadFileHandler handles all GET requests on /files/:file-id,
-// /files/download and /files/metadata and dispatches to the right
-// handler. See ReadMetadataHandler and ReadFileContentHandler.
-//
-// @TODO: get rid of this handler which should be split in two
-// distinct handlers on the router level. This is not handled properly
-// by httprouter-v1.
-func ReadFileHandler(c *gin.Context) {
-	fileID := c.Param("file-id")
-
-	// Path /files/metadata is handled specifically to read file
-	// metadata informations
-	if fileID == MetadataPath {
-		ReadMetadataHandler(c)
-	} else {
-		ReadFileContentHandler(c)
-	}
-}
-
 // ReadMetadataHandler handles all GET requests on /files/metadata
 // aiming at getting file metadata from its path.
 //
@@ -365,8 +346,16 @@ func ReadFileContentHandler(c *gin.Context) {
 
 // Routes sets the routing for the files service
 func Routes(router *gin.RouterGroup) {
-	router.HEAD("/:file-id", ReadFileHandler)
-	router.GET("/:file-id", ReadFileHandler)
+	// @TODO: get rid of this handler when switching to
+	// echo/httprouterv2.
+	router.GET("/:file-id", func(c *gin.Context) {
+		if c.Param("file-id") == MetadataPath {
+			ReadMetadataHandler(c)
+		} else {
+			ReadFileContentHandler(c)
+		}
+	})
+	router.HEAD("/:file-id", ReadFileContentHandler)
 
 	router.POST("/", CreationHandler)
 	router.POST("/:folder-id", CreationHandler)

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -776,8 +776,14 @@ func TestMain(m *testing.M) {
 	router.POST("/files/:folder-id", CreationHandler)
 	router.PATCH("/files/:file-id", ModificationHandler)
 	router.PUT("/files/:file-id", OverwriteFileContentHandler)
-	router.HEAD("/files/:file-id", ReadFileHandler)
-	router.GET("/files/:file-id", ReadFileHandler)
+	router.HEAD("/files/:file-id", ReadFileContentHandler)
+	router.GET("/files/:file-id", func(c *gin.Context) {
+		if c.Param("file-id") == MetadataPath {
+			ReadMetadataHandler(c)
+		} else {
+			ReadFileContentHandler(c)
+		}
+	})
 	ts = httptest.NewServer(router)
 	defer ts.Close()
 	os.Exit(m.Run())


### PR DESCRIPTION
I opted for an intermediary solution for now to handle path and move actions: remove the `Path` field from `FileDoc` and keep it in `DirDoc`.

Files and Directories are still in different databases, but this will be removed soon.