### PR TITLE
Fix pouchdb integration tests

### DIFF
--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -6,6 +6,9 @@ sleep 3
 cd integration-tests/pouchdb
 npm install
 npm run test
+testresult=$?
 
 pidstack=$(jobs -pr)
 [ -n "$pidstack" ] && kill -9 $pidstack
+
+exit $testresult

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -5,8 +5,7 @@ sleep 5
 go run main.go instances add dev
 
 cd integration-tests/pouchdb
-npm install
-npm run test
+npm install && npm run test
 testresult=$?
 
 pidstack=$(jobs -pr)

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
-go run main.go instances add dev
 go run main.go serve &
-sleep 3
+sleep 5
+go run main.go instances add dev
+
 cd integration-tests/pouchdb
 npm install
 npm run test


### PR DESCRIPTION
I just saw the integration does not pass, but because the bash script was not properly passing its exit code, travis was green. 

This should both fix error reporting & the bug in travis.