### PR TITLE
Jobs eventstream and queue size

### DIFF
--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -241,7 +241,6 @@ Accept: application/vnd.api+json
   "data": {
     "type": "io.cozy.jobs",
     "id": "123123",
-    "rev": "1-12334",
     "attributes": {
       "worker": "sendmail",
       "trigger": "@cron",
@@ -321,7 +320,6 @@ Accept: application/vnd.api+json
   "data": {
     "type": "io.cozy.triggers",
     "id": "123123",
-    "rev": "1-12334",
     "attributes": {
       "type": "@interval",
       "arguments": "30m10s",
@@ -358,7 +356,6 @@ Accept: application/vnd.api+json
   "data": {
     "type": "io.cozy.triggers",
     "id": "123123",
-    "rev": "1-12334",
     "attributes": {
       "type": "@interval",
       "arguments": "30m10s",
@@ -396,7 +393,6 @@ Accept: application/vnd.api+json
     {
       "type": "io.cozy.triggers",
       "id": "123123",
-      "rev": "1-12334",
       "attributes": {},
       "links": {
         "self": "/jobs/triggers/123123"

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -212,50 +212,7 @@ Example and description of a job creation options — as you can see, the option
 ```
 
 
-### GET /jobs/:job-id
-
-Get a job description given its ID.
-
-#### Status codes
-
-* 200 OK, when the job is found its description written
-* 404 Not Found, when the job has not been found (it either never existed or is finished)
-
-#### Request
-
-```http
-GET /jobs/123123 HTTP/1.1
-Accept: application/vnd.api+json
-```
-
-#### Response
-
-```json
-{
-  "data": {
-    "type": "io.cozy.jobs",
-    "id": "123123",
-    "rev": "1-12334",
-    "attributes": {
-      "worker": "sendmail",
-      "trigger": "@cron",
-      "trigger_id": "4321",
-      "options": {
-        "priority": 3,
-      },
-      "state": "running",
-      "try_count": 1,
-      "queued_at": "2016-09-19T12:35:08Z",
-      "started_at": "2016-09-19T12:35:08Z",
-      "errors": [],
-      "output": {}
-    }
-  }
-}
-```
-
-
-### POST /jobs/queue/:worker-name
+### POST /jobs/queue/:worker-type
 
 Enqueue programmatically a new job.
 
@@ -309,14 +266,14 @@ Accept: application/vnd.api+json
 ```
 
 
-### GET /jobs/queue
+### GET /jobs/queue/:worker-type
 
 List the jobs in the queue.
 
 #### Request
 
 ```http
-GET /jobs/queue HTTP/1.1
+GET /jobs/queue/sendmail HTTP/1.1
 Accept: application/vnd.api+json
 ```
 
@@ -327,25 +284,14 @@ Accept: application/vnd.api+json
   "links": {
     "next": "/jobs/queue?page[cursor]=123123"
   },
-  "meta": {
+  "data": {
     "count": 12
-  },
-  "data": [
-    {
-      "type": "io.cozy.jobs",
-      "id": "123123",
-      "rev": "1-12334",
-      "attributes": {},
-      "links": {
-        "self": "/jobs/123123"
-      }
-    }
-  ]
+  }
 }
 ```
 
 
-### POST /jobs/triggers/:worker-name
+### POST /jobs/triggers/:trigger-name
 
 Add a trigger of the worker. See [triggers' descriptions](#triggers) to see the types of trigger and their arguments syntax.
 

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -10,6 +10,8 @@ const (
 	Manifests = "io.cozy.manifests"
 	// Jobs doc type for queued jobs
 	Jobs = "io.cozy.jobs"
+	// Queues doc type for jobs queues
+	Queues = "io.cozy.queues"
 	// Settings doc type for settings to customize an instance
 	Settings = "io.cozy.settings"
 	// Sessions doc type for sessions identifying a connection

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -28,7 +28,7 @@ type (
 	// Queue interface is used to represent an asynchronous queue of jobs from
 	// which it is possible to enqueue and consume jobs.
 	Queue interface {
-		Enqueue(Job) error
+		Enqueue(job Job) error
 		Consume() (Job, error)
 		Len() int
 		Close()
@@ -45,7 +45,11 @@ type (
 		// This method is asynchronous and returns a chan of JobInfos to observe
 		// the job changing states. This channel does not need to be subscribed,
 		// messages will be dropped if no listeners.
-		PushJob(*JobRequest) (*JobInfos, <-chan *JobInfos, error)
+		PushJob(request *JobRequest) (*JobInfos, <-chan *JobInfos, error)
+
+		// QueueLen returns the total element in the queue of the specified worker
+		// type.
+		QueueLen(workerType string) (int, error)
 	}
 
 	// Job interface represents a job.

--- a/pkg/jobs/mem_jobs.go
+++ b/pkg/jobs/mem_jobs.go
@@ -4,6 +4,7 @@ import (
 	"container/list"
 	"errors"
 	"sync"
+	"time"
 )
 
 var (
@@ -171,6 +172,7 @@ func (j *MemJob) Infos() *JobInfos {
 func (j *MemJob) AckConsumed() error {
 	j.infmu.Lock()
 	job := *j.infos
+	job.StartedAt = time.Now()
 	job.State = Running
 	j.infos = &job
 	j.infmu.Unlock()

--- a/pkg/jobs/mem_jobs.go
+++ b/pkg/jobs/mem_jobs.go
@@ -160,6 +160,16 @@ func (b *MemBroker) PushJob(req *JobRequest) (*JobInfos, <-chan *JobInfos, error
 	return infos, jobch, nil
 }
 
+// QueueLen returns the size of the number of elements in queue of the
+// specified worker type.
+func (b *MemBroker) QueueLen(workerType string) (int, error) {
+	q, ok := b.queues[workerType]
+	if !ok {
+		return 0, ErrUnknownWorker
+	}
+	return q.Len(), nil
+}
+
 // Infos returns the associated job infos
 func (j *MemJob) Infos() *JobInfos {
 	j.infmu.RLock()

--- a/pkg/jobs/worker.go
+++ b/pkg/jobs/worker.go
@@ -15,10 +15,6 @@ var (
 	defaultMaxExecTime  = 60 * time.Second
 	defaultRetryDelay   = 60 * time.Millisecond
 	defaultTimeout      = 10 * time.Second
-
-	maxMaxExecCount = 5
-	maxMaxExecTime  = 5 * time.Minute
-	maxTimeout      = 1 * time.Minute
 )
 
 type (

--- a/pkg/jobs/worker.go
+++ b/pkg/jobs/worker.go
@@ -86,37 +86,32 @@ func (w *Worker) work(workerID string) {
 
 func (w *Worker) defaultedConf(opts *JobOptions) *WorkerConfig {
 	c := &(*w.Conf)
-	if opts != nil {
-		if opts.MaxExecCount != 0 {
-			c.MaxExecCount = opts.MaxExecCount
-		}
-		if opts.MaxExecTime > 0 {
-			c.MaxExecTime = opts.MaxExecTime
-		}
-		if opts.Timeout > 0 {
-			c.Timeout = opts.Timeout
-		}
-	}
 	if c.Concurrency == 0 {
 		c.Concurrency = uint(defaultConcurrency)
 	}
 	if c.MaxExecCount == 0 {
 		c.MaxExecCount = uint(defaultMaxExecCount)
-	} else if c.MaxExecCount > uint(maxMaxExecCount) {
-		c.MaxExecCount = uint(maxMaxExecCount)
 	}
 	if c.MaxExecTime == 0 {
 		c.MaxExecTime = defaultMaxExecTime
-	} else if c.MaxExecTime > maxMaxExecTime {
-		c.MaxExecTime = maxMaxExecTime
 	}
 	if c.RetryDelay == 0 {
 		c.RetryDelay = defaultRetryDelay
 	}
 	if c.Timeout == 0 {
 		c.Timeout = defaultTimeout
-	} else if c.Timeout > maxTimeout {
-		c.Timeout = maxTimeout
+	}
+	if opts == nil {
+		return c
+	}
+	if opts.MaxExecCount != 0 && opts.MaxExecCount < c.MaxExecCount {
+		c.MaxExecCount = opts.MaxExecCount
+	}
+	if opts.MaxExecTime > 0 && opts.MaxExecTime < c.MaxExecTime {
+		c.MaxExecTime = opts.MaxExecTime
+	}
+	if opts.Timeout > 0 && opts.Timeout < c.Timeout {
+		c.Timeout = opts.Timeout
 	}
 	return c
 }

--- a/web/jobs/jobs.go
+++ b/web/jobs/jobs.go
@@ -12,7 +12,7 @@ import (
 	"github.com/labstack/echo"
 )
 
-const TypeTextEventStream = "text/event-stream"
+const typeTextEventStream = "text/event-stream"
 
 type (
 	apiJob struct {
@@ -89,12 +89,12 @@ func pushJob(c echo.Context) error {
 	}
 
 	accept := c.Request().Header.Get("Accept")
-	if accept != TypeTextEventStream {
+	if accept != typeTextEventStream {
 		return jsonapi.Data(c, http.StatusAccepted, &apiJob{job}, nil)
 	}
 
 	w := c.Response().Writer
-	w.Header().Set("Content-Type", TypeTextEventStream)
+	w.Header().Set("Content-Type", typeTextEventStream)
 	w.WriteHeader(200)
 	if err := streamJob(job, w); err != nil {
 		return nil

--- a/web/jsonapi/data.go
+++ b/web/jsonapi/data.go
@@ -16,7 +16,7 @@ type Object interface {
 
 // Meta is a container for the couchdb revision, in JSON-API land
 type Meta struct {
-	Rev string `json:"rev"`
+	Rev string `json:"rev,omitempty"`
 }
 
 // LinksList is the common links used in JSON-API for the top-level or a


### PR DESCRIPTION
Includes commits from #200 

This PR adds the possibility to watch jobs state from `POST /jobs/queue/:worker-type` with and `Accept: text/event-stream` header.

It also adds the endpoint `GET /jobs/queue/:worker-type` returning the number of elements currently in the queue.