### PR TITLE
Add mango selector with multiple keys/values

### DIFF
--- a/vfs/file.go
+++ b/vfs/file.go
@@ -189,11 +189,11 @@ func GetFileDocFromPath(c *Context, name string) (*FileDoc, error) {
 	}
 
 	folderID := parent.ID()
-	selector := mango.And(
-		mango.Equal("folder_id", folderID),
-		mango.Equal("name", path.Base(name)),
-		mango.Equal("type", FileType),
-	)
+	selector := mango.Map{
+		"folder_id": folderID,
+		"name":      path.Base(name),
+		"type":      FileType,
+	}
 
 	var docs []*FileDoc
 	req := &couchdb.FindRequest{


### PR DESCRIPTION
This PR add the possibility to pass a map of key / values as a mango selector (instead of having to do a `And{Eq, Eq, ...}`)

Note: `$eq` selector is [equivalent](https://docs.mongodb.com/manual/reference/operator/query/eq/) to `{ field: value }` object 