### PR TITLE
Move global consts in their own package

### DIFF
--- a/cmd/files.go
+++ b/cmd/files.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/pkg/vfs"
 	"github.com/dustin/go-humanize"
@@ -218,7 +219,7 @@ func lsCmd(c *instance.Instance, root string, w io.Writer, verbose, human, all b
 			mdate = attrs.UpdatedAt.Format("Jan 02 2015")
 		}
 
-		if f.Attrs.Type == vfs.DirType {
+		if f.Attrs.Type == consts.DirType {
 			typ = "d"
 			exec = "x"
 		} else {
@@ -287,7 +288,7 @@ func treeCmd(c *instance.Instance, root string, w io.Writer) error {
 		return err
 	}
 
-	if doc.Data.ID == vfs.RootDirID {
+	if doc.Data.ID == consts.RootDirID {
 		_, err = fmt.Fprintln(w, "/")
 	} else {
 		_, err = fmt.Fprintln(w, doc.Data.Attrs.Name)
@@ -319,7 +320,7 @@ func treeRecurs(c *instance.Instance, doc *fileAPIData, root string, level int, 
 			return
 		}
 
-		if f.Attrs.Type == vfs.DirType {
+		if f.Attrs.Type == consts.DirType {
 			var child *fileAPIData
 			child, err = filesRequest(c, "GET", "/files/"+f.ID, nil, nil)
 			if err != nil {

--- a/pkg/apps/apps.go
+++ b/pkg/apps/apps.go
@@ -3,20 +3,18 @@ package apps
 import (
 	"strings"
 
+	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/web/jsonapi"
 )
 
 const (
-	// ManifestDocType is manifest type
-	ManifestDocType = "io.cozy.manifests"
 	// ManifestMaxSize is the manifest maximum size
 	ManifestMaxSize = 2 << (2 * 10) // 2MB
+	// ManifestFilename is the name of the manifest at the root of the
+	// application directory
+	ManifestFilename = "manifest.webapp"
 )
-
-// ManifestFilename is the name of the manifest at the root of the
-// application directory
-const ManifestFilename = "manifest.webapp"
 
 // State is the state of the application
 type State string
@@ -94,14 +92,14 @@ type Manifest struct {
 
 // ID returns the manifest identifier - see couchdb.Doc interface
 func (m *Manifest) ID() string {
-	return ManifestDocType + "/" + m.Slug
+	return consts.Manifests + "/" + m.Slug
 }
 
 // Rev return the manifest revision - see couchdb.Doc interface
 func (m *Manifest) Rev() string { return m.ManRev }
 
 // DocType returns the manifest doctype - see couchdb.Doc interfaces
-func (m *Manifest) DocType() string { return ManifestDocType }
+func (m *Manifest) DocType() string { return consts.Manifests }
 
 // SetID is used to change the file identifier - see couchdb.Doc
 // interface
@@ -132,7 +130,7 @@ func (m *Manifest) Included() []jsonapi.Object {
 func List(db couchdb.Database) ([]*Manifest, error) {
 	var docs []*Manifest
 	req := &couchdb.AllDocsRequest{Limit: 100}
-	err := couchdb.GetAllDocs(db, ManifestDocType, req, &docs)
+	err := couchdb.GetAllDocs(db, consts.Manifests, req, &docs)
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +140,7 @@ func List(db couchdb.Database) ([]*Manifest, error) {
 // GetBySlug returns an app identified by its slug
 func GetBySlug(db couchdb.Database, slug string) (*Manifest, error) {
 	man := &Manifest{}
-	err := couchdb.GetDoc(db, ManifestDocType, ManifestDocType+"/"+slug, man)
+	err := couchdb.GetDoc(db, consts.Manifests, consts.Manifests+"/"+slug, man)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/apps/installer_test.go
+++ b/pkg/apps/installer_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cozy/checkup"
 	"github.com/cozy/cozy-stack/pkg/config"
+	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/vfs"
 	"github.com/spf13/afero"
@@ -340,13 +341,13 @@ func TestMain(m *testing.M) {
 		Transport: &transport{},
 	}
 
-	err = couchdb.ResetDB(c, ManifestDocType)
+	err = couchdb.ResetDB(c, consts.Manifests)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
 
-	err = couchdb.ResetDB(c, vfs.FsDocType)
+	err = couchdb.ResetDB(c, consts.Files)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
@@ -363,7 +364,7 @@ func TestMain(m *testing.M) {
 	time.Sleep(100 * time.Millisecond)
 
 	for _, index := range vfs.Indexes {
-		err = couchdb.DefineIndex(c, vfs.FsDocType, index)
+		err = couchdb.DefineIndex(c, consts.Files, index)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
@@ -377,8 +378,8 @@ func TestMain(m *testing.M) {
 
 	res := m.Run()
 
-	couchdb.DeleteDB(c, ManifestDocType)
-	couchdb.DeleteDB(c, vfs.FsDocType)
+	couchdb.DeleteDB(c, consts.Manifests)
+	couchdb.DeleteDB(c, consts.Files)
 	ts.Close()
 
 	localGitCmd.Process.Signal(os.Interrupt)

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -1,0 +1,34 @@
+package consts
+
+const (
+	// Instances doc type for User's instance document
+	Instances = "instances"
+
+	// Files doc type for type for files and directories
+	Files = "io.cozy.files"
+	// Manifests doc type for application manifests
+	Manifests = "io.cozy.manifests"
+	// Settings doc type for settings to customize an instance
+	Settings = "io.cozy.settings"
+	// Sessions doc type for sessions identifying a connection
+	Sessions = "io.cozy.sessions"
+
+	// OAuthClients doc type for OAuth2 clients
+	OAuthClients = "io.cozy.oauth.clients"
+	// OAuthAccessCodes doc type for OAuth2 access codes
+	OAuthAccessCodes = "io.cozy.oauth.access_codes"
+)
+
+const (
+	// DirType is the type attribute for directories
+	DirType = "directory"
+	// FileType is the type attribute for files
+	FileType = "file"
+)
+
+const (
+	// RootDirID is the root directory identifier
+	RootDirID = "io.cozy.files.root-dir"
+	// TrashDirID is the trash directory identifier
+	TrashDirID = "io.cozy.files.trash-dir"
+)

--- a/pkg/couchdb/errors.go
+++ b/pkg/couchdb/errors.go
@@ -40,7 +40,7 @@ import (
 // 		{"error":"conflict","reason":"Document update conflict."}
 // 412 Precondition Failed : The request headers from the client and the
 // 		capabilities of the server do not match.
-// 415 Bad Content Type : The content consts.supported, and the content type of
+// 415 Bad Content Type : The content types supported, and the content type of
 // 		the information being requested or submitted indicate that the content
 // 		type is not supported.
 // 416 Requested Range Not Satisfiable : The range specified in the request

--- a/pkg/couchdb/errors.go
+++ b/pkg/couchdb/errors.go
@@ -40,7 +40,7 @@ import (
 // 		{"error":"conflict","reason":"Document update conflict."}
 // 412 Precondition Failed : The request headers from the client and the
 // 		capabilities of the server do not match.
-// 415 Bad Content Type : The content types supported, and the content type of
+// 415 Bad Content Type : The content consts.supported, and the content type of
 // 		the information being requested or submitted indicate that the content
 // 		type is not supported.
 // 416 Requested Range Not Satisfiable : The range specified in the request

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/cozy/cozy-stack/pkg/apps"
 	"github.com/cozy/cozy-stack/pkg/config"
+	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
 	"github.com/cozy/cozy-stack/pkg/crypto"
@@ -18,9 +18,6 @@ import (
 	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/spf13/afero"
 )
-
-// InstanceType : The couchdb type for an Instance
-const InstanceType = "instances"
 
 const (
 	registerTokenLen = 16
@@ -73,7 +70,7 @@ type Instance struct {
 }
 
 // DocType implements couchdb.Doc
-func (i *Instance) DocType() string { return InstanceType }
+func (i *Instance) DocType() string { return consts.Instances }
 
 // ID implements couchdb.Doc
 func (i *Instance) ID() string { return i.DocID }
@@ -141,7 +138,7 @@ func (i *Instance) createInCouchdb() (err error) {
 		return err
 	}
 	byDomain := mango.IndexOnFields("domain")
-	return couchdb.DefineIndex(couchdb.GlobalDB, InstanceType, byDomain)
+	return couchdb.DefineIndex(couchdb.GlobalDB, consts.Instances, byDomain)
 }
 
 // createRootDir creates the root directory for this instance
@@ -178,7 +175,7 @@ func (i *Instance) createRootDir() error {
 // createFSIndexes creates the index needed by VFS
 func (i *Instance) createFSIndexes() error {
 	for _, index := range vfs.Indexes {
-		err := couchdb.DefineIndex(i, vfs.FsDocType, index)
+		err := couchdb.DefineIndex(i, consts.Files, index)
 		if err != nil {
 			return err
 		}
@@ -188,13 +185,13 @@ func (i *Instance) createFSIndexes() error {
 
 // createAppsDB creates the database needed for Apps
 func (i *Instance) createAppsDB() error {
-	return couchdb.CreateDB(i, apps.ManifestDocType)
+	return couchdb.CreateDB(i, consts.Manifests)
 }
 
 // createSettings creates the settings database and some documents like the
 // default theme
 func (i *Instance) createSettings() error {
-	err := couchdb.CreateDB(i, settings.SettingsDocType)
+	err := couchdb.CreateDB(i, consts.Settings)
 	if err != nil {
 		return err
 	}
@@ -277,7 +274,7 @@ func Get(domain string) (*Instance, error) {
 		Selector: mango.Equal("domain", domain),
 		Limit:    1,
 	}
-	err := couchdb.FindDocs(couchdb.GlobalDB, InstanceType, req, &instances)
+	err := couchdb.FindDocs(couchdb.GlobalDB, consts.Instances, req, &instances)
 	if couchdb.IsNoDatabaseError(err) {
 		return nil, ErrNotFound
 	}
@@ -304,7 +301,7 @@ func Get(domain string) (*Instance, error) {
 func List() ([]*Instance, error) {
 	var docs []*Instance
 	req := &couchdb.AllDocsRequest{Limit: 100}
-	err := couchdb.GetAllDocs(couchdb.GlobalDB, InstanceType, req, &docs)
+	err := couchdb.GetAllDocs(couchdb.GlobalDB, consts.Instances, req, &docs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/instance/instance_test.go
+++ b/pkg/instance/instance_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cozy/checkup"
 	"github.com/cozy/cozy-stack/pkg/config"
+	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
 	"github.com/cozy/cozy-stack/pkg/vfs"
@@ -69,7 +70,7 @@ func TestInstancehasOAuthSecret(t *testing.T) {
 func TestInstanceHasRootDir(t *testing.T) {
 	var root vfs.DirDoc
 	prefix := getDB(t, "test.cozycloud.cc")
-	err := couchdb.GetDoc(prefix, vfs.FsDocType, vfs.RootDirID, &root)
+	err := couchdb.GetDoc(prefix, consts.Files, consts.RootDirID, &root)
 	if assert.NoError(t, err) {
 		assert.Equal(t, root.Fullpath, "/")
 	}
@@ -79,7 +80,7 @@ func TestInstanceHasIndexes(t *testing.T) {
 	var results []*vfs.DirDoc
 	prefix := getDB(t, "test.cozycloud.cc")
 	req := &couchdb.FindRequest{Selector: mango.Equal("path", "/")}
-	err := couchdb.FindDocs(prefix, vfs.FsDocType, req, &results)
+	err := couchdb.FindDocs(prefix, consts.Files, req, &results)
 	assert.NoError(t, err)
 	assert.Len(t, results, 1)
 }

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -3,15 +3,13 @@ package settings
 
 import (
 	"github.com/cozy/cozy-stack/pkg/config"
+	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 )
 
-// SettingsDocType is the document type for CouchDB
-const SettingsDocType = "io.cozy.settings"
-
 // DefaultThemeID is the ID of the document that contains the variables for the
 // default theme
-const DefaultThemeID = SettingsDocType + "-theme"
+const DefaultThemeID = consts.Settings + "-theme"
 
 // Theme is a struct that contains all the values for the CSS variables used
 // in the CSS called "theme.css". This stylesheet is ued by the client-side
@@ -45,7 +43,7 @@ func (t *Theme) ID() string { return t.ThemeID }
 func (t *Theme) Rev() string { return t.ThemeRev }
 
 // DocType returns the theme document type
-func (t *Theme) DocType() string { return SettingsDocType }
+func (t *Theme) DocType() string { return consts.Settings }
 
 // SetID changes the theme qualified identifier
 func (t *Theme) SetID(id string) { t.ThemeID = id }
@@ -84,7 +82,7 @@ func CreateDefaultTheme(db couchdb.Database) error {
 // DefaultTheme return the document for the default theme
 func DefaultTheme(db couchdb.Database) (*Theme, error) {
 	theme := &Theme{}
-	err := couchdb.GetDoc(db, SettingsDocType, DefaultThemeID, theme)
+	err := couchdb.GetDoc(db, consts.Settings, DefaultThemeID, theme)
 	return theme, err
 }
 

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/cozy/cozy-stack/pkg/config"
+	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/stretchr/testify/assert"
 )
@@ -23,12 +24,12 @@ func TestTheme(t *testing.T) {
 
 func TestMain(m *testing.M) {
 	config.UseTestFile()
-	err := couchdb.ResetDB(TestPrefix, SettingsDocType)
+	err := couchdb.ResetDB(TestPrefix, consts.Settings)
 	if err != nil {
-		fmt.Printf("Cant reset db (%s, %s) %s\n", TestPrefix, SettingsDocType, err.Error())
+		fmt.Printf("Cant reset db (%s, %s) %s\n", TestPrefix, consts.Settings, err.Error())
 		os.Exit(1)
 	}
 	res := m.Run()
-	couchdb.DeleteDB(TestPrefix, SettingsDocType)
+	couchdb.DeleteDB(TestPrefix, consts.Settings)
 	os.Exit(res)
 }

--- a/pkg/vfs/file.go
+++ b/pkg/vfs/file.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
 	"github.com/cozy/cozy-stack/web/jsonapi"
@@ -54,7 +55,7 @@ func (f *FileDoc) ID() string { return f.DocID }
 func (f *FileDoc) Rev() string { return f.DocRev }
 
 // DocType returns the file document type
-func (f *FileDoc) DocType() string { return FsDocType }
+func (f *FileDoc) DocType() string { return consts.Files }
 
 // SetID changes the file qualified identifier
 func (f *FileDoc) SetID(id string) { f.DocID = id }
@@ -65,7 +66,7 @@ func (f *FileDoc) SetRev(rev string) { f.DocRev = rev }
 // Path is used to generate the file path
 func (f *FileDoc) Path(c Context) (string, error) {
 	var parentPath string
-	if f.DirID == RootDirID {
+	if f.DirID == consts.RootDirID {
 		parentPath = "/"
 	} else {
 		parent, err := f.Parent(c)
@@ -106,7 +107,7 @@ func (f *FileDoc) Relationships() jsonapi.RelationshipMap {
 			},
 			Data: jsonapi.ResourceIdentifier{
 				ID:   f.DirID,
-				Type: FsDocType,
+				Type: consts.Files,
 			},
 		},
 	}
@@ -124,14 +125,14 @@ func NewFileDoc(name, dirID string, size int64, md5Sum []byte, mime, class strin
 	}
 
 	if dirID == "" {
-		dirID = RootDirID
+		dirID = consts.RootDirID
 	}
 
 	tags = uniqueTags(tags)
 
 	createDate := time.Now()
 	doc = &FileDoc{
-		Type:  FileType,
+		Type:  consts.FileType,
 		Name:  name,
 		DirID: dirID,
 
@@ -152,11 +153,11 @@ func NewFileDoc(name, dirID string, size int64, md5Sum []byte, mime, class strin
 // database.
 func GetFileDoc(c Context, fileID string) (*FileDoc, error) {
 	doc := &FileDoc{}
-	err := couchdb.GetDoc(c, FsDocType, fileID, doc)
+	err := couchdb.GetDoc(c, consts.Files, fileID, doc)
 	if err != nil {
 		return nil, err
 	}
-	if doc.Type != FileType {
+	if doc.Type != consts.FileType {
 		return nil, os.ErrNotExist
 	}
 	return doc, nil
@@ -182,7 +183,7 @@ func GetFileDocFromPath(c Context, name string) (*FileDoc, error) {
 	selector := mango.Map{
 		"dir_id": dirID,
 		"name":   path.Base(name),
-		"type":   FileType,
+		"type":   consts.FileType,
 	}
 
 	var docs []*FileDoc
@@ -190,7 +191,7 @@ func GetFileDocFromPath(c Context, name string) (*FileDoc, error) {
 		Selector: selector,
 		Limit:    1,
 	}
-	err = couchdb.FindDocs(c, FsDocType, req, &docs)
+	err = couchdb.FindDocs(c, consts.Files, req, &docs)
 	if err != nil {
 		return nil, err
 	}
@@ -527,7 +528,7 @@ func TrashFile(c Context, olddoc *FileDoc) (newdoc *FileDoc, err error) {
 		return nil, ErrFileInTrash
 	}
 
-	trashDirID := TrashDirID
+	trashDirID := consts.TrashDirID
 	restorePath := path.Dir(oldpath)
 
 	tryOrUseSuffix(olddoc.Name, conflictFormat, func(name string) error {

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
 	"github.com/spf13/afero"
@@ -35,23 +36,10 @@ const DefaultContentType = "application/octet-stream"
 const ForbiddenFilenameChars = "/\x00"
 
 const (
-	// FsDocType is document type
-	FsDocType = "io.cozy.files"
-	// RootDirID is the identifier of the root directory
-	RootDirID = "io.cozy.files.root-dir"
-	// TrashDirID is the identifier of the trash directory
-	TrashDirID = "io.cozy.files.trash-dir"
 	// TrashDirName is the path of the trash directory
 	TrashDirName = "/.cozy_trash"
 	// AppsDirName is the path of the directory in which apps are stored
 	AppsDirName = "/.cozy_apps"
-)
-
-const (
-	// DirType is the type attribute for directories
-	DirType = "directory"
-	// FileType is the type attribute for files
-	FileType = "file"
 )
 
 const (
@@ -98,9 +86,9 @@ type DirOrFileDoc struct {
 // the DirOrFileDoc
 func (fd *DirOrFileDoc) Refine() (dir *DirDoc, file *FileDoc) {
 	switch fd.Type {
-	case DirType:
+	case consts.DirType:
 		dir = &fd.DirDoc
-	case FileType:
+	case consts.FileType:
 		file = &FileDoc{
 			Type:        fd.Type,
 			DocID:       fd.DocID,
@@ -125,7 +113,7 @@ func (fd *DirOrFileDoc) Refine() (dir *DirDoc, file *FileDoc) {
 // without knowing in advance its type.
 func GetDirOrFileDoc(c Context, fileID string, withChildren bool) (dirDoc *DirDoc, fileDoc *FileDoc, err error) {
 	dirOrFile := &DirOrFileDoc{}
-	err = couchdb.GetDoc(c, FsDocType, fileID, dirOrFile)
+	err = couchdb.GetDoc(c, consts.Files, fileID, dirOrFile)
 	if err != nil {
 		return
 	}

--- a/pkg/vfs/vfs_test.go
+++ b/pkg/vfs/vfs_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cozy/checkup"
 	"github.com/cozy/cozy-stack/pkg/config"
+	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -50,7 +51,7 @@ func createTree(tree H, dirID string) (*DirDoc, error) {
 	}
 
 	if dirID == "" {
-		dirID = RootDirID
+		dirID = consts.RootDirID
 	}
 
 	var err error
@@ -186,7 +187,7 @@ func TestCreateAndGetFile(t *testing.T) {
 		},
 	}
 
-	olddoc, err := createTree(origtree, RootDirID)
+	olddoc, err := createTree(origtree, consts.RootDirID)
 
 	if !assert.NoError(t, err) {
 		return
@@ -224,7 +225,7 @@ func TestUpdateDir(t *testing.T) {
 		},
 	}
 
-	doc1, err := createTree(origtree, RootDirID)
+	doc1, err := createTree(origtree, consts.RootDirID)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -301,7 +302,7 @@ func TestWalk(t *testing.T) {
 		},
 	}
 
-	_, err := createTree(walktree, RootDirID)
+	_, err := createTree(walktree, consts.RootDirID)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -357,14 +358,14 @@ func TestMain(m *testing.M) {
 	vfsC.prefix = "dev/"
 	vfsC.fs = afero.NewBasePathFs(afero.NewOsFs(), tempdir)
 
-	err = couchdb.ResetDB(vfsC, FsDocType)
+	err = couchdb.ResetDB(vfsC, consts.Files)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
 
 	for _, index := range Indexes {
-		err = couchdb.DefineIndex(vfsC, FsDocType, index)
+		err = couchdb.DefineIndex(vfsC, consts.Files, index)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
@@ -381,7 +382,7 @@ func TestMain(m *testing.M) {
 	res := m.Run()
 
 	os.RemoveAll(tempdir)
-	couchdb.DeleteDB(vfsC, FsDocType)
+	couchdb.DeleteDB(vfsC, consts.Files)
 
 	os.Exit(res)
 }

--- a/web/auth/access_code.go
+++ b/web/auth/access_code.go
@@ -1,13 +1,11 @@
 package auth
 
 import (
+	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/crypto"
 	"github.com/cozy/cozy-stack/pkg/instance"
 )
-
-// AccessCodeDocType is the CouchRev document type for OAuth2 access codes
-const AccessCodeDocType = "io.cozy.oauth.access_codes"
 
 // AccessCode is struct used during the OAuth2 flow. It has to be persisted in
 // CouchDB, not just sent as a JSON Web Token, because it can be used only
@@ -27,7 +25,7 @@ func (ac *AccessCode) ID() string { return ac.Code }
 func (ac *AccessCode) Rev() string { return ac.CouchRev }
 
 // DocType returns the access code document type
-func (ac *AccessCode) DocType() string { return AccessCodeDocType }
+func (ac *AccessCode) DocType() string { return consts.OAuthAccessCodes }
 
 // SetID changes the access code qualified identifier
 func (ac *AccessCode) SetID(id string) { ac.Code = id }

--- a/web/auth/auth.go
+++ b/web/auth/auth.go
@@ -10,6 +10,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/cozy/cozy-stack/pkg/apps"
+	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/web/jsonapi"
@@ -205,7 +206,7 @@ func checkAuthorizeParams(c echo.Context, params *authorizeParams) (bool, error)
 	}
 
 	params.client = new(Client)
-	if err := couchdb.GetDoc(params.instance, ClientDocType, params.clientID, params.client); err != nil {
+	if err := couchdb.GetDoc(params.instance, consts.OAuthClients, params.clientID, params.client); err != nil {
 		return true, c.Render(http.StatusBadRequest, "error.html", echo.Map{
 			"Error": "The client must be registered",
 		})
@@ -356,7 +357,7 @@ func accessToken(c echo.Context) error {
 			})
 		}
 		accessCode := &AccessCode{}
-		if err = couchdb.GetDoc(instance, AccessCodeDocType, code, accessCode); err != nil {
+		if err = couchdb.GetDoc(instance, consts.OAuthAccessCodes, code, accessCode); err != nil {
 			return c.JSON(http.StatusBadRequest, echo.Map{
 				"error": "invalid code",
 			})

--- a/web/auth/auth_test.go
+++ b/web/auth/auth_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/cozy/cozy-stack/pkg/config"
+	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/crypto"
 	"github.com/cozy/cozy-stack/pkg/instance"
@@ -720,7 +721,7 @@ func TestAuthorizeSuccess(t *testing.T) {
 	if assert.Equal(t, "302 Found", res.Status) {
 		var results []AccessCode
 		req := &couchdb.AllDocsRequest{}
-		couchdb.GetAllDocs(db, AccessCodeDocType, req, &results)
+		couchdb.GetAllDocs(db, consts.OAuthAccessCodes, req, &results)
 		if assert.Len(t, results, 1) {
 			code = results[0].Code
 			expected := fmt.Sprintf("https://example.org/oauth/callback?access_code=%s&state=123456#", code)

--- a/web/auth/client.go
+++ b/web/auth/client.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/crypto"
 	"github.com/cozy/cozy-stack/pkg/instance"
@@ -14,9 +15,6 @@ import (
 )
 
 const (
-	// ClientDocType is the CouchDB document type for OAuth2 clients
-	ClientDocType = "io.cozy.oauth.clients"
-
 	// ClientSecretLen is the number of random bytes used for generating the client secret
 	ClientSecretLen = 24
 
@@ -66,7 +64,7 @@ func (c *Client) ID() string { return c.CouchID }
 func (c *Client) Rev() string { return c.CouchRev }
 
 // DocType returns the client document type
-func (c *Client) DocType() string { return ClientDocType }
+func (c *Client) DocType() string { return consts.OAuthClients }
 
 // SetID changes the client qualified identifier
 func (c *Client) SetID(id string) { c.CouchID = id }
@@ -83,7 +81,7 @@ func (c *Client) transformIDAndRev() {
 // FindClient loads a client from the database
 func FindClient(i *instance.Instance, id string) (Client, error) {
 	var c Client
-	if err := couchdb.GetDoc(i, ClientDocType, id, &c); err != nil {
+	if err := couchdb.GetDoc(i, consts.OAuthClients, id, &c); err != nil {
 		log.Errorf("Impossible to find the client %s: %s", id, err)
 		return c, err
 	}

--- a/web/auth/session.go
+++ b/web/auth/session.go
@@ -6,15 +6,13 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/crypto"
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/labstack/echo"
 )
-
-// SessionsType : The couchdb type for a session
-const SessionsType = "io.cozy.sessions"
 
 // SessionCookieName : name of the cookie created by cozy
 const SessionCookieName = "cozysessid"
@@ -43,7 +41,7 @@ type Session struct {
 }
 
 // DocType implements couchdb.Doc
-func (s *Session) DocType() string { return SessionsType }
+func (s *Session) DocType() string { return consts.Sessions }
 
 // ID implements couchdb.Doc
 func (s *Session) ID() string { return s.DocID }
@@ -99,7 +97,7 @@ func GetSession(c echo.Context) (*Session, error) {
 		return nil, err
 	}
 
-	err = couchdb.GetDoc(i, SessionsType, string(sessionID), &s)
+	err = couchdb.GetDoc(i, consts.Sessions, string(sessionID), &s)
 	// invalid session id
 	if couchdb.IsNotFoundError(err) {
 		return nil, ErrInvalidID

--- a/web/data/permissions.go
+++ b/web/data/permissions.go
@@ -4,9 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/cozy/cozy-stack/pkg/instance"
-	"github.com/cozy/cozy-stack/pkg/vfs"
-	"github.com/cozy/cozy-stack/web/auth"
+	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/labstack/echo"
 )
 
@@ -14,9 +12,9 @@ var readable = true
 var none = false
 
 var blackList = map[string]bool{
-	auth.SessionsType:     none,
-	vfs.FsDocType:         readable,
-	instance.InstanceType: readable,
+	consts.Sessions:  none,
+	consts.Files:     readable,
+	consts.Instances: readable,
 }
 
 // CheckReadable will abort the context and returns false if the doctype

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/pkg/vfs"
@@ -36,9 +37,9 @@ func CreationHandler(c echo.Context) error {
 	var doc jsonapi.Object
 	var err error
 	switch c.QueryParam("Type") {
-	case vfs.FileType:
+	case consts.FileType:
 		doc, err = createFileHandler(c, instance)
-	case vfs.DirType:
+	case consts.DirType:
 		doc, err = createDirHandler(c, instance)
 	default:
 		err = ErrDocTypeInvalid
@@ -346,7 +347,7 @@ func TrashHandler(c echo.Context) error {
 func ReadTrashFilesHandler(c echo.Context) error {
 	instance := middlewares.GetInstance(c)
 
-	trash, err := vfs.GetDirDoc(instance, vfs.TrashDirID, true)
+	trash, err := vfs.GetDirDoc(instance, consts.TrashDirID, true)
 	if err != nil {
 		return wrapVfsError(err)
 	}

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cozy/checkup"
 	"github.com/cozy/cozy-stack/pkg/config"
+	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/pkg/vfs"
 	"github.com/cozy/cozy-stack/web/errors"
@@ -1054,7 +1055,7 @@ func TestFileRestoreWithWithoutParent(t *testing.T) {
 	}
 	restoredData = restoredData["attributes"].(map[string]interface{})
 	assert.Equal(t, "torestorefilewithconflict", restoredData["name"].(string))
-	assert.NotEqual(t, vfs.RootDirID, restoredData["dir_id"].(string))
+	assert.NotEqual(t, consts.RootDirID, restoredData["dir_id"].(string))
 }
 
 func TestFileRestoreWithWithoutParent2(t *testing.T) {
@@ -1089,7 +1090,7 @@ func TestFileRestoreWithWithoutParent2(t *testing.T) {
 	}
 	restoredData = restoredData["attributes"].(map[string]interface{})
 	assert.Equal(t, "torestorefilewithconflict2", restoredData["name"].(string))
-	assert.NotEqual(t, vfs.RootDirID, restoredData["dir_id"].(string))
+	assert.NotEqual(t, consts.RootDirID, restoredData["dir_id"].(string))
 }
 
 func TestDirRestore(t *testing.T) {


### PR DESCRIPTION
This PR adds a `pkg/consts` package containing global identifiers that we use throughout the projet. Mainly the `io.cozy.*` doctypes. Moving them in a separate package has two main advantages:

  - prevent circular dependencies just to import a const string
  - prevent importing the whole package just to import small consts (for a client for instance)