### PR TITLE
Add actual instances management

### DIFF
--- a/cmd/instance.go
+++ b/cmd/instance.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/cozy/cozy-stack/instance"
+	"github.com/spf13/cobra"
+)
+
+var flagLocale string
+var flagApps []string
+
+// serveCmd represents the serve command
+var instanceCmdGroup = &cobra.Command{
+	Use:   "instances [command]",
+	Short: "Manage instances of a stack",
+	Long: `
+cozy-stack instance allow to manage the instances of this stack
+
+An instance is a logical space owned by one user and identified by a domain.
+For example, bob.cozycloud.cc is the instance of Bob. A single cozy-stack
+process can manage several instances.
+
+Each instance has a separate space for storing files and a prefix used to
+create its CouchDB databases.
+	`,
+	Run: func(cmd *cobra.Command, args []string) { cmd.Help() },
+}
+
+var addInstanceCmd = &cobra.Command{
+	Use:   "add [domain]",
+	Short: "Manage instances of a stack",
+	Long: `
+cozy-stack instance add allows to create an instance on the cozy for a
+given domain.
+	`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := Configure(); err != nil {
+			return err
+		}
+
+		if len(args) == 0 {
+			return cmd.Help()
+		}
+
+		domain := args[0]
+
+		instance, err := instance.Create(domain, flagLocale, flagApps)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Instance created for domain %s:\n%v\n", instance, domain)
+		return nil
+	},
+}
+
+func init() {
+	instanceCmdGroup.AddCommand(addInstanceCmd)
+	addInstanceCmd.Flags().StringVar(&flagLocale, "locale", "en", "Locale of the new cozy instance")
+	addInstanceCmd.Flags().StringSliceVar(&flagApps, "apps", nil, "Apps to be preinstalled")
+	RootCmd.AddCommand(instanceCmdGroup)
+}

--- a/couchdb/couchdb.go
+++ b/couchdb/couchdb.go
@@ -269,6 +269,20 @@ func CreateNamedDoc(dbprefix string, doc Doc) (err error) {
 	return err
 }
 
+// CreateNamedDocWithDB is equivalent to CreateNamedDoc but creates the database
+// if it does not exist
+func CreateNamedDocWithDB(dbprefix string, doc Doc) (err error) {
+	err = CreateNamedDoc(dbprefix, doc)
+	if coucherr, ok := err.(*Error); ok && coucherr.Reason == "wrong_doctype" {
+		err = CreateDB(dbprefix, doc.DocType())
+		if err != nil {
+			return err
+		}
+		return CreateNamedDoc(dbprefix, doc)
+	}
+	return err
+}
+
 func createDocOrDb(dbprefix string, doc Doc, response interface{}) (err error) {
 	doctype := doc.DocType()
 	db := makeDBName(dbprefix, doctype)

--- a/debug.log
+++ b/debug.log
@@ -1,28 +1,0 @@
-[couchdb request] DELETE dev%2Fio-cozy-files 
-[couchdb request] PUT dev%2Fio-cozy-files 
-[couchdb request] POST dev%2Fio-cozy-files/_index {"index":{"fields":["folder_id","name"]}}
-[couchdb request] PUT dev%2Fio-cozy-files/io.cozy.files.rootdir {"type":"","_id":"io.cozy.files.rootdir","name":"","folder_id":"","created_at":"0001-01-01T00:00:00Z","updated_at":"0001-01-01T00:00:00Z","path":"/","tags":null}
-=== RUN   TestGetFileDocFromPathAtRoot
-[couchdb request] POST dev%2Fio-cozy-files {"type":"file","name":"toto","folder_id":"io.cozy.files.rootdir","created_at":"2016-11-02T15:39:41.073890175+01:00","updated_at":"2016-11-02T15:39:41.073890175+01:00","size":"7","md5sum":"MHm6zuV/0aAEzvWpObXh4A==","mime":"foo/bar","class":"foo","executable":false,"tags":[]}
-[couchdb request] POST dev%2Fio-cozy-files/_find {"selector":{"path":"/"},"limit":1}
-[couchdb request] POST dev%2Fio-cozy-files/_find {"selector":{"$and":[{"folder_id":"io.cozy.files.rootdir"},{"name":"toto"},{"type":"file"}]},"limit":1}
-[couchdb request] POST dev%2Fio-cozy-files/_find {"selector":{"path":"/"},"limit":1}
-[couchdb request] POST dev%2Fio-cozy-files/_find {"selector":{"$and":[{"folder_id":"io.cozy.files.rootdir"},{"name":"noooo"},{"type":"file"}]},"limit":1}
---- PASS: TestGetFileDocFromPathAtRoot (0.03s)
-=== RUN   TestGetFileDocFromPath
-[couchdb request] GET dev%2Fio-cozy-files/io.cozy.files.rootdir 
-[couchdb request] POST dev%2Fio-cozy-files {"type":"file","name":"toto","folder_id":"io.cozy.files.rootdir","created_at":"2016-11-02T15:39:41.111469439+01:00","updated_at":"2016-11-02T15:39:41.111469439+01:00","size":"7","md5sum":"MHm6zuV/0aAEzvWpObXh4A==","mime":"foo/bar","class":"foo","executable":false,"tags":[]}
-[couchdb request] POST dev%2Fio-cozy-files/_find {"selector":{"path":"/container"},"limit":1}
-[couchdb request] POST dev%2Fio-cozy-files/_find {"selector":{"path":"/container"},"limit":1}
---- FAIL: TestGetFileDocFromPath (0.03s)
-	assertions.go:241:                         	Error Trace:	vfs_test.go:49
-			Error:		Received unexpected error:
-			file does not exist
-		
-	assertions.go:241:                         	Error Trace:	vfs_test.go:67
-			Error:		Received unexpected error:
-			file does not exist
-		
-FAIL
-exit status 1
-FAIL	github.com/cozy/cozy-stack/vfs	0.165s

--- a/debug.log
+++ b/debug.log
@@ -1,0 +1,28 @@
+[couchdb request] DELETE dev%2Fio-cozy-files 
+[couchdb request] PUT dev%2Fio-cozy-files 
+[couchdb request] POST dev%2Fio-cozy-files/_index {"index":{"fields":["folder_id","name"]}}
+[couchdb request] PUT dev%2Fio-cozy-files/io.cozy.files.rootdir {"type":"","_id":"io.cozy.files.rootdir","name":"","folder_id":"","created_at":"0001-01-01T00:00:00Z","updated_at":"0001-01-01T00:00:00Z","path":"/","tags":null}
+=== RUN   TestGetFileDocFromPathAtRoot
+[couchdb request] POST dev%2Fio-cozy-files {"type":"file","name":"toto","folder_id":"io.cozy.files.rootdir","created_at":"2016-11-02T15:39:41.073890175+01:00","updated_at":"2016-11-02T15:39:41.073890175+01:00","size":"7","md5sum":"MHm6zuV/0aAEzvWpObXh4A==","mime":"foo/bar","class":"foo","executable":false,"tags":[]}
+[couchdb request] POST dev%2Fio-cozy-files/_find {"selector":{"path":"/"},"limit":1}
+[couchdb request] POST dev%2Fio-cozy-files/_find {"selector":{"$and":[{"folder_id":"io.cozy.files.rootdir"},{"name":"toto"},{"type":"file"}]},"limit":1}
+[couchdb request] POST dev%2Fio-cozy-files/_find {"selector":{"path":"/"},"limit":1}
+[couchdb request] POST dev%2Fio-cozy-files/_find {"selector":{"$and":[{"folder_id":"io.cozy.files.rootdir"},{"name":"noooo"},{"type":"file"}]},"limit":1}
+--- PASS: TestGetFileDocFromPathAtRoot (0.03s)
+=== RUN   TestGetFileDocFromPath
+[couchdb request] GET dev%2Fio-cozy-files/io.cozy.files.rootdir 
+[couchdb request] POST dev%2Fio-cozy-files {"type":"file","name":"toto","folder_id":"io.cozy.files.rootdir","created_at":"2016-11-02T15:39:41.111469439+01:00","updated_at":"2016-11-02T15:39:41.111469439+01:00","size":"7","md5sum":"MHm6zuV/0aAEzvWpObXh4A==","mime":"foo/bar","class":"foo","executable":false,"tags":[]}
+[couchdb request] POST dev%2Fio-cozy-files/_find {"selector":{"path":"/container"},"limit":1}
+[couchdb request] POST dev%2Fio-cozy-files/_find {"selector":{"path":"/container"},"limit":1}
+--- FAIL: TestGetFileDocFromPath (0.03s)
+	assertions.go:241:                         	Error Trace:	vfs_test.go:49
+			Error:		Received unexpected error:
+			file does not exist
+		
+	assertions.go:241:                         	Error Trace:	vfs_test.go:67
+			Error:		Received unexpected error:
+			file does not exist
+		
+FAIL
+exit status 1
+FAIL	github.com/cozy/cozy-stack/vfs	0.165s

--- a/docs/instance.md
+++ b/docs/instance.md
@@ -100,7 +100,7 @@ Renaming
 An instance is renamed through the command line.
 
 ```sh
-$ cozy-stack rename <olddomain> <newdomain>
+$ cozy-stack instances rename <olddomain> <newdomain>
 ```
 
 Renaming an instance only change the HostName in global/instances base.
@@ -115,5 +115,5 @@ An instance is destroyed through the command line.
 A confirmation is asked from the CLI user unless the --yes flag is passed
 
 ```sh
-$ cozy-stack destroy <domain>
+$ cozy-stack instances destroy <domain>
 ```

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -54,7 +54,7 @@ func (i *Instance) createInCouchdb() (err error) {
 	return couchdb.DefineIndex(globalDBPrefix, instanceType, byDomain)
 }
 
-// CreateRootFolder creates the root folder for this instance
+// createRootFolder creates the root folder for this instance
 func (i *Instance) createRootFolder() error {
 	root := vfs.MakeRoot()
 	prefix := i.GetDatabasePrefix()
@@ -66,7 +66,7 @@ func (i *Instance) createRootFolder() error {
 	// TODO (vfs) should we also create the root folder on FS ?
 }
 
-// CreateRootFolder creates the root folder for this instance
+// createFSIndexes creates the index needed by VFS
 func (i *Instance) createFSIndexes() (err error) {
 	prefix := i.GetDatabasePrefix()
 	byParent := mango.IndexOnFields("folder_id", "name", "type")
@@ -76,10 +76,7 @@ func (i *Instance) createFSIndexes() (err error) {
 		return err
 	}
 	err = couchdb.DefineIndex(prefix, vfs.FsDocType, byPath)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // Create contains the whole process involved in creating an instance

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -1,0 +1,167 @@
+package instance
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/cozy/cozy-stack/couchdb"
+	"github.com/cozy/cozy-stack/couchdb/mango"
+	"github.com/cozy/cozy-stack/vfs"
+	"github.com/spf13/afero"
+)
+
+const globalDBPrefix = "global/"
+const instanceType = "instances"
+
+// An Instance has the informations relatives to the logical cozy instance,
+// like the domain, the locale or the access to the databases and files storage
+// It is a couchdb.Doc to be persisted in couchdb.
+type Instance struct {
+	DocID      string `json:"_id,omitempty"`  // couchdb _id
+	DocRev     string `json:"_rev,omitempty"` // couchdb _rev
+	Domain     string `json:"domain"`         // The main DNS domain, like example.cozycloud.cc
+	StorageURL string `json:"storage"`        // Where the binaries are persisted
+	storage    afero.Fs
+}
+
+// DocType implements couchdb.Doc
+func (i *Instance) DocType() string { return instanceType }
+
+// ID implements couchdb.Doc
+func (i *Instance) ID() string { return i.DocID }
+
+// SetID implements couchdb.Doc
+func (i *Instance) SetID(v string) { i.DocID = v }
+
+// Rev implements couchdb.Doc
+func (i *Instance) Rev() string { return i.DocRev }
+
+// SetRev implements couchdb.Doc
+func (i *Instance) SetRev(v string) { i.DocRev = v }
+
+// ensure Instance implements couchdb.Doc
+var _ couchdb.Doc = (*Instance)(nil)
+
+// CreateInCouchdb create the instance doc in the global database
+func (i *Instance) createInCouchdb() (err error) {
+	err = couchdb.CreateDoc(globalDBPrefix, i)
+	if err != nil {
+		return err
+	}
+	byDomain := mango.IndexOnFields("domain")
+	return couchdb.DefineIndex(globalDBPrefix, instanceType, byDomain)
+}
+
+// CreateRootFolder creates the root folder for this instance
+func (i *Instance) createRootFolder() error {
+	root := vfs.MakeRoot()
+	prefix := i.GetDatabasePrefix()
+	err := couchdb.CreateDB(prefix, root.DocType())
+	if err != nil {
+		return err
+	}
+	return couchdb.CreateNamedDoc(prefix, root)
+	// TODO (vfs) should we also create the root folder on FS ?
+}
+
+// CreateRootFolder creates the root folder for this instance
+func (i *Instance) createFSIndexes() (err error) {
+	prefix := i.GetDatabasePrefix()
+	byParent := mango.IndexOnFields("folder_id", "name", "type")
+	byPath := mango.IndexOnFields("path")
+	err = couchdb.DefineIndex(prefix, vfs.FsDocType, byParent)
+	if err != nil {
+		return err
+	}
+	err = couchdb.DefineIndex(prefix, vfs.FsDocType, byPath)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Create contains the whole process involved in creating an instance
+func Create(domain string, locale string, apps []string) (*Instance, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	storageURL := "file://localhost" + wd + "/" + domain + "/"
+
+	i := &Instance{
+		Domain:     domain,
+		StorageURL: storageURL,
+	}
+	if err := i.createInCouchdb(); err != nil {
+		return nil, err
+	}
+	if err := i.createRootFolder(); err != nil {
+		return nil, err
+	}
+	if err := i.createFSIndexes(); err != nil {
+		return nil, err
+	}
+
+	// TODO figure out what to do with locale
+	// TODO install apps
+
+	return i, nil
+}
+
+// Get retrieves the instance for a request by its host.
+func Get(domainarg string) (*Instance, error) {
+	domain := domainarg
+	// TODO this is not fail-safe, to be modified before production
+	if domain == "" || strings.Contains(domain, "127.0.0.1") || strings.Contains(domain, "localhost") {
+		domain = "dev"
+	}
+
+	var instances []*Instance
+	req := &couchdb.FindRequest{
+		Selector: mango.Equal("domain", domain),
+		Limit:    1,
+	}
+	err := couchdb.FindDocs(globalDBPrefix, instanceType, req, &instances)
+	if couchdb.IsNoDatabaseError(err) {
+		return nil, fmt.Errorf("No instance for domain %v, use 'cozy-stack instance add'", domain)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if len(instances) == 0 {
+		return nil, fmt.Errorf("No instance for domain %v, use 'cozy-stack instance add'", domain)
+	}
+
+	return instances[0], nil
+
+}
+
+// GetStorageProvider returns the afero storage provider where the binaries for
+// the current instance are persisted
+func (i *Instance) GetStorageProvider() (afero.Fs, error) {
+	if i.storage != nil {
+		return i.storage, nil
+	}
+	u, err := url.Parse(i.StorageURL)
+	if err != nil {
+		return nil, err
+	}
+	switch u.Scheme {
+	case "file":
+		i.storage = afero.NewBasePathFs(afero.NewOsFs(), u.Path)
+	case "mem":
+		i.storage = afero.NewMemMapFs()
+	default:
+		return nil, fmt.Errorf("Unknown storage provider: %v", u.Scheme)
+	}
+	return i.storage, nil
+}
+
+// GetDatabasePrefix returns the prefix to use in database naming for the
+// current instance
+func (i *Instance) GetDatabasePrefix() string {
+	return i.Domain + "/"
+}

--- a/instance/instance_test.go
+++ b/instance/instance_test.go
@@ -51,7 +51,7 @@ func TestInstanceHasRootFolder(t *testing.T) {
 	prefix := getDBPrefix(t, "test.cozycloud.cc")
 	err := couchdb.GetDoc(prefix, vfs.FsDocType, vfs.RootFolderID, &root)
 	if assert.NoError(t, err) {
-		assert.Equal(t, root.Path, "/")
+		assert.Equal(t, root.Fullpath, "/")
 	}
 }
 
@@ -75,7 +75,7 @@ func TestMain(m *testing.M) {
 	}
 	couchdb.DeleteDB(globalDBPrefix, instanceType)
 	couchdb.DeleteDB("test.cozycloud.cc/", vfs.FsDocType)
-	// ignore err, it is expected
+	os.RemoveAll("/usr/local/var/cozy2/")
 
 	os.Exit(m.Run())
 }

--- a/instance/instance_test.go
+++ b/instance/instance_test.go
@@ -1,0 +1,89 @@
+package instance
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cozy/cozy-stack/couchdb"
+	"github.com/cozy/cozy-stack/couchdb/mango"
+	"github.com/cozy/cozy-stack/vfs"
+	"github.com/sourcegraph/checkup"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetInstanceNoDB(t *testing.T) {
+	instance, err := Get("no.instance.cozycloud.cc")
+	if assert.Error(t, err, "An error is expected") {
+		assert.Nil(t, instance)
+		assert.Contains(t, err.Error(), "No instance", "the error is not explicit")
+		assert.Contains(t, err.Error(), "no.instance.cozycloud.cc", "the error is not explicit")
+	}
+}
+
+func TestCreateInstance(t *testing.T) {
+	instance, err := Create("test.cozycloud.cc", "en", nil)
+	if assert.NoError(t, err) {
+		assert.NotEmpty(t, instance.ID())
+		assert.Equal(t, instance.Domain, "test.cozycloud.cc")
+	}
+}
+
+func TestGetWrongInstance(t *testing.T) {
+	instance, err := Get("no.instance.cozycloud.cc")
+	if assert.Error(t, err, "An error is expected") {
+		assert.Nil(t, instance)
+		assert.Contains(t, err.Error(), "No instance", "the error is not explicit")
+		assert.Contains(t, err.Error(), "no.instance.cozycloud.cc", "the error is not explicit")
+	}
+}
+
+func TestGetCorrectInstance(t *testing.T) {
+	instance, err := Get("test.cozycloud.cc")
+	if assert.NoError(t, err, "An error is expected") {
+		assert.NotNil(t, instance)
+		assert.Equal(t, instance.Domain, "test.cozycloud.cc")
+	}
+}
+
+func TestInstanceHasRootFolder(t *testing.T) {
+	var root vfs.DirDoc
+	prefix := getDBPrefix(t, "test.cozycloud.cc")
+	err := couchdb.GetDoc(prefix, vfs.FsDocType, vfs.RootFolderID, &root)
+	if assert.NoError(t, err) {
+		assert.Equal(t, root.Path, "/")
+	}
+}
+
+func TestInstanceHasIndexes(t *testing.T) {
+	var results []*vfs.DirDoc
+	prefix := getDBPrefix(t, "test.cozycloud.cc")
+	req := &couchdb.FindRequest{Selector: mango.Equal("path", "/")}
+	err := couchdb.FindDocs(prefix, vfs.FsDocType, req, &results)
+	assert.NoError(t, err)
+	assert.Len(t, results, 1)
+}
+
+func TestMain(m *testing.M) {
+	const CouchDBURL = "http://localhost:5984/"
+	const TestPrefix = "dev/"
+
+	db, err := checkup.HTTPChecker{URL: CouchDBURL}.Check()
+	if err != nil || db.Status() != checkup.Healthy {
+		fmt.Println("This test need couchdb to run.")
+		os.Exit(1)
+	}
+	couchdb.DeleteDB(globalDBPrefix, instanceType)
+	couchdb.DeleteDB("test.cozycloud.cc/", vfs.FsDocType)
+	// ignore err, it is expected
+
+	os.Exit(m.Run())
+}
+
+func getDBPrefix(t *testing.T, domain string) string {
+	instance, err := Get(domain)
+	if !assert.NoError(t, err, "Should get instance %v", domain) {
+		t.FailNow()
+	}
+	return instance.GetDatabasePrefix()
+}

--- a/vfs/directory.go
+++ b/vfs/directory.go
@@ -253,6 +253,27 @@ func CreateDirectory(c *Context, doc *DirDoc) (err error) {
 	return couchdb.CreateDoc(c.db, doc)
 }
 
+// CreateRootDirectory creates the root folder for this context
+func CreateRootDirectory(c *Context) (err error) {
+	root := &DirDoc{
+		Type:     DirType,
+		ObjID:    RootFolderID,
+		Fullpath: "/",
+	}
+	err = c.fs.MkdirAll(root.Fullpath, 0755)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if err != nil {
+			c.fs.Remove(root.Fullpath)
+		}
+	}()
+
+	return couchdb.CreateNamedDocWithDB(c.db, root)
+}
+
 // ModifyDirectoryMetadata modify the metadata associated to a
 // directory. It can be used to rename or move the directory in the
 // VFS.

--- a/vfs/directory.go
+++ b/vfs/directory.go
@@ -170,10 +170,6 @@ func NewDirDoc(name, folderID string, tags []string, parent *DirDoc) (doc *DirDo
 		folderID = RootFolderID
 	}
 
-	if folderID == RootFolderID && parent == nil {
-		parent = getRootDirDoc()
-	}
-
 	tags = uniqueTags(tags)
 
 	createDate := time.Now()
@@ -195,9 +191,6 @@ func NewDirDoc(name, folderID string, tags []string, parent *DirDoc) (doc *DirDo
 // GetDirDoc is used to fetch directory document information
 // form the database.
 func GetDirDoc(c *Context, fileID string, withChildren bool) (*DirDoc, error) {
-	if fileID == RootFolderID {
-		return getRootDirDoc(), nil
-	}
 	doc := &DirDoc{}
 	err := couchdb.GetDoc(c.db, FsDocType, fileID, doc)
 	if couchdb.IsNotFoundError(err) {
@@ -220,21 +213,19 @@ func GetDirDoc(c *Context, fileID string, withChildren bool) (*DirDoc, error) {
 func GetDirDocFromPath(c *Context, pth string, withChildren bool) (*DirDoc, error) {
 	var doc *DirDoc
 	var err error
-	if pth == "/" {
-		doc = getRootDirDoc()
-	} else {
-		var docs []*DirDoc
-		sel := mango.Equal("path", path.Clean(pth))
-		req := &couchdb.FindRequest{Selector: sel, Limit: 1}
-		err = couchdb.FindDocs(c.db, FsDocType, req, &docs)
-		if err != nil {
-			return nil, err
-		}
-		if len(docs) == 0 {
-			return nil, os.ErrNotExist
-		}
-		doc = docs[0]
+
+	var docs []*DirDoc
+	sel := mango.Equal("path", path.Clean(pth))
+	req := &couchdb.FindRequest{Selector: sel, Limit: 1}
+	err = couchdb.FindDocs(c.db, FsDocType, req, &docs)
+	if err != nil {
+		return nil, err
 	}
+	if len(docs) == 0 {
+		return nil, os.ErrNotExist
+	}
+	doc = docs[0]
+
 	if withChildren {
 		err = doc.FetchFiles(c)
 	}

--- a/vfs/file.go
+++ b/vfs/file.go
@@ -184,11 +184,7 @@ func GetFileDocFromPath(c *Context, pth string) (*FileDoc, error) {
 
 	dirpath := path.Dir(pth)
 	var parent *DirDoc
-	if dirpath == "/" {
-		parent = getRootDirDoc()
-	} else {
-		parent, err = GetDirDocFromPath(c, dirpath, false)
-	}
+	parent, err = GetDirDocFromPath(c, dirpath, false)
 
 	if err != nil {
 		return nil, err

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -158,6 +158,14 @@ func getRootDirDoc() *DirDoc {
 	}
 }
 
+// MakeRoot returns a new instance of a DirDoc usable as root
+func MakeRoot() *DirDoc {
+	return &DirDoc{
+		ObjID:    RootFolderID,
+		Fullpath: "/",
+	}
+}
+
 func normalizeDocPatch(data, patch *DocPatch, cdate time.Time) (*DocPatch, error) {
 	if patch.FolderID == nil {
 		patch.FolderID = data.FolderID

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -140,14 +140,6 @@ func getParentDir(c *Context, parent *DirDoc, folderID string) (*DirDoc, error) 
 	return parent, err
 }
 
-// MakeRoot returns a new instance of a DirDoc usable as root
-func MakeRoot() *DirDoc {
-	return &DirDoc{
-		ObjID:    RootFolderID,
-		Fullpath: "/",
-	}
-}
-
 func normalizeDocPatch(data, patch *DocPatch, cdate time.Time) (*DocPatch, error) {
 	if patch.FolderID == nil {
 		patch.FolderID = data.FolderID

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -81,11 +81,6 @@ func (fd *dirOrFile) refine() (typ string, dir *DirDoc, file *FileDoc) {
 // GetDirOrFileDoc is used to fetch a document from its identifier
 // without knowing in advance its type.
 func GetDirOrFileDoc(c *Context, fileID string, withChildren bool) (typ string, dirDoc *DirDoc, fileDoc *FileDoc, err error) {
-	if fileID == RootFolderID {
-		typ, dirDoc = DirType, getRootDirDoc()
-		return
-	}
-
 	dirOrFile := &dirOrFile{}
 	err = couchdb.GetDoc(c.db, FsDocType, fileID, dirOrFile)
 	if err != nil {
@@ -141,21 +136,8 @@ func getParentDir(c *Context, parent *DirDoc, folderID string) (*DirDoc, error) 
 		return parent, nil
 	}
 	var err error
-	if folderID == RootFolderID {
-		parent = getRootDirDoc()
-	} else {
-		parent, err = GetDirDoc(c, folderID, false)
-	}
+	parent, err = GetDirDoc(c, folderID, false)
 	return parent, err
-}
-
-// @TODO: do a fetch from couchdb when instance creation is ok.
-func getRootDirDoc() *DirDoc {
-	return &DirDoc{
-		ObjID:    RootFolderID,
-		ObjRev:   "1-",
-		Fullpath: "/",
-	}
 }
 
 // MakeRoot returns a new instance of a DirDoc usable as root

--- a/vfs/vfs_test.go
+++ b/vfs/vfs_test.go
@@ -90,6 +90,11 @@ func TestMain(m *testing.M) {
 	fs := afero.NewMemMapFs()
 
 	vfsC = NewContext(fs, TestPrefix)
+	err = CreateRootDirectory(vfsC)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 
 	os.Exit(m.Run())
 }

--- a/web/data/data_test.go
+++ b/web/data/data_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/cozy/cozy-stack/couchdb"
+	"github.com/cozy/cozy-stack/instance"
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/gin-gonic/gin"
 	"github.com/sourcegraph/checkup"
@@ -97,7 +98,7 @@ func doRequest(req *http.Request, out interface{}) (jsonres map[string]interface
 
 }
 
-func injectInstance(instance *middlewares.Instance) gin.HandlerFunc {
+func injectInstance(instance *instance.Instance) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		c.Set("instance", instance)
 	}
@@ -118,7 +119,7 @@ func TestMain(m *testing.M) {
 	}
 
 	gin.SetMode(gin.TestMode)
-	instance := &middlewares.Instance{
+	instance := &instance.Instance{
 		Domain:     Host,
 		StorageURL: "mem://test",
 	}

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -425,13 +425,11 @@ func WrapVfsError(err error) *jsonapi.Error {
 
 func getVfsContext(c *gin.Context) (*vfs.Context, error) {
 	instance := middlewares.GetInstance(c)
-	dbprefix := instance.GetDatabasePrefix()
-	fs, err := instance.GetStorageProvider()
+	vfsC, err := instance.GetVFSContext()
 	if err != nil {
 		jsonapi.AbortWithError(c, jsonapi.InternalServerError(err))
 		return nil, err
 	}
-	vfsC := vfs.NewContext(fs, dbprefix)
 	return vfsC, nil
 }
 

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -871,6 +871,7 @@ func TestMain(m *testing.M) {
 		Domain:     "test",
 		StorageURL: "file://localhost" + tempdir,
 	}
+	testInstance.Create()
 
 	router := gin.New()
 	router.Use(injectInstance(testInstance))

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -531,7 +531,7 @@ func TestModifyMetadataDirMoveWithRel(t *testing.T) {
 	res3, _ := patchFile(t, "/files/"+folder1ID, "io.cozy.folders", folder1ID, nil, parent)
 	assert.Equal(t, 200, res3.StatusCode)
 
-	storage, _ := instance.GetStorageProvider()
+	storage, _ := testInstance.GetStorageProvider()
 	exists, err := afero.DirExists(storage, "/dirmodmemoveinmewithrel/dirmodmewithrel")
 	assert.NoError(t, err)
 	assert.True(t, exists)

--- a/web/middlewares/instance.go
+++ b/web/middlewares/instance.go
@@ -3,76 +3,26 @@
 package middlewares
 
 import (
-	"fmt"
-	"net/url"
-	"os"
-	"strings"
-
+	"github.com/cozy/cozy-stack/instance"
 	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/gin-gonic/gin"
-	"github.com/spf13/afero"
 )
-
-// An Instance has the informations relatives to the logical cozy instance,
-// like the domain, the locale or the access to the databases and files storage
-type Instance struct {
-	Domain     string // The main DNS domain, like example.cozycloud.cc
-	StorageURL string // Where the binaries are persisted
-	storage    afero.Fs
-}
-
-// GetStorageProvider returns the afero storage provider where the binaries for
-// the current instance are persisted
-func (instance *Instance) GetStorageProvider() (afero.Fs, error) {
-	if instance.storage != nil {
-		return instance.storage, nil
-	}
-	u, err := url.Parse(instance.StorageURL)
-	if err != nil {
-		return nil, err
-	}
-	switch u.Scheme {
-	case "file":
-		instance.storage = afero.NewBasePathFs(afero.NewOsFs(), u.Path)
-	case "mem":
-		instance.storage = afero.NewMemMapFs()
-	default:
-		return nil, fmt.Errorf("Unknown storage provider: %v", u.Scheme)
-	}
-	return instance.storage, nil
-}
-
-// GetDatabasePrefix returns the prefix to use in database naming for the
-// current instance
-func (instance *Instance) GetDatabasePrefix() string {
-	return instance.Domain + "/"
-}
 
 // SetInstance creates a gin middleware to put the instance in the gin context
 // for next handlers
 func SetInstance() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		domain := c.Request.Host
-		// TODO this is not fail-safe, to be modified before production
-		if domain == "" || strings.Contains(c.Request.Host, "127.0.0.1") || strings.Contains(c.Request.Host, "localhost") {
-			domain = "dev"
-		}
-		wd, err := os.Getwd()
+		i, err := instance.Get(c.Request.Host)
 		if err != nil {
 			jsonapi.AbortWithError(c, jsonapi.InternalServerError(err))
 			return
 		}
-		storageURL := "file://localhost" + wd + "/" + domain + "/"
-		instance := &Instance{
-			Domain:     domain,
-			StorageURL: storageURL,
-		}
-		c.Set("instance", instance)
+		c.Set("instance", i)
 	}
 }
 
 // GetInstance will return the instance linked to the given gin
 // context or panic if none exists
-func GetInstance(c *gin.Context) *Instance {
-	return c.MustGet("instance").(*Instance)
+func GetInstance(c *gin.Context) *instance.Instance {
+	return c.MustGet("instance").(*instance.Instance)
 }

--- a/web/middlewares/instance_test.go
+++ b/web/middlewares/instance_test.go
@@ -6,13 +6,14 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cozy/cozy-stack/instance"
 	"github.com/gin-gonic/gin"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGetStorageProvider(t *testing.T) {
-	instance := Instance{
+	instance := instance.Instance{
 		Domain:     "test.cozycloud.cc",
 		StorageURL: "mem://test",
 	}
@@ -36,7 +37,7 @@ func TestSetInstance(t *testing.T) {
 	router.GET("/", func(c *gin.Context) {
 		instanceInterface, exists := c.Get("instance")
 		assert.True(t, exists, "the instance should have been set in the gin context")
-		instance := instanceInterface.(*Instance)
+		instance := instanceInterface.(*instance.Instance)
 		assert.Equal(t, "dev", instance.Domain, "the domain should have been set in the instance")
 		storage, err := instance.GetStorageProvider()
 		assert.NoError(t, err)


### PR DESCRIPTION
- Instances are created through the CLI
- Instances are stored in a Couchdb DB named global/instances
- When an instances is created, we also create vfs root directory and vfs indexes.
- If there is no instance for the request's Host header, an error is returned (exception for localhost -> dev)

@jinroh I did not change the several places where you commented about the root folder. Let's discuss next week. 

**FUTURE**
- Handle subdomains (someapp.bob.cozycloud.cc)
- Move creation of `global/instances byDomain` request into stack initialization (Not a priority, win a few ms on instance creation ...)
