### PR TITLE
Sharing recipient creation 

### DIFF
--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -94,12 +94,13 @@ type Instance struct {
 
 // Options holds the parameters to create a new instance.
 type Options struct {
-	Domain   string
-	Locale   string
-	Timezone string
-	Email    string
-	Apps     []string
-	Dev      bool
+	Domain     string
+	Locale     string
+	Timezone   string
+	Email      string
+	PublicName string
+	Apps       []string
+	Dev        bool
 }
 
 // DocType implements couchdb.Doc
@@ -134,8 +135,9 @@ func (i *Instance) Included() []jsonapi.Object {
 
 // settings is a struct used for the settings of an instance
 type instanceSettings struct {
-	Timezone string `json:"tz,omitempty"`
-	Email    string `json:"email,omitempty"`
+	Timezone   string `json:"tz,omitempty"`
+	Email      string `json:"email,omitempty"`
+	PublicName string `json:"public_name,omitempty"`
 }
 
 func (s *instanceSettings) ID() string      { return consts.InstanceSettingsID }
@@ -398,8 +400,9 @@ func Create(opts *Options) (*Instance, error) {
 		return nil, err
 	}
 	settingsDoc := &instanceSettings{
-		Timezone: opts.Timezone,
-		Email:    opts.Email,
+		Timezone:   opts.Timezone,
+		Email:      opts.Email,
+		PublicName: opts.PublicName,
 	}
 	if err := couchdb.CreateNamedDoc(i, settingsDoc); err != nil {
 		return nil, err

--- a/pkg/sharings/errors.go
+++ b/pkg/sharings/errors.go
@@ -28,4 +28,6 @@ var (
 	// ErrSharerDidNotReceiveAnswer is used when a recipient has not received a
 	// http.StatusOK after sending her answer to the sharer.
 	ErrSharerDidNotReceiveAnswer = errors.New("Sharer did not receive the answer")
+	//ErrPublicNameNotDefined is used when a sharer wants to register to a recipient
+	ErrPublicNameNotDefined = errors.New("The Cozy's public name must be defined")
 )

--- a/pkg/sharings/recipients.go
+++ b/pkg/sharings/recipients.go
@@ -1,9 +1,9 @@
 package sharings
 
 import (
+	"github.com/cozy/cozy-stack/client/auth"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
-	"github.com/cozy/cozy-stack/pkg/oauth"
 	"github.com/cozy/cozy-stack/web/jsonapi"
 )
 
@@ -13,7 +13,7 @@ type Recipient struct {
 	RRev   string `json:"_rev,omitempty"`
 	Email  string `json:"email"`
 	URL    string `json:"url"`
-	Client *oauth.Client
+	Client *auth.Client
 }
 
 // ID returns the recipient qualified identifier

--- a/pkg/sharings/recipients.go
+++ b/pkg/sharings/recipients.go
@@ -1,9 +1,12 @@
 package sharings
 
 import (
+	"net/http"
+
 	"github.com/cozy/cozy-stack/client/auth"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/web/jsonapi"
 )
 
@@ -40,6 +43,52 @@ func (r *Recipient) Included() []jsonapi.Object { return nil }
 // Links implements jsonapi.Doc
 func (r *Recipient) Links() *jsonapi.LinksList {
 	return &jsonapi.LinksList{Self: "/recipients/" + r.RID}
+}
+
+// Register creates a OAuth request and register to the Recipient
+func (r *Recipient) Register(instance *instance.Instance) error {
+	if r.URL == "" {
+		return ErrRecipientHasNoURL
+	}
+	client := new(http.Client)
+	req := &auth.Request{
+		Domain:     r.URL,
+		HTTPClient: client,
+	}
+	redirectURI := instance.Domain + "/sharings/answer"
+
+	// Get the Cozy's public name
+	doc := &couchdb.JSONDoc{}
+	err := couchdb.GetDoc(instance, consts.Settings, consts.InstanceSettingsID, doc)
+	if err != nil {
+		return err
+	}
+	sharerPublicName, _ := doc.M["public_name"].(string)
+	if sharerPublicName == "" {
+		return ErrPublicNameNotDefined
+	}
+
+	authClient := &auth.Client{
+		RedirectURIs: []string{redirectURI},
+		ClientName:   sharerPublicName,
+		ClientKind:   "sharing",
+		SoftwareID:   "github.com/cozy/cozy-stack",
+		ClientURI:    instance.Domain,
+	}
+
+	resClient, err := req.RegisterClient(authClient)
+	if err != nil {
+		return err
+	}
+
+	r.Client = resClient
+	return couchdb.UpdateDoc(instance, r)
+}
+
+// CreateRecipient inserts a Recipient document in database
+func CreateRecipient(db couchdb.Database, doc *Recipient) error {
+	err := couchdb.CreateDoc(db, doc)
+	return err
 }
 
 var (

--- a/pkg/sharings/send_mails_test.go
+++ b/pkg/sharings/send_mails_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cozy/cozy-stack/client/auth"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
-	"github.com/cozy/cozy-stack/pkg/oauth"
 	"github.com/cozy/cozy-stack/pkg/permissions"
 	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/stretchr/testify/assert"
@@ -14,7 +14,7 @@ import (
 
 var rec = &Recipient{
 	URL: "",
-	Client: &oauth.Client{
+	Client: &auth.Client{
 		ClientID:     "",
 		RedirectURIs: []string{},
 	},

--- a/pkg/sharings/sharings_test.go
+++ b/pkg/sharings/sharings_test.go
@@ -10,13 +10,13 @@ import (
 	"testing"
 
 	"github.com/cozy/checkup"
+	"github.com/cozy/cozy-stack/client/auth"
 	"github.com/cozy/cozy-stack/pkg/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
 	"github.com/cozy/cozy-stack/pkg/crypto"
 	"github.com/cozy/cozy-stack/pkg/instance"
-	"github.com/cozy/cozy-stack/pkg/oauth"
 	"github.com/cozy/cozy-stack/pkg/permissions"
 	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/stretchr/testify/assert"
@@ -80,7 +80,7 @@ func TestGetSharingRecipientFromClientIDNoClient(t *testing.T) {
 func TestGetSharingRecipientFromClientIDSuccess(t *testing.T) {
 	clientID := "fake client"
 
-	client := &oauth.Client{
+	client := &auth.Client{
 		ClientID: clientID,
 	}
 	recipient := &Recipient{
@@ -145,7 +145,7 @@ func TestSharingRefusedSuccess(t *testing.T) {
 	state := "stateoftheart2"
 	clientID := "thriftshopclient"
 
-	client := &oauth.Client{
+	client := &auth.Client{
 		ClientID: clientID,
 	}
 	recipient := &Recipient{

--- a/tests/testutils/test_utils.go
+++ b/tests/testutils/test_utils.go
@@ -67,6 +67,11 @@ func (c *TestSetup) CleanupAndDie(msg ...interface{}) {
 	Fatal(msg...)
 }
 
+// Cleanup cleanup the TestSetup
+func (c *TestSetup) Cleanup() {
+	c.cleanup()
+}
+
 // AddCleanup adds a function to be run when the test is finished.
 func (c *TestSetup) AddCleanup(f func() error) {
 	next := c.cleanup

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -231,8 +231,8 @@ func TestMain(m *testing.M) {
 	ts = setup.GetTestServer("/sharings", Routes)
 	ts2 = setup2.GetTestServer("/auth", auth.Routes)
 
+	setup.AddCleanup(func() error { setup2.Cleanup(); return nil })
 	os.Exit(setup.Run())
-	os.Exit(setup2.Run())
 }
 
 func postJSON(u string, v echo.Map) (*http.Response, error) {

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -26,7 +26,6 @@ var ts2 *httptest.Server
 var testInstance *instance.Instance
 var clientOAuth *oauth.Client
 var clientID string
-var instanceURL *url.URL
 var jar http.CookieJar
 var client *http.Client
 


### PR DESCRIPTION
This allows to create a sharing recipient throught a `POST sharings/recipient` route. 

It triggers the creation of the recipient in the sharer database, and the OAuth registration of the sharer to the Cozy's recipient.
Note that the` public_name` option in the instance settings has been added, as it is needed for the OAuth `client_name` parameter.