### PR TITLE
[APPS] Improve error handling

### DIFF
--- a/apps/apps.go
+++ b/apps/apps.go
@@ -44,7 +44,7 @@ const (
 	Ready = "ready"
 )
 
-var slugReg = regexp.MustCompile(`[A-Za-z0-9\\-]`)
+var slugReg = regexp.MustCompile(`^[A-Za-z0-9\-]+$`)
 
 // Access is a string representing the access permission level. It can
 // either be read, write or readwrite.
@@ -64,7 +64,6 @@ type Developer struct {
 
 // Manifest contains all the informations about an application.
 type Manifest struct {
-	ManID  string `json:"_id,omitempty"`  // Manifest identifier
 	ManRev string `json:"_rev,omitempty"` // Manifest revision
 
 	Name        string     `json:"name"`
@@ -86,7 +85,9 @@ type Manifest struct {
 }
 
 // ID returns the manifest identifier - see couchdb.Doc interface
-func (m *Manifest) ID() string { return m.ManID }
+func (m *Manifest) ID() string {
+	return ManifestDocType + "/" + m.Slug
+}
 
 // Rev return the manifest revision - see couchdb.Doc interface
 func (m *Manifest) Rev() string { return m.ManRev }
@@ -96,7 +97,7 @@ func (m *Manifest) DocType() string { return ManifestDocType }
 
 // SetID is used to change the file identifier - see couchdb.Doc
 // interface
-func (m *Manifest) SetID(id string) { m.ManID = id }
+func (m *Manifest) SetID(id string) {}
 
 // SetRev is used to change the file revision - see couchdb.Doc
 // interface
@@ -104,7 +105,7 @@ func (m *Manifest) SetRev(rev string) { m.ManRev = rev }
 
 // SelfLink is used to generate a JSON-API link for the file - see
 // jsonapi.Object interface
-func (m *Manifest) SelfLink() string { return "/apps/" + m.ManID }
+func (m *Manifest) SelfLink() string { return "/apps/" + m.Slug }
 
 // Relationships is used to generate the parent relationship in JSON-API format
 // - see jsonapi.Object interface
@@ -141,12 +142,20 @@ func List(db couchdb.Database) ([]*Manifest, error) {
 	return docs, nil
 }
 
+// GetBySlug returns an app identified by its slug
+func GetBySlug(db couchdb.Database, slug string) (*Manifest, error) {
+	man := &Manifest{}
+	err := couchdb.GetDoc(db, ManifestDocType, slug, man)
+	if err != nil {
+		return nil, err
+	}
+	return man, nil
+}
+
 // Installer is used to install or update applications.
 type Installer struct {
 	cli Client
 
-	// TODO: fix this mess with contexts
-	db   couchdb.Database
 	vfsC vfs.Context
 
 	slug string
@@ -159,9 +168,8 @@ type Installer struct {
 }
 
 // NewInstaller creates a new Installer
-// @TODO: fix this mess with contexts
-func NewInstaller(vfsC vfs.Context, db couchdb.Database, slug, src string) (*Installer, error) {
-	if !slugReg.MatchString(slug) {
+func NewInstaller(vfsC vfs.Context, slug, src string) (*Installer, error) {
+	if slug == "" || !slugReg.MatchString(slug) {
 		return nil, ErrInvalidSlugName
 	}
 
@@ -184,7 +192,6 @@ func NewInstaller(vfsC vfs.Context, db couchdb.Database, slug, src string) (*Ins
 
 	inst := &Installer{
 		cli:  cli,
-		db:   db,
 		vfsC: vfsC,
 
 		slug: slug,
@@ -273,7 +280,6 @@ func (i *Installer) getOrCreateManifest(src, slug string) (man *Manifest, err er
 			err = i.handleErr(err)
 		} else {
 			i.man = man
-			i.manc <- man
 		}
 	}()
 
@@ -281,8 +287,7 @@ func (i *Installer) getOrCreateManifest(src, slug string) (man *Manifest, err er
 		panic("Manifest is already defined")
 	}
 
-	man = &Manifest{}
-	err = couchdb.GetDoc(i.db, ManifestDocType, slug, man)
+	man, err = GetBySlug(i.vfsC, slug)
 	if err != nil && !couchdb.IsNotFoundError(err) {
 		return nil, err
 	}
@@ -296,6 +301,7 @@ func (i *Installer) getOrCreateManifest(src, slug string) (man *Manifest, err er
 	}
 
 	defer r.Close()
+	man = &Manifest{}
 	err = json.NewDecoder(io.LimitReader(r, ManifestMaxSize)).Decode(&man)
 	if err != nil {
 		return nil, ErrBadManifest
@@ -305,7 +311,7 @@ func (i *Installer) getOrCreateManifest(src, slug string) (man *Manifest, err er
 	man.Source = src
 	man.State = Available
 
-	err = couchdb.CreateDoc(i.db, man)
+	err = couchdb.CreateNamedDoc(i.vfsC, man)
 	return
 }
 
@@ -331,14 +337,15 @@ func (i *Installer) updateManifest(newman *Manifest) (err error) {
 	newman.SetID(oldman.ID())
 	newman.SetRev(oldman.Rev())
 
-	return couchdb.UpdateDoc(i.db, newman)
+	return couchdb.UpdateDoc(i.vfsC, newman)
 }
 
 // WaitManifest should be used to monitor the progress of the
 // Installer.
-func (i *Installer) WaitManifest() (man *Manifest, err error) {
+func (i *Installer) WaitManifest() (man *Manifest, done bool, err error) {
 	select {
 	case man = <-i.manc:
+		done = man.State == Ready
 		return
 	case err = <-i.errc:
 		return

--- a/apps/apps.go
+++ b/apps/apps.go
@@ -8,7 +8,6 @@ import (
 	"regexp"
 
 	"github.com/cozy/cozy-stack/couchdb"
-	"github.com/cozy/cozy-stack/couchdb/mango"
 	"github.com/cozy/cozy-stack/vfs"
 	"github.com/cozy/cozy-stack/web/jsonapi"
 )
@@ -134,9 +133,8 @@ type Client interface {
 // TODO: pagination
 func List(db couchdb.Database) ([]*Manifest, error) {
 	var docs []*Manifest
-	sel := mango.Empty()
-	req := &couchdb.FindRequest{Selector: sel, Limit: 10}
-	err := couchdb.FindDocs(db, ManifestDocType, req, &docs)
+	req := &couchdb.AllDocsRequest{Limit: 100}
+	err := couchdb.GetAllDocs(db, ManifestDocType, req, &docs)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/apps.go
+++ b/apps/apps.go
@@ -2,7 +2,6 @@ package apps
 
 import (
 	"encoding/json"
-	"errors"
 	"io"
 	"net/url"
 	"path"
@@ -24,6 +23,10 @@ const (
 // AppsDirectory is the name of the directory in which apps are stored
 const AppsDirectory = "/_cozyapps"
 
+// ManifestFilename is the name of the manifest at the root of the
+// application directory
+const ManifestFilename = "manifest.webapp"
+
 // State is the state of the application
 type State string
 
@@ -43,22 +46,6 @@ const (
 )
 
 var slugReg = regexp.MustCompile(`[A-Za-z0-9\\-]`)
-
-var (
-	// ErrInvalidSlugName is used when the given slud name is not valid
-	ErrInvalidSlugName = errors.New("Invalid slug name")
-	// ErrNotSupportedSource is used when the source transport or
-	// protocol is not supported
-	ErrNotSupportedSource = errors.New("Invalid or not supported source scheme")
-	// ErrSourceNotReachable is used when the given source for
-	// application is not reachable
-	ErrSourceNotReachable = errors.New("Application source is not reachable")
-	// ErrBadManifest when the manifest is not valid or malformed
-	ErrBadManifest = errors.New("Application manifest is invalid or malformed")
-	// ErrBadState is used when trying to use the application while in a
-	// state that is not appropriate for the given operation.
-	ErrBadState = errors.New("Application is not in valid state to perform this operation")
-)
 
 // Access is a string representing the access permission level. It can
 // either be read, write or readwrite.
@@ -237,6 +224,13 @@ func (i *Installer) Install() (newman *Manifest, err error) {
 
 	newman = &(*oldman)
 	newman.State = Installing
+
+	defer func() {
+		if err != nil {
+			newman.State = Errored
+			i.updateManifest(newman)
+		}
+	}()
 
 	err = i.updateManifest(newman)
 	if err != nil {

--- a/apps/apps_test.go
+++ b/apps/apps_test.go
@@ -1,0 +1,153 @@
+package apps
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cozy/cozy-stack/config"
+	"github.com/cozy/cozy-stack/couchdb"
+	"github.com/cozy/cozy-stack/vfs"
+	"github.com/sourcegraph/checkup"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+type TestContext struct {
+	prefix string
+	fs     afero.Fs
+}
+
+func (c TestContext) Prefix() string { return c.prefix }
+func (c TestContext) FS() afero.Fs   { return c.fs }
+
+var c = &TestContext{
+	prefix: "apps-test/",
+	fs:     afero.NewMemMapFs(),
+}
+
+func TestInstallBadSlug(t *testing.T) {
+	_, err := NewInstaller(c, "", "git://foo.bar")
+	if assert.Error(t, err) {
+		assert.Equal(t, ErrInvalidSlugName, err)
+	}
+
+	_, err = NewInstaller(c, "coucou/", "git://foo.bar")
+	if assert.Error(t, err) {
+		assert.Equal(t, ErrInvalidSlugName, err)
+	}
+}
+
+func TestInstallBadAppsSource(t *testing.T) {
+	_, err := NewInstaller(c, "app2", "")
+	if assert.Error(t, err) {
+		assert.Equal(t, ErrNotSupportedSource, err)
+	}
+
+	_, err = NewInstaller(c, "app3", "foo://bar.baz")
+	if assert.Error(t, err) {
+		assert.Equal(t, ErrNotSupportedSource, err)
+	}
+
+	_, err = NewInstaller(c, "app4", "git://bar  .baz")
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "invalid character")
+	}
+}
+
+func TestInstallSuccessful(t *testing.T) {
+	inst, err := NewInstaller(c, "cozy-mini", "git://github.com/nono/cozy-mini.git")
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	go inst.Install()
+
+	var state State
+	for {
+		man, done, err := inst.WaitManifest()
+		if !assert.NoError(t, err) {
+			return
+		}
+		if state == "" {
+			assert.EqualValues(t, Installing, man.State)
+		} else if state == Installing {
+			assert.EqualValues(t, Ready, man.State)
+			assert.True(t, done)
+			break
+		} else {
+			t.Fatalf("invalid state")
+			return
+		}
+		state = man.State
+	}
+}
+
+func TestInstallAldreadyExist(t *testing.T) {
+	inst, err := NewInstaller(c, "conflictslug", "git://github.com/nono/cozy-mini.git")
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	go inst.Install()
+
+	for {
+		var done bool
+		_, done, err = inst.WaitManifest()
+		if !assert.NoError(t, err) {
+			return
+		}
+		if done {
+			break
+		}
+	}
+
+	inst, err = NewInstaller(c, "conflictslug", "git://github.com/nono/cozy-mini.git")
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	go inst.Install()
+
+	_, _, err = inst.WaitManifest()
+	assert.Error(t, err)
+}
+
+func TestMain(m *testing.M) {
+	config.UseTestFile()
+
+	db, err := checkup.HTTPChecker{URL: config.CouchURL()}.Check()
+	if err != nil || db.Status() != checkup.Healthy {
+		fmt.Println("This test need couchdb to run.")
+		os.Exit(1)
+	}
+
+	err = couchdb.ResetDB(c, ManifestDocType)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	err = couchdb.ResetDB(c, vfs.FsDocType)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	for _, index := range vfs.Indexes {
+		err = couchdb.DefineIndex(c, vfs.FsDocType, index)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	}
+
+	if err = vfs.CreateRootDirDoc(c); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	res := m.Run()
+
+	os.Exit(res)
+}

--- a/apps/errors.go
+++ b/apps/errors.go
@@ -1,0 +1,22 @@
+package apps
+
+import "errors"
+
+var (
+	// ErrInvalidSlugName is used when the given slud name is not valid
+	ErrInvalidSlugName = errors.New("Invalid slug name")
+	// ErrNotSupportedSource is used when the source transport or
+	// protocol is not supported
+	ErrNotSupportedSource = errors.New("Invalid or not supported source scheme")
+	// ErrManifestNotReachable is used when the manifest of the
+	// application is not reachable
+	ErrManifestNotReachable = errors.New("Application manifest " + ManifestFilename + " is not reachable")
+	// ErrSourceNotReachable is used when the given source for
+	// application is not reachable
+	ErrSourceNotReachable = errors.New("Application source is not reachable")
+	// ErrBadManifest when the manifest is not valid or malformed
+	ErrBadManifest = errors.New("Application manifest is invalid or malformed")
+	// ErrBadState is used when trying to use the application while in a
+	// state that is not appropriate for the given operation.
+	ErrBadState = errors.New("Application is not in valid state to perform this operation")
+)

--- a/apps/git.go
+++ b/apps/git.go
@@ -18,7 +18,6 @@ import (
 	gitFS "gopkg.in/src-d/go-git.v4/utils/fs"
 )
 
-const manifestFilename = "manifest.webapp"
 const githubRawManifestURL = "https://raw.githubusercontent.com/%s/%s/%s/%s"
 
 var githubURLRegex = regexp.MustCompile(`/([^/]+)/([^/]+).git`)
@@ -64,14 +63,14 @@ func (g *gitClient) fetchManifestFromGithub(src *url.URL) (io.ReadCloser, error)
 		branch = "master"
 	}
 
-	manURL := fmt.Sprintf(githubRawManifestURL, user, project, branch, manifestFilename)
+	manURL := fmt.Sprintf(githubRawManifestURL, user, project, branch, ManifestFilename)
 	resp, err := http.Get(manURL)
 	if err != nil {
-		return nil, ErrSourceNotReachable
+		return nil, ErrManifestNotReachable
 	}
 
 	if resp.StatusCode != 200 {
-		return nil, ErrSourceNotReachable
+		return nil, ErrManifestNotReachable
 	}
 
 	return resp.Body, nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -116,21 +116,5 @@ func Configure() error {
 		return err
 	}
 
-	if err := configureLogger(); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func configureLogger() error {
-	loggerCfg := config.GetConfig().Logger
-
-	logLevel, err := log.ParseLevel(loggerCfg.Level)
-	if err != nil {
-		return err
-	}
-
-	log.SetLevel(logLevel)
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 
@@ -147,7 +148,7 @@ func UseViper(v *viper.Viper) error {
 		},
 	}
 
-	return nil
+	return configureLogger()
 }
 
 // UseTestFile can be used in a test file to inject a configuration
@@ -189,6 +190,18 @@ func UseTestYAML(yaml string) {
 	}
 
 	return
+}
+
+func configureLogger() error {
+	loggerCfg := config.Logger
+
+	logLevel, err := log.ParseLevel(loggerCfg.Level)
+	if err != nil {
+		return err
+	}
+
+	log.SetLevel(logLevel)
+	return nil
 }
 
 func parseMode(mode string) (string, error) {

--- a/couchdb/couchdb.go
+++ b/couchdb/couchdb.go
@@ -498,10 +498,10 @@ type FindRequest struct {
 // AllDocsRequest is used to build a _all_docs request
 type AllDocsRequest struct {
 	Descending  bool     `json:"descending,omitempty"`
+	IncludeDocs bool     `json:"include_docs,omitempty"`
 	Keys        []string `json:"keys,omitempty"`
 	Limit       int      `json:"limit,omitempty"`
 	Skip        int      `json:"skip,omitempty"`
 	StartKey    string   `json:"start_key,omitempty"`
 	EndKey      string   `json:"end_key,omitempty"`
-	IncludeDocs bool     `json:"include_docs,omitempty"`
 }

--- a/couchdb/mango/query.go
+++ b/couchdb/mango/query.go
@@ -111,24 +111,11 @@ func (lf logicFilter) MarshalJSON() ([]byte, error) {
 	return json.Marshal(lf.ToMango())
 }
 
-type emptyFilter struct{}
-
-func (ef emptyFilter) ToMango() Map {
-	return make(Map)
-}
-
-func (ef emptyFilter) MarshalJSON() ([]byte, error) {
-	return []byte("{}"), nil
-}
-
 // ensure ValueFilter & LogicFilter match FilterInterface
 var _ Filter = (*valueFilter)(nil)
 var _ Filter = (*logicFilter)(nil)
 
 // Some Filter creation function
-
-// Empty returns a wildcard filter to select all documents
-func Empty() Filter { return &emptyFilter{} }
 
 // And returns a filter combining several filters
 func And(filters ...Filter) Filter { return logicFilter{and, filters} }

--- a/docs/apps.md
+++ b/docs/apps.md
@@ -258,6 +258,15 @@ Install or update an application, ie download the files and put them in
 `/apps/:slug` in the virtual file system of the user, create an `io.cozy/apps`
 document, register the permissions, etc.
 
+This endpoint is asynchronous and returns a successful return as soon as the application installation has started, meaning we have successfully reached the manifest and started to fetch application data.
+
+#### Status codes
+
+* 202 Accepted, when the application installation has been accepted.
+* 400 Bad-Request, when the manifest of the application could not be processed (for instance, it is not valid JSON).
+* 404 Not Found, when the manifest or the source of the application is not reachable.
+* 422 Unprocessable Entity, when the sent data is invalid (for example, the slug is invalid or the Source parameter is not a proper or supported url)
+
 #### Query-String
 
 Parameter | Description
@@ -304,6 +313,7 @@ An application can be in one of these states:
 - `installing`, the installation is running and the app will soon be usable
 - `upgrading`, a new version is being installed
 - `uninstalling`, the app will be removed, and will return to the `available` state.
+- `errored`, the app is in an error state and can not be used.
 
 #### Request
 

--- a/vfs/directory.go
+++ b/vfs/directory.go
@@ -197,6 +197,9 @@ func GetDirDoc(c Context, fileID string, withChildren bool) (*DirDoc, error) {
 		err = ErrParentDoesNotExist
 	}
 	if err != nil {
+		if fileID == RootFolderID {
+			panic("Root folder is not in database")
+		}
 		return nil, err
 	}
 	if doc.Type != DirType {
@@ -222,6 +225,9 @@ func GetDirDocFromPath(c Context, name string, withChildren bool) (*DirDoc, erro
 		return nil, err
 	}
 	if len(docs) == 0 {
+		if name == "/" {
+			panic("Root folder is not in database")
+		}
 		return nil, os.ErrNotExist
 	}
 	doc = docs[0]

--- a/web/apps/apps.go
+++ b/web/apps/apps.go
@@ -13,24 +13,6 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func wrapAppsError(err error) *jsonapi.Error {
-	if urlErr, isURLErr := err.(*url.Error); isURLErr {
-		return jsonapi.InvalidParameter("Source", urlErr)
-	}
-
-	switch err {
-	case apps.ErrInvalidSlugName:
-		return jsonapi.InvalidParameter("slug", err)
-	case apps.ErrNotSupportedSource:
-		return jsonapi.InvalidParameter("Source", err)
-	case apps.ErrSourceNotReachable:
-		return jsonapi.BadRequest(err)
-	case apps.ErrBadManifest:
-		return jsonapi.BadRequest(err)
-	}
-	return jsonapi.InternalServerError(err)
-}
-
 // InstallHandler handles all POST /:slug request and tries to install
 // the application with the given Source.
 func InstallHandler(c *gin.Context) {
@@ -87,4 +69,24 @@ func ListHandler(c *gin.Context) {
 func Routes(router *gin.RouterGroup) {
 	router.GET("/", ListHandler)
 	router.POST("/:slug", InstallHandler)
+}
+
+func wrapAppsError(err error) *jsonapi.Error {
+	if urlErr, isURLErr := err.(*url.Error); isURLErr {
+		return jsonapi.InvalidParameter("Source", urlErr)
+	}
+
+	switch err {
+	case apps.ErrInvalidSlugName:
+		return jsonapi.InvalidParameter("slug", err)
+	case apps.ErrNotSupportedSource:
+		return jsonapi.InvalidParameter("Source", err)
+	case apps.ErrManifestNotReachable:
+		return jsonapi.NotFound(err)
+	case apps.ErrSourceNotReachable:
+		return jsonapi.NotFound(err)
+	case apps.ErrBadManifest:
+		return jsonapi.BadRequest(err)
+	}
+	return jsonapi.InternalServerError(err)
 }


### PR DESCRIPTION
This PR should improve the error handling of `/apps`:
  - distinguish error for manifest not reachable
  - add documentation of status codes
  - add documentation on the async nature of the `POST /apps/:slug` request
  - set persisted manifest in `errored` state when an error ocured while installing