### PR TITLE
Add sharing creation

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -27,6 +27,11 @@ const (
 	// Doctypes doc type for doctype list
 	Doctypes = "io.cozy.doctypes"
 
+	// Sharings doc type for sharing descriptors
+	Sharings = "io.cozy.sharings"
+	// Recipients doc type for sharing recipients
+	Recipients = "io.cozy.recipients"
+
 	// OAuthClients doc type for OAuth2 clients
 	OAuthClients = "io.cozy.oauth.clients"
 	// OAuthAccessCodes doc type for OAuth2 access codes
@@ -52,4 +57,13 @@ const (
 	DiskUsageID = "io.cozy.settings.disk-usage"
 	// InstanceSettingsID is the id of settings document for the instance
 	InstanceSettingsID = "io.cozy.settings.instance"
+)
+
+const (
+	// OneShotSharing is a sharing with no continuous updates
+	OneShotSharing = "one-shot"
+	// MasterSlaveSharing is a sharing with unilateral continuous updates
+	MasterSlaveSharing = ""
+	// MasterMasterSharing is a sharing with bilateral continuous updates
+	MasterMasterSharing = ""
 )

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -27,7 +27,7 @@ const (
 	// Doctypes doc type for doctype list
 	Doctypes = "io.cozy.doctypes"
 
-	// Sharings doc type for sharing descriptors
+	// Sharings doc type for document and file sharing
 	Sharings = "io.cozy.sharings"
 	// Recipients doc type for sharing recipients
 	Recipients = "io.cozy.recipients"
@@ -63,7 +63,16 @@ const (
 	// OneShotSharing is a sharing with no continuous updates
 	OneShotSharing = "one-shot"
 	// MasterSlaveSharing is a sharing with unilateral continuous updates
-	MasterSlaveSharing = ""
+	MasterSlaveSharing = "master-slave"
 	// MasterMasterSharing is a sharing with bilateral continuous updates
-	MasterMasterSharing = ""
+	MasterMasterSharing = "master-master"
+)
+
+const (
+	// PendingStatus is the sharing pending status
+	PendingStatus = "pending"
+	// RefusedStatus is the sharing refused status
+	RefusedStatus = "refused"
+	// AcceptedStatus is the sharing accepted status
+	AcceptedStatus = "accepted"
 )

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -69,10 +69,10 @@ const (
 )
 
 const (
-	// PendingStatus is the sharing pending status
-	PendingStatus = "pending"
-	// RefusedStatus is the sharing refused status
-	RefusedStatus = "refused"
-	// AcceptedStatus is the sharing accepted status
-	AcceptedStatus = "accepted"
+	// PendingSharingStatus is the sharing pending status
+	PendingSharingStatus = "pending"
+	// RefusedSharingStatus is the sharing refused status
+	RefusedSharingStatus = "refused"
+	// AcceptedSharingStatus is the sharing accepted status
+	AcceptedSharingStatus = "accepted"
 )

--- a/pkg/sharings/errors.go
+++ b/pkg/sharings/errors.go
@@ -1,0 +1,44 @@
+package sharings
+
+import "errors"
+
+var (
+	// ErrBadSharingType is used when the given sharing type is not valid
+	ErrBadSharingType = errors.New("Invalid sharing type")
+
+	/*
+		// ErrParentDoesNotExist is used when the parent directory does not
+		// exist
+		ErrParentDoesNotExist = errors.New("Parent directory with given DirID does not exist")
+		// ErrForbiddenDocMove is used when trying to move a document in an
+		// illicit destination
+		ErrForbiddenDocMove = errors.New("Forbidden document move")
+		// ErrIllegalFilename is used when the given filename is not allowed
+		ErrIllegalFilename = errors.New("Invalid filename: empty or contains an illegal character")
+		// ErrIllegalTime is used when a time given (creation or
+		// modification) is not allowed
+		ErrIllegalTime = errors.New("Invalid time given")
+		// ErrInvalidHash is used when the given hash does not match the
+		// calculated one
+		ErrInvalidHash = errors.New("Invalid hash")
+		// ErrContentLengthMismatch is used when the content-length does not
+		// match the calculated one
+		ErrContentLengthMismatch = errors.New("Content length does not match")
+		// ErrConflict is used when the access to a file or directory is in
+		// conflict with another
+		ErrConflict = errors.New("Conflict access to same file or directory")
+		// ErrFileInTrash is used when the file is already in the trash
+		ErrFileInTrash = errors.New("File or directory is already in the trash")
+		// ErrFileNotInTrash is used when the file is not in the trash
+		ErrFileNotInTrash = errors.New("File or directory is not in the trash")
+		// ErrNonAbsolutePath is used when the given path is not absolute
+		// while it is required to be
+		ErrNonAbsolutePath = errors.New("Path should be abolute")
+		// ErrDirNotEmpty is used to inform that the directory is not
+		// empty
+		ErrDirNotEmpty = errors.New("Directory is not empty")
+		// ErrWrongCouchdbState is given when couchdb gives us an unexpected value
+		ErrWrongCouchdbState = errors.New("Wrong couchdb reduce value")
+	*/
+
+)

--- a/pkg/sharings/errors.go
+++ b/pkg/sharings/errors.go
@@ -5,40 +5,6 @@ import "errors"
 var (
 	// ErrBadSharingType is used when the given sharing type is not valid
 	ErrBadSharingType = errors.New("Invalid sharing type")
-
-	/*
-		// ErrParentDoesNotExist is used when the parent directory does not
-		// exist
-		ErrParentDoesNotExist = errors.New("Parent directory with given DirID does not exist")
-		// ErrForbiddenDocMove is used when trying to move a document in an
-		// illicit destination
-		ErrForbiddenDocMove = errors.New("Forbidden document move")
-		// ErrIllegalFilename is used when the given filename is not allowed
-		ErrIllegalFilename = errors.New("Invalid filename: empty or contains an illegal character")
-		// ErrIllegalTime is used when a time given (creation or
-		// modification) is not allowed
-		ErrIllegalTime = errors.New("Invalid time given")
-		// ErrInvalidHash is used when the given hash does not match the
-		// calculated one
-		ErrInvalidHash = errors.New("Invalid hash")
-		// ErrContentLengthMismatch is used when the content-length does not
-		// match the calculated one
-		ErrContentLengthMismatch = errors.New("Content length does not match")
-		// ErrConflict is used when the access to a file or directory is in
-		// conflict with another
-		ErrConflict = errors.New("Conflict access to same file or directory")
-		// ErrFileInTrash is used when the file is already in the trash
-		ErrFileInTrash = errors.New("File or directory is already in the trash")
-		// ErrFileNotInTrash is used when the file is not in the trash
-		ErrFileNotInTrash = errors.New("File or directory is not in the trash")
-		// ErrNonAbsolutePath is used when the given path is not absolute
-		// while it is required to be
-		ErrNonAbsolutePath = errors.New("Path should be abolute")
-		// ErrDirNotEmpty is used to inform that the directory is not
-		// empty
-		ErrDirNotEmpty = errors.New("Directory is not empty")
-		// ErrWrongCouchdbState is given when couchdb gives us an unexpected value
-		ErrWrongCouchdbState = errors.New("Wrong couchdb reduce value")
-	*/
-
+	//ErrRecipientDoesNotExist is used when the given recipient does not exist
+	ErrRecipientDoesNotExist = errors.New("Recipient with given ID does not exist")
 )

--- a/pkg/sharings/recipients.go
+++ b/pkg/sharings/recipients.go
@@ -10,7 +10,7 @@ import (
 type Recipient struct {
 	RID    string `json:"_id,omitempty"`
 	RRev   string `json:"_rev,omitempty"`
-	Mail   string `json:"mail"`
+	Email  string `json:"email"`
 	URL    string `json:"url"`
 	Client *oauth.Client
 }

--- a/pkg/sharings/recipients.go
+++ b/pkg/sharings/recipients.go
@@ -2,6 +2,7 @@ package sharings
 
 import (
 	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/oauth"
 	"github.com/cozy/cozy-stack/web/jsonapi"
 )
@@ -40,3 +41,8 @@ func (r *Recipient) Included() []jsonapi.Object { return nil }
 func (r *Recipient) Links() *jsonapi.LinksList {
 	return &jsonapi.LinksList{Self: "/recipients/" + r.RID}
 }
+
+var (
+	_ couchdb.Doc    = &Recipient{}
+	_ jsonapi.Object = &Recipient{}
+)

--- a/pkg/sharings/recipients.go
+++ b/pkg/sharings/recipients.go
@@ -1,15 +1,42 @@
 package sharings
 
-import "github.com/cozy/cozy-stack/pkg/oauth"
+import (
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/oauth"
+	"github.com/cozy/cozy-stack/web/jsonapi"
+)
 
 // Recipient is a struct describing a sharing recipient
 type Recipient struct {
-	RID      string `json:"_id,omitempty"`
-	RRev     string `json:"_rev,omitempty"`
-	Mail     string `json:"mail"`
-	Url      string `json:"url"`
-	ClientID oauth.Client
+	RID    string `json:"_id,omitempty"`
+	RRev   string `json:"_rev,omitempty"`
+	Mail   string `json:"mail"`
+	URL    string `json:"url"`
+	Client *oauth.Client
 }
 
-// Recipients is a set of recipient
-type Recipients []Recipient
+// ID returns the recipient qualified identifier
+func (r *Recipient) ID() string { return r.RID }
+
+// Rev returns the recipient revision
+func (r *Recipient) Rev() string { return r.RRev }
+
+// DocType returns the recipient document type
+func (r *Recipient) DocType() string { return consts.Recipients }
+
+// SetID changes the recipient qualified identifier
+func (r *Recipient) SetID(id string) { r.RID = id }
+
+// SetRev changes the recipient revision
+func (r *Recipient) SetRev(rev string) { r.RRev = rev }
+
+// Relationships implements jsonapi.Doc
+func (r *Recipient) Relationships() jsonapi.RelationshipMap { return nil }
+
+// Included implements jsonapi.Doc
+func (r *Recipient) Included() []jsonapi.Object { return nil }
+
+// Links implements jsonapi.Doc
+func (r *Recipient) Links() *jsonapi.LinksList {
+	return &jsonapi.LinksList{Self: "/recipients/" + r.RID}
+}

--- a/pkg/sharings/recipients.go
+++ b/pkg/sharings/recipients.go
@@ -1,0 +1,15 @@
+package sharings
+
+import "github.com/cozy/cozy-stack/pkg/oauth"
+
+// Recipient is a struct describing a sharing recipient
+type Recipient struct {
+	RID      string `json:"_id,omitempty"`
+	RRev     string `json:"_rev,omitempty"`
+	Mail     string `json:"mail"`
+	Url      string `json:"url"`
+	ClientID oauth.Client
+}
+
+// Recipients is a set of recipient
+type Recipients []Recipient

--- a/pkg/sharings/sharings.go
+++ b/pkg/sharings/sharings.go
@@ -25,8 +25,8 @@ type Sharing struct {
 // SharingRecipient contains the information about a recipient for a sharing
 type SharingRecipient struct {
 	Status       string `json:"status,omitempty"`
-	AccessToken  string `json:"status,omitempty"`
-	RefreshToken string `json:"status,omitempty"`
+	AccessToken  string `json:"access_token,omitempty"`
+	RefreshToken string `json:"refresh_token,omitempty"`
 
 	RefRecipient jsonapi.ResourceIdentifier `json:"recipient,omitempty"`
 
@@ -133,10 +133,7 @@ func CheckSharingCreation(db couchdb.Database, sharing *Sharing) error {
 // Create inserts a Sharing document in database
 func Create(db couchdb.Database, doc *Sharing) error {
 	err := couchdb.CreateDoc(db, doc)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 var (

--- a/pkg/sharings/sharings.go
+++ b/pkg/sharings/sharings.go
@@ -1,25 +1,36 @@
 package sharings
 
 import (
-	"fmt"
-
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/permissions"
+	"github.com/cozy/cozy-stack/pkg/utils"
 	"github.com/cozy/cozy-stack/web/jsonapi"
 )
 
-// Sharing is a struct containing all the information about a sharing
+// Sharing contains all the information about a sharing
 type Sharing struct {
-	SID       string `json:"_id,omitempty"`
-	SRev      string `json:"_rev,omitempty"`
-	Type      string `json:"type"`
-	Owner     bool   `json:"owner,omitempty"`
-	Desc      string `json:"desc,omitempty"`
-	SharingID string `json:"sharing_id,omitempty"`
+	SID         string `json:"_id,omitempty"`
+	SRev        string `json:"_rev,omitempty"`
+	Type        string `json:"type,omitempty"`
+	Owner       bool   `json:"owner"`
+	Desc        string `json:"desc,omitempty"`
+	SharingID   string `json:"sharing_id,omitempty"`
+	SharingType string `json:"sharing_type"`
 
-	Permissions permissions.Set `json:"permissions,omitempty"`
-	Recipients  Recipients      `json:"recipients,omitempty"`
+	Permissions *permissions.Set    `json:"permissions,omitempty"`
+	SRecipients []*SharingRecipient `json:"recipients,omitempty"`
+}
+
+// SharingRecipient contains the information about a recipient for a sharing
+type SharingRecipient struct {
+	Status       string
+	AccessToken  string
+	RefreshToken string
+
+	RefRecipient jsonapi.ResourceIdentifier `json:"recipient,omitempty"`
+
+	recipient *Recipient
 }
 
 // ID returns the sharing qualified identifier
@@ -37,35 +48,93 @@ func (s *Sharing) SetID(id string) { s.SID = id }
 // SetRev changes the sharing revision
 func (s *Sharing) SetRev(rev string) { s.SRev = rev }
 
-// Relationships implements jsonapi.Doc
-func (s *Sharing) Relationships() jsonapi.RelationshipMap { return nil }
-
-// Included implements jsonapi.Doc
-func (s *Sharing) Included() []jsonapi.Object { return nil }
-
 // Links implements jsonapi.Doc
 func (s *Sharing) Links() *jsonapi.LinksList {
 	return &jsonapi.LinksList{Self: "/sharing/" + s.SID}
 }
 
-// Create creates a Sharing document
+// Recipients returns the sharing recipients
+func (s *Sharing) Recipients(db couchdb.Database) ([]*SharingRecipient, error) {
+	var sRecipients []*SharingRecipient
+
+	for _, sRec := range s.SRecipients {
+		recipient, err := GetRecipient(db, sRec.RefRecipient.ID)
+		if err != nil {
+			return nil, err
+		}
+		sRec.recipient = recipient
+		sRecipients = append(sRecipients, sRec)
+	}
+
+	s.SRecipients = sRecipients
+	return sRecipients, nil
+}
+
+// Relationships is part of the jsonapi.Object interface
+// It is used to generate the recipients relationships
+func (s *Sharing) Relationships() jsonapi.RelationshipMap {
+	l := len(s.SRecipients)
+	i := 0
+
+	data := make([]jsonapi.ResourceIdentifier, l)
+	for _, rec := range s.SRecipients {
+		r := rec.recipient
+		data[i] = jsonapi.ResourceIdentifier{ID: r.ID(), Type: r.DocType()}
+		i++
+	}
+	contents := jsonapi.Relationship{Data: data}
+	return jsonapi.RelationshipMap{"recipients": contents}
+}
+
+// Included is part of the jsonapi.Object interface
+func (s *Sharing) Included() []jsonapi.Object {
+	var included []jsonapi.Object
+	for _, rec := range s.SRecipients {
+		r := rec.recipient
+		included = append(included, r)
+	}
+	return included
+}
+
+// GetRecipient returns the Recipient stored in database from a given ID
+func GetRecipient(db couchdb.Database, recID string) (*Recipient, error) {
+	doc := &Recipient{}
+	err := couchdb.GetDoc(db, consts.Recipients, recID, doc)
+	if couchdb.IsNotFoundError(err) {
+		err = ErrRecipientDoesNotExist
+	}
+	return doc, err
+}
+
+// CheckSharingCreation initializes and check some sharing fields at creation
+func CheckSharingCreation(db couchdb.Database, sharing *Sharing) error {
+
+	sharingType := sharing.SharingType
+	if sharingType != consts.OneShotSharing &&
+		sharingType != consts.MasterSlaveSharing &&
+		sharingType != consts.MasterMasterSharing {
+		return ErrBadSharingType
+	}
+
+	sRecipients, err := sharing.Recipients(db)
+	if err != nil {
+		return err
+	}
+	for _, sRec := range sRecipients {
+		sRec.Status = consts.PendingStatus
+	}
+
+	sharing.Owner = true
+	sharing.SharingID = utils.RandomString(32)
+
+	return nil
+}
+
+// Create inserts a Sharing document in database
 func Create(db couchdb.Database, doc *Sharing) (*Sharing, error) {
-
-	fmt.Println("let's create doc")
-
-	/*doc := &Sharing{
-		SID:         sharingID,
-		Type:        sharingType,
-		Owner:       owner,
-		Desc:        desc,
-		Permissions: perm,
-		Recipients:  rec,
-	}*/
-
 	err := couchdb.CreateDoc(db, doc)
 	if err != nil {
 		return nil, err
 	}
-
 	return doc, nil
 }

--- a/pkg/sharings/sharings.go
+++ b/pkg/sharings/sharings.go
@@ -121,7 +121,7 @@ func CheckSharingCreation(db couchdb.Database, sharing *Sharing) error {
 		return err
 	}
 	for _, sRec := range sRecipients {
-		sRec.Status = consts.PendingStatus
+		sRec.Status = consts.PendingSharingStatus
 	}
 
 	sharing.Owner = true
@@ -131,10 +131,10 @@ func CheckSharingCreation(db couchdb.Database, sharing *Sharing) error {
 }
 
 // Create inserts a Sharing document in database
-func Create(db couchdb.Database, doc *Sharing) (*Sharing, error) {
+func Create(db couchdb.Database, doc *Sharing) error {
 	err := couchdb.CreateDoc(db, doc)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	return doc, nil
+	return nil
 }

--- a/pkg/sharings/sharings.go
+++ b/pkg/sharings/sharings.go
@@ -1,0 +1,71 @@
+package sharings
+
+import (
+	"fmt"
+
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/permissions"
+	"github.com/cozy/cozy-stack/web/jsonapi"
+)
+
+// Sharing is a struct containing all the information about a sharing
+type Sharing struct {
+	SID       string `json:"_id,omitempty"`
+	SRev      string `json:"_rev,omitempty"`
+	Type      string `json:"type"`
+	Owner     bool   `json:"owner,omitempty"`
+	Desc      string `json:"desc,omitempty"`
+	SharingID string `json:"sharing_id,omitempty"`
+
+	Permissions permissions.Set `json:"permissions,omitempty"`
+	Recipients  Recipients      `json:"recipients,omitempty"`
+}
+
+// ID returns the sharing qualified identifier
+func (s *Sharing) ID() string { return s.SID }
+
+// Rev returns the sharing revision
+func (s *Sharing) Rev() string { return s.SRev }
+
+// DocType returns the sharing document type
+func (s *Sharing) DocType() string { return consts.Sharings }
+
+// SetID changes the sharing qualified identifier
+func (s *Sharing) SetID(id string) { s.SID = id }
+
+// SetRev changes the sharing revision
+func (s *Sharing) SetRev(rev string) { s.SRev = rev }
+
+// Relationships implements jsonapi.Doc
+func (s *Sharing) Relationships() jsonapi.RelationshipMap { return nil }
+
+// Included implements jsonapi.Doc
+func (s *Sharing) Included() []jsonapi.Object { return nil }
+
+// Links implements jsonapi.Doc
+func (s *Sharing) Links() *jsonapi.LinksList {
+	return &jsonapi.LinksList{Self: "/sharing/" + s.SID}
+}
+
+// Create creates a Sharing document
+func Create(db couchdb.Database, doc *Sharing) (*Sharing, error) {
+
+	fmt.Println("let's create doc")
+
+	/*doc := &Sharing{
+		SID:         sharingID,
+		Type:        sharingType,
+		Owner:       owner,
+		Desc:        desc,
+		Permissions: perm,
+		Recipients:  rec,
+	}*/
+
+	err := couchdb.CreateDoc(db, doc)
+	if err != nil {
+		return nil, err
+	}
+
+	return doc, nil
+}

--- a/pkg/sharings/sharings.go
+++ b/pkg/sharings/sharings.go
@@ -138,3 +138,8 @@ func Create(db couchdb.Database, doc *Sharing) error {
 	}
 	return nil
 }
+
+var (
+	_ couchdb.Doc    = &Sharing{}
+	_ jsonapi.Object = &Sharing{}
+)

--- a/pkg/sharings/sharings.go
+++ b/pkg/sharings/sharings.go
@@ -24,9 +24,9 @@ type Sharing struct {
 
 // SharingRecipient contains the information about a recipient for a sharing
 type SharingRecipient struct {
-	Status       string
-	AccessToken  string
-	RefreshToken string
+	Status       string `json:"status,omitempty"`
+	AccessToken  string `json:"status,omitempty"`
+	RefreshToken string `json:"status,omitempty"`
 
 	RefRecipient jsonapi.ResourceIdentifier `json:"recipient,omitempty"`
 

--- a/pkg/sharings/sharings_test.go
+++ b/pkg/sharings/sharings_test.go
@@ -34,7 +34,7 @@ func TestCreate(t *testing.T) {
 	sharing := &Sharing{
 		SharingType: consts.OneShotSharing,
 	}
-	_, err := Create(TestPrefix, sharing)
+	err := Create(TestPrefix, sharing)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, sharing.ID())
 	assert.NotEmpty(t, sharing.Rev())
@@ -77,7 +77,7 @@ func TestCheckSharingCreation(t *testing.T) {
 
 	sRecipients := sharing.SRecipients
 	for _, sRec := range sRecipients {
-		assert.Equal(t, consts.PendingStatus, sRec.Status)
+		assert.Equal(t, consts.PendingSharingStatus, sRec.Status)
 	}
 }
 

--- a/pkg/sharings/sharings_test.go
+++ b/pkg/sharings/sharings_test.go
@@ -1,0 +1,102 @@
+package sharings
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cozy/checkup"
+	"github.com/cozy/cozy-stack/pkg/config"
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/web/jsonapi"
+	"github.com/stretchr/testify/assert"
+)
+
+var TestPrefix = couchdb.SimpleDatabasePrefix("couchdb-tests")
+
+func TestGetRecipient(t *testing.T) {
+	recipient := &Recipient{}
+
+	_, err := GetRecipient(TestPrefix, "maurice")
+	assert.Error(t, err)
+	assert.Equal(t, ErrRecipientDoesNotExist, err)
+
+	err = couchdb.CreateDoc(TestPrefix, recipient)
+	assert.NoError(t, err)
+
+	doc, err := GetRecipient(TestPrefix, recipient.RID)
+	assert.NoError(t, err)
+	assert.Equal(t, recipient, doc)
+}
+
+func TestCreate(t *testing.T) {
+	sharing := &Sharing{
+		SharingType: consts.OneShotSharing,
+	}
+	_, err := Create(TestPrefix, sharing)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, sharing.ID())
+	assert.NotEmpty(t, sharing.Rev())
+	assert.NotEmpty(t, sharing.DocType())
+}
+
+func TestCheckSharingCreation(t *testing.T) {
+
+	rec := &Recipient{
+		Email: "test@test.fr",
+	}
+
+	sRec := &SharingRecipient{
+		RefRecipient: jsonapi.ResourceIdentifier{
+			ID:   "123",
+			Type: consts.Recipients,
+		},
+	}
+
+	sharing := &Sharing{
+		SharingType: "shotmedown",
+		SRecipients: []*SharingRecipient{sRec},
+	}
+
+	err := CheckSharingCreation(TestPrefix, sharing)
+	assert.Error(t, err)
+
+	sharing.SharingType = consts.OneShotSharing
+	err = CheckSharingCreation(TestPrefix, sharing)
+	assert.Error(t, err)
+
+	err = couchdb.CreateDoc(TestPrefix, rec)
+	assert.NoError(t, err)
+
+	sRec.RefRecipient.ID = rec.RID
+	err = CheckSharingCreation(TestPrefix, sharing)
+	assert.NoError(t, err)
+	assert.Equal(t, true, sharing.Owner)
+	assert.NotEmpty(t, sharing.SharingID)
+
+	sRecipients := sharing.SRecipients
+	for _, sRec := range sRecipients {
+		assert.Equal(t, consts.PendingStatus, sRec.Status)
+	}
+}
+
+func TestMain(m *testing.M) {
+	config.UseTestFile()
+
+	db, err := checkup.HTTPChecker{URL: config.CouchURL()}.Check()
+	if err != nil || db.Status() != checkup.Healthy {
+		fmt.Println("This test need couchdb to run.")
+		os.Exit(1)
+	}
+
+	err = couchdb.ResetDB(TestPrefix, consts.Sharings)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	res := m.Run()
+	couchdb.DeleteDB(TestPrefix, consts.Sharings)
+	os.Exit(res)
+}

--- a/web/routing.go
+++ b/web/routing.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/cozy/cozy-stack/web/permissions"
 	"github.com/cozy/cozy-stack/web/settings"
+	"github.com/cozy/cozy-stack/web/sharings"
 	_ "github.com/cozy/cozy-stack/web/statik" // Generated file with the packed assets
 	"github.com/cozy/cozy-stack/web/status"
 	"github.com/cozy/cozy-stack/web/version"
@@ -148,6 +149,7 @@ func SetupRoutes(router *echo.Echo) error {
 	jobs.Routes(router.Group("/jobs", mws...))
 	permissions.Routes(router.Group("/permissions", mws...))
 	settings.Routes(router.Group("/settings", mws...))
+	sharings.Routes(router.Group("/sharings", mws...))
 	status.Routes(router.Group("/status"))
 	version.Routes(router.Group("/version"))
 

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -1,0 +1,74 @@
+package sharings
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/sharings"
+	"github.com/cozy/cozy-stack/web/jsonapi"
+	"github.com/cozy/cozy-stack/web/middlewares"
+	"github.com/labstack/echo"
+)
+
+// ErrDocTypeInvalid is used when the document type sent is not
+// recognized
+var ErrDocTypeInvalid = errors.New("Invalid document type")
+
+func checkStruct(c echo.Context) error {
+
+	doctype := c.Get("type")
+	if doctype != consts.OneShotSharing &&
+		doctype != consts.MasterSlaveSharing &&
+		doctype != consts.MasterMasterSharing {
+		return c.Render(http.StatusBadRequest, "error.html", echo.Map{
+			"Error": "Invalid document type",
+		})
+	}
+
+	/*
+		case consts.FileType:
+			doc, err = createFileHandler(c, instance)
+		case consts.DirType:
+			doc, err = createDirHandler(c, instance)
+		default:
+			err = ErrDocTypeInvalid
+		}
+	*/
+	return nil
+}
+
+// CreateSharing initializes a sharing by creating a document
+func CreateSharing(c echo.Context) error {
+	instance := middlewares.GetInstance(c)
+
+	//check parameters
+	//if err := checkStruct(c); err != nil {
+	//	return c.JSON(err.Code, err)
+	//}
+
+	// create document
+
+	sharing := new(sharings.Sharing)
+
+	if err := c.Bind(sharing); err != nil {
+		return err
+	}
+
+	doc, err := sharings.Create(instance, sharing)
+
+	if err != nil {
+		return err
+	}
+
+	// check each recipient and start oAuth dance
+
+	return jsonapi.Data(c, http.StatusAccepted, doc, nil)
+
+}
+
+// Routes sets the routing for the status service
+func Routes(router *echo.Group) {
+	// API Routes
+	router.POST("/", CreateSharing)
+}

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -1,73 +1,47 @@
 package sharings
 
 import (
-	"errors"
 	"net/http"
 
-	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/sharings"
 	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/labstack/echo"
 )
 
-// ErrDocTypeInvalid is used when the document type sent is not
-// recognized
-var ErrDocTypeInvalid = errors.New("Invalid document type")
-
-func checkStruct(c echo.Context) error {
-
-	doctype := c.Get("type")
-	if doctype != consts.OneShotSharing &&
-		doctype != consts.MasterSlaveSharing &&
-		doctype != consts.MasterMasterSharing {
-		return c.Render(http.StatusBadRequest, "error.html", echo.Map{
-			"Error": "Invalid document type",
-		})
-	}
-
-	/*
-		case consts.FileType:
-			doc, err = createFileHandler(c, instance)
-		case consts.DirType:
-			doc, err = createDirHandler(c, instance)
-		default:
-			err = ErrDocTypeInvalid
-		}
-	*/
-	return nil
-}
-
-// CreateSharing initializes a sharing by creating a document
+// CreateSharing initializes a sharing by creating the associated document
 func CreateSharing(c echo.Context) error {
 	instance := middlewares.GetInstance(c)
 
-	//check parameters
-	//if err := checkStruct(c); err != nil {
-	//	return c.JSON(err.Code, err)
-	//}
-
-	// create document
-
 	sharing := new(sharings.Sharing)
-
 	if err := c.Bind(sharing); err != nil {
 		return err
 	}
 
-	doc, err := sharings.Create(instance, sharing)
+	if err := sharings.CheckSharingCreation(instance, sharing); err != nil {
+		return wrapErrors(err)
+	}
 
+	doc, err := sharings.Create(instance, sharing)
 	if err != nil {
 		return err
 	}
 
-	// check each recipient and start oAuth dance
-
-	return jsonapi.Data(c, http.StatusAccepted, doc, nil)
-
+	return jsonapi.Data(c, http.StatusOK, doc, nil)
 }
 
-// Routes sets the routing for the status service
+// wrapErrors returns a formatted error
+func wrapErrors(err error) error {
+	switch err {
+	case sharings.ErrBadSharingType:
+		return jsonapi.InvalidParameter("sharing_type", err)
+	case sharings.ErrRecipientDoesNotExist:
+		return jsonapi.NotFound(err)
+	}
+	return err
+}
+
+// Routes sets the routing for the sharing service
 func Routes(router *echo.Group) {
 	// API Routes
 	router.POST("/", CreateSharing)

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -22,12 +22,12 @@ func CreateSharing(c echo.Context) error {
 		return wrapErrors(err)
 	}
 
-	doc, err := sharings.Create(instance, sharing)
+	err := sharings.Create(instance, sharing)
 	if err != nil {
 		return err
 	}
 
-	return jsonapi.Data(c, http.StatusCreated, doc, nil)
+	return jsonapi.Data(c, http.StatusCreated, sharing, nil)
 }
 
 // Routes sets the routing for the sharing service

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -27,7 +27,13 @@ func CreateSharing(c echo.Context) error {
 		return err
 	}
 
-	return jsonapi.Data(c, http.StatusOK, doc, nil)
+	return jsonapi.Data(c, http.StatusCreated, doc, nil)
+}
+
+// Routes sets the routing for the sharing service
+func Routes(router *echo.Group) {
+	// API Routes
+	router.POST("/", CreateSharing)
 }
 
 // wrapErrors returns a formatted error
@@ -39,10 +45,4 @@ func wrapErrors(err error) error {
 		return jsonapi.NotFound(err)
 	}
 	return err
-}
-
-// Routes sets the routing for the sharing service
-func Routes(router *echo.Group) {
-	// API Routes
-	router.POST("/", CreateSharing)
 }

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -19,7 +19,6 @@ import (
 )
 
 var ts *httptest.Server
-var client *http.Client
 var testInstance *instance.Instance
 
 func TestCreateSharingWithBadType(t *testing.T) {

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -1,0 +1,104 @@
+package sharings
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/cozy/checkup"
+	"github.com/cozy/cozy-stack/pkg/config"
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/instance"
+	"github.com/cozy/cozy-stack/web/errors"
+	"github.com/labstack/echo"
+	"github.com/stretchr/testify/assert"
+)
+
+var ts *httptest.Server
+var client *http.Client
+var testInstance *instance.Instance
+
+func TestCreateSharingWithBadType(t *testing.T) {
+	res, err := postJSON("/sharings/", echo.Map{
+		"sharing_type": "shary pie",
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 422, res.StatusCode)
+}
+
+func TestCreateSharingWithNonExistingRecipient(t *testing.T) {
+	type recipient map[string]map[string]string
+
+	rec := recipient{
+		"recipient": {
+			"id": "hodor",
+		},
+	}
+	recipients := []recipient{rec}
+
+	res, err := postJSON("/sharings/", echo.Map{
+		"sharing_type": consts.OneShotSharing,
+		"recipients":   recipients,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 404, res.StatusCode)
+}
+
+func TestCreateSharingSuccess(t *testing.T) {
+	res, err := postJSON("/sharings/", echo.Map{
+		"sharing_type": consts.OneShotSharing,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 201, res.StatusCode)
+}
+
+func TestMain(m *testing.M) {
+	config.UseTestFile()
+
+	db, err := checkup.HTTPChecker{URL: config.CouchURL()}.Check()
+	if err != nil || db.Status() != checkup.Healthy {
+		fmt.Println("This test needs couchdb to run.")
+		os.Exit(1)
+	}
+
+	instance.Destroy("test-sharings")
+	testInstance, err = instance.Create(&instance.Options{
+		Domain: "test-sharings",
+		Locale: "en",
+	})
+	if err != nil {
+		fmt.Println("Could not create test instance.", err)
+		os.Exit(1)
+	}
+
+	handler := echo.New()
+	handler.HTTPErrorHandler = errors.ErrorHandler
+	handler.Use(injectInstance(testInstance))
+	Routes(handler.Group("/sharings"))
+
+	ts = httptest.NewServer(handler)
+
+	res := m.Run()
+	ts.Close()
+	instance.Destroy("test-sharings")
+
+	os.Exit(res)
+}
+
+func postJSON(u string, v echo.Map) (*http.Response, error) {
+	body, _ := json.Marshal(v)
+	return http.Post(ts.URL+u, "application/json", bytes.NewReader(body))
+}
+
+func injectInstance(i *instance.Instance) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			c.Set("instance", i)
+			return next(c)
+		}
+	}
+}


### PR DESCRIPTION
This adds the possibility to create a new sharing through a `/sharings/` route.
A new sharing structure is defined, as well as a recipient structure and the link between them.
Some tests are added for the `web` and `pkg` part.

Note that no verification is done on the shared documents, I think it should be done in the permission part (check the documents exist, etc).