### PR TITLE
Effectively use configuration for CouchDB url

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1,13 +1,10 @@
 package cmd
 
 import (
-	"strconv"
-
-	"github.com/gin-gonic/gin"
-	"github.com/spf13/cobra"
-
 	"github.com/cozy/cozy-stack/config"
 	"github.com/cozy/cozy-stack/web"
+	"github.com/gin-gonic/gin"
+	"github.com/spf13/cobra"
 )
 
 // serveCmd represents the serve command
@@ -25,8 +22,7 @@ Use the --port and --host flags to change the listening option.`,
 		router := getGin()
 		web.SetupRoutes(router)
 
-		addr := config.GetConfig().Host + ":" + strconv.Itoa(config.GetConfig().Port)
-		return router.Run(addr)
+		return router.Run(config.ServerAddr())
 	},
 }
 
@@ -35,7 +31,7 @@ func init() {
 }
 
 func getGin() *gin.Engine {
-	if config.GetConfig().Mode == config.Production {
+	if config.IsMode(config.Production) {
 		gin.SetMode(gin.ReleaseMode)
 	}
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/cozy/cozy-stack/config"
 	"github.com/spf13/cobra"
-	"strconv"
 )
 
 // statusCmd represents the status command
@@ -23,7 +22,7 @@ var statusCmd = &cobra.Command{
 
 		url := &url.URL{
 			Scheme: "http",
-			Host:   config.GetConfig().Host + ":" + strconv.Itoa(config.GetConfig().Port),
+			Host:   config.ServerAddr(),
 			Path:   "status",
 		}
 		resp, err := http.Get(url.String())

--- a/config/config.go
+++ b/config/config.go
@@ -34,39 +34,6 @@ type Config struct {
 	Logger  Logger
 }
 
-// FsURL returns a copy of the filesystem URL
-func (c *Config) FsURL() *url.URL {
-	u, err := url.Parse(c.Fs.URL)
-	if err != nil {
-		panic(fmt.Errorf("Malformed configuration fs url %s.", c.Fs.URL))
-	}
-	return u
-}
-
-// BuildRelFsURL build a new url from the filesystem URL by adding the
-// specified relative path.
-func (c *Config) BuildRelFsURL(rel string) *url.URL {
-	u := c.FsURL()
-	if u.Path == "" {
-		u.Path = "/"
-	}
-	u.Path = path.Join(u.Path, rel)
-	return u
-}
-
-// BuildAbsFsURL build a new url from the filesystem URL by changing
-// the path to the specified absolute one.
-func (c *Config) BuildAbsFsURL(abs string) *url.URL {
-	u := c.FsURL()
-	u.Path = path.Join("/", abs)
-	return u
-}
-
-// CouchURL returns the CouchDB string url
-func (c *Config) CouchURL() string {
-	return c.CouchDB.URL
-}
-
 const (
 	// Production mode
 	Production string = "production"
@@ -89,14 +56,59 @@ type Logger struct {
 	Level string
 }
 
+// FsURL returns a copy of the filesystem URL
+func FsURL() *url.URL {
+	u, err := url.Parse(config.Fs.URL)
+	if err != nil {
+		panic(fmt.Errorf("Malformed configuration fs url %s.", config.Fs.URL))
+	}
+	return u
+}
+
+// BuildRelFsURL build a new url from the filesystem URL by adding the
+// specified relative path.
+func BuildRelFsURL(rel string) *url.URL {
+	u := FsURL()
+	if u.Path == "" {
+		u.Path = "/"
+	}
+	u.Path = path.Join(u.Path, rel)
+	return u
+}
+
+// BuildAbsFsURL build a new url from the filesystem URL by changing
+// the path to the specified absolute one.
+func BuildAbsFsURL(abs string) *url.URL {
+	u := FsURL()
+	u.Path = path.Join("/", abs)
+	return u
+}
+
+// ServerAddr returns the address on which the stack is run
+func ServerAddr() string {
+	return config.Host + ":" + strconv.Itoa(config.Port)
+}
+
+// CouchURL returns the CouchDB string url
+func CouchURL() string {
+	return config.CouchDB.URL
+}
+
+// IsMode returns whether or not the mode is equal to the specified
+// one
+func IsMode(mode string) bool {
+	return config.Mode == mode
+}
+
+// IsDevRelease returns whether or not the binary is a development
+// release
+func IsDevRelease() bool {
+	return BuildMode == Development
+}
+
 // GetConfig returns the configured instance of Config
 func GetConfig() *Config {
 	return config
-}
-
-// IsDevRelease returns true is the binary is a development release
-func IsDevRelease() bool {
-	return BuildMode == Development
 }
 
 // UseViper sets the configured instance of Config

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -15,5 +15,5 @@ func TestUseViper(t *testing.T) {
 	UseViper(cfg)
 
 	assert.Equal(t, Production, GetConfig().Mode)
-	assert.Equal(t, "http://db:1234/", GetConfig().CouchURL())
+	assert.Equal(t, "http://db:1234/", CouchURL())
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -15,6 +15,5 @@ func TestUseViper(t *testing.T) {
 	UseViper(cfg)
 
 	assert.Equal(t, Production, GetConfig().Mode)
-	assert.Equal(t, "db", GetConfig().CouchDB.Host)
-	assert.Equal(t, 1234, GetConfig().CouchDB.Port)
+	assert.Equal(t, "http://db:1234/", GetConfig().CouchURL())
 }

--- a/couchdb/couchdb.go
+++ b/couchdb/couchdb.go
@@ -137,7 +137,7 @@ func makeRequest(method, path string, reqbody interface{}, resbody interface{}) 
 		log.Debugf("[couchdb request] %s %s %s", method, path, string(reqjson))
 	}
 
-	req, err := http.NewRequest(method, config.GetConfig().CouchURL()+path, bytes.NewReader(reqjson))
+	req, err := http.NewRequest(method, config.CouchURL()+path, bytes.NewReader(reqjson))
 	// Possible err = wrong method, unparsable url
 	if err != nil {
 		return newRequestError(err)

--- a/couchdb/couchdb.go
+++ b/couchdb/couchdb.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/cozy/cozy-stack/config"
 	"github.com/cozy/cozy-stack/couchdb/mango"
 )
 
@@ -99,11 +100,6 @@ func (j JSONDoc) Get(key string) interface{} {
 	return j.M[key]
 }
 
-// CouchURL is the URL where to check if CouchDB is up
-func CouchURL() string {
-	return "http://localhost:5984/"
-}
-
 var couchdbClient = &http.Client{}
 
 func makeDBName(dbprefix, doctype string) string {
@@ -141,7 +137,7 @@ func makeRequest(method, path string, reqbody interface{}, resbody interface{}) 
 		log.Debugf("[couchdb request] %s %s %s", method, path, string(reqjson))
 	}
 
-	req, err := http.NewRequest(method, CouchURL()+path, bytes.NewReader(reqjson))
+	req, err := http.NewRequest(method, config.GetConfig().CouchURL()+path, bytes.NewReader(reqjson))
 	// Possible err = wrong method, unparsable url
 	if err != nil {
 		return newRequestError(err)

--- a/couchdb/couchdb_test.go
+++ b/couchdb/couchdb_test.go
@@ -166,7 +166,7 @@ func TestMain(m *testing.M) {
 	config.UseTestFile()
 
 	// First we make sure couchdb is started
-	db, err := checkup.HTTPChecker{URL: config.GetConfig().CouchURL()}.Check()
+	db, err := checkup.HTTPChecker{URL: config.CouchURL()}.Check()
 	if err != nil || db.Status() != checkup.Healthy {
 		fmt.Println("This test need couchdb to run.")
 		os.Exit(1)

--- a/couchdb/couchdb_test.go
+++ b/couchdb/couchdb_test.go
@@ -5,12 +5,11 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cozy/cozy-stack/config"
 	"github.com/cozy/cozy-stack/couchdb/mango"
 	"github.com/sourcegraph/checkup"
 	"github.com/stretchr/testify/assert"
 )
-
-var CouchDBURL = "http://localhost:5984/"
 
 func TestErrors(t *testing.T) {
 	err := Error{StatusCode: 404, Name: "not_found", Reason: "missing"}
@@ -164,12 +163,15 @@ func TestQuery(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
+	config.UseTestFile()
+
 	// First we make sure couchdb is started
-	couchdb, err := checkup.HTTPChecker{URL: CouchDBURL}.Check()
-	if err != nil || couchdb.Status() != checkup.Healthy {
+	db, err := checkup.HTTPChecker{URL: config.GetConfig().CouchURL()}.Check()
+	if err != nil || db.Status() != checkup.Healthy {
 		fmt.Println("This test need couchdb to run.")
 		os.Exit(1)
 	}
+
 	err = ResetDB(TestPrefix, TestDoctype)
 	if err != nil {
 		fmt.Printf("Cant reset db (%s, %s) %s\n", TestPrefix, TestDoctype, err.Error())

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -154,9 +154,10 @@ func (i *Instance) Create() error {
 
 // Get retrieves the instance for a request by its host.
 func Get(domain string) (*Instance, error) {
-	// TODO this is not fail-safe, to be modified before production
-	if domain == "" || strings.Contains(domain, "127.0.0.1") || strings.Contains(domain, "localhost") {
-		domain = "dev"
+	if config.IsDevRelease() {
+		if domain == "" || strings.Contains(domain, "127.0.0.1") || strings.Contains(domain, "localhost") {
+			domain = "dev"
+		}
 	}
 
 	var instances []*Instance

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -77,8 +77,6 @@ func (i *Instance) createRootFolder() error {
 		return err
 	}
 
-	config := config.GetConfig()
-
 	rootFsURL := config.BuildAbsFsURL("/")
 	domainURL := config.BuildRelFsURL(i.Domain)
 
@@ -117,7 +115,7 @@ func Create(domain string, locale string, apps []string) (*Instance, error) {
 		return nil, ErrIllegalDomain
 	}
 
-	domainURL := config.GetConfig().BuildRelFsURL(domain)
+	domainURL := config.BuildRelFsURL(domain)
 	i := &Instance{
 		Domain:     domain,
 		StorageURL: domainURL.String(),
@@ -208,8 +206,8 @@ func Destroy(domain string) (*Instance, error) {
 		return nil, err
 	}
 
-	rootFsURL := config.GetConfig().BuildAbsFsURL("/")
-	domainURL := config.GetConfig().BuildRelFsURL(i.Domain)
+	rootFsURL := config.BuildAbsFsURL("/")
+	domainURL := config.BuildRelFsURL(i.Domain)
 
 	rootFs, err := createFs(rootFsURL)
 	if err != nil {

--- a/instance/instance_test.go
+++ b/instance/instance_test.go
@@ -107,12 +107,9 @@ func TestInstanceDestroy(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	const CouchDBURL = "http://localhost:5984/"
-	const TestPrefix = "dev/"
+	config.UseTestFile()
 
-	config.UseTestFile("..")
-
-	db, err := checkup.HTTPChecker{URL: CouchDBURL}.Check()
+	db, err := checkup.HTTPChecker{URL: config.GetConfig().CouchURL()}.Check()
 	if err != nil || db.Status() != checkup.Healthy {
 		fmt.Println("This test need couchdb to run.")
 		os.Exit(1)

--- a/instance/instance_test.go
+++ b/instance/instance_test.go
@@ -109,7 +109,7 @@ func TestInstanceDestroy(t *testing.T) {
 func TestMain(m *testing.M) {
 	config.UseTestFile()
 
-	db, err := checkup.HTTPChecker{URL: config.GetConfig().CouchURL()}.Check()
+	db, err := checkup.HTTPChecker{URL: config.CouchURL()}.Check()
 	if err != nil || db.Status() != checkup.Healthy {
 		fmt.Println("This test need couchdb to run.")
 		os.Exit(1)

--- a/vfs/vfs_test.go
+++ b/vfs/vfs_test.go
@@ -71,7 +71,7 @@ func TestGetFileDocFromPath(t *testing.T) {
 func TestMain(m *testing.M) {
 	config.UseTestFile()
 
-	db, err := checkup.HTTPChecker{URL: config.GetConfig().CouchURL()}.Check()
+	db, err := checkup.HTTPChecker{URL: config.CouchURL()}.Check()
 	if err != nil || db.Status() != checkup.Healthy {
 		fmt.Println("This test need couchdb to run.")
 		os.Exit(1)

--- a/vfs/vfs_test.go
+++ b/vfs/vfs_test.go
@@ -7,13 +7,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cozy/cozy-stack/config"
 	"github.com/cozy/cozy-stack/couchdb"
 	"github.com/sourcegraph/checkup"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 )
-
-const CouchDBURL = "http://localhost:5984/"
 
 const TestPrefix = "dev/"
 
@@ -70,7 +69,9 @@ func TestGetFileDocFromPath(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	db, err := checkup.HTTPChecker{URL: CouchDBURL}.Check()
+	config.UseTestFile()
+
+	db, err := checkup.HTTPChecker{URL: config.GetConfig().CouchURL()}.Check()
 	if err != nil || db.Status() != checkup.Healthy {
 		fmt.Println("This test need couchdb to run.")
 		os.Exit(1)

--- a/web/data/data_test.go
+++ b/web/data/data_test.go
@@ -38,7 +38,7 @@ var ts *httptest.Server
 // some test helpers files.
 
 func couchReq(method, path string, body io.Reader) (*http.Response, error) {
-	req, err := http.NewRequest(method, config.GetConfig().CouchURL()+path, body)
+	req, err := http.NewRequest(method, config.CouchURL()+path, body)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +113,7 @@ func getDocForTest() couchdb.JSONDoc {
 func TestMain(m *testing.M) {
 	config.UseTestFile()
 
-	db, err := checkup.HTTPChecker{URL: config.GetConfig().CouchURL()}.Check()
+	db, err := checkup.HTTPChecker{URL: config.CouchURL()}.Check()
 	if err != nil || db.Status() != checkup.Healthy {
 		fmt.Println("This test need couchdb to run.")
 		os.Exit(1)

--- a/web/data/data_test.go
+++ b/web/data/data_test.go
@@ -22,7 +22,6 @@ import (
 
 var client = &http.Client{}
 
-const CouchURL = "http://localhost:5984/"
 const Host = "example.com"
 const Type = "io.cozy.events"
 const ID = "4521C325F6478E45"
@@ -39,7 +38,7 @@ var ts *httptest.Server
 // some test helpers files.
 
 func couchReq(method, path string, body io.Reader) (*http.Response, error) {
-	req, err := http.NewRequest(method, CouchURL+path, body)
+	req, err := http.NewRequest(method, config.GetConfig().CouchURL()+path, body)
 	if err != nil {
 		return nil, err
 	}
@@ -112,16 +111,15 @@ func getDocForTest() couchdb.JSONDoc {
 }
 
 func TestMain(m *testing.M) {
-	// First we make sure couchdb is started
-	couchdb, err := checkup.HTTPChecker{URL: CouchURL}.Check()
-	if err != nil || couchdb.Status() != checkup.Healthy {
+	config.UseTestFile()
+
+	db, err := checkup.HTTPChecker{URL: config.GetConfig().CouchURL()}.Check()
+	if err != nil || db.Status() != checkup.Healthy {
 		fmt.Println("This test need couchdb to run.")
 		os.Exit(1)
 	}
 
 	gin.SetMode(gin.TestMode)
-
-	config.UseTestFile("../..")
 
 	inst, err := instance.Create(Host, "en", nil)
 	if err != nil {

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -860,7 +860,7 @@ func TestGetDirectoryMetadataFromID(t *testing.T) {
 func TestMain(m *testing.M) {
 	config.UseTestFile()
 
-	db, err := checkup.HTTPChecker{URL: config.GetConfig().CouchURL()}.Check()
+	db, err := checkup.HTTPChecker{URL: config.CouchURL()}.Check()
 	if err != nil || db.Status() != checkup.Healthy {
 		fmt.Println("This test need couchdb to run.")
 		os.Exit(1)

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const CouchURL = "http://localhost:5984/"
 const TestPrefix = "test/"
 
 var ts *httptest.Server
@@ -859,8 +858,9 @@ func TestGetDirectoryMetadataFromID(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	// First we make sure couchdb is started
-	db, err := checkup.HTTPChecker{URL: CouchURL}.Check()
+	config.UseTestFile()
+
+	db, err := checkup.HTTPChecker{URL: config.GetConfig().CouchURL()}.Check()
 	if err != nil || db.Status() != checkup.Healthy {
 		fmt.Println("This test need couchdb to run.")
 		os.Exit(1)
@@ -891,7 +891,6 @@ func TestMain(m *testing.M) {
 
 	gin.SetMode(gin.TestMode)
 
-	config.UseTestFile("../..")
 	config.GetConfig().Fs.URL = fmt.Sprintf("file://localhost%s", tempdir)
 
 	testInstance, err = instance.Create("test", "en", nil)

--- a/web/jsonapi/jsonapi_test.go
+++ b/web/jsonapi/jsonapi_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cozy/cozy-stack/config"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 )
@@ -142,6 +143,7 @@ func TestData(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
+	config.UseTestFile()
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
 	router.GET("/foos/courge", func(c *gin.Context) {

--- a/web/middlewares/instance_test.go
+++ b/web/middlewares/instance_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cozy/cozy-stack/config"
 	"github.com/cozy/cozy-stack/instance"
 	"github.com/gin-gonic/gin"
 	"github.com/spf13/afero"
@@ -52,6 +53,7 @@ func TestSetInstance(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
+	config.UseTestFile()
 	gin.SetMode(gin.TestMode)
 	os.Exit(m.Run())
 }

--- a/web/status/status.go
+++ b/web/status/status.go
@@ -20,7 +20,7 @@ func Status(c *gin.Context) {
 
 	checker := checkup.HTTPChecker{
 		Name:     "CouchDB",
-		URL:      config.GetConfig().CouchURL(),
+		URL:      config.CouchURL(),
 		Attempts: 3,
 	}
 	couchdb, err := checker.Check()

--- a/web/status/status.go
+++ b/web/status/status.go
@@ -5,12 +5,10 @@ package status
 import (
 	"net/http"
 
+	"github.com/cozy/cozy-stack/config"
 	"github.com/gin-gonic/gin"
 	"github.com/sourcegraph/checkup"
 )
-
-// CouchDBURL is the URL where to check if CouchDB is up
-var CouchDBURL = "http://localhost:5984/"
 
 // Status responds with the status of the service
 //
@@ -22,7 +20,7 @@ func Status(c *gin.Context) {
 
 	checker := checkup.HTTPChecker{
 		Name:     "CouchDB",
-		URL:      CouchDBURL,
+		URL:      config.GetConfig().CouchURL(),
 		Attempts: 3,
 	}
 	couchdb, err := checker.Check()

--- a/web/status/status_test.go
+++ b/web/status/status_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cozy/cozy-stack/config"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 )
@@ -33,6 +34,7 @@ func TestRoutes(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
+	config.UseTestFile()
 	gin.SetMode(gin.TestMode)
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
This PR removes all the hardcoded addresses to CouchDB url and uses the passed configuration instead.