### PR TITLE
[VFS] Tags replace on patch

### DIFF
--- a/vfs/directory.go
+++ b/vfs/directory.go
@@ -174,6 +174,8 @@ func NewDirDoc(name, folderID string, tags []string, parent *DirDoc) (doc *DirDo
 		parent = getRootDirDoc()
 	}
 
+	tags = uniqueTags(tags)
+
 	createDate := time.Now()
 	doc = &DirDoc{
 		Type:     DirType,

--- a/vfs/file.go
+++ b/vfs/file.go
@@ -398,62 +398,51 @@ func (fc *FileCreation) Close() error {
 
 // ModifyFileMetadata modify the metadata associated to a file. It can
 // be used to rename or move the file in the VFS.
-func ModifyFileMetadata(c *Context, olddoc *FileDoc, data *DocMetaAttributes) (newdoc *FileDoc, err error) {
-	parent, err := olddoc.Parent(c)
+func ModifyFileMetadata(c *Context, olddoc *FileDoc, patch *DocPatch) (newdoc *FileDoc, err error) {
+	cdate := olddoc.CreatedAt
+	patch, err = normalizeDocPatch(&DocPatch{
+		Name:       &olddoc.Name,
+		FolderID:   &olddoc.FolderID,
+		Tags:       &olddoc.Tags,
+		UpdatedAt:  &olddoc.UpdatedAt,
+		Executable: &olddoc.Executable,
+	}, patch, cdate)
+
 	if err != nil {
 		return
 	}
 
-	name := olddoc.Name
-	tags := olddoc.Tags
-	exec := olddoc.Executable
-	folderID := olddoc.FolderID
-	mdate := olddoc.UpdatedAt
-
-	if data.FolderID != nil && *data.FolderID != folderID {
-		folderID = *data.FolderID
-	}
-
-	if data.Name != "" {
-		name = data.Name
-	}
-
-	if data.Tags != nil {
-		tags = appendTags(tags, data.Tags)
-	}
-
-	if data.Executable != nil {
-		exec = *data.Executable
-	}
-
-	if data.UpdatedAt != nil {
-		mdate = *data.UpdatedAt
-	}
-
-	if mdate.Before(olddoc.CreatedAt) {
-		err = ErrIllegalTime
-		return
-	}
-
 	newdoc, err = NewFileDoc(
-		name,
-		folderID,
+		*patch.Name,
+		*patch.FolderID,
 		olddoc.Size,
 		olddoc.MD5Sum,
 		olddoc.Mime,
 		olddoc.Class,
-		exec,
-		tags,
-		parent,
+		*patch.Executable,
+		*patch.Tags,
+		nil,
 	)
+	if err != nil {
+		return
+	}
+
+	var parent *DirDoc
+	if newdoc.FolderID != olddoc.FolderID {
+		parent, err = newdoc.Parent(c)
+	} else {
+		parent = olddoc.parent
+	}
+
 	if err != nil {
 		return
 	}
 
 	newdoc.SetID(olddoc.ID())
 	newdoc.SetRev(olddoc.Rev())
-	newdoc.CreatedAt = olddoc.CreatedAt
-	newdoc.UpdatedAt = mdate
+	newdoc.CreatedAt = cdate
+	newdoc.UpdatedAt = *patch.UpdatedAt
+	newdoc.parent = parent
 
 	oldpath, err := olddoc.Path(c)
 	if err != nil {
@@ -471,8 +460,8 @@ func ModifyFileMetadata(c *Context, olddoc *FileDoc, data *DocMetaAttributes) (n
 		}
 	}
 
-	if exec != olddoc.Executable {
-		err = c.fs.Chmod(newpath, getFileMode(exec))
+	if newdoc.Executable != olddoc.Executable {
+		err = c.fs.Chmod(newpath, getFileMode(newdoc.Executable))
 		if err != nil {
 			return
 		}

--- a/vfs/file.go
+++ b/vfs/file.go
@@ -140,7 +140,7 @@ func NewFileDoc(name, folderID string, size int64, md5Sum []byte, mime, class st
 		folderID = RootFolderID
 	}
 
-	tags = appendTags(nil, tags)
+	tags = uniqueTags(tags)
 
 	createDate := time.Now()
 	doc = &FileDoc{

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -192,7 +192,7 @@ func checkFileName(str string) error {
 
 func uniqueTags(tags []string) []string {
 	m := make(map[string]struct{})
-	var clone []string
+	clone := make([]string, 0)
 	for _, tag := range tags {
 		tag = strings.TrimSpace(tag)
 		if tag == "" {

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -166,9 +166,6 @@ func normalizeDocPatch(data, patch *DocPatch, cdate time.Time) (*DocPatch, error
 
 	if patch.Tags == nil {
 		patch.Tags = data.Tags
-	} else {
-		newtags := appendTags(*data.Tags, *patch.Tags)
-		patch.Tags = &newtags
 	}
 
 	if patch.UpdatedAt == nil {
@@ -193,27 +190,18 @@ func checkFileName(str string) error {
 	return nil
 }
 
-func appendTags(oldtags, newtags []string) []string {
-	mtags := make(map[string]struct{})
-	var stags []string
-
-	addTag := func(tag string) {
+func uniqueTags(tags []string) []string {
+	m := make(map[string]struct{})
+	var clone []string
+	for _, tag := range tags {
 		tag = strings.TrimSpace(tag)
 		if tag == "" {
-			return
+			continue
 		}
-		if _, ok := mtags[tag]; !ok {
-			stags = append(stags, tag)
-			mtags[tag] = struct{}{}
+		if _, ok := m[tag]; !ok {
+			clone = append(clone, tag)
+			m[tag] = struct{}{}
 		}
 	}
-
-	for _, tag := range oldtags {
-		addTag(tag)
-	}
-	for _, tag := range newtags {
-		addTag(tag)
-	}
-
-	return stags
+	return clone
 }

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -215,9 +215,9 @@ func OverwriteFileContentHandler(c *gin.Context) {
 
 // @TODO: get rid of this with jsonapi package
 type jsonData struct {
-	Type  string                 `json:"type"`
-	ID    string                 `json:"id"`
-	Attrs *vfs.DocMetaAttributes `json:"attributes"`
+	Type  string        `json:"type"`
+	ID    string        `json:"id"`
+	Attrs *vfs.DocPatch `json:"attributes"`
 }
 
 type jsonDataContainer struct {

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -404,7 +404,7 @@ func TestModifyMetadataFileMove(t *testing.T) {
 	assert.True(t, ok)
 
 	attrs := map[string]interface{}{
-		"tags":       []string{"bar", "baz"},
+		"tags":       []string{"bar", "bar", "baz"},
 		"name":       "moved",
 		"folder_id":  folderID,
 		"executable": true,
@@ -421,7 +421,7 @@ func TestModifyMetadataFileMove(t *testing.T) {
 
 	assert.Equal(t, "text/plain", attrs3["mime"])
 	assert.Equal(t, "moved", attrs3["name"])
-	assert.EqualValues(t, []interface{}{"foo", "bar", "baz"}, attrs3["tags"])
+	assert.EqualValues(t, []interface{}{"bar", "baz"}, attrs3["tags"])
 	assert.Equal(t, "text", attrs3["class"])
 	assert.Equal(t, "rL0Y20zC+Fzt72VPzMSk2A==", attrs3["md5sum"])
 	assert.Equal(t, true, attrs3["executable"])

--- a/web/jsonapi/data.go
+++ b/web/jsonapi/data.go
@@ -62,6 +62,8 @@ type ObjectMarshalling struct {
 	Relationships RelationshipMap  `json:"relationships,omitempty"`
 }
 
+// GetRelationship returns the relationship with the given name from
+// the relationships map.
 func (o *ObjectMarshalling) GetRelationship(name string) (*Relationship, bool) {
 	rel, ok := o.Relationships[name]
 	if !ok {

--- a/web/jsonapi/jsonapi.go
+++ b/web/jsonapi/jsonapi.go
@@ -69,6 +69,8 @@ func AbortWithError(c *gin.Context, e *Error) {
 	c.Abort()
 }
 
+// Bind is used to unmarshal an input JSONApi document. It binds an
+// incoming request to a attribute type.
 func Bind(req *http.Request, attrs interface{}) (*ObjectMarshalling, error) {
 	decoder := json.NewDecoder(req.Body)
 	var doc *Document

--- a/web/jsonapi/jsonapi.go
+++ b/web/jsonapi/jsonapi.go
@@ -54,6 +54,8 @@ func Data(c *gin.Context, statusCode int, o Object, links *LinksList) {
 
 // AbortWithError can be called to abort the current http request/response
 // processing, and send an error in the JSON-API format
+//
+// TODO could be nice to have AbortWithErrors(c *gin.Context, errors ErrorList)
 func AbortWithError(c *gin.Context, e *Error) {
 	doc := Document{
 		Errors: ErrorList{e},
@@ -67,4 +69,18 @@ func AbortWithError(c *gin.Context, e *Error) {
 	c.Abort()
 }
 
-// TODO could be nice to have AbortWithErrors(c *gin.Context, errors ErrorList)
+func Bind(req *http.Request, attrs interface{}) (*ObjectMarshalling, error) {
+	decoder := json.NewDecoder(req.Body)
+	var doc *Document
+	if err := decoder.Decode(&doc); err != nil {
+		return nil, err
+	}
+	var obj *ObjectMarshalling
+	if err := json.Unmarshal(*doc.Data, &obj); err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(*obj.Attributes, &attrs); err != nil {
+		return nil, err
+	}
+	return obj, nil
+}

--- a/web/jsonapi/jsonapi.go
+++ b/web/jsonapi/jsonapi.go
@@ -77,9 +77,15 @@ func Bind(req *http.Request, attrs interface{}) (*ObjectMarshalling, error) {
 	if err := decoder.Decode(&doc); err != nil {
 		return nil, err
 	}
+	if doc.Data == nil {
+		return nil, BadJSON()
+	}
 	var obj *ObjectMarshalling
 	if err := json.Unmarshal(*doc.Data, &obj); err != nil {
 		return nil, err
+	}
+	if obj.Attributes == nil {
+		return nil, BadJSON()
 	}
 	if err := json.Unmarshal(*obj.Attributes, &attrs); err != nil {
 		return nil, err


### PR DESCRIPTION
**To merge after #61**

In current version of patching, the tags field was in append mode only. This had two bad side-effect, IMHO:
- stateful API
- impossible to remove or replace

I don't think we want to go to the [jsonpatch](http://jsonpatch.com/) path, so I just rely on a simple replace.

---

This PR also mutualise some code between dirs and files and removes some legacy code used to unmarshal jsonapi document. A `jsonapi.Bind` function has been introduced to do that.
