### PR TITLE
Add sendmail worker

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,7 +74,7 @@ func init() {
 	flags.Int("couchdb-port", 5984, "couchdbdb port")
 	checkNoErr(viper.BindPFlag("couchdb.port", flags.Lookup("couchdb-port")))
 
-	flags.String("mail-host", "", "mail smtp host")
+	flags.String("mail-host", "localhost", "mail smtp host")
 	checkNoErr(viper.BindPFlag("mail.host", flags.Lookup("mail-host")))
 
 	flags.Int("mail-port", 465, "mail smtp port")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,6 +74,21 @@ func init() {
 	flags.Int("couchdb-port", 5984, "couchdbdb port")
 	checkNoErr(viper.BindPFlag("couchdb.port", flags.Lookup("couchdb-port")))
 
+	flags.String("mail-host", "", "mail smtp host")
+	checkNoErr(viper.BindPFlag("mail.host", flags.Lookup("mail-host")))
+
+	flags.Int("mail-port", 465, "mail smtp port")
+	checkNoErr(viper.BindPFlag("mail.port", flags.Lookup("mail-port")))
+
+	flags.String("mail-username", "", "mail smtp username")
+	checkNoErr(viper.BindPFlag("mail.username", flags.Lookup("mail-username")))
+
+	flags.String("mail-password", "", "mail smtp password")
+	checkNoErr(viper.BindPFlag("mail.password", flags.Lookup("mail-password")))
+
+	flags.Bool("mail-disable-tls", false, "disable smtp over tls")
+	checkNoErr(viper.BindPFlag("mail.disable_tls", flags.Lookup("mail-disable-tls")))
+
 	flags.String("log-level", "info", "define the log level")
 	checkNoErr(viper.BindPFlag("log.level", flags.Lookup("log-level")))
 }

--- a/cozy.dist.yaml
+++ b/cozy.dist.yaml
@@ -27,14 +27,24 @@ fs:
 
   # url: file://localhost/var/lib/cozy
 
-
 couchdb:
-    # couchdb host - flags: --couchdb-host
-    host: localhost
-    # couchdb port - flags: --couchdb-port
-    port: 5984
+  # couchdb host - flags: --couchdb-host
+  host: localhost
+  # couchdb port - flags: --couchdb-port
+  port: 5984
 
+mail:
+  # mail smtp host - flags: --mail-host
+  host: smtp.home
+  # mail smtp port - flags: --mail-port
+  port: 465
+  # mail smtp username - flags: --mail-username
+  username: user
+  # mail smtp password - flags: --mail-password
+  password: pass
+  # disable mail tls - flags: --mail-disable-tls
+  disable_tls: false
 
 log:
-    # logger level (debug, info, warning, panic, fatal) - flags: --log-level
-    level: info
+  # logger level (debug, info, warning, panic, fatal) - flags: --log-level
+  level: info

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"net"
 	"net/url"
 	"path"
 	"path/filepath"
@@ -10,6 +11,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/cozy/cozy-stack/pkg/utils"
+	"github.com/cozy/gomail"
 	"github.com/spf13/viper"
 )
 
@@ -66,6 +68,7 @@ type Config struct {
 	AdminPort  int
 	Fs         Fs
 	CouchDB    CouchDB
+	Mail       *gomail.DialerOptions
 	Logger     Logger
 }
 
