### PR TITLE
Mutualize common error wrapping

### DIFF
--- a/web/apps/apps.go
+++ b/web/apps/apps.go
@@ -60,11 +60,7 @@ func Serve(c echo.Context, domain, slug string) error {
 	return nil
 }
 
-func wrapAppsError(err error) *jsonapi.Error {
-	if urlErr, isURLErr := err.(*url.Error); isURLErr {
-		return jsonapi.InvalidParameter("Source", urlErr)
-	}
-
+func wrapAppsError(err error) error {
 	switch err {
 	case apps.ErrInvalidSlugName:
 		return jsonapi.InvalidParameter("slug", err)
@@ -76,9 +72,11 @@ func wrapAppsError(err error) *jsonapi.Error {
 		return jsonapi.BadRequest(err)
 	case apps.ErrBadManifest:
 		return jsonapi.BadRequest(err)
-
 	}
-	return jsonapi.InternalServerError(err)
+	if _, ok := err.(*url.Error); ok {
+		return jsonapi.InvalidParameter("Source", err)
+	}
+	return err
 }
 
 // InstallHandler handles all POST /:slug request and tries to install

--- a/web/auth/auth.go
+++ b/web/auth/auth.go
@@ -14,7 +14,7 @@ func redirectSuccessLogin(c echo.Context, slug string) error {
 	instance := middlewares.GetInstance(c)
 	session, err := NewSession(instance)
 	if err != nil {
-		return jsonapi.InternalServerError(err)
+		return err
 	}
 	c.SetCookie(session.ToCookie())
 	return c.Redirect(http.StatusSeeOther, instance.SubDomain(slug))

--- a/web/data/data.go
+++ b/web/data/data.go
@@ -3,7 +3,6 @@ package data
 
 import (
 	"net/http"
-	"os"
 
 	"github.com/cozy/cozy-stack/couchdb"
 	"github.com/cozy/cozy-stack/web/jsonapi"
@@ -36,7 +35,7 @@ func getDoc(c echo.Context) error {
 	var out couchdb.JSONDoc
 	err := couchdb.GetDoc(instance, doctype, docid, &out)
 	if err != nil {
-		return wrapError(err)
+		return err
 	}
 
 	out.Type = doctype
@@ -64,7 +63,7 @@ func createDoc(c echo.Context) error {
 
 	err := couchdb.CreateDoc(instance, doc)
 	if err != nil {
-		return wrapError(err)
+		return err
 	}
 
 	return c.JSON(http.StatusCreated, echo.Map{
@@ -108,7 +107,7 @@ func updateDoc(c echo.Context) error {
 	}
 
 	if err != nil {
-		return wrapError(err)
+		return err
 	}
 
 	return c.JSON(http.StatusOK, echo.Map{
@@ -145,7 +144,7 @@ func deleteDoc(c echo.Context) error {
 
 	tombrev, err := couchdb.Delete(instance, doctype, docid, rev)
 	if err != nil {
-		return wrapError(err)
+		return err
 	}
 
 	return c.JSON(http.StatusOK, echo.Map{
@@ -178,7 +177,7 @@ func defineIndex(c echo.Context) error {
 		}
 	}
 	if err != nil {
-		return wrapError(err)
+		return err
 	}
 
 	return c.JSON(http.StatusOK, result)
@@ -200,7 +199,7 @@ func findDocuments(c echo.Context) error {
 	var results []couchdb.JSONDoc
 	err := couchdb.FindDocsRaw(instance, doctype, &findRequest, &results)
 	if err != nil {
-		return wrapError(err)
+		return err
 	}
 
 	return c.JSON(http.StatusOK, echo.Map{"docs": results})
@@ -216,14 +215,4 @@ func Routes(router *echo.Group) {
 	router.POST("/:doctype/_index", defineIndex)
 	router.POST("/:doctype/_find", findDocuments)
 	// router.DELETE("/:doctype/:docid", DeleteDoc)
-}
-
-func wrapError(err error) error {
-	if os.IsExist(err) {
-		return jsonapi.Conflict(err)
-	}
-	if os.IsNotExist(err) {
-		return jsonapi.NotFound(err)
-	}
-	return err
 }

--- a/web/middlewares/instance.go
+++ b/web/middlewares/instance.go
@@ -2,7 +2,6 @@ package middlewares
 
 import (
 	"github.com/cozy/cozy-stack/instance"
-	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/labstack/echo"
 )
 
@@ -15,7 +14,7 @@ func NeedInstance(next echo.HandlerFunc) echo.HandlerFunc {
 		}
 		i, err := instance.Get(c.Request().Host)
 		if err != nil {
-			return jsonapi.InternalServerError(err)
+			return err
 		}
 		c.Set("instance", i)
 		return next(c)


### PR DESCRIPTION
Common errors (`os.Exist` / `os.NotExit` / `couchdb.Errors` / ...) are handled in our common `HTTPErrorHandler`.

This PR mutualizes more of these types of err handling.