### PR TITLE
Add sharing authorization

### DIFF
--- a/pkg/sharings/sharings.go
+++ b/pkg/sharings/sharings.go
@@ -122,7 +122,7 @@ func GetRecipient(db couchdb.Database, recID string) (*Recipient, error) {
 	return doc, err
 }
 
-//CheckSharingType returns an error if the sharing type is incorrect
+// CheckSharingType returns an error if the sharing type is incorrect
 func CheckSharingType(sharingType string) error {
 	switch sharingType {
 	case consts.OneShotSharing, consts.MasterSlaveSharing, consts.MasterMasterSharing:

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -2,36 +2,14 @@ package sharings
 
 import (
 	"net/http"
-	"net/url"
 
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
-	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/pkg/sharings"
 	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/labstack/echo"
 )
-
-// sendAuthorize retrieve the OAuth authorize parameters from the query string
-// and redirect to the authorize page
-func sendAuthorize(c echo.Context, instance *instance.Instance, state, scope string) error {
-	clientID := c.QueryParam("client_id")
-	redirectURI := c.QueryParam("redirect_uri")
-	responseType := c.QueryParam("response_type")
-
-	values := url.Values{
-		"state":         {state},
-		"client_id":     {clientID},
-		"redirect_uri":  {redirectURI},
-		"scope":         {scope},
-		"response_type": {responseType},
-	}
-
-	redirectAuthorize := instance.PageURL("/auth/authorize", values)
-
-	return c.Redirect(http.StatusSeeOther, redirectAuthorize)
-}
 
 // SharingRequest handles a sharing request from the recipient side
 // It creates a tempory sharing document and redirect to the authorize page
@@ -47,7 +25,9 @@ func SharingRequest(c echo.Context) error {
 	if err != nil {
 		return wrapErrors(err)
 	}
-	return sendAuthorize(c, instance, state, scope)
+
+	redirectAuthorize := instance.PageURL("/auth/authorize", c.QueryParams())
+	return c.Redirect(http.StatusSeeOther, redirectAuthorize)
 }
 
 // CreateSharing initializes a sharing by creating the associated document

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/cookiejar"
 	"net/http/httptest"
 	"net/url"
 	"os"
@@ -14,14 +15,35 @@ import (
 	"github.com/cozy/cozy-stack/pkg/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/instance"
+	"github.com/cozy/cozy-stack/pkg/oauth"
 	"github.com/cozy/cozy-stack/pkg/permissions"
+	"github.com/cozy/cozy-stack/web/auth"
 	"github.com/cozy/cozy-stack/web/errors"
+	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/labstack/echo"
 	"github.com/stretchr/testify/assert"
 )
 
 var ts *httptest.Server
 var testInstance *instance.Instance
+var jar *testJar
+var client *http.Client
+var clientOAuth oauth.Client
+var clientID string
+var instanceURL *url.URL
+var domain string
+
+type testJar struct {
+	Jar *cookiejar.Jar
+}
+
+func (j *testJar) Cookies(u *url.URL) (cookies []*http.Cookie) {
+	return j.Jar.Cookies(instanceURL)
+}
+
+func (j *testJar) SetCookies(u *url.URL, cookies []*http.Cookie) {
+	j.Jar.SetCookies(instanceURL, cookies)
+}
 
 type jsonData struct {
 	Type  string                 `json:"type"`
@@ -32,41 +54,43 @@ type jsonData struct {
 
 func TestSharingRequestNoScope(t *testing.T) {
 	urlVal := url.Values{}
-	res, err := requestGET(urlVal, "/sharings/request")
+	res, err := requestGET("/sharings/request", urlVal)
 	assert.NoError(t, err)
 	assert.Equal(t, 400, res.StatusCode)
 }
 
 func TestSharingRequestNoState(t *testing.T) {
-	urlVal := url.Values{}
-	urlVal["scope"] = []string{"dummyscope"}
-	res, err := requestGET(urlVal, "/sharings/request")
+	urlVal := url.Values{
+		"scope": {"dummyscope"},
+	}
+	res, err := requestGET("/sharings/request", urlVal)
 	assert.NoError(t, err)
 	assert.Equal(t, 400, res.StatusCode)
 }
 
 func TestSharingRequestNoSharingType(t *testing.T) {
-	urlVal := url.Values{}
-	urlVal["scope"] = []string{"dummyscope"}
-	urlVal["state"] = []string{"dummystate"}
-	res, err := requestGET(urlVal, "/sharings/request")
+	urlVal := url.Values{
+		"scope": {"dummyscope"},
+		"state": {"dummystate"},
+	}
+	res, err := requestGET("/sharings/request", urlVal)
 	assert.NoError(t, err)
 	assert.Equal(t, 422, res.StatusCode)
 }
 
 func TestSharingRequestBadScope(t *testing.T) {
-	urlVal := url.Values{}
-	urlVal["scope"] = []string{":"}
-	urlVal["state"] = []string{"dummystate"}
-	urlVal["sharing_type"] = []string{consts.OneShotSharing}
-
-	_, err := requestGET(urlVal, "/sharings/request")
+	urlVal := url.Values{
+		"scope":        []string{":"},
+		"state":        {"dummystate"},
+		"sharing_type": {consts.OneShotSharing},
+	}
+	res, err := requestGET("/sharings/request", urlVal)
 	assert.NoError(t, err)
-	//assert.Equal(t, 422, res.StatusCode)
-
+	assert.Equal(t, 500, res.StatusCode)
 }
 
 func TestSharingRequestSuccess(t *testing.T) {
+
 	rule := permissions.Rule{
 		Type:        "io.cozy.events",
 		Title:       "event",
@@ -82,29 +106,21 @@ func TestSharingRequestSuccess(t *testing.T) {
 	desc := "share cher"
 
 	urlVal := url.Values{
-		"desc":         []string{desc},
-		"state":        []string{state},
-		"scope":        []string{scope},
-		"sharing_type": []string{consts.OneShotSharing},
+		"desc":          {desc},
+		"state":         {state},
+		"scope":         {scope},
+		"sharing_type":  {consts.OneShotSharing},
+		"client_id":     {clientID},
+		"redirect_uri":  {clientOAuth.RedirectURIs[0]},
+		"response_type": {"code"},
 	}
-	res, err := requestGET(urlVal, "/sharings/request")
-	assert.NoError(t, err)
-	assert.Equal(t, 201, res.StatusCode)
 
-	var obj map[string]interface{}
-	err = extractJSONRes(res, &obj)
+	req, _ := http.NewRequest("GET", ts.URL+"/sharings/request?"+urlVal.Encode(), nil)
+	req.Host = domain
+	res, err := client.Do(req)
+	defer res.Body.Close()
 	assert.NoError(t, err)
-	data := obj["data"].(map[string]interface{})
-	attrs := data["attributes"].(map[string]interface{})
-	owner := attrs["owner"].(bool)
-	assert.Equal(t, false, owner)
-	sharingType := attrs["sharing_type"].(string)
-	assert.Equal(t, consts.OneShotSharing, sharingType)
-	sharingID := attrs["sharing_id"].(string)
-	assert.Equal(t, state, sharingID)
-	description := attrs["desc"].(string)
-	assert.Equal(t, desc, description)
-
+	assert.Equal(t, http.StatusSeeOther, res.StatusCode)
 }
 
 func TestCreateSharingWithBadType(t *testing.T) {
@@ -160,9 +176,11 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	instance.Destroy("test-sharings")
+	domain = "test-sharings"
+
+	instance.Destroy(domain)
 	testInstance, err = instance.Create(&instance.Options{
-		Domain: "test-sharings",
+		Domain: domain,
 		Locale: "en",
 	})
 	if err != nil {
@@ -170,16 +188,48 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
+	instanceURL, _ = url.Parse("https://" + domain + "/")
+	j, _ := cookiejar.New(nil)
+	jar = &testJar{
+		Jar: j,
+	}
+	client = &http.Client{
+		CheckRedirect: noRedirect,
+		Jar:           jar,
+	}
+
+	testInstance.RegisterPassphrase([]byte("MyPassphrase"), testInstance.RegisterToken)
+
+	r := echo.New()
+	r.GET("/test", func(c echo.Context) error {
+		var content string
+		if middlewares.IsLoggedIn(c) {
+			content = "logged_in"
+		} else {
+			content = "who_are_you"
+		}
+		return c.String(http.StatusOK, content)
+	}, middlewares.NeedInstance, middlewares.LoadSession)
+
+	clientOAuth = oauth.Client{
+		RedirectURIs: []string{"http://localhost/oauth/callback"},
+		ClientName:   "test-permissions",
+		SoftwareID:   "github.com/cozy/cozy-stack/web/data",
+	}
+	clientOAuth.Create(testInstance)
+	clientID = clientOAuth.ClientID
+
 	handler := echo.New()
 	handler.HTTPErrorHandler = errors.ErrorHandler
 	handler.Use(injectInstance(testInstance))
+	auth.Routes(handler.Group("/auth"))
 	Routes(handler.Group("/sharings"))
 
 	ts = httptest.NewServer(handler)
 
 	res := m.Run()
 	ts.Close()
-	instance.Destroy("test-sharings")
+	instance.Destroy(domain)
 
 	os.Exit(res)
 }
@@ -189,9 +239,12 @@ func postJSON(u string, v echo.Map) (*http.Response, error) {
 	return http.Post(ts.URL+u, "application/json", bytes.NewReader(body))
 }
 
-func requestGET(v url.Values, u string) (*http.Response, error) {
-	reqURL := v.Encode()
-	return http.Get(ts.URL + u + "?" + reqURL)
+func requestGET(u string, v url.Values) (*http.Response, error) {
+	if v != nil {
+		reqURL := v.Encode()
+		return http.Get(ts.URL + u + "?" + reqURL)
+	}
+	return http.Get(ts.URL + u)
 }
 
 func extractJSONRes(res *http.Response, mp *map[string]interface{}) error {
@@ -208,4 +261,8 @@ func injectInstance(i *instance.Instance) echo.MiddlewareFunc {
 			return next(c)
 		}
 	}
+}
+
+func noRedirect(*http.Request, []*http.Request) error {
+	return http.ErrUseLastResponse
 }

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -131,6 +131,16 @@ func TestCreateSharingWithBadType(t *testing.T) {
 	assert.Equal(t, 422, res.StatusCode)
 }
 
+func TestSendMailsWithWrongSharingID(t *testing.T) {
+	req, _ := http.NewRequest("PUT", ts.URL+"/sharings/wrongid/sendMails",
+		nil)
+
+	res, err := http.DefaultClient.Do(req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 404, res.StatusCode)
+}
+
 func TestCreateSharingWithNonExistingRecipient(t *testing.T) {
 	type recipient map[string]map[string]string
 

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -118,8 +118,8 @@ func TestSharingRequestSuccess(t *testing.T) {
 	req, _ := http.NewRequest("GET", ts.URL+"/sharings/request?"+urlVal.Encode(), nil)
 	req.Host = domain
 	res, err := client.Do(req)
-	defer res.Body.Close()
 	assert.NoError(t, err)
+	defer res.Body.Close()
 	assert.Equal(t, http.StatusSeeOther, res.StatusCode)
 }
 
@@ -155,16 +155,6 @@ func TestCreateSharingSuccess(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, 201, res.StatusCode)
-}
-
-func TestSendMailsWithWrongSharingID(t *testing.T) {
-	req, _ := http.NewRequest("PUT", ts.URL+"/sharings/wrongid/sendMails",
-		nil)
-
-	res, err := http.DefaultClient.Do(req)
-
-	assert.NoError(t, err)
-	assert.Equal(t, 404, res.StatusCode)
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
When a recipient receive a sharing request throught an URL sent by mail, he is redirected to the OAuth authorize page, based on the information specified in the query string. 
This is done in addition to the sharing document creation.
