### PR TITLE
Commands app-token and oauth-token

### DIFF
--- a/cmd/instances.go
+++ b/cmd/instances.go
@@ -166,27 +166,43 @@ All data associated with this domain will be permanently lost.
 	},
 }
 
-var tokenInstanceCmd = &cobra.Command{
-	Use:   "token [domain] [slug]",
+var appTokenInstanceCmd = &cobra.Command{
+	Use:   "token-app [domain] [slug]",
 	Short: "Generate a new application token",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 2 {
 			return cmd.Help()
 		}
-		q := url.Values{
-			"Domain": {args[0]},
-			"Slug":   {args[1]},
-		}
-		res, err := clientRequest(instancesClient(), "GET", "/instances/token", q, nil)
+		token, err := tokenRequest(url.Values{
+			"Domain":   {args[0]},
+			"Subject":  {args[1]},
+			"Audience": {"app"},
+		})
 		if err != nil {
 			return err
 		}
-		defer res.Body.Close()
-		b, err := ioutil.ReadAll(res.Body)
+		_, err = fmt.Println(token)
+		return err
+	},
+}
+
+var oauthTokenInstanceCmd = &cobra.Command{
+	Use:   "token-oauth [domain] [clientid] [scopes]",
+	Short: "Generate a new OAuth access token",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 3 {
+			return cmd.Help()
+		}
+		token, err := tokenRequest(url.Values{
+			"Domain":   {args[0]},
+			"Subject":  {args[1]},
+			"Audience": {"access-token"},
+			"Scope":    {strings.Join(args[2:], " ")},
+		})
 		if err != nil {
 			return err
 		}
-		_, err = fmt.Println(string(b))
+		_, err = fmt.Println(token)
 		return err
 	},
 }
@@ -235,11 +251,25 @@ func instancesRequest(method, path string, q url.Values, body interface{}) (*ins
 	return doc.Data, nil
 }
 
+func tokenRequest(q url.Values) (string, error) {
+	res, err := clientRequest(instancesClient(), "GET", "/instances/token", q, nil)
+	if err != nil {
+		return "", err
+	}
+	defer res.Body.Close()
+	b, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(b), err
+}
+
 func init() {
 	instanceCmdGroup.AddCommand(addInstanceCmd)
 	instanceCmdGroup.AddCommand(lsInstanceCmd)
 	instanceCmdGroup.AddCommand(destroyInstanceCmd)
-	instanceCmdGroup.AddCommand(tokenInstanceCmd)
+	instanceCmdGroup.AddCommand(appTokenInstanceCmd)
+	instanceCmdGroup.AddCommand(oauthTokenInstanceCmd)
 	addInstanceCmd.Flags().StringVar(&flagLocale, "locale", instance.DefaultLocale, "Locale of the new cozy instance")
 	addInstanceCmd.Flags().StringVar(&flagTimezone, "tz", "", "The timezone for the user")
 	addInstanceCmd.Flags().StringVar(&flagEmail, "email", "", "The email of the owner")

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ import (
 
 func main() {
 	if err := cmd.RootCmd.Execute(); err != nil {
-		log.Errorf(err.Error())
+		log.Error(err.Error())
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Adds a generic endpoint `GET /instances/token` to generate different kinds of tokens together with two commands:

  - `cozy-stack instances token-app [domain] [slug]`
  - `cozy-stack instances token-oauth [domain] [clientid] [scopes]`