### PR TITLE
[VFS] Fix error returned on a conflictual file modification

### DIFF
--- a/vfs/errors.go
+++ b/vfs/errors.go
@@ -20,4 +20,7 @@ var (
 	// ErrContentLengthMismatch is used when the content-length does not
 	// match the calculated one
 	ErrContentLengthMismatch = errors.New("Content length does not match")
+	// ErrConflict is used when the access to a file or directory is in
+	// conflict with another
+	ErrConflict = errors.New("Conflict access to same file or directory")
 )

--- a/vfs/file.go
+++ b/vfs/file.go
@@ -307,6 +307,13 @@ func CreateFile(c *Context, newdoc, olddoc *FileDoc) (*File, error) {
 	if olddoc != nil {
 		bakpath = fmt.Sprintf("/.%s_%s", olddoc.ID(), olddoc.Rev())
 		if err = safeRenameFile(c, newpath, bakpath); err != nil {
+			// in case of a concurrent access to this method, it can happend
+			// that the file has already been renamed. In this case the
+			// safeRenameFile will return an os.ErrNotExist error. But this
+			// error is misleading since it does not reflect the conflict.
+			if os.IsNotExist(err) {
+				err = ErrConflict
+			}
 			return nil, err
 		}
 	}

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -388,7 +388,7 @@ func WrapVfsError(err error) *jsonapi.Error {
 	if couchErr, isCouchErr := err.(*couchdb.Error); isCouchErr {
 		return jsonapi.WrapCouchError(couchErr)
 	}
-	if os.IsExist(err) {
+	if os.IsExist(err) || err == vfs.ErrConflict {
 		return &jsonapi.Error{
 			Status: http.StatusConflict,
 			Title:  "Conflict",


### PR DESCRIPTION
This PR should fix a misleading error returned in certain conditions when a file is modified concurrently:

```
in case of a concurrent access to this method, it can happend
that the file has already been renamed. In this case the
safeRenameFile will return an os.ErrNotExist error. But this
error is misleading since it does not reflect the conflict.
```

@aenario waiting for your return on this one.