### PR TITLE
Remove the TODO about trust on first use

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -289,11 +289,6 @@ GET /auth/authorize?client_id=oauth-client-1&response_type=code&scope=files/imag
 Host: cozy.example.org
 ```
 
-**Note** we follow the TOFU principle (Trust On First Use). It means that if
-the user has already said yes for this authorization and scopes, she will be
-redirected to the app directly. As for `/auth/login`, the fragment is
-overriden in the redirection with `#` (an empty fragment).
-
 **Note** we warn the user that he is about to share his data with an
 application which only the callback URI is guaranteed.
 
@@ -316,7 +311,7 @@ URL:
 
 ```http
 HTTP/1.1 302 Moved Temporarily
-Location: https://client.org/?state=Eh6ahshepei5Oojo&access_code=Aih7ohth
+Location: https://client.org/?state=Eh6ahshepei5Oojo&access_code=Aih7ohth#
 ```
 
 ### POST /auth/access_token

--- a/web/auth/auth.go
+++ b/web/auth/auth.go
@@ -238,8 +238,6 @@ func authorizeForm(c echo.Context) error {
 		return c.Redirect(http.StatusSeeOther, u.String())
 	}
 
-	// TODO Trust On First Use
-
 	permissions := strings.Split(params.scope, " ")
 	params.client.ClientID = params.client.CouchID
 	return c.Render(http.StatusOK, "authorize.html", echo.Map{


### PR DESCRIPTION
The trust on first use principle is useful when using OAuth as
authentication (OpenID), and when there are many users using the same
OAuth2 server. It's not the case for Cozy, so we can skip this part.