### PR TITLE
Tests should not leave artifacts

### DIFF
--- a/apps/apps_test.go
+++ b/apps/apps_test.go
@@ -149,5 +149,8 @@ func TestMain(m *testing.M) {
 
 	res := m.Run()
 
+	couchdb.DeleteDB(c, ManifestDocType)
+	couchdb.DeleteDB(c, vfs.FsDocType)
+
 	os.Exit(res)
 }

--- a/couchdb/couchdb_test.go
+++ b/couchdb/couchdb_test.go
@@ -19,7 +19,7 @@ func TestErrors(t *testing.T) {
 
 const TestDoctype = "io.cozy.testobject"
 
-var TestPrefix = SimpleDatabasePrefix("dev")
+var TestPrefix = SimpleDatabasePrefix("couchdb-tests")
 
 type testDoc struct {
 	TestID  string `json:"_id,omitempty"`
@@ -193,5 +193,9 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	os.Exit(m.Run())
+	res := m.Run()
+
+	DeleteDB(TestPrefix, TestDoctype)
+
+	os.Exit(res)
 }

--- a/instance/instance_test.go
+++ b/instance/instance_test.go
@@ -186,7 +186,12 @@ func TestMain(m *testing.M) {
 
 	os.RemoveAll("/usr/local/var/cozy2/")
 
-	os.Exit(m.Run())
+	res := m.Run()
+
+	Destroy("test.cozycloud.cc")
+	Destroy("test.cozycloud.cc.duplicate")
+
+	os.Exit(res)
 }
 
 func getDB(t *testing.T, domain string) couchdb.Database {

--- a/vfs/vfs_test.go
+++ b/vfs/vfs_test.go
@@ -17,10 +17,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const TestPrefix = "dev/"
-
-const CouchDBURL = "http://localhost:5984/"
-
 type TestContext struct {
 	prefix string
 	fs     afero.Fs
@@ -385,6 +381,7 @@ func TestMain(m *testing.M) {
 	res := m.Run()
 
 	os.RemoveAll(tempdir)
+	couchdb.DeleteDB(vfsC, FsDocType)
 
 	os.Exit(res)
 }


### PR DESCRIPTION
While preparing today review, I saw my couchdb was a mess, tests were not properly cleaning after themselves.