### PR TITLE
Remove typ string from GetDirOrFile* return values

### DIFF
--- a/vfs/directory.go
+++ b/vfs/directory.go
@@ -406,14 +406,13 @@ func fetchChildren(c Context, parent *DirDoc) (files []*FileDoc, dirs []*DirDoc,
 	}
 
 	for _, doc := range docs {
-		typ, dir, file := doc.refine()
-		switch typ {
-		case FileType:
-			file.parent = parent
-			files = append(files, file)
-		case DirType:
+		dir, file := doc.refine()
+		if dir != nil {
 			dir.parent = parent
 			dirs = append(dirs, dir)
+		} else {
+			file.parent = parent
+			files = append(files, file)
 		}
 	}
 

--- a/vfs/vfs_test.go
+++ b/vfs/vfs_test.go
@@ -311,16 +311,16 @@ func TestWalk(t *testing.T) {
 	}
 
 	walked := ""
-	Walk(vfsC, "/walk", func(name string, typ string, dir *DirDoc, file *FileDoc, err error) error {
+	Walk(vfsC, "/walk", func(name string, dir *DirDoc, file *FileDoc, err error) error {
 		if !assert.NoError(t, err) {
 			return err
 		}
 
-		if typ == DirType && !assert.Equal(t, dir.Fullpath, name) {
+		if dir != nil && !assert.Equal(t, dir.Fullpath, name) {
 			return fmt.Errorf("Bad fullpath")
 		}
 
-		if typ == FileType && !assert.True(t, strings.HasSuffix(name, file.Name)) {
+		if file != nil && !assert.True(t, strings.HasSuffix(name, file.Name)) {
 			return fmt.Errorf("Bad fullpath")
 		}
 

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -186,14 +186,13 @@ func ModificationHandler(c *gin.Context) {
 
 	fileID := c.Param("file-id")
 
-	var typ string
 	var file *vfs.FileDoc
 	var dir *vfs.DirDoc
 
 	if fileID == "metadata" {
-		typ, dir, file, err = vfs.GetDirOrFileDocFromPath(instance, c.Query("Path"), false)
+		dir, file, err = vfs.GetDirOrFileDocFromPath(instance, c.Query("Path"), false)
 	} else {
-		typ, dir, file, err = vfs.GetDirOrFileDoc(instance, fileID, false)
+		dir, file, err = vfs.GetDirOrFileDoc(instance, fileID, false)
 	}
 
 	if err != nil {
@@ -202,10 +201,9 @@ func ModificationHandler(c *gin.Context) {
 	}
 
 	var doc couchdb.Doc
-	switch typ {
-	case vfs.DirType:
+	if dir != nil {
 		doc = dir
-	case vfs.FileType:
+	} else {
 		doc = file
 	}
 
@@ -238,17 +236,16 @@ func ReadMetadataFromIDHandler(c *gin.Context, fileID string) {
 
 	instance := middlewares.GetInstance(c)
 
-	typ, dir, file, err := vfs.GetDirOrFileDoc(instance, fileID, true)
+	dir, file, err := vfs.GetDirOrFileDoc(instance, fileID, true)
 	if err != nil {
 		jsonapi.AbortWithError(c, WrapVfsError(err))
 		return
 	}
 
 	var data jsonapi.Object
-	switch typ {
-	case vfs.DirType:
+	if dir != nil {
 		data = dir
-	case vfs.FileType:
+	} else {
 		data = file
 	}
 
@@ -264,17 +261,16 @@ func ReadMetadataFromPathHandler(c *gin.Context) {
 
 	instance := middlewares.GetInstance(c)
 
-	typ, dir, file, err := vfs.GetDirOrFileDocFromPath(instance, c.Query("Path"), true)
+	dir, file, err := vfs.GetDirOrFileDocFromPath(instance, c.Query("Path"), true)
 	if err != nil {
 		jsonapi.AbortWithError(c, WrapVfsError(err))
 		return
 	}
 
 	var data jsonapi.Object
-	switch typ {
-	case vfs.DirType:
+	if dir != nil {
 		data = dir
-	case vfs.FileType:
+	} else {
 		data = file
 	}
 
@@ -332,17 +328,16 @@ func TrashHandler(c *gin.Context) {
 
 	fileID := c.Param("file-id")
 
-	typ, dir, file, err := vfs.GetDirOrFileDoc(instance, fileID, true)
+	dir, file, err := vfs.GetDirOrFileDoc(instance, fileID, true)
 	if err != nil {
 		jsonapi.AbortWithError(c, WrapVfsError(err))
 		return
 	}
 
 	var data jsonapi.Object
-	switch typ {
-	case vfs.DirType:
+	if dir != nil {
 		data, err = vfs.TrashDir(instance, dir)
-	case vfs.FileType:
+	} else {
 		data, err = vfs.TrashFile(instance, file)
 	}
 


### PR DESCRIPTION
This PR is a little proposal to remove the `typ string` return value of the `GetDirOrFile*` functions.

It is not ideal but I think it makes it clearer that either dir or file is non nil, and avoid to have to "switch" over a string without a default case.