### PR TITLE
Fix the OAuth redirectionss for a user not yet logged-in

### DIFF
--- a/web/auth/auth.go
+++ b/web/auth/auth.go
@@ -124,10 +124,12 @@ func checkRedirectParam(c echo.Context, defaultRedirect string) (string, error) 
 	}
 
 	instance := middlewares.GetInstance(c)
-	parts := strings.SplitN(u.Host, ".", 2)
-	if len(parts) != 2 || parts[1] != instance.Domain || parts[0] == "" {
-		return "", echo.NewHTTPError(http.StatusBadRequest,
-			"bad url: should be subdomain")
+	if u.Host != instance.Domain {
+		parts := strings.SplitN(u.Host, ".", 2)
+		if len(parts) != 2 || parts[1] != instance.Domain || parts[0] == "" {
+			return "", echo.NewHTTPError(http.StatusBadRequest,
+				"bad url: should be subdomain")
+		}
 	}
 
 	// To protect against stealing authorization code with redirection, the
@@ -228,7 +230,7 @@ func authorizeForm(c echo.Context) error {
 
 	if !IsLoggedIn(c) {
 		redirect := url.Values{
-			"redirect": {c.Request().URL.String()},
+			"redirect": {params.instance.PageURL(c.Request().URL.String())},
 		}
 		u := url.URL{
 			Scheme:   "https",

--- a/web/auth/auth_test.go
+++ b/web/auth/auth_test.go
@@ -171,22 +171,6 @@ func TestShowLoginPageWithRedirectBadURL(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "400 Bad Request", res3.Status)
 	assert.Equal(t, "text/plain; charset=utf-8", res3.Header.Get("Content-Type"))
-
-	req4, _ := http.NewRequest("GET", ts.URL+"/auth/login?redirect="+url.QueryEscape("https://"+domain+"/foo/bar"), nil)
-	req4.Host = domain
-	res4, err := client.Do(req4)
-	defer res4.Body.Close()
-	assert.NoError(t, err)
-	assert.Equal(t, "400 Bad Request", res4.Status)
-	assert.Equal(t, "text/plain; charset=utf-8", res4.Header.Get("Content-Type"))
-
-	req5, _ := http.NewRequest("GET", ts.URL+"/auth/login?redirect="+url.QueryEscape("https://."+domain+"/foo/bar"), nil)
-	req5.Host = domain
-	res5, err := client.Do(req5)
-	defer res5.Body.Close()
-	assert.NoError(t, err)
-	assert.Equal(t, "400 Bad Request", res5.Status)
-	assert.Equal(t, "text/plain; charset=utf-8", res5.Header.Get("Content-Type"))
 }
 
 func TestShowLoginPageWithRedirectXSS(t *testing.T) {


### PR DESCRIPTION
If the user is not yet logged in when he starts the OAuth2 authorization code flow, he will be redirectered to the login page with a `redirect` parameter that will be rejected. This PR fixes this and allow the user to complete the OAuth2 flow.