### PR TITLE
Add _changes API

### DIFF
--- a/couchdb/changes.go
+++ b/couchdb/changes.go
@@ -1,0 +1,143 @@
+package couchdb
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/google/go-querystring/query"
+)
+
+// ChangesFeedMode is a value for the feed parameter of a ChangesRequest
+type ChangesFeedMode string
+
+// ChangesFeedStyle is a value for the style parameter of a ChangesRequest
+type ChangesFeedStyle string
+
+const (
+	// ChangesModeNormal is the only mode supported by cozy-stack
+	ChangesModeNormal ChangesFeedMode = "normal"
+	// ChangesStyleAllDocs pass all revisions including conflicts
+	ChangesStyleAllDocs ChangesFeedStyle = "all_docs"
+	// ChangesStyleMainOnly only pass the winning revision
+	ChangesStyleMainOnly ChangesFeedStyle = "main_only"
+)
+
+// ValidChangesMode convert any string into a ChangesFeedMode or gives an error
+// if the string is invalid.
+func ValidChangesMode(feed string) (ChangesFeedMode, error) {
+	if feed == "" || feed == string(ChangesModeNormal) {
+		return ChangesModeNormal, nil
+	}
+
+	err := fmt.Errorf("Unsuported feed value '%s'", feed)
+	return ChangesModeNormal, err
+}
+
+// ValidChangesStyle convert any string into a ChangesFeedStyle or gives an
+// error if the string is invalid.
+func ValidChangesStyle(style string) (ChangesFeedStyle, error) {
+	if style == "" || style == string(ChangesStyleMainOnly) {
+		return ChangesStyleMainOnly, nil
+	}
+	if style == string(ChangesStyleAllDocs) {
+		return ChangesStyleAllDocs, nil
+	}
+	err := fmt.Errorf("Unsuported style value '%s'", style)
+	return ChangesStyleMainOnly, err
+}
+
+// A ChangesRequest are all parameters than can be passed to a changes feed
+type ChangesRequest struct {
+	DocType string `url:"-"`
+	// Includes conflicts information in response. Ignored if include_docs isn’t
+	// true. Default is false.
+	Conflicts bool `url:"conflicts,omitempty"`
+	// Return the change results in descending sequence order (most recent change
+	// first). Default is false.
+	Descending bool `url:"descending,omitempty"`
+	// see Changes Feeds. Default is normal.
+	Feed ChangesFeedMode `url:"feed,omitempty"`
+	// Reference to a filter function from a design document that will filter
+	// whole stream emitting only filtered events. See the section Change
+	// Notifications in the book CouchDB The Definitive Guide for more
+	// information.
+	Filter string `url:"filter,omitempty"`
+	// Period in milliseconds after which an empty line is sent in the results.
+	// Only applicable for longpoll, continuous, and eventsource feeds. Overrides
+	// any timeout to keep the feed alive indefinitely. Default is 60000. May be
+	// true to use default value.
+	Heartbeat int `url:"heartbeat,omitempty"`
+	// Include the associated document with each result. If there are conflicts,
+	// only the winning revision is returned. Default is false.
+	IncludeDocs bool `url:"include_docs,omitempty"`
+	// Include the Base64-encoded content of attachments in the documents that
+	// are included if include_docs is true. Ignored if include_docs isn’t true.
+	// Default is false.
+	Attachments bool `url:"attachments,omitempty"`
+	// Include encoding information in attachment stubs if include_docs is true
+	// and the particular attachment is compressed. Ignored if include_docs isn’t
+	// true. Default is false.
+	AttEncodingInfo bool `url:"att_encoding_info,omitempty"`
+	// Alias of Last-Event-ID header.
+	LastEventID int `url:"last,omitempty"`
+	// Limit number of result rows to the specified value (note that using 0 here
+	//  has the same effect as 1).
+	Limit int `url:"limit,omitempty"`
+	// Start the results from the change immediately after the given update
+	// sequence. Can be valid update sequence or now value. Default is 0.
+	Since string `url:"since,omitempty"`
+	// Specifies how many revisions are returned in the changes array. The
+	// default, main_only, will only return the current “winning” revision;
+	// all_docs will return all leaf revisions (including conflicts and deleted
+	// former conflicts).
+	Style ChangesFeedStyle `url:"style,omitempty"`
+	// Maximum period in milliseconds to wait for a change before the response
+	// is sent, even if there are no results. Only applicable for longpoll or
+	// continuous feeds. Default value is specified by httpd/changes_timeout
+	// configuration option. Note that 60000 value is also the default maximum
+	// timeout to prevent undetected dead connections.
+	Timeout int `url:"timeout,omitempty"`
+	// Allows to use view functions as filters. Documents counted as “passed” for
+	// view filter in case if map function emits at least one record for them.
+	// See _view for more info.
+	View string `url:"view,omitempty"`
+}
+
+// A ChangesResponse is the response provided by a GetChanges call
+type ChangesResponse struct {
+	LastSeq string   `json:"last_seq"` // Last change update sequence
+	Pending int      `json:"pending"`  // Count of remaining items in the feed
+	Results []Change `json:"results"`  // Changes made to a database
+}
+
+// A Change is an atomic change in couchdb
+type Change struct {
+	DocID   string  `json:"id"`
+	Seq     string  `json:"seq"`
+	Doc     JSONDoc `json:"doc"`
+	Changes []struct {
+		Rev string `json:"rev"`
+	} `json:"changes"`
+}
+
+// GetChanges returns a list of change in couchdb
+func GetChanges(db Database, req *ChangesRequest) (*ChangesResponse, error) {
+	if req.DocType == "" {
+		return nil, errors.New("Empty doctype in GetChanges")
+	}
+
+	v, err := query.Values(req)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ChangesResponse
+	url := makeDBName(db, req.DocType) + "/_changes?" + v.Encode()
+	err = makeRequest("GET", url, nil, &response)
+
+	if err != nil {
+		return nil, err
+	}
+	return &response, nil
+
+}

--- a/couchdb/changes.go
+++ b/couchdb/changes.go
@@ -49,24 +49,25 @@ func ValidChangesStyle(style string) (ChangesFeedStyle, error) {
 // A ChangesRequest are all parameters than can be passed to a changes feed
 type ChangesRequest struct {
 	DocType string `url:"-"`
+	// see Changes Feeds. Default is normal.
+	Feed ChangesFeedMode `url:"feed,omitempty"`
+	// Maximum period in milliseconds to wait for a change before the response
+	// is sent, even if there are no results. Only applicable for longpoll or
+	// continuous feeds. Default value is specified by httpd/changes_timeout
+	// configuration option. Note that 60000 value is also the default maximum
+	// timeout to prevent undetected dead connections.
+	Timeout int `url:"timeout,omitempty"`
+	// Period in milliseconds after which an empty line is sent in the results.
+	// Only applicable for longpoll, continuous, and eventsource feeds. Overrides
+	// any timeout to keep the feed alive indefinitely. Default is 60000. May be
+	// true to use default value.
+	Heartbeat int `url:"heartbeat,omitempty"`
 	// Includes conflicts information in response. Ignored if include_docs isn’t
 	// true. Default is false.
 	Conflicts bool `url:"conflicts,omitempty"`
 	// Return the change results in descending sequence order (most recent change
 	// first). Default is false.
 	Descending bool `url:"descending,omitempty"`
-	// see Changes Feeds. Default is normal.
-	Feed ChangesFeedMode `url:"feed,omitempty"`
-	// Reference to a filter function from a design document that will filter
-	// whole stream emitting only filtered events. See the section Change
-	// Notifications in the book CouchDB The Definitive Guide for more
-	// information.
-	Filter string `url:"filter,omitempty"`
-	// Period in milliseconds after which an empty line is sent in the results.
-	// Only applicable for longpoll, continuous, and eventsource feeds. Overrides
-	// any timeout to keep the feed alive indefinitely. Default is 60000. May be
-	// true to use default value.
-	Heartbeat int `url:"heartbeat,omitempty"`
 	// Include the associated document with each result. If there are conflicts,
 	// only the winning revision is returned. Default is false.
 	IncludeDocs bool `url:"include_docs,omitempty"`
@@ -91,12 +92,11 @@ type ChangesRequest struct {
 	// all_docs will return all leaf revisions (including conflicts and deleted
 	// former conflicts).
 	Style ChangesFeedStyle `url:"style,omitempty"`
-	// Maximum period in milliseconds to wait for a change before the response
-	// is sent, even if there are no results. Only applicable for longpoll or
-	// continuous feeds. Default value is specified by httpd/changes_timeout
-	// configuration option. Note that 60000 value is also the default maximum
-	// timeout to prevent undetected dead connections.
-	Timeout int `url:"timeout,omitempty"`
+	// Reference to a filter function from a design document that will filter
+	// whole stream emitting only filtered events. See the section Change
+	// Notifications in the book CouchDB The Definitive Guide for more
+	// information.
+	Filter string `url:"filter,omitempty"`
 	// Allows to use view functions as filters. Documents counted as “passed” for
 	// view filter in case if map function emits at least one record for them.
 	// See _view for more info.

--- a/couchdb/changes_test.go
+++ b/couchdb/changes_test.go
@@ -1,0 +1,1 @@
+package couchdb

--- a/couchdb/changes_test.go
+++ b/couchdb/changes_test.go
@@ -1,1 +1,0 @@
-package couchdb

--- a/web/data/data.go
+++ b/web/data/data.go
@@ -2,7 +2,6 @@
 package data
 
 import (
-	"fmt"
 	"net/http"
 	"strconv"
 
@@ -49,7 +48,7 @@ func createDoc(c echo.Context) error {
 	doctype := c.Get("doctype").(string)
 	instance := middlewares.GetInstance(c)
 
-	var doc = couchdb.JSONDoc{Type: doctype}
+	doc := couchdb.JSONDoc{Type: doctype}
 	if err := c.Bind(&doc.M); err != nil {
 		return jsonapi.NewError(http.StatusBadRequest, err)
 	}
@@ -220,8 +219,7 @@ func changesFeed(c echo.Context) error {
 	// Drop a clear error for parameters not supported by stack
 	for key := range c.QueryParams() {
 		if !allowedChangesParams[key] {
-			err := fmt.Errorf("Unsuported query parameter '%s'", key)
-			return jsonapi.NewError(http.StatusBadRequest, err)
+			return jsonapi.NewError(http.StatusBadRequest, "Unsuported query parameter '%s'", key)
 		}
 	}
 
@@ -235,12 +233,11 @@ func changesFeed(c echo.Context) error {
 		return jsonapi.NewError(http.StatusBadRequest, err)
 	}
 
-	var limitString = c.QueryParam("limit")
-	var limit = 0
+	limitString := c.QueryParam("limit")
+	limit := 0
 	if limitString != "" {
 		if limit, err = strconv.Atoi(limitString); err != nil {
-			err = fmt.Errorf("Invalid limit value '%s'", err.Error())
-			return jsonapi.NewError(http.StatusBadRequest, err)
+			return jsonapi.NewError(http.StatusBadRequest, "Invalid limit value '%s'", err.Error())
 		}
 	}
 
@@ -251,6 +248,10 @@ func changesFeed(c echo.Context) error {
 		Since:   c.QueryParam("since"),
 		Limit:   limit,
 	})
+
+	if err != nil {
+		return err
+	}
 
 	return c.JSON(http.StatusOK, results)
 }

--- a/web/data/data.go
+++ b/web/data/data.go
@@ -2,7 +2,9 @@
 package data
 
 import (
+	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/cozy/cozy-stack/couchdb"
 	"github.com/cozy/cozy-stack/web/jsonapi"
@@ -205,9 +207,60 @@ func findDocuments(c echo.Context) error {
 	return c.JSON(http.StatusOK, echo.Map{"docs": results})
 }
 
+var allowedChangesParams = map[string]bool{
+	"feed":  true,
+	"style": true,
+	"since": true,
+	"limit": true,
+}
+
+func changesFeed(c echo.Context) error {
+	instance := middlewares.GetInstance(c)
+
+	// Drop a clear error for parameters not supported by stack
+	for key := range c.QueryParams() {
+		if !allowedChangesParams[key] {
+			err := fmt.Errorf("Unsuported query parameter '%s'", key)
+			return jsonapi.NewError(http.StatusBadRequest, err)
+		}
+	}
+
+	feed, err := couchdb.ValidChangesMode(c.QueryParam("feed"))
+	if err != nil {
+		return jsonapi.NewError(http.StatusBadRequest, err)
+	}
+
+	feedStyle, err := couchdb.ValidChangesStyle(c.QueryParam("style"))
+	if err != nil {
+		return jsonapi.NewError(http.StatusBadRequest, err)
+	}
+
+	var limitString = c.QueryParam("limit")
+	var limit = 0
+	if limitString != "" {
+		if limit, err = strconv.Atoi(limitString); err != nil {
+			err = fmt.Errorf("Invalid limit value '%s'", err.Error())
+			return jsonapi.NewError(http.StatusBadRequest, err)
+		}
+	}
+
+	results, err := couchdb.GetChanges(instance, &couchdb.ChangesRequest{
+		DocType: c.Get("doctype").(string),
+		Feed:    feed,
+		Style:   feedStyle,
+		Since:   c.QueryParam("since"),
+		Limit:   limit,
+	})
+
+	return c.JSON(http.StatusOK, results)
+}
+
 // Routes sets the routing for the status service
 func Routes(router *echo.Group) {
 	router.Use(validDoctype)
+	router.GET("/:doctype/_changes", changesFeed)
+	// POST=GET see http://docs.couchdb.org/en/2.0.0/api/database/changes.html#post--db-_changes)
+	router.POST("/:doctype/_changes", changesFeed)
 	router.GET("/:doctype/:docid", getDoc)
 	router.PUT("/:doctype/:docid", updateDoc)
 	router.DELETE("/:doctype/:docid", deleteDoc)


### PR DESCRIPTION
This is the first step in allowing couch protocol replication from and to cozy-stack.

There is no documentation for it as the only guarantee we make on this API for now is "It will allow a couchdb or pouchdb to replicate from a cozy" 

What differs from exploration : 
I added style=all_docs support, as couchdb 2 seems to use it in replication