### PR TITLE
Make hosts message clearer in dev script

### DIFF
--- a/scripts/cozy-app-dev.sh
+++ b/scripts/cozy-app-dev.sh
@@ -229,9 +229,10 @@ check_hosts() {
 	devhost=$(cat /etc/hosts | grep ${COZY_PROXY_HOST} || echo "")
 	apphost=$(cat /etc/hosts | grep app.${COZY_PROXY_HOST} || echo "")
 	if [ -z "${devhost}" ] || [ -z "${apphost}" ]; then
-		echo ""
-		echo_err "You should probaby add the following line in the /etc/hosts file:"
-		echo_err "127.0.0.1\t${COZY_PROXY_HOST} app.${COZY_PROXY_HOST}"
+		echo -e ""
+		echo -e "You should have the following line in your /etc/hosts file:"
+		echo -e "127.0.0.1\t${COZY_PROXY_HOST} app.${COZY_PROXY_HOST}"
+		echo -e ""
 	fi
 }
 


### PR DESCRIPTION
Removed the "error:" prefix, added a newline and made the message clearer.