### PR TITLE
Fix request url in mail invitation

### DIFF
--- a/pkg/sharings/send_mails.go
+++ b/pkg/sharings/send_mails.go
@@ -153,11 +153,17 @@ func generateOAuthQueryString(s *Sharing, r *Recipient, scheme string) (string, 
 		return "", err
 	}
 
-	oAuthQuery := url.URL{
-		Host: r.URL,
-		Path: "/sharings/request",
+	oAuthQuery, err := url.Parse(r.URL)
+	if err != nil {
+		return "", err
 	}
-
+	// Special scenario: if r.URL doesn't have an "http://" or "https://" prefix
+	// then `url.Parse` doesn't set any host.
+	if oAuthQuery.Host == "" {
+		oAuthQuery.Host = r.URL
+	}
+	// Where to send the answer.
+	oAuthQuery.Path = "/sharings/request"
 	// The link/button we put in the email has to have an http:// or https://
 	// prefix, otherwise it cannot be open in the browser.
 	if oAuthQuery.Scheme != "http" && oAuthQuery.Scheme != "https" {

--- a/pkg/sharings/send_mails.go
+++ b/pkg/sharings/send_mails.go
@@ -153,9 +153,9 @@ func generateOAuthQueryString(s *Sharing, r *Recipient, scheme string) (string, 
 		return "", err
 	}
 
-	oAuthQuery, err := url.Parse(r.URL)
-	if err != nil {
-		return "", err
+	oAuthQuery := url.URL{
+		Host: r.URL,
+		Path: "/sharings/request",
 	}
 
 	// The link/button we put in the email has to have an http:// or https://

--- a/pkg/sharings/send_mails_test.go
+++ b/pkg/sharings/send_mails_test.go
@@ -85,10 +85,24 @@ func TestGenerateOAuthQueryStringWhenRecipientHasNoURL(t *testing.T) {
 }
 
 func TestGenerateOAuthQueryStringSuccess(t *testing.T) {
+	// First test: no scheme in the url.
 	rec.URL = "this.is.url"
 	expectedStr := "http://this.is.url/sharings/request?client_id=sparta&redirect_uri=redirect.me.to.sparta&response_type=code&scope=&sharing_type=one-shot&state=sparta-id"
 
 	oAuthQueryString, err := generateOAuthQueryString(sharing, rec, instanceScheme)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedStr, oAuthQueryString)
+
+	// Second test: "http" scheme in the url.
+	rec.URL = "http://this.is.url"
+	oAuthQueryString, err = generateOAuthQueryString(sharing, rec, instanceScheme)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedStr, oAuthQueryString)
+
+	// Third test: "https" scheme in the url.
+	rec.URL = "https://this.is.url"
+	expectedStr = "https://this.is.url/sharings/request?client_id=sparta&redirect_uri=redirect.me.to.sparta&response_type=code&scope=&sharing_type=one-shot&state=sparta-id"
+	oAuthQueryString, err = generateOAuthQueryString(sharing, rec, instanceScheme)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedStr, oAuthQueryString)
 }

--- a/pkg/sharings/send_mails_test.go
+++ b/pkg/sharings/send_mails_test.go
@@ -78,7 +78,7 @@ func TestGenerateOAuthQueryStringWhenThereIsNoOAuthClient(t *testing.T) {
 func TestGenerateOAuthQueryStringWhenRecipientHasNoURL(t *testing.T) {
 	rec.Client.RedirectURIs = []string{"redirect.me.to.sparta"}
 
-	oauthQueryString, err := generateOAuthQueryString(sharing, rec, "http")
+	oauthQueryString, err := generateOAuthQueryString(sharing, rec, instanceScheme)
 	assert.Error(t, err)
 	assert.Equal(t, ErrRecipientHasNoURL, err)
 	assert.Equal(t, "", oauthQueryString)
@@ -86,9 +86,11 @@ func TestGenerateOAuthQueryStringWhenRecipientHasNoURL(t *testing.T) {
 
 func TestGenerateOAuthQueryStringSuccess(t *testing.T) {
 	rec.URL = "this.is.url"
+	expectedStr := "http://this.is.url/sharings/request?client_id=sparta&redirect_uri=redirect.me.to.sparta&response_type=code&scope=&sharing_type=one-shot&state=sparta-id"
 
-	_, err := generateOAuthQueryString(sharing, rec, instanceScheme)
+	oAuthQueryString, err := generateOAuthQueryString(sharing, rec, instanceScheme)
 	assert.NoError(t, err)
+	assert.Equal(t, expectedStr, oAuthQueryString)
 }
 
 func TestSendSharingMails(t *testing.T) {


### PR DESCRIPTION
The url's link in the mail must have its path equal to
"/sharings/request".

This PR fixes this mistake and adds a test that verify that the produced
link is correct.