### PR TITLE
Fix /version/ and /status/ when no instance

### DIFF
--- a/web/router.go
+++ b/web/router.go
@@ -34,11 +34,12 @@ import (
 
 // SetupRoutes sets the routing for HTTP endpoints to the Go methods
 func SetupRoutes(router *gin.Engine) {
-	router.Use(middlewares.SetInstance())
 	router.Use(middlewares.ErrorHandler())
+	status.Routes(router.Group("/status"))
+	version.Routes(router.Group("/version"))
+
+	router.Use(middlewares.SetInstance())
 	apps.Routes(router.Group("/apps"))
 	data.Routes(router.Group("/data"))
 	files.Routes(router.Group("/files"))
-	status.Routes(router.Group("/status"))
-	version.Routes(router.Group("/version"))
 }


### PR DESCRIPTION
This PR reorder the web router to allow `/version/` and `/status/` routes to respond even if no instance are created.