### PR TITLE
Add build.sh deploy command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 swagger-ui
 /.cozy
 *.log
+local.env

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ curl -H 'Accept: application/json' 'http://localhost:8080/status/'
 
 To build a release of cozy-stack, a `build.sh` script can automate the work. The `release` option of this script will generate a binary with a name containing the version of the file, along with a SHA-256 sum of the binary.
 
+You can use a `local.env` at the root of the repository to add your default values for environment variables.
+
 See `./build.sh --help` for more informations.
 
 ```sh


### PR DESCRIPTION
This PR add a deploy command to our build script. This should hopefully help to fully automate our deployment with travis.