### PR TITLE
Unify Contexts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /storage
 swagger-ui
 /.cozy
+*.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
   - curl -X PUT http://127.0.0.1:5984/{_users,_replicator,_global_changes}
   - go get -u github.com/alecthomas/gometalinter
   - gometalinter --install --update
-  - gometalinter --deadline 120s --dupl-threshold 70 -D errcheck -D gocyclo ./...
+  - gometalinter --deadline 120s --dupl-threshold 70 -D interfacer -D errcheck -D gocyclo ./...
 
 after_failure:
   - docker ps -a

--- a/apps/apps.go
+++ b/apps/apps.go
@@ -139,13 +139,13 @@ type Client interface {
 	FetchManifest() (io.ReadCloser, error)
 	// Fetch should download the application and install it in the given
 	// directory.
-	Fetch(vfsC *vfs.Context, appdir string) error
+	Fetch(vfsC vfs.Context, appdir string) error
 }
 
 // List returns the list of installed applications.
 //
 // TODO: pagination
-func List(db string) ([]*Manifest, error) {
+func List(db couchdb.Database) ([]*Manifest, error) {
 	var docs []*Manifest
 	sel := mango.Empty()
 	req := &couchdb.FindRequest{Selector: sel, Limit: 10}
@@ -161,8 +161,8 @@ type Installer struct {
 	cli Client
 
 	// TODO: fix this mess with contexts
-	db   string
-	vfsC *vfs.Context
+	db   couchdb.Database
+	vfsC vfs.Context
 
 	slug string
 	src  string
@@ -175,7 +175,7 @@ type Installer struct {
 
 // NewInstaller creates a new Installer
 // @TODO: fix this mess with contexts
-func NewInstaller(vfsC *vfs.Context, db, slug, src string) (*Installer, error) {
+func NewInstaller(vfsC vfs.Context, db couchdb.Database, slug, src string) (*Installer, error) {
 	if !slugReg.MatchString(slug) {
 		return nil, ErrInvalidSlugName
 	}
@@ -244,7 +244,7 @@ func (i *Installer) Install() (newman *Manifest, err error) {
 	}
 
 	appdir := path.Join(AppsDirectory, newman.Slug)
-	err = i.vfsC.MkdirAll(appdir)
+	err = vfs.MkdirAll(i.vfsC, appdir)
 	if err != nil {
 		return
 	}

--- a/couchdb/couchdb.go
+++ b/couchdb/couchdb.go
@@ -32,6 +32,20 @@ type Database interface {
 	Prefix() string
 }
 
+// SimpleDatabase implements the Database interface
+type simpleDB struct{ prefix string }
+
+// Prefix implements the Database interface on simpleDB
+func (sdb *simpleDB) Prefix() string { return sdb.prefix + "/" }
+
+// SimpleDatabasePrefix returns a Database from a prefix, useful for test
+func SimpleDatabasePrefix(prefix string) Database {
+	return &simpleDB{prefix}
+}
+
+// GlobalDB is the prefix used for stack-scoped db
+var GlobalDB = SimpleDatabasePrefix("global")
+
 // JSONDoc is a map representing a simple json object that implements
 // the Doc interface.
 type JSONDoc struct {

--- a/couchdb/couchdb.go
+++ b/couchdb/couchdb.go
@@ -122,17 +122,20 @@ func (j JSONDoc) Get(key string) interface{} {
 
 var couchdbClient = &http.Client{}
 
+func escapeCouchdbName(name string) string {
+	name = strings.Replace(name, ".", "-", -1)
+	name = strings.Replace(name, ":", "-", -1)
+	return strings.ToLower(name)
+}
+
 func makeDBName(db Database, doctype string) string {
 	// @TODO This should be better analysed
-	dbname := db.Prefix() + doctype
-	dbname = strings.Replace(dbname, ".", "-", -1)
-	dbname = strings.Replace(dbname, ":", "-", -1)
-	dbname = strings.ToLower(dbname)
+	dbname := escapeCouchdbName(db.Prefix() + doctype)
 	return url.QueryEscape(dbname)
 }
 
 func dbNameHasPrefix(dbname, dbprefix string) (bool, string) {
-	dbprefix = strings.Replace(dbprefix, ".", "-", -1)
+	dbprefix = escapeCouchdbName(dbprefix)
 	if !strings.HasPrefix(dbname, dbprefix) {
 		return false, ""
 	}

--- a/couchdb/couchdb_test.go
+++ b/couchdb/couchdb_test.go
@@ -18,7 +18,12 @@ func TestErrors(t *testing.T) {
 }
 
 const TestDoctype = "io.cozy.testobject"
-const TestPrefix = "dev/"
+
+type TestDB struct{ prefix string }
+
+func (d *TestDB) Prefix() string { return d.prefix }
+
+var TestPrefix = &TestDB{"dev/"}
 
 type testDoc struct {
 	TestID  string `json:"_id,omitempty"`

--- a/couchdb/couchdb_test.go
+++ b/couchdb/couchdb_test.go
@@ -19,11 +19,7 @@ func TestErrors(t *testing.T) {
 
 const TestDoctype = "io.cozy.testobject"
 
-type TestDB struct{ prefix string }
-
-func (d *TestDB) Prefix() string { return d.prefix }
-
-var TestPrefix = &TestDB{"dev/"}
+var TestPrefix = SimpleDatabasePrefix("dev")
 
 type testDoc struct {
 	TestID  string `json:"_id,omitempty"`
@@ -164,7 +160,6 @@ func TestQuery(t *testing.T) {
 		assert.Equal(t, doc4.ID(), out2[1].ID())
 	}
 
-	fmt.Println("results", out)
 }
 
 func TestMain(m *testing.M) {

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -13,13 +13,8 @@ import (
 	"github.com/spf13/afero"
 )
 
-type dbPrefix struct{ prefix string }
-
-func (p *dbPrefix) Prefix() string { return p.prefix + "/" }
-
-var globalDBPrefix = &dbPrefix{"global"}
-
-const instanceType = "instances"
+// InstanceType : The couchdb type for an Instance
+const InstanceType = "instances"
 
 var (
 	// ErrNotFound is used when the seeked instance was not found
@@ -42,7 +37,7 @@ type Instance struct {
 }
 
 // DocType implements couchdb.Doc
-func (i *Instance) DocType() string { return instanceType }
+func (i *Instance) DocType() string { return InstanceType }
 
 // ID implements couchdb.Doc
 func (i *Instance) ID() string { return i.DocID }
@@ -68,21 +63,16 @@ func (i *Instance) createInCouchdb() (err error) {
 	if err != nil && err != ErrNotFound {
 		return err
 	}
-	err = couchdb.CreateDoc(globalDBPrefix, i)
+	err = couchdb.CreateDoc(couchdb.GlobalDB, i)
 	if err != nil {
 		return err
 	}
 	byDomain := mango.IndexOnFields("domain")
-	return couchdb.DefineIndex(globalDBPrefix, instanceType, byDomain)
+	return couchdb.DefineIndex(couchdb.GlobalDB, InstanceType, byDomain)
 }
 
 // createRootFolder creates the root folder for this instance
 func (i *Instance) createRootFolder() error {
-	vfsC, err := i.GetVFSContext()
-	if err != nil {
-		return err
-	}
-
 	rootFsURL := config.BuildAbsFsURL("/")
 	domainURL := config.BuildRelFsURL(i.Domain)
 
@@ -95,7 +85,7 @@ func (i *Instance) createRootFolder() error {
 		return err
 	}
 
-	if err = vfs.CreateRootDirDoc(vfsC); err != nil {
+	if err = vfs.CreateRootDirDoc(i); err != nil {
 		rootFs.Remove(domainURL.Path)
 		return err
 	}
@@ -126,48 +116,45 @@ func Create(domain string, locale string, apps []string) (*Instance, error) {
 		StorageURL: domainURL.String(),
 	}
 
-	err := i.Create()
+	var err error
+
+	if err != nil {
+		return nil, err
+	}
+	err = i.makeStorageFs()
 	if err != nil {
 		return nil, err
 	}
 
-	return i, nil
-}
-
-func (i *Instance) checkAndMakeStorage() error {
-	u, err := url.Parse(i.StorageURL)
+	err = i.createInCouchdb()
 	if err != nil {
-		return err
-	}
-	switch u.Scheme {
-	case "file":
-		i.storage = afero.NewBasePathFs(afero.NewOsFs(), u.Path)
-	case "mem":
-		i.storage = afero.NewMemMapFs()
-	default:
-		return fmt.Errorf("Unknown storage provider: %v", u.Scheme)
-	}
-	return nil
-}
-
-// Create performs the necessary setups for this instance to be usable
-func (i *Instance) Create() error {
-	if err := i.createInCouchdb(); err != nil {
-		return err
+		return nil, err
 	}
 
-	if err := i.createRootFolder(); err != nil {
-		return err
+	err = i.createRootFolder()
+	if err != nil {
+		return nil, err
 	}
 
-	if err := i.createFSIndexes(); err != nil {
-		return err
+	err = i.createFSIndexes()
+	if err != nil {
+		return nil, err
 	}
+
 	// TODO atomicity with defer
 	// TODO figure out what to do with locale
 	// TODO install apps
 
-	return nil
+	return i, nil
+}
+
+func (i *Instance) makeStorageFs() error {
+	u, err := url.Parse(i.StorageURL)
+	if err != nil {
+		return err
+	}
+	i.storage, err = createFs(u)
+	return err
 }
 
 // Get retrieves the instance for a request by its host.
@@ -183,7 +170,7 @@ func Get(domain string) (*Instance, error) {
 		Selector: mango.Equal("domain", domain),
 		Limit:    1,
 	}
-	err := couchdb.FindDocs(globalDBPrefix, instanceType, req, &instances)
+	err := couchdb.FindDocs(couchdb.GlobalDB, InstanceType, req, &instances)
 	if couchdb.IsNoDatabaseError(err) {
 		return nil, ErrNotFound
 	}
@@ -195,7 +182,8 @@ func Get(domain string) (*Instance, error) {
 		return nil, ErrNotFound
 	}
 
-	if err = instances[0].checkAndMakeStorage(); err != nil {
+	err = instances[0].makeStorageFs()
+	if err != nil {
 		return nil, err
 	}
 
@@ -210,7 +198,7 @@ func List() ([]*Instance, error) {
 	var docs []*Instance
 	sel := mango.Empty()
 	req := &couchdb.FindRequest{Selector: sel, Limit: 100}
-	err := couchdb.FindDocs(globalDBPrefix, instanceType, req, &docs)
+	err := couchdb.FindDocs(couchdb.GlobalDB, InstanceType, req, &docs)
 	return docs, err
 }
 
@@ -222,7 +210,7 @@ func Destroy(domain string) (*Instance, error) {
 		return nil, err
 	}
 
-	if err = couchdb.DeleteDoc(globalDBPrefix, i); err != nil {
+	if err = couchdb.DeleteDoc(couchdb.GlobalDB, i); err != nil {
 		return nil, err
 	}
 
@@ -249,12 +237,7 @@ func Destroy(domain string) (*Instance, error) {
 // the current instance are persisted
 func (i *Instance) FS() afero.Fs {
 	if i.storage == nil {
-		storageURL, err := url.Parse(i.StorageURL)
-		if err != nil {
-			panic(err)
-		}
-		i.storage, err = createFs(storageURL)
-		if err != nil {
+		if err := i.makeStorageFs(); err != nil {
 			panic(err)
 		}
 	}

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -202,7 +202,7 @@ func Destroy(domain string) (*Instance, error) {
 		return nil, err
 	}
 
-	if err = couchdb.DeleteAllDBs(i.Domain + "/"); err != nil {
+	if err = couchdb.DeleteAllDBs(i); err != nil {
 		return nil, err
 	}
 

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -118,9 +118,6 @@ func Create(domain string, locale string, apps []string) (*Instance, error) {
 
 	var err error
 
-	if err != nil {
-		return nil, err
-	}
 	err = i.makeStorageFs()
 	if err != nil {
 		return nil, err

--- a/instance/instance_test.go
+++ b/instance/instance_test.go
@@ -50,7 +50,7 @@ func TestGetWrongInstance(t *testing.T) {
 
 func TestGetCorrectInstance(t *testing.T) {
 	instance, err := Get("test.cozycloud.cc")
-	if assert.NoError(t, err, "An error is expected") {
+	if assert.NoError(t, err) {
 		assert.NotNil(t, instance)
 		assert.Equal(t, instance.Domain, "test.cozycloud.cc")
 	}

--- a/instance/instance_test.go
+++ b/instance/instance_test.go
@@ -58,7 +58,7 @@ func TestGetCorrectInstance(t *testing.T) {
 
 func TestInstanceHasRootFolder(t *testing.T) {
 	var root vfs.DirDoc
-	prefix := getDBPrefix(t, "test.cozycloud.cc")
+	prefix := getDB(t, "test.cozycloud.cc")
 	err := couchdb.GetDoc(prefix, vfs.FsDocType, vfs.RootFolderID, &root)
 	if assert.NoError(t, err) {
 		assert.Equal(t, root.Fullpath, "/")
@@ -67,7 +67,7 @@ func TestInstanceHasRootFolder(t *testing.T) {
 
 func TestInstanceHasIndexes(t *testing.T) {
 	var results []*vfs.DirDoc
-	prefix := getDBPrefix(t, "test.cozycloud.cc")
+	prefix := getDB(t, "test.cozycloud.cc")
 	req := &couchdb.FindRequest{Selector: mango.Equal("path", "/")}
 	err := couchdb.FindDocs(prefix, vfs.FsDocType, req, &results)
 	assert.NoError(t, err)
@@ -114,7 +114,6 @@ func TestMain(m *testing.M) {
 		fmt.Println("This test need couchdb to run.")
 		os.Exit(1)
 	}
-
 	Destroy("test.cozycloud.cc")
 	Destroy("test.cozycloud.cc.duplicate")
 	os.RemoveAll("/usr/local/var/cozy2/")
@@ -122,10 +121,10 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func getDBPrefix(t *testing.T, domain string) string {
+func getDB(t *testing.T, domain string) couchdb.Database {
 	instance, err := Get(domain)
 	if !assert.NoError(t, err, "Should get instance %v", domain) {
 		t.FailNow()
 	}
-	return instance.GetDatabasePrefix()
+	return instance
 }

--- a/vfs/vfs_test.go
+++ b/vfs/vfs_test.go
@@ -16,7 +16,17 @@ import (
 
 const TestPrefix = "dev/"
 
-var vfsC *Context
+const CouchDBURL = "http://localhost:5984/"
+
+type TestContext struct {
+	prefix string
+	fs     afero.Fs
+}
+
+func (c TestContext) Prefix() string { return c.prefix }
+func (c TestContext) FS() afero.Fs   { return c.fs }
+
+var vfsC TestContext
 
 func TestGetFileDocFromPathAtRoot(t *testing.T) {
 	doc, err := NewFileDoc("toto", "", -1, nil, "foo/bar", "foo", false, []string{})
@@ -76,24 +86,26 @@ func TestMain(m *testing.M) {
 		fmt.Println("This test need couchdb to run.")
 		os.Exit(1)
 	}
-	err = couchdb.ResetDB(TestPrefix, FsDocType)
+
+	vfsC.prefix = "dev/"
+
+	err = couchdb.ResetDB(vfsC, FsDocType)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
 
 	for _, index := range Indexes {
-		err = couchdb.DefineIndex(TestPrefix, FsDocType, index)
+		err = couchdb.DefineIndex(vfsC, FsDocType, index)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
 		}
 	}
 
-	fs := afero.NewMemMapFs()
+	vfsC.fs = afero.NewMemMapFs()
+	err = CreateRootDirectory(vfsC)
 
-	vfsC = NewContext(fs, TestPrefix)
-	err = CreateRootDirDoc(vfsC)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/vfs/vfs_test.go
+++ b/vfs/vfs_test.go
@@ -88,6 +88,7 @@ func TestMain(m *testing.M) {
 	}
 
 	vfsC.prefix = "dev/"
+	vfsC.fs = afero.NewMemMapFs()
 
 	err = couchdb.ResetDB(vfsC, FsDocType)
 	if err != nil {
@@ -103,8 +104,7 @@ func TestMain(m *testing.M) {
 		}
 	}
 
-	vfsC.fs = afero.NewMemMapFs()
-	err = CreateRootDirectory(vfsC)
+	CreateRootDirDoc(vfsC)
 
 	if err != nil {
 		fmt.Println(err)

--- a/web/apps/apps.go
+++ b/web/apps/apps.go
@@ -35,16 +35,9 @@ func wrapAppsError(err error) *jsonapi.Error {
 // the application with the given Source.
 func InstallHandler(c *gin.Context) {
 	instance := middlewares.GetInstance(c)
-	vfsC, err := instance.GetVFSContext()
-	if err != nil {
-		jsonapi.AbortWithError(c, jsonapi.InternalServerError(err))
-		return
-	}
-
-	db := instance.GetDatabasePrefix()
 	src := c.Query("Source")
 	slug := c.Param("slug")
-	inst, err := apps.NewInstaller(vfsC, db, slug, src)
+	inst, err := apps.NewInstaller(instance, instance, slug, src)
 	if err != nil {
 		jsonapi.AbortWithError(c, wrapAppsError(err))
 		return
@@ -76,7 +69,7 @@ func InstallHandler(c *gin.Context) {
 // installed applications.
 func ListHandler(c *gin.Context) {
 	instance := middlewares.GetInstance(c)
-	docs, err := apps.List(instance.GetDatabasePrefix())
+	docs, err := apps.List(instance)
 	if err != nil {
 		jsonapi.AbortWithError(c, wrapAppsError(err))
 		return

--- a/web/data/data.go
+++ b/web/data/data.go
@@ -27,10 +27,8 @@ func getDoc(c *gin.Context) {
 	doctype := c.MustGet("doctype").(string)
 	docid := c.Param("docid")
 
-	prefix := instance.GetDatabasePrefix()
-
 	var out couchdb.JSONDoc
-	err := couchdb.GetDoc(prefix, doctype, docid, &out)
+	err := couchdb.GetDoc(instance, doctype, docid, &out)
 	if err != nil {
 		c.AbortWithError(HTTPStatus(err), err)
 		return
@@ -43,7 +41,6 @@ func getDoc(c *gin.Context) {
 func createDoc(c *gin.Context) {
 	doctype := c.MustGet("doctype").(string)
 	instance := middlewares.GetInstance(c)
-	prefix := instance.GetDatabasePrefix()
 
 	var doc = couchdb.JSONDoc{Type: doctype}
 	if err := binding.JSON.Bind(c.Request, &doc.M); err != nil {
@@ -57,7 +54,7 @@ func createDoc(c *gin.Context) {
 		return
 	}
 
-	err := couchdb.CreateDoc(prefix, doc)
+	err := couchdb.CreateDoc(instance, doc)
 	if err != nil {
 		c.AbortWithError(HTTPStatus(err), err)
 		return
@@ -74,7 +71,6 @@ func createDoc(c *gin.Context) {
 
 func updateDoc(c *gin.Context) {
 	instance := middlewares.GetInstance(c)
-	prefix := instance.GetDatabasePrefix()
 
 	var doc couchdb.JSONDoc
 	if err := binding.JSON.Bind(c.Request, &doc); err != nil {
@@ -99,9 +95,9 @@ func updateDoc(c *gin.Context) {
 	var err error
 	if doc.ID() == "" {
 		doc.SetID(c.Param("docid"))
-		err = couchdb.CreateNamedDoc(prefix, doc)
+		err = couchdb.CreateNamedDoc(instance, doc)
 	} else {
-		err = couchdb.UpdateDoc(prefix, doc)
+		err = couchdb.UpdateDoc(instance, doc)
 	}
 
 	if err != nil {
@@ -122,7 +118,6 @@ func deleteDoc(c *gin.Context) {
 	instance := middlewares.GetInstance(c)
 	doctype := c.MustGet("doctype").(string)
 	docid := c.Param("docid")
-	prefix := instance.GetDatabasePrefix()
 	revHeader := c.Request.Header.Get("If-Match")
 	revQuery := c.Query("rev")
 	rev := ""
@@ -141,7 +136,7 @@ func deleteDoc(c *gin.Context) {
 		return
 	}
 
-	tombrev, err := couchdb.Delete(prefix, doctype, docid, rev)
+	tombrev, err := couchdb.Delete(instance, doctype, docid, rev)
 	if err != nil {
 		c.AbortWithError(HTTPStatus(err), err)
 		return

--- a/web/data/data_test.go
+++ b/web/data/data_test.go
@@ -26,7 +26,8 @@ const Host = "example.com"
 const Type = "io.cozy.events"
 const ID = "4521C325F6478E45"
 const ExpectedDBName = "example-com%2Fio-cozy-events"
-const TestPrefix = "example-com/"
+
+var testInstance = &instance.Instance{Domain: "example-com"}
 
 var DOCUMENT = []byte(`{
 	"test": "testvalue"
@@ -106,7 +107,7 @@ func injectInstance(instance *instance.Instance) gin.HandlerFunc {
 
 func getDocForTest() couchdb.JSONDoc {
 	doc := couchdb.JSONDoc{Type: Type, M: map[string]interface{}{"test": "value"}}
-	couchdb.CreateDoc(TestPrefix, &doc)
+	couchdb.CreateDoc(testInstance, &doc)
 	return doc
 }
 
@@ -126,6 +127,7 @@ func TestMain(m *testing.M) {
 		fmt.Println("Could not create test instance.", err)
 		os.Exit(1)
 	}
+	instance.Create()
 
 	router := gin.New()
 	router.Use(middlewares.ErrorHandler())

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -24,8 +24,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const TestPrefix = "test/"
-
 var ts *httptest.Server
 var testInstance *instance.Instance
 
@@ -221,7 +219,7 @@ func TestCreateDirRootSuccess(t *testing.T) {
 	res, _ := createDir(t, "/files/?Name=coucou&Type=io.cozy.folders")
 	assert.Equal(t, 201, res.StatusCode)
 
-	storage, _ := testInstance.GetStorageProvider()
+	storage := testInstance.FS()
 	exists, err := afero.DirExists(storage, "/coucou")
 	assert.NoError(t, err)
 	assert.True(t, exists)
@@ -241,7 +239,7 @@ func TestCreateDirWithParentSuccess(t *testing.T) {
 	res2, _ := createDir(t, "/files/"+parentID+"?Name=child&Type=io.cozy.folders")
 	assert.Equal(t, 201, res2.StatusCode)
 
-	storage, _ := testInstance.GetStorageProvider()
+	storage := testInstance.FS()
 	exists, err := afero.DirExists(storage, "/dirparent/child")
 	assert.NoError(t, err)
 	assert.True(t, exists)
@@ -302,7 +300,7 @@ func TestUploadBadHash(t *testing.T) {
 	res, _ := upload(t, "/files/?Type=io.cozy.files&Name=badhash", "text/plain", body, "3FbbMXfH+PdjAlWFfVb1dQ==")
 	assert.Equal(t, 412, res.StatusCode)
 
-	storage, _ := testInstance.GetStorageProvider()
+	storage := testInstance.FS()
 	_, err := afero.ReadFile(storage, "/badhash")
 	assert.Error(t, err)
 }
@@ -312,7 +310,7 @@ func TestUploadAtRootSuccess(t *testing.T) {
 	res, _ := upload(t, "/files/?Type=io.cozy.files&Name=goodhash", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
 	assert.Equal(t, 201, res.StatusCode)
 
-	storage, _ := testInstance.GetStorageProvider()
+	storage := testInstance.FS()
 	buf, err := afero.ReadFile(storage, "/goodhash")
 	assert.NoError(t, err)
 	assert.Equal(t, body, string(buf))
@@ -365,7 +363,7 @@ func TestUploadWithParentSuccess(t *testing.T) {
 	res2, _ := upload(t, "/files/"+parentID+"?Type=io.cozy.files&Name=goodhash", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
 	assert.Equal(t, 201, res2.StatusCode)
 
-	storage, _ := testInstance.GetStorageProvider()
+	storage := testInstance.FS()
 	buf, err := afero.ReadFile(storage, "/fileparent/goodhash")
 	assert.NoError(t, err)
 	assert.Equal(t, body, string(buf))
@@ -488,7 +486,7 @@ func TestModifyMetadataDirMove(t *testing.T) {
 	res3, _ := patchFile(t, "/files/"+folder1ID, "io.cozy.folders", folder1ID, attrs1, nil)
 	assert.Equal(t, 200, res3.StatusCode)
 
-	storage, _ := testInstance.GetStorageProvider()
+	storage := testInstance.FS()
 	exists, err := afero.DirExists(storage, "/dirmodmemoveinme/renamed")
 	assert.NoError(t, err)
 	assert.True(t, exists)
@@ -535,7 +533,7 @@ func TestModifyMetadataDirMoveWithRel(t *testing.T) {
 	res3, _ := patchFile(t, "/files/"+folder1ID, "io.cozy.folders", folder1ID, nil, parent)
 	assert.Equal(t, 200, res3.StatusCode)
 
-	storage, _ := testInstance.GetStorageProvider()
+	storage := testInstance.FS()
 	exists, err := afero.DirExists(storage, "/dirmodmemoveinmewithrel/dirmodmewithrel")
 	assert.NoError(t, err)
 	assert.True(t, exists)
@@ -602,7 +600,7 @@ func TestModifyContentSuccess(t *testing.T) {
 	var buf []byte
 	var fileInfo os.FileInfo
 
-	storage, _ := testInstance.GetStorageProvider()
+	storage := testInstance.FS()
 	res1, data1 := upload(t, "/files/?Type=io.cozy.files&Name=willbemodified&Executable=true", "text/plain", "foo", "")
 	assert.Equal(t, 201, res1.StatusCode)
 
@@ -727,7 +725,7 @@ func TestModifyContentConcurrently(t *testing.T) {
 		assert.True(t, strings.HasPrefix(s.rev, strconv.Itoa(i+2)+"-"))
 	}
 
-	storage, _ := testInstance.GetStorageProvider()
+	storage := testInstance.FS()
 	buf, err := afero.ReadFile(storage, "/willbemodifiedconcurrently")
 	assert.NoError(t, err)
 

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -15,9 +15,7 @@ import (
 	"testing"
 
 	"github.com/cozy/cozy-stack/config"
-	"github.com/cozy/cozy-stack/couchdb"
 	"github.com/cozy/cozy-stack/instance"
-	"github.com/cozy/cozy-stack/vfs"
 	"github.com/gin-gonic/gin"
 	"github.com/sourcegraph/checkup"
 	"github.com/spf13/afero"
@@ -606,7 +604,6 @@ func TestModifyContentSuccess(t *testing.T) {
 
 	buf, err = afero.ReadFile(storage, "/willbemodified")
 	assert.NoError(t, err)
-
 	assert.Equal(t, "foo", string(buf))
 	fileInfo, err = storage.Stat("/willbemodified")
 	assert.NoError(t, err)
@@ -713,13 +710,13 @@ func TestModifyContentConcurrently(t *testing.T) {
 	for i := 0; i < n; i++ {
 		select {
 		case res := <-errs:
-			assert.True(t, res.StatusCode == 409 || res.StatusCode == 503)
+			assert.True(t, res.StatusCode == 409 || res.StatusCode == 503, "status code is %v and not 409 or 503", res.StatusCode)
 		case res := <-done:
 			successes = append(successes, res)
 		}
 	}
 
-	assert.True(t, len(successes) >= 1)
+	assert.True(t, len(successes) >= 1, "there is at least one success")
 
 	for i, s := range successes {
 		assert.True(t, strings.HasPrefix(s.rev, strconv.Itoa(i+2)+"-"))
@@ -864,20 +861,6 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	err = couchdb.ResetDB(TestPrefix, vfs.FsDocType)
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-
-	for _, index := range vfs.Indexes {
-		err = couchdb.DefineIndex(TestPrefix, vfs.FsDocType, index)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
-	}
-
 	tempdir, err := ioutil.TempDir("", "cozy-stack")
 	if err != nil {
 		fmt.Println("Could not create temporary directory.")
@@ -891,6 +874,7 @@ func TestMain(m *testing.M) {
 
 	config.GetConfig().Fs.URL = fmt.Sprintf("file://localhost%s", tempdir)
 
+	instance.Destroy("test")
 	testInstance, err = instance.Create("test", "en", nil)
 	if err != nil {
 		fmt.Println("Could not create test instance.", err)
@@ -899,27 +883,7 @@ func TestMain(m *testing.M) {
 
 	router := gin.New()
 	router.Use(injectInstance(testInstance))
-	router.POST("/files/", CreationHandler)
-	router.POST("/files/:folder-id", CreationHandler)
-	router.PATCH("/files/:file-id", ModificationHandler)
-	router.PUT("/files/:file-id", OverwriteFileContentHandler)
-	router.HEAD("/files/download/:file-id", func(c *gin.Context) {
-		ReadFileContentHandler(c, c.Param("file-id"))
-	})
-	router.GET("/files/:dl-meta-or-file-id/*file-id", func(c *gin.Context) {
-		fileID := c.Param("file-id")[1:]
-		ReadFileContentHandler(c, fileID)
-	})
-	router.GET("/files/:dl-meta-or-file-id", func(c *gin.Context) {
-		dlMeta := c.Param("dl-meta-or-file-id")
-		if dlMeta == "download" {
-			ReadFileContentHandler(c, "")
-		} else if dlMeta == "metadata" {
-			ReadMetadataFromPathHandler(c)
-		} else {
-			ReadMetadataFromIDHandler(c, dlMeta)
-		}
-	})
+	Routes(router.Group("/files"))
 
 	ts = httptest.NewServer(router)
 

--- a/web/middlewares/instance_test.go
+++ b/web/middlewares/instance_test.go
@@ -13,16 +13,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetStorageProvider(t *testing.T) {
-	instance := instance.Instance{
-		Domain:     "test.cozycloud.cc",
-		StorageURL: "mem://test",
-	}
-	instance.Create()
+func TestFS(t *testing.T) {
+	instance, err := instance.Create("test", "en", nil)
+	assert.NoError(t, err)
 	content := []byte{'b', 'a', 'r'}
 	storage := instance.FS()
 	assert.NotNil(t, storage, "the instance should have a memory storage provider")
-	err := afero.WriteFile(storage, "foo", content, 0644)
+	err = afero.WriteFile(storage, "foo", content, 0644)
 	assert.NoError(t, err)
 	storage = instance.FS()
 	assert.NoError(t, err)
@@ -53,6 +50,9 @@ func TestSetInstance(t *testing.T) {
 
 func TestMain(m *testing.M) {
 	config.UseTestFile()
+	instance.Destroy("test")
 	gin.SetMode(gin.TestMode)
-	os.Exit(m.Run())
+	res := m.Run()
+	instance.Destroy("test")
+	os.Exit(res)
 }

--- a/web/middlewares/instance_test.go
+++ b/web/middlewares/instance_test.go
@@ -18,13 +18,13 @@ func TestGetStorageProvider(t *testing.T) {
 		Domain:     "test.cozycloud.cc",
 		StorageURL: "mem://test",
 	}
+	instance.Create()
 	content := []byte{'b', 'a', 'r'}
-	storage, err := instance.GetStorageProvider()
-	assert.NoError(t, err)
+	storage := instance.FS()
 	assert.NotNil(t, storage, "the instance should have a memory storage provider")
-	err = afero.WriteFile(storage, "foo", content, 0644)
+	err := afero.WriteFile(storage, "foo", content, 0644)
 	assert.NoError(t, err)
-	storage, err = instance.GetStorageProvider()
+	storage = instance.FS()
 	assert.NoError(t, err)
 	assert.NotNil(t, storage, "the instance should have a memory storage provider")
 	buf, err := afero.ReadFile(storage, "foo")
@@ -40,8 +40,7 @@ func TestSetInstance(t *testing.T) {
 		assert.True(t, exists, "the instance should have been set in the gin context")
 		instance := instanceInterface.(*instance.Instance)
 		assert.Equal(t, "dev", instance.Domain, "the domain should have been set in the instance")
-		storage, err := instance.GetStorageProvider()
-		assert.NoError(t, err)
+		storage := instance.FS()
 		assert.NotNil(t, storage, "the instance should have a storage provider")
 		c.String(http.StatusOK, "OK")
 	})


### PR DESCRIPTION
Following #66 here is a first shoot at unifying all the contexts, Basically : 

- replace `dbprefix string` by a `couchdb.Database interface{GetPrefix() string}`
- replace `vfs.Context struct` by an interface extending `couchdb.Database` with `GetFS() afero.Fs`
- make Instance implements both Interfaces
- only pass reference to the instance around
- create appropriate test for each package (in couchdb a custom couchdb.Database, in vfs a custom vfs.Context, in data Instance) 