@@ -114,12 +117,12 @@ func BuildAbsFsURL(abs string) *url.URL {
 
 // ServerAddr returns the address on which the stack is run
 func ServerAddr() string {
-	return config.Host + ":" + strconv.Itoa(config.Port)
+	return net.JoinHostPort(config.Host, strconv.Itoa(config.Port))
 }
 
 // AdminServerAddr returns the address on which the administration is listening
 func AdminServerAddr() string {
-	return config.AdminHost + ":" + strconv.Itoa(config.AdminPort)
+	return net.JoinHostPort(config.AdminHost, strconv.Itoa(config.AdminPort))
 }
 
 // CouchURL returns the CouchDB string url
@@ -166,6 +169,13 @@ func UseViper(v *viper.Viper) error {
 		},
 		CouchDB: CouchDB{
 			URL: couchURL,
+		},
+		Mail: &gomail.DialerOptions{
+			Host:       v.GetString("mail.host"),
+			Port:       v.GetInt("mail.port"),
+			Username:   v.GetString("mail.username"),
+			Password:   v.GetString("mail.password"),
+			DisableTLS: v.GetBool("mail.disable_tls"),
 		},
 		Logger: Logger{
 			Level: v.GetString("log.level"),

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -164,3 +164,14 @@ func (m *Message) Unmarshal(msg interface{}) error {
 		return ErrUnknownMessageType
 	}
 }
+
+func (w *WorkerConfig) clone() *WorkerConfig {
+	return &WorkerConfig{
+		WorkerFunc:   w.WorkerFunc,
+		Concurrency:  w.Concurrency,
+		MaxExecCount: w.MaxExecCount,
+		MaxExecTime:  w.MaxExecTime,
+		Timeout:      w.Timeout,
+		RetryDelay:   w.RetryDelay,
+	}
+}

--- a/pkg/jobs/worker.go
+++ b/pkg/jobs/worker.go
@@ -82,7 +82,7 @@ func (w *Worker) work(workerID string) {
 }
 
 func (w *Worker) defaultedConf(opts *JobOptions) *WorkerConfig {
-	c := &(*w.Conf)
+	c := w.Conf.clone()
 	if c.Concurrency == 0 {
 		c.Concurrency = uint(defaultConcurrency)
 	}

--- a/pkg/jobs/workers/mail.go
+++ b/pkg/jobs/workers/mail.go
@@ -1,0 +1,126 @@
+package workers
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"html/template"
+	"time"
+
+	"github.com/cozy/cozy-stack/pkg/config"
+	"github.com/cozy/cozy-stack/pkg/jobs"
+	"github.com/cozy/gomail"
+)
+
+func init() {
+	jobs.AddWorker("sendmail", &jobs.WorkerConfig{
+		Concurrency:  4,
+		MaxExecCount: 3,
+		Timeout:      10 * time.Second,
+		WorkerFunc:   SendMail,
+	})
+
+	jobs.AddWorker("sendmail-template", &jobs.WorkerConfig{
+		Concurrency:  4,
+		MaxExecCount: 3,
+		Timeout:      10 * time.Second,
+		WorkerFunc:   SendMailTemplate,
+	})
+}
+
+// MailAddress contains the name and mail of a mail recipient.
+type MailAddress struct {
+	Name string `json:"name"`
+	Mail string `json:"mail"`
+}
+
+type mailOptions struct {
+	From    *MailAddress          `json:"from"`
+	To      []*MailAddress        `json:"to"`
+	Subject string                `json:"subject"`
+	Dialer  *gomail.DialerOptions `json:"dialer,omitempty"`
+	Date    *time.Time            `json:"date"`
+}
+
+// MailManualOptions should be used as the options of a mail with manually
+// defined content: body and body content-type. It is used as the input of the
+// "sendmail" worker.
+type MailManualOptions struct {
+	*mailOptions
+	Body     string `json:"body"`
+	BodyType string `json:"body_type"`
+}
+
+// MailTemplateOptions should be used as the options of a mail with a templated
+// content: template and values. It is used as the input of the
+// "sendmail-template" worker.
+type MailTemplateOptions struct {
+	*mailOptions
+	Template string      `json:"template"`
+	Values   interface{} `json:"values"`
+}
+
+// SendMail is the sendmail worker function.
+func SendMail(ctx context.Context, m *jobs.Message) error {
+	var opts MailManualOptions
+	if err := m.Unmarshal(&opts); err != nil {
+		return err
+	}
+	return sendMail(ctx, opts.mailOptions, opts.BodyType, opts.Body)
+}
+
+// SendMailTemplate is the sendmail-template worker function.
+func SendMailTemplate(ctx context.Context, m *jobs.Message) error {
+	var opts MailTemplateOptions
+	if err := m.Unmarshal(&opts); err != nil {
+		return err
+	}
+	t, err := template.New("mail").Parse(opts.Template)
+	if err != nil {
+		return err
+	}
+	b := new(bytes.Buffer)
+	if err = t.Execute(b, opts.Values); err != nil {
+		return err
+	}
+	return sendMail(ctx, opts.mailOptions, "text/html", b.String())
+}
+
+func sendMail(ctx context.Context, opts *mailOptions, bodyType, body string) error {
+	if bodyType == "" {
+		bodyType = "text/plain"
+	}
+	if bodyType != "text/plain" && bodyType != "text/html" {
+		return fmt.Errorf("Unknown body content-type %s", bodyType)
+	}
+	if opts.Subject == "" {
+		return fmt.Errorf("Missing mail subject")
+	}
+
+	dialerOptions := opts.Dialer
+	if dialerOptions == nil {
+		dialerOptions = config.GetConfig().Mail
+	}
+
+	mail := gomail.NewMessage()
+	toAddresses := make([]string, len(opts.To))
+	for i, to := range opts.To {
+		toAddresses[i] = mail.FormatAddress(to.Mail, to.Name)
+	}
+
+	mail.SetBody(bodyType, body)
+	mail.SetHeaders(map[string][]string{
+		"From":    {mail.FormatAddress(opts.From.Mail, opts.From.Name)},
+		"To":      toAddresses,
+		"Subject": {opts.Subject},
+	})
+	if opts.Date != nil {
+		mail.SetDateHeader("Date", *opts.Date)
+	}
+
+	dialer := gomail.NewDialer(dialerOptions)
+	if deadline, ok := ctx.Deadline(); ok {
+		dialer.SetDeadline(deadline)
+	}
+	return dialer.DialAndSend(mail)
+}

--- a/pkg/jobs/workers/mail.go
+++ b/pkg/jobs/workers/mail.go
@@ -31,12 +31,12 @@ type MailAddress struct {
 // content: body and body content-type. It is used as the input of the
 // "sendmail" worker.
 type MailOptions struct {
-	From     *MailAddress          `json:"from"`
-	To       []*MailAddress        `json:"to"`
-	Subject  string                `json:"subject"`
-	Dialer   *gomail.DialerOptions `json:"dialer,omitempty"`
-	Date     *time.Time            `json:"date"`
-	Contents []*MailPart
+	From    *MailAddress          `json:"from"`
+	To      []*MailAddress        `json:"to"`
+	Subject string                `json:"subject"`
+	Dialer  *gomail.DialerOptions `json:"dialer,omitempty"`
+	Date    *time.Time            `json:"date"`
+	Parts   []*MailPart
 }
 
 // MailPart represent a part of the content of the mail. It has a type
@@ -81,7 +81,7 @@ func SendMail(ctx context.Context, m *jobs.Message) error {
 		"Subject": {opts.Subject},
 	})
 	mail.SetDateHeader("Date", date)
-	for _, part := range opts.Contents {
+	for _, part := range opts.Parts {
 		if err := addContent(mail, part); err != nil {
 			return err
 		}

--- a/pkg/jobs/workers/mail.go
+++ b/pkg/jobs/workers/mail.go
@@ -19,13 +19,6 @@ func init() {
 		Timeout:      10 * time.Second,
 		WorkerFunc:   SendMail,
 	})
-
-	jobs.AddWorker("sendmail-template", &jobs.WorkerConfig{
-		Concurrency:  4,
-		MaxExecCount: 3,
-		Timeout:      10 * time.Second,
-		WorkerFunc:   SendMailTemplate,
-	})
 }
 
 // MailAddress contains the name and mail of a mail recipient.
@@ -34,93 +27,95 @@ type MailAddress struct {
 	Mail string `json:"mail"`
 }
 
-type mailOptions struct {
-	From    *MailAddress          `json:"from"`
-	To      []*MailAddress        `json:"to"`
-	Subject string                `json:"subject"`
-	Dialer  *gomail.DialerOptions `json:"dialer,omitempty"`
-	Date    *time.Time            `json:"date"`
-}
-
-// MailManualOptions should be used as the options of a mail with manually
-// defined content: body and body content-type. It is used as the input of the
+// MailOptions should be used as the options of a mail with manually defined
+// content: body and body content-type. It is used as the input of the
 // "sendmail" worker.
-type MailManualOptions struct {
-	*mailOptions
-	Body     string `json:"body"`
-	BodyType string `json:"body_type"`
+type MailOptions struct {
+	From     *MailAddress          `json:"from"`
+	To       []*MailAddress        `json:"to"`
+	Subject  string                `json:"subject"`
+	Dialer   *gomail.DialerOptions `json:"dialer,omitempty"`
+	Date     *time.Time            `json:"date"`
+	Contents []*MailPart
 }
 
-// MailTemplateOptions should be used as the options of a mail with a templated
-// content: template and values. It is used as the input of the
-// "sendmail-template" worker.
-type MailTemplateOptions struct {
-	*mailOptions
+// MailPart represent a part of the content of the mail. It has a type
+// specifying the content type of the part, and can used with:
+//   - Template field as a html template parsed and executed with the specified
+//     Values field
+//   - Body field used directly as body of the part.
+type MailPart struct {
+	Type     string      `json:"body_type"`
+	Body     string      `json:"body"`
 	Template string      `json:"template"`
 	Values   interface{} `json:"values"`
 }
 
 // SendMail is the sendmail worker function.
 func SendMail(ctx context.Context, m *jobs.Message) error {
-	var opts MailManualOptions
+	var opts MailOptions
 	if err := m.Unmarshal(&opts); err != nil {
 		return err
-	}
-	return sendMail(ctx, opts.mailOptions, opts.BodyType, opts.Body)
-}
-
-// SendMailTemplate is the sendmail-template worker function.
-func SendMailTemplate(ctx context.Context, m *jobs.Message) error {
-	var opts MailTemplateOptions
-	if err := m.Unmarshal(&opts); err != nil {
-		return err
-	}
-	t, err := template.New("mail").Parse(opts.Template)
-	if err != nil {
-		return err
-	}
-	b := new(bytes.Buffer)
-	if err = t.Execute(b, opts.Values); err != nil {
-		return err
-	}
-	return sendMail(ctx, opts.mailOptions, "text/html", b.String())
-}
-
-func sendMail(ctx context.Context, opts *mailOptions, bodyType, body string) error {
-	if bodyType == "" {
-		bodyType = "text/plain"
-	}
-	if bodyType != "text/plain" && bodyType != "text/html" {
-		return fmt.Errorf("Unknown body content-type %s", bodyType)
 	}
 	if opts.Subject == "" {
 		return fmt.Errorf("Missing mail subject")
 	}
-
+	mail := gomail.NewMessage()
 	dialerOptions := opts.Dialer
 	if dialerOptions == nil {
 		dialerOptions = config.GetConfig().Mail
 	}
-
-	mail := gomail.NewMessage()
+	var date time.Time
+	if opts.Date == nil {
+		date = time.Now()
+	} else {
+		date = *opts.Date
+	}
 	toAddresses := make([]string, len(opts.To))
 	for i, to := range opts.To {
 		toAddresses[i] = mail.FormatAddress(to.Mail, to.Name)
 	}
-
-	mail.SetBody(bodyType, body)
 	mail.SetHeaders(map[string][]string{
 		"From":    {mail.FormatAddress(opts.From.Mail, opts.From.Name)},
 		"To":      toAddresses,
 		"Subject": {opts.Subject},
 	})
-	if opts.Date != nil {
-		mail.SetDateHeader("Date", *opts.Date)
+	mail.SetDateHeader("Date", date)
+	for _, part := range opts.Contents {
+		if err := addContent(mail, part); err != nil {
+			return err
+		}
 	}
-
 	dialer := gomail.NewDialer(dialerOptions)
 	if deadline, ok := ctx.Deadline(); ok {
 		dialer.SetDeadline(deadline)
 	}
 	return dialer.DialAndSend(mail)
+}
+
+func addContent(mail *gomail.Message, part *MailPart) error {
+	contentType := part.Type
+	var body string
+	if part.Template != "" {
+		contentType = "text/html"
+		t, err := template.New("mail").Parse(part.Template)
+		if err != nil {
+			return err
+		}
+		b := new(bytes.Buffer)
+		if err = t.Execute(b, part.Values); err != nil {
+			return err
+		}
+		body = b.String()
+	} else {
+		body = part.Body
+	}
+	if contentType == "" {
+		contentType = "text/plain"
+	}
+	if contentType != "text/plain" && contentType != "text/html" {
+		return fmt.Errorf("Unknown body content-type %s", contentType)
+	}
+	mail.AddAlternative(contentType, body)
+	return nil
 }

--- a/pkg/jobs/workers/mail_test.go
+++ b/pkg/jobs/workers/mail_test.go
@@ -62,7 +62,7 @@ QUIT
 				Port:       port,
 				DisableTLS: true,
 			},
-			Contents: []*MailPart{
+			Parts: []*MailPart{
 				&MailPart{
 					Body: "Hey !!!",
 					Type: "text/plain",
@@ -142,7 +142,7 @@ QUIT
 				Port:       port,
 				DisableTLS: true,
 			},
-			Contents: []*MailPart{
+			Parts: []*MailPart{
 				&MailPart{
 					Template: tpl,
 					Values:   data,
@@ -175,7 +175,7 @@ func TestMailBadBodyType(t *testing.T) {
 		From:    &MailAddress{Mail: "me@me"},
 		To:      []*MailAddress{&MailAddress{Mail: "you@you"}},
 		Subject: "Up?",
-		Contents: []*MailPart{
+		Parts: []*MailPart{
 			&MailPart{
 				Type: "text/qsdqsd",
 				Body: "foo",
@@ -261,7 +261,7 @@ QUIT
 				Port:       port,
 				DisableTLS: true,
 			},
-			Contents: []*MailPart{
+			Parts: []*MailPart{
 				&MailPart{
 					Type: "text/plain",
 					Body: "foo",

--- a/pkg/jobs/workers/mail_test.go
+++ b/pkg/jobs/workers/mail_test.go
@@ -1,0 +1,269 @@
+package workers
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"net"
+	"net/textproto"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cozy/cozy-stack/pkg/jobs"
+	"github.com/cozy/gomail"
+	"github.com/stretchr/testify/assert"
+)
+
+const serverString = `220 hello world
+502 EH?
+250 smtp.me at your service
+250 Sender ok
+250 Receiver ok
+354 Go ahead
+250 Data ok
+221 Goodbye
+`
+
+func TestMailSendServer(t *testing.T) {
+	clientString := `EHLO localhost
+HELO localhost
+MAIL FROM:<me@me>
+RCPT TO:<you1@you>
+DATA
+Hey !!!
+.
+QUIT
+`
+
+	expectedHeaders := map[string]string{
+		"From":    "me@me",
+		"To":      "you1@you",
+		"Subject": "Up?",
+		"Date":    "Mon, 01 Jan 0001 00:00:00 +0000",
+		"Content-Transfer-Encoding": "quoted-printable",
+		"Content-Type":              "text/plain; charset=UTF-8",
+		"Mime-Version":              "1.0",
+	}
+
+	mailServer(t, serverString, clientString, expectedHeaders, func(host string, port int) error {
+		msg, err := jobs.NewMessage("json", &MailManualOptions{
+			mailOptions: &mailOptions{
+				From: &MailAddress{Mail: "me@me"},
+				To: []*MailAddress{
+					&MailAddress{Mail: "you1@you"},
+				},
+				Date:    &time.Time{},
+				Subject: "Up?",
+				Dialer: &gomail.DialerOptions{
+					Host:       host,
+					Port:       port,
+					DisableTLS: true,
+				},
+			},
+			Body:     "Hey !!!",
+			BodyType: "text/plain",
+		})
+		if err != nil {
+			return err
+		}
+		return SendMail(context.Background(), msg)
+	})
+}
+
+func TestMailSendTemplateMail(t *testing.T) {
+	clientString := `EHLO localhost
+HELO localhost
+MAIL FROM:<me@me>
+RCPT TO:<you1@you>
+DATA
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset=3D"UTF-8">
+    <title>My page</title>
+  </head>
+  <body>
+    <div>My photos</div><div>My blog</div>
+  </body>
+</html>
+.
+QUIT
+`
+
+	expectedHeaders := map[string]string{
+		"From":    "me@me",
+		"To":      "you1@you",
+		"Subject": "Up?",
+		"Date":    "Mon, 01 Jan 0001 00:00:00 +0000",
+		"Content-Transfer-Encoding": "quoted-printable",
+		"Content-Type":              "text/html; charset=UTF-8",
+		"Mime-Version":              "1.0",
+	}
+
+	const tpl = `
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>{{.Title}}</title>
+  </head>
+  <body>
+    {{range .Items}}<div>{{ . }}</div>{{else}}<div><strong>no rows</strong></div>{{end}}
+  </body>
+</html>`
+
+	data := struct {
+		Title string
+		Items []string
+	}{
+		Title: "My page",
+		Items: []string{
+			"My photos",
+			"My blog",
+		},
+	}
+
+	mailServer(t, serverString, clientString, expectedHeaders, func(host string, port int) error {
+		msg, err := jobs.NewMessage("json", &MailTemplateOptions{
+			mailOptions: &mailOptions{
+				From: &MailAddress{Mail: "me@me"},
+				To: []*MailAddress{
+					&MailAddress{Mail: "you1@you"},
+				},
+				Date:    &time.Time{},
+				Subject: "Up?",
+				Dialer: &gomail.DialerOptions{
+					Host:       host,
+					Port:       port,
+					DisableTLS: true,
+				},
+			},
+			Template: tpl,
+			Values:   data,
+		})
+		if err != nil {
+			return err
+		}
+		return SendMailTemplate(context.Background(), msg)
+	})
+}
+
+func TestMailMissingSubject(t *testing.T) {
+	msg, err := jobs.NewMessage("json", &MailManualOptions{
+		mailOptions: &mailOptions{
+			From: &MailAddress{Mail: "me@me"},
+			To:   []*MailAddress{&MailAddress{Mail: "you@you"}},
+		},
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+	err = SendMail(context.Background(), msg)
+	if assert.Error(t, err) {
+		assert.Equal(t, "Missing mail subject", err.Error())
+	}
+}
+
+func TestMailBadBodyType(t *testing.T) {
+	err := sendMail(context.Background(), &mailOptions{
+		From: &MailAddress{Mail: "me@me"},
+		To:   []*MailAddress{&MailAddress{Mail: "you@you"}},
+	}, "text/qsdqsd", "foo")
+	if assert.Error(t, err) {
+		assert.Equal(t, "Unknown body content-type text/qsdqsd", err.Error())
+	}
+}
+
+func mailServer(t *testing.T, serverString, clientString string, expectedHeader map[string]string, send func(string, int) error) {
+	serverString = strings.Join(strings.Split(serverString, "\n"), "\r\n")
+	clientString = strings.Join(strings.Split(clientString, "\n"), "\r\n")
+
+	var cmdbuf bytes.Buffer
+	bcmdbuf := bufio.NewWriter(&cmdbuf)
+	headers := make(map[string]string)
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Unable to to create listener: %v", err)
+	}
+	defer l.Close()
+
+	// prevent data race on bcmdbuf
+	var done = make(chan struct{})
+	go func(data []string) {
+
+		defer close(done)
+
+		conn, err := l.Accept()
+		if err != nil {
+			t.Errorf("Accept error: %v", err)
+			return
+		}
+		defer conn.Close()
+
+		tc := textproto.NewConn(conn)
+		readdata := false
+		readhead := false
+		for i := 0; i < len(data) && data[i] != ""; i++ {
+			tc.PrintfLine(data[i])
+			for len(data[i]) >= 4 && data[i][3] == '-' {
+				i++
+				tc.PrintfLine(data[i])
+			}
+			if data[i] == "221 Goodbye" {
+				return
+			}
+			read := false
+			for !read || data[i] == "354 Go ahead" {
+				msg, err := tc.ReadLine()
+				if readdata && msg != "." {
+					if msg == "" {
+						readhead = true
+						read = true
+						continue
+					}
+					if readhead {
+						bcmdbuf.Write([]byte(msg + "\r\n"))
+					} else {
+						parts := strings.SplitN(msg, ": ", 2)
+						if len(parts) != 2 {
+							t.Fatal("Could not parse headers")
+						}
+						headers[parts[0]] = parts[1]
+					}
+				} else {
+					if msg == "." {
+						readdata = false
+					}
+					if msg == "DATA" {
+						readdata = true
+					}
+					bcmdbuf.Write([]byte(msg + "\r\n"))
+					read = true
+				}
+				if err != nil {
+					t.Errorf("Read error: %v", err)
+					return
+				}
+				if data[i] == "354 Go ahead" && msg == "." {
+					break
+				}
+			}
+		}
+	}(strings.Split(serverString, "\r\n"))
+
+	host, port, _ := net.SplitHostPort(l.Addr().String())
+	portI, _ := strconv.Atoi(port)
+	if err := send(host, portI); err != nil {
+		t.Errorf("%v", err)
+	}
+
+	<-done
+	bcmdbuf.Flush()
+	actualcmds := cmdbuf.String()
+	if !assert.Equal(t, clientString, actualcmds) {
+		return
+	}
+	assert.EqualValues(t, expectedHeader, headers)
+}

--- a/web/jobs/jobs.go
+++ b/web/jobs/jobs.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/jobs"
+	_ "github.com/cozy/cozy-stack/pkg/jobs/workers" // import all workers
 	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/labstack/echo"


### PR DESCRIPTION
This PR adds a `sendmail` and a `sendmail-template` workers to send mails.

The sendmail-template accepts a template html string along with values. It may be not really useful as is, but could become interesting with a preset of predefined HTML templates.