### PR TITLE
A recipient can refuse a sharing

### DIFF
--- a/pkg/sharings/errors.go
+++ b/pkg/sharings/errors.go
@@ -27,6 +27,5 @@ var (
 	ErrSharingIDNotUnique = errors.New("Several sharings with this id found")
 	// ErrSharerDidNotReceiveAnswer is used when a recipient has not received a
 	// http.StatusOK after sending her answer to the sharer.
-	ErrSharerDidNotReceiveAnswer = errors.New(`Sharer did not receive the
-        answer`)
+	ErrSharerDidNotReceiveAnswer = errors.New("Sharer did not receive the answer")
 )

--- a/pkg/sharings/errors.go
+++ b/pkg/sharings/errors.go
@@ -25,4 +25,8 @@ var (
 	ErrNoOAuthClient = errors.New("No OAuth client was found")
 	//ErrSharingIDNotUnique is used when several occurences of the same sharing id are found
 	ErrSharingIDNotUnique = errors.New("Several sharings with this id found")
+	// ErrSharerDidNotReceiveAnswer is used when a recipient has not received a
+	// http.StatusOK after sending her answer to the sharer.
+	ErrSharerDidNotReceiveAnswer = errors.New(`Sharer did not receive the
+        answer`)
 )

--- a/pkg/sharings/send_mails.go
+++ b/pkg/sharings/send_mails.go
@@ -97,8 +97,7 @@ func SendSharingMails(instance *instance.Instance, s *Sharing) error {
 // logErrorAndSetRecipientStatus will log an error in the stack and set the
 // status of the impacted recipient to "error".
 func logErrorAndSetRecipientStatus(rs *RecipientStatus, err error) bool {
-	log.Error(`[Sharing] An error occurred while trying to send
-        the email invitation`, err)
+	log.Error("[Sharing] An error occurred while trying to send the email invitation: ", err)
 	rs.Status = consts.ErrorSharingStatus
 	return true
 }

--- a/pkg/sharings/sharings.go
+++ b/pkg/sharings/sharings.go
@@ -1,12 +1,20 @@
 package sharings
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	log "github.com/Sirupsen/logrus"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
+	"github.com/cozy/cozy-stack/pkg/oauth"
 	"github.com/cozy/cozy-stack/pkg/permissions"
 	"github.com/cozy/cozy-stack/pkg/utils"
 	"github.com/cozy/cozy-stack/web/jsonapi"
+	"github.com/labstack/echo"
 )
 
 // Sharing contains all the information about a sharing
@@ -186,6 +194,60 @@ func SharingRefused(db couchdb.Database, state, clientID string) error {
 	recStatus.Status = consts.RefusedSharingStatus
 	err = couchdb.UpdateDoc(db, sharing)
 	return err
+}
+
+// RecipientRefusedSharing executes all the actions induced by a refusal from
+// the recipient: the sharing document is deleted and the sharer is informed.
+func RecipientRefusedSharing(db couchdb.Database, sharingID, clientID string) error {
+	// We get the sharing document through its sharing id…
+	var res []Sharing
+	err := couchdb.FindDocs(db, consts.Sharings, &couchdb.FindRequest{
+		Selector: mango.Equal("sharing_id", sharingID),
+	}, &res)
+	if err != nil {
+		return err
+	} else if len(res) < 1 {
+		return ErrSharingDoesNotExist
+	} else if len(res) > 1 {
+		return ErrSharingIDNotUnique
+	}
+	sharing := &res[0]
+
+	// … and we delete it because it is no longer needed.
+	err = couchdb.DeleteDoc(db, sharing)
+	if err != nil {
+		return err
+	}
+
+	// We get the sharer's oauth client so that we can get her Cozy's url
+	// through the `ClientURI`.
+	sharer := &oauth.Client{}
+	err = couchdb.GetDoc(db, consts.OAuthClients, clientID, sharer)
+	if err != nil {
+		return ErrNoOAuthClient
+	}
+
+	// We send the refusal.
+	bodyRaw := echo.Map{
+		"client_id": clientID,
+		"state":     sharingID,
+	}
+	body, _ := json.Marshal(bodyRaw)
+
+	url := fmt.Sprintf("%s/sharings/answer", sharer.ClientURI)
+	resp, err := http.Post(url, "application/json", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		log.Errorf(`[Sharing] The sharer might not have received the answer,
+            she replied with: %s`, resp.Status)
+		return ErrSharerDidNotReceiveAnswer
+	}
+
+	return nil
 }
 
 // CreateSharingRequest checks fields integrity and creates a sharing document

