### PR TITLE
Fix go-git

### DIFF
--- a/pkg/apps/git.go
+++ b/pkg/apps/git.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cozy/cozy-stack/pkg/vfs"
 	git "gopkg.in/src-d/go-git.v4"
+	gitObj "gopkg.in/src-d/go-git.v4/plumbing/object"
 	gitSt "gopkg.in/src-d/go-git.v4/storage/filesystem"
 	gitFS "gopkg.in/src-d/go-git.v4/utils/fs"
 )
@@ -127,7 +128,7 @@ func (g *gitClient) Fetch(vfsC vfs.Context, appdir string) error {
 		return err
 	}
 
-	return files.ForEach(func(f *git.File) (err error) {
+	return files.ForEach(func(f *gitObj.File) (err error) {
 		abs := path.Join(appdir, f.Name)
 		dir := path.Dir(abs)
 

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -186,20 +186,21 @@ func OpenFile(c Context, name string, flag int, perm os.FileMode) (*File, error)
 		return Open(c, doc)
 	}
 
-	var err error
 	var dirID string
-	var olddoc *FileDoc
-	var parent *DirDoc
-
-	if flag&os.O_CREATE != 0 {
-		if parent, err = GetDirDocFromPath(c, path.Dir(name), false); err != nil {
+	olddoc, err := GetFileDocFromPath(c, name)
+	if os.IsNotExist(err) && flag&os.O_CREATE != 0 {
+		var parent *DirDoc
+		parent, err = GetDirDocFromPath(c, path.Dir(name), false)
+		if err != nil {
 			return nil, err
 		}
 		dirID = parent.ID()
-	} else if flag&os.O_WRONLY != 0 {
-		if olddoc, err = GetFileDocFromPath(c, name); err != nil {
-			return nil, err
-		}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if olddoc != nil {
 		dirID = olddoc.DirID
 	}
 


### PR DESCRIPTION
This PR should fix the new go-git package (File struct has changed of package).

It also fixes `OpenFile` func used with `O_CREATE` flag when the file already exists.