### PR TITLE
Improve mango docs

### DIFF
--- a/couchdb/couchdb.go
+++ b/couchdb/couchdb.go
@@ -432,11 +432,11 @@ func FindDocsRaw(db Database, doctype string, req interface{}, results interface
 
 // IndexCreationResponse is the response from couchdb when we create an Index
 type IndexCreationResponse struct {
-	Result string `json:"result"`
-	Error  string `json:"error"`
-	Reason string `json:"reason"`
-	ID     string `json:"id"`
-	Name   string `json:"name"`
+	Result string `json:"result,omitempty"`
+	Error  string `json:"error,omitempty"`
+	Reason string `json:"reason,omitempty"`
+	ID     string `json:"id,omitempty"`
+	Name   string `json:"name,omitempty"`
 }
 
 type updateResponse struct {
@@ -453,6 +453,7 @@ type findResponse struct {
 // A FindRequest is a structure containin
 type FindRequest struct {
 	Selector mango.Filter  `json:"selector"`
+	UseIndex string        `json:"use_index,omitempty"`
 	Limit    int           `json:"limit,omitempty"`
 	Skip     int           `json:"skip,omitempty"`
 	Sort     *mango.SortBy `json:"sort,omitempty"`

--- a/docs/mango.md
+++ b/docs/mango.md
@@ -74,8 +74,9 @@ Content-Type: application/json
   },
   "limit": 2,
   "skip": 3,
-  "sort": "date",
-  "fields": ["_id", "_type", "_date"]
+  "sort": ["calendar", "date"],
+  "fields": ["_id", "_type", "_date"],
+  "use_index": "_design/a5f4711fc9448864a13c81dc71e660b524d7410c"
 }
 ```
 
@@ -104,5 +105,8 @@ Content-Type: application/json
 ```
 
 ### Details
-- You can use the `{}` empty selector to get all docs for a db (beware it will also includes `_design/` docs)
 - If an index does not exist for the selector, an error 400 is returned
+- The sort field must contains all fields used in selector
+- The sort field must match an existing index
+- It is possible to sort in reverse direction `sort:[{"calendar":"desc"}, {"date": "desc"}]` but **all fields** must be sorted in same direction.
+- `use_index` is optional but recommended.


### PR DESCRIPTION
Following PO testing of  [DS-13 / E-20] , we identified some issues in docs.

- Using {} selector to get all docs was a hack and broke when we forbid unoptimised queries, remove it from the docs. We should replace it by an HTTP API for couchdb.GetAllDocs (see #100)
- Sort field must be an array and match an existing index,.

And @jinroh saw that it is more efficient to `use_index`,  in [couchdb docs](http://docs.couchdb.org/en/2.0.0/api/database/find.html#index-selection)

For now, the API is just a proxy to couchdb, so we only improve docs to match API behaviour.
Later we might imagine improving API to match user expectation, like autocompleting the beginning of sort field.