--- a/pkg/sharings/sharings_test.go
+++ b/pkg/sharings/sharings_test.go
@@ -268,13 +268,12 @@ func TestRecipientRefusedSharingSuccess(t *testing.T) {
 				t.Fail()
 			}
 			defer r.Body.Close()
-			data := struct {
-				SharingID string `json:"state"`
-				ClientID  string `json:"client_id"`
-			}{}
+			data := SharingAnswer{}
 			_ = json.Unmarshal(body, &data)
 			assert.Equal(t, testSharingID, data.SharingID)
 			assert.Equal(t, testClientID, data.ClientID)
+			assert.Empty(t, data.AccessToken)
+			assert.Empty(t, data.RefreshToken)
 
 			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 			w.WriteHeader(http.StatusOK)

--- a/pkg/sharings/sharings_test.go
+++ b/pkg/sharings/sharings_test.go
@@ -272,7 +272,7 @@ func TestRecipientRefusedSharingSuccess(t *testing.T) {
 				SharingID string `json:"state"`
 				ClientID  string `json:"client_id"`
 			}{}
-			err = json.Unmarshal(body, &data)
+			_ = json.Unmarshal(body, &data)
 			assert.Equal(t, testSharingID, data.SharingID)
 			assert.Equal(t, testClientID, data.ClientID)
 
@@ -288,6 +288,9 @@ func TestRecipientRefusedSharingSuccess(t *testing.T) {
 	}
 
 	docSharingTestID, err := insertSharingDocumentInDB(TestPrefix, testSharingID, testClientID)
+	if err != nil {
+		t.Fail()
+	}
 
 	err = RecipientRefusedSharing(TestPrefix, testSharingID, testClientID)
 	assert.NoError(t, err)

--- a/pkg/sharings/sharings_test.go
+++ b/pkg/sharings/sharings_test.go
@@ -442,7 +442,7 @@ func insertSharingDocumentInDB(db couchdb.Database, sharingID, clientID string) 
 	}
 	sharing.M["sharing_id"] = sharingID
 	sharing.M["client_id"] = clientID
-	err := couchdb.CreateDoc(TestPrefix, sharing)
+	err := couchdb.CreateDoc(db, sharing)
 	if err != nil {
 		fmt.Printf("Error occurred while trying to insert document: %v\n", err)
 		return "", err
@@ -459,5 +459,5 @@ func insertClientDocumentInDB(db couchdb.Database, clientID, url string) error {
 	client.SetID(clientID)
 	client.M["client_uri"] = url
 
-	return couchdb.CreateNamedDocWithDB(TestPrefix, client)
+	return couchdb.CreateNamedDocWithDB(db, client)
 }

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -24,6 +24,8 @@ var testInstance *instance.Instance
 var clientOAuth *oauth.Client
 var clientID string
 var instanceURL *url.URL
+var jar http.CookieJar
+var client *http.Client
 
 func TestRecipientRefusedSharingWithNoState(t *testing.T) {
 	res, err := postForm("/sharings/formRefuse", &url.Values{
@@ -189,6 +191,12 @@ func TestMain(m *testing.M) {
 	testInstance = setup.GetTestInstance()
 	instanceURL, _ = url.Parse("https://" + testInstance.Domain + "/")
 
+	jar = setup.GetCookieJar()
+	client = &http.Client{
+		CheckRedirect: noRedirect,
+		Jar:           jar,
+	}
+
 	clientOAuth, _ = setup.GetTestClient("")
 	clientID = clientOAuth.ClientID
 
@@ -211,7 +219,7 @@ func requestGET(u string, v url.Values) (*http.Response, error) {
 
 func postForm(u string, v *url.Values) (*http.Response, error) {
 	req, _ := http.NewRequest("POST", ts.URL+u, bytes.NewBufferString(v.Encode()))
-	req.Host = domain
+	req.Host = testInstance.Domain
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	return client.Do(req)
 }


### PR DESCRIPTION
This PR adds a route POST /sharings/formRefuse that, once called, will
trigger the refusal of the sharing.

This refusal is divided into two steps:
1. Deleting the corresponding sharing document;
2. Informing the sharer of the refusal.

