### PR TITLE
Sharing request

### DIFF
--- a/pkg/sharings/errors.go
+++ b/pkg/sharings/errors.go
@@ -7,4 +7,8 @@ var (
 	ErrBadSharingType = errors.New("Invalid sharing type")
 	//ErrRecipientDoesNotExist is used when the given recipient does not exist
 	ErrRecipientDoesNotExist = errors.New("Recipient with given ID does not exist")
+	//ErrMissingScope is used when a request is missing the mandatory scope
+	ErrMissingScope = errors.New("The scope parameter is mandatory")
+	//ErrMissingState is used when a request is missing the mandatory state
+	ErrMissingState = errors.New("The state parameter is mandatory")
 )

--- a/pkg/sharings/sharings.go
+++ b/pkg/sharings/sharings.go
@@ -119,14 +119,14 @@ func CheckSharingType(sharingType string) error {
 // CreateSharingRequest checks fields integrity and creates a sharing document
 // for an incoming sharing request
 func CreateSharingRequest(db couchdb.Database, state, sharingType, scope string) (*Sharing, error) {
-	if scope == "" {
-		return nil, ErrMissingScope
-	}
 	if state == "" {
 		return nil, ErrMissingState
 	}
 	if err := CheckSharingType(sharingType); err != nil {
 		return nil, err
+	}
+	if scope == "" {
+		return nil, ErrMissingScope
 	}
 	permissions, err := permissions.UnmarshalScopeString(scope)
 	if err != nil {

--- a/pkg/sharings/sharings.go
+++ b/pkg/sharings/sharings.go
@@ -118,7 +118,7 @@ func CheckSharingType(sharingType string) error {
 
 // CreateSharingRequest checks fields integrity and creates a sharing document
 // for an incoming sharing request
-func CreateSharingRequest(db couchdb.Database, state, sharingType, scope string) (*Sharing, error) {
+func CreateSharingRequest(db couchdb.Database, desc, state, sharingType, scope string) (*Sharing, error) {
 	if state == "" {
 		return nil, ErrMissingState
 	}
@@ -138,6 +138,7 @@ func CreateSharingRequest(db couchdb.Database, state, sharingType, scope string)
 		SharingID:   state,
 		Permissions: permissions,
 		Owner:       false,
+		Desc:        desc,
 	}
 
 	err = Create(db, sharing)

--- a/pkg/sharings/sharings.go
+++ b/pkg/sharings/sharings.go
@@ -108,12 +108,11 @@ func GetRecipient(db couchdb.Database, recID string) (*Recipient, error) {
 
 //CheckSharingType returns an error if the sharing type is incorrect
 func CheckSharingType(sharingType string) error {
-	if sharingType != consts.OneShotSharing &&
-		sharingType != consts.MasterSlaveSharing &&
-		sharingType != consts.MasterMasterSharing {
-		return ErrBadSharingType
+	switch sharingType {
+	case consts.OneShotSharing, consts.MasterSlaveSharing, consts.MasterMasterSharing:
+		return nil
 	}
-	return nil
+	return ErrBadSharingType
 }
 
 // CreateSharingRequest checks fields integrity and creates a sharing document

--- a/pkg/sharings/sharings_test.go
+++ b/pkg/sharings/sharings_test.go
@@ -44,15 +44,15 @@ func TestCheckSharingTypeSuccess(t *testing.T) {
 }
 
 func TestCreateSharingRequestBadParams(t *testing.T) {
-	_, err := CreateSharingRequest(TestPrefix, "", "", "")
+	_, err := CreateSharingRequest(TestPrefix, "", "", "", "")
 	assert.Error(t, err)
 
 	state := "1234"
-	_, err = CreateSharingRequest(TestPrefix, state, "", "")
+	_, err = CreateSharingRequest(TestPrefix, "", state, "", "")
 	assert.Error(t, err)
 
 	sharingType := consts.OneShotSharing
-	_, err = CreateSharingRequest(TestPrefix, state, sharingType, "")
+	_, err = CreateSharingRequest(TestPrefix, "", state, sharingType, "")
 	assert.Error(t, err)
 
 }
@@ -60,6 +60,7 @@ func TestCreateSharingRequestBadParams(t *testing.T) {
 func TestCreateSharingRequestSuccess(t *testing.T) {
 	state := "1234"
 	sharingType := consts.OneShotSharing
+	desc := "share cher"
 
 	rule := permissions.Rule{
 		Type:   "io.cozy.events",
@@ -71,7 +72,7 @@ func TestCreateSharingRequestSuccess(t *testing.T) {
 	scope, err := set.MarshalScopeString()
 	assert.NoError(t, err)
 
-	sharing, err := CreateSharingRequest(TestPrefix, state, sharingType, scope)
+	sharing, err := CreateSharingRequest(TestPrefix, desc, state, sharingType, scope)
 	assert.NoError(t, err)
 	assert.Equal(t, state, sharing.SharingID)
 	assert.Equal(t, sharingType, sharing.SharingType)

--- a/pkg/sharings/sharings_test.go
+++ b/pkg/sharings/sharings_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/permissions"
 	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/stretchr/testify/assert"
 )
@@ -30,7 +31,54 @@ func TestGetRecipient(t *testing.T) {
 	assert.Equal(t, recipient, doc)
 }
 
-func TestCreate(t *testing.T) {
+func TestCheckSharingTypeBadType(t *testing.T) {
+	sharingType := "mybad"
+	err := CheckSharingType(sharingType)
+	assert.Error(t, err)
+}
+
+func TestCheckSharingTypeSuccess(t *testing.T) {
+	sharingType := consts.OneShotSharing
+	err := CheckSharingType(sharingType)
+	assert.NoError(t, err)
+}
+
+func TestCreateSharingRequestBadParams(t *testing.T) {
+	_, err := CreateSharingRequest(TestPrefix, "", "", "")
+	assert.Error(t, err)
+
+	state := "1234"
+	_, err = CreateSharingRequest(TestPrefix, state, "", "")
+	assert.Error(t, err)
+
+	sharingType := consts.OneShotSharing
+	_, err = CreateSharingRequest(TestPrefix, state, sharingType, "")
+	assert.Error(t, err)
+
+}
+
+func TestCreateSharingRequestSuccess(t *testing.T) {
+	state := "1234"
+	sharingType := consts.OneShotSharing
+
+	rule := permissions.Rule{
+		Type:   "io.cozy.events",
+		Verbs:  permissions.Verbs(permissions.POST),
+		Values: []string{"1234"},
+	}
+
+	set := permissions.Set{rule}
+	scope, err := set.MarshalScopeString()
+	assert.NoError(t, err)
+
+	sharing, err := CreateSharingRequest(TestPrefix, state, sharingType, scope)
+	assert.NoError(t, err)
+	assert.Equal(t, state, sharing.SharingID)
+	assert.Equal(t, sharingType, sharing.SharingType)
+	assert.Equal(t, &set, sharing.Permissions)
+}
+
+func TestCreateSuccess(t *testing.T) {
 	sharing := &Sharing{
 		SharingType: consts.OneShotSharing,
 	}

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -1,13 +1,61 @@
 package sharings
 
 import (
+	"fmt"
 	"net/http"
 
+	"github.com/cozy/cozy-stack/pkg/permissions"
 	"github.com/cozy/cozy-stack/pkg/sharings"
 	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/labstack/echo"
 )
+
+// SharingRequest handles a sharing request from the recipient side
+// It creates a tempory sharing document, waiting for the recipient answer
+func SharingRequest(c echo.Context) error {
+	//Get the permissions and sharing id
+	scope := c.QueryParam("scope")
+	if scope == "" {
+		return wrapErrors(sharings.ErrMissingScope)
+	}
+	state := c.QueryParam("state")
+	if state == "" {
+		return wrapErrors(sharings.ErrMissingState)
+	}
+	sharingType := c.QueryParam("sharing_type")
+	//TODO : Check sharing type integrity
+	if sharingType == "" {
+		return wrapErrors(sharings.ErrBadSharingType)
+	}
+	fmt.Printf("scope : %v\n", scope)
+	permissions, err := permissions.UnmarshalScopeString(scope)
+	if err != nil {
+		fmt.Println("error...")
+		return err
+	}
+	fmt.Printf("perm : %+v", permissions)
+
+	sharing := &sharings.Sharing{
+		SharingType: sharingType,
+		SharingID:   state,
+		Permissions: permissions,
+		Owner:       false,
+	}
+
+	instance := middlewares.GetInstance(c)
+	_, err = sharings.Create(instance, sharing)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("state : %v", sharing.SharingID)
+
+	//TODO call the OAuth authorize to display the permissions
+	//TODO return the permission html
+
+	return jsonapi.Data(c, http.StatusCreated, sharing, nil)
+}
 
 // CreateSharing initializes a sharing by creating the associated document
 func CreateSharing(c echo.Context) error {
@@ -34,6 +82,7 @@ func CreateSharing(c echo.Context) error {
 func Routes(router *echo.Group) {
 	// API Routes
 	router.POST("/", CreateSharing)
+	router.GET("/request", SharingRequest)
 }
 
 // wrapErrors returns a formatted error
@@ -43,6 +92,10 @@ func wrapErrors(err error) error {
 		return jsonapi.InvalidParameter("sharing_type", err)
 	case sharings.ErrRecipientDoesNotExist:
 		return jsonapi.NotFound(err)
+	case sharings.ErrMissingScope:
+		return jsonapi.BadRequest(err)
+	case sharings.ErrMissingState:
+		return jsonapi.BadRequest(err)
 	}
 	return err
 }

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -1,10 +1,8 @@
 package sharings
 
 import (
-	"fmt"
 	"net/http"
 
-	"github.com/cozy/cozy-stack/pkg/permissions"
 	"github.com/cozy/cozy-stack/pkg/sharings"
 	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/cozy/cozy-stack/web/middlewares"
@@ -16,40 +14,15 @@ import (
 func SharingRequest(c echo.Context) error {
 	//Get the permissions and sharing id
 	scope := c.QueryParam("scope")
-	if scope == "" {
-		return wrapErrors(sharings.ErrMissingScope)
-	}
 	state := c.QueryParam("state")
-	if state == "" {
-		return wrapErrors(sharings.ErrMissingState)
-	}
 	sharingType := c.QueryParam("sharing_type")
-	//TODO : Check sharing type integrity
-	if sharingType == "" {
-		return wrapErrors(sharings.ErrBadSharingType)
-	}
-	fmt.Printf("scope : %v\n", scope)
-	permissions, err := permissions.UnmarshalScopeString(scope)
-	if err != nil {
-		fmt.Println("error...")
-		return err
-	}
-	fmt.Printf("perm : %+v", permissions)
-
-	sharing := &sharings.Sharing{
-		SharingType: sharingType,
-		SharingID:   state,
-		Permissions: permissions,
-		Owner:       false,
-	}
 
 	instance := middlewares.GetInstance(c)
-	_, err = sharings.Create(instance, sharing)
-	if err != nil {
-		return err
-	}
 
-	fmt.Printf("state : %v", sharing.SharingID)
+	sharing, err := sharings.CreateSharingRequest(instance, state, sharingType, scope)
+	if err != nil {
+		return wrapErrors(err)
+	}
 
 	//TODO call the OAuth authorize to display the permissions
 	//TODO return the permission html

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -12,7 +12,6 @@ import (
 // SharingRequest handles a sharing request from the recipient side
 // It creates a tempory sharing document, waiting for the recipient answer
 func SharingRequest(c echo.Context) error {
-	//Get the permissions and sharing id
 	scope := c.QueryParam("scope")
 	state := c.QueryParam("state")
 	sharingType := c.QueryParam("sharing_type")

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -15,16 +15,14 @@ func SharingRequest(c echo.Context) error {
 	scope := c.QueryParam("scope")
 	state := c.QueryParam("state")
 	sharingType := c.QueryParam("sharing_type")
+	desc := c.QueryParam("desc")
 
 	instance := middlewares.GetInstance(c)
 
-	sharing, err := sharings.CreateSharingRequest(instance, state, sharingType, scope)
+	sharing, err := sharings.CreateSharingRequest(instance, desc, state, sharingType, scope)
 	if err != nil {
 		return wrapErrors(err)
 	}
-
-	//TODO call the OAuth authorize to display the permissions
-	//TODO return the permission html
 
 	return jsonapi.Data(c, http.StatusCreated, sharing, nil)
 }

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -181,7 +181,6 @@ func postJSON(u string, v echo.Map) (*http.Response, error) {
 
 func requestGET(v url.Values, u string) (*http.Response, error) {
 	reqURL := v.Encode()
-	fmt.Printf("url : %v\n", reqURL)
 	return http.Get(ts.URL + u + "?" + reqURL)
 }
 

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -79,8 +79,10 @@ func TestSharingRequestSuccess(t *testing.T) {
 	assert.NoError(t, err)
 
 	state := "sharing_id"
+	desc := "share cher"
 
 	urlVal := url.Values{
+		"desc":         []string{desc},
 		"state":        []string{state},
 		"scope":        []string{scope},
 		"sharing_type": []string{consts.OneShotSharing},
@@ -100,6 +102,8 @@ func TestSharingRequestSuccess(t *testing.T) {
 	assert.Equal(t, consts.OneShotSharing, sharingType)
 	sharingID := attrs["sharing_id"].(string)
 	assert.Equal(t, state, sharingID)
+	description := attrs["desc"].(string)
+	assert.Equal(t, desc, description)
 
 }
 

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"testing"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/instance"
+	"github.com/cozy/cozy-stack/pkg/permissions"
 	"github.com/cozy/cozy-stack/web/errors"
 	"github.com/labstack/echo"
 	"github.com/stretchr/testify/assert"
@@ -20,6 +22,86 @@ import (
 
 var ts *httptest.Server
 var testInstance *instance.Instance
+
+type jsonData struct {
+	Type  string                 `json:"type"`
+	ID    string                 `json:"id"`
+	Attrs map[string]interface{} `json:"attributes,omitempty"`
+	Rels  map[string]interface{} `json:"relationships,omitempty"`
+}
+
+func TestSharingRequestNoScope(t *testing.T) {
+	urlVal := url.Values{}
+	res, err := requestGET(urlVal, "/sharings/request")
+	assert.NoError(t, err)
+	assert.Equal(t, 400, res.StatusCode)
+}
+
+func TestSharingRequestNoState(t *testing.T) {
+	urlVal := url.Values{}
+	urlVal["scope"] = []string{"dummyscope"}
+	res, err := requestGET(urlVal, "/sharings/request")
+	assert.NoError(t, err)
+	assert.Equal(t, 400, res.StatusCode)
+}
+
+func TestSharingRequestNoSharingType(t *testing.T) {
+	urlVal := url.Values{}
+	urlVal["scope"] = []string{"dummyscope"}
+	urlVal["state"] = []string{"dummystate"}
+	res, err := requestGET(urlVal, "/sharings/request")
+	assert.NoError(t, err)
+	assert.Equal(t, 422, res.StatusCode)
+}
+
+func TestSharingRequestBadScope(t *testing.T) {
+	urlVal := url.Values{}
+	urlVal["scope"] = []string{":"}
+	urlVal["state"] = []string{"dummystate"}
+	urlVal["sharing_type"] = []string{consts.OneShotSharing}
+
+	_, err := requestGET(urlVal, "/sharings/request")
+	assert.NoError(t, err)
+	//assert.Equal(t, 422, res.StatusCode)
+
+}
+
+func TestSharingRequestSuccess(t *testing.T) {
+	rule := permissions.Rule{
+		Type:        "io.cozy.events",
+		Title:       "event",
+		Description: "My event",
+		Verbs:       permissions.VerbSet{permissions.POST: {}},
+		Values:      []string{"1234"},
+	}
+	set := permissions.Set{rule}
+	scope, err := set.MarshalScopeString()
+	assert.NoError(t, err)
+
+	state := "sharing_id"
+
+	urlVal := url.Values{
+		"state":        []string{state},
+		"scope":        []string{scope},
+		"sharing_type": []string{consts.OneShotSharing},
+	}
+	res, err := requestGET(urlVal, "/sharings/request")
+	assert.NoError(t, err)
+	assert.Equal(t, 201, res.StatusCode)
+
+	var obj map[string]interface{}
+	err = extractJSONRes(res, &obj)
+	assert.NoError(t, err)
+	data := obj["data"].(map[string]interface{})
+	attrs := data["attributes"].(map[string]interface{})
+	owner := attrs["owner"].(bool)
+	assert.Equal(t, false, owner)
+	sharingType := attrs["sharing_type"].(string)
+	assert.Equal(t, consts.OneShotSharing, sharingType)
+	sharingID := attrs["sharing_id"].(string)
+	assert.Equal(t, state, sharingID)
+
+}
 
 func TestCreateSharingWithBadType(t *testing.T) {
 	res, err := postJSON("/sharings/", echo.Map{
@@ -91,6 +173,19 @@ func TestMain(m *testing.M) {
 func postJSON(u string, v echo.Map) (*http.Response, error) {
 	body, _ := json.Marshal(v)
 	return http.Post(ts.URL+u, "application/json", bytes.NewReader(body))
+}
+
+func requestGET(v url.Values, u string) (*http.Response, error) {
+	reqURL := v.Encode()
+	fmt.Printf("url : %v\n", reqURL)
+	return http.Get(ts.URL + u + "?" + reqURL)
+}
+
+func extractJSONRes(res *http.Response, mp *map[string]interface{}) error {
+	if res.StatusCode >= 300 {
+		return nil
+	}
+	return json.NewDecoder(res.Body).Decode(mp)
 }
 
 func injectInstance(i *instance.Instance) echo.MiddlewareFunc {


### PR DESCRIPTION
Add a sharing request reception handler. 
It covers the case where a recipient received a mail with an URL containing the sharing informations in the query-string and clicked on this URL (the actual sending mail PR will come soon).

A sharing document is then created in the recipient database, which will be later used to ask the recipient if he accepts the sharing or not.