### PR TITLE
Fix replication of _design doc

### DIFF
--- a/web/data/data.go
+++ b/web/data/data.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
-	"strings"
 
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/web/jsonapi"
@@ -39,7 +38,7 @@ func getDoc(c echo.Context) error {
 		return dbStatus(c)
 	}
 
-	if docid[0] == '_' && !strings.HasPrefix(docid, "_design") {
+	if docid[0] == '_' {
 		return fmt.Errorf("Unsuported couchdb operation %s", docid)
 	}
 

--- a/web/data/data.go
+++ b/web/data/data.go
@@ -2,7 +2,6 @@
 package data
 
 import (
-	"fmt"
 	"net/http"
 	"strconv"
 
@@ -39,7 +38,7 @@ func getDoc(c echo.Context) error {
 	}
 
 	if docid[0] == '_' {
-		return fmt.Errorf("Unsuported couchdb operation %s", docid)
+		return jsonapi.NewError(http.StatusBadRequest, "Unsuported couchdb operation %s", docid)
 	}
 
 	revs := c.QueryParam("revs")

--- a/web/data/data_test.go
+++ b/web/data/data_test.go
@@ -161,6 +161,22 @@ func TestWrongDoctype(t *testing.T) {
 
 }
 
+func TestUnderscoreName(t *testing.T) {
+	req, _ := http.NewRequest("GET", ts.URL+"/data/"+Type+"/_foo", nil)
+	req.Header.Add("Host", Host)
+	_, res, err := doRequest(req, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "400 Bad Request", res.Status, "should get a 400")
+}
+
+func TestGetDesign(t *testing.T) {
+	req, _ := http.NewRequest("GET", ts.URL+"/data/"+Type+"/_design/test", nil)
+	req.Header.Add("Host", Host)
+	_, res, err := doRequest(req, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "400 Bad Request", res.Status, "should get a 400")
+}
+
 func TestVFSDoctype(t *testing.T) {
 
 	var in = jsonReader(&map[string]interface{}{

--- a/web/data/replication.go
+++ b/web/data/replication.go
@@ -16,6 +16,19 @@ func proxy(c echo.Context, path string) error {
 	return nil
 }
 
+func getDesignDoc(c echo.Context) error {
+	docid := c.Param("designdocid")
+
+	revs := c.QueryParam("revs")
+	if revs == "true" {
+		return proxy(c, "_design/"+docid)
+	}
+
+	return c.JSON(http.StatusBadRequest, echo.Map{
+		"error": "_design docs are only readable for replication",
+	})
+}
+
 func getLocalDoc(c echo.Context) error {
 	doctype := c.Get("doctype").(string)
 	docid := c.Param("docid")
@@ -87,6 +100,7 @@ func replicationRoutes(router *echo.Group) {
 	// Routes used only for replication
 	router.GET("/", dataAPIWelcome)
 	router.GET("/:doctype/", dbStatus)
+	router.GET("/:doctype/_design/:designdocid", getDesignDoc)
 	router.GET("/:doctype/_changes", changesFeed)
 	// POST=GET see http://docs.couchdb.org/en/2.0.0/api/database/changes.html#post--db-_changes)
 	router.POST("/:doctype/_changes", changesFeed)


### PR DESCRIPTION
Turns out the previous fix did not work with the way echo routes.

This should allow replicating any db, even if it contains _design doc.

Working on adding tests for this.