### PR TITLE
Jobs scheduler and @at trigger

### DIFF
--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -290,7 +290,7 @@ Accept: application/vnd.api+json
 ```
 
 
-### POST /jobs/triggers/:trigger-name
+### POST /jobs/triggers/:worker-type
 
 Add a trigger of the worker. See [triggers' descriptions](#triggers) to see the types of trigger and their arguments syntax.
 

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -290,14 +290,14 @@ Accept: application/vnd.api+json
 ```
 
 
-### POST /jobs/triggers/:worker-type
+### POST /jobs/triggers
 
 Add a trigger of the worker. See [triggers' descriptions](#triggers) to see the types of trigger and their arguments syntax.
 
 #### Request
 
 ```http
-POST /jobs/triggers/sendmail HTTP/1.1
+POST /jobs/triggers HTTP/1.1
 Accept: application/vnd.api+json
 ```
 
@@ -305,6 +305,8 @@ Accept: application/vnd.api+json
 {
   "type": "@interval",
   "arguments": "30m10s",
+  "worker": "sendmail",
+  "worker_arguments": {},
   "options": {
     "priority": 3,
     "timeout": 60,
@@ -374,14 +376,14 @@ Accept: application/vnd.api+json
 ```
 
 
-### GET /jobs/triggers/
+### GET /jobs/triggers
 
 Get the list of triggers.
 
 #### Request
 
 ```http
-GET /jobs/triggers/ HTTP/1.1
+GET /jobs/triggers HTTP/1.1
 Accept: application/vnd.api+json
 ```
 

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -18,6 +18,8 @@ const (
 	Settings = "io.cozy.settings"
 	// Sessions doc type for sessions identifying a connection
 	Sessions = "io.cozy.sessions"
+	// Triggers doc type for triggers, jobs launchers
+	Triggers = "io.cozy.triggers"
 
 	// OAuthClients doc type for OAuth2 clients
 	OAuthClients = "io.cozy.oauth.clients"

--- a/pkg/couchdb/couchdb.go
+++ b/pkg/couchdb/couchdb.go
@@ -185,7 +185,7 @@ func makeRequest(method, path string, reqbody interface{}, resbody interface{}) 
 	}
 
 	if log.GetLevel() == log.DebugLevel {
-		log.Debugf("[couchdb] request: %s %s %s", method, path, string(reqjson))
+		log.Debugf("[couchdb] request: %s %s %s", method, path, string(bytes.TrimSpace(reqjson)))
 	}
 
 	req, err := http.NewRequest(method, config.CouchURL()+path, bytes.NewReader(reqjson))
@@ -226,7 +226,7 @@ func makeRequest(method, path string, reqbody interface{}, resbody interface{}) 
 		if err != nil {
 			return err
 		}
-		log.Debugf("[couchdb] response: %s", string(data))
+		log.Debugf("[couchdb] response: %s", string(bytes.TrimSpace(data)))
 		err = json.Unmarshal(data, &resbody)
 	} else {
 		err = json.NewDecoder(resp.Body).Decode(&resbody)

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -139,9 +139,29 @@ func (i *Instance) FS() afero.Fs {
 	return i.storage
 }
 
+// StartJobSystem creates all the resources necessary for the instance's job
+// system to work properly.
+func (i *Instance) StartJobSystem() error {
+	broker := jobs.NewMemBroker(i.Domain, jobs.GetWorkersList())
+	scheduler := jobs.NewMemScheduler(i.Domain, jobs.NewTriggerCouchStorage(i))
+	return scheduler.Start(broker)
+}
+
+// StopJobSystem stops all the resources used by the job system associated with
+// the instance.
+func (i *Instance) StopJobSystem() error {
+	// TODO
+	return nil
+}
+
 // JobsBroker returns the jobs broker associated with the instance
 func (i *Instance) JobsBroker() jobs.Broker {
-	return jobs.NewMemBroker(i.Domain, jobs.GetWorkersList())
+	return jobs.GetMemBroker(i.Domain)
+}
+
+// JobsScheduler returns the jobs scheduler associated with the instance
+func (i *Instance) JobsScheduler() jobs.Scheduler {
+	return jobs.GetMemScheduler(i.Domain)
 }
 
 // Prefix returns the prefix to use in database naming for the
@@ -342,6 +362,11 @@ func Create(opts *Options) (*Instance, error) {
 		return nil, err
 	}
 
+	err = i.StartJobSystem()
+	if err != nil {
+		return nil, err
+	}
+
 	doc := &instanceSettings{
 		Timezone: opts.Timezone,
 		Email:    opts.Email,
@@ -420,6 +445,10 @@ func Destroy(domain string) (*Instance, error) {
 	}
 
 	if err = couchdb.DeleteAllDBs(i); err != nil {
+		return nil, err
+	}
+
+	if err = i.StopJobSystem(); err != nil {
 		return nil, err
 	}
 

--- a/pkg/jobs/errors.go
+++ b/pkg/jobs/errors.go
@@ -9,4 +9,8 @@ var (
 	ErrUnknownWorker = errors.New("Could not find worker")
 	// ErrUnknownMessageType is used for an unknown message encoding type
 	ErrUnknownMessageType = errors.New("Unknown message encoding type")
+	// ErrUnknownTrigger is used when the trigger type is not recognized
+	ErrUnknownTrigger = errors.New("Unknown trigger type")
+	// ErrNotFoundTrigger is used when the trigger was not found
+	ErrNotFoundTrigger = errors.New("Trigger with specified ID does not exist")
 )

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -3,7 +3,6 @@ package jobs
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"time"
 
 	"github.com/cozy/cozy-stack/pkg/utils"
@@ -183,7 +182,7 @@ func NewTrigger(infos *TriggerInfos) (Trigger, error) {
 	case "@interval":
 		return NewIntervalTrigger(infos)
 	default:
-		return nil, errors.New("Unknown trigger type")
+		return nil, ErrUnknownTrigger
 	}
 }
 

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -160,8 +160,8 @@ type (
 		Type       string      `json:"type"`
 		WorkerType string      `json:"worker"`
 		Arguments  string      `json:"arguments"`
-		Message    *Message    `json:"message"`
 		Options    *JobOptions `json:"options"`
+		Message    *Message    `json:"message"`
 	}
 
 	// TriggerRequest struct contains the paramameters to create a new trigger.
@@ -178,6 +178,10 @@ func NewTrigger(infos *TriggerInfos) (Trigger, error) {
 	switch infos.Type {
 	case "@at":
 		return NewAtTrigger(infos)
+	case "@in":
+		return NewInTrigger(infos)
+	case "@interval":
+		return NewIntervalTrigger(infos)
 	default:
 		return nil, errors.New("Unknown trigger type")
 	}

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -3,6 +3,7 @@ package jobs
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"time"
 
 	"github.com/cozy/cozy-stack/pkg/utils"
@@ -121,7 +122,66 @@ type (
 		Timeout      time.Duration `json:"timeout"`
 		RetryDelay   time.Duration `json:"retry_delay"`
 	}
+
+	// Scheduler interface is used to represent a scheduler that is responsible
+	// to listen respond to triggers jobs requests and send them to the broker.
+	Scheduler interface {
+		Start(broker Broker) error
+		Add(trigger Trigger) error
+		Get(id string) (Trigger, error)
+		Delete(id string) error
+		GetAll() ([]Trigger, error)
+	}
+
+	// Trigger interface is used to represent a trigger.
+	Trigger interface {
+		Type() string
+		Infos() *TriggerInfos
+		// Schedule should return a channel on which the trigger can send job
+		// requests when it decides to.
+		Schedule() <-chan *JobRequest
+		// Unschedule should be used to clean the trigger states and should close
+		// the returns jobs channel.
+		Unschedule()
+	}
+
+	// TriggerStorage interface is used to represent a persistent layer on which
+	// triggers are stored.
+	TriggerStorage interface {
+		GetAll() ([]Trigger, error)
+		Add(trigger Trigger) error
+		Delete(trigger Trigger) error
+	}
+
+	// TriggerInfos is a struct containing all the options of a trigger.
+	TriggerInfos struct {
+		ID         string      `json:"_id,omitempty"`
+		Rev        string      `json:"_rev,omitempty"`
+		Type       string      `json:"type"`
+		WorkerType string      `json:"worker"`
+		Arguments  string      `json:"arguments"`
+		Message    *Message    `json:"message"`
+		Options    *JobOptions `json:"options"`
+	}
+
+	// TriggerRequest struct contains the paramameters to create a new trigger.
+	TriggerRequest struct {
+		Type      string          `json:"type"`
+		Arguments json.RawMessage `json:"arguments"`
+		Options   *WorkerConfig   `json:"options"`
+	}
 )
+
+// NewTrigger creates the trigger associates with the specified trigger
+// options.
+func NewTrigger(infos *TriggerInfos) (Trigger, error) {
+	switch infos.Type {
+	case "@at":
+		return NewAtTrigger(infos)
+	default:
+		return nil, errors.New("Unknown trigger type")
+	}
+}
 
 // NewJobInfos creates a new JobInfos instance from a job request.
 func NewJobInfos(req *JobRequest) *JobInfos {

--- a/pkg/jobs/mem_jobs.go
+++ b/pkg/jobs/mem_jobs.go
@@ -284,17 +284,17 @@ func GetMemScheduler(domain string) Scheduler {
 // scheduler's storage and associate for each of them a go routine in which
 // they wait for the trigger send job requests.
 func (s *MemScheduler) Start(b Broker) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	ts, err := s.storage.GetAll()
 	if err != nil {
 		return err
 	}
-	s.mu.Lock()
 	s.broker = b
 	for _, t := range ts {
 		s.ts[t.Infos().ID] = t
 		go s.schedule(t)
 	}
-	s.mu.Unlock()
 	return nil
 }
 

--- a/pkg/jobs/mem_jobs.go
+++ b/pkg/jobs/mem_jobs.go
@@ -349,16 +349,16 @@ func (s *MemScheduler) GetAll() ([]Trigger, error) {
 }
 
 func (s *MemScheduler) schedule(t Trigger) {
-	log.Debugf("[trigger] %s: Starting trigger with ID %s", t.Type(), t.Infos().ID)
+	log.Debugf("[jobs] trigger %s(%s): Starting trigger", t.Type(), t.Infos().ID)
 	for req := range t.Schedule() {
-		log.Debugf("[trigger] %s: Pushing new job", t.Type())
+		log.Debugf("[jobs] trigger %s(%s): Pushing new job", t.Type(), t.Infos().ID)
 		if _, _, err := s.broker.PushJob(req); err != nil {
-			log.Errorf("[trigger] %s: Could not schedule a new job %s: %s", t.Type(), t.Infos().ID, err.Error())
+			log.Errorf("[jobs] trigger %s(%s): Could not schedule a new job %s: %s", t.Type(), t.Infos().ID, err.Error())
 		}
 	}
-	log.Debugf("[trigger] %s: Closing trigger with ID %s", t.Type(), t.Infos().ID)
+	log.Debugf("[jobs] trigger %s(%s): Closing trigger", t.Type(), t.Infos().ID)
 	if err := s.Delete(t.Infos().ID); err != nil {
-		log.Errorf("[trigger] %s: Could not delete trigger with ID: %s", t.Infos().ID, err.Error())
+		log.Errorf("[jobs] trigger %s(%s): Could not delete trigger: %s", t.Type(), t.Infos().ID, err.Error())
 	}
 }
 

--- a/pkg/jobs/mem_jobs.go
+++ b/pkg/jobs/mem_jobs.go
@@ -353,7 +353,7 @@ func (s *MemScheduler) schedule(t Trigger) {
 	for req := range t.Schedule() {
 		log.Debugf("[jobs] trigger %s(%s): Pushing new job", t.Type(), t.Infos().ID)
 		if _, _, err := s.broker.PushJob(req); err != nil {
-			log.Errorf("[jobs] trigger %s(%s): Could not schedule a new job %s: %s", t.Type(), t.Infos().ID, err.Error())
+			log.Errorf("[jobs] trigger %s(%s): Could not schedule a new job: %s", t.Type(), t.Infos().ID, err.Error())
 		}
 	}
 	log.Debugf("[jobs] trigger %s(%s): Closing trigger", t.Type(), t.Infos().ID)

--- a/pkg/jobs/mem_jobs.go
+++ b/pkg/jobs/mem_jobs.go
@@ -5,11 +5,16 @@ import (
 	"errors"
 	"sync"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 var (
 	memBrokers   map[string]*MemBroker
-	memBrokersMu sync.Mutex
+	memBrokersMu sync.RWMutex
+
+	memSchedulers   map[string]*MemScheduler
+	memSchedulersMu sync.Mutex
 )
 
 type (
@@ -29,6 +34,16 @@ type (
 	MemBroker struct {
 		domain string
 		queues map[string]*MemQueue
+	}
+
+	// MemScheduler is a centralized scheduler of many triggers. It stars all of
+	// them and schedules jobs accordingly.
+	MemScheduler struct {
+		broker  Broker
+		storage TriggerStorage
+
+		ts map[string]Trigger
+		mu sync.RWMutex
 	}
 
 	// MemJob struct contains all the parameters of a job.
@@ -135,6 +150,14 @@ func NewMemBroker(domain string, ws WorkersList) Broker {
 	return b
 }
 
+// GetMemBroker returns the in-memory broker associated with the specified
+// domain.
+func GetMemBroker(domain string) Broker {
+	memBrokersMu.RLock()
+	defer memBrokersMu.RUnlock()
+	return memBrokers[domain]
+}
+
 // Domain returns the broker's domain
 func (b *MemBroker) Domain() string {
 	return b.domain
@@ -186,7 +209,7 @@ func (j *MemJob) AckConsumed() error {
 	job.State = Running
 	j.infos = &job
 	j.infmu.Unlock()
-	return j.asyncSend(job, false)
+	return j.asyncSend(&job, false)
 }
 
 // Ack sets the job infos state to Done an sends the new job infos on the
@@ -197,7 +220,7 @@ func (j *MemJob) Ack() error {
 	job.State = Done
 	j.infos = &job
 	j.infmu.Unlock()
-	return j.asyncSend(job, true)
+	return j.asyncSend(&job, true)
 }
 
 // Nack sets the job infos state to Errored, set the specified error has the
@@ -209,12 +232,12 @@ func (j *MemJob) Nack(err error) error {
 	job.Error = err
 	j.infos = &job
 	j.infmu.Unlock()
-	return j.asyncSend(job, true)
+	return j.asyncSend(&job, true)
 }
 
-func (j *MemJob) asyncSend(job JobInfos, closed bool) error {
+func (j *MemJob) asyncSend(job *JobInfos, closed bool) error {
 	select {
-	case j.jobch <- &job:
+	case j.jobch <- job:
 	default:
 	}
 	if closed {
@@ -233,8 +256,115 @@ func (j *MemJob) Unmarshal() error {
 	return errors.New("should not be unmarshaled")
 }
 
+// NewMemScheduler creates a new in-memory scheduler that will load all
+// registered triggers and schedule their work.
+func NewMemScheduler(domain string, storage TriggerStorage) *MemScheduler {
+	memSchedulersMu.Lock()
+	defer memSchedulersMu.Unlock()
+	if memSchedulers == nil {
+		memSchedulers = make(map[string]*MemScheduler)
+	}
+	s := &MemScheduler{
+		storage: storage,
+		ts:      make(map[string]Trigger),
+	}
+	memSchedulers[domain] = s
+	return s
+}
+
+// GetMemScheduler returns the in-memory scheduler associated with the
+// specified domain.
+func GetMemScheduler(domain string) Scheduler {
+	memSchedulersMu.Lock()
+	defer memSchedulersMu.Unlock()
+	return memSchedulers[domain]
+}
+
+// Start will start the scheduler by actually loading all triggers from the
+// scheduler's storage and associate for each of them a go routine in which
+// they wait for the trigger send job requests.
+func (s *MemScheduler) Start(b Broker) error {
+	ts, err := s.storage.GetAll()
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.broker = b
+	for _, t := range ts {
+		s.ts[t.Infos().ID] = t
+		go s.schedule(t)
+	}
+	s.mu.Unlock()
+	return nil
+}
+
+// Add will add a new trigger to the scheduler. The trigger is persisted in
+// storage.
+func (s *MemScheduler) Add(t Trigger) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.storage.Add(t); err != nil {
+		return err
+	}
+	s.ts[t.Infos().ID] = t
+	go s.schedule(t)
+	return nil
+}
+
+// Get returns the trigger with the specified ID.
+func (s *MemScheduler) Get(id string) (Trigger, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	t, ok := s.ts[id]
+	if !ok {
+		return nil, errors.New("Trigger with specified ID does not exist")
+	}
+	return t, nil
+}
+
+// Delete removes the trigger with the specified ID. The trigger is unscheduled
+// and remove from the storage.
+func (s *MemScheduler) Delete(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	t, ok := s.ts[id]
+	if !ok {
+		return errors.New("Trigger with specified ID does not exist")
+	}
+	if err := s.storage.Delete(t); err != nil {
+		return err
+	}
+	delete(s.ts, id)
+	t.Unschedule()
+	return nil
+}
+
+// GetAll returns all the running in-memory triggers.
+func (s *MemScheduler) GetAll() ([]Trigger, error) {
+	v := make([]Trigger, 0, len(s.ts))
+	for _, t := range s.ts {
+		v = append(v, t)
+	}
+	return v, nil
+}
+
+func (s *MemScheduler) schedule(t Trigger) {
+	log.Debugf("[trigger] %s: Starting trigger with ID %s", t.Type(), t.Infos().ID)
+	for req := range t.Schedule() {
+		log.Debugf("[trigger] %s: Pushing new job", t.Type())
+		if _, _, err := s.broker.PushJob(req); err != nil {
+			log.Errorf("[trigger] %s: Could not schedule a new job %s: %s", t.Type(), t.Infos().ID, err.Error())
+		}
+	}
+	log.Debugf("[trigger] %s: Closing trigger with ID %s", t.Type(), t.Infos().ID)
+	if err := s.Delete(t.Infos().ID); err != nil {
+		log.Errorf("[trigger] %s: Could not delete trigger with ID: %s", t.Infos().ID, err.Error())
+	}
+}
+
 var (
-	_ Queue  = &MemQueue{}
-	_ Broker = &MemBroker{}
-	_ Job    = &MemJob{}
+	_ Queue     = &MemQueue{}
+	_ Broker    = &MemBroker{}
+	_ Job       = &MemJob{}
+	_ Scheduler = &MemScheduler{}
 )

--- a/pkg/jobs/mem_jobs.go
+++ b/pkg/jobs/mem_jobs.go
@@ -317,7 +317,7 @@ func (s *MemScheduler) Get(id string) (Trigger, error) {
 	defer s.mu.RUnlock()
 	t, ok := s.ts[id]
 	if !ok {
-		return nil, errors.New("Trigger with specified ID does not exist")
+		return nil, ErrNotFoundTrigger
 	}
 	return t, nil
 }
@@ -329,7 +329,7 @@ func (s *MemScheduler) Delete(id string) error {
 	defer s.mu.Unlock()
 	t, ok := s.ts[id]
 	if !ok {
-		return errors.New("Trigger with specified ID does not exist")
+		return ErrNotFoundTrigger
 	}
 	if err := s.storage.Delete(t); err != nil {
 		return err

--- a/pkg/jobs/mem_storage.go
+++ b/pkg/jobs/mem_storage.go
@@ -38,7 +38,7 @@ func (s *CouchStorage) GetAll() ([]Trigger, error) {
 	var ts []Trigger
 	// TODO(pagination): use a sort of couchdb.WalkDocs function when available.
 	req := &couchdb.AllDocsRequest{Limit: 100}
-	if err := couchdb.GetAllDocs(s.db, consts.Triggers, req, infos); err != nil {
+	if err := couchdb.GetAllDocs(s.db, consts.Triggers, req, &infos); err != nil {
 		if couchdb.IsNoDatabaseError(err) {
 			return ts, nil
 		}

--- a/pkg/jobs/mem_storage.go
+++ b/pkg/jobs/mem_storage.go
@@ -1,0 +1,66 @@
+package jobs
+
+import (
+	"encoding/json"
+
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+)
+
+type triggerDoc struct {
+	t Trigger
+}
+
+func (t triggerDoc) ID() string        { return t.t.Infos().ID }
+func (t triggerDoc) Rev() string       { return t.t.Infos().Rev }
+func (t triggerDoc) DocType() string   { return consts.Triggers }
+func (t triggerDoc) SetID(id string)   { t.t.Infos().ID = id }
+func (t triggerDoc) SetRev(rev string) { t.t.Infos().Rev = rev }
+func (t triggerDoc) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.t.Infos())
+}
+
+// CouchStorage implements the TriggerStorage interface and uses CouchDB as the
+// underlying storage for triggers.
+type CouchStorage struct {
+	db couchdb.Database
+}
+
+// NewTriggerCouchStorage returns a new instance of CouchStorage using the
+// specified database.
+func NewTriggerCouchStorage(db couchdb.Database) *CouchStorage {
+	return &CouchStorage{db}
+}
+
+// GetAll implements the GetAll method of the TriggerStorage.
+func (s *CouchStorage) GetAll() ([]Trigger, error) {
+	var infos []*TriggerInfos
+	var ts []Trigger
+	// TODO(pagination): use a sort of couchdb.WalkDocs function when available.
+	req := &couchdb.AllDocsRequest{Limit: 100}
+	if err := couchdb.GetAllDocs(s.db, consts.Triggers, req, infos); err != nil {
+		if couchdb.IsNoDatabaseError(err) {
+			return ts, nil
+		}
+		return nil, err
+	}
+	ts = make([]Trigger, 0, len(infos))
+	for _, info := range infos {
+		t, err := NewTrigger(info)
+		if err != nil {
+			return nil, err
+		}
+		ts = append(ts, t)
+	}
+	return ts, nil
+}
+
+// Add implements the Add method of the TriggerStorage.
+func (s *CouchStorage) Add(trigger Trigger) error {
+	return couchdb.CreateDoc(s.db, &triggerDoc{trigger})
+}
+
+// Delete implements the Delete method of the TriggerStorage.
+func (s *CouchStorage) Delete(trigger Trigger) error {
+	return couchdb.DeleteDoc(s.db, &triggerDoc{trigger})
+}

--- a/pkg/jobs/trigger_at.go
+++ b/pkg/jobs/trigger_at.go
@@ -5,6 +5,7 @@ import "time"
 // AtTrigger implements the @at trigger type. It schedules a job at a specified
 // time in the future.
 type AtTrigger struct {
+	typ  string
 	at   time.Time
 	in   *TriggerInfos
 	done chan struct{}
@@ -12,21 +13,38 @@ type AtTrigger struct {
 
 // NewAtTrigger returns a new instance of AtTrigger given the specified
 // options.
-func NewAtTrigger(in *TriggerInfos) (*AtTrigger, error) {
-	at, err := time.Parse(time.RFC3339, in.Arguments)
+func NewAtTrigger(infos *TriggerInfos) (*AtTrigger, error) {
+	at, err := time.Parse(time.RFC3339, infos.Arguments)
 	if err != nil {
 		return nil, err
 	}
 	return &AtTrigger{
+		typ:  "@at",
 		at:   at,
-		in:   in,
+		in:   infos,
+		done: make(chan struct{}),
+	}, nil
+}
+
+// NewInTrigger returns a new instance of InTrigger given the specified
+// options.
+func NewInTrigger(infos *TriggerInfos) (*AtTrigger, error) {
+	d, err := time.ParseDuration(infos.Arguments)
+	if err != nil {
+		return nil, err
+	}
+	at := time.Now().Add(d)
+	return &AtTrigger{
+		typ:  "@in",
+		at:   at,
+		in:   infos,
 		done: make(chan struct{}),
 	}, nil
 }
 
 // Type implements the Type method of the Trigger interface.
 func (a *AtTrigger) Type() string {
-	return "@at"
+	return a.typ
 }
 
 // Schedule implements the Schedule method of the Trigger interface.

--- a/pkg/jobs/trigger_at.go
+++ b/pkg/jobs/trigger_at.go
@@ -1,0 +1,67 @@
+package jobs
+
+import "time"
+
+// AtTrigger implements the @at trigger type. It schedules a job at a specified
+// time in the future.
+type AtTrigger struct {
+	at   time.Time
+	in   *TriggerInfos
+	done chan struct{}
+}
+
+// NewAtTrigger returns a new instance of AtTrigger given the specified
+// options.
+func NewAtTrigger(in *TriggerInfos) (*AtTrigger, error) {
+	at, err := time.Parse(time.RFC3339, in.Arguments)
+	if err != nil {
+		return nil, err
+	}
+	return &AtTrigger{
+		at:   at,
+		in:   in,
+		done: make(chan struct{}),
+	}, nil
+}
+
+// Type implements the Type method of the Trigger interface.
+func (a *AtTrigger) Type() string {
+	return "@at"
+}
+
+// Schedule implements the Schedule method of the Trigger interface.
+func (a *AtTrigger) Schedule() <-chan *JobRequest {
+	ch := make(chan *JobRequest)
+	at := a.at
+	duration := time.Since(at)
+	if duration >= 0 {
+		close(ch)
+		return ch
+	}
+	go func() {
+		select {
+		case <-time.After(-duration):
+			req := &JobRequest{
+				WorkerType: a.in.WorkerType,
+				Message:    a.in.Message,
+				Options:    a.in.Options,
+			}
+			ch <- req
+			close(ch)
+		case <-a.done:
+		}
+	}()
+	return ch
+}
+
+// Unschedule implements the Unschedule method of the Trigger interface.
+func (a *AtTrigger) Unschedule() {
+	close(a.done)
+}
+
+// Infos implements the Infos method of the Trigger interface.
+func (a *AtTrigger) Infos() *TriggerInfos {
+	return a.in
+}
+
+var _ Trigger = &AtTrigger{}

--- a/pkg/jobs/trigger_at.go
+++ b/pkg/jobs/trigger_at.go
@@ -1,6 +1,10 @@
 package jobs
 
-import "time"
+import (
+	"time"
+
+	"github.com/cozy/cozy-stack/web/jsonapi"
+)
 
 // AtTrigger implements the @at trigger type. It schedules a job at a specified
 // time in the future.
@@ -16,7 +20,7 @@ type AtTrigger struct {
 func NewAtTrigger(infos *TriggerInfos) (*AtTrigger, error) {
 	at, err := time.Parse(time.RFC3339, infos.Arguments)
 	if err != nil {
-		return nil, err
+		return nil, jsonapi.BadRequest(err)
 	}
 	return &AtTrigger{
 		typ:  "@at",
@@ -31,7 +35,7 @@ func NewAtTrigger(infos *TriggerInfos) (*AtTrigger, error) {
 func NewInTrigger(infos *TriggerInfos) (*AtTrigger, error) {
 	d, err := time.ParseDuration(infos.Arguments)
 	if err != nil {
-		return nil, err
+		return nil, jsonapi.BadRequest(err)
 	}
 	at := time.Now().Add(d)
 	return &AtTrigger{

--- a/pkg/jobs/trigger_interval.go
+++ b/pkg/jobs/trigger_interval.go
@@ -1,0 +1,67 @@
+package jobs
+
+import (
+	"errors"
+	"time"
+)
+
+// IntervalTrigger implements the @interval trigger. It triggers a job on a
+// fixed period of time.
+type IntervalTrigger struct {
+	du   time.Duration
+	in   *TriggerInfos
+	done chan struct{}
+}
+
+// NewIntervalTrigger returns a new instace of IntervalTriven given the
+// specified options.
+func NewIntervalTrigger(infos *TriggerInfos) (*IntervalTrigger, error) {
+	d, err := time.ParseDuration(infos.Arguments)
+	if err != nil {
+		return nil, err
+	}
+	if d < 1*time.Second {
+		return nil, errors.New("Invalid interval duration")
+	}
+	return &IntervalTrigger{
+		du:   d,
+		in:   infos,
+		done: make(chan struct{}),
+	}, nil
+}
+
+// Type implements the Type method of the Trigger interface.
+func (i *IntervalTrigger) Type() string {
+	return "@interval"
+}
+
+// Schedule implements the Schedule method of the Trigger interface.
+func (i *IntervalTrigger) Schedule() <-chan *JobRequest {
+	ch := make(chan *JobRequest)
+	go func() {
+		for {
+			select {
+			case <-time.After(i.du):
+				ch <- &JobRequest{
+					WorkerType: i.in.WorkerType,
+					Message:    i.in.Message,
+					Options:    i.in.Options,
+				}
+			case <-i.done:
+			}
+		}
+	}()
+	return ch
+}
+
+// Unschedule implements the Unschedule method of the Trigger interface.
+func (i *IntervalTrigger) Unschedule() {
+	close(i.done)
+}
+
+// Infos implements the Infos method of the Trigger interface.
+func (i *IntervalTrigger) Infos() *TriggerInfos {
+	return i.in
+}
+
+var _ Trigger = &IntervalTrigger{}

--- a/pkg/jobs/trigger_interval.go
+++ b/pkg/jobs/trigger_interval.go
@@ -3,6 +3,8 @@ package jobs
 import (
 	"errors"
 	"time"
+
+	"github.com/cozy/cozy-stack/web/jsonapi"
 )
 
 // IntervalTrigger implements the @interval trigger. It triggers a job on a
@@ -18,10 +20,10 @@ type IntervalTrigger struct {
 func NewIntervalTrigger(infos *TriggerInfos) (*IntervalTrigger, error) {
 	d, err := time.ParseDuration(infos.Arguments)
 	if err != nil {
-		return nil, err
+		return nil, jsonapi.BadRequest(err)
 	}
 	if d < 1*time.Second {
-		return nil, errors.New("Invalid interval duration")
+		return nil, jsonapi.BadRequest(errors.New("Invalid interval duration"))
 	}
 	return &IntervalTrigger{
 		du:   d,

--- a/pkg/jobs/workers/mail.go
+++ b/pkg/jobs/workers/mail.go
@@ -36,7 +36,7 @@ type MailOptions struct {
 	Subject string                `json:"subject"`
 	Dialer  *gomail.DialerOptions `json:"dialer,omitempty"`
 	Date    *time.Time            `json:"date"`
-	Parts   []*MailPart
+	Parts   []*MailPart           `json:"parts"`
 }
 
 // MailPart represent a part of the content of the mail. It has a type

--- a/web/jobs/jobs.go
+++ b/web/jobs/jobs.go
@@ -149,11 +149,21 @@ func getTrigger(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	return jsonapi.Data(c, http.StatusCreated, &apiTrigger{t}, nil)
+	return jsonapi.Data(c, http.StatusOK, &apiTrigger{t}, nil)
 }
 
 func getAllTriggers(c echo.Context) error {
-	return nil
+	instance := middlewares.GetInstance(c)
+	scheduler := instance.JobsScheduler()
+	ts, err := scheduler.GetAll()
+	if err != nil {
+		return err
+	}
+	objs := make([]jsonapi.Object, 0, len(ts))
+	for _, t := range ts {
+		objs = append(objs, &apiTrigger{t})
+	}
+	return jsonapi.DataList(c, http.StatusOK, objs, nil)
 }
 
 // Routes sets the routing for the jobs service

--- a/web/jobs/jobs.go
+++ b/web/jobs/jobs.go
@@ -219,6 +219,10 @@ func wrapJobsError(err error) error {
 	switch err {
 	case jobs.ErrUnknownWorker:
 		return jsonapi.NotFound(err)
+	case jobs.ErrNotFoundTrigger:
+		return jsonapi.NotFound(err)
+	case jobs.ErrUnknownTrigger:
+		return jsonapi.InvalidAttribute("Type", err)
 	}
 	return err
 }

--- a/web/jobs/jobs.go
+++ b/web/jobs/jobs.go
@@ -171,10 +171,7 @@ func getTrigger(c echo.Context) error {
 func deleteTrigger(c echo.Context) error {
 	instance := middlewares.GetInstance(c)
 	scheduler := instance.JobsScheduler()
-	if err := scheduler.Delete(c.Param("trigger-id")); err != nil {
-		return err
-	}
-	return nil
+	return scheduler.Delete(c.Param("trigger-id"))
 }
 
 func getAllTriggers(c echo.Context) error {

--- a/web/jobs/jobs.go
+++ b/web/jobs/jobs.go
@@ -83,7 +83,7 @@ func getQueue(c echo.Context) error {
 	workerType := c.Param("worker-type")
 	count, err := instance.JobsBroker().QueueLen(workerType)
 	if err != nil {
-		return err
+		return wrapJobsError(err)
 	}
 	o := &apiQueue{
 		workerType: workerType,
@@ -97,7 +97,7 @@ func pushJob(c echo.Context) error {
 
 	req := &apiJobRequest{}
 	if err := c.Bind(&req); err != nil {
-		return err
+		return wrapJobsError(err)
 	}
 
 	job, ch, err := instance.JobsBroker().PushJob(&jobs.JobRequest{
@@ -136,7 +136,7 @@ func newTrigger(c echo.Context) error {
 	scheduler := instance.JobsScheduler()
 	req := &apiTriggerRequest{}
 	if err := c.Bind(&req); err != nil {
-		return err
+		return wrapJobsError(err)
 	}
 
 	t, err := jobs.NewTrigger(&jobs.TriggerInfos{
@@ -150,10 +150,10 @@ func newTrigger(c echo.Context) error {
 		},
 	})
 	if err != nil {
-		return err
+		return wrapJobsError(err)
 	}
 	if err = scheduler.Add(t); err != nil {
-		return err
+		return wrapJobsError(err)
 	}
 	return jsonapi.Data(c, http.StatusCreated, &apiTrigger{t}, nil)
 }
@@ -163,7 +163,7 @@ func getTrigger(c echo.Context) error {
 	scheduler := instance.JobsScheduler()
 	t, err := scheduler.Get(c.Param("trigger-id"))
 	if err != nil {
-		return err
+		return wrapJobsError(err)
 	}
 	return jsonapi.Data(c, http.StatusOK, &apiTrigger{t}, nil)
 }
@@ -171,7 +171,7 @@ func getTrigger(c echo.Context) error {
 func deleteTrigger(c echo.Context) error {
 	instance := middlewares.GetInstance(c)
 	scheduler := instance.JobsScheduler()
-	return scheduler.Delete(c.Param("trigger-id"))
+	return wrapJobsError(scheduler.Delete(c.Param("trigger-id")))
 }
 
 func getAllTriggers(c echo.Context) error {
@@ -179,7 +179,7 @@ func getAllTriggers(c echo.Context) error {
 	scheduler := instance.JobsScheduler()
 	ts, err := scheduler.GetAll()
 	if err != nil {
-		return err
+		return wrapJobsError(err)
 	}
 	objs := make([]jsonapi.Object, 0, len(ts))
 	for _, t := range ts {

--- a/web/jobs/jobs.go
+++ b/web/jobs/jobs.go
@@ -168,6 +168,15 @@ func getTrigger(c echo.Context) error {
 	return jsonapi.Data(c, http.StatusOK, &apiTrigger{t}, nil)
 }
 
+func deleteTrigger(c echo.Context) error {
+	instance := middlewares.GetInstance(c)
+	scheduler := instance.JobsScheduler()
+	if err := scheduler.Delete(c.Param("trigger-id")); err != nil {
+		return err
+	}
+	return nil
+}
+
 func getAllTriggers(c echo.Context) error {
 	instance := middlewares.GetInstance(c)
 	scheduler := instance.JobsScheduler()
@@ -187,9 +196,10 @@ func Routes(router *echo.Group) {
 	router.POST("/queue/:worker-type", pushJob)
 	router.GET("/queue/:worker-type", getQueue)
 
-	router.POST("/triggers/:worker-type", newTrigger)
+	router.GET("/triggers", getAllTriggers)
+	router.POST("/triggers", newTrigger)
 	router.GET("/triggers/:trigger-id", getTrigger)
-	router.GET("/triggers/", getAllTriggers)
+	router.DELETE("/triggers/:trigger-id", deleteTrigger)
 }
 
 func streamJob(job *jobs.JobInfos, w http.ResponseWriter) error {

--- a/web/jobs/jobs_test.go
+++ b/web/jobs/jobs_test.go
@@ -10,8 +10,10 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/cozy/cozy-stack/pkg/config"
+	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/pkg/jobs"
 	"github.com/cozy/cozy-stack/web/errors"
@@ -89,6 +91,195 @@ func TestCreateJobWithEventStream(t *testing.T) {
 	assert.Equal(t, i, len(events))
 }
 
+func TestAddGetAndDeleteTriggerAt(t *testing.T) {
+	at := time.Now().Add(1 * time.Second).Format(time.RFC3339)
+	body, _ := json.Marshal(map[string]interface{}{
+		"type":             "@at",
+		"arguments":        at,
+		"worker":           "print",
+		"worker_arguments": "foo",
+	})
+	res1, err := http.Post(ts.URL+"/jobs/triggers", "application/json", bytes.NewReader(body))
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer res1.Body.Close()
+	assert.Equal(t, http.StatusCreated, res1.StatusCode)
+
+	var v struct {
+		Data struct {
+			ID         string             `json:"id"`
+			Type       string             `json:"type"`
+			Attributes *jobs.TriggerInfos `json:"attributes"`
+		}
+	}
+	err = json.NewDecoder(res1.Body).Decode(&v)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	triggerID := v.Data.ID
+	assert.Equal(t, consts.Triggers, v.Data.Type)
+	assert.Equal(t, "@at", v.Data.Attributes.Type)
+	assert.Equal(t, at, v.Data.Attributes.Arguments)
+	assert.Equal(t, "print", v.Data.Attributes.WorkerType)
+
+	body, _ = json.Marshal(map[string]interface{}{
+		"type":             "@at",
+		"arguments":        "garbage",
+		"worker":           "print",
+		"worker_arguments": "foo",
+	})
+	res2, err := http.Post(ts.URL+"/jobs/triggers", "application/json", bytes.NewReader(body))
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, http.StatusBadRequest, res2.StatusCode)
+
+	res3, err := http.Get(ts.URL + "/jobs/triggers/" + triggerID)
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, http.StatusOK, res3.StatusCode)
+
+	req4, err := http.NewRequest("DELETE", ts.URL+"/jobs/triggers/"+triggerID, nil)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	res4, err := http.DefaultClient.Do(req4)
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, http.StatusOK, res4.StatusCode)
+
+	res5, err := http.Get(ts.URL + "/jobs/triggers/" + triggerID)
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, http.StatusNotFound, res5.StatusCode)
+}
+
+func TestAddGetAndDeleteTriggerIn(t *testing.T) {
+	body, _ := json.Marshal(map[string]interface{}{
+		"type":             "@in",
+		"arguments":        "1s",
+		"worker":           "print",
+		"worker_arguments": "foo",
+	})
+	res1, err := http.Post(ts.URL+"/jobs/triggers", "application/json", bytes.NewReader(body))
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer res1.Body.Close()
+	assert.Equal(t, http.StatusCreated, res1.StatusCode)
+
+	var v struct {
+		Data struct {
+			ID         string             `json:"id"`
+			Type       string             `json:"type"`
+			Attributes *jobs.TriggerInfos `json:"attributes"`
+		}
+	}
+	err = json.NewDecoder(res1.Body).Decode(&v)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	triggerID := v.Data.ID
+	assert.Equal(t, consts.Triggers, v.Data.Type)
+	assert.Equal(t, "@in", v.Data.Attributes.Type)
+	assert.Equal(t, "1s", v.Data.Attributes.Arguments)
+	assert.Equal(t, "print", v.Data.Attributes.WorkerType)
+
+	body, _ = json.Marshal(map[string]interface{}{
+		"type":             "@in",
+		"arguments":        "garbage",
+		"worker":           "print",
+		"worker_arguments": "foo",
+	})
+	res2, err := http.Post(ts.URL+"/jobs/triggers", "application/json", bytes.NewReader(body))
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, http.StatusBadRequest, res2.StatusCode)
+
+	res3, err := http.Get(ts.URL + "/jobs/triggers/" + triggerID)
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, http.StatusOK, res3.StatusCode)
+
+	req4, err := http.NewRequest("DELETE", ts.URL+"/jobs/triggers/"+triggerID, nil)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	res4, err := http.DefaultClient.Do(req4)
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, http.StatusOK, res4.StatusCode)
+
+	res5, err := http.Get(ts.URL + "/jobs/triggers/" + triggerID)
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, http.StatusNotFound, res5.StatusCode)
+}
+
+func TestGetAllJobs(t *testing.T) {
+	var v struct {
+		Data []struct {
+			ID         string             `json:"id"`
+			Type       string             `json:"type"`
+			Attributes *jobs.TriggerInfos `json:"attributes"`
+		}
+	}
+
+	res1, err := http.Get(ts.URL + "/jobs/triggers")
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, http.StatusOK, res1.StatusCode)
+
+	err = json.NewDecoder(res1.Body).Decode(&v)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Len(t, v.Data, 0)
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"type":             "@interval",
+		"arguments":        "1s",
+		"worker":           "print",
+		"worker_arguments": "foo",
+	})
+	_, err = http.Post(ts.URL+"/jobs/triggers", "application/json", bytes.NewReader(body))
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	res3, err := http.Get(ts.URL + "/jobs/triggers")
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, http.StatusOK, res3.StatusCode)
+
+	err = json.NewDecoder(res3.Body).Decode(&v)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	if assert.Len(t, v.Data, 1) {
+		assert.Equal(t, consts.Triggers, v.Data[0].Type)
+		assert.Equal(t, "@interval", v.Data[0].Attributes.Type)
+		assert.Equal(t, "1s", v.Data[0].Attributes.Arguments)
+		assert.Equal(t, "print", v.Data[0].Attributes.WorkerType)
+	}
+}
+
 func parseEventStream(r *bufio.Reader, evch chan *event) error {
 	defer close(evch)
 	var ev *event
@@ -135,6 +326,11 @@ func TestMain(m *testing.M) {
 	})
 	if err != nil {
 		fmt.Println("Could not create test instance.", err)
+		os.Exit(1)
+	}
+
+	if err = inst.StartJobSystem(); err != nil {
+		fmt.Println(err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Adds a in-memory scheduler system usable by self-hosted instances, with the necessary interface abstraction to foresee our job scheduler with distributed stacks.

The storage used as persistence of the triggers, with this in-mem scheduler, is CouchDB, using the `io.cozy.triggers` doctype. On startup, the jobs broker and jobs scheduler associated to each instance are started.

------

Todo: 
  - [x] Add tests