### PR TITLE
[VFS] Get dir meta

### DIFF
--- a/couchdb/mango/index_test.go
+++ b/couchdb/mango/index_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 func TestIndexMarshaling(t *testing.T) {
-	def := IndexOnFields("folderID", "name")
+	def := IndexOnFields("folder_id", "name")
 	jsonbytes, _ := json.Marshal(def)
-	expected := `{"index":{"fields":["folderID","name"]}}`
+	expected := `{"index":{"fields":["folder_id","name"]}}`
 	assert.Equal(t, expected, string(jsonbytes), "index should MarshalJSON properly")
 }

--- a/couchdb/mango/query_test.go
+++ b/couchdb/mango/query_test.go
@@ -36,9 +36,9 @@ func TestQueryMarshaling(t *testing.T) {
 }
 
 func TestSortMarshaling(t *testing.T) {
-	s1 := &SortBy{"folderID", Asc}
+	s1 := &SortBy{"folder_id", Asc}
 	j1, err := json.Marshal(s1)
 	if assert.NoError(t, err) {
-		assert.Equal(t, j1, []byte(`["folderID","asc"]`))
+		assert.Equal(t, j1, []byte(`["folder_id","asc"]`))
 	}
 }

--- a/docs/files.md
+++ b/docs/files.md
@@ -54,10 +54,11 @@ Location: http://cozy.example.com/files/6494e0ac-dfcb-11e5-88c1-472e84a9cbee
 ```json
 {
   "data": {
-    "type": "io.cozy.folders",
+    "type": "io.cozy.files",
     "id": "6494e0ac-dfcb-11e5-88c1-472e84a9cbee",
     "rev": "1-ff3beeb456eb",
     "attributes": {
+      "type": "directory",
       "name": "phone",
       "created_at": "2016-09-19T12:35:08Z",
       "updated_at": "2016-09-19T12:35:08Z",
@@ -69,7 +70,7 @@ Location: http://cozy.example.com/files/6494e0ac-dfcb-11e5-88c1-472e84a9cbee
           "related": "/files/fce1a6c0-dfc5-11e5-8d1a-1f854d4aaf81"
         },
         "data": {
-          "type": "io.cozy.folders",
+          "type": "io.cozy.files",
           "id": "fce1a6c0-dfc5-11e5-8d1a-1f854d4aaf81"
         }
       }
@@ -113,10 +114,11 @@ Content-Type: application/vnd.api+json
     "next": "/files/fce1a6c0-dfc5-11e5-8d1a-1f854d4aaf81?page[cursor]=9152d568-7e7c-11e6-a377-37cbfb190b4b"
   },
   "data": {
-    "type": "io.cozy.folders",
+    "type": "io.cozy.files",
     "id": "fce1a6c0-dfc5-11e5-8d1a-1f854d4aaf81",
     "rev": "1-e36ab092",
     "attributes": {
+      "type": "directory",
       "name": "Documents",
       "created_at": "2016-09-19T12:35:00Z",
       "updated_at": "2016-09-19T12:35:00Z",
@@ -125,7 +127,7 @@ Content-Type: application/vnd.api+json
     "relationships": {
       "contents": {
         "data": [
-          { "type": "io.cozy.folders", "id": "6494e0ac-dfcb-11e5-88c1-472e84a9cbee" },
+          { "type": "io.cozy.files", "id": "6494e0ac-dfcb-11e5-88c1-472e84a9cbee" },
           { "type": "io.cozy.files", "id": "9152d568-7e7c-11e6-a377-37cbfb190b4b" }
         ]
       }
@@ -135,10 +137,11 @@ Content-Type: application/vnd.api+json
     }
   },
   "included": [{
-    "type": "io.cozy.folders",
+    "type": "io.cozy.files",
     "id": "6494e0ac-dfcb-11e5-88c1-472e84a9cbee",
     "rev": "1-ff3beeb456eb",
     "attributes": {
+      "type": "directory",
       "name": "phone",
       "created_at": "2016-09-19T12:35:08Z",
       "updated_at": "2016-09-19T12:35:08Z",
@@ -150,7 +153,7 @@ Content-Type: application/vnd.api+json
           "related": "/files/fce1a6c0-dfc5-11e5-8d1a-1f854d4aaf81"
         },
         "data": {
-          "type": "io.cozy.folders",
+          "type": "io.cozy.files",
           "id": "fce1a6c0-dfc5-11e5-8d1a-1f854d4aaf81"
         }
       }
@@ -163,6 +166,7 @@ Content-Type: application/vnd.api+json
     "id": "9152d568-7e7c-11e6-a377-37cbfb190b4b",
     "rev": "1-0e6d5b72",
     "attributes": {
+      "type": "file",
       "name": "hello.txt",
       "md5sum": "86fb269d190d2c85f6e0468ceca42a20",
       "created_at": "2016-09-19T12:38:04Z",
@@ -179,7 +183,7 @@ Content-Type: application/vnd.api+json
           "related": "/files/fce1a6c0-dfc5-11e5-8d1a-1f854d4aaf81"
         },
         "data": {
-          "type": "io.cozy.folders",
+          "type": "io.cozy.files",
           "id": "fce1a6c0-dfc5-11e5-8d1a-1f854d4aaf81"
         }
       }
@@ -259,6 +263,7 @@ Location: http://cozy.example.com/files/9152d568-7e7c-11e6-a377-37cbfb190b4b
     "id": "9152d568-7e7c-11e6-a377-37cbfb190b4b",
     "rev": "1-0e6d5b72",
     "attributes": {
+      "type": "file",
       "name": "hello.txt",
       "md5sum": "86fb269d190d2c85f6e0468ceca42a20",
       "created_at": "2016-09-19T12:38:04Z",
@@ -275,7 +280,7 @@ Location: http://cozy.example.com/files/9152d568-7e7c-11e6-a377-37cbfb190b4b
           "related": "/files/fce1a6c0-dfc5-11e5-8d1a-1f854d4aaf81"
         },
         "data": {
-          "type": "io.cozy.folders",
+          "type": "io.cozy.files",
           "id": "fce1a6c0-dfc5-11e5-8d1a-1f854d4aaf81"
         }
       }
@@ -369,6 +374,7 @@ Content-Type: application/vnd.api+json
     "id": "9152d568-7e7c-11e6-a377-37cbfb190b4b",
     "rev": "2-d903b54c",
     "attributes": {
+      "type": "file",
       "name": "hello.txt",
       "md5sum": "b59bc37d6441d96785bda7ab2ae98f75",
       "created_at": "2016-09-19T12:38:04Z",
@@ -385,7 +391,7 @@ Content-Type: application/vnd.api+json
           "related": "/files/fce1a6c0-dfc5-11e5-8d1a-1f854d4aaf81"
         },
         "data": {
-          "type": "io.cozy.folders",
+          "type": "io.cozy.files",
           "id": "fce1a6c0-dfc5-11e5-8d1a-1f854d4aaf81"
         }
       }
@@ -430,6 +436,7 @@ Location: http://cozy.example.com/files/9152d568-7e7c-11e6-a377-37cbfb190b4b
     "id": "9152d568-7e7c-11e6-a377-37cbfb190b4b",
     "rev": "1-0e6d5b72",
     "attributes": {
+      "type": "file",
       "name": "hello.txt",
       "md5sum": "86fb269d190d2c85f6e0468ceca42a20",
       "created_at": "2016-09-19T12:38:04Z",
@@ -446,7 +453,7 @@ Location: http://cozy.example.com/files/9152d568-7e7c-11e6-a377-37cbfb190b4b
           "related": "/files/fce1a6c0-dfc5-11e5-8d1a-1f854d4aaf81"
         },
         "data": {
-          "type": "io.cozy.folders",
+          "type": "io.cozy.files",
           "id": "fce1a6c0-dfc5-11e5-8d1a-1f854d4aaf81"
         }
       }
@@ -485,13 +492,14 @@ Content-Type: application/vnd.api+json
     "type": "io.cozy.files",
     "id": "9152d568-7e7c-11e6-a377-37cbfb190b4b",
     "attributes": {
+      "type": "file",
       "name": "hi.txt",
       "tags": ["poem"]
     },
     "relationships": {
       "parent": {
         "data": {
-          "type": "io.cozy.folders",
+          "type": "io.cozy.files",
           "id": "f2f36fec-8018-11e6-abd8-8b3814d9a465"
         }
       }
@@ -523,6 +531,7 @@ Location: http://cozy.example.com/files/9152d568-7e7c-11e6-a377-37cbfb190b4b
     "id": "9152d568-7e7c-11e6-a377-37cbfb190b4b",
     "rev": "1-0e6d5b72",
     "attributes": {
+      "type": "file",
       "name": "hi.txt",
       "md5sum": "86fb269d190d2c85f6e0468ceca42a20",
       "created_at": "2016-09-19T12:38:04Z",
@@ -539,7 +548,7 @@ Location: http://cozy.example.com/files/9152d568-7e7c-11e6-a377-37cbfb190b4b
           "related": "/files/f2f36fec-8018-11e6-abd8-8b3814d9a465"
         },
         "data": {
-          "type": "io.cozy.folders",
+          "type": "io.cozy.files",
           "id": "f2f36fec-8018-11e6-abd8-8b3814d9a465"
         }
       }
@@ -615,6 +624,7 @@ Content-Type: application/vnd.api+json
     "id": "df24aac0-7f3d-11e6-81c0-d38812bfa0a8",
     "rev": "1-3b75377c",
     "attributes": {
+      "type": "file",
       "name": "foo.txt",
       "md5sum": "b01341e7803c800cc8db4de46f377a87",
       "created_at": "2016-09-19T12:38:04Z",
@@ -633,6 +643,7 @@ Content-Type: application/vnd.api+json
     "id": "4a4fc582-7f3e-11e6-b9ca-278406b6ddd4",
     "rev": "1-4a09030e",
     "attributes": {
+      "type": "file",
       "name": "bar.txt",
       "md5sum": "aeab87eb49d3f4e0e5625ada9b49f8e1",
       "created_at": "2016-09-19T12:38:04Z",

--- a/vfs/errors.go
+++ b/vfs/errors.go
@@ -9,9 +9,6 @@ var (
 	// ErrForbiddenDocMove is used when trying to move a document in an
 	// illicit destination
 	ErrForbiddenDocMove = errors.New("Forbidden document move")
-	// ErrDocTypeInvalid is used when the document type sent is not
-	// recognized
-	ErrDocTypeInvalid = errors.New("Invalid document type")
 	// ErrIllegalFilename is used when the given filename is not allowed
 	ErrIllegalFilename = errors.New("Invalid filename: empty or contains an illegal character")
 	// ErrIllegalTime is used when a time given (creation or

--- a/vfs/file.go
+++ b/vfs/file.go
@@ -25,9 +25,9 @@ type FileDoc struct {
 	// from couch.
 	Type string `json:"type"`
 	// Qualified file identifier
-	FID string `json:"_id,omitempty"`
+	ObjID string `json:"_id,omitempty"`
 	// File revision
-	FRev string `json:"_rev,omitempty"`
+	ObjRev string `json:"_rev,omitempty"`
 	// File name
 	Name string `json:"name"`
 	// Parent folder identifier
@@ -49,12 +49,12 @@ type FileDoc struct {
 // ID returns the file qualified identifier (part of couchdb.Doc
 // interface)
 func (f *FileDoc) ID() string {
-	return f.FID
+	return f.ObjID
 }
 
 // Rev returns the file revision (part of couchdb.Doc interface)
 func (f *FileDoc) Rev() string {
-	return f.FRev
+	return f.ObjRev
 }
 
 // DocType returns the file document type (part of couchdb.Doc
@@ -66,19 +66,19 @@ func (f *FileDoc) DocType() string {
 // SetID is used to change the file qualified identifier (part of
 // couchdb.Doc interface)
 func (f *FileDoc) SetID(id string) {
-	f.FID = id
+	f.ObjID = id
 }
 
 // SetRev is used to change the file revision (part of couchdb.Doc
 // interface)
 func (f *FileDoc) SetRev(rev string) {
-	f.FRev = rev
+	f.ObjRev = rev
 }
 
 // SelfLink is used to generate a JSON-API link for the file (part of
 // jsonapi.Object interface)
 func (f *FileDoc) SelfLink() string {
-	return "/files/" + f.FID
+	return "/files/" + f.ObjID
 }
 
 // Path is used to generate the file path

--- a/vfs/vfs_test.go
+++ b/vfs/vfs_test.go
@@ -66,7 +66,7 @@ func TestMain(m *testing.M) {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	err = couchdb.DefineIndex(TestPrefix, FsDocType, mango.IndexOnFields("folder_id", "name", "path"))
+	err = couchdb.DefineIndex(TestPrefix, FsDocType, mango.IndexOnFields("folder_id", "name"))
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/vfs/vfs_test.go
+++ b/vfs/vfs_test.go
@@ -36,7 +36,7 @@ func TestGetFileDocFromPathAtRoot(t *testing.T) {
 }
 
 func TestGetFileDocFromPath(t *testing.T) {
-	dir, _ := NewDirDoc("container", "", nil)
+	dir, _ := NewDirDoc("container", "", nil, nil)
 	err := CreateDirectory(vfsC, dir)
 	assert.NoError(t, err)
 
@@ -61,22 +61,12 @@ func TestMain(m *testing.M) {
 		fmt.Println("This test need couchdb to run.")
 		os.Exit(1)
 	}
-	err = couchdb.ResetDB(TestPrefix, string(FileDocType))
+	err = couchdb.ResetDB(TestPrefix, FsDocType)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	err = couchdb.ResetDB(TestPrefix, string(FolderDocType))
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-	err = couchdb.DefineIndex(TestPrefix, string(FolderDocType), mango.IndexOnFields("path"))
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-	err = couchdb.DefineIndex(TestPrefix, string(FileDocType), mango.IndexOnFields("folder_id", "name"))
+	err = couchdb.DefineIndex(TestPrefix, FsDocType, mango.IndexOnFields("folder_id", "name", "path"))
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)


### PR DESCRIPTION
This PR is quite simple but is has some implications and changes regarding the current doc.

By having files and directories sharing the same doctype `io.cozy.files`, I made these changes:

  - `DirDoc` and `FileDoc` now have a `Type string` field (either `"file"` or `"directory"`)
  - The ID of the root directory is `io.cozy.files.rootdir`

I did not change **input** side of the API, which still has the notion of `io.cozy.folders`. So clearly, this PR is a work in progress and I would understand if we don't want to merge it as-is.

--

Note: the notion of RootDirectory is handled "manually" in the code. I did not introduce a special object in the database.