### PR TITLE
Make cozy-stack a couchdb replication source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ go:
   - 1.7.3
 
 before_install:
-  - docker run -d -p 5984:5984 --name couch klaemo/couchdb:2.0.0
+  - docker run -d -p 5984:5984 --net=host --name couch klaemo/couchdb:2.0.0
 
 before_script:
   - curl -X PUT http://127.0.0.1:5984/{_users,_replicator,_global_changes}

--- a/couchdb/couchdb.go
+++ b/couchdb/couchdb.go
@@ -217,9 +217,9 @@ func fixErrorNoDatabaseIsWrongDoctype(err error) {
 }
 
 // DBStatus re
-func DBStatus(db Database, doctype string) (DBStatusResponse, error) {
+func DBStatus(db Database, doctype string) (*DBStatusResponse, error) {
 	var out DBStatusResponse
-	return out, makeRequest("GET", makeDBName(db, doctype), nil, &out)
+	return &out, makeRequest("GET", makeDBName(db, doctype), nil, &out)
 }
 
 // GetDoc fetch a document by its docType and ID, out is filled with

--- a/web/data/data_test.go
+++ b/web/data/data_test.go
@@ -152,12 +152,11 @@ func TestWrongDoctype(t *testing.T) {
 	out, res, err := doRequest(req, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "404 Not Found", res.Status, "should get a 404")
-	out = out["errors"].([]interface{})[0].(map[string]interface{})
-	if assert.Contains(t, out, "title") {
-		assert.Equal(t, "not_found", out["title"], "should give a json title")
+	if assert.Contains(t, out, "error") {
+		assert.Equal(t, "not_found", out["error"], "should give a json name")
 	}
-	if assert.Contains(t, out, "detail") {
-		assert.Equal(t, "wrong_doctype", out["detail"], "should give a detail")
+	if assert.Contains(t, out, "reason") {
+		assert.Equal(t, "wrong_doctype", out["reason"], "should give a reason")
 	}
 
 }
@@ -173,9 +172,8 @@ func TestVFSDoctype(t *testing.T) {
 	out, res, err := doRequest(req, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "403 Forbidden", res.Status, "should get a 403")
-	out = out["errors"].([]interface{})[0].(map[string]interface{})
-	if assert.Contains(t, out, "detail") {
-		assert.Contains(t, out["detail"], "reserved", "should give a clear detail")
+	if assert.Contains(t, out, "error") {
+		assert.Contains(t, out["error"], "reserved", "should give a clear reason")
 	}
 }
 
@@ -185,12 +183,11 @@ func TestWrongID(t *testing.T) {
 	out, res, err := doRequest(req, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "404 Not Found", res.Status, "should get a 404")
-	out = out["errors"].([]interface{})[0].(map[string]interface{})
-	if assert.Contains(t, out, "title") {
-		assert.Equal(t, "not_found", out["title"], "should give a json title")
+	if assert.Contains(t, out, "error") {
+		assert.Equal(t, "not_found", out["error"], "should give a json name")
 	}
-	if assert.Contains(t, out, "detail") {
-		assert.Equal(t, "missing", out["detail"], "should give a detail")
+	if assert.Contains(t, out, "reason") {
+		assert.Equal(t, "missing", out["reason"], "should give a reason")
 	}
 }
 
@@ -201,12 +198,11 @@ func TestWrongHost(t *testing.T) {
 	out, res, err := doRequest(req, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "404 Not Found", res.Status, "should get a 404")
-	out = out["errors"].([]interface{})[0].(map[string]interface{})
-	if assert.Contains(t, out, "title") {
-		assert.Equal(t, "not_found", out["title"], "should give a json title")
+	if assert.Contains(t, out, "error") {
+		assert.Equal(t, "not_found", out["error"], "should give a json name")
 	}
-	if assert.Contains(t, out, "detail") {
-		assert.Equal(t, "wrong_doctype", out["detail"], "should give a detail")
+	if assert.Contains(t, out, "reason") {
+		assert.Equal(t, "wrong_doctype", out["reason"], "should give a reason")
 	}
 }
 
@@ -567,16 +563,14 @@ func TestFindDocumentsWithoutIndex(t *testing.T) {
 	req.Header.Add("Host", Host)
 	req.Header.Set("Content-Type", "application/json")
 	var out2 struct {
-		Errors []struct {
-			Title  string `json:"title"`
-			Detail string `json:"detail"`
-		} `json:"errors"`
+		Error  string `json:"error"`
+		Reason string `json:"reason"`
 	}
 	_, res, err := doRequest(req, &out2)
 	assert.Equal(t, "400 Bad Request", res.Status, "should get a 200")
 	assert.NoError(t, err)
-	assert.Contains(t, out2.Errors[0].Title, "no_index")
-	assert.Contains(t, out2.Errors[0].Detail, "no matching index")
+	assert.Contains(t, out2.Error, "no_index")
+	assert.Contains(t, out2.Reason, "no matching index")
 }
 
 func TestGetChanges(t *testing.T) {

--- a/web/data/permissions.go
+++ b/web/data/permissions.go
@@ -1,12 +1,12 @@
 package data
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/cozy/cozy-stack/instance"
 	"github.com/cozy/cozy-stack/vfs"
 	"github.com/cozy/cozy-stack/web/auth"
-	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/labstack/echo"
 )
 
@@ -27,8 +27,10 @@ func CheckReadable(c echo.Context, doctype string) error {
 		return nil
 	}
 
-	return jsonapi.NewError(http.StatusForbidden,
-		"reserved doctype %v unreadable", doctype)
+	return &echo.HTTPError{
+		Code:    http.StatusForbidden,
+		Message: fmt.Sprintf("reserved doctype %s unreadable", doctype),
+	}
 }
 
 // CheckWritable will abort the echo context if the doctype
@@ -39,6 +41,8 @@ func CheckWritable(c echo.Context, doctype string) error {
 		return nil
 	}
 
-	return jsonapi.NewError(http.StatusForbidden,
-		"reserved doctype %v unwritable", doctype)
+	return &echo.HTTPError{
+		Code:    http.StatusForbidden,
+		Message: fmt.Sprintf("reserved doctype %s unwritable", doctype),
+	}
 }

--- a/web/data/replication.go
+++ b/web/data/replication.go
@@ -1,0 +1,95 @@
+package data
+
+import (
+	"net/http"
+
+	"github.com/cozy/cozy-stack/couchdb"
+	"github.com/cozy/cozy-stack/web/middlewares"
+	"github.com/labstack/echo"
+)
+
+func proxy(c echo.Context, path string) error {
+	doctype := c.Get("doctype").(string)
+	instance := middlewares.GetInstance(c)
+	p := couchdb.Proxy(instance, doctype, path)
+	p.ServeHTTP(c.Response(), c.Request())
+	return nil
+}
+
+func getLocalDoc(c echo.Context) error {
+	doctype := c.Get("doctype").(string)
+	docid := c.Param("docid")
+
+	if err := CheckReadable(c, doctype); err != nil {
+		return err
+	}
+
+	return proxy(c, "_local/"+docid)
+
+}
+
+func setLocalDoc(c echo.Context) error {
+	doctype := c.Get("doctype").(string)
+	docid := c.Param("docid")
+
+	if err := CheckReadable(c, doctype); err != nil {
+		return err
+	}
+
+	return proxy(c, "_local/"+docid)
+}
+
+func bulkGet(c echo.Context) error {
+	doctype := c.Get("doctype").(string)
+
+	if err := CheckReadable(c, doctype); err != nil {
+		return err
+	}
+
+	return proxy(c, "_bulk_get")
+}
+
+func fullCommit(c echo.Context) error {
+	doctype := c.Get("doctype").(string)
+
+	if err := CheckReadable(c, doctype); err != nil {
+		return err
+	}
+
+	return proxy(c, "_ensure_full_commit")
+}
+
+// GetDoc get a doc by its type and id
+func dbStatus(c echo.Context) error {
+	instance := middlewares.GetInstance(c)
+	doctype := c.Get("doctype").(string)
+
+	if err := CheckReadable(c, doctype); err != nil {
+		return err
+	}
+
+	status, err := couchdb.DBStatus(instance, doctype)
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(http.StatusOK, status)
+}
+
+func replicationRoutes(router *echo.Group) {
+	// Routes used only for replication
+	router.GET("/:doctype/", dbStatus)
+	router.GET("/:doctype/_changes", changesFeed)
+	// POST=GET see http://docs.couchdb.org/en/2.0.0/api/database/changes.html#post--db-_changes)
+	router.POST("/:doctype/_changes", changesFeed)
+
+	router.POST("/:doctype/_ensure_full_commit", fullCommit)
+
+	// useful for Pouchdb replication
+	router.GET("/:doctype/_bulk_get", bulkGet)
+
+	// for storing checkpoints
+	router.GET("/:doctype/_local/:docid", getLocalDoc)
+	router.PUT("/:doctype/_local/:docid", setLocalDoc)
+
+}

--- a/web/data/replication_test.go
+++ b/web/data/replication_test.go
@@ -1,0 +1,44 @@
+package data
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/cozy/cozy-stack/config"
+	"github.com/cozy/cozy-stack/couchdb"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReplicationFromcozy(t *testing.T) {
+	assert.NoError(t, couchdb.ResetDB(testInstance, Type))
+	// creates 3 docs
+	var doc1 = getDocForTest()
+	var _ = getDocForTest()
+	var _ = getDocForTest()
+
+	var source = ts.URL + "/data/" + Type
+	var target = config.CouchURL() + "replication-target"
+	var replicator = config.CouchURL() + "_replicate"
+
+	req, _ := http.NewRequest("DELETE", target, nil)
+	doRequest(req, nil)
+	// err is expected
+
+	req, _ = http.NewRequest("PUT", target, nil)
+	_, _, err := doRequest(req, nil)
+	assert.NoError(t, err)
+
+	req, _ = http.NewRequest("POST", replicator, jsonReader(&map[string]interface{}{
+		"source": source,
+		"target": target,
+	}))
+	req.Header.Add("Content-Type", "application/json")
+	_, _, err = doRequest(req, nil)
+	assert.NoError(t, err)
+
+	req, _ = http.NewRequest("GET", target+"/"+doc1.ID(), nil)
+	out, res, err := doRequest(req, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "200 OK", res.Status)
+	assert.Equal(t, out["_id"], doc1.ID())
+}


### PR DESCRIPTION
Simply handles the following routes by proxying to couchdb.

```
GET /:doctype/
GET /:doctype/_changes
POST /:doctype/_changes
POST /:doctype/_ensure_full_commit
GET /:doctype/_bulk_get
GET /:doctype/_local/:docid
PUT /:doctype/_local/:docid
```