### PR TITLE
Add jobs timeout and retry with backoff delay

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -89,8 +89,7 @@ func clientRequestAndClose(c *client, method, path string, q url.Values, body in
 	if err != nil {
 		return err
 	}
-	res.Body.Close()
-	return nil
+	return res.Body.Close()
 }
 
 func clientRequestParsed(c *client, method, path string, q url.Values, body interface{}, v interface{}) error {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -61,13 +61,19 @@ example: cozy-stack config passwd ~/.cozy
 			return fmt.Errorf("%s is not a directory", directory)
 		}
 
-		fmt.Fprintf(os.Stdout, "Passphrase:")
+		_, err = fmt.Fprintf(os.Stdout, "Passphrase:")
+		if err != nil {
+			return err
+		}
 		pass1, err := gopass.GetPasswdMasked()
 		if err != nil {
 			return err
 		}
 
-		fmt.Fprintf(os.Stdout, "Confirmation:")
+		_, err = fmt.Fprintf(os.Stdout, "Confirmation:")
+		if err != nil {
+			return err
+		}
 		pass2, err := gopass.GetPasswdMasked()
 		if err != nil {
 			return err

--- a/cmd/files.go
+++ b/cmd/files.go
@@ -55,7 +55,9 @@ directories inside your cozy instance, using the command line
 interface. It also provide an import command to import from your
 current filesystem into cozy.
 `,
-	Run: func(cmd *cobra.Command, args []string) { cmd.Help() },
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmd.Help()
+	},
 }
 
 var execFilesCmd = &cobra.Command{

--- a/cmd/instances.go
+++ b/cmd/instances.go
@@ -33,7 +33,9 @@ process can manage several instances.
 Each instance has a separate space for storing files and a prefix used to
 create its CouchDB databases.
 `,
-	Run: func(cmd *cobra.Command, args []string) { cmd.Help() },
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmd.Help()
+	},
 }
 
 var addInstanceCmd = &cobra.Command{
@@ -66,7 +68,7 @@ given domain.
 
 		i, err := instancesRequest("POST", "/instances/", q, nil)
 		if err != nil {
-			log.Errorf("Error while creating instance for domain %s", domain)
+			log.Errorf("Failed to create instance for domain %s", domain)
 			return err
 		}
 
@@ -136,7 +138,7 @@ All data associated with this domain will be permanently lost.
 
 		i, err := instancesRequest("DELETE", "/instances/"+url.QueryEscape(domain), nil, nil)
 		if err != nil {
-			log.Errorf("Error while removing instance for domain %s", domain)
+			log.Errorf("Failed to remove instance for domain %s", domain)
 			return err
 		}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,34 +48,34 @@ func init() {
 	flags.StringVarP(&cfgFile, "config", "c", "", "configuration file (default \"$HOME/.cozy.yaml\")")
 
 	flags.String("host", "localhost", "server host")
-	viper.BindPFlag("host", flags.Lookup("host"))
+	checkNoErr(viper.BindPFlag("host", flags.Lookup("host")))
 
 	flags.IntP("port", "p", 8080, "server port")
-	viper.BindPFlag("port", flags.Lookup("port"))
+	checkNoErr(viper.BindPFlag("port", flags.Lookup("port")))
 
 	flags.String("subdomains", "nested", "hwo to structure the subdomains for apps (can be nested or flat)")
-	viper.BindPFlag("subdomains", flags.Lookup("subdomains"))
+	checkNoErr(viper.BindPFlag("subdomains", flags.Lookup("subdomains")))
 
 	flags.String("assets", "", "path to the directory with the assets (use the packed assets by default)")
-	viper.BindPFlag("assets", flags.Lookup("assets"))
+	checkNoErr(viper.BindPFlag("assets", flags.Lookup("assets")))
 
 	flags.String("admin-host", "localhost", "administration server host")
-	viper.BindPFlag("admin.host", flags.Lookup("admin-host"))
+	checkNoErr(viper.BindPFlag("admin.host", flags.Lookup("admin-host")))
 
 	flags.Int("admin-port", 6060, "administration server port")
-	viper.BindPFlag("admin.port", flags.Lookup("admin-port"))
+	checkNoErr(viper.BindPFlag("admin.port", flags.Lookup("admin-port")))
 
 	flags.String("fs-url", fmt.Sprintf("file://localhost%s/%s", binDir, DefaultStorageDir), "filesystem url")
-	viper.BindPFlag("fs.url", flags.Lookup("fs-url"))
+	checkNoErr(viper.BindPFlag("fs.url", flags.Lookup("fs-url")))
 
 	flags.String("couchdb-host", "localhost", "couchdbdb host")
-	viper.BindPFlag("couchdb.host", flags.Lookup("couchdb-host"))
+	checkNoErr(viper.BindPFlag("couchdb.host", flags.Lookup("couchdb-host")))
 
 	flags.Int("couchdb-port", 5984, "couchdbdb port")
-	viper.BindPFlag("couchdb.port", flags.Lookup("couchdb-port"))
+	checkNoErr(viper.BindPFlag("couchdb.port", flags.Lookup("couchdb-port")))
 
 	flags.String("log-level", "info", "define the log level")
-	viper.BindPFlag("log.level", flags.Lookup("log-level"))
+	checkNoErr(viper.BindPFlag("log.level", flags.Lookup("log-level")))
 }
 
 // Configure Viper to read the environment and the optional config file
@@ -95,12 +95,12 @@ func Configure() error {
 
 	if err := viper.ReadInConfig(); err != nil {
 		if _, isParseErr := err.(viper.ConfigParseError); isParseErr {
-			log.Errorf("Error while reading cozy-stack configurations from %s", viper.ConfigFileUsed())
+			log.Errorf("Failed to read cozy-stack configurations from %s", viper.ConfigFileUsed())
 			return err
 		}
 
 		if cfgFile != "" {
-			return fmt.Errorf("Unable to locate config file: %s\n", cfgFile)
+			return fmt.Errorf("Could not locate config file: %s\n", cfgFile)
 		}
 	}
 
@@ -113,4 +113,10 @@ func Configure() error {
 	}
 
 	return nil
+}
+
+func checkNoErr(err error) {
+	if err != nil {
+		panic(err)
+	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -53,7 +53,7 @@ const (
 
 // AdminSecretFileName is the name of the file containing the administration
 // hashed passphrase.
-const AdminSecretFileName = "cozy-admin-passphrase"
+const AdminSecretFileName = "cozy-admin-passphrase" // #nosec
 
 var config *Config
 

--- a/pkg/couchdb/couchdb.go
+++ b/pkg/couchdb/couchdb.go
@@ -160,7 +160,7 @@ func makeRequest(method, path string, reqbody interface{}, resbody interface{}) 
 	}
 
 	if log.GetLevel() == log.DebugLevel {
-		log.Debugf("[couchdb request] %s %s %s", method, path, string(reqjson))
+		log.Debugf("[couchdb] request: %s %s %s", method, path, string(reqjson))
 	}
 
 	req, err := http.NewRequest(method, config.CouchURL()+path, bytes.NewReader(reqjson))
@@ -187,7 +187,7 @@ func makeRequest(method, path string, reqbody interface{}, resbody interface{}) 
 		} else {
 			err = newCouchdbError(resp.StatusCode, body)
 		}
-		log.Debugf("[couchdb error] %s", err.Error())
+		log.Debugf("[couchdb] error: %s", err.Error())
 		return err
 	}
 
@@ -201,7 +201,7 @@ func makeRequest(method, path string, reqbody interface{}, resbody interface{}) 
 		if err != nil {
 			return err
 		}
-		log.Debugf("[couchdb response] %s", string(data))
+		log.Debugf("[couchdb] response: %s", string(data))
 		err = json.Unmarshal(data, &resbody)
 	} else {
 		err = json.NewDecoder(resp.Body).Decode(&resbody)

--- a/pkg/crypto/scrypt.go
+++ b/pkg/crypto/scrypt.go
@@ -74,13 +74,13 @@ func (h *scryptHash) UnmarshalText(hashbytes []byte) error {
 	}
 
 	h.salt = make([]byte, hex.DecodedLen(len(vals[4])))
-	hex.Decode(h.salt, vals[4])
+	_, err = hex.Decode(h.salt, vals[4])
 	if err != nil {
 		return ErrInvalidHash
 	}
 
 	h.dk = make([]byte, hex.DecodedLen(len(vals[5])))
-	hex.Decode(h.dk, vals[5])
+	_, err = hex.Decode(h.dk, vals[5])
 	if err != nil {
 		return ErrInvalidHash
 	}

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -20,14 +20,15 @@ import (
 	"github.com/spf13/afero"
 )
 
+/* #nosec */
 const (
 	registerTokenLen = 16
 	sessionSecretLen = 64
 	oauthSecretLen   = 128
-
-	// DefaultLocale is the default locale when creating an instance
-	DefaultLocale = "en"
 )
+
+// DefaultLocale is the default locale when creating an instance
+const DefaultLocale = "en"
 
 var (
 	// ErrNotFound is used when the seeked instance was not found
@@ -221,7 +222,9 @@ func (i *Instance) createRootDir() error {
 
 	defer func() {
 		if err != nil {
-			rootFs.RemoveAll(domainURL.Path)
+			if rmerr := rootFs.RemoveAll(domainURL.Path); rmerr != nil {
+				log.Warn("[instance] Could not remove the instance directory")
+			}
 		}
 	}()
 
@@ -486,7 +489,7 @@ func (i *Instance) CheckPassphrase(pass []byte) error {
 	i.PassphraseHash = newHash
 	err = couchdb.UpdateDoc(couchdb.GlobalDB, i)
 	if err != nil {
-		log.Error("Failed to update hash in db", err)
+		log.Error("[instance] Failed to update hash in db", err)
 	}
 
 	return nil

--- a/pkg/jobs/errors.go
+++ b/pkg/jobs/errors.go
@@ -9,4 +9,6 @@ var (
 	ErrUnknownWorker = errors.New("Could not find worker")
 	// ErrUnknownMessageType is used for an unknown message encoding type
 	ErrUnknownMessageType = errors.New("Unknown message encoding type")
+	// ErrTimedOut is used by a worker function when it has timed out
+	ErrTimedOut = errors.New("Worker timed out")
 )

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -3,7 +3,6 @@ package jobs
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"time"
 )
 
@@ -92,8 +91,4 @@ func (m *Message) Unmarshal(msg interface{}) error {
 	default:
 		return ErrUnknownMessageType
 	}
-}
-
-func makeQueueName(domain, workerType string) string {
-	return fmt.Sprintf("%s/%s", domain, workerType)
 }

--- a/pkg/jobs/worker.go
+++ b/pkg/jobs/worker.go
@@ -2,49 +2,159 @@ package jobs
 
 import (
 	"fmt"
+	"math/rand"
+	"sync/atomic"
+	"time"
 
 	log "github.com/Sirupsen/logrus"
 )
 
+var (
+	defaultConcurrency  = 1
+	defaultMaxExecCount = 3
+	defaultMaxExecTime  = 60 * time.Second
+	defaultRetryDelay   = 60 * time.Millisecond
+	defaultTimeout      = 10 * time.Second
+)
+
 type (
 	// WorkerFunc represent the work function that a worker should implement.
-	WorkerFunc func(msg *Message) error
+	WorkerFunc func(msg *Message, timeout <-chan time.Time) error
 
 	// Worker is a unit of work that will consume from a queue and execute the do
 	// method for each jobs it pulls.
 	Worker struct {
-		Domain      string
-		Type        string
-		Concurrency int
-		Func        WorkerFunc
+		Domain string
+		Type   string
+		Conf   *WorkerConfig
 
-		q Queue
+		q       Queue
+		started int32
 	}
 )
 
 // Start is used to start the worker consumption of messages from its queue.
-func (w *Worker) Start() {
-	for i := 0; i < w.Concurrency; i++ {
-		go func(workerID string) {
-			// TODO: err handling and persistence
-			for {
-				job, err := w.q.Consume()
-				if err != nil {
-					if err != ErrQueueClosed {
-						log.Errorf("[job] %s: error while consuming queue (%s)", workerID, err.Error())
-					}
-					return
-				}
-				if err = w.Func(job.Message); err != nil {
-					log.Errorf("[job] %s: error while performing job (%s)", workerID, err.Error())
-				}
+func (w *Worker) Start(q Queue) {
+	if !atomic.CompareAndSwapInt32(&w.started, 0, 1) {
+		return
+	}
+	w.q = q
+	c := &(*w.Conf)
+	if c.Concurrency == 0 {
+		c.Concurrency = uint(defaultConcurrency)
+	}
+	if c.MaxExecCount == 0 {
+		c.MaxExecCount = uint(defaultMaxExecCount)
+	}
+	if c.MaxExecTime == 0 {
+		c.MaxExecTime = defaultMaxExecTime
+	}
+	if c.RetryDelay == 0 {
+		c.RetryDelay = defaultRetryDelay
+	}
+	if c.Timeout == 0 {
+		c.Timeout = defaultTimeout
+	}
+	w.Conf = c
+	for i := 0; i < int(c.Concurrency); i++ {
+		name := fmt.Sprintf("%s/%s/%d", w.Domain, w.Type, i)
+		go w.work(name)
+	}
+}
+
+func (w *Worker) work(workerID string) {
+	// TODO: err handling and persistence
+	for {
+		job, err := w.q.Consume()
+		if err != nil {
+			if err != ErrQueueClosed {
+				log.Errorf("[job] %s: error while consuming queue (%s)",
+					workerID, err.Error())
 			}
-		}(fmt.Sprintf("%s/%s/%d", w.Domain, w.Type, i))
+			return
+		}
+		t := &task{
+			job:  job,
+			conf: w.Conf,
+		}
+		if err = t.run(); err != nil {
+			log.Errorf("[job] %s: error while performing job %s (%s)",
+				workerID, job.ID, err.Error())
+		}
 	}
 }
 
 // Stop will stop the worker's consumption of its queue. It will also close the
 // associated queue.
 func (w *Worker) Stop() {
+	if !atomic.CompareAndSwapInt32(&w.started, 1, 0) {
+		return
+	}
 	w.q.Close()
+}
+
+type task struct {
+	job  *Job
+	conf *WorkerConfig
+
+	startTime time.Time
+	execCount uint
+}
+
+func (t *task) run() (err error) {
+	t.startTime = time.Now()
+	t.execCount = 0
+	for {
+		retry, delay, timeout := t.nextDelay()
+		if !retry {
+			return err
+		}
+		if err != nil {
+			log.Warnf("[job] %s: %s (retry in %s)", t.job.ID, err.Error(), delay)
+		}
+		if delay > 0 {
+			time.Sleep(delay)
+		}
+		log.Debugf("[job] %s: run %d (timeout %s)", t.job.ID, t.execCount, timeout)
+		err = t.conf.WorkerFunc(t.job.Message, time.After(timeout))
+		if err == nil {
+			break
+		}
+		t.execCount++
+	}
+	return nil
+}
+
+func (t *task) nextDelay() (bool, time.Duration, time.Duration) {
+	c := t.conf
+	execTime := time.Since(t.startTime)
+
+	if t.execCount >= c.MaxExecCount || execTime > c.MaxExecTime {
+		return false, 0, 0
+	}
+
+	// the worker timeout should take into account the maximum execution time
+	// allowed to the task
+	timeout := c.Timeout
+	if execTime+timeout > c.MaxExecTime {
+		timeout = execTime - c.MaxExecTime
+	}
+
+	var nextDelay time.Duration
+	if t.execCount == 0 {
+		// on first execution, execute immediatly
+		nextDelay = 0
+	} else {
+		nextDelay = c.RetryDelay << (t.execCount - 1)
+
+		// fuzzDelay number between delay * (1 +/- 0.1)
+		fuzzDelay := int(0.1 * float64(nextDelay))
+		nextDelay = nextDelay + time.Duration((rand.Intn(2*fuzzDelay) - fuzzDelay))
+	}
+
+	if execTime+nextDelay > c.MaxExecTime {
+		return false, 0, 0
+	}
+
+	return true, nextDelay, timeout
 }

--- a/pkg/jobs/workers_list.go
+++ b/pkg/jobs/workers_list.go
@@ -1,33 +1,52 @@
 package jobs
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 // WorkersList is a map associating a worker type with its acutal
 // configuration.
-type WorkersList map[string]WorkerConfig
+type WorkersList map[string]*WorkerConfig
 
 // WorkerConfig is the configuration parameter of a worker defined by the job
 // system. It contains parameters of the worker along with the worker main
 // function that perform the work against a job's message.
 type WorkerConfig struct {
-	Concurrency int
-	WorkerFunc  WorkerFunc
+	WorkerFunc   WorkerFunc
+	Concurrency  uint
+	MaxExecCount uint
+	MaxExecTime  time.Duration
+	Timeout      time.Duration
+	RetryDelay   time.Duration
 }
 
 // WorkersList is the list of available workers with their associated Do
 // function.
-var workersList = WorkersList{
-	"print": {
-		Concurrency: 4,
-		WorkerFunc: func(m *Message) error {
-			var msg string
-			if err := m.Unmarshal(&msg); err != nil {
+var workersList WorkersList
+
+func init() {
+	workersList = WorkersList{
+		"print": {
+			Concurrency: 4,
+			WorkerFunc: func(m *Message, _ <-chan time.Time) error {
+				var msg string
+				if err := m.Unmarshal(&msg); err != nil {
+					return err
+				}
+				_, err := fmt.Println(msg)
 				return err
-			}
-			_, err := fmt.Println(msg)
-			return err
+			},
 		},
-	},
+		"timeout": {
+			Concurrency: 4,
+			Timeout:     1 * time.Second,
+			WorkerFunc: func(_ *Message, timeout <-chan time.Time) error {
+				<-timeout
+				return ErrTimedOut
+			},
+		},
+	}
 }
 
 // GetWorkersList returns a globally defined worker config list

--- a/pkg/oauth/client.go
+++ b/pkg/oauth/client.go
@@ -16,7 +16,7 @@ import (
 )
 
 // ClientSecretLen is the number of random bytes used for generating the client secret
-const ClientSecretLen = 24
+const ClientSecretLen = 24 // #nosec
 
 // Client is a struct for OAuth2 client. Most of the fields are described in
 // the OAuth 2.0 Dynamic Client Registration Protocol. The exception is
@@ -74,7 +74,7 @@ func (c *Client) TransformIDAndRev() {
 func FindClient(i *instance.Instance, id string) (Client, error) {
 	var c Client
 	if err := couchdb.GetDoc(i, consts.OAuthClients, id, &c); err != nil {
-		log.Errorf("Impossible to find the client %s: %s", id, err)
+		log.Errorf("[oauth] Failed to find the client %s: %s", id, err)
 		return c, err
 	}
 	return c, nil

--- a/pkg/permissions/claims.go
+++ b/pkg/permissions/claims.go
@@ -2,6 +2,7 @@ package permissions
 
 import jwt "gopkg.in/dgrijalva/jwt-go.v3"
 
+// #nosec
 const (
 	// ContextAudience is the audience for JWT used by apps
 	ContextAudience = "context"

--- a/pkg/sessions/session.go
+++ b/pkg/sessions/session.go
@@ -112,7 +112,7 @@ func GetSession(c echo.Context, i *instance.Instance) (*Session, error) {
 		s.LastSeen = time.Now()
 		err := couchdb.UpdateDoc(i, &s)
 		if err != nil {
-			log.Warn("Failed to update session last seen.")
+			log.Warn("[session] Failed to update session last seen:", err)
 		}
 	}
 
@@ -123,7 +123,10 @@ func GetSession(c echo.Context, i *instance.Instance) (*Session, error) {
 // Delete is a function to delete the session in couchdb,
 // and returns a cookie with a negative MaxAge to clear it
 func (s *Session) Delete(i *instance.Instance) *http.Cookie {
-	couchdb.DeleteDoc(i, s)
+	err := couchdb.DeleteDoc(i, s)
+	if err != nil {
+		log.Error("[session] Failed to delete session:", err)
+	}
 	return &http.Cookie{
 		Name:   SessionCookieName,
 		Value:  "",

--- a/web/apps/apps.go
+++ b/web/apps/apps.go
@@ -92,7 +92,7 @@ func serveApp(c echo.Context, i *instance.Instance, app *apps.Manifest, vpath st
 	}
 	tmpl, err := template.New(file).Parse(string(buf))
 	if err != nil {
-		log.Printf("%s cannot be parsed as a template: %s", vpath, err)
+		log.Printf("[apps] %s cannot be parsed as a template: %s", vpath, err)
 		return vfs.ServeFileContent(i, doc, "", c.Request(), c.Response())
 	}
 	res.Header().Set("Content-Type", doc.Mime)
@@ -166,8 +166,6 @@ func InstallOrUpdateHandler(c echo.Context) error {
 		return wrapAppsError(err)
 	}
 
-	jsonapi.Data(c, http.StatusAccepted, man, nil)
-
 	go func() {
 		for {
 			_, done, err := inst.Poll()
@@ -181,7 +179,7 @@ func InstallOrUpdateHandler(c echo.Context) error {
 		}
 	}()
 
-	return nil
+	return jsonapi.Data(c, http.StatusAccepted, man, nil)
 }
 
 // ListHandler handles all GET / requests which can be used to list

--- a/web/errors/errors.go
+++ b/web/errors/errors.go
@@ -24,6 +24,7 @@ func ErrorHandler(err error, c echo.Context) {
 	req := c.Request()
 
 	if he, ok = err.(*echo.HTTPError); ok {
+		// #nosec
 		if !res.Committed {
 			if c.Request().Method == http.MethodHead {
 				c.NoContent(he.Code)
@@ -32,7 +33,7 @@ func ErrorHandler(err error, c echo.Context) {
 			}
 		}
 		if config.IsDevRelease() {
-			log.Errorf("[HTTP %s %s] %s", req.Method, req.URL.Path, err)
+			log.Errorf("[http] %s %s %s", req.Method, req.URL.Path, err)
 		}
 		return
 	}
@@ -55,6 +56,7 @@ func ErrorHandler(err error, c echo.Context) {
 		}
 	}
 
+	// #nosec
 	if !res.Committed {
 		if c.Request().Method == http.MethodHead {
 			c.NoContent(je.Status)
@@ -64,6 +66,6 @@ func ErrorHandler(err error, c echo.Context) {
 	}
 
 	if config.IsDevRelease() {
-		log.Errorf("[HTTP %s %s] %s", req.Method, req.URL.Path, err)
+		log.Errorf("[http] %s %s %s", req.Method, req.URL.Path, err)
 	}
 }


### PR DESCRIPTION
This PR adds timeout and retry with backoff for jobs workers:

  - timeout is handled by giving the worker a timeout chan. we have to trust the worker to timeout properly by reacting to this channel since it is not possible from an outside observer to stop a go-routing
  - retry has three parameters:
    - `MaxExecCount`: the maximum total number of time the worker is executed
    - `MaxExecTime`: the maximum total amount of time it is allowed to spin on a job
    - `RetryDelay`: the initial retry delay applied between each retry. the delay is calculated by `RetryDelay * 2^(ExecCount-1) * (1 + RandomNum(-0.2, 0.2))`