### PR TITLE
Move mango indexes definition inside VFS package

### DIFF
--- a/cmd/instance.go
+++ b/cmd/instance.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/cozy/cozy-stack/instance"
 	"github.com/spf13/cobra"
@@ -49,7 +51,7 @@ given domain.
 			return err
 		}
 
-		log.Infof("Instance created for domain %s", domain)
+		fmt.Printf("Instance created with success for domain %s\n", domain)
 		log.Debugf("> %v", instance)
 		return nil
 	},

--- a/couchdb/couchdb.go
+++ b/couchdb/couchdb.go
@@ -325,7 +325,7 @@ func CreateDoc(dbprefix string, doc Doc) (err error) {
 
 // DefineIndex define the index on the doctype database
 // see query package on how to define an index
-func DefineIndex(dbprefix, doctype string, index mango.IndexDefinitionRequest) error {
+func DefineIndex(dbprefix, doctype string, index mango.Index) error {
 	url := makeDBName(dbprefix, doctype) + "/_index"
 	var response indexCreationResponse
 	return makeRequest("POST", url, &index, &response)

--- a/couchdb/mango/index.go
+++ b/couchdb/mango/index.go
@@ -11,12 +11,6 @@ func (def IndexFields) MarshalJSON() ([]byte, error) {
 	return json.Marshal(makeMap("fields", []string(def)))
 }
 
-// NewIndexFields returns an IndexFields from a list of string
-// arguments
-func NewIndexFields(fields ...string) IndexFields {
-	return IndexFields(fields)
-}
-
 // An Index is a request to be POSTED to create the index
 type Index struct {
 	Name  string      `json:"name,omitempty"`

--- a/couchdb/mango/index.go
+++ b/couchdb/mango/index.go
@@ -2,26 +2,32 @@ package mango
 
 import "encoding/json"
 
-// An IndexDefinition is just a list of fields to be indexed.
-type IndexDefinition []string
+// An IndexFields is just a list of fields to be indexed.
+type IndexFields []string
 
-// MarshalJSON implements the json.Marshaller interface on IndexDefinition
+// MarshalJSON implements the json.Marshaller interface on IndexFields
 // by wrapping it in a {"fields": ...}
-func (def IndexDefinition) MarshalJSON() ([]byte, error) {
+func (def IndexFields) MarshalJSON() ([]byte, error) {
 	return json.Marshal(makeMap("fields", []string(def)))
 }
 
-// An IndexDefinitionRequest is a request to be POSTED to create the index
-type IndexDefinitionRequest struct {
-	Name  string          `json:"name,omitempty"`
-	DDoc  string          `json:"ddoc,omitempty"`
-	Index IndexDefinition `json:"index"`
+// NewIndexFields returns an IndexFields from a list of string
+// arguments
+func NewIndexFields(fields ...string) IndexFields {
+	return IndexFields(fields)
 }
 
-// IndexOnFields constructs a new IndexDefinitionRequest
+// An Index is a request to be POSTED to create the index
+type Index struct {
+	Name  string      `json:"name,omitempty"`
+	DDoc  string      `json:"ddoc,omitempty"`
+	Index IndexFields `json:"index"`
+}
+
+// IndexOnFields constructs a new Index
 // it lets couchdb defaults for index & designdoc names.
-func IndexOnFields(fields ...string) IndexDefinitionRequest {
-	return IndexDefinitionRequest{
-		Index: IndexDefinition(fields),
+func IndexOnFields(fields ...string) Index {
+	return Index{
+		Index: IndexFields(fields),
 	}
 }

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -63,16 +63,15 @@ func (i *Instance) createRootFolder() error {
 }
 
 // createFSIndexes creates the index needed by VFS
-func (i *Instance) createFSIndexes() (err error) {
+func (i *Instance) createFSIndexes() error {
 	prefix := i.GetDatabasePrefix()
-	byParent := mango.IndexOnFields("folder_id", "name", "type")
-	byPath := mango.IndexOnFields("path")
-	err = couchdb.DefineIndex(prefix, vfs.FsDocType, byParent)
-	if err != nil {
-		return err
+	for _, index := range vfs.Indexes {
+		err := couchdb.DefineIndex(prefix, vfs.FsDocType, index)
+		if err != nil {
+			return err
+		}
 	}
-	err = couchdb.DefineIndex(prefix, vfs.FsDocType, byPath)
-	return err
+	return nil
 }
 
 // Create build an instance and .Create it

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -19,21 +19,12 @@ import (
 
 // Indexes is the list of required indexes by the VFS inside CouchDB.
 var Indexes = []mango.Index{
-	mango.Index{
-		Name:  "FileFromParent",
-		DDoc:  "used to lookup a file given its parent",
-		Index: mango.NewIndexFields("folder_id", "name", "type"),
-	},
-	mango.Index{
-		Name:  "DirectoryPath",
-		DDoc:  "used to lookup a directory given its path",
-		Index: mango.NewIndexFields("path"),
-	},
-	mango.Index{
-		Name:  "DirectoryChildren",
-		DDoc:  "used to lookup children of a directory",
-		Index: mango.NewIndexFields("folder_id"),
-	},
+	// Used to lookup a file given its parent
+	mango.IndexOnFields("folder_id", "name", "type"),
+	// Used to lookup a directory given its path
+	mango.IndexOnFields("path"),
+	// Used to lookup children of a directory
+	mango.IndexOnFields("folder_id"),
 }
 
 // DefaultContentType is used for files uploaded with no content-type

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -13,8 +13,28 @@ import (
 	"time"
 
 	"github.com/cozy/cozy-stack/couchdb"
+	"github.com/cozy/cozy-stack/couchdb/mango"
 	"github.com/spf13/afero"
 )
+
+// Indexes is the list of required indexes by the VFS inside CouchDB.
+var Indexes = []mango.Index{
+	mango.Index{
+		Name:  "FileFromParent",
+		DDoc:  "used to lookup a file given its parent",
+		Index: mango.NewIndexFields("folder_id", "name", "type"),
+	},
+	mango.Index{
+		Name:  "DirectoryPath",
+		DDoc:  "used to lookup a directory given its path",
+		Index: mango.NewIndexFields("path"),
+	},
+	mango.Index{
+		Name:  "DirectoryChildren",
+		DDoc:  "used to lookup children of a directory",
+		Index: mango.NewIndexFields("folder_id"),
+	},
+}
 
 // DefaultContentType is used for files uploaded with no content-type
 const DefaultContentType = "application/octet-stream"

--- a/vfs/vfs_test.go
+++ b/vfs/vfs_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/cozy/cozy-stack/couchdb"
-	"github.com/cozy/cozy-stack/couchdb/mango"
 	"github.com/sourcegraph/checkup"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -81,10 +80,13 @@ func TestMain(m *testing.M) {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	err = couchdb.DefineIndex(TestPrefix, FsDocType, mango.IndexOnFields("folder_id", "name"))
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+
+	for _, index := range Indexes {
+		err = couchdb.DefineIndex(TestPrefix, FsDocType, index)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
 	}
 
 	fs := afero.NewMemMapFs()

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -865,10 +865,18 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	err = couchdb.ResetDB(TestPrefix, string(vfs.FsDocType))
+	err = couchdb.ResetDB(TestPrefix, vfs.FsDocType)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
+	}
+
+	for _, index := range vfs.Indexes {
+		err = couchdb.DefineIndex(TestPrefix, vfs.FsDocType, index)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
 	}
 
 	tempdir, err := ioutil.TempDir("", "cozy-stack")


### PR DESCRIPTION
This PR main goal is to have the definition of all VFS indexes directly inside the vfs package. This helps for tests and, IMHO, is clearer.

@aenario I changed a few of the names in `mango/index`, if you ok with that ? :
  - `s/IndexDefinition/IndexFields/`
  - `s/IndexDefinitionRequest/Index/`