### PR TITLE
Jobs: use context instead of timeout channels

### DIFF
--- a/pkg/jobs/errors.go
+++ b/pkg/jobs/errors.go
@@ -9,6 +9,4 @@ var (
 	ErrUnknownWorker = errors.New("Could not find worker")
 	// ErrUnknownMessageType is used for an unknown message encoding type
 	ErrUnknownMessageType = errors.New("Unknown message encoding type")
-	// ErrTimedOut is used by a worker function when it has timed out
-	ErrTimedOut = errors.New("Worker timed out")
 )


### PR DESCRIPTION
As suggested by @aenario, this PR uses `context.Context` to handle jobs timeout.