### PR TITLE
Add a timeout to couchdb and apps http clients

### DIFF
--- a/pkg/apps/git.go
+++ b/pkg/apps/git.go
@@ -32,6 +32,10 @@ func newGitFetcher(ctx vfs.Context) *gitFetcher {
 	return &gitFetcher{ctx: ctx}
 }
 
+var manifestClient = &http.Client{
+	Timeout: 60 * time.Second,
+}
+
 func (g *gitFetcher) FetchManifest(src *url.URL) (io.ReadCloser, error) {
 	var err error
 
@@ -45,7 +49,7 @@ func (g *gitFetcher) FetchManifest(src *url.URL) (io.ReadCloser, error) {
 		return nil, err
 	}
 
-	res, err := http.Get(u)
+	res, err := manifestClient.Get(u)
 	if err != nil || res.StatusCode != 200 {
 		return nil, ErrManifestNotReachable
 	}

--- a/pkg/apps/installer_test.go
+++ b/pkg/apps/installer_test.go
@@ -32,7 +32,6 @@ type transport struct{}
 func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req2 := new(http.Request)
 	*req2 = *req
-	fmt.Println(req.URL.String())
 	req2.URL, _ = url.Parse(ts.URL)
 	return http.DefaultTransport.RoundTrip(req2)
 }
@@ -337,7 +336,7 @@ func TestMain(m *testing.M) {
 		io.WriteString(w, manifest())
 	}))
 
-	http.DefaultClient = &http.Client{
+	manifestClient = &http.Client{
 		Transport: &transport{},
 	}
 

--- a/pkg/couchdb/couchdb.go
+++ b/pkg/couchdb/couchdb.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"strings"
+	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/cozy/cozy-stack/pkg/config"
@@ -122,7 +123,9 @@ func (j JSONDoc) Get(key string) interface{} {
 	return j.M[key]
 }
 
-var couchdbClient = &http.Client{}
+var couchdbClient = &http.Client{
+	Timeout: 5 * time.Second,
+}
 
 func escapeCouchdbName(name string) string {
 	name = strings.Replace(name, ".", "-", -1)


### PR DESCRIPTION
It is safer to have a timeout on HTTP clients, to avoid stuck connections when a service is down.

See https://medium.com/@nate510/don-t-use-go-s-default-http-client-4804cb19f779