### PR TITLE
Sharing acceptation handler

### DIFF
--- a/pkg/sharings/recipients.go
+++ b/pkg/sharings/recipients.go
@@ -48,16 +48,13 @@ func (r *Recipient) Links() *jsonapi.LinksList {
 
 // ExtractDomain returns the recipient's domain without the scheme
 func (r *Recipient) ExtractDomain() (string, error) {
-	var rURL string
 	if r.URL == "" {
 		return "", ErrRecipientHasNoURL
 	}
-	tokens := strings.Split(r.URL, "://")
-	rURL = r.URL
-	if len(tokens) > 1 {
-		rURL = tokens[1]
+	if tokens := strings.Split(r.URL, "://"); len(tokens) > 1 {
+		return tokens[1], nil
 	}
-	return rURL, nil
+	return r.URL, nil
 }
 
 // GetAccessToken sends an access_token requests to the recipient, using the

--- a/pkg/sharings/recipients.go
+++ b/pkg/sharings/recipients.go
@@ -48,28 +48,28 @@ func (r *Recipient) Links() *jsonapi.LinksList {
 
 // ExtractDomain returns the recipient's domain without the scheme
 func (r *Recipient) ExtractDomain() (string, error) {
-	var rUrl string
+	var rURL string
 	if r.URL == "" {
 		return "", ErrRecipientHasNoURL
 	}
 	tokens := strings.Split(r.URL, "://")
-	rUrl = r.URL
+	rURL = r.URL
 	if len(tokens) > 1 {
-		rUrl = tokens[1]
+		rURL = tokens[1]
 	}
-	return rUrl, nil
+	return rURL, nil
 }
 
 // GetAccessToken sends an access_token requests to the recipient, using the
 // given authorization code
 func (r *Recipient) GetAccessToken(code string) (*auth.AccessToken, error) {
 	client := new(http.Client)
-	rUrl, err := r.ExtractDomain()
+	rURL, err := r.ExtractDomain()
 	if err != nil {
 		return nil, err
 	}
 	req := &auth.Request{
-		Domain:     rUrl,
+		Domain:     rURL,
 		HTTPClient: client,
 	}
 	return req.GetAccessToken(r.Client, code)
@@ -77,13 +77,13 @@ func (r *Recipient) GetAccessToken(code string) (*auth.AccessToken, error) {
 
 // Register creates a OAuth request and register to the Recipient
 func (r *Recipient) Register(instance *instance.Instance) error {
-	rUrl, err := r.ExtractDomain()
+	rURL, err := r.ExtractDomain()
 	if err != nil {
 		return err
 	}
 	client := new(http.Client)
 	req := &auth.Request{
-		Domain:     rUrl,
+		Domain:     rURL,
 		HTTPClient: client,
 	}
 	redirectURI := instance.Scheme() + "://" + instance.Domain + "/sharings/answer"

--- a/pkg/sharings/recipients.go
+++ b/pkg/sharings/recipients.go
@@ -45,6 +45,17 @@ func (r *Recipient) Links() *jsonapi.LinksList {
 	return &jsonapi.LinksList{Self: "/recipients/" + r.RID}
 }
 
+// GetAccessToken sends an access_token requests to the recipient, using the
+// given authorization code
+func (r *Recipient) GetAccessToken(code string) (*auth.AccessToken, error) {
+	client := new(http.Client)
+	req := &auth.Request{
+		Domain:     r.URL,
+		HTTPClient: client,
+	}
+	return req.GetAccessToken(r.Client, code)
+}
+
 // Register creates a OAuth request and register to the Recipient
 func (r *Recipient) Register(instance *instance.Instance) error {
 	if r.URL == "" {
@@ -55,7 +66,7 @@ func (r *Recipient) Register(instance *instance.Instance) error {
 		Domain:     r.URL,
 		HTTPClient: client,
 	}
-	redirectURI := instance.Domain + "/sharings/answer"
+	redirectURI := instance.Scheme() + "://" + instance.Domain + "/sharings/answer"
 
 	// Get the Cozy's public name
 	doc := &couchdb.JSONDoc{}

--- a/web/auth/auth.go
+++ b/web/auth/auth.go
@@ -405,6 +405,7 @@ func authorize(c echo.Context) error {
 	q := u.Query()
 	q.Set("access_code", access.Code)
 	q.Set("state", params.state)
+	q.Set("client_id", params.clientID)
 	u.RawQuery = q.Encode()
 	u.Fragment = ""
 

--- a/web/auth/auth_test.go
+++ b/web/auth/auth_test.go
@@ -817,7 +817,7 @@ func TestAuthorizeSuccess(t *testing.T) {
 		couchdb.GetAllDocs(testInstance, consts.OAuthAccessCodes, req, &results)
 		if assert.Len(t, results, 1) {
 			code = results[0].Code
-			expected := fmt.Sprintf("https://example.org/oauth/callback?access_code=%s&state=123456#", code)
+			expected := fmt.Sprintf("https://example.org/oauth/callback?access_code=%s&client_id=%s&state=123456#", code, clientID)
 			assert.Equal(t, expected, res.Header.Get("Location"))
 			assert.Equal(t, results[0].ClientID, clientID)
 			assert.Equal(t, results[0].Scope, "files:read")

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -13,25 +13,22 @@ import (
 
 // SharingAnswer handles a sharing answer from the sharer side
 func SharingAnswer(c echo.Context) error {
-
 	var err error
 
-	state := c.FormValue("state")
-	clientID := c.FormValue("client_id")
-	scope := c.FormValue("scope")
-	accessCode := c.FormValue("access_code")
+	state := c.QueryParam("state")
+	clientID := c.QueryParam("client_id")
+	accessCode := c.QueryParam("access_code")
 
 	instance := middlewares.GetInstance(c)
 
-	// The sharing is refused if there is no access code or scope
-	sharingAccepted := scope != "" && accessCode != ""
+	// The sharing is refused if there is no access code
+	sharingAccepted := accessCode != ""
 
 	if sharingAccepted {
-		//TODO: handle the acceptation
+		err = sharings.SharingAccepted(instance, state, clientID, accessCode)
 	} else {
 		err = sharings.SharingRefused(instance, state, clientID)
 	}
-
 	if err != nil {
 		return wrapErrors(err)
 	}
@@ -158,6 +155,7 @@ func Routes(router *echo.Group) {
 	router.GET("/request", SharingRequest)
 	router.POST("/answer", SharingAnswer)
 	router.POST("/formRefuse", RecipientRefusedSharing)
+	router.GET("/answer", SharingAnswer)
 	router.POST("/recipient", AddRecipient)
 }
 

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -14,6 +14,7 @@ import (
 // SharingAnswer handles a sharing answer from the sharer side
 func SharingAnswer(c echo.Context) error {
 	var err error
+	var u string
 
 	state := c.QueryParam("state")
 	clientID := c.QueryParam("client_id")
@@ -25,16 +26,14 @@ func SharingAnswer(c echo.Context) error {
 	sharingAccepted := accessCode != ""
 
 	if sharingAccepted {
-		err = sharings.SharingAccepted(instance, state, clientID, accessCode)
+		u, err = sharings.SharingAccepted(instance, state, clientID, accessCode)
 	} else {
-		err = sharings.SharingRefused(instance, state, clientID)
+		u, err = sharings.SharingRefused(instance, state, clientID)
 	}
 	if err != nil {
 		return wrapErrors(err)
 	}
-	return c.JSON(http.StatusOK, echo.Map{
-		"message": "Answer received",
-	})
+	return c.Redirect(http.StatusFound, u)
 }
 
 // AddRecipient adds a sharing Recipient and register to its server

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -152,9 +152,9 @@ func Routes(router *echo.Group) {
 	router.POST("/", CreateSharing)
 	router.PUT("/:id/sendMails", SendSharingMails)
 	router.GET("/request", SharingRequest)
+	router.GET("/answer", SharingAnswer)
 	router.POST("/answer", SharingAnswer)
 	router.POST("/formRefuse", RecipientRefusedSharing)
-	router.GET("/answer", SharingAnswer)
 	router.POST("/recipient", AddRecipient)
 }
 

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -23,9 +23,7 @@ func SharingAnswer(c echo.Context) error {
 	instance := middlewares.GetInstance(c)
 
 	// The sharing is refused if there is no access code
-	sharingAccepted := accessCode != ""
-
-	if sharingAccepted {
+	if accessCode != "" {
 		u, err = sharings.SharingAccepted(instance, state, clientID, accessCode)
 	} else {
 		u, err = sharings.SharingRefused(instance, state, clientID)

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -116,6 +116,7 @@ func TestSharingAnswerBadCode(t *testing.T) {
 	assert.NotNil(t, recipient)
 	assert.NotNil(t, recipient.Client.ClientID)
 	sharing, err := createSharing(t, recipient)
+	assert.NoError(t, err)
 	assert.NotNil(t, sharing)
 
 	urlVal := url.Values{
@@ -134,6 +135,7 @@ func TestSharingAnswerSuccess(t *testing.T) {
 	assert.NotNil(t, recipient)
 	assert.NotNil(t, recipient.Client.ClientID)
 	sharing, err := createSharing(t, recipient)
+	assert.NoError(t, err)
 	assert.NotNil(t, sharing)
 
 	access, err := generateAccessCode(t, recipient.Client.ClientID, "")

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -36,7 +36,7 @@ var recipientURL string
 func createRecipient(t *testing.T) (*sharings.Recipient, error) {
 	recipient := &sharings.Recipient{
 		Email: "test.fr",
-		URL:   recipientURL,
+		URL:   "http://" + recipientURL,
 	}
 	err := sharings.CreateRecipient(testInstance, recipient)
 	assert.NoError(t, err)

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -15,8 +15,10 @@ import (
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/pkg/oauth"
 	"github.com/cozy/cozy-stack/pkg/permissions"
+	"github.com/cozy/cozy-stack/pkg/sharings"
 	"github.com/cozy/cozy-stack/tests/testutils"
 	"github.com/cozy/cozy-stack/web/auth"
+	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/labstack/echo"
 	"github.com/stretchr/testify/assert"
 )
@@ -24,35 +26,55 @@ import (
 var ts *httptest.Server
 var ts2 *httptest.Server
 var testInstance *instance.Instance
+var recipientIn *instance.Instance
 var clientOAuth *oauth.Client
 var clientID string
 var jar http.CookieJar
 var client *http.Client
+var recipientURL string
 
-func TestRecipientRefusedSharingWithNoState(t *testing.T) {
-	res, err := postForm("/sharings/formRefuse", &url.Values{
-		"state": {""},
-	})
+func createRecipient(t *testing.T) (*sharings.Recipient, error) {
+	recipient := &sharings.Recipient{
+		Email: "test.fr",
+		URL:   recipientURL,
+	}
+	err := sharings.CreateRecipient(testInstance, recipient)
 	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "400 Bad Request", res.Status)
+	err = recipient.Register(testInstance)
+	assert.NoError(t, err)
+	return recipient, err
 }
 
-func TestRecipientRefusedSharingWithNoClientID(t *testing.T) {
-	res, err := postForm("/sharings/formRefuse", &url.Values{
-		"state":     {"dummystate"},
-		"client_id": {""},
-	})
+func createSharing(t *testing.T, recipient *sharings.Recipient) (*sharings.Sharing, error) {
+	recStatus := &sharings.RecipientStatus{
+		RefRecipient: jsonapi.ResourceIdentifier{
+			ID:   recipient.RID,
+			Type: consts.Recipients,
+		},
+	}
+
+	sharing := &sharings.Sharing{
+		SharingType:      consts.OneShotSharing,
+		RecipientsStatus: []*sharings.RecipientStatus{recStatus},
+	}
+	err := sharings.CheckSharingCreation(testInstance, sharing)
 	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "400 Bad Request", res.Status)
+	err = sharings.Create(testInstance, sharing)
+	assert.NoError(t, err)
+	return sharing, err
+}
+
+func generateAccessCode(t *testing.T, clientID, scope string) (*oauth.AccessCode, error) {
+	access, err := oauth.CreateAccessCode(recipientIn, clientID, scope)
+	assert.NoError(t, err)
+	return access, err
 }
 
 func TestSharingAnswerBadState(t *testing.T) {
-	state := ""
-	res, err := postJSON("/sharings/answer", echo.Map{
-		"state": state,
-	})
+	urlVal := url.Values{
+		"state": {""},
+	}
+	res, err := requestGET("/sharings/answer", urlVal)
 	assert.NoError(t, err)
 	assert.Equal(t, 404, res.StatusCode)
 }
@@ -79,21 +101,56 @@ func TestAddRecipientSuccess(t *testing.T) {
 }
 
 func TestSharingAnswerBadClientID(t *testing.T) {
-	state := "stateoftheart"
-	clientID2 := "myclient"
-	res, err := postJSON("/sharings/answer", echo.Map{
-		"state":     state,
-		"client_id": clientID2,
-	})
+	urlVal := url.Values{
+		"state":     {"stateoftheart"},
+		"client_id": {"myclient"},
+	}
+	res, err := requestGET("/sharings/answer", urlVal)
 	assert.NoError(t, err)
 	assert.Equal(t, 404, res.StatusCode)
 }
 
-func TestSharingRequestNoScope(t *testing.T) {
+func TestSharingAnswerBadCode(t *testing.T) {
+	recipient, err := createRecipient(t)
+	assert.NoError(t, err)
+	assert.NotNil(t, recipient)
+	assert.NotNil(t, recipient.Client.ClientID)
+	sharing, err := createSharing(t, recipient)
+	assert.NotNil(t, sharing)
+
 	urlVal := url.Values{
-		"state":        {"dummystate"},
-		"sharing_type": {consts.OneShotSharing},
+		"state":       {sharing.SharingID},
+		"client_id":   {recipient.Client.ClientID},
+		"access_code": {"fakeaccess"},
 	}
+	res, err := requestGET("/sharings/answer", urlVal)
+	assert.NoError(t, err)
+	assert.Equal(t, 500, res.StatusCode)
+}
+
+func TestSharingAnswerSuccess(t *testing.T) {
+	recipient, err := createRecipient(t)
+	assert.NoError(t, err)
+	assert.NotNil(t, recipient)
+	assert.NotNil(t, recipient.Client.ClientID)
+	sharing, err := createSharing(t, recipient)
+	assert.NotNil(t, sharing)
+
+	access, err := generateAccessCode(t, recipient.Client.ClientID, "")
+	assert.NoError(t, err)
+	assert.NotNil(t, access)
+
+	urlVal := url.Values{
+		"state":       {sharing.SharingID},
+		"client_id":   {recipient.Client.ClientID},
+		"access_code": {access.Code},
+	}
+	_, err = requestGET("/sharings/answer", urlVal)
+	assert.NoError(t, err)
+}
+
+func TestSharingRequestNoScope(t *testing.T) {
+	urlVal := url.Values{}
 	res, err := requestGET("/sharings/request", urlVal)
 	assert.NoError(t, err)
 	assert.Equal(t, 400, res.StatusCode)
@@ -210,7 +267,6 @@ func TestCreateSharingSuccess(t *testing.T) {
 func TestMain(m *testing.M) {
 	config.UseTestFile()
 	testutils.NeedCouchdb()
-
 	setup := testutils.NewSetup(m, "sharing_test_alice")
 	setup2 := testutils.NewSetup(m, "sharing_test_bob")
 	testInstance = setup.GetTestInstance(&instance.Options{
@@ -225,13 +281,19 @@ func TestMain(m *testing.M) {
 		CheckRedirect: noRedirect,
 		Jar:           jar,
 	}
+	recipientIn = setup2.GetTestInstance(&instance.Options{
+		PublicName: "Bob",
+	})
+
 	clientOAuth, _ = setup.GetTestClient("")
 	clientID = clientOAuth.ClientID
 
 	ts = setup.GetTestServer("/sharings", Routes)
 	ts2 = setup2.GetTestServer("/auth", auth.Routes)
+	recipientURL = strings.Split(ts2.URL, "http://")[1]
 
 	setup.AddCleanup(func() error { setup2.Cleanup(); return nil })
+
 	os.Exit(setup.Run())
 }
 
@@ -248,11 +310,11 @@ func requestGET(u string, v url.Values) (*http.Response, error) {
 	return http.Get(ts.URL + u)
 }
 
-func postForm(u string, v *url.Values) (*http.Response, error) {
+func formPOST(u string, v url.Values) (*http.Response, error) {
 	req, _ := http.NewRequest("POST", ts.URL+u, bytes.NewBufferString(v.Encode()))
 	req.Host = testInstance.Domain
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	return client.Do(req)
+	noRedirectClient := http.Client{CheckRedirect: noRedirect}
+	return noRedirectClient.Do(req)
 }
 
 func extractJSONRes(res *http.Response, mp *map[string]interface{}) error {


### PR DESCRIPTION
This allows to handle a recipient's sharing answer on the sharer side.

From the user point of view, he is redirected to his own Cozy, after being redirected to the sharer Cozy.
Behind the hoods, the answer triggers an `access_token` request to the recipient and an update in database with the new credentials and recipient status.

Note the `auth/authorize` redirection has been completed with a the `client_id`, as it is required by the sharer to identify the recipient.