### PR TITLE
Add an asset handling step on build.sh script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /cozy-stack*
 /storage
 /.cozy
+/.assets
 *.log
 local.env
 integration-tests/pouchdb/node_modules

--- a/assets/externals
+++ b/assets/externals
@@ -1,0 +1,15 @@
+# This files contains all the external assets that are required
+# for a release of cozy-stack
+#
+# Assets should be declared using the following format, with one or more
+# newlines between each asset declaration. Lines starting with # or empty
+# lines are ignored
+#
+#  name     ./text/myasset.txt
+#  url      http://foobar.com/assetpath.txt
+#  sha256   ad414b6b70f583168d2de14c0b7479e1a4ddda3427ea17064ace9e5fbf1b42be
+#
+
+name    ./js/cozy-client.js
+url     https://raw.githubusercontent.com/cozy/cozy-client-js/0a253f9ab27d3f0a24226be411f98535dddb7e83/dist/cozy-client.js
+sha256  9cf064f0af53fab7f67fef3bb16624f6376c1986a09c72cd5cb408bd4454f0b3

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -24,6 +24,7 @@ usage() {
 	echo -e "\nCommands:\n"
 	echo -e "  release  builds a release of the current working-tree"
 	echo -e "  deploy   builds a release of the current working-tree and deploys it"
+	echo -e "  assets   move and download all the required assets (see: ./assets/externals)"
 	echo -e "  clean    remove all generated files from the working-tree"
 
 	echo -e "\nEnvironment variables:"
@@ -144,15 +145,22 @@ do_deploy() {
 }
 
 do_assets() {
+	clean_assets
 	prepare_assets
+	printf "executing go generate... "
 	go generate ./web/routing
+	echo "ok"
+	clean_assets
+}
+
+clean_assets() {
+	rm -rf "${WORK_DIR}/.assets"
 }
 
 prepare_assets() {
 	assets_dst="${WORK_DIR}/.assets"
 	assets_src="${WORK_DIR}/assets"
 
-	rm -rf "${assets_dst}"
 	mkdir "${assets_dst}"
 
 	asset_name=""
@@ -225,6 +233,7 @@ download_asset() {
 
 do_clean() {
 	find "${WORK_DIR}" -name "cozy-stack-*" -print -delete
+	clean_assets
 }
 
 check_env() {

--- a/web/routing/routing.go
+++ b/web/routing/routing.go
@@ -1,4 +1,4 @@
-//go:generate statik -src=../../assets -dest=..
+//go:generate statik -src=../../.assets -dest=..
 
 package routing
 


### PR DESCRIPTION
Add a simple step to the build script to download assets described in `assets/externals` file.

This step is called with the before the `release` command or using the new `assets` command.