### PR TITLE
Always create the settings for an instance

### DIFF
--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -342,14 +342,12 @@ func Create(opts *Options) (*Instance, error) {
 		return nil, err
 	}
 
-	if opts.Timezone != "" || opts.Email != "" {
-		doc := &instanceSettings{
-			Timezone: opts.Timezone,
-			Email:    opts.Email,
-		}
-		if err = couchdb.CreateNamedDoc(i, doc); err != nil {
-			return nil, err
-		}
+	doc := &instanceSettings{
+		Timezone: opts.Timezone,
+		Email:    opts.Email,
+	}
+	if err = couchdb.CreateNamedDoc(i, doc); err != nil {
+		return nil, err
 	}
 
 	// TODO atomicity with defer


### PR DESCRIPTION
It is better to always create the settings document for instance, even if empty. It makes the /settings/instance endpoint easier for clients with the locale hack (ie the locale is stored in the instance itself, not in the settings document, so it's weird to have a 404 or no revision when asking for /settings/instance when there is a locale but no timezone/email).