### PR TITLE
fix: new query parameter added in _changes request

### DIFF
--- a/web/data/data.go
+++ b/web/data/data.go
@@ -298,6 +298,7 @@ var allowedChangesParams = map[string]bool{
 	"limit":     true,
 	"timeout":   true,
 	"heartbeat": true, // Pouchdb sends heartbeet even for non-continuous
+	"_nonce": true, // Pouchdb sends a request hash for cache purpose
 }
 
 func changesFeed(c echo.Context) error {

--- a/web/data/data.go
+++ b/web/data/data.go
@@ -298,7 +298,7 @@ var allowedChangesParams = map[string]bool{
 	"limit":     true,
 	"timeout":   true,
 	"heartbeat": true, // Pouchdb sends heartbeet even for non-continuous
-	"_nonce": true, // Pouchdb sends a request hash for cache purpose
+	"_nonce":    true, // Pouchdb sends a request hash to avoid agressive caching by some browsers
 }
 
 func changesFeed(c echo.Context) error {


### PR DESCRIPTION
In a third party application with pouchdb, there is `_changes` request sent to know changes.
Sometimes (chromium Version 57.0.2987.110) this request sends an extra query parameter for cache purpose called `_nonce` and containing a request hash.
That is the very reason I suggest this PR.
