### PR TITLE
More uniform cmd output

### DIFF
--- a/cmd/instance.go
+++ b/cmd/instance.go
@@ -55,8 +55,8 @@ given domain.
 			return err
 		}
 
-		fmt.Printf("Instance created with success for domain %s\n", domain)
-		log.Debugf("> %v", instance)
+		log.Infof("Instance created with success for domain %s", domain)
+		log.Debugf("Instance created: %#v", instance)
 		return nil
 	},
 }
@@ -79,12 +79,14 @@ by this server.
 		}
 
 		if len(instances) == 0 {
-			fmt.Printf("No instances\n")
+			log.Warnf("No instances")
+			return nil
 		}
 
 		for _, i := range instances {
-			fmt.Printf("instance %s for domain %s (storage: %s)\n", i.DocID, i.Domain, i.StorageURL)
+			fmt.Printf("instance: %s\tdomain: %s\tstorage: %s\n", i.DocID, i.Domain, i.StorageURL)
 		}
+
 		return nil
 	},
 }
@@ -105,7 +107,7 @@ and all its data.
 		fmt.Printf(`
 Are you sure you want to remove instance for domain %s ?
 All data associated with this domain will be permanently lost.
-[yes/NO]:`, domain)
+[yes/NO]: `, domain)
 
 		in, err := reader.ReadString('\n')
 		if err != nil {
@@ -120,11 +122,11 @@ All data associated with this domain will be permanently lost.
 
 		instance, err := instance.Destroy(domain)
 		if err != nil {
-			log.Errorf("Error while remove instance for domain %s", domain)
+			log.Errorf("Error while removing instance for domain %s", domain)
 			return err
 		}
 
-		fmt.Printf("Instance for domain %s has been destroyed with success\n", instance.Domain)
+		log.Infof("Instance for domain %s has been destroyed with success", instance.Domain)
 		return nil
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,6 +45,8 @@ profiles you.`,
 	},
 	// Do not display usage on error
 	SilenceUsage: true,
+	// We have our own way to display error messages
+	SilenceErrors: true,
 }
 
 var cfgFile string
@@ -97,7 +99,7 @@ func Configure() error {
 
 	if err := viper.ReadInConfig(); err != nil {
 		if _, isParseErr := err.(viper.ConfigParseError); isParseErr {
-			fmt.Fprintf(os.Stderr, "Error: While reading cozy-stack configurations from %s\n", viper.ConfigFileUsed())
+			log.Errorf("Error while reading cozy-stack configurations from %s", viper.ConfigFileUsed())
 			return err
 		}
 
@@ -107,7 +109,7 @@ func Configure() error {
 	}
 
 	if viper.ConfigFileUsed() != "" {
-		fmt.Println("Using config file:", viper.ConfigFileUsed())
+		log.Debugf("Using config file: %s", viper.ConfigFileUsed())
 	}
 
 	if err := config.UseViper(viper.GetViper()); err != nil {

--- a/couchdb/errors.go
+++ b/couchdb/errors.go
@@ -61,10 +61,7 @@ type Error struct {
 }
 
 func (e *Error) Error() string {
-	if e.CouchdbJSON != nil {
-		return fmt.Sprintf("CouchdbError %d : %s", e.StatusCode, e.CouchdbJSON)
-	}
-	return fmt.Sprintf("CouchdbError %d : %s(%s)", e.StatusCode, e.Name, e.Reason)
+	return fmt.Sprintf("CouchDB: %d %s (%s)", e.StatusCode, e.Name, e.Reason)
 }
 
 // JSON returns the json representation of this error

--- a/main.go
+++ b/main.go
@@ -25,11 +25,13 @@ package main
 import (
 	"os"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/cozy/cozy-stack/cmd"
 )
 
 func main() {
 	if err := cmd.RootCmd.Execute(); err != nil {
+		log.Errorf(err.Error())
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Tries to uniform a little the stdout/stderr outputs of cozy-stack.

The simple rule I tried to implement:

  - use `log` formatting (with logrus) for any error or information (like success of a command etc.)
  - use non log `fmt.Print` for command output that could be processed (like the table returned by `instances ls` or `config`)
