### PR TITLE
Dev script should not try to launch couchdb

### DIFF
--- a/docs/client-app-dev.md
+++ b/docs/client-app-dev.md
@@ -16,7 +16,7 @@ To run the `scripts/cozy-app-dev.sh` directly on you system, you'll need to foll
   - `go`
   - `curl`
   - `git`
-  - `couchdb2` (optionally installed on your computer, you need at least a running instance on couchdb2 though)
+  - `couchdb2`: you need at least a running instance of CouchDB 2
 
 Examples:
 
@@ -28,6 +28,12 @@ You'll need to add the following line to your `/etc/hosts` file:
 
 ```
 127.0.0.1  app.cozy.local,cozy.local
+```
+
+If your CouchDB 2 instance is not running on `localhost:5984`, you can specify another host and port with the variables `COUCHDB_HOST` and `COUCHDB_PORT` like so:
+
+```sh
+$ COUCHDB_HOST=couchdb.local COUCHDB_PORT=1234 ./scripts/cozy-app-dev.sh -d ~/code/myapp
 ```
 
 You can have more informations about the usage of this script with the following command:

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -83,5 +83,7 @@ RUN mkdir -p /data/cozy-app && mkdir -p /data/cozy-storage
 
 EXPOSE 8080 5984
 
-ENTRYPOINT ["/usr/bin/cozy-app-dev.sh"]
-CMD ["-d", "/data/cozy-app", "-f", "/data/cozy-storage"]
+CMD couchdb 2>/dev/null 1>/dev/null & \
+    /usr/bin/cozy-app-dev.sh \
+      -d /data/cozy-app \
+      -f /data/cozy-storage


### PR DESCRIPTION
I removed the responsibility to launch CouchDB from the script under certain conditions. It should make it simpler.

Now the script rely on the fact that the user is responsible to launch CouchDB and accept `COUCHDB_HOST` `COUCHDB_PORT` to parameterize its address.