### PR TITLE
Move indexes and views declarations in const package

### DIFF
--- a/pkg/apps/installer_test.go
+++ b/pkg/apps/installer_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cozy/cozy-stack/pkg/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
-	"github.com/cozy/cozy-stack/pkg/permissions"
 	"github.com/cozy/cozy-stack/pkg/vfs"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -509,21 +508,13 @@ func TestMain(m *testing.M) {
 
 	time.Sleep(100 * time.Millisecond)
 
-	for _, index := range vfs.Indexes {
-		err = couchdb.DefineIndex(c, consts.Files, index)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
-	}
-
 	err = couchdb.ResetDB(c, consts.Permissions)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
 
-	err = couchdb.DefineIndex(c, consts.Permissions, permissions.Index)
+	err = couchdb.DefineIndexes(c, consts.Indexes)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/pkg/consts/views.go
+++ b/pkg/consts/views.go
@@ -22,7 +22,7 @@ var Indexes = []*mango.Index{
 	mango.IndexOnFields(Files, "path"),
 }
 
-// DiskUsageView is the name of the view used for computing the disk usage
+// DiskUsageView is the view used for computing the disk usage
 var DiskUsageView = &couchdb.View{
 	Name:    "disk-usage",
 	Doctype: Files,
@@ -36,8 +36,8 @@ function(doc) {
 	Reduce: "_sum",
 }
 
-// FilesReferencedByView is the name of the view used for fetching files
-// referenced by a given document
+// FilesReferencedByView is the view used for fetching files referenced by a
+// given document
 var FilesReferencedByView = &couchdb.View{
 	Name:    "referenced-by",
 	Doctype: Files,
@@ -51,6 +51,8 @@ function(doc) {
 }`,
 }
 
+// PermissionsShareByCView is the view for fetching the permissions associated
+// to a document via a token code.
 var PermissionsShareByCView = &couchdb.View{
 	Name:    "byToken",
 	Doctype: Permissions,
@@ -64,6 +66,8 @@ function(doc) {
 }`,
 }
 
+// PermissionsShareByDocView is the view for fetching a list of permissions
+// associated to a list of IDs.
 var PermissionsShareByDocView = &couchdb.View{
 	Name:    "byDoc",
 	Doctype: Permissions,

--- a/pkg/consts/views.go
+++ b/pkg/consts/views.go
@@ -90,6 +90,7 @@ var Views = []*couchdb.View{
 	DiskUsageView,
 	FilesReferencedByView,
 	PermissionsShareByCView,
+	PermissionsShareByDocView,
 }
 
 // ViewsByDoctype returns the list of views for a specified doc type.

--- a/pkg/consts/views.go
+++ b/pkg/consts/views.go
@@ -1,0 +1,111 @@
+package consts
+
+import (
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
+)
+
+// GlobalIndexes is the index list required on the global databases to run
+// properly.
+var GlobalIndexes = []*mango.Index{
+	mango.IndexOnFields(Instances, "domain"),
+}
+
+// Indexes is the index list required by an instance to run properly.
+var Indexes = []*mango.Index{
+	// Permissions
+	mango.IndexOnFields(Permissions, "source_id", "type"),
+
+	// Used to lookup a file given its parent, and the children of a directory
+	mango.IndexOnFields(Files, "dir_id", "name"),
+	// Used to lookup a directory given its path
+	mango.IndexOnFields(Files, "path"),
+}
+
+// DiskUsageView is the name of the view used for computing the disk usage
+var DiskUsageView = &couchdb.View{
+	Name:    "disk-usage",
+	Doctype: Files,
+	Map: `
+function(doc) {
+  if (doc.type === 'file') {
+    emit(doc._id, +doc.size);
+  }
+}
+`,
+	Reduce: "_sum",
+}
+
+// FilesReferencedByView is the name of the view used for fetching files
+// referenced by a given document
+var FilesReferencedByView = &couchdb.View{
+	Name:    "referenced-by",
+	Doctype: Files,
+	Map: `
+function(doc) {
+  if (doc.type === 'file' && isArray(doc.referenced_by)) {
+    for (var i = 0; i < doc.referenced_by.length; i++) {
+      emit([doc.referenced_by[i].type, doc.referenced_by[i].id]);
+    }
+  }
+}`,
+}
+
+var PermissionsShareByCView = &couchdb.View{
+	Name:    "byToken",
+	Doctype: Permissions,
+	Map: `
+function(doc) {
+  if (doc.type === "share" && doc.codes) {
+    Object.keys(doc.codes).forEach(function(k) {
+      emit(doc.codes[k]);
+    })
+  }
+}`,
+}
+
+var PermissionsShareByDocView = &couchdb.View{
+	Name:    "byDoc",
+	Doctype: Permissions,
+	Map: `
+function(doc){
+  if (doc.type === "share" && doc.permissions) {
+    Object.keys(doc.permissions).forEach(function(k) {
+      var p = doc.permissions[k];
+      var selector = p.selector || "_id";
+      for (var i=0; i<p.values.length; i++) {
+        emit([p.type, selector, p.values[i]], p.verbs);
+      }
+    });
+  }
+}`,
+}
+
+// Views is the required couchdb views for computing the disk usage
+var Views = []*couchdb.View{
+	DiskUsageView,
+	FilesReferencedByView,
+	PermissionsShareByCView,
+}
+
+// ViewsByDoctype returns the list of views for a specified doc type.
+func ViewsByDoctype(doctype string) []*couchdb.View {
+	var views []*couchdb.View
+	for _, view := range Views {
+		if view.Doctype == doctype {
+			views = append(views, view)
+		}
+	}
+	return views
+}
+
+// IndexesByDoctype returns the list of indexes for a specified doc type.
+func IndexesByDoctype(doctype string) []*mango.Index {
+	var indexes []*mango.Index
+	for _, index := range Indexes {
+		if index.Doctype == doctype {
+			indexes = append(indexes, index)
+		}
+	}
+	return indexes
+}

--- a/pkg/consts/views.go
+++ b/pkg/consts/views.go
@@ -85,7 +85,7 @@ function(doc){
 }`,
 }
 
-// Views is the required couchdb views for computing the disk usage
+// Views is the list of all views that are created by the stack.
 var Views = []*couchdb.View{
 	DiskUsageView,
 	FilesReferencedByView,

--- a/pkg/couchdb/couchdb_test.go
+++ b/pkg/couchdb/couchdb_test.go
@@ -124,11 +124,11 @@ func TestGetAllDocs(t *testing.T) {
 }
 
 func TestDefineIndex(t *testing.T) {
-	err := DefineIndex(TestPrefix, TestDoctype, mango.IndexOnFields("fieldA", "fieldB"))
+	err := DefineIndex(TestPrefix, mango.IndexOnFields(TestDoctype, "fieldA", "fieldB"))
 	assert.NoError(t, err)
 
 	// if I try to define the same index several time
-	err2 := DefineIndex(TestPrefix, TestDoctype, mango.IndexOnFields("fieldA", "fieldB"))
+	err2 := DefineIndex(TestPrefix, mango.IndexOnFields(TestDoctype, "fieldA", "fieldB"))
 	assert.NoError(t, err2)
 }
 
@@ -148,7 +148,7 @@ func TestQuery(t *testing.T) {
 		}
 	}
 
-	err := DefineIndex(TestPrefix, TestDoctype, mango.IndexOnFields("fieldA", "fieldB"))
+	err := DefineIndex(TestPrefix, mango.IndexOnFields(TestDoctype, "fieldA", "fieldB"))
 	if !assert.NoError(t, err) {
 		t.FailNow()
 		return

--- a/pkg/couchdb/mango/index.go
+++ b/pkg/couchdb/mango/index.go
@@ -11,17 +11,24 @@ func (def IndexFields) MarshalJSON() ([]byte, error) {
 	return json.Marshal(makeMap("fields", []string(def)))
 }
 
-// An Index is a request to be POSTED to create the index
-type Index struct {
+// IndexRequest is a request to be POSTED to create the index
+type IndexRequest struct {
 	Name  string      `json:"name,omitempty"`
 	DDoc  string      `json:"ddoc,omitempty"`
 	Index IndexFields `json:"index"`
 }
 
+// Index contains an index request on a specified domain.
+type Index struct {
+	Doctype string
+	Request *IndexRequest
+}
+
 // IndexOnFields constructs a new Index
 // it lets couchdb defaults for index & designdoc names.
-func IndexOnFields(fields ...string) Index {
-	return Index{
-		Index: IndexFields(fields),
+func IndexOnFields(doctype string, fields ...string) *Index {
+	return &Index{
+		Doctype: doctype,
+		Request: &IndexRequest{Index: IndexFields(fields)},
 	}
 }

--- a/pkg/couchdb/mango/index_test.go
+++ b/pkg/couchdb/mango/index_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 func TestIndexMarshaling(t *testing.T) {
-	def := IndexOnFields("dir_id", "name")
-	jsonbytes, _ := json.Marshal(def)
+	def := IndexOnFields("io.cozy.foo", "dir_id", "name")
+	jsonbytes, _ := json.Marshal(def.Request)
 	expected := `{"index":{"fields":["dir_id","name"]}}`
 	assert.Equal(t, expected, string(jsonbytes), "index should MarshalJSON properly")
 }

--- a/pkg/vfs/references.go
+++ b/pkg/vfs/references.go
@@ -11,10 +11,8 @@ import (
 // @TODO pagination
 func FilesReferencedBy(db couchdb.Database, doctype, id string) ([]jsonapi.ResourceIdentifier, error) {
 	var res couchdb.ViewResponse
-	err := couchdb.ExecView(db, &couchdb.ViewRequest{
-		Doctype:  consts.Files,
-		ViewName: FilesReferencedByView,
-		Key:      []string{doctype, id},
+	err := couchdb.ExecView(db, consts.FilesReferencedByView, &couchdb.ViewRequest{
+		Key: []string{doctype, id},
 	}, &res)
 	if err != nil {
 		return nil, err

--- a/pkg/vfs/vfs_test.go
+++ b/pkg/vfs/vfs_test.go
@@ -576,15 +576,13 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	for _, index := range Indexes {
-		err = couchdb.DefineIndex(vfsC, consts.Files, index)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
+	err = couchdb.DefineIndexes(vfsC, consts.IndexesByDoctype(consts.Files))
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
 	}
 
-	if err = couchdb.DefineViews(vfsC, consts.Files, Views); err != nil {
+	if err = couchdb.DefineViews(vfsC, consts.ViewsByDoctype(consts.Files)); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/web/data/replication_test.go
+++ b/web/data/replication_test.go
@@ -50,7 +50,7 @@ func TestReplicationFromcozy(t *testing.T) {
 
 	// add more docs, including a _design doc
 	var doc4 = getDocForTest()
-	err = couchdb.DefineIndex(testInstance, Type, mango.IndexOnFields("test"))
+	err = couchdb.DefineIndex(testInstance, mango.IndexOnFields(Type, "test"))
 	assert.NoError(t, err)
 
 	// replicate again

--- a/web/permissions/permissions_test.go
+++ b/web/permissions/permissions_test.go
@@ -47,12 +47,12 @@ func TestMain(m *testing.M) {
 		fmt.Println("Cant reset db", err)
 		os.Exit(1)
 	}
-	err = couchdb.DefineIndexes(testInstance, consts.Indexes)
+	err = couchdb.DefineIndexes(testInstance, consts.IndexesByDoctype(consts.Permissions))
 	if err != nil {
 		fmt.Println("Cant define index", err)
 		os.Exit(1)
 	}
-	err = couchdb.DefineViews(testInstance, consts.Views)
+	err = couchdb.DefineViews(testInstance, consts.ViewsByDoctype(consts.Permissions))
 	if err != nil {
 		fmt.Println("cant define views", err)
 		os.Exit(1)

--- a/web/permissions/permissions_test.go
+++ b/web/permissions/permissions_test.go
@@ -47,12 +47,12 @@ func TestMain(m *testing.M) {
 		fmt.Println("Cant reset db", err)
 		os.Exit(1)
 	}
-	err = couchdb.DefineIndex(testInstance, consts.Permissions, permissions.Index)
+	err = couchdb.DefineIndexes(testInstance, consts.Indexes)
 	if err != nil {
 		fmt.Println("Cant define index", err)
 		os.Exit(1)
 	}
-	err = couchdb.DefineViews(testInstance, consts.Permissions, permissions.Views)
+	err = couchdb.DefineViews(testInstance, consts.Views)
 	if err != nil {
 		fmt.Println("cant define views", err)
 		os.Exit(1)


### PR DESCRIPTION
This PR is a little refactoring to store all the views and indexes declarations into the `consts` package. It should offer a clearer view of all the indexes and views that are defined by the stack.

The `ExecuteView` method takes a `View` pointer which make it also less error-prone.

The `instance.Create` function has been inlined to so that it is easier to see all the creation steps it goes though.