### PR TITLE
Realtime fix

### DIFF
--- a/pkg/realtime/memtopic.go
+++ b/pkg/realtime/memtopic.go
@@ -9,15 +9,9 @@ type topic struct {
 	unsubscribe chan *sub
 	broadcast   chan *Event
 
-	empty chan bool
-
 	// set of this topic subs, it should only be manipulated by the topic
 	// loop goroutine
 	subs map[*sub]struct{}
-}
-
-func (t *topic) publish(e *Event) {
-	go func() { t.broadcast <- e }()
 }
 
 func topicKey(instance, doctype string) string {
@@ -30,13 +24,11 @@ func makeTopic(h *hub, key string) *topic {
 	topic := &topic{
 		hub:         h,
 		key:         key,
-		subscribe:   make(chan *sub),
-		unsubscribe: make(chan *sub),
-		broadcast:   make(chan *Event),
-		empty:       make(chan bool),
+		subscribe:   make(chan *sub, 1), // 1-sized buffer to be async
+		unsubscribe: make(chan *sub, 1), // 1-sized buffer to be async
+		broadcast:   make(chan *Event, 10),
 		subs:        make(map[*sub]struct{}),
 	}
-
 	go topic.loop()
 	return topic
 }
@@ -46,7 +38,9 @@ func (t *topic) loop() {
 		select {
 		case e := <-t.broadcast:
 			for s := range t.subs {
-				s.send <- e
+				if !s.closed() {
+					s.send <- e
+				}
 			}
 		case s := <-t.subscribe:
 			t.subs[s] = struct{}{}
@@ -54,7 +48,7 @@ func (t *topic) loop() {
 			delete(t.subs, s)
 			if len(t.subs) == 0 {
 				t.hub.remove(t)
-				break
+				return
 			}
 		}
 	}

--- a/pkg/realtime/memtopic.go
+++ b/pkg/realtime/memtopic.go
@@ -48,14 +48,13 @@ func (t *topic) loop() {
 			for s := range t.subs {
 				s.send <- e
 			}
-
 		case s := <-t.subscribe:
 			t.subs[s] = struct{}{}
-
 		case s := <-t.unsubscribe:
 			delete(t.subs, s)
 			if len(t.subs) == 0 {
 				t.hub.remove(t)
+				break
 			}
 		}
 	}

--- a/pkg/realtime/realtime.go
+++ b/pkg/realtime/realtime.go
@@ -34,5 +34,5 @@ type EventChannel interface {
 	// Read returns a chan for events
 	Read() <-chan *Event
 	// Close closes the channel
-	Close()
+	Close() error
 }

--- a/pkg/realtime/realtime.go
+++ b/pkg/realtime/realtime.go
@@ -34,7 +34,5 @@ type EventChannel interface {
 	// Read returns a chan for events
 	Read() <-chan *Event
 	// Close closes the channel
-	Close() error
-	// Close returns a
-	CloseNotify() <-chan bool
+	Close()
 }

--- a/pkg/realtime/realtime_test.go
+++ b/pkg/realtime/realtime_test.go
@@ -53,8 +53,13 @@ func TestRealtime(t *testing.T) {
 
 	wg.Wait()
 
-	c.Close()
-	c2.Close()
+	err := c.Close()
+	assert.NoError(t, err)
+	err = c2.Close()
+	assert.NoError(t, err)
+
+	err = c.Close()
+	assert.Error(t, err)
 
 	h.Publish(&Event{
 		DocType: "io.cozy.testobject",


### PR DESCRIPTION
Fixes on the realtime package:

  - goroutine leak in the topic loop (not released)
  - asynchrounous send with fixed size buffer for `subscribe`/`unsubscribe` channels (instead of goroutines)
  - close/send race on the `send` channel, guarded with an atomic state