### PR TITLE
Handle refused sharing answer

### DIFF
--- a/pkg/apps/installer_test.go
+++ b/pkg/apps/installer_test.go
@@ -514,7 +514,13 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	err = couchdb.DefineIndexes(c, consts.Indexes)
+	err = couchdb.DefineIndexes(c, consts.IndexesByDoctype(consts.Files))
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	err = couchdb.DefineIndexes(c, consts.IndexesByDoctype(consts.Permissions))
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -1,41 +1,37 @@
 package consts
 
-const (
-	// Instances doc type for User's instance document
-	Instances = "instances"
+// Instances doc type for User's instance document
+const Instances = "instances"
 
-	// Files doc type for type for files and directories
-	Files = "io.cozy.files"
-	// Archives doc type for zip archives with files and directories
-	Archives = "io.cozy.files.archives"
+const (
 	// Apps doc type for application manifests
 	Apps = "io.cozy.apps"
-	// Jobs doc type for queued jobs
-	Jobs = "io.cozy.jobs"
-	// Queues doc type for jobs queues
-	Queues = "io.cozy.queues"
-	// Settings doc type for settings to customize an instance
-	Settings = "io.cozy.settings"
-	// Sessions doc type for sessions identifying a connection
-	Sessions = "io.cozy.sessions"
-	// Triggers doc type for triggers, jobs launchers
-	Triggers = "io.cozy.triggers"
-
-	// Permissions doc type for permissions identifying a connection
-	Permissions = "io.cozy.permissions"
-
+	// Archives doc type for zip archives with files and directories
+	Archives = "io.cozy.files.archives"
 	// Doctypes doc type for doctype list
 	Doctypes = "io.cozy.doctypes"
-
-	// Sharings doc type for document and file sharing
-	Sharings = "io.cozy.sharings"
-	// Recipients doc type for sharing recipients
-	Recipients = "io.cozy.recipients"
-
-	// OAuthClients doc type for OAuth2 clients
-	OAuthClients = "io.cozy.oauth.clients"
+	// Files doc type for type for files and directories
+	Files = "io.cozy.files"
+	// Jobs doc type for queued jobs
+	Jobs = "io.cozy.jobs"
 	// OAuthAccessCodes doc type for OAuth2 access codes
 	OAuthAccessCodes = "io.cozy.oauth.access_codes"
+	// OAuthClients doc type for OAuth2 clients
+	OAuthClients = "io.cozy.oauth.clients"
+	// Permissions doc type for permissions identifying a connection
+	Permissions = "io.cozy.permissions"
+	// Queues doc type for jobs queues
+	Queues = "io.cozy.queues"
+	// Recipients doc type for sharing recipients
+	Recipients = "io.cozy.recipients"
+	// Sessions doc type for sessions identifying a connection
+	Sessions = "io.cozy.sessions"
+	// Settings doc type for settings to customize an instance
+	Settings = "io.cozy.settings"
+	// Sharings doc type for document and file sharing
+	Sharings = "io.cozy.sharings"
+	// Triggers doc type for triggers, jobs launchers
+	Triggers = "io.cozy.triggers"
 )
 
 const (

--- a/pkg/consts/views.go
+++ b/pkg/consts/views.go
@@ -15,6 +15,8 @@ var GlobalIndexes = []*mango.Index{
 var Indexes = []*mango.Index{
 	// Permissions
 	mango.IndexOnFields(Permissions, "source_id", "type"),
+	// Sharings
+	mango.IndexOnFields(Sharings, "sharing_id"),
 
 	// Used to lookup a file given its parent, and the children of a directory
 	mango.IndexOnFields(Files, "dir_id", "name"),

--- a/pkg/couchdb/couchdb.go
+++ b/pkg/couchdb/couchdb.go
@@ -435,7 +435,6 @@ func createDocOrDb(db Database, doc Doc, response interface{}) error {
 	if err == nil || !IsNoDatabaseError(err) {
 		return err
 	}
-
 	err = CreateDB(db, doctype)
 	if err == nil {
 		err = makeRequest("POST", dbname, doc, response)

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -397,7 +397,6 @@ func Create(opts *Options) (*Instance, error) {
 	if err := settings.CreateDefaultTheme(i); err != nil {
 		return nil, err
 	}
-
 	settingsDoc := &instanceSettings{
 		Timezone: opts.Timezone,
 		Email:    opts.Email,

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -391,9 +391,13 @@ func Create(opts *Options) (*Instance, error) {
 	if err := couchdb.CreateDB(i, consts.Permissions); err != nil {
 		return nil, err
 	}
+	if err := couchdb.CreateDB(i, consts.Sharings); err != nil {
+		return nil, err
+	}
 	if err := settings.CreateDefaultTheme(i); err != nil {
 		return nil, err
 	}
+
 	settingsDoc := &instanceSettings{
 		Timezone: opts.Timezone,
 		Email:    opts.Email,

--- a/pkg/sharings/errors.go
+++ b/pkg/sharings/errors.go
@@ -23,4 +23,6 @@ var (
 	// ErrNoOAuthClient is used when the owner of the Cozy has not yet
 	// registered to the recipient as an OAuth client.
 	ErrNoOAuthClient = errors.New("No OAuth client was found")
+	//ErrSharingIDNotUnique is used when several occurences of the same sharing id are found
+	ErrSharingIDNotUnique = errors.New("Several sharings with this id found")
 )

--- a/pkg/sharings/sharings.go
+++ b/pkg/sharings/sharings.go
@@ -3,6 +3,7 @@ package sharings
 import (
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
 	"github.com/cozy/cozy-stack/pkg/permissions"
 	"github.com/cozy/cozy-stack/pkg/utils"
 	"github.com/cozy/cozy-stack/web/jsonapi"
@@ -122,13 +123,69 @@ func GetRecipient(db couchdb.Database, recID string) (*Recipient, error) {
 	return doc, err
 }
 
-// CheckSharingType returns an error if the sharing type is incorrect
+// GetSharingRecipientFromClientID returns the Recipient associated with the given clientID
+func (s *Sharing) GetSharingRecipientFromClientID(db couchdb.Database, clientID string) (*RecipientStatus, error) {
+	for _, recStatus := range s.RecipientsStatus {
+		recipient, err := GetRecipient(db, recStatus.RefRecipient.ID)
+		if err != nil {
+			return nil, err
+		}
+		recStatus.recipient = recipient
+
+		if recipient.Client.ClientID == clientID {
+			return recStatus, nil
+		}
+	}
+	return nil, nil
+}
+
+//CheckSharingType returns an error if the sharing type is incorrect
 func CheckSharingType(sharingType string) error {
 	switch sharingType {
 	case consts.OneShotSharing, consts.MasterSlaveSharing, consts.MasterMasterSharing:
 		return nil
 	}
 	return ErrBadSharingType
+}
+
+// findSharingRecipient retrieve a sharing recipient from its clientID and sharingID
+func findSharingRecipient(db couchdb.Database, sharingID, clientID string) (*Sharing, *RecipientStatus, error) {
+	var res []Sharing
+
+	err := couchdb.FindDocs(db, consts.Sharings, &couchdb.FindRequest{
+		Selector: mango.Equal(consts.IndexSharing, sharingID),
+	}, &res)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(res) < 1 {
+		return nil, nil, ErrSharingDoesNotExist
+	} else if len(res) > 2 {
+		return nil, nil, ErrSharingIDNotUnique
+	}
+
+	sharing := &res[0]
+
+	sRec, err := sharing.GetSharingRecipientFromClientID(db, clientID)
+	if err != nil {
+		return nil, nil, err
+	}
+	if sRec == nil {
+		return nil, nil, ErrRecipientDoesNotExist
+	}
+
+	return sharing, sRec, nil
+}
+
+// SharingRefused handles a rejectedsharing on the sharer side
+func SharingRefused(db couchdb.Database, state, clientID string) error {
+	sharing, recStatus, err := findSharingRecipient(db, state, clientID)
+	if err != nil {
+		return err
+	}
+	recStatus.Status = consts.RefusedSharingStatus
+	err = couchdb.UpdateDoc(db, sharing)
+	return err
 }
 
 // CreateSharingRequest checks fields integrity and creates a sharing document

--- a/pkg/sharings/sharings.go
+++ b/pkg/sharings/sharings.go
@@ -153,7 +153,7 @@ func findSharingRecipient(db couchdb.Database, sharingID, clientID string) (*Sha
 	var res []Sharing
 
 	err := couchdb.FindDocs(db, consts.Sharings, &couchdb.FindRequest{
-		Selector: mango.Equal(consts.IndexSharing, sharingID),
+		Selector: mango.Equal("sharing_id", sharingID),
 	}, &res)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/sharings/sharings_test.go
+++ b/pkg/sharings/sharings_test.go
@@ -9,8 +9,10 @@ import (
 	"github.com/cozy/cozy-stack/pkg/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
 	"github.com/cozy/cozy-stack/pkg/crypto"
 	"github.com/cozy/cozy-stack/pkg/instance"
+	"github.com/cozy/cozy-stack/pkg/oauth"
 	"github.com/cozy/cozy-stack/pkg/permissions"
 	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/stretchr/testify/assert"
@@ -48,6 +50,117 @@ func TestCheckSharingTypeSuccess(t *testing.T) {
 	sharingType := consts.OneShotSharing
 	err := CheckSharingType(sharingType)
 	assert.NoError(t, err)
+}
+
+func TestGetSharingRecipientFromClientIDNoRecipient(t *testing.T) {
+	var rStatus *RecipientStatus
+	sharing := &Sharing{}
+	rec, err := sharing.GetSharingRecipientFromClientID(TestPrefix, "")
+	assert.NoError(t, err)
+	assert.Equal(t, rStatus, rec)
+}
+
+func TestGetSharingRecipientFromClientIDNoClient(t *testing.T) {
+	clientID := "fake client"
+
+	rStatus := &RecipientStatus{
+		RefRecipient: jsonapi.ResourceIdentifier{ID: "id", Type: "type"},
+	}
+	sharing := &Sharing{
+		RecipientsStatus: []*RecipientStatus{rStatus},
+	}
+	_, err := sharing.GetSharingRecipientFromClientID(TestPrefix, clientID)
+	assert.Error(t, err)
+}
+
+func TestGetSharingRecipientFromClientIDSuccess(t *testing.T) {
+	clientID := "fake client"
+
+	client := &oauth.Client{
+		ClientID: clientID,
+	}
+	recipient := &Recipient{
+		Client: client,
+	}
+
+	couchdb.CreateDoc(TestPrefix, recipient)
+	rStatus := &RecipientStatus{
+		RefRecipient: jsonapi.ResourceIdentifier{ID: recipient.RID},
+	}
+
+	sharing := &Sharing{
+		RecipientsStatus: []*RecipientStatus{rStatus},
+	}
+
+	recStatus, err := sharing.GetSharingRecipientFromClientID(TestPrefix, clientID)
+	assert.NoError(t, err)
+	assert.Equal(t, rStatus, recStatus)
+
+}
+
+func TestSharingRefusedNoSharing(t *testing.T) {
+	state := "fake state"
+	clientID := "fake client"
+	err := SharingRefused(TestPrefix, state, clientID)
+	assert.Error(t, err)
+}
+
+func TestSharingRefusedNoClient(t *testing.T) {
+	state := "stateoftheart"
+	clientID := "fake client"
+
+	sharing := &Sharing{
+		SharingID: state,
+	}
+	err := couchdb.CreateDoc(TestPrefix, sharing)
+	assert.NoError(t, err)
+	err = SharingRefused(TestPrefix, state, clientID)
+	assert.Error(t, err)
+}
+
+func TestSharingRefusedStateNotUnique(t *testing.T) {
+	state := "stateoftheart"
+	clientID := "fake client"
+	sharing1 := &Sharing{
+		SharingID: state,
+	}
+	sharing2 := &Sharing{
+		SharingID: state,
+	}
+	err := couchdb.CreateDoc(TestPrefix, sharing1)
+	assert.NoError(t, err)
+	err = couchdb.CreateDoc(TestPrefix, sharing2)
+	assert.NoError(t, err)
+
+	err = SharingRefused(TestPrefix, state, clientID)
+	assert.Error(t, err)
+}
+
+func TestSharingRefusedSuccess(t *testing.T) {
+
+	state := "stateoftheart2"
+	clientID := "thriftshopclient"
+
+	client := &oauth.Client{
+		ClientID: clientID,
+	}
+	recipient := &Recipient{
+		Client: client,
+	}
+	err := couchdb.CreateDoc(TestPrefix, recipient)
+	assert.NoError(t, err)
+	rStatus := &RecipientStatus{
+		RefRecipient: jsonapi.ResourceIdentifier{ID: recipient.RID},
+	}
+	sharing := &Sharing{
+		SharingID:        state,
+		RecipientsStatus: []*RecipientStatus{rStatus},
+	}
+	err = couchdb.CreateDoc(TestPrefix, sharing)
+	assert.NoError(t, err)
+	err = SharingRefused(TestPrefix, state, clientID)
+	assert.NoError(t, err)
+
 }
 
 func TestCreateSharingRequestBadParams(t *testing.T) {
@@ -166,6 +279,14 @@ func TestMain(m *testing.M) {
 	err = couchdb.CreateNamedDocWithDB(in, settingsDoc)
 	if err != nil {
 		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	mangoIndex := mango.IndexOnFields(consts.IndexSharing)
+	err = couchdb.DefineIndex(TestPrefix, consts.Sharings, mangoIndex)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
 	}
 
 	res := m.Run()

--- a/pkg/sharings/sharings_test.go
+++ b/pkg/sharings/sharings_test.go
@@ -282,8 +282,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	mangoIndex := mango.IndexOnFields(consts.IndexSharing)
-	err = couchdb.DefineIndex(TestPrefix, consts.Sharings, mangoIndex)
+	err = couchdb.DefineIndex(TestPrefix, mango.IndexOnFields(consts.Sharings, "sharing_id"))
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/web/data/data_test.go
+++ b/web/data/data_test.go
@@ -188,6 +188,7 @@ func TestAllDoctypes(t *testing.T) {
 		"io.cozy.events",
 		"io.cozy.files",
 		"io.cozy.settings",
+		"io.cozy.sharings",
 	}
 	assert.Equal(t, expected, dbs)
 }

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -15,7 +15,6 @@ import (
 func SharingAnswer(c echo.Context) error {
 
 	var err error
-	var sharingAccepted bool
 
 	state := c.FormValue("state")
 	clientID := c.FormValue("client_id")
@@ -25,11 +24,7 @@ func SharingAnswer(c echo.Context) error {
 	instance := middlewares.GetInstance(c)
 
 	// The sharing is refused if there is no access code or scope
-	if scope == "" || accessCode == "" {
-		sharingAccepted = false
-	} else {
-		sharingAccepted = true
-	}
+	sharingAccepted := scope != "" && accessCode != ""
 
 	if sharingAccepted {
 		//TODO: handle the acceptation

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -11,6 +11,40 @@ import (
 	"github.com/labstack/echo"
 )
 
+// SharingAnswer handles a sharing answer from the sharer side
+func SharingAnswer(c echo.Context) error {
+
+	var err error
+	var sharingAccepted bool
+
+	state := c.FormValue("state")
+	clientID := c.FormValue("client_id")
+	scope := c.FormValue("scope")
+	accessCode := c.FormValue("access_code")
+
+	instance := middlewares.GetInstance(c)
+
+	// The sharing is refused if there is no access code or scope
+	if scope == "" || accessCode == "" {
+		sharingAccepted = false
+	} else {
+		sharingAccepted = true
+	}
+
+	if sharingAccepted {
+		//TODO: handle the acceptation
+	} else {
+		err = sharings.SharingRefused(instance, state, clientID)
+	}
+
+	if err != nil {
+		return wrapErrors(err)
+	}
+	return c.JSON(http.StatusOK, echo.Map{
+		"message": "Answer received",
+	})
+}
+
 // SharingRequest handles a sharing request from the recipient side
 // It creates a tempory sharing document and redirect to the authorize page
 func SharingRequest(c echo.Context) error {
@@ -84,6 +118,7 @@ func Routes(router *echo.Group) {
 	router.POST("/", CreateSharing)
 	router.PUT("/:id/sendMails", SendSharingMails)
 	router.GET("/request", SharingRequest)
+	router.POST("/answer", SharingAnswer)
 }
 
 // wrapErrors returns a formatted error

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -45,11 +45,24 @@ func (j *testJar) SetCookies(u *url.URL, cookies []*http.Cookie) {
 	j.Jar.SetCookies(instanceURL, cookies)
 }
 
-type jsonData struct {
-	Type  string                 `json:"type"`
-	ID    string                 `json:"id"`
-	Attrs map[string]interface{} `json:"attributes,omitempty"`
-	Rels  map[string]interface{} `json:"relationships,omitempty"`
+func TestSharingAnswerBadState(t *testing.T) {
+	state := ""
+	res, err := postJSON("/sharings/answer", echo.Map{
+		"state": state,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 404, res.StatusCode)
+}
+
+func TestSharingAnswerBadClientID(t *testing.T) {
+	state := "stateoftheart"
+	clientID2 := "myclient"
+	res, err := postJSON("/sharings/answer", echo.Map{
+		"state":     state,
+		"client_id": clientID2,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 404, res.StatusCode)
 }
 
 func TestSharingRequestNoScope(t *testing.T) {


### PR DESCRIPTION
This handles a refused sharing answer on the sharer side to eventually update the recipient sharing status.
For this end, a mango index is used to retrieve the sharing document from the state parameter, and then the recipient from the client_id parameter.