### PR TITLE
Fix root directory creation

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -72,7 +72,11 @@ do_release() {
 	BUILD_TIME=`date -u +"%Y-%m-%dT%H:%M:%SZ"`
 	BUILD_MODE=${COZY_ENV}
 
-	go build -ldflags "-X github.com/cozy/cozy-stack/config.Version=${VERSION_STRING} -X github.com/cozy/cozy-stack/config.BuildTime=${BUILD_TIME} -X github.com/cozy/cozy-stack/config.BuildMode=${BUILD_MODE}" \
+	go build -ldflags "\
+		-X github.com/cozy/cozy-stack/config.Version=${VERSION_STRING} \
+		-X github.com/cozy/cozy-stack/config.BuildTime=${BUILD_TIME} \
+		-X github.com/cozy/cozy-stack/config.BuildMode=${BUILD_MODE}
+		" \
 		-o ${BINARY}
 
 	openssl dgst -sha256 -hex ${BINARY} > ${BINARY}.sha256

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,6 +45,11 @@ profiles you.`,
 var cfgFile string
 
 func init() {
+	pwd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+
 	flags := RootCmd.PersistentFlags()
 	flags.StringVarP(&cfgFile, "config", "c", "", "configuration file (default \"$HOME/.cozy.yaml\")")
 
@@ -57,7 +62,7 @@ func init() {
 	flags.IntP("port", "p", 8080, "server port")
 	viper.BindPFlag("port", flags.Lookup("port"))
 
-	flags.String("fs-url", "files://localhost/tmp/cozy2", "filesystem url")
+	flags.String("fs-url", fmt.Sprintf("files://localhost%s/storage", pwd), "filesystem url")
 	viper.BindPFlag("fs.url", flags.Lookup("fs-url"))
 
 	flags.String("couchdb-host", "localhost", "couchdbdb host")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,6 +57,9 @@ func init() {
 	flags.IntP("port", "p", 8080, "server port")
 	viper.BindPFlag("port", flags.Lookup("port"))
 
+	flags.String("fs-url", "files://localhost/tmp/cozy2", "filesystem url")
+	viper.BindPFlag("fs.url", flags.Lookup("fs-url"))
+
 	flags.String("couchdb-host", "localhost", "couchdbdb host")
 	viper.BindPFlag("couchdb.host", flags.Lookup("couchdb-host"))
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -62,7 +62,7 @@ func init() {
 	flags.IntP("port", "p", 8080, "server port")
 	viper.BindPFlag("port", flags.Lookup("port"))
 
-	flags.String("fs-url", fmt.Sprintf("files://localhost%s/storage", pwd), "filesystem url")
+	flags.String("fs-url", fmt.Sprintf("file://localhost%s/storage", pwd), "filesystem url")
 	viper.BindPFlag("fs.url", flags.Lookup("fs-url"))
 
 	flags.String("couchdb-host", "localhost", "couchdbdb host")

--- a/cozy.dist.yaml
+++ b/cozy.dist.yaml
@@ -10,7 +10,9 @@ port: 8080
 
 fs:
   # file system url - flags: --fs-url
-  url: file://localhost/tmp/cozy2
+  # default url is the directory relative to the binary: ./storage
+
+  # url: file://localhost/var/lib/cozy
 
 
 couchdb:

--- a/cozy.dist.yaml
+++ b/cozy.dist.yaml
@@ -8,6 +8,11 @@ host: localhost
 port: 8080
 
 
+fs:
+  # file system url - flags: --fs-url
+  url: file://localhost/tmp/cozy2
+
+
 couchdb:
     # couchdb host - flags: --couchdb-host
     host: localhost

--- a/cozy.test.yaml
+++ b/cozy.test.yaml
@@ -1,0 +1,15 @@
+# cozy-stack configuration file for tests
+
+mode: development
+host: localhost
+port: 8080
+
+fs:
+  url: mem://test
+
+couchdb:
+    host: localhost
+    port: 5984
+
+log:
+    level: info

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -3,6 +3,7 @@ package instance
 import (
 	"fmt"
 	"net/url"
+	"path"
 	"strings"
 
 	"github.com/cozy/cozy-stack/couchdb"
@@ -13,6 +14,8 @@ import (
 
 const globalDBPrefix = "global/"
 const instanceType = "instances"
+
+const globalFsURL = "file://localhost/tmp/cozy2"
 
 // An Instance has the informations relatives to the logical cozy instance,
 // like the domain, the locale or the access to the databases and files storage
@@ -59,7 +62,27 @@ func (i *Instance) createRootFolder() error {
 	if err != nil {
 		return err
 	}
-	return vfs.CreateRootDirectory(vfsC)
+
+	rootURL, err := url.Parse(globalFsURL)
+	if err != nil {
+		return err
+	}
+
+	rootFs, err := createFs(rootURL)
+	if err != nil {
+		return err
+	}
+
+	if err = rootFs.Mkdir(i.Domain, 0755); err != nil {
+		return err
+	}
+
+	if err = vfs.CreateRootDirDoc(vfsC); err != nil {
+		rootFs.Remove(i.Domain)
+		return err
+	}
+
+	return nil
 }
 
 // createFSIndexes creates the index needed by VFS
@@ -77,15 +100,23 @@ func (i *Instance) createFSIndexes() (err error) {
 
 // Create build an instance and .Create it
 func Create(domain string, locale string, apps []string) (*Instance, error) {
-	// TODO use a base directory provided by stack level config
-	base := "/tmp/cozy2/"
-	storageURL := "file://localhost" + base + "/" + domain + "/"
+	if strings.ContainsAny(domain, vfs.ForbiddenFilenameChars) || domain == ".." || domain == "." {
+		return nil, fmt.Errorf("Domain is malformed")
+	}
+
+	storageURL, err := url.Parse(globalFsURL)
+	if err != nil {
+		return nil, err
+	}
+
+	storageURL.Path = path.Join(storageURL.Path, domain)
 
 	i := &Instance{
 		Domain:     domain,
-		StorageURL: storageURL,
+		StorageURL: storageURL.String(),
 	}
-	err := i.Create()
+
+	err = i.Create()
 	if err != nil {
 		return nil, err
 	}
@@ -98,9 +129,11 @@ func (i *Instance) Create() error {
 	if err := i.createInCouchdb(); err != nil {
 		return err
 	}
+
 	if err := i.createRootFolder(); err != nil {
 		return err
 	}
+
 	if err := i.createFSIndexes(); err != nil {
 		return err
 	}
@@ -113,8 +146,7 @@ func (i *Instance) Create() error {
 }
 
 // Get retrieves the instance for a request by its host.
-func Get(domainarg string) (*Instance, error) {
-	domain := domainarg
+func Get(domain string) (*Instance, error) {
 	// TODO this is not fail-safe, to be modified before production
 	if domain == "" || strings.Contains(domain, "127.0.0.1") || strings.Contains(domain, "localhost") {
 		domain = "dev"
@@ -138,7 +170,6 @@ func Get(domainarg string) (*Instance, error) {
 	}
 
 	return instances[0], nil
-
 }
 
 // GetStorageProvider returns the afero storage provider where the binaries for
@@ -147,19 +178,12 @@ func (i *Instance) GetStorageProvider() (afero.Fs, error) {
 	if i.storage != nil {
 		return i.storage, nil
 	}
-	u, err := url.Parse(i.StorageURL)
+	storageURL, err := url.Parse(i.StorageURL)
 	if err != nil {
 		return nil, err
 	}
-	switch u.Scheme {
-	case "file":
-		i.storage = afero.NewBasePathFs(afero.NewOsFs(), u.Path)
-	case "mem":
-		i.storage = afero.NewMemMapFs()
-	default:
-		return nil, fmt.Errorf("Unknown storage provider: %v", u.Scheme)
-	}
-	return i.storage, nil
+	i.storage, err = createFs(storageURL)
+	return i.storage, err
 }
 
 // GetDatabasePrefix returns the prefix to use in database naming for the
@@ -176,4 +200,16 @@ func (i *Instance) GetVFSContext() (c *vfs.Context, err error) {
 		return nil, err
 	}
 	return vfs.NewContext(fs, dbprefix), nil
+}
+
+func createFs(u *url.URL) (fs afero.Fs, err error) {
+	switch u.Scheme {
+	case "file":
+		fs = afero.NewBasePathFs(afero.NewOsFs(), u.Path)
+	case "mem":
+		fs = afero.NewMemMapFs()
+	default:
+		err = fmt.Errorf("Unknown storage provider: %v", u.Scheme)
+	}
+	return
 }

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/cozy/cozy-stack/config"
 	"github.com/cozy/cozy-stack/couchdb"
 	"github.com/cozy/cozy-stack/couchdb/mango"
 	"github.com/cozy/cozy-stack/vfs"
@@ -14,8 +15,6 @@ import (
 
 const globalDBPrefix = "global/"
 const instanceType = "instances"
-
-const globalFsURL = "file://localhost/tmp/cozy2"
 
 // An Instance has the informations relatives to the logical cozy instance,
 // like the domain, the locale or the access to the databases and files storage
@@ -63,12 +62,8 @@ func (i *Instance) createRootFolder() error {
 		return err
 	}
 
-	rootURL, err := url.Parse(globalFsURL)
-	if err != nil {
-		return err
-	}
-
-	rootFs, err := createFs(rootURL)
+	rootFsURL := config.GetConfig().Fs.URL
+	rootFs, err := createFs(rootFsURL)
 	if err != nil {
 		return err
 	}
@@ -104,7 +99,9 @@ func Create(domain string, locale string, apps []string) (*Instance, error) {
 		return nil, fmt.Errorf("Domain is malformed")
 	}
 
-	storageURL, err := url.Parse(globalFsURL)
+	rootFsURL := config.GetConfig().Fs.URL
+
+	storageURL, err := url.Parse(rootFsURL.String())
 	if err != nil {
 		return nil, err
 	}

--- a/instance/instance_test.go
+++ b/instance/instance_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cozy/cozy-stack/config"
 	"github.com/cozy/cozy-stack/couchdb"
 	"github.com/cozy/cozy-stack/couchdb/mango"
 	"github.com/cozy/cozy-stack/vfs"
@@ -27,6 +28,17 @@ func TestCreateInstance(t *testing.T) {
 		assert.NotEmpty(t, instance.ID())
 		assert.Equal(t, instance.Domain, "test.cozycloud.cc")
 	}
+}
+
+func TestCreateInstanceBadDomain(t *testing.T) {
+	_, err := Create("..", "en", nil)
+	assert.Error(t, err, "An error is expected")
+
+	_, err = Create(".", "en", nil)
+	assert.Error(t, err, "An error is expected")
+
+	_, err = Create("foo/bar", "en", nil)
+	assert.Error(t, err, "An error is expected")
 }
 
 func TestGetWrongInstance(t *testing.T) {
@@ -67,6 +79,8 @@ func TestInstanceHasIndexes(t *testing.T) {
 func TestMain(m *testing.M) {
 	const CouchDBURL = "http://localhost:5984/"
 	const TestPrefix = "dev/"
+
+	config.UseTestFile("..")
 
 	db, err := checkup.HTTPChecker{URL: CouchDBURL}.Check()
 	if err != nil || db.Status() != checkup.Healthy {

--- a/vfs/directory.go
+++ b/vfs/directory.go
@@ -253,25 +253,13 @@ func CreateDirectory(c *Context, doc *DirDoc) (err error) {
 	return couchdb.CreateDoc(c.db, doc)
 }
 
-// CreateRootDirectory creates the root folder for this context
-func CreateRootDirectory(c *Context) (err error) {
-	root := &DirDoc{
+// CreateRootDirDoc creates the root folder for this context
+func CreateRootDirDoc(c *Context) error {
+	return couchdb.CreateNamedDocWithDB(c.db, &DirDoc{
 		Type:     DirType,
 		ObjID:    RootFolderID,
 		Fullpath: "/",
-	}
-	err = c.fs.MkdirAll(root.Fullpath, 0755)
-	if err != nil {
-		return err
-	}
-
-	defer func() {
-		if err != nil {
-			c.fs.Remove(root.Fullpath)
-		}
-	}()
-
-	return couchdb.CreateNamedDocWithDB(c.db, root)
+	})
 }
 
 // ModifyDirMetadata modify the metadata associated to a directory. It

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -251,7 +251,6 @@ func (c *Context) MkdirAll(name string) error {
 		if err != nil {
 			return err
 		}
-		base = path.Dir(name)
 		break
 	}
 

--- a/vfs/vfs_test.go
+++ b/vfs/vfs_test.go
@@ -90,7 +90,7 @@ func TestMain(m *testing.M) {
 	fs := afero.NewMemMapFs()
 
 	vfsC = NewContext(fs, TestPrefix)
-	err = CreateRootDirectory(vfsC)
+	err = CreateRootDirDoc(vfsC)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/web/apps/apps.go
+++ b/web/apps/apps.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/cozy/cozy-stack/apps"
 	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/cozy/cozy-stack/web/middlewares"
@@ -63,6 +64,7 @@ func InstallHandler(c *gin.Context) {
 		for {
 			_, err := inst.WaitManifest()
 			if err != nil {
+				log.Errorf("[apps] %s could not be installed: %v", slug, err)
 				break
 			}
 			// TODO: do nothing for now

--- a/web/data/data_test.go
+++ b/web/data/data_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cozy/cozy-stack/config"
 	"github.com/cozy/cozy-stack/couchdb"
 	"github.com/cozy/cozy-stack/instance"
 	"github.com/cozy/cozy-stack/web/middlewares"
@@ -119,9 +120,13 @@ func TestMain(m *testing.M) {
 	}
 
 	gin.SetMode(gin.TestMode)
-	instance := &instance.Instance{
-		Domain:     Host,
-		StorageURL: "mem://test",
+
+	config.UseTestFile("../..")
+
+	instance, err := instance.Create(Host, "en", nil)
+	if err != nil {
+		fmt.Println("Could not create test instance.", err)
+		os.Exit(1)
 	}
 
 	router := gin.New()

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -149,6 +149,10 @@ func patchFile(t *testing.T, path, docType, id string, attrs map[string]interfac
 	}
 
 	b, err := json.Marshal(map[string]*jsonData{"data": bodyreq})
+	if !assert.NoError(t, err) {
+		return
+	}
+
 	req, err := http.NewRequest("PATCH", ts.URL+path, bytes.NewReader(b))
 	if !assert.NoError(t, err) {
 		return
@@ -603,6 +607,8 @@ func TestModifyContentSuccess(t *testing.T) {
 	assert.Equal(t, 201, res1.StatusCode)
 
 	buf, err = afero.ReadFile(storage, "/willbemodified")
+	assert.NoError(t, err)
+
 	assert.Equal(t, "foo", string(buf))
 	fileInfo, err = storage.Stat("/willbemodified")
 	assert.NoError(t, err)

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -14,6 +14,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/cozy/cozy-stack/config"
 	"github.com/cozy/cozy-stack/couchdb"
 	"github.com/cozy/cozy-stack/instance"
 	"github.com/cozy/cozy-stack/vfs"
@@ -881,11 +882,19 @@ func TestMain(m *testing.M) {
 	}()
 
 	gin.SetMode(gin.TestMode)
-	testInstance = &instance.Instance{
-		Domain:     "test",
-		StorageURL: "file://localhost" + tempdir,
+
+	config.UseTestFile("../..")
+	config.GetConfig().Fs.URL = &url.URL{
+		Scheme: "file",
+		Host:   "localhost",
+		Path:   tempdir,
 	}
-	testInstance.Create()
+
+	testInstance, err = instance.Create("test", "en", nil)
+	if err != nil {
+		fmt.Println("Could not create test instance.", err)
+		os.Exit(1)
+	}
 
 	router := gin.New()
 	router.Use(injectInstance(testInstance))


### PR DESCRIPTION
This is a fix for the root directory creation code and `instances add`. In the current code, the directory creation on the actual file system could not work since we were using a namespaced fs to build its own root directory.

~~I left the `globalFsURL` pointing at `file://localhost/tmp/cozy2` for now. I'm working a way to pass that from the configuration (and have a way to inject configuration from tests).~~