### PR TITLE
Allow to update a git application

### DIFF
--- a/pkg/apps/apps.go
+++ b/pkg/apps/apps.go
@@ -1,11 +1,9 @@
 package apps
 
 import (
-	"io"
 	"strings"
 
 	"github.com/cozy/cozy-stack/pkg/couchdb"
-	"github.com/cozy/cozy-stack/pkg/vfs"
 	"github.com/cozy/cozy-stack/web/jsonapi"
 )
 
@@ -78,6 +76,7 @@ type Manifest struct {
 	Slug        string     `json:"slug"`
 	Source      string     `json:"source"`
 	State       State      `json:"state"`
+	Error       string     `json:"error,omitempty"`
 	Icon        string     `json:"icon"`
 	Description string     `json:"description"`
 	Developer   *Developer `json:"developer"`
@@ -125,17 +124,6 @@ func (m *Manifest) Relationships() jsonapi.RelationshipMap {
 // Included is part of the jsonapi.Object interface
 func (m *Manifest) Included() []jsonapi.Object {
 	return []jsonapi.Object{}
-}
-
-// Client interface should be implemented by the underlying transport
-// used to fetch the application data.
-type Client interface {
-	// FetchManifest should returns an io.ReadCloser to read the
-	// manifest data
-	FetchManifest() (io.ReadCloser, error)
-	// Fetch should download the application and install it in the given
-	// directory.
-	Fetch(vfsC vfs.Context, appdir string) error
 }
 
 // List returns the list of installed applications.

--- a/pkg/apps/git.go
+++ b/pkg/apps/git.go
@@ -119,7 +119,7 @@ func (g *gitFetcher) pull(appdir, gitdir string, src *url.URL) error {
 
 	// TODO: permanently remove application files instead of moving them to the
 	// trash
-	err = vfs.Walk(c, appdir, func(name string, dir *vfs.DirDoc, file *vfs.FileDoc, err error) error {
+	err = vfs.Walk(ctx, appdir, func(name string, dir *vfs.DirDoc, file *vfs.FileDoc, err error) error {
 		if err != nil {
 			return err
 		}
@@ -132,9 +132,9 @@ func (g *gitFetcher) pull(appdir, gitdir string, src *url.URL) error {
 		}
 
 		if dir != nil {
-			_, err = vfs.TrashDir(c, dir)
+			_, err = vfs.TrashDir(ctx, dir)
 		} else {
-			_, err = vfs.TrashFile(c, file)
+			_, err = vfs.TrashFile(ctx, file)
 		}
 		if err != nil {
 			return err

--- a/pkg/apps/git.go
+++ b/pkg/apps/git.go
@@ -19,73 +19,61 @@ import (
 	gitFS "gopkg.in/src-d/go-git.v4/utils/fs"
 )
 
-const githubRawManifestURL = "https://raw.githubusercontent.com/%s/%s/%s/%s"
+const ghRawManifestURL = "https://raw.githubusercontent.com/%s/%s/%s/%s"
 
-var githubURLRegex = regexp.MustCompile(`/([^/]+)/([^/]+).git`)
+// ghURLRegex is used to identify github
+var ghURLRegex = regexp.MustCompile(`/([^/]+)/([^/]+).git`)
 
-type gitClient struct {
-	vfsC vfs.Context
-	src  string
+type gitFetcher struct {
+	ctx vfs.Context
 }
 
-func newGitClient(vfsC vfs.Context, rawurl string) *gitClient {
-	return &gitClient{vfsC: vfsC, src: rawurl}
+func newGitFetcher(ctx vfs.Context) *gitFetcher {
+	return &gitFetcher{ctx: ctx}
 }
 
-func (g *gitClient) FetchManifest() (io.ReadCloser, error) {
-	src, err := url.Parse(g.src)
+func (g *gitFetcher) FetchManifest(src *url.URL) (io.ReadCloser, error) {
+	var err error
+
+	var u string
+	if src.Host == "github.com" {
+		u, err = resolveGithubURL(src)
+	} else {
+		u, err = resolveManifestURL(src)
+	}
 	if err != nil {
 		return nil, err
 	}
 
-	if src.Host == "github.com" {
-		return g.fetchManifestFromGithub(src)
-	}
-
-	// TODO
-	return nil, errors.New("Not implemented")
-}
-
-func (g *gitClient) fetchManifestFromGithub(src *url.URL) (io.ReadCloser, error) {
-	submatch := githubURLRegex.FindStringSubmatch(src.Path)
-	if len(submatch) != 3 {
-		return nil, &url.Error{
-			Op:  "parsepath",
-			URL: src.String(),
-			Err: errors.New("Could not parse url git path"),
-		}
-	}
-
-	user, project := submatch[1], submatch[2]
-	var branch string
-	if src.Fragment != "" {
-		branch = src.Fragment
-	} else {
-		branch = "master"
-	}
-
-	manURL := fmt.Sprintf(githubRawManifestURL, user, project, branch, ManifestFilename)
-	resp, err := http.Get(manURL)
-	if err != nil {
+	res, err := http.Get(u)
+	if err != nil || res.StatusCode != 200 {
 		return nil, ErrManifestNotReachable
 	}
 
-	if resp.StatusCode != 200 {
-		return nil, ErrManifestNotReachable
-	}
-
-	return resp.Body, nil
+	return res.Body, nil
 }
 
-func (g *gitClient) Fetch(vfsC vfs.Context, appdir string) error {
+func (g *gitFetcher) Fetch(src *url.URL, appdir string) error {
+	ctx := g.ctx
+
 	gitdir := path.Join(appdir, ".git")
-	_, err := vfs.Mkdir(vfsC, gitdir, nil)
+	_, err := vfs.Mkdir(ctx, gitdir, nil)
+	if os.IsExist(err) {
+		return g.pull(appdir, gitdir, src)
+	}
 	if err != nil {
 		return err
 	}
 
-	gfs := newGFS(vfsC, gitdir)
-	storage, err := gitSt.NewStorage(gfs)
+	return g.clone(appdir, gitdir, src)
+}
+
+// clone creates a new bare git repository and install all the files of the
+// last commit in the application tree.
+func (g *gitFetcher) clone(appdir, gitdir string, src *url.URL) error {
+	ctx := g.ctx
+
+	storage, err := gitSt.NewStorage(newGFS(ctx, gitdir))
 	if err != nil {
 		return err
 	}
@@ -95,16 +83,6 @@ func (g *gitClient) Fetch(vfsC vfs.Context, appdir string) error {
 		return err
 	}
 
-	src, err := url.Parse(g.src)
-	if err != nil {
-		return err
-	}
-
-	// go-git does not support git protocol. we switch to https silently.
-	if src.Scheme == "git" {
-		src.Scheme = "https"
-	}
-
 	err = rep.Clone(&git.CloneOptions{
 		URL:   src.String(),
 		Depth: 1,
@@ -112,6 +90,41 @@ func (g *gitClient) Fetch(vfsC vfs.Context, appdir string) error {
 	if err != nil {
 		return err
 	}
+
+	return g.copyFiles(appdir, rep)
+}
+
+// pull will fetch the latest objects from the default remote and if updates
+// are available, it will update the application tree files.
+func (g *gitFetcher) pull(appdir, gitdir string, src *url.URL) error {
+	ctx := g.ctx
+
+	storage, err := gitSt.NewStorage(newGFS(ctx, gitdir))
+	if err != nil {
+		return err
+	}
+
+	rep, err := git.NewRepository(storage)
+	if err != nil {
+		return err
+	}
+
+	err = rep.Pull(&git.PullOptions{})
+	if err == git.NoErrAlreadyUpToDate {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	// TODO: remove all files from the tree before copying new ones. or just try
+	// to remove/update only the modified files.
+
+	return g.copyFiles(appdir, rep)
+}
+
+func (g *gitFetcher) copyFiles(appdir string, rep *git.Repository) error {
+	ctx := g.ctx
 
 	ref, err := rep.Head()
 	if err != nil {
@@ -132,12 +145,12 @@ func (g *gitClient) Fetch(vfsC vfs.Context, appdir string) error {
 		abs := path.Join(appdir, f.Name)
 		dir := path.Dir(abs)
 
-		_, err = vfs.MkdirAll(vfsC, dir, nil)
+		_, err = vfs.MkdirAll(ctx, dir, nil)
 		if err != nil {
 			return
 		}
 
-		file, err := vfs.Create(vfsC, abs)
+		file, err := vfs.Create(ctx, abs)
 		if err != nil {
 			return
 		}
@@ -160,8 +173,40 @@ func (g *gitClient) Fetch(vfsC vfs.Context, appdir string) error {
 	})
 }
 
+func resolveGithubURL(src *url.URL) (string, error) {
+	match := ghURLRegex.FindStringSubmatch(src.Path)
+	if len(match) != 3 {
+		return "", &url.Error{
+			Op:  "parsepath",
+			URL: src.String(),
+			Err: errors.New("Could not parse url git path"),
+		}
+	}
+
+	user, project := match[1], match[2]
+	var branch string
+	if src.Fragment != "" {
+		branch = src.Fragment
+	} else {
+		branch = "master"
+	}
+
+	u := fmt.Sprintf(ghRawManifestURL, user, project, branch, ManifestFilename)
+	return u, nil
+}
+
+func resolveManifestURL(src *url.URL) (string, error) {
+	srccopy, _ := url.Parse(src.String())
+	srccopy.Scheme = "http"
+	if srccopy.Path[len(srccopy.Path)-1] != '/' {
+		srccopy.Path += "/"
+	}
+	srccopy.Path = srccopy.Path + ManifestFilename
+	return srccopy.String(), nil
+}
+
 type gfs struct {
-	vfsC vfs.Context
+	ctx  vfs.Context
 	base string
 	dir  *vfs.DirDoc
 }
@@ -205,14 +250,14 @@ func (f *gfile) Close() error {
 	return f.f.Close()
 }
 
-func newGFS(vfsC vfs.Context, base string) *gfs {
-	dir, err := vfs.GetDirDocFromPath(vfsC, base, false)
+func newGFS(ctx vfs.Context, base string) *gfs {
+	dir, err := vfs.GetDirDocFromPath(ctx, base, false)
 	if err != nil {
 		panic(err)
 	}
 
 	return &gfs{
-		vfsC: vfsC,
+		ctx:  ctx,
 		base: path.Clean(base),
 		dir:  dir,
 	}
@@ -225,12 +270,12 @@ func (fs *gfs) OpenFile(name string, flag int, perm os.FileMode) (gitFS.File, er
 	dirbase := path.Dir(fullpath)
 
 	if flag&os.O_CREATE != 0 {
-		if _, err = vfs.MkdirAll(fs.vfsC, dirbase, nil); err != nil {
+		if _, err = vfs.MkdirAll(fs.ctx, dirbase, nil); err != nil {
 			return nil, err
 		}
 	}
 
-	file, err := vfs.OpenFile(fs.vfsC, fullpath, flag, perm)
+	file, err := vfs.OpenFile(fs.ctx, fullpath, flag, perm)
 	if err != nil {
 		return nil, err
 	}
@@ -244,7 +289,7 @@ func (fs *gfs) Create(name string) (gitFS.File, error) {
 
 func (fs *gfs) Open(name string) (gitFS.File, error) {
 	fullpath := fs.Join(fs.base, name)
-	f, err := vfs.OpenFile(fs.vfsC, fullpath, os.O_RDONLY, 0)
+	f, err := vfs.OpenFile(fs.ctx, fullpath, os.O_RDONLY, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -252,15 +297,15 @@ func (fs *gfs) Open(name string) (gitFS.File, error) {
 }
 
 func (fs *gfs) Remove(name string) error {
-	return vfs.Remove(fs.vfsC, fs.Join(fs.base, name))
+	return vfs.Remove(fs.ctx, fs.Join(fs.base, name))
 }
 
 func (fs *gfs) Stat(name string) (gitFS.FileInfo, error) {
-	return vfs.Stat(fs.vfsC, fs.Join(fs.base, name))
+	return vfs.Stat(fs.ctx, fs.Join(fs.base, name))
 }
 
 func (fs *gfs) ReadDir(name string) ([]gitFS.FileInfo, error) {
-	l, err := vfs.ReadDir(fs.vfsC, fs.Join(fs.base, name))
+	l, err := vfs.ReadDir(fs.ctx, fs.Join(fs.base, name))
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +332,7 @@ func (fs *gfs) TempFile(dirname, prefix string) (gitFS.File, error) {
 }
 
 func (fs *gfs) Rename(from, to string) error {
-	return vfs.Rename(fs.vfsC, fs.Join(fs.base, from), fs.Join(fs.base, to))
+	return vfs.Rename(fs.ctx, fs.Join(fs.base, from), fs.Join(fs.base, to))
 }
 
 func (fs *gfs) Join(elem ...string) string {
@@ -295,7 +340,7 @@ func (fs *gfs) Join(elem ...string) string {
 }
 
 func (fs *gfs) Dir(name string) gitFS.Filesystem {
-	return newGFS(fs.vfsC, fs.Join(fs.base, name))
+	return newGFS(fs.ctx, fs.Join(fs.base, name))
 }
 
 func (fs *gfs) Base() string {
@@ -303,7 +348,7 @@ func (fs *gfs) Base() string {
 }
 
 var (
-	_ Client           = &gitClient{}
+	_ Fetcher          = &gitFetcher{}
 	_ gitFS.Filesystem = &gfs{}
 	_ gitFS.File       = &gfile{}
 )

--- a/pkg/apps/git.go
+++ b/pkg/apps/git.go
@@ -16,7 +16,7 @@ import (
 	git "gopkg.in/src-d/go-git.v4"
 	gitObj "gopkg.in/src-d/go-git.v4/plumbing/object"
 	gitSt "gopkg.in/src-d/go-git.v4/storage/filesystem"
-	gitFS "gopkg.in/src-d/go-git.v4/utils/fs"
+	gitFS "srcd.works/go-billy.v1"
 )
 
 const ghRawManifestURL = "https://raw.githubusercontent.com/%s/%s/%s/%s"

--- a/pkg/apps/installer.go
+++ b/pkg/apps/installer.go
@@ -18,10 +18,10 @@ type Installer struct {
 	fetcher Fetcher
 	ctx     vfs.Context
 
+	man  *Manifest
 	src  *url.URL
 	slug string
 
-	man  *Manifest
 	err  error
 	errc chan error
 	manc chan *Manifest

--- a/pkg/apps/installer_test.go
+++ b/pkg/apps/installer_test.go
@@ -352,6 +352,12 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
+	err = vfs.CreateTrashDir(c)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
 	go serveGitRep()
 
 	time.Sleep(100 * time.Millisecond)

--- a/pkg/apps/installer_test.go
+++ b/pkg/apps/installer_test.go
@@ -2,8 +2,16 @@ package apps
 
 import (
 	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
+	"os/exec"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/cozy/checkup"
 	"github.com/cozy/cozy-stack/pkg/config"
@@ -12,6 +20,74 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 )
+
+var localGitCmd *exec.Cmd
+var localGitDir string
+var localVersion = "1.0.0"
+var ts *httptest.Server
+
+type transport struct{}
+
+func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req2 := new(http.Request)
+	*req2 = *req
+	fmt.Println(req.URL.String())
+	req2.URL, _ = url.Parse(ts.URL)
+	return http.DefaultTransport.RoundTrip(req2)
+}
+
+func manifest() string {
+	return strings.Replace(`{
+  "description": "A mini app to test cozy-stack-v2",
+  "developer": {
+    "name": "Bruno",
+    "url": "cozy.io"
+  },
+  "license": "MIT",
+  "name": "mini-app",
+  "permissions": {},
+  "slug": "mini",
+  "version": "`+localVersion+`"
+}`, "\n", "", -1)
+}
+
+func serveGitRep() {
+	dir, err := ioutil.TempDir("", "cozy-app")
+	if err != nil {
+		panic(err)
+	}
+	localGitDir = dir
+	args := `
+echo '` + manifest() + `' > manifest.webapp && \
+git init . && \
+git add . && \
+git commit -m "Initial commit"`
+	cmd := exec.Command("sh", "-c", args)
+	cmd.Dir = localGitDir
+	if err := cmd.Run(); err != nil {
+		panic(err)
+	}
+
+	// "git daemon --reuseaddr --base-path=./ --export-all ./.git"
+	localGitCmd = exec.Command("git", "daemon", "--reuseaddr", "--base-path=./", "--export-all", "./.git")
+	localGitCmd.Dir = localGitDir
+	if out, err := localGitCmd.CombinedOutput(); err != nil {
+		fmt.Println(string(out))
+		panic(err)
+	}
+}
+
+func doUpgrade() {
+	localVersion = "2.0.0"
+	args := `
+echo '` + manifest() + `' > manifest.webapp && \
+git commit -am "Upgrade commit"`
+	cmd := exec.Command("sh", "-c", args)
+	cmd.Dir = localGitDir
+	if err := cmd.Run(); err != nil {
+		panic(err)
+	}
+}
 
 type TestContext struct {
 	prefix string
@@ -27,55 +103,76 @@ var c = &TestContext{
 }
 
 func TestInstallBadSlug(t *testing.T) {
-	_, err := NewInstaller(c, "", "git://foo.bar")
+	_, err := NewInstaller(c, &InstallerOptions{
+		SourceURL: "git://foo.bar",
+	})
 	if assert.Error(t, err) {
 		assert.Equal(t, ErrInvalidSlugName, err)
 	}
 
-	_, err = NewInstaller(c, "coucou/", "git://foo.bar")
+	_, err = NewInstaller(c, &InstallerOptions{
+		Slug:      "coucou/",
+		SourceURL: "git://foo.bar",
+	})
 	if assert.Error(t, err) {
 		assert.Equal(t, ErrInvalidSlugName, err)
 	}
 }
 
 func TestInstallBadAppsSource(t *testing.T) {
-	_, err := NewInstaller(c, "app2", "")
+	_, err := NewInstaller(c, &InstallerOptions{
+		Slug:      "app2",
+		SourceURL: "",
+	})
 	if assert.Error(t, err) {
 		assert.Equal(t, ErrNotSupportedSource, err)
 	}
 
-	_, err = NewInstaller(c, "app3", "foo://bar.baz")
+	_, err = NewInstaller(c, &InstallerOptions{
+		Slug:      "app3",
+		SourceURL: "foo://bar.baz",
+	})
 	if assert.Error(t, err) {
 		assert.Equal(t, ErrNotSupportedSource, err)
 	}
 
-	_, err = NewInstaller(c, "app4", "git://bar  .baz")
+	_, err = NewInstaller(c, &InstallerOptions{
+		Slug:      "app4",
+		SourceURL: "git://bar  .baz",
+	})
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "invalid character")
 	}
 }
 
 func TestInstallSuccessful(t *testing.T) {
-	inst, err := NewInstaller(c, "cozy-mini", "git://github.com/nono/cozy-mini.git")
+	inst, err := NewInstaller(c, &InstallerOptions{
+		Slug:      "local-cozy-mini",
+		SourceURL: "git://localhost/",
+	})
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	go inst.Install()
+	go inst.InstallOrUpdate()
 
 	var state State
-	var manifest *Manifest
 	for {
-		man, done, err := inst.WaitManifest()
+		man, done, err := inst.Poll()
 		if !assert.NoError(t, err) {
 			return
 		}
 		if state == "" {
-			assert.EqualValues(t, Installing, man.State)
+			if !assert.EqualValues(t, Installing, man.State) {
+				return
+			}
 		} else if state == Installing {
-			assert.EqualValues(t, Ready, man.State)
-			assert.True(t, done)
-			manifest = man
+			if !assert.EqualValues(t, Ready, man.State) {
+				return
+			}
+			if !assert.True(t, done) {
+				return
+			}
 			break
 		} else {
 			t.Fatalf("invalid state")
@@ -83,26 +180,22 @@ func TestInstallSuccessful(t *testing.T) {
 		}
 		state = man.State
 	}
-
-	assert.Len(t, manifest.Contexts, 1)
-	ctx, ok := manifest.Contexts["/"]
-	assert.True(t, ok, "The manifest should have the default context")
-	assert.Equal(t, "/", ctx.Folder)
-	assert.Equal(t, "index.html", ctx.Index)
-	assert.Equal(t, false, ctx.Public)
 }
 
-func TestInstallAlreadyExist(t *testing.T) {
-	inst, err := NewInstaller(c, "conflictslug", "git://github.com/nono/cozy-mini.git")
+func TestInstallAldreadyExist(t *testing.T) {
+	inst, err := NewInstaller(c, &InstallerOptions{
+		Slug:      "cozy-app-a",
+		SourceURL: "git://localhost/",
+	})
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	go inst.Install()
+	go inst.InstallOrUpdate()
 
 	for {
 		var done bool
-		_, done, err = inst.WaitManifest()
+		_, done, err = inst.Poll()
 		if !assert.NoError(t, err) {
 			return
 		}
@@ -111,15 +204,123 @@ func TestInstallAlreadyExist(t *testing.T) {
 		}
 	}
 
-	inst, err = NewInstaller(c, "conflictslug", "git://github.com/nono/cozy-mini.git")
+	inst, err = NewInstaller(c, &InstallerOptions{
+		Slug:      "cozy-app-a",
+		SourceURL: "git://localhost/",
+	})
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	go inst.Install()
+	go inst.InstallOrUpdate()
 
-	_, _, err = inst.WaitManifest()
-	assert.Error(t, err)
+	man, done, err := inst.Poll()
+	if !assert.NoError(t, err) {
+		return
+	}
+	if !assert.EqualValues(t, Ready, man.State) {
+		return
+	}
+	if !assert.True(t, done) {
+		return
+	}
+}
+
+func TestInstallWithUpgrade(t *testing.T) {
+	inst, err := NewInstaller(c, &InstallerOptions{
+		Slug:      "cozy-app-b",
+		SourceURL: "git://localhost/",
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	go inst.InstallOrUpdate()
+
+	for {
+		var done bool
+		_, done, err = inst.Poll()
+		if !assert.NoError(t, err) {
+			return
+		}
+		if done {
+			break
+		}
+	}
+
+	doUpgrade()
+
+	inst, err = NewInstaller(c, &InstallerOptions{
+		Slug:      "cozy-app-b",
+		SourceURL: "git://localhost/",
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	go inst.InstallOrUpdate()
+
+	var state State
+	for {
+		man, done, err := inst.Poll()
+		if !assert.NoError(t, err) {
+			return
+		}
+		if state == "" {
+			if !assert.EqualValues(t, Upgrading, man.State) {
+				return
+			}
+		} else if state == Upgrading {
+			if !assert.EqualValues(t, Ready, man.State) {
+				return
+			}
+			if !assert.True(t, done) {
+				return
+			}
+			break
+		} else {
+			t.Fatalf("invalid state")
+			return
+		}
+		state = man.State
+	}
+}
+
+func TestInstallFromGithub(t *testing.T) {
+	inst, err := NewInstaller(c, &InstallerOptions{
+		Slug:      "github-cozy-mini",
+		SourceURL: "git://github.com/nono/cozy-mini.git",
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	go inst.InstallOrUpdate()
+
+	var state State
+	for {
+		man, done, err := inst.Poll()
+		if !assert.NoError(t, err) {
+			return
+		}
+		if state == "" {
+			if !assert.EqualValues(t, Installing, man.State) {
+				return
+			}
+		} else if state == Installing {
+			if !assert.EqualValues(t, Ready, man.State) {
+				return
+			}
+			if !assert.True(t, done) {
+				return
+			}
+			break
+		} else {
+			t.Fatalf("invalid state")
+			return
+		}
+		state = man.State
+	}
 }
 
 func TestMain(m *testing.M) {
@@ -129,6 +330,14 @@ func TestMain(m *testing.M) {
 	if err != nil || db.Status() != checkup.Healthy {
 		fmt.Println("This test need couchdb to run.")
 		os.Exit(1)
+	}
+
+	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, manifest())
+	}))
+
+	http.DefaultClient = &http.Client{
+		Transport: &transport{},
 	}
 
 	err = couchdb.ResetDB(c, ManifestDocType)
@@ -142,6 +351,10 @@ func TestMain(m *testing.M) {
 		fmt.Println(err)
 		os.Exit(1)
 	}
+
+	go serveGitRep()
+
+	time.Sleep(100 * time.Millisecond)
 
 	for _, index := range vfs.Indexes {
 		err = couchdb.DefineIndex(c, vfs.FsDocType, index)
@@ -160,6 +373,9 @@ func TestMain(m *testing.M) {
 
 	couchdb.DeleteDB(c, ManifestDocType)
 	couchdb.DeleteDB(c, vfs.FsDocType)
+	ts.Close()
+
+	localGitCmd.Process.Signal(os.Interrupt)
 
 	os.Exit(res)
 }

--- a/pkg/vfs/directory.go
+++ b/pkg/vfs/directory.go
@@ -188,6 +188,9 @@ func GetDirDoc(c Context, fileID string, withChildren bool) (*DirDoc, error) {
 		if fileID == RootDirID {
 			panic("Root directory is not in database")
 		}
+		if fileID == TrashDirID {
+			panic("Trash directory is not in database")
+		}
 		return nil, err
 	}
 	if doc.Type != DirType {


### PR DESCRIPTION
This PR adds the possibility to upgrade an application. The version comparison between to manifest is done by a simple string comparison (no order).

The modifications of the application files is still clunky since we do not have yet a proper `Remove` method implemented. It only adds and/or override the files, without deleting removed ones.

Testing is done with a local git daemon.