### PR TITLE
Handle passphrase hash update differently

### DIFF
--- a/pkg/crypto/scrypt_test.go
+++ b/pkg/crypto/scrypt_test.go
@@ -22,24 +22,23 @@ func TestGenerateFromPassphrase(t *testing.T) {
 }
 
 func TestCompareGoodHashAndPassphrase(t *testing.T) {
-	err := CompareHashAndPassphrase(goodhash, pass)
+	_, err := CompareHashAndPassphrase(goodhash, pass)
 	assert.NoError(t, err)
 }
 
 func TestCompareBadHashAndPassphrase(t *testing.T) {
-	err := CompareHashAndPassphrase(badhash, pass)
+	_, err := CompareHashAndPassphrase(badhash, pass)
 	assert.Error(t, err)
 }
 
 func TestUpdateHashNoUpdate(t *testing.T) {
-	newhash, err := UpdateHash(goodhash, pass)
-	assert.Error(t, err)
-	assert.Nil(t, newhash)
-	assert.Equal(t, err, ErrNoUpdateNeeded)
+	needUpdate, err := CompareHashAndPassphrase(goodhash, pass)
+	assert.NoError(t, err)
+	assert.False(t, needUpdate)
 }
 
 func TestUpdateHashNeedUpdate(t *testing.T) {
-	newhash, err := UpdateHash(oldhash, pass)
+	needUpdate, err := CompareHashAndPassphrase(oldhash, pass)
 	assert.NoError(t, err)
-	assert.NotEqual(t, len(oldhash), len(newhash))
+	assert.True(t, needUpdate)
 }

--- a/web/middlewares/basic_auth.go
+++ b/web/middlewares/basic_auth.go
@@ -2,6 +2,7 @@ package middlewares
 
 import (
 	"bytes"
+	"errors"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -42,8 +43,13 @@ func BasicAuth(secretFileName string) echo.MiddlewareFunc {
 
 			b = bytes.TrimSpace(b)
 
-			if err := crypto.CompareHashAndPassphrase(b, []byte(passphrase)); err != nil {
+			needUpdate, err := crypto.CompareHashAndPassphrase(b, []byte(passphrase))
+			if err != nil {
 				return echo.NewHTTPError(http.StatusForbidden, "bad passphrase")
+			}
+
+			if needUpdate {
+				return errors.New("Passphrase hash needs update and should be regenerated !")
 			}
 
 			return next(c)


### PR DESCRIPTION
Just stumbled across the passphrase update mechanism (in case the scrypt attribute are changed and the hash needs to be updated) and was a bit confused.

The changes in this PR:
  - remove the `UpdateHash` method (which is more a `ShouldUpdateHash`)
  - make the `CompareHashAndPassphrase` return a `needUpdate` boolean along with an error

This has two advantages:
  - do not require double hash checking (one by `Compare` and the other by `UpdateHash`) on each passphrase check (in case of a success)
  - "force" the user of the `CompareHashAndPassphrase` method to handle the case where the hash is outdated