### PR TITLE
Unify usage of folder vs directory and use directory

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,9 +23,9 @@ var ConfigPaths = []string{
 	"/etc/cozy",
 }
 
-// DefaultStorageDirectory is the default directory name in which data
+// DefaultStorageDir is the default directory name in which data
 // is stored relatively to the cozy-stack binary.
-const DefaultStorageDirectory = "storage"
+const DefaultStorageDir = "storage"
 
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
@@ -71,7 +71,7 @@ func init() {
 	flags.StringP("assets", "", "./assets", "path to the directory with the assets")
 	viper.BindPFlag("assets", flags.Lookup("assets"))
 
-	flags.String("fs-url", fmt.Sprintf("file://localhost%s/%s", binDir, DefaultStorageDirectory), "filesystem url")
+	flags.String("fs-url", fmt.Sprintf("file://localhost%s/%s", binDir, DefaultStorageDir), "filesystem url")
 	viper.BindPFlag("fs.url", flags.Lookup("fs-url"))
 
 	flags.String("couchdb-host", "localhost", "couchdbdb host")

--- a/couchdb/mango/index_test.go
+++ b/couchdb/mango/index_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 func TestIndexMarshaling(t *testing.T) {
-	def := IndexOnFields("folder_id", "name")
+	def := IndexOnFields("dir_id", "name")
 	jsonbytes, _ := json.Marshal(def)
-	expected := `{"index":{"fields":["folder_id","name"]}}`
+	expected := `{"index":{"fields":["dir_id","name"]}}`
 	assert.Equal(t, expected, string(jsonbytes), "index should MarshalJSON properly")
 }

--- a/couchdb/mango/query_test.go
+++ b/couchdb/mango/query_test.go
@@ -20,25 +20,25 @@ func DeepEqual(t *testing.T, map1, map2 interface{}) bool {
 }
 
 func TestQueryMarshaling(t *testing.T) {
-	q1 := Equal("FolderID", "ab123")
-	DeepEqual(t, q1.ToMango(), M{"FolderID": "ab123"})
+	q1 := Equal("DirID", "ab123")
+	DeepEqual(t, q1.ToMango(), M{"DirID": "ab123"})
 	q2 := Gt("Size", 1000)
 	DeepEqual(t, q2.ToMango(), M{"Size": M{"$gt": 1000}})
 	q3 := And(q1, q2)
 	DeepEqual(t, q3.ToMango(),
 		M{"$and": S{
-			M{"FolderID": "ab123"},
+			M{"DirID": "ab123"},
 			M{"Size": M{"$gt": 1000}},
 		}})
 
-	q4 := Not(Equal("FolderID", "ab123"))
-	DeepEqual(t, q4.ToMango(), M{"$not": M{"FolderID": "ab123"}})
+	q4 := Not(Equal("DirID", "ab123"))
+	DeepEqual(t, q4.ToMango(), M{"$not": M{"DirID": "ab123"}})
 }
 
 func TestSortMarshaling(t *testing.T) {
-	s1 := &SortBy{"folder_id", Asc}
+	s1 := &SortBy{"dir_id", Asc}
 	j1, err := json.Marshal(s1)
 	if assert.NoError(t, err) {
-		assert.Equal(t, j1, []byte(`["folder_id","asc"]`))
+		assert.Equal(t, j1, []byte(`["dir_id","asc"]`))
 	}
 }

--- a/docs/files.md
+++ b/docs/files.md
@@ -9,39 +9,39 @@ having to know the underlying storage layer. The metadata are kept in CouchDB,
 but the binaries can go to the local system, or a Swift instance.
 
 
-Folders
--------
+Directories
+-----------
 
-A folder is a container for files and sub-folders.
+A directory is a container for files and sub-directories.
 
 Its path is the path of its parent, a slash (`/`), and its name. It's case
 sensitive.
 
-### POST /files/:folder-id
+### POST /files/:dir-id
 
-Create a new folder. The `folder-id` parameter is optional. When it's not
-given, the folder is created at the root of the virtual file system.
+Create a new directory. The `dir-id` parameter is optional. When it's not
+given, the directory is created at the root of the virtual file system.
 
 #### Query-String
 
 Parameter | Description
 ----------|------------------
-Type      | `io.cozy.folders`
-Name      | the folder name
+Type      | `directory`
+Name      | the directory name
 Tags      | an array of tags
 
 #### Request
 
 ```http
 POST
-/files/fce1a6c0-dfc5-11e5-8d1a-1f854d4aaf81?Type=io.cozy.folders&Name=phone&Tags=bills,konnectors HTTP/1.1
+/files/fce1a6c0-dfc5-11e5-8d1a-1f854d4aaf81?Type=directory&Name=phone&Tags=bills,konnectors HTTP/1.1
 Accept: application/vnd.api+json
 ```
 
 #### Status codes
 
-* 201 Created, when the folder has been successfully created
-* 404 Not Found, when the parent folder does not exist
+* 201 Created, when the directory has been successfully created
+* 404 Not Found, when the parent directory does not exist
 * 409 Conflict, when a directory with the same name already exists
 * 422 Unprocessable Entity, when the `Type` or `Name` parameter is missing or invalid
 
@@ -86,7 +86,7 @@ Location: http://cozy.example.com/files/6494e0ac-dfcb-11e5-88c1-472e84a9cbee
 
 ### GET /files/:file-id
 
-Get a folder or a file informations. In the case of a folder, it contains the list of files and sub-folders inside it.
+Get a directory or a file informations. In the case of a directory, it contains the list of files and sub-directories inside it.
 Contents is paginated. By default, only the 100 first entries are given.
 
 ### Query-String
@@ -197,9 +197,9 @@ Content-Type: application/vnd.api+json
 }
 ```
 
-### DELETE /files/:folder-id
+### DELETE /files/:dir-id
 
-Put a folder and its subtree in the trash.
+Put a directory and its subtree in the trash.
 
 
 Files
@@ -207,7 +207,7 @@ Files
 
 A file is a binary content with some metadata.
 
-### POST /files/:folder-id
+### POST /files/:dir-id
 
 Upload a file
 
@@ -215,7 +215,7 @@ Upload a file
 
 Parameter | Description
 ----------|---------------------------------------------------
-Type      | `io.cozy.files`
+Type      | `file`
 Name      | the file name
 Tags      | an array of tags
 Executable| `true` if the file is executable (UNIX permission)
@@ -232,7 +232,7 @@ Date          | The modification date of the file
 #### Request
 
 ```http
-POST /files/fce1a6c0-dfc5-11e5-8d1a-1f854d4aaf81?Type=io.cozy.files&Name=hello.txt HTTP/1.1
+POST /files/fce1a6c0-dfc5-11e5-8d1a-1f854d4aaf81?Type=file&Name=hello.txt HTTP/1.1
 Accept: application/vnd.api+json
 Content-Length: 12
 Content-MD5: hvsmnRkNLIX24EaM7KQqIA==
@@ -245,7 +245,7 @@ Hello world!
 #### Status codes
 
 * 201 Created, when the file has been successfully created
-* 404 Not Found, when the parent folder does not exist
+* 404 Not Found, when the parent directory does not exist
 * 409 Conflict, when a file with the same name already exists
 * 412 Precondition Failed, when the md5sum is `Content-MD5` is not equal to the md5sum computed by the server
 * 422 Unprocessable Entity, when the sent data is invalid (for example, the parent doesn't exist, `Type` or `Name` parameter is missing or invalid, etc.)
@@ -469,16 +469,16 @@ Location: http://cozy.example.com/files/9152d568-7e7c-11e6-a377-37cbfb190b4b
 
 ### PATCH /files/:file-id and PATCH /files/metadata
 
-Both endpoints can be used to update the metadata of a file or folder, or to
+Both endpoints can be used to update the metadata of a file or directory, or to
 rename/move it. The difference is the first one uses an id to identify the
-file/folder to update, and the second one uses the path.
+file/directory to update, and the second one uses the path.
 
-The parent relationship can be updated to move a file or folder.
+The parent relationship can be updated to move a file or directory.
 
 #### HTTP headers
 
 It's possible to send the `If-Match` header, with the previous revision of the
-file/folder (optional).
+file/directory (optional).
 
 #### Request
 
@@ -512,10 +512,10 @@ Content-Type: application/vnd.api+json
 
 #### Status codes
 
-* 200 OK, when the file or folder metadata has been successfully updated
-* 400 Bad Request, when a the folder is asked to move to one of its sub-folders
-* 404 Not Found, when the file/folder wasn't existing
-* 412 Precondition Failed, when the `If-Match` header is set and doesn't match the last revision of the file/folder
+* 200 OK, when the file or directory metadata has been successfully updated
+* 400 Bad Request, when a the directory is asked to move to one of its sub-directories
+* 404 Not Found, when the file/directory wasn't existing
+* 412 Precondition Failed, when the `If-Match` header is set and doesn't match the last revision of the file/directory
 * 422 Unprocessable Entity, when the sent data is invalid (for example, the parent doesn't exist)
 
 #### Response
@@ -565,8 +565,7 @@ Location: http://cozy.example.com/files/9152d568-7e7c-11e6-a377-37cbfb190b4b
 ### POST /files/archive
 
 Create an archive and download it. The body of the request lists the files and
-folders that will be included in the archive. For folders, it includes all the
-files and sub-folders in the archive.
+directories that will be included in the archive. For directories, it includes all the files and sub-directories in the archive.
 
 #### Request
 

--- a/docs/instance.md
+++ b/docs/instance.md
@@ -53,10 +53,7 @@ and creates the proper databases ($PREFIX/$DOCTYPE) for these doctypes:
 
 Then, it creates the following indexes for these doctypes :
 
-- `io.cozy.apps : ["slug"]`
-- `io.cozy.manifest : ["url"]`
-- `io.cozy.files: ["dir_id", "name"], ["directory", "updated_at"]`
-- **TODO :** complete this list
+- **TODO :** complete this list of indexes
 
 Then, it creates some directories:
 

--- a/docs/instance.md
+++ b/docs/instance.md
@@ -48,7 +48,6 @@ and creates the proper databases ($PREFIX/$DOCTYPE) for these doctypes:
 - `io.cozy.apps`
 - `io.cozy.manifests`
 - `io.cozy.files`
-- `io.cozy.folders`
 - `io.cozy.notifications`
 - `io.cozy.settings`
 
@@ -56,24 +55,23 @@ Then, it creates the following indexes for these doctypes :
 
 - `io.cozy.apps : ["slug"]`
 - `io.cozy.manifest : ["url"]`
-- `io.cozy.files & io.cozy.folders: ["FolderId", "name"], ["FolderId", "modifiedDate"]`
+- `io.cozy.files: ["dir_id", "name"], ["directory", "updated_at"]`
 - **TODO :** complete this list
 
-Then, it creates some folders:
+Then, it creates some directories:
 
-- `/`, with the id `io.cozy.folders-root`
-- `/Apps`, with the id `io.cozy.folders-apps`
-- `/Documents`, with the id `io.cozy.folders-documents`
-- `/Documents/Downloads`, with the id `io.cozy.folders-downloads`
-- `/Documents/Pictures`, with the id `io.cozy.folders-pictures`
-- `/Documents/Music`, with the id `io.cozy.folders-music`
-- `/Documents/Videos`, with the id `io.cozy.folders-videos`
+- `/`, with the id `io.cozy.files.root-dir`
+- `/Apps`, with the id `io.cozy.files.apps-dir`
+- `/Documents`, with the id `io.cozy.files.documents-dir`
+- `/Documents/Downloads`, with the id `io.cozy.files.downloads-dir`
+- `/Documents/Pictures`, with the id `io.cozy.files.pictures-dir`
+- `/Documents/Music`, with the id `io.cozy.files.music-dir`
+- `/Documents/Videos`, with the id `io.cozy.files.videos-dir`
 
-**The ids are forced to known values:**  even if these folders are moved or
+**The ids are forced to known values:**  even if these directories are moved or
 renamed, they can still be found for the permissions.
 
-**The names are localized:** If a locale is provided through the CLI, the folders will be created with
-names in this locale. Otherwise, theses folders will be created in english and renamed to localized name the first time the locale is set (during onboarding).
+**The names are localized:** If a locale is provided through the CLI, the directories will be created with names in this locale. Otherwise, theses directories will be created in english and renamed to localized name the first time the locale is set (during onboarding).
 
 Then it creates the basic settings
 

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -103,8 +103,8 @@ func (i *Instance) createInCouchdb() (err error) {
 	return couchdb.DefineIndex(couchdb.GlobalDB, InstanceType, byDomain)
 }
 
-// createRootFolder creates the root folder for this instance
-func (i *Instance) createRootFolder() error {
+// createRootDir creates the root directory for this instance
+func (i *Instance) createRootDir() error {
 	rootFsURL := config.BuildAbsFsURL("/")
 	domainURL := config.BuildRelFsURL(i.Domain)
 
@@ -181,7 +181,7 @@ func Create(domain string, locale string, apps []string) (*Instance, error) {
 		return nil, err
 	}
 
-	err = i.createRootFolder()
+	err = i.createRootDir()
 	if err != nil {
 		return nil, err
 	}

--- a/instance/instance_test.go
+++ b/instance/instance_test.go
@@ -57,10 +57,10 @@ func TestGetCorrectInstance(t *testing.T) {
 	}
 }
 
-func TestInstanceHasRootFolder(t *testing.T) {
+func TestInstanceHasRootDir(t *testing.T) {
 	var root vfs.DirDoc
 	prefix := getDB(t, "test.cozycloud.cc")
-	err := couchdb.GetDoc(prefix, vfs.FsDocType, vfs.RootFolderID, &root)
+	err := couchdb.GetDoc(prefix, vfs.FsDocType, vfs.RootDirID, &root)
 	if assert.NoError(t, err) {
 		assert.Equal(t, root.Fullpath, "/")
 	}

--- a/vfs/errors.go
+++ b/vfs/errors.go
@@ -3,9 +3,9 @@ package vfs
 import "errors"
 
 var (
-	// ErrParentDoesNotExist is used when the parent folder does not
+	// ErrParentDoesNotExist is used when the parent directory does not
 	// exist
-	ErrParentDoesNotExist = errors.New("Parent folder with given FolderID does not exist")
+	ErrParentDoesNotExist = errors.New("Parent directory with given DirID does not exist")
 	// ErrForbiddenDocMove is used when trying to move a document in an
 	// illicit destination
 	ErrForbiddenDocMove = errors.New("Forbidden document move")
@@ -28,7 +28,7 @@ var (
 	// ErrNonAbsolutePath is used when the given path is not absolute
 	// while it is required to be
 	ErrNonAbsolutePath = errors.New("Path should be abolute")
-	// ErrDirectoryNotEmpty is used to inform that the directory is not
+	// ErrDirNotEmpty is used to inform that the directory is not
 	// empty
-	ErrDirectoryNotEmpty = errors.New("Directory is not empty")
+	ErrDirNotEmpty = errors.New("Directory is not empty")
 )

--- a/vfs/vfs_test.go
+++ b/vfs/vfs_test.go
@@ -44,20 +44,20 @@ func printH(h H, str string, count int) string {
 	return str
 }
 
-func createTree(tree H, folderID string) (*DirDoc, error) {
+func createTree(tree H, dirID string) (*DirDoc, error) {
 	if tree == nil {
 		return nil, nil
 	}
 
-	if folderID == "" {
-		folderID = RootFolderID
+	if dirID == "" {
+		dirID = RootDirID
 	}
 
 	var err error
 	var dirdoc *DirDoc
 	for name, children := range tree {
 		if name[len(name)-1] == '/' {
-			dirdoc, err = NewDirDoc(name[:len(name)-1], folderID, nil, nil)
+			dirdoc, err = NewDirDoc(name[:len(name)-1], dirID, nil, nil)
 			if err != nil {
 				return nil, err
 			}
@@ -68,7 +68,7 @@ func createTree(tree H, folderID string) (*DirDoc, error) {
 				return nil, err
 			}
 		} else {
-			filedoc, err := NewFileDoc(name, folderID, -1, nil, "", "", false, nil)
+			filedoc, err := NewFileDoc(name, dirID, -1, nil, "", "", false, nil)
 			if err != nil {
 				return nil, err
 			}
@@ -186,7 +186,7 @@ func TestCreateAndGetFile(t *testing.T) {
 		},
 	}
 
-	olddoc, err := createTree(origtree, RootFolderID)
+	olddoc, err := createTree(origtree, RootDirID)
 
 	if !assert.NoError(t, err) {
 		return
@@ -224,7 +224,7 @@ func TestUpdateDir(t *testing.T) {
 		},
 	}
 
-	doc1, err := createTree(origtree, RootFolderID)
+	doc1, err := createTree(origtree, RootDirID)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -258,7 +258,7 @@ func TestUpdateDir(t *testing.T) {
 
 	newfolid := dirchild2.ID()
 	_, err = ModifyDirMetadata(vfsC, dirchild3, &DocPatch{
-		FolderID: &newfolid,
+		DirID: &newfolid,
 	})
 	if !assert.NoError(t, err) {
 		return
@@ -301,7 +301,7 @@ func TestWalk(t *testing.T) {
 		},
 	}
 
-	_, err := createTree(walktree, RootFolderID)
+	_, err := createTree(walktree, RootDirID)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -214,25 +214,25 @@ func TestCreateDirWithNoType(t *testing.T) {
 }
 
 func TestCreateDirWithNoName(t *testing.T) {
-	res, _ := createDir(t, "/files/?Type=io.cozy.folders")
+	res, _ := createDir(t, "/files/?Type=directory")
 	assert.Equal(t, 422, res.StatusCode)
 }
 
 func TestCreateDirOnNonExistingParent(t *testing.T) {
-	res, _ := createDir(t, "/files/noooop?Name=foo&Type=io.cozy.folders")
+	res, _ := createDir(t, "/files/noooop?Name=foo&Type=directory")
 	assert.Equal(t, 404, res.StatusCode)
 }
 
 func TestCreateDirAlreadyExists(t *testing.T) {
-	res1, _ := createDir(t, "/files/?Name=iexist&Type=io.cozy.folders")
+	res1, _ := createDir(t, "/files/?Name=iexist&Type=directory")
 	assert.Equal(t, 201, res1.StatusCode)
 
-	res2, _ := createDir(t, "/files/?Name=iexist&Type=io.cozy.folders")
+	res2, _ := createDir(t, "/files/?Name=iexist&Type=directory")
 	assert.Equal(t, 409, res2.StatusCode)
 }
 
 func TestCreateDirRootSuccess(t *testing.T) {
-	res, _ := createDir(t, "/files/?Name=coucou&Type=io.cozy.folders")
+	res, _ := createDir(t, "/files/?Name=coucou&Type=directory")
 	assert.Equal(t, 201, res.StatusCode)
 
 	storage := testInstance.FS()
@@ -242,7 +242,7 @@ func TestCreateDirRootSuccess(t *testing.T) {
 }
 
 func TestCreateDirWithParentSuccess(t *testing.T) {
-	res1, data1 := createDir(t, "/files/?Name=dirparent&Type=io.cozy.folders")
+	res1, data1 := createDir(t, "/files/?Name=dirparent&Type=directory")
 	assert.Equal(t, 201, res1.StatusCode)
 
 	var ok bool
@@ -252,7 +252,7 @@ func TestCreateDirWithParentSuccess(t *testing.T) {
 	parentID, ok := data1["id"].(string)
 	assert.True(t, ok)
 
-	res2, _ := createDir(t, "/files/"+parentID+"?Name=child&Type=io.cozy.folders")
+	res2, _ := createDir(t, "/files/"+parentID+"?Name=child&Type=directory")
 	assert.Equal(t, 201, res2.StatusCode)
 
 	storage := testInstance.FS()
@@ -262,10 +262,10 @@ func TestCreateDirWithParentSuccess(t *testing.T) {
 }
 
 func TestCreateDirWithIllegalCharacter(t *testing.T) {
-	res1, _ := createDir(t, "/files/?Name=coucou/les/copains!&Type=io.cozy.folders")
+	res1, _ := createDir(t, "/files/?Name=coucou/les/copains!&Type=directory")
 	assert.Equal(t, 422, res1.StatusCode)
 
-	res2, _ := createDir(t, "/files/?Name=j'ai\x00untrou!&Type=io.cozy.folders")
+	res2, _ := createDir(t, "/files/?Name=j'ai\x00untrou!&Type=directory")
 	assert.Equal(t, 422, res2.StatusCode)
 }
 
@@ -274,7 +274,7 @@ func TestCreateDirConcurrently(t *testing.T) {
 	errs := make(chan *http.Response)
 
 	doCreateDir := func(name string) {
-		res, _ := createDir(t, "/files/?Name="+name+"&Type=io.cozy.folders")
+		res, _ := createDir(t, "/files/?Name="+name+"&Type=directory")
 		if res.StatusCode == 201 {
 			done <- res
 		} else {
@@ -307,13 +307,13 @@ func TestUploadWithNoType(t *testing.T) {
 }
 
 func TestUploadWithNoName(t *testing.T) {
-	res, _ := upload(t, "/files/?Type=io.cozy.files", "text/plain", "foo", "")
+	res, _ := upload(t, "/files/?Type=file", "text/plain", "foo", "")
 	assert.Equal(t, 422, res.StatusCode)
 }
 
 func TestUploadBadHash(t *testing.T) {
 	body := "foo"
-	res, _ := upload(t, "/files/?Type=io.cozy.files&Name=badhash", "text/plain", body, "3FbbMXfH+PdjAlWFfVb1dQ==")
+	res, _ := upload(t, "/files/?Type=file&Name=badhash", "text/plain", body, "3FbbMXfH+PdjAlWFfVb1dQ==")
 	assert.Equal(t, 412, res.StatusCode)
 
 	storage := testInstance.FS()
@@ -323,7 +323,7 @@ func TestUploadBadHash(t *testing.T) {
 
 func TestUploadAtRootSuccess(t *testing.T) {
 	body := "foo"
-	res, _ := upload(t, "/files/?Type=io.cozy.files&Name=goodhash", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
+	res, _ := upload(t, "/files/?Type=file&Name=goodhash", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
 	assert.Equal(t, 201, res.StatusCode)
 
 	storage := testInstance.FS()
@@ -337,7 +337,7 @@ func TestUploadConcurrently(t *testing.T) {
 	errs := make(chan *http.Response)
 
 	doUpload := func(name, body string) {
-		res, _ := upload(t, "/files/?Type=io.cozy.files&Name="+name, "text/plain", body, "")
+		res, _ := upload(t, "/files/?Type=file&Name="+name, "text/plain", body, "")
 		if res.StatusCode == 201 {
 			done <- res
 		} else {
@@ -365,7 +365,7 @@ func TestUploadConcurrently(t *testing.T) {
 }
 
 func TestUploadWithParentSuccess(t *testing.T) {
-	res1, data1 := createDir(t, "/files/?Name=fileparent&Type=io.cozy.folders")
+	res1, data1 := createDir(t, "/files/?Name=fileparent&Type=directory")
 	assert.Equal(t, 201, res1.StatusCode)
 
 	var ok bool
@@ -376,7 +376,7 @@ func TestUploadWithParentSuccess(t *testing.T) {
 	assert.True(t, ok)
 
 	body := "foo"
-	res2, _ := upload(t, "/files/"+parentID+"?Type=io.cozy.files&Name=goodhash", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
+	res2, _ := upload(t, "/files/"+parentID+"?Type=file&Name=goodhash", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
 	assert.Equal(t, 201, res2.StatusCode)
 
 	storage := testInstance.FS()
@@ -387,15 +387,15 @@ func TestUploadWithParentSuccess(t *testing.T) {
 
 func TestUploadAtRootAlreadyExists(t *testing.T) {
 	body := "foo"
-	res1, _ := upload(t, "/files/?Type=io.cozy.files&Name=iexistfile", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
+	res1, _ := upload(t, "/files/?Type=file&Name=iexistfile", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
 	assert.Equal(t, 201, res1.StatusCode)
 
-	res2, _ := upload(t, "/files/?Type=io.cozy.files&Name=iexistfile", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
+	res2, _ := upload(t, "/files/?Type=file&Name=iexistfile", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
 	assert.Equal(t, 409, res2.StatusCode)
 }
 
 func TestUploadWithParentAlreadyExists(t *testing.T) {
-	_, dirdata := createDir(t, "/files/?Type=io.cozy.folders&Name=container")
+	_, dirdata := createDir(t, "/files/?Type=directory&Name=container")
 
 	var ok bool
 	dirdata, ok = dirdata["data"].(map[string]interface{})
@@ -405,16 +405,16 @@ func TestUploadWithParentAlreadyExists(t *testing.T) {
 	assert.True(t, ok)
 
 	body := "foo"
-	res1, _ := upload(t, "/files/"+parentID+"?Type=io.cozy.files&Name=iexistfile", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
+	res1, _ := upload(t, "/files/"+parentID+"?Type=file&Name=iexistfile", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
 	assert.Equal(t, 201, res1.StatusCode)
 
-	res2, _ := upload(t, "/files/"+parentID+"?Type=io.cozy.files&Name=iexistfile", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
+	res2, _ := upload(t, "/files/"+parentID+"?Type=file&Name=iexistfile", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
 	assert.Equal(t, 409, res2.StatusCode)
 }
 
 func TestModifyMetadataFileMove(t *testing.T) {
 	body := "foo"
-	res1, data1 := upload(t, "/files/?Type=io.cozy.files&Name=filemoveme&Tags=foo,bar", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
+	res1, data1 := upload(t, "/files/?Type=file&Name=filemoveme&Tags=foo,bar", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
 	assert.Equal(t, 201, res1.StatusCode)
 
 	var ok bool
@@ -424,23 +424,23 @@ func TestModifyMetadataFileMove(t *testing.T) {
 	fileID, ok := data1["id"].(string)
 	assert.True(t, ok)
 
-	res2, data2 := createDir(t, "/files/?Name=movemeinme&Type=io.cozy.folders")
+	res2, data2 := createDir(t, "/files/?Name=movemeinme&Type=directory")
 	assert.Equal(t, 201, res2.StatusCode)
 
 	data2, ok = data2["data"].(map[string]interface{})
 	assert.True(t, ok)
 
-	folderID, ok := data2["id"].(string)
+	dirID, ok := data2["id"].(string)
 	assert.True(t, ok)
 
 	attrs := map[string]interface{}{
 		"tags":       []string{"bar", "bar", "baz"},
 		"name":       "moved",
-		"folder_id":  folderID,
+		"dir_id":     dirID,
 		"executable": true,
 	}
 
-	res3, data3 := patchFile(t, "/files/"+fileID, "io.cozy.files", fileID, attrs, nil)
+	res3, data3 := patchFile(t, "/files/"+fileID, "file", fileID, attrs, nil)
 	assert.Equal(t, 200, res3.StatusCode)
 
 	data3, ok = data3["data"].(map[string]interface{})
@@ -460,10 +460,10 @@ func TestModifyMetadataFileMove(t *testing.T) {
 
 func TestModifyMetadataFileConflict(t *testing.T) {
 	body := "foo"
-	res1, data1 := upload(t, "/files/?Type=io.cozy.files&Name=fmodme1&Tags=foo,bar", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
+	res1, data1 := upload(t, "/files/?Type=file&Name=fmodme1&Tags=foo,bar", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
 	assert.Equal(t, 201, res1.StatusCode)
 
-	res2, _ := upload(t, "/files/?Type=io.cozy.files&Name=fmodme2&Tags=foo,bar", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
+	res2, _ := upload(t, "/files/?Type=file&Name=fmodme2&Tags=foo,bar", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
 	assert.Equal(t, 201, res2.StatusCode)
 
 	file1ID, _ := extractDirData(t, data1)
@@ -472,34 +472,34 @@ func TestModifyMetadataFileConflict(t *testing.T) {
 		"name": "fmodme2",
 	}
 
-	res3, _ := patchFile(t, "/files/"+file1ID, "io.cozy.files", file1ID, attrs, nil)
+	res3, _ := patchFile(t, "/files/"+file1ID, "file", file1ID, attrs, nil)
 	assert.Equal(t, 409, res3.StatusCode)
 }
 
 func TestModifyMetadataDirMove(t *testing.T) {
-	res1, data1 := createDir(t, "/files/?Name=dirmodme&Type=io.cozy.folders&Tags=foo,bar,bar")
+	res1, data1 := createDir(t, "/files/?Name=dirmodme&Type=directory&Tags=foo,bar,bar")
 	assert.Equal(t, 201, res1.StatusCode)
 
-	folder1ID, _ := extractDirData(t, data1)
+	dir1ID, _ := extractDirData(t, data1)
 
-	reschild1, _ := createDir(t, "/files/"+folder1ID+"?Name=child1&Type=io.cozy.folders")
+	reschild1, _ := createDir(t, "/files/"+dir1ID+"?Name=child1&Type=directory")
 	assert.Equal(t, 201, reschild1.StatusCode)
 
-	reschild2, _ := createDir(t, "/files/"+folder1ID+"?Name=child2&Type=io.cozy.folders")
+	reschild2, _ := createDir(t, "/files/"+dir1ID+"?Name=child2&Type=directory")
 	assert.Equal(t, 201, reschild2.StatusCode)
 
-	res2, data2 := createDir(t, "/files/?Name=dirmodmemoveinme&Type=io.cozy.folders")
+	res2, data2 := createDir(t, "/files/?Name=dirmodmemoveinme&Type=directory")
 	assert.Equal(t, 201, res2.StatusCode)
 
-	folder2ID, _ := extractDirData(t, data2)
+	dir2ID, _ := extractDirData(t, data2)
 
 	attrs1 := map[string]interface{}{
-		"tags":      []string{"bar", "baz"},
-		"name":      "renamed",
-		"folder_id": folder2ID,
+		"tags":   []string{"bar", "baz"},
+		"name":   "renamed",
+		"dir_id": dir2ID,
 	}
 
-	res3, _ := patchFile(t, "/files/"+folder1ID, "io.cozy.folders", folder1ID, attrs1, nil)
+	res3, _ := patchFile(t, "/files/"+dir1ID, "directory", dir1ID, attrs1, nil)
 	assert.Equal(t, 200, res3.StatusCode)
 
 	storage := testInstance.FS()
@@ -508,45 +508,45 @@ func TestModifyMetadataDirMove(t *testing.T) {
 	assert.True(t, exists)
 
 	attrs2 := map[string]interface{}{
-		"tags":      []string{"bar", "baz"},
-		"name":      "renamed",
-		"folder_id": folder1ID,
+		"tags":   []string{"bar", "baz"},
+		"name":   "renamed",
+		"dir_id": dir1ID,
 	}
 
-	res4, _ := patchFile(t, "/files/"+folder2ID, "io.cozy.folders", folder2ID, attrs2, nil)
+	res4, _ := patchFile(t, "/files/"+dir2ID, "directory", dir2ID, attrs2, nil)
 	assert.Equal(t, 412, res4.StatusCode)
 
-	res5, _ := patchFile(t, "/files/"+folder1ID, "io.cozy.folders", folder1ID, attrs2, nil)
+	res5, _ := patchFile(t, "/files/"+dir1ID, "directory", dir1ID, attrs2, nil)
 	assert.Equal(t, 412, res5.StatusCode)
 }
 
 func TestModifyMetadataDirMoveWithRel(t *testing.T) {
-	res1, data1 := createDir(t, "/files/?Name=dirmodmewithrel&Type=io.cozy.folders&Tags=foo,bar,bar")
+	res1, data1 := createDir(t, "/files/?Name=dirmodmewithrel&Type=directory&Tags=foo,bar,bar")
 	assert.Equal(t, 201, res1.StatusCode)
 
-	folder1ID, _ := extractDirData(t, data1)
+	dir1ID, _ := extractDirData(t, data1)
 
-	reschild1, datachild1 := createDir(t, "/files/"+folder1ID+"?Name=child1&Type=io.cozy.folders")
+	reschild1, datachild1 := createDir(t, "/files/"+dir1ID+"?Name=child1&Type=directory")
 	assert.Equal(t, 201, reschild1.StatusCode)
 
-	reschild2, datachild2 := createDir(t, "/files/"+folder1ID+"?Name=child2&Type=io.cozy.folders")
+	reschild2, datachild2 := createDir(t, "/files/"+dir1ID+"?Name=child2&Type=directory")
 	assert.Equal(t, 201, reschild2.StatusCode)
 
-	res2, data2 := createDir(t, "/files/?Name=dirmodmemoveinmewithrel&Type=io.cozy.folders")
+	res2, data2 := createDir(t, "/files/?Name=dirmodmemoveinmewithrel&Type=directory")
 	assert.Equal(t, 201, res2.StatusCode)
 
-	folder2ID, _ := extractDirData(t, data2)
+	dir2ID, _ := extractDirData(t, data2)
 	child1ID, _ := extractDirData(t, datachild1)
 	child2ID, _ := extractDirData(t, datachild2)
 
 	fmt.Println(child1ID, child2ID)
 
 	parent := &jsonData{
-		ID:   folder2ID,
+		ID:   dir2ID,
 		Type: "io.cozy.files",
 	}
 
-	res3, _ := patchFile(t, "/files/"+folder1ID, "io.cozy.folders", folder1ID, nil, parent)
+	res3, _ := patchFile(t, "/files/"+dir1ID, "directory", dir1ID, nil, parent)
 	assert.Equal(t, 200, res3.StatusCode)
 
 	storage := testInstance.FS()
@@ -556,20 +556,20 @@ func TestModifyMetadataDirMoveWithRel(t *testing.T) {
 }
 
 func TestModifyMetadataDirMoveConflict(t *testing.T) {
-	res1, _ := createDir(t, "/files/?Name=conflictmodme1&Type=io.cozy.folders&Tags=foo,bar,bar")
+	res1, _ := createDir(t, "/files/?Name=conflictmodme1&Type=directory&Tags=foo,bar,bar")
 	assert.Equal(t, 201, res1.StatusCode)
 
-	res2, data2 := createDir(t, "/files/?Name=conflictmodme2&Type=io.cozy.folders")
+	res2, data2 := createDir(t, "/files/?Name=conflictmodme2&Type=directory")
 	assert.Equal(t, 201, res2.StatusCode)
 
-	folder2ID, _ := extractDirData(t, data2)
+	dir2ID, _ := extractDirData(t, data2)
 
 	attrs1 := map[string]interface{}{
 		"tags": []string{"bar", "baz"},
 		"name": "conflictmodme1",
 	}
 
-	res3, _ := patchFile(t, "/files/"+folder2ID, "io.cozy.folders", folder2ID, attrs1, nil)
+	res3, _ := patchFile(t, "/files/"+dir2ID, "directory", dir2ID, attrs1, nil)
 	assert.Equal(t, 409, res3.StatusCode)
 }
 
@@ -579,7 +579,7 @@ func TestModifyContentNoFileID(t *testing.T) {
 }
 
 func TestModifyContentBadRev(t *testing.T) {
-	res1, data1 := upload(t, "/files/?Type=io.cozy.files&Name=modbadrev&Executable=true", "text/plain", "foo", "")
+	res1, data1 := upload(t, "/files/?Type=file&Name=modbadrev&Executable=true", "text/plain", "foo", "")
 	assert.Equal(t, 201, res1.StatusCode)
 
 	var ok bool
@@ -617,7 +617,7 @@ func TestModifyContentSuccess(t *testing.T) {
 	var fileInfo os.FileInfo
 
 	storage := testInstance.FS()
-	res1, data1 := upload(t, "/files/?Type=io.cozy.files&Name=willbemodified&Executable=true", "text/plain", "foo", "")
+	res1, data1 := upload(t, "/files/?Type=file&Name=willbemodified&Executable=true", "text/plain", "foo", "")
 	assert.Equal(t, 201, res1.StatusCode)
 
 	buf, err = afero.ReadFile(storage, "/willbemodified")
@@ -692,7 +692,7 @@ func TestModifyContentConcurrently(t *testing.T) {
 	done := make(chan *result)
 	errs := make(chan *http.Response)
 
-	res, data := upload(t, "/files/?Type=io.cozy.files&Name=willbemodifiedconcurrently&Executable=true", "text/plain", "foo", "")
+	res, data := upload(t, "/files/?Type=file&Name=willbemodifiedconcurrently&Executable=true", "text/plain", "foo", "")
 	if !assert.Equal(t, 201, res.StatusCode) {
 		return
 	}
@@ -767,7 +767,7 @@ func TestDownloadFileBadPath(t *testing.T) {
 
 func TestDownloadFileByIDSuccess(t *testing.T) {
 	body := "foo"
-	res1, filedata := upload(t, "/files/?Type=io.cozy.files&Name=downloadme1", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
+	res1, filedata := upload(t, "/files/?Type=file&Name=downloadme1", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
 	assert.Equal(t, 201, res1.StatusCode)
 
 	var ok bool
@@ -790,7 +790,7 @@ func TestDownloadFileByIDSuccess(t *testing.T) {
 
 func TestDownloadFileByPathSuccess(t *testing.T) {
 	body := "foo"
-	res1, _ := upload(t, "/files/?Type=io.cozy.files&Name=downloadme2", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
+	res1, _ := upload(t, "/files/?Type=file&Name=downloadme2", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
 	assert.Equal(t, 201, res1.StatusCode)
 
 	res2, resbody := download(t, "/files/download?Path="+url.QueryEscape("/downloadme2"), "")
@@ -805,7 +805,7 @@ func TestDownloadFileByPathSuccess(t *testing.T) {
 
 func TestDownloadRangeSuccess(t *testing.T) {
 	body := "foo,bar"
-	res1, _ := upload(t, "/files/?Type=io.cozy.files&Name=downloadmebyrange", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
+	res1, _ := upload(t, "/files/?Type=file&Name=downloadmebyrange", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
 	assert.Equal(t, 201, res1.StatusCode)
 
 	res2, _ := download(t, "/files/download?Path="+url.QueryEscape("/downloadmebyrange"), "nimp")
@@ -825,15 +825,15 @@ func TestGetFileMetadataFromPath(t *testing.T) {
 	assert.Equal(t, 404, res1.StatusCode)
 
 	body := "foo,bar"
-	res2, _ := upload(t, "/files/?Type=io.cozy.files&Name=getmetadata", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
+	res2, _ := upload(t, "/files/?Type=file&Name=getmetadata", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
 	assert.Equal(t, 201, res2.StatusCode)
 
 	res3, _ := http.Get(ts.URL + "/files/metadata?Path=/getmetadata")
 	assert.Equal(t, 200, res3.StatusCode)
 }
 
-func TestGetDirectoryMetadataFromPath(t *testing.T) {
-	res1, _ := createDir(t, "/files/?Name=getdirmeta&Type=io.cozy.folders")
+func TestGetDirMetadataFromPath(t *testing.T) {
+	res1, _ := createDir(t, "/files/?Name=getdirmeta&Type=directory")
 	assert.Equal(t, 201, res1.StatusCode)
 
 	res2, _ := http.Get(ts.URL + "/files/metadata?Path=/getdirmeta")
@@ -845,7 +845,7 @@ func TestGetFileMetadataFromID(t *testing.T) {
 	assert.Equal(t, 404, res1.StatusCode)
 
 	body := "foo,bar"
-	res2, data2 := upload(t, "/files/?Type=io.cozy.files&Name=getmetadatafromid", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
+	res2, data2 := upload(t, "/files/?Type=file&Name=getmetadatafromid", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
 	assert.Equal(t, 201, res2.StatusCode)
 
 	fileID, _ := extractDirData(t, data2)
@@ -854,14 +854,14 @@ func TestGetFileMetadataFromID(t *testing.T) {
 	assert.Equal(t, 200, res3.StatusCode)
 }
 
-func TestGetDirectoryMetadataFromID(t *testing.T) {
-	res1, data1 := createDir(t, "/files/?Name=getdirmetafromid&Type=io.cozy.folders")
+func TestGetDirMetadataFromID(t *testing.T) {
+	res1, data1 := createDir(t, "/files/?Name=getdirmetafromid&Type=directory")
 	assert.Equal(t, 201, res1.StatusCode)
 
 	parentID, _ := extractDirData(t, data1)
 
 	body := "foo"
-	res2, data2 := upload(t, "/files/"+parentID+"?Type=io.cozy.files&Name=firstfile", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
+	res2, data2 := upload(t, "/files/"+parentID+"?Type=file&Name=firstfile", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
 	assert.Equal(t, 201, res2.StatusCode)
 
 	fileID, _ := extractDirData(t, data2)
@@ -870,19 +870,19 @@ func TestGetDirectoryMetadataFromID(t *testing.T) {
 	assert.Equal(t, 200, res3.StatusCode)
 }
 
-func TestDirectoryTrash(t *testing.T) {
-	res1, data1 := createDir(t, "/files/?Name=totrashdir&Type=io.cozy.folders")
+func TestDirTrash(t *testing.T) {
+	res1, data1 := createDir(t, "/files/?Name=totrashdir&Type=directory")
 	if !assert.Equal(t, 201, res1.StatusCode) {
 		return
 	}
 
 	dirID, _ := extractDirData(t, data1)
 
-	res2, _ := createDir(t, "/files/"+dirID+"?Name=child1&Type=io.cozy.files")
+	res2, _ := createDir(t, "/files/"+dirID+"?Name=child1&Type=file")
 	if !assert.Equal(t, 201, res2.StatusCode) {
 		return
 	}
-	res3, _ := createDir(t, "/files/"+dirID+"?Name=child2&Type=io.cozy.files")
+	res3, _ := createDir(t, "/files/"+dirID+"?Name=child2&Type=file")
 	if !assert.Equal(t, 201, res3.StatusCode) {
 		return
 	}
@@ -915,7 +915,7 @@ func TestDirectoryTrash(t *testing.T) {
 
 func TestFileTrash(t *testing.T) {
 	body := "foo,bar"
-	res1, data1 := upload(t, "/files/?Type=io.cozy.files&Name=totrashfile", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
+	res1, data1 := upload(t, "/files/?Type=file&Name=totrashfile", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
 	if !assert.Equal(t, 201, res1.StatusCode) {
 		return
 	}
@@ -940,12 +940,12 @@ func TestFileTrash(t *testing.T) {
 
 func TestTrashList(t *testing.T) {
 	body := "foo,bar"
-	res1, data1 := upload(t, "/files/?Type=io.cozy.files&Name=tolistfile", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
+	res1, data1 := upload(t, "/files/?Type=file&Name=tolistfile", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
 	if !assert.Equal(t, 201, res1.StatusCode) {
 		return
 	}
 
-	res2, data2 := createDir(t, "/files/?Name=tolistdir&Type=io.cozy.folders")
+	res2, data2 := createDir(t, "/files/?Name=tolistdir&Type=directory")
 	if !assert.Equal(t, 201, res2.StatusCode) {
 		return
 	}


### PR DESCRIPTION
This PR propose to unify the usage of the words folder vs directory and uses the word directory only.

The breaking changes of this PR are:
  - the remove of the notion of `io.cozy.folders` for the creation API of files and directories. It uses for the query parameter `Type` the values `file` or `directory`
  - the renaming (and fixed doc) of the some directory IDs: `io.cozy.files.root-dir` and `io.cozy.files.trash-dir` (instead of `io.cozy.files.rootdir` and `io.cozy.files.trashdir`), to make it clearer for the next custom directories we'll have to introduce.

Also, for all the go code, the work `Dir` is used instead of `Directory` which was still hanging around in some function names, even if `Dir` was already mostly used.


----

If you prefer the word folder, I can change to that direction too. The main point of this PR is to unify things.