### PR TITLE
README: Add instructions to create the dev instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,28 +63,6 @@ xdg-open http://localhost:2015/index.html?url=http://localhost:2015/specs/swagge
 
 ## With Docker
 
-### Building a `cozy-stack` binary
-
-To build a `cozy-stack` binary with Docker using the **local** source code, run:
-
-```bash
-# From your cozy-stack developement folder
-docker run -it --rm --name cozy-stack \
-    -v $(pwd):/go/src/github.com/cozy/cozy-stack \
-    -v $(pwd):/go/bin \
-    golang:1.7.1 \
-    go get -v github.com/cozy/cozy-stack
-```
-
-The `cozy-stack` binary is now present in the current folder. Run it with:
-
-```bash
-./cozy-stack serve
-```
-
-The cozy-stack server listens on http://localhost:8080/ by default.
-
-
 ### Running a CouchDB instance
 
 This will run a new instance of CouchDB in `single` mode (no cluster) and in `admin-party-mode` (no user).
@@ -99,6 +77,42 @@ $ curl -X PUT http://127.0.0.1:5984/{_users,_replicator,_global_changes}
 ```
 
 Verify your installation at: http://127.0.0.1:5984/_utils/#verifyinstall
+
+
+### Building a `cozy-stack` binary
+
+To build a `cozy-stack` binary with Docker using the **local** source code, run:
+
+```bash
+# From your cozy-stack developement folder
+docker run -it --rm --name cozy-stack \
+    -v $(pwd):/go/src/github.com/cozy/cozy-stack \
+    -v $(pwd):/go/bin \
+    golang:1.7.1 \
+    go get -v github.com/cozy/cozy-stack
+```
+
+The `cozy-stack` binary is now present in the current folder.
+
+Create a *dev* instance:
+
+```bash
+./cozy-stack instances add dev  # assuming couchdb is running
+```
+
+Then run the server with:
+
+```bash
+./cozy-stack serve
+```
+
+The cozy-stack server listens on http://localhost:8080/ by default.
+
+Make sure the full stack is up with:
+
+```bash
+curl -H 'Accept: application/json' 'http://localhost:8080/status/'
+```
 
 
 ## How to contribute?


### PR DESCRIPTION
Moved the CouchDB section first, so newcomers have a database
instance before running the `instances add` command.

Also added instructions to create the `storage/` directory.

Merge `--ff`?