### PR TITLE
Add administration api and rely on it for instances cli

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -1,0 +1,120 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+type apiErrors struct {
+	Errors []struct {
+		Status string `json:"status"`
+		Title  string `json:"title"`
+		Detail string `json:"detail"`
+	}
+}
+
+type client struct {
+	c *http.Client
+
+	addr string
+	pass string
+}
+
+func clientCreateRequest(c *client, method, path string, q url.Values, r io.Reader) (*http.Request, error) {
+	u := url.URL{
+		Scheme: "http",
+		Host:   c.addr,
+		Path:   path,
+	}
+	if q != nil {
+		u.RawQuery = q.Encode()
+	}
+	log.Debugf("%s %s", method, u.String())
+	req, err := http.NewRequest(method, u.String(), r)
+	if err != nil {
+		return nil, err
+	}
+	if c.pass != "" {
+		req.SetBasicAuth("", c.pass)
+	}
+	return req, nil
+}
+
+func clientRequest(c *client, method, path string, q url.Values, body interface{}) (*http.Response, error) {
+	var r io.Reader
+	var ok bool
+	if body != nil {
+		if r, ok = body.(io.Reader); !ok {
+			var b []byte
+			b, err := json.Marshal(body)
+			if err != nil {
+				return nil, err
+			}
+			r = bytes.NewBuffer(b)
+		}
+	}
+
+	req, err := clientCreateRequest(c, method, path, q, r)
+	if err != nil {
+		return nil, err
+	}
+
+	var client *http.Client
+	if c.c != nil {
+		client = c.c
+	} else {
+		client = http.DefaultClient
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := clientErrCheck(res); err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+func clientRequestAndClose(c *client, method, path string, q url.Values, body interface{}) error {
+	res, err := clientRequest(c, method, path, q, body)
+	if err != nil {
+		return err
+	}
+	res.Body.Close()
+	return nil
+}
+
+func clientRequestParsed(c *client, method, path string, q url.Values, body interface{}, v interface{}) error {
+	res, err := clientRequest(c, method, path, q, body)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	return json.NewDecoder(res.Body).Decode(&v)
+}
+
+func clientErrCheck(res *http.Response) error {
+	if res.StatusCode >= 200 && res.StatusCode < 300 {
+		return nil
+	}
+	defer res.Body.Close()
+	b, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return err
+	}
+	var errs apiErrors
+	if err := json.Unmarshal(b, &errs); err != nil || errs.Errors == nil || len(errs.Errors) == 0 {
+		return fmt.Errorf("Unknown error %d (%v)", res.StatusCode, string(b))
+	}
+	apiErr := errs.Errors[0]
+	return fmt.Errorf("%s (%s %s)", apiErr.Detail, apiErr.Status, apiErr.Title)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,18 +11,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-// ConfigFilename is the default configuration filename that cozy
-// search for
-const ConfigFilename = "cozy"
-
-// ConfigPaths is the list of directories used to search for a
-// configuration file
-var ConfigPaths = []string{
-	".cozy",
-	"$HOME/.cozy",
-	"/etc/cozy",
-}
-
 // DefaultStorageDir is the default directory name in which data
 // is stored relatively to the cozy-stack binary.
 const DefaultStorageDir = "storage"
@@ -62,11 +50,17 @@ func init() {
 	flags.StringP("mode", "m", config.BuildMode, "server mode: development or production")
 	viper.BindPFlag("mode", flags.Lookup("mode"))
 
-	flags.StringP("host", "", "localhost", "server host")
+	flags.String("host", "localhost", "server host")
 	viper.BindPFlag("host", flags.Lookup("host"))
 
 	flags.IntP("port", "p", 8080, "server port")
 	viper.BindPFlag("port", flags.Lookup("port"))
+
+	flags.String("admin-host", "localhost", "administration server host")
+	viper.BindPFlag("admin.host", flags.Lookup("admin-host"))
+
+	flags.Int("admin-port", 6060, "administration server port")
+	viper.BindPFlag("admin.port", flags.Lookup("admin-port"))
 
 	flags.String("assets", "", "path to the directory with the assets (use the packed assets by default)")
 	viper.BindPFlag("assets", flags.Lookup("assets"))
@@ -93,8 +87,8 @@ func Configure() error {
 		// Read given config file and skip other paths
 		viper.SetConfigFile(cfgFile)
 	} else {
-		viper.SetConfigName(ConfigFilename)
-		for _, cfgPath := range ConfigPaths {
+		viper.SetConfigName(config.Filename)
+		for _, cfgPath := range config.Paths {
 			viper.AddConfigPath(cfgPath)
 		}
 	}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -32,7 +32,22 @@ Use the --port and --host flags to change the listening option.`,
 			return err
 		}
 
-		return main.Start(config.ServerAddr())
+		admin := echo.New()
+		if err := routing.SetupAdminRoutes(admin); err != nil {
+			return err
+		}
+
+		errs := make(chan error)
+
+		go func() {
+			errs <- admin.Start(config.AdminServerAddr())
+		}()
+
+		go func() {
+			errs <- main.Start(config.ServerAddr())
+		}()
+
+		return <-errs
 	},
 }
 

--- a/cozy.dist.yaml
+++ b/cozy.dist.yaml
@@ -10,6 +10,11 @@ port: 8080
 # default is to use the assets packed in the binary
 assets: ""
 
+admin:
+  # server host - flags: --admin-host
+  host: localhost
+  # server port - flags: --admin-port
+  port: 6060
 
 fs:
   # file system url - flags: --fs-url

--- a/docs/config.md
+++ b/docs/config.md
@@ -3,6 +3,9 @@
 Configuration
 =============
 
+Main Configuration file
+-----------------------
+
 You can configure your `cozy-stack` using a configuration file. This file
 should be named `cozy.yaml` or `cozy.json` depending on the format of your
 chosing, and should be present in one of these directories (ordered by
@@ -17,11 +20,27 @@ command line interface. See `cozy-stack --help`.
 
 See the example to check what contains the configuration.
 
-Example
--------
+### Example
 
 You can see an example of configuration in the
 [cozy.dist.yaml](./cozy.dist.yaml) file at the root of this repository.
 
 This example's values represent the default values of the configuration. The
 equivalent cli flag are also filled in.
+
+
+Administration secrect
+----------------------
+
+To access to the administration API (the `/admin/*` routes), a secret passphrase should be stored in a `cozy-admin-passphrase`. This file should be in one of the configuration directories, along with the main config file.
+
+The passphrase is stored in a salted-hashed representation using scrypt. To generate this file, you can use the `cozy-stack config passwd [config directory]` command. This command will ask you for a passphrase and will create the `cozy-admin-passphrase` in the specified directory.
+
+### Example
+
+```sh
+cozy-stack config passwd ~/.cozy
+# Hashed passphrase outputed in ~/.cozy/cozy-admin-passphrase
+cat ~/.cozy/cozy-admin-passphrase
+# scrypt$16384$8$1$936bd62faf633b5f946f653c21161a9b$4e0d11dfa5fc1676ed329938b11a6584d30e603e0d06b8a63a99e8cec392d682
+```

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cozy/cozy-stack/crypto"
 	"github.com/cozy/cozy-stack/settings"
 	"github.com/cozy/cozy-stack/vfs"
+	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/spf13/afero"
 )
 
@@ -83,6 +84,21 @@ func (i *Instance) Rev() string { return i.DocRev }
 
 // SetRev implements couchdb.Doc
 func (i *Instance) SetRev(v string) { i.DocRev = v }
+
+// SelfLink is used to generate a JSON-API link for the instance
+func (i *Instance) SelfLink() string {
+	return "/instances/" + i.DocID
+}
+
+// Relationships is used to generate the content relationship in JSON-API format
+func (i *Instance) Relationships() jsonapi.RelationshipMap {
+	return jsonapi.RelationshipMap{}
+}
+
+// Included is part of the jsonapi.Object interface
+func (i *Instance) Included() []jsonapi.Object {
+	return nil
+}
 
 // Addr returns the full address of the domain of the instance
 // TODO https is hardcoded

--- a/web/instances/instances.go
+++ b/web/instances/instances.go
@@ -1,0 +1,65 @@
+package instances
+
+import (
+	"net/http"
+
+	"github.com/cozy/cozy-stack/instance"
+	"github.com/cozy/cozy-stack/web/jsonapi"
+	"github.com/labstack/echo"
+)
+
+func createHandler(c echo.Context) error {
+	domain := c.QueryParam("Domain")
+	locale := c.QueryParam("Locale")
+	i, err := instance.Create(domain, locale, nil)
+	if err != nil {
+		return wrapError(err)
+	}
+	return jsonapi.Data(c, http.StatusCreated, i, nil)
+}
+
+func listHandler(c echo.Context) error {
+	is, err := instance.List()
+	if err != nil {
+		return wrapError(err)
+	}
+
+	objs := make([]jsonapi.Object, len(is))
+	for i, in := range is {
+		objs[i] = in
+	}
+
+	return jsonapi.DataList(c, http.StatusOK, objs, nil)
+}
+
+func deleteHandler(c echo.Context) error {
+	domain := c.Param("domain")
+	i, err := instance.Destroy(domain)
+	if err != nil {
+		return wrapError(err)
+	}
+	return jsonapi.Data(c, http.StatusOK, i, nil)
+}
+
+func wrapError(err error) error {
+	switch err {
+	case instance.ErrNotFound:
+		return jsonapi.NotFound(err)
+	case instance.ErrExists:
+		return jsonapi.Conflict(err)
+	case instance.ErrIllegalDomain:
+		return jsonapi.InvalidParameter("domain", err)
+	case instance.ErrMissingToken:
+		return jsonapi.BadRequest(err)
+	case instance.ErrInvalidToken:
+		return jsonapi.BadRequest(err)
+	}
+	return err
+}
+
+// Routes sets the routing for the instances service
+func Routes(router *echo.Group) {
+	router.GET("/", listHandler)
+	router.POST("/", createHandler)
+	router.DELETE("/:domain", deleteHandler)
+}

--- a/web/middlewares/basic_auth.go
+++ b/web/middlewares/basic_auth.go
@@ -1,0 +1,52 @@
+package middlewares
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"os"
+
+	"github.com/cozy/cozy-stack/config"
+	"github.com/cozy/cozy-stack/crypto"
+	"github.com/labstack/echo"
+)
+
+// BasicAuth use HTTP basic authentication to authenticate a user. The secret
+// of the user should be stored in a file with the specified name, stored in
+// one of the the config.Paths directories.
+//
+// The format of the secret is the same as our hashed passwords in database: a
+// scrypt hash with a salt contained in the value.
+func BasicAuth(secretFileName string) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			_, passphrase, ok := c.Request().BasicAuth()
+			if !ok {
+				return echo.NewHTTPError(http.StatusUnauthorized, "missing basic auth")
+			}
+
+			shadowFile, err := config.FindConfigFile(secretFileName)
+			if err != nil {
+				return echo.NewHTTPError(http.StatusInternalServerError, err)
+			}
+
+			f, err := os.Open(shadowFile)
+			if err != nil {
+				return echo.NewHTTPError(http.StatusInternalServerError, err)
+			}
+
+			b, err := ioutil.ReadAll(f)
+			if err != nil {
+				return echo.NewHTTPError(http.StatusInternalServerError, err)
+			}
+
+			b = bytes.TrimSpace(b)
+
+			if err := crypto.CompareHashAndPassphrase(b, []byte(passphrase)); err != nil {
+				return echo.NewHTTPError(http.StatusForbidden, "bad passphrase")
+			}
+
+			return next(c)
+		}
+	}
+}

--- a/web/server.go
+++ b/web/server.go
@@ -25,10 +25,8 @@ package web
 import (
 	"strings"
 
-	"github.com/cozy/cozy-stack/config"
 	"github.com/cozy/cozy-stack/instance"
 	"github.com/labstack/echo"
-	"github.com/labstack/echo/middleware"
 )
 
 func splitHost(host string) (instanceHost string, appSlug string) {
@@ -42,14 +40,6 @@ func splitHost(host string) (instanceHost string, appSlug string) {
 // Create returns a new web server that will handle that apps routing given the
 // host of the request.
 func Create(router *echo.Echo, serveApps func(c echo.Context, domain, slug string) error) (*echo.Echo, error) {
-	recoverMiddleware := middleware.RecoverWithConfig(middleware.RecoverConfig{
-		StackSize:         1 << 10, // 1 KB
-		DisableStackAll:   !config.IsDevRelease(),
-		DisablePrintStack: !config.IsDevRelease(),
-	})
-
-	router.Use(recoverMiddleware)
-
 	main := echo.New()
 	main.Any("/*", func(c echo.Context) error {
 		// TODO(optim): minimize the number of instance requests


### PR DESCRIPTION
This PR adds an administration endpoint on a separate port (6060 by default).

This administration offers for now the possibility to handle instances through an HTTP API:

- `POST /instances/?Domain=...`
- `GET /instances/`
- `DELETE /instances/:domain`

The `instances` cli command uses has been changed to use this API.