### PR TITLE
[Bug] Fix routing of files for default app route

### DIFF
--- a/pkg/apps/apps.go
+++ b/pkg/apps/apps.go
@@ -95,7 +95,7 @@ type Manifest struct {
 	Version     string       `json:"version"`
 	License     string       `json:"license"`
 	Permissions *Permissions `json:"permissions"`
-	Routes    Routes     `json:"routes"`
+	Routes      Routes       `json:"routes"`
 }
 
 // ID returns the manifest identifier - see couchdb.Doc interface
@@ -165,7 +165,12 @@ func (m *Manifest) FindRoute(vpath string) (Route, string) {
 	rest := ""
 	specificity := 0
 	for key, ctx := range m.Routes {
-		keys := strings.Split(key, "/")
+		var keys []string
+		if key == "/" {
+			keys = []string{""}
+		} else {
+			keys = strings.Split(key, "/")
+		}
 		count := len(keys)
 		if count > lenParts || count < specificity {
 			continue

--- a/pkg/apps/apps_test.go
+++ b/pkg/apps/apps_test.go
@@ -63,6 +63,20 @@ func TestFindRoute(t *testing.T) {
 	assert.Equal(t, "", ctx.Folder)
 }
 
+func TestNoRegression217(t *testing.T) {
+	var man Manifest
+	man.Routes = make(Routes)
+	man.Routes["/"] = Route{
+		Folder: "/",
+		Index:  "index.html",
+		Public: false,
+	}
+
+	ctx, rest := man.FindRoute("/any/path")
+	assert.Equal(t, "/", ctx.Folder)
+	assert.Equal(t, "any/path", rest)
+}
+
 func TestBuildToken(t *testing.T) {
 	manifest := &Manifest{
 		Slug: "my-app",


### PR DESCRIPTION
When installing an application which does not define complex routing,the default route created is 

```
"routes":{"/":{"folder":"/","index":"index.html","public":false}}}
```

The current version of FindRoute does not match this route with /any/other/path.txt