### PR TITLE
Splitting of Authorization header in constant time

### DIFF
--- a/web/middlewares/bearer_token.go
+++ b/web/middlewares/bearer_token.go
@@ -9,33 +9,36 @@ import (
 	jwt "gopkg.in/dgrijalva/jwt-go.v3"
 )
 
+const bearerPrefix = "Bearer "
+
 // ParseBearerAuth parses the Authorization HTTP header for a bearer token
 func ParseBearerAuth(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		header := c.Request().Header.Get("Authorization")
-		parts := strings.Split(header, " ")
-		if len(parts) == 2 && parts[0] == "Bearer" {
-			instance := GetInstance(c)
-			var claims permissions.Claims
-			keyFunc := func(token *jwt.Token) (interface{}, error) {
-				switch token.Claims.(*permissions.Claims).Audience {
-				case permissions.AppAudience:
-					return instance.SessionSecret, nil
-				case permissions.RefreshTokenAudience, permissions.AccessTokenAudience:
-					return instance.OAuthSecret, nil
-				}
-				return nil, permissions.ErrInvalidAudience
-			}
-			err := crypto.ParseJWT(parts[1], keyFunc, &claims)
-			if err != nil {
-				return err
-			}
-			if claims.Issuer != instance.Domain {
-				return permissions.ErrInvalidToken
-			}
-			// TODO check validity
-			c.Set("token_claims", claims)
+		auth := c.Request().Header.Get("Authorization")
+		if !strings.HasPrefix(auth, bearerPrefix) {
+			return next(c)
 		}
+		tokenString := auth[len(bearerPrefix):]
+		instance := GetInstance(c)
+		keyFunc := func(token *jwt.Token) (interface{}, error) {
+			switch token.Claims.(*permissions.Claims).Audience {
+			case permissions.AppAudience:
+				return instance.SessionSecret, nil
+			case permissions.RefreshTokenAudience, permissions.AccessTokenAudience:
+				return instance.OAuthSecret, nil
+			}
+			return nil, permissions.ErrInvalidAudience
+		}
+		var claims permissions.Claims
+		err := crypto.ParseJWT(tokenString, keyFunc, &claims)
+		if err != nil {
+			return err
+		}
+		if claims.Issuer != instance.Domain {
+			return permissions.ErrInvalidToken
+		}
+		// TODO check validity
+		c.Set("token_claims", claims)
 		return next(c)
 	}
 }


### PR DESCRIPTION
This PR makes the Bearer "parsing" constant time (using `strings.HasPrefix` instead of `strings.Split`).
The diff is better watchable [without whitespaces](https://github.com/cozy/cozy-stack/commit/13175f79f06fec68d739a6fcc3a8af5fec3a743f?w=0)