### PR TITLE
Fix --apps flag when used as empty string

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -43,6 +43,23 @@ func StripPort(domain string) string {
 	return domain
 }
 
+// SplitTrimString slices s into all substrings a s separated by sep, like
+// strings.Split. In addition it will trim all those substrings and filter out
+// the empty ones.
+func SplitTrimString(s, sep string) []string {
+	if s == "" {
+		return nil
+	}
+	var parts []string
+	for _, part := range strings.Split(s, ",") {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			parts = append(parts, part)
+		}
+	}
+	return parts
+}
+
 // FileExists returns whether or not the file exists on the current file
 // system.
 func FileExists(name string) (bool, error) {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -61,6 +61,17 @@ func TestStripPort(t *testing.T) {
 	assert.Equal(t, "localhost:8080:8081", d3)
 }
 
+func TestSplitTrimString(t *testing.T) {
+	parts1 := SplitTrimString("", ",")
+	assert.EqualValues(t, []string(nil), parts1)
+	parts2 := SplitTrimString("foo,bar,baz,", ",")
+	assert.EqualValues(t, []string{"foo", "bar", "baz"}, parts2)
+	parts3 := SplitTrimString(",,,,", ",")
+	assert.EqualValues(t, []string(nil), parts3)
+	parts4 := SplitTrimString("foo  ,, bar,  baz  ,", ",")
+	assert.EqualValues(t, []string{"foo", "bar", "baz"}, parts4)
+}
+
 func TestFileExists(t *testing.T) {
 	exists, err := FileExists("/no/such/file")
 	assert.NoError(t, err)

--- a/web/instances/instances.go
+++ b/web/instances/instances.go
@@ -2,12 +2,12 @@ package instances
 
 import (
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/pkg/oauth"
 	"github.com/cozy/cozy-stack/pkg/permissions"
+	"github.com/cozy/cozy-stack/pkg/utils"
 	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/labstack/echo"
 )
@@ -18,7 +18,7 @@ func createHandler(c echo.Context) error {
 		Locale:   c.QueryParam("Locale"),
 		Timezone: c.QueryParam("Timezone"),
 		Email:    c.QueryParam("Email"),
-		Apps:     strings.Split(c.QueryParam("Apps"), ","),
+		Apps:     utils.SplitTrimString(c.QueryParam("Apps"), ","),
 		Dev:      (c.QueryParam("Dev") == "true"),
 	})
 	if err != nil {


### PR DESCRIPTION
Since `strings.Split("", ",")` is the array `[]string{""}`, the CLI `cozy-stack instances add "foo.bar"` would try to install an app and result in the error `Failed to install Unknown app`.