### PR TITLE
Create all directories required on instance creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /storage
 swagger-ui
 /.cozy
+/storage/*

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 /storage
 swagger-ui
 /.cozy
-/storage/*

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/cozy/cozy-stack/config"
@@ -49,7 +50,7 @@ profiles you.`,
 var cfgFile string
 
 func init() {
-	pwd, err := os.Getwd()
+	binDir, err := filepath.Abs(filepath.Dir(os.Args[0]))
 	if err != nil {
 		panic(err)
 	}
@@ -66,7 +67,7 @@ func init() {
 	flags.IntP("port", "p", 8080, "server port")
 	viper.BindPFlag("port", flags.Lookup("port"))
 
-	flags.String("fs-url", fmt.Sprintf("file://localhost%s/%s", pwd, DefaultStorageDirectory), "filesystem url")
+	flags.String("fs-url", fmt.Sprintf("file://localhost%s/%s", binDir, DefaultStorageDirectory), "filesystem url")
 	viper.BindPFlag("fs.url", flags.Lookup("fs-url"))
 
 	flags.String("couchdb-host", "localhost", "couchdbdb host")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,10 @@ var ConfigPaths = []string{
 	"/etc/cozy",
 }
 
+// DefaultStorageDirectory is the default directory name in which data
+// is stored relatively to the cozy-stack binary.
+const DefaultStorageDirectory = "storage"
+
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
 	Use:   "cozy-stack",
@@ -62,7 +66,7 @@ func init() {
 	flags.IntP("port", "p", 8080, "server port")
 	viper.BindPFlag("port", flags.Lookup("port"))
 
-	flags.String("fs-url", fmt.Sprintf("file://localhost%s/storage", pwd), "filesystem url")
+	flags.String("fs-url", fmt.Sprintf("file://localhost%s/%s", pwd, DefaultStorageDirectory), "filesystem url")
 	viper.BindPFlag("fs.url", flags.Lookup("fs-url"))
 
 	flags.String("couchdb-host", "localhost", "couchdbdb host")

--- a/config/config.go
+++ b/config/config.go
@@ -32,6 +32,34 @@ type Config struct {
 	Logger  Logger
 }
 
+// FsURL returns a copy of the filesystem URL
+func (c *Config) FsURL() *url.URL {
+	u, err := url.Parse(c.Fs.URL)
+	if err != nil {
+		panic(fmt.Errorf("Malformed configuration fs url %s.", c.Fs.URL))
+	}
+	return u
+}
+
+// BuildRelFsURL build a new url from the filesystem URL by adding the
+// specified relative path.
+func (c *Config) BuildRelFsURL(rel string) *url.URL {
+	u := c.FsURL()
+	if u.Path == "" {
+		u.Path = "/"
+	}
+	u.Path = path.Join(u.Path, rel)
+	return u
+}
+
+// BuildAbsFsURL build a new url from the filesystem URL by changing
+// the path to the specified absolute one.
+func (c *Config) BuildAbsFsURL(abs string) *url.URL {
+	u := c.FsURL()
+	u.Path = path.Join("/", abs)
+	return u
+}
+
 const (
 	// Production mode
 	Production string = "production"
@@ -41,7 +69,7 @@ const (
 
 // Fs contains the configuration values of the file-system
 type Fs struct {
-	URL *url.URL
+	URL string
 }
 
 // CouchDB contains the configuration values of the database
@@ -67,7 +95,8 @@ func UseViper(v *viper.Viper) error {
 		return err
 	}
 
-	fsURL, err := url.Parse(v.GetString("fs.url"))
+	fsURL := v.GetString("fs.url")
+	_, err = url.Parse(fsURL)
 	if err != nil {
 		return err
 	}

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -892,11 +892,7 @@ func TestMain(m *testing.M) {
 	gin.SetMode(gin.TestMode)
 
 	config.UseTestFile("../..")
-	config.GetConfig().Fs.URL = &url.URL{
-		Scheme: "file",
-		Host:   "localhost",
-		Path:   tempdir,
-	}
+	config.GetConfig().Fs.URL = fmt.Sprintf("file://localhost%s", tempdir)
 
 	testInstance, err = instance.Create("test", "en", nil)
 	if err != nil {


### PR DESCRIPTION
Re-implement what was the good behavior: cozy-stack should create *all* the necessary directories to run on `instances add`.