### PR TITLE
Add development instances to help development on the stack

### DIFF
--- a/cmd/files.go
+++ b/cmd/files.go
@@ -563,7 +563,7 @@ type fileAPIPatch struct {
 }
 
 func filesClient(c *instance.Instance) *client {
-	return &client{addr: c.Addr()}
+	return &client{addr: c.Domain}
 }
 
 func filesRequest(c *instance.Instance, method, path string, q url.Values, body interface{}) (*fileAPIData, error) {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/cozy/cozy-stack/pkg/config"
 	"github.com/cozy/cozy-stack/web"
 	"github.com/cozy/cozy-stack/web/apps"
@@ -35,6 +37,14 @@ Use the --port and --host flags to change the listening option.`,
 		admin := echo.New()
 		if err := routing.SetupAdminRoutes(admin); err != nil {
 			return err
+		}
+
+		if config.IsDevRelease() {
+			fmt.Println(`
+                      !! DEVELOPMENT RELEASE !!
+You are running a development release which may deactivate some very important
+security features. Please do not use this binary as your production server.
+`)
 		}
 
 		errs := make(chan error)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -40,8 +40,7 @@ Use the --port and --host flags to change the listening option.`,
 		}
 
 		if config.IsDevRelease() {
-			fmt.Println(`
-                      !! DEVELOPMENT RELEASE !!
+			fmt.Println(`                       !! DEVELOPMENT RELEASE !!
 You are running a development release which may deactivate some very important
 security features. Please do not use this binary as your production server.
 `)

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -270,6 +270,7 @@ func Create(opts *Options) (*Instance, error) {
 		}
 	}
 
+	locale := opts.Locale
 	if locale == "" {
 		locale = DefaultLocale
 	}

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -54,6 +54,7 @@ type Instance struct {
 	Domain     string `json:"domain"`         // The main DNS domain, like example.cozycloud.cc
 	Locale     string `json:"locale"`         // The locale used on the server
 	StorageURL string `json:"storage"`        // Where the binaries are persisted
+	Dev        bool   `json:"dev"`            // Whether or not the instance is for development
 
 	// PassphraseHash is a hash of the user's passphrase. For more informations,
 	// see crypto.GenerateFromPassphrase.
@@ -71,6 +72,14 @@ type Instance struct {
 	OAuthSecret []byte `json:"oauthSecret,omitempty"`
 
 	storage afero.Fs
+}
+
+// Options holds the parameters to create a new instance.
+type Options struct {
+	Domain string
+	Locale string
+	Apps   []string
+	Dev    bool
 }
 
 // DocType implements couchdb.Doc
@@ -120,30 +129,61 @@ func (i *Instance) Prefix() string {
 	return i.Domain + "/"
 }
 
-// Addr returns the full address of the domain of the instance
-func (i *Instance) Addr() string {
-	if config.IsDevRelease() && i.Domain == "dev" {
-		return "localhost:8080"
+// Scheme returns the scheme used for URLs. It is https by default and http
+// for development instances.
+func (i *Instance) Scheme() string {
+	if i.Dev {
+		return "http"
 	}
-	return i.Domain
+	return "https"
 }
 
 // SubDomain returns the full url for a subdomain of this instance
 // useful with apps slugs
 func (i *Instance) SubDomain(s string) string {
+	var domain string
 	if config.GetConfig().Subdomains == config.NestedSubdomains {
-		return "https://" + s + "." + i.Addr() + "/"
+		domain = s + "." + i.Domain
+	} else {
+		parts := strings.SplitN(i.Domain, ".", 2)
+		domain = parts[0] + "-" + s + "." + parts[1]
 	}
-	parts := strings.SplitN(i.Addr(), ".", 2)
-	return "https://" + parts[0] + "-" + s + "." + parts[1] + "/"
+	u := url.URL{
+		Scheme: i.Scheme(),
+		Host:   domain,
+		Path:   "/",
+	}
+	return u.String()
 }
 
-// PageURL returns the full URL for a page on the cozy stack
-func (i *Instance) PageURL(page string) string {
-	return "https://" + i.Domain + page
+// FromURL normalizes a given url with the scheme and domain of the instance.
+func (i *Instance) FromURL(u *url.URL) string {
+	u2 := url.URL{
+		Scheme:   i.Scheme(),
+		Host:     i.Domain,
+		Path:     u.Path,
+		RawQuery: u.RawQuery,
+		Fragment: u.Fragment,
+	}
+	return u2.String()
 }
 
-// createInCouchdb create the instance doc in the global database
+// PageURL returns the full URL for a path on the cozy stack
+func (i *Instance) PageURL(path string, queries url.Values) string {
+	var query string
+	if queries != nil {
+		query = queries.Encode()
+	}
+	u := url.URL{
+		Scheme:   i.Scheme(),
+		Host:     i.Domain,
+		Path:     path,
+		RawQuery: query,
+	}
+	return u.String()
+}
+
+// createInCouchdb creates the instance doc in the global database
 func (i *Instance) createInCouchdb() (err error) {
 	if _, err = Get(i.Domain); err == nil {
 		return ErrExists
@@ -217,7 +257,8 @@ func (i *Instance) createSettings() error {
 }
 
 // Create build an instance and .Create it
-func Create(domain string, locale string, apps []string) (*Instance, error) {
+func Create(opts *Options) (*Instance, error) {
+	domain := opts.Domain
 	if strings.ContainsAny(domain, vfs.ForbiddenFilenameChars) || domain == ".." || domain == "." {
 		return nil, ErrIllegalDomain
 	}
@@ -238,6 +279,8 @@ func Create(domain string, locale string, apps []string) (*Instance, error) {
 	i.Locale = locale
 	i.Domain = domain
 	i.StorageURL = config.BuildRelFsURL(domain).String()
+
+	i.Dev = opts.Dev
 
 	i.PassphraseHash = nil
 	i.RegisterToken = crypto.GenerateRandomBytes(registerTokenLen)
@@ -293,12 +336,6 @@ func (i *Instance) makeStorageFs() error {
 
 // Get retrieves the instance for a request by its host.
 func Get(domain string) (*Instance, error) {
-	if config.IsDevRelease() {
-		if domain == "" || strings.Contains(domain, "127.0.0.1") || strings.Contains(domain, "localhost") {
-			domain = "dev"
-		}
-	}
-
 	var instances []*Instance
 	req := &couchdb.FindRequest{
 		Selector: mango.Equal("domain", domain),

--- a/pkg/instance/instance_test.go
+++ b/pkg/instance/instance_test.go
@@ -41,7 +41,10 @@ func TestGetInstanceNoDB(t *testing.T) {
 }
 
 func TestCreateInstance(t *testing.T) {
-	instance, err := Create("test.cozycloud.cc", "en", nil)
+	instance, err := Create(&Options{
+		Domain: "test.cozycloud.cc",
+		Locale: "en",
+	})
 	if assert.NoError(t, err) {
 		assert.NotEmpty(t, instance.ID())
 		assert.Equal(t, instance.Domain, "test.cozycloud.cc")
@@ -49,13 +52,22 @@ func TestCreateInstance(t *testing.T) {
 }
 
 func TestCreateInstanceBadDomain(t *testing.T) {
-	_, err := Create("..", "en", nil)
+	_, err := Create(&Options{
+		Domain: "..",
+		Locale: "en",
+	})
 	assert.Error(t, err, "An error is expected")
 
-	_, err = Create(".", "en", nil)
+	_, err = Create(&Options{
+		Domain: ".",
+		Locale: "en",
+	})
 	assert.Error(t, err, "An error is expected")
 
-	_, err = Create("foo/bar", "en", nil)
+	_, err = Create(&Options{
+		Domain: "foo/bar",
+		Locale: "en",
+	})
 	assert.Error(t, err, "An error is expected")
 }
 
@@ -188,11 +200,17 @@ func TestCheckPassphrase(t *testing.T) {
 }
 
 func TestInstanceNoDuplicate(t *testing.T) {
-	_, err := Create("test.cozycloud.cc.duplicate", "en", nil)
+	_, err := Create(&Options{
+		Domain: "test.cozycloud.cc.duplicate",
+		Locale: "en",
+	})
 	if !assert.NoError(t, err) {
 		return
 	}
-	i, err := Create("test.cozycloud.cc.duplicate", "en", nil)
+	i, err := Create(&Options{
+		Domain: "test.cozycloud.cc.duplicate",
+		Locale: "en",
+	})
 	if assert.Error(t, err, "Should not be possible to create duplicate") {
 		assert.Nil(t, i)
 		assert.Contains(t, err.Error(), "Instance already exists", "the error is not explicit")
@@ -202,7 +220,10 @@ func TestInstanceNoDuplicate(t *testing.T) {
 func TestInstanceDestroy(t *testing.T) {
 	Destroy("test.cozycloud.cc")
 
-	_, err := Create("test.cozycloud.cc", "en", nil)
+	_, err := Create(&Options{
+		Domain: "test.cozycloud.cc",
+		Locale: "en",
+	})
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/pkg/sessions/session.go
+++ b/pkg/sessions/session.go
@@ -3,6 +3,7 @@ package sessions
 import (
 	"errors"
 	"net/http"
+	"strings"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
@@ -127,7 +128,7 @@ func (s *Session) Delete(i *instance.Instance) *http.Cookie {
 		Value:  "",
 		MaxAge: -1,
 		Path:   "/",
-		Domain: "." + i.Domain,
+		Domain: stripPort("." + i.Domain),
 	}
 }
 
@@ -143,8 +144,8 @@ func (s *Session) ToCookie() (*http.Cookie, error) {
 		Value:    string(encoded),
 		MaxAge:   SessionMaxAge,
 		Path:     "/",
-		Domain:   "." + s.Instance.Domain,
-		Secure:   true,
+		Domain:   stripPort("." + s.Instance.Domain),
+		Secure:   !s.Instance.Dev,
 		HttpOnly: true,
 	}, nil
 }
@@ -161,8 +162,8 @@ func (s *Session) ToAppCookie(domain string) (*http.Cookie, error) {
 		Value:    string(encoded),
 		MaxAge:   86400, // 1 day
 		Path:     "/",
-		Domain:   domain,
-		Secure:   true,
+		Domain:   stripPort(domain),
+		Secure:   !s.Instance.Dev,
 		HttpOnly: true,
 	}, nil
 }
@@ -190,4 +191,12 @@ func cookieMACConfig(i *instance.Instance) *crypto.MACConfig {
 		MaxAge: SessionMaxAge,
 		MaxLen: 256,
 	}
+}
+
+func stripPort(domain string) string {
+	if strings.Contains(domain, ":") {
+		parts := strings.SplitN(domain, ":", 2)
+		return parts[0]
+	}
+	return domain
 }

--- a/pkg/sessions/session.go
+++ b/pkg/sessions/session.go
@@ -2,6 +2,7 @@ package sessions
 
 import (
 	"errors"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -195,8 +196,11 @@ func cookieMACConfig(i *instance.Instance) *crypto.MACConfig {
 
 func stripPort(domain string) string {
 	if strings.Contains(domain, ":") {
-		parts := strings.SplitN(domain, ":", 2)
-		return parts[0]
+		cleaned, _, err := net.SplitHostPort(domain)
+		if err != nil {
+			return domain
+		}
+		return cleaned
 	}
 	return domain
 }

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -2,7 +2,7 @@
 
 go run main.go serve &
 sleep 5
-go run main.go instances add dev
+go run main.go instances add --dev localhost:8080
 
 cd integration-tests/pouchdb
 npm install && npm run test

--- a/web/apps/apps.go
+++ b/web/apps/apps.go
@@ -43,7 +43,7 @@ func buildCtxToken(i *instance.Instance, app *apps.Manifest, ctx apps.Context) s
 
 func tryAuthWithSessionCode(c echo.Context, i *instance.Instance, value string) error {
 	u := c.Request().URL
-	u.Scheme = "https"
+	u.Scheme = i.Scheme()
 	u.Host = c.Request().Host
 	if code := sessions.FindCode(value, u.Host); code != nil {
 		var session sessions.Session
@@ -80,13 +80,7 @@ func serveApp(c echo.Context, i *instance.Instance, app *apps.Manifest, vpath st
 		redirect := url.Values{
 			"redirect": {i.SubDomain(app.Slug) + c.Request().URL.String()},
 		}
-		u := url.URL{
-			Scheme:   "https",
-			Host:     i.Domain,
-			Path:     "/auth/login",
-			RawQuery: redirect.Encode(),
-		}
-		return c.Redirect(http.StatusFound, u.String())
+		return c.Redirect(http.StatusFound, i.PageURL("/auth/login", redirect))
 	}
 	if file == "" {
 		file = ctx.Index

--- a/web/apps/apps_test.go
+++ b/web/apps/apps_test.go
@@ -254,7 +254,10 @@ func TestMain(m *testing.M) {
 	defer func() { cfg.Subdomains = was }()
 
 	instance.Destroy(domain)
-	testInstance, err = instance.Create(domain, "en", nil)
+	testInstance, err = instance.Create(&instance.Options{
+		Domain: domain,
+		Locale: "en",
+	})
 	if err != nil {
 		fmt.Println("Could not create test instance.", err)
 		os.Exit(1)

--- a/web/auth/auth_test.go
+++ b/web/auth/auth_test.go
@@ -975,7 +975,10 @@ func TestMain(m *testing.M) {
 	}
 	config.UseTestFile()
 	instance.Destroy(domain)
-	i, _ := instance.Create(domain, "en", nil)
+	i, _ := instance.Create(&instance.Options{
+		Domain: domain,
+		Locale: "en",
+	})
 	db = i
 	registerToken = i.RegisterToken
 	oauthSecret = i.OAuthSecret

--- a/web/data/data_test.go
+++ b/web/data/data_test.go
@@ -106,7 +106,10 @@ func TestMain(m *testing.M) {
 
 	instance.Destroy(Host)
 
-	inst, err := instance.Create(Host, "en", nil)
+	inst, err := instance.Create(&instance.Options{
+		Domain: Host,
+		Locale: "en",
+	})
 	if err != nil {
 		fmt.Println("Could not create test instance.", err)
 		os.Exit(1)

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -1206,7 +1206,10 @@ func TestMain(m *testing.M) {
 	config.GetConfig().Fs.URL = fmt.Sprintf("file://localhost%s", tempdir)
 
 	instance.Destroy("test-files")
-	testInstance, err = instance.Create("test-files", "en", nil)
+	testInstance, err = instance.Create(&instance.Options{
+		Domain: "test-files",
+		Locale: "en",
+	})
 	if err != nil {
 		fmt.Println("Could not create test instance.", err)
 		os.Exit(1)

--- a/web/instances/instances.go
+++ b/web/instances/instances.go
@@ -2,6 +2,7 @@ package instances
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/web/jsonapi"
@@ -9,9 +10,12 @@ import (
 )
 
 func createHandler(c echo.Context) error {
-	domain := c.QueryParam("Domain")
-	locale := c.QueryParam("Locale")
-	i, err := instance.Create(domain, locale, nil)
+	i, err := instance.Create(&instance.Options{
+		Domain: c.QueryParam("Domain"),
+		Locale: c.QueryParam("Locale"),
+		Apps:   strings.Split(c.QueryParam("Apps"), ","),
+		Dev:    (c.QueryParam("Dev") == "true"),
+	})
 	if err != nil {
 		return wrapError(err)
 	}

--- a/web/server_test.go
+++ b/web/server_test.go
@@ -71,7 +71,10 @@ func TestParseHost(t *testing.T) {
 func TestMain(m *testing.M) {
 	config.UseTestFile()
 	instance.Destroy(domain)
-	instance.Create(domain, "en", nil)
+	instance.Create(&instance.Options{
+		Domain: domain,
+		Locale: "en",
+	})
 	res := m.Run()
 	instance.Destroy(domain)
 	os.Exit(res)


### PR DESCRIPTION
This PR add many tweaks to improve the development on the stack:

  - notion of development instances with a dev flag
  - the dev script now automatically register a new "cozy.local:8080" instance with a password "cozy"
  - the cookies are functional even on instances with a port in the name
  - removed the special instance named "dev" for "localhost" and "127.0.0.1" hosts