### PR TITLE
[VFS] Remove the requirement to pass Type query param for modify/read

### DIFF
--- a/vfs/directory.go
+++ b/vfs/directory.go
@@ -179,6 +179,9 @@ func GetDirectoryDoc(c *Context, fileID string, withChildren bool) (*DirDoc, err
 	if err != nil {
 		return nil, err
 	}
+	if doc.Type != DirType {
+		return nil, os.ErrNotExist
+	}
 	if withChildren {
 		err = doc.FetchFiles(c)
 	}

--- a/vfs/directory.go
+++ b/vfs/directory.go
@@ -165,9 +165,9 @@ func NewDirDoc(name, folderID string, tags []string, parent *DirDoc) (doc *DirDo
 	return
 }
 
-// GetDirectoryDoc is used to fetch directory document information
+// GetDirDoc is used to fetch directory document information
 // form the database.
-func GetDirectoryDoc(c *Context, fileID string, withChildren bool) (*DirDoc, error) {
+func GetDirDoc(c *Context, fileID string, withChildren bool) (*DirDoc, error) {
 	if fileID == RootFolderID {
 		return getRootDirDoc(), nil
 	}
@@ -188,9 +188,9 @@ func GetDirectoryDoc(c *Context, fileID string, withChildren bool) (*DirDoc, err
 	return doc, err
 }
 
-// GetDirectoryDocFromPath is used to fetch directory document information from
+// GetDirDocFromPath is used to fetch directory document information from
 // the database from its path.
-func GetDirectoryDocFromPath(c *Context, pth string, withChildren bool) (*DirDoc, error) {
+func GetDirDocFromPath(c *Context, pth string, withChildren bool) (*DirDoc, error) {
 	var doc *DirDoc
 	var err error
 	if pth == "/" {

--- a/vfs/file.go
+++ b/vfs/file.go
@@ -155,10 +155,16 @@ func NewFileDoc(name, folderID string, size int64, md5Sum []byte, mime, class st
 
 // GetFileDoc is used to fetch file document information form the
 // database.
-func GetFileDoc(c *Context, fileID string) (doc *FileDoc, err error) {
-	doc = &FileDoc{}
-	err = couchdb.GetDoc(c.db, FsDocType, fileID, doc)
-	return doc, err
+func GetFileDoc(c *Context, fileID string) (*FileDoc, error) {
+	doc := &FileDoc{}
+	err := couchdb.GetDoc(c.db, FsDocType, fileID, doc)
+	if err != nil {
+		return nil, err
+	}
+	if doc.Type != FileType {
+		return nil, os.ErrNotExist
+	}
+	return doc, nil
 }
 
 // GetFileDocFromPath is used to fetch file document information from
@@ -182,6 +188,7 @@ func GetFileDocFromPath(c *Context, pth string) (*FileDoc, error) {
 	selector := mango.And(
 		mango.Equal("folder_id", folderID),
 		mango.Equal("name", path.Base(pth)),
+		mango.Equal("type", FileType),
 	)
 
 	var docs []*FileDoc

--- a/vfs/file.go
+++ b/vfs/file.go
@@ -87,7 +87,7 @@ func (f *FileDoc) Path(c *Context) (string, error) {
 	if f.FolderID == RootFolderID {
 		parentPath = "/"
 	} else if f.parent == nil {
-		parent, err := GetDirectoryDoc(c, f.FolderID, false)
+		parent, err := GetDirDoc(c, f.FolderID, false)
 		if err != nil {
 			return "", err
 		}
@@ -176,7 +176,7 @@ func GetFileDocFromPath(c *Context, pth string) (*FileDoc, error) {
 	dirpath := path.Dir(pth)
 	if dirpath != "/" {
 		var parent *DirDoc
-		parent, err = GetDirectoryDocFromPath(c, dirpath, false)
+		parent, err = GetDirDocFromPath(c, dirpath, false)
 		if err != nil {
 			return nil, err
 		}

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -100,7 +100,7 @@ func GetDirOrFileDoc(c *Context, fileID string) (typ string, dirDoc *DirDoc, fil
 // GetDirOrFileDocFromPath is used to fetch a document from its path
 // without knowning in advance its type.
 func GetDirOrFileDocFromPath(c *Context, pth string, withChildren bool) (typ string, dirDoc *DirDoc, fileDoc *FileDoc, err error) {
-	dirDoc, err = GetDirectoryDocFromPath(c, pth, withChildren)
+	dirDoc, err = GetDirDocFromPath(c, pth, withChildren)
 	if err != nil && !os.IsNotExist(err) {
 		return
 	}
@@ -164,7 +164,7 @@ func getFilePath(c *Context, name, folderID string) (pth string, parentDoc *DirD
 	if folderID == "" || folderID == RootFolderID {
 		parentPath = "/"
 	} else {
-		parentDoc, err = GetDirectoryDoc(c, folderID, false)
+		parentDoc, err = GetDirDoc(c, folderID, false)
 		if err != nil {
 			return
 		}

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -713,14 +713,14 @@ func TestDownloadRangeSuccess(t *testing.T) {
 }
 
 func TestGetFileMetadata(t *testing.T) {
-	res1, _ := http.Get(ts.URL + "/files/metadata?Path=/noooooop&Type=io.cozy.files")
+	res1, _ := http.Get(ts.URL + "/files/metadata?Path=/noooooop")
 	assert.Equal(t, 404, res1.StatusCode)
 
 	body := "foo,bar"
 	res2, _ := upload(t, "/files/?Type=io.cozy.files&Name=getmetadata", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
 	assert.Equal(t, 201, res2.StatusCode)
 
-	res3, _ := http.Get(ts.URL + "/files/metadata?Path=/getmetadata&Type=io.cozy.files")
+	res3, _ := http.Get(ts.URL + "/files/metadata?Path=/getmetadata")
 	assert.Equal(t, 200, res3.StatusCode)
 }
 
@@ -739,7 +739,7 @@ func TestGetDirectoryMetadata(t *testing.T) {
 	res2, _ := upload(t, "/files/"+parentID+"?Type=io.cozy.files&Name=firstfile", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
 	assert.Equal(t, 201, res2.StatusCode)
 
-	res3, _ := http.Get(ts.URL + "/files/metadata?Path=/getdirmeta&Type=io.cozy.folders")
+	res3, _ := http.Get(ts.URL + "/files/metadata?Path=/getdirmeta")
 	assert.Equal(t, 200, res3.StatusCode)
 }
 
@@ -757,7 +757,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	err = couchdb.DefineIndex(TestPrefix, vfs.FsDocType, mango.IndexOnFields("folder_id", "name"))
+	err = couchdb.DefineIndex(TestPrefix, vfs.FsDocType, mango.IndexOnFields("folder_id", "name", "type"))
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)


### PR DESCRIPTION
This PR removes the need to pass `?Type=` query param for `GET / PATCH` requests.