### PR TITLE
Set http prefix to url in sharing mail

### DIFF
--- a/pkg/sharings/send_mails_test.go
+++ b/pkg/sharings/send_mails_test.go
@@ -91,33 +91,6 @@ func TestGenerateOAuthQueryStringSuccess(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestSetHTTPPrefixToURLWhenURLAlreadyHasAPrefix(t *testing.T) {
-	url := "https://correct.url.fr"
-	res := setHTTPPrefixToURL(url, "https")
-	assert.Equal(t, url, res)
-
-	res = setHTTPPrefixToURL(url, "http")
-	assert.Equal(t, url, res)
-
-	url = "http://correct.url.fr"
-	res = setHTTPPrefixToURL(url, "https")
-	assert.Equal(t, url, res)
-
-	res = setHTTPPrefixToURL(url, "http")
-	assert.Equal(t, url, res)
-}
-
-func TestSetHTTPPrefixToURLWhenURLDoesNotHaveOne(t *testing.T) {
-	url := "incomplete.url.fr"
-	urlExpected := "https://" + url
-	res := setHTTPPrefixToURL(url, "https")
-	assert.Equal(t, urlExpected, res)
-
-	urlExpected = "http://" + url
-	res = setHTTPPrefixToURL(url, "http")
-	assert.Equal(t, urlExpected, res)
-}
-
 func TestSendSharingMails(t *testing.T) {
 	// We provoke the error that occurrs when a recipient has no URL or no
 	// OAuth client by creating an incomplete recipient document.


### PR DESCRIPTION
If the url specified in the recipient's structure is not prefixed by
either "http" or "https" the button generated in the invitation email
cannot be correctly handled.

This PR fixes this problem by prefixing it by the appropriate value,
depending on `instance.Scheme()`. If the url is already prefixed then
nothing is changed.