### PR TITLE
Move some methods to the utils package

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cozy/cozy-stack/pkg/config"
 	"github.com/cozy/cozy-stack/pkg/crypto"
+	"github.com/cozy/cozy-stack/pkg/utils"
 	"github.com/howeyc/gopass"
 	"github.com/spf13/cobra"
 )
@@ -52,7 +53,7 @@ example: cozy-stack config passwd ~/.cozy
 			return cmd.Help()
 		}
 
-		directory := filepath.Join(config.AbsPath(args[0]))
+		directory := filepath.Join(utils.AbsPath(args[0]))
 		info, err := os.Stat(directory)
 		if err != nil {
 			return err

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,14 +3,13 @@ package config
 import (
 	"fmt"
 	"net/url"
-	"os"
 	"path"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/cozy/cozy-stack/pkg/utils"
 	"github.com/spf13/viper"
 )
 
@@ -238,8 +237,8 @@ func UseTestYAML(yaml string) {
 // searching.
 func FindConfigFile(name string) (string, error) {
 	for _, cp := range Paths {
-		filename := filepath.Join(AbsPath(cp), name)
-		ok, err := exists(filename)
+		filename := filepath.Join(utils.AbsPath(cp), name)
+		ok, err := utils.FileExists(filename)
 		if err != nil {
 			return "", err
 		}
@@ -265,51 +264,4 @@ func configureLogger() error {
 
 	log.SetLevel(logLevel)
 	return nil
-}
-
-func exists(name string) (bool, error) {
-	_, err := os.Stat(name)
-	if err == nil {
-		return true, nil
-	}
-	if os.IsNotExist(err) {
-		return false, nil
-	}
-	return false, err
-}
-
-func userHomeDir() string {
-	if runtime.GOOS == "windows" {
-		home := os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
-		if home == "" {
-			home = os.Getenv("USERPROFILE")
-		}
-		return home
-	}
-	return os.Getenv("HOME")
-}
-
-// AbsPath returns an absolute path relative.
-func AbsPath(inPath string) string {
-	if strings.HasPrefix(inPath, "~") {
-		inPath = userHomeDir() + inPath[len("~"):]
-	} else if strings.HasPrefix(inPath, "$HOME") {
-		inPath = userHomeDir() + inPath[len("$HOME"):]
-	}
-
-	if strings.HasPrefix(inPath, "$") {
-		end := strings.Index(inPath, string(os.PathSeparator))
-		inPath = os.Getenv(inPath[1:end]) + inPath[end:]
-	}
-
-	if filepath.IsAbs(inPath) {
-		return filepath.Clean(inPath)
-	}
-
-	p, err := filepath.Abs(inPath)
-	if err == nil {
-		return filepath.Clean(p)
-	}
-
-	return ""
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -2,6 +2,10 @@ package utils
 
 import (
 	"math/rand"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"time"
 )
 
@@ -21,4 +25,54 @@ func RandomString(n int) string {
 		b[i] = letters[urand.Intn(lenLetters)]
 	}
 	return string(b)
+}
+
+// FileExists returns whether or not the file exists on the current file
+// system.
+func FileExists(name string) (bool, error) {
+	_, err := os.Stat(name)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
+}
+
+// UserHomeDir returns the user's home directory
+func UserHomeDir() string {
+	if runtime.GOOS == "windows" {
+		home := os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
+		if home == "" {
+			home = os.Getenv("USERPROFILE")
+		}
+		return home
+	}
+	return os.Getenv("HOME")
+}
+
+// AbsPath returns an absolute path relative.
+func AbsPath(inPath string) string {
+	if strings.HasPrefix(inPath, "~") {
+		inPath = UserHomeDir() + inPath[len("~"):]
+	} else if strings.HasPrefix(inPath, "$HOME") {
+		inPath = UserHomeDir() + inPath[len("$HOME"):]
+	}
+
+	if strings.HasPrefix(inPath, "$") {
+		end := strings.Index(inPath, string(os.PathSeparator))
+		inPath = os.Getenv(inPath[1:end]) + inPath[end:]
+	}
+
+	if filepath.IsAbs(inPath) {
+		return filepath.Clean(inPath)
+	}
+
+	p, err := filepath.Abs(inPath)
+	if err == nil {
+		return filepath.Clean(p)
+	}
+
+	return ""
 }


### PR DESCRIPTION
Now that we have a `utils` package, we can move some general methods in it.

This PR moves `UserHomeDir`, `FileExists` and `AbsPath` which are mostly utils functions for the CLI or config.