### PR TITLE
[VFS] Higher level interface closer to our data modeling

### DIFF
--- a/pkg/apps/installer_test.go
+++ b/pkg/apps/installer_test.go
@@ -1,6 +1,7 @@
 package apps
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -18,7 +19,6 @@ import (
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/vfs"
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -34,6 +34,23 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	*req2 = *req
 	req2.URL, _ = url.Parse(ts.URL)
 	return http.DefaultTransport.RoundTrip(req2)
+}
+
+func fileContainsBytes(fs vfs.VFS, name string, data []byte) (bool, error) {
+	doc, err := fs.FileByPath(name)
+	if err != nil {
+		return false, err
+	}
+	f, err := fs.OpenFile(doc)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+	b, err := ioutil.ReadAll(f)
+	if err != nil {
+		return false, err
+	}
+	return bytes.Contains(b, data), nil
 }
 
 func manifest() string {
@@ -98,20 +115,18 @@ git checkout -`
 	}
 }
 
-var c = &TestContext{
-	prefix: "apps-test/",
-	fs:     afero.NewMemMapFs(),
-}
+var db couchdb.Database
+var fs vfs.VFS
 
 func TestInstallBadSlug(t *testing.T) {
-	_, err := NewInstaller(c, &InstallerOptions{
+	_, err := NewInstaller(db, fs, &InstallerOptions{
 		SourceURL: "git://foo.bar",
 	})
 	if assert.Error(t, err) {
 		assert.Equal(t, ErrInvalidSlugName, err)
 	}
 
-	_, err = NewInstaller(c, &InstallerOptions{
+	_, err = NewInstaller(db, fs, &InstallerOptions{
 		Slug:      "coucou/",
 		SourceURL: "git://foo.bar",
 	})
@@ -121,7 +136,7 @@ func TestInstallBadSlug(t *testing.T) {
 }
 
 func TestInstallBadAppsSource(t *testing.T) {
-	_, err := NewInstaller(c, &InstallerOptions{
+	_, err := NewInstaller(db, fs, &InstallerOptions{
 		Slug:      "app3",
 		SourceURL: "foo://bar.baz",
 	})
@@ -129,7 +144,7 @@ func TestInstallBadAppsSource(t *testing.T) {
 		assert.Equal(t, ErrNotSupportedSource, err)
 	}
 
-	_, err = NewInstaller(c, &InstallerOptions{
+	_, err = NewInstaller(db, fs, &InstallerOptions{
 		Slug:      "app4",
 		SourceURL: "git://bar  .baz",
 	})
@@ -139,7 +154,7 @@ func TestInstallBadAppsSource(t *testing.T) {
 }
 
 func TestInstallSuccessful(t *testing.T) {
-	inst, err := NewInstaller(c, &InstallerOptions{
+	inst, err := NewInstaller(db, fs, &InstallerOptions{
 		Slug:      "local-cozy-mini",
 		SourceURL: "git://localhost/",
 	})
@@ -174,16 +189,16 @@ func TestInstallSuccessful(t *testing.T) {
 		state = man.State
 	}
 
-	ok, err := afero.Exists(c.FS(), "/.cozy_apps/local-cozy-mini/manifest.webapp")
+	ok, err := vfs.Exists(fs, "/.cozy_apps/local-cozy-mini/manifest.webapp")
 	assert.NoError(t, err)
 	assert.True(t, ok, "The manifest is present")
-	ok, err = afero.FileContainsBytes(c.FS(), "/.cozy_apps/local-cozy-mini/manifest.webapp", []byte("1.0.0"))
+	ok, err = fileContainsBytes(fs, "/.cozy_apps/local-cozy-mini/manifest.webapp", []byte("1.0.0"))
 	assert.NoError(t, err)
 	assert.True(t, ok, "The manifest has the right version")
 }
 
 func TestInstallAldreadyExist(t *testing.T) {
-	inst, err := NewInstaller(c, &InstallerOptions{
+	inst, err := NewInstaller(db, fs, &InstallerOptions{
 		Slug:      "cozy-app-a",
 		SourceURL: "git://localhost/",
 	})
@@ -204,7 +219,7 @@ func TestInstallAldreadyExist(t *testing.T) {
 		}
 	}
 
-	inst, err = NewInstaller(c, &InstallerOptions{
+	inst, err = NewInstaller(db, fs, &InstallerOptions{
 		Slug:      "cozy-app-a",
 		SourceURL: "git://localhost/",
 	})
@@ -219,7 +234,7 @@ func TestInstallAldreadyExist(t *testing.T) {
 }
 
 func TestInstallWithUpgrade(t *testing.T) {
-	inst, err := NewInstaller(c, &InstallerOptions{
+	inst, err := NewInstaller(db, fs, &InstallerOptions{
 		Slug:      "cozy-app-b",
 		SourceURL: "git://localhost/",
 	})
@@ -240,16 +255,16 @@ func TestInstallWithUpgrade(t *testing.T) {
 		}
 	}
 
-	ok, err := afero.Exists(c.FS(), "/.cozy_apps/local-cozy-mini/manifest.webapp")
+	ok, err := vfs.Exists(fs, "/.cozy_apps/local-cozy-mini/manifest.webapp")
 	assert.NoError(t, err)
 	assert.True(t, ok, "The manifest is present")
-	ok, err = afero.FileContainsBytes(c.FS(), "/.cozy_apps/local-cozy-mini/manifest.webapp", []byte("1.0.0"))
+	ok, err = fileContainsBytes(fs, "/.cozy_apps/local-cozy-mini/manifest.webapp", []byte("1.0.0"))
 	assert.NoError(t, err)
 	assert.True(t, ok, "The manifest has the right version")
 
 	doUpgrade(2)
 
-	inst, err = NewInstaller(c, &InstallerOptions{
+	inst, err = NewInstaller(db, fs, &InstallerOptions{
 		Slug:      "cozy-app-b",
 		SourceURL: "git://localhost/",
 	})
@@ -284,10 +299,10 @@ func TestInstallWithUpgrade(t *testing.T) {
 		state = man.State
 	}
 
-	ok, err = afero.Exists(c.FS(), "/.cozy_apps/cozy-app-b/manifest.webapp")
+	ok, err = vfs.Exists(fs, "/.cozy_apps/cozy-app-b/manifest.webapp")
 	assert.NoError(t, err)
 	assert.True(t, ok, "The manifest is present")
-	ok, err = afero.FileContainsBytes(c.FS(), "/.cozy_apps/cozy-app-b/manifest.webapp", []byte("2.0.0"))
+	ok, err = fileContainsBytes(fs, "/.cozy_apps/cozy-app-b/manifest.webapp", []byte("2.0.0"))
 	assert.NoError(t, err)
 	assert.True(t, ok, "The manifest has the right version")
 }
@@ -295,7 +310,7 @@ func TestInstallWithUpgrade(t *testing.T) {
 func TestInstallAndUpgradeWithBranch(t *testing.T) {
 	doUpgrade(3)
 
-	inst, err := NewInstaller(c, &InstallerOptions{
+	inst, err := NewInstaller(db, fs, &InstallerOptions{
 		Slug:      "local-cozy-mini-branch",
 		SourceURL: "git://localhost/#branch",
 	})
@@ -330,19 +345,19 @@ func TestInstallAndUpgradeWithBranch(t *testing.T) {
 		state = man.State
 	}
 
-	ok, err := afero.Exists(c.FS(), "/.cozy_apps/local-cozy-mini-branch/manifest.webapp")
+	ok, err := vfs.Exists(fs, "/.cozy_apps/local-cozy-mini-branch/manifest.webapp")
 	assert.NoError(t, err)
 	assert.True(t, ok, "The manifest is present")
-	ok, err = afero.FileContainsBytes(c.FS(), "/.cozy_apps/local-cozy-mini-branch/manifest.webapp", []byte("3.0.0"))
+	ok, err = fileContainsBytes(fs, "/.cozy_apps/local-cozy-mini-branch/manifest.webapp", []byte("3.0.0"))
 	assert.NoError(t, err)
 	assert.True(t, ok, "The manifest has the right version")
-	ok, err = afero.Exists(c.FS(), "/.cozy_apps/local-cozy-mini-branch/branch")
+	ok, err = vfs.Exists(fs, "/.cozy_apps/local-cozy-mini-branch/branch")
 	assert.NoError(t, err)
 	assert.True(t, ok, "The good branch was checked out")
 
 	doUpgrade(4)
 
-	inst, err = NewInstaller(c, &InstallerOptions{
+	inst, err = NewInstaller(db, fs, &InstallerOptions{
 		Slug:      "local-cozy-mini-branch",
 		SourceURL: "git://localhost/#branch",
 	})
@@ -377,19 +392,19 @@ func TestInstallAndUpgradeWithBranch(t *testing.T) {
 		state = man.State
 	}
 
-	ok, err = afero.Exists(c.FS(), "/.cozy_apps/local-cozy-mini-branch/manifest.webapp")
+	ok, err = vfs.Exists(fs, "/.cozy_apps/local-cozy-mini-branch/manifest.webapp")
 	assert.NoError(t, err)
 	assert.True(t, ok, "The manifest is present")
-	ok, err = afero.FileContainsBytes(c.FS(), "/.cozy_apps/local-cozy-mini-branch/manifest.webapp", []byte("4.0.0"))
+	ok, err = fileContainsBytes(fs, "/.cozy_apps/local-cozy-mini-branch/manifest.webapp", []byte("4.0.0"))
 	assert.NoError(t, err)
 	assert.True(t, ok, "The manifest has the right version")
-	ok, err = afero.Exists(c.FS(), "/.cozy_apps/local-cozy-mini-branch/branch")
+	ok, err = vfs.Exists(fs, "/.cozy_apps/local-cozy-mini-branch/branch")
 	assert.NoError(t, err)
 	assert.True(t, ok, "The good branch was checked out")
 }
 
 func TestInstallFromGithub(t *testing.T) {
-	inst, err := NewInstaller(c, &InstallerOptions{
+	inst, err := NewInstaller(db, fs, &InstallerOptions{
 		Slug:      "github-cozy-mini",
 		SourceURL: "git://github.com/nono/cozy-mini.git",
 	})
@@ -426,7 +441,7 @@ func TestInstallFromGithub(t *testing.T) {
 }
 
 func TestUninstall(t *testing.T) {
-	inst1, err := NewInstaller(c, &InstallerOptions{
+	inst1, err := NewInstaller(db, fs, &InstallerOptions{
 		Slug:      "github-cozy-delete",
 		SourceURL: "git://localhost/",
 	})
@@ -444,7 +459,7 @@ func TestUninstall(t *testing.T) {
 			break
 		}
 	}
-	inst2, err := NewInstaller(c, &InstallerOptions{Slug: "github-cozy-delete"})
+	inst2, err := NewInstaller(db, fs, &InstallerOptions{Slug: "github-cozy-delete"})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -452,7 +467,7 @@ func TestUninstall(t *testing.T) {
 	if !assert.NoError(t, err) {
 		return
 	}
-	inst3, err := NewInstaller(c, &InstallerOptions{Slug: "github-cozy-delete"})
+	inst3, err := NewInstaller(db, fs, &InstallerOptions{Slug: "github-cozy-delete"})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -464,8 +479,8 @@ func TestUninstall(t *testing.T) {
 func TestMain(m *testing.M) {
 	config.UseTestFile()
 
-	db, err := checkup.HTTPChecker{URL: config.CouchURL()}.Check()
-	if err != nil || db.Status() != checkup.Healthy {
+	check, err := checkup.HTTPChecker{URL: config.CouchURL()}.Check()
+	if err != nil || check.Status() != checkup.Healthy {
 		fmt.Println("This test need couchdb to run.")
 		os.Exit(1)
 	}
@@ -478,19 +493,21 @@ func TestMain(m *testing.M) {
 		Transport: &transport{},
 	}
 
-	err = couchdb.ResetDB(c, consts.Apps)
+	db = couchdb.SimpleDatabasePrefix("apps-test")
+
+	err = couchdb.ResetDB(db, consts.Apps)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
 
-	err = couchdb.ResetDB(c, consts.Files)
+	err = couchdb.ResetDB(db, consts.Files)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
 
-	err = vfs.CreateTrashDir(c)
+	fs, err = vfs.NewAferoVFS(db, "mem://")
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
@@ -500,33 +517,34 @@ func TestMain(m *testing.M) {
 
 	time.Sleep(100 * time.Millisecond)
 
-	err = couchdb.ResetDB(c, consts.Permissions)
+	err = couchdb.ResetDB(db, consts.Permissions)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
 
-	err = couchdb.DefineIndexes(c, consts.IndexesByDoctype(consts.Files))
+	err = couchdb.DefineIndexes(db, consts.IndexesByDoctype(consts.Files))
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
 
-	err = couchdb.DefineIndexes(c, consts.IndexesByDoctype(consts.Permissions))
+	err = couchdb.DefineIndexes(db, consts.IndexesByDoctype(consts.Permissions))
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
 
-	if err = vfs.CreateRootDirDoc(c); err != nil {
+	err = fs.Init()
+	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
 
 	res := m.Run()
 
-	couchdb.DeleteDB(c, consts.Apps)
-	couchdb.DeleteDB(c, consts.Files)
+	couchdb.DeleteDB(db, consts.Apps)
+	couchdb.DeleteDB(db, consts.Files)
 	ts.Close()
 
 	localGitCmd.Process.Signal(os.Interrupt)

--- a/pkg/apps/installer_test.go
+++ b/pkg/apps/installer_test.go
@@ -98,14 +98,6 @@ git checkout -`
 	}
 }
 
-type TestContext struct {
-	prefix string
-	fs     afero.Fs
-}
-
-func (c TestContext) Prefix() string { return c.prefix }
-func (c TestContext) FS() afero.Fs   { return c.fs }
-
 var c = &TestContext{
 	prefix: "apps-test/",
 	fs:     afero.NewMemMapFs(),

--- a/pkg/apps/installer_test.go
+++ b/pkg/apps/installer_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/vfs"
+	"github.com/cozy/cozy-stack/pkg/vfs/vfsafero"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -507,7 +508,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	fs, err = vfs.NewAferoVFS(db, "mem://")
+	fs, err = vfsafero.New(db, "mem://")
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/permissions"
 	"github.com/cozy/cozy-stack/pkg/settings"
 	"github.com/cozy/cozy-stack/pkg/vfs"
+	"github.com/cozy/cozy-stack/pkg/vfs/vfsafero"
 	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/leonelquinteros/gotext"
 	jwt "gopkg.in/dgrijalva/jwt-go.v3"
@@ -161,7 +162,7 @@ func (i *Instance) VFS() vfs.VFS {
 		}
 		switch u.Scheme {
 		case "file", "mem":
-			i.storage, err = vfs.NewAferoVFS(i, i.StorageURL)
+			i.storage, err = vfsafero.New(i, i.StorageURL)
 		case "swift":
 			err = errors.New("instance: storage provider swift not implemened")
 		default:
@@ -487,7 +488,7 @@ func Destroy(domain string) (*Instance, error) {
 		return nil, err
 	}
 
-	if err = i.VFS().Destroy(); err != nil {
+	if err = i.VFS().Delete(); err != nil {
 		return nil, err
 	}
 

--- a/pkg/instance/instance_test.go
+++ b/pkg/instance/instance_test.go
@@ -373,11 +373,11 @@ func TestGetFs(t *testing.T) {
 	content := []byte{'b', 'a', 'r'}
 	err := instance.makeStorageFs()
 	assert.NoError(t, err)
-	storage := instance.FS()
+	storage := instance.VFS()
 	assert.NotNil(t, storage, "the instance should have a memory storage provider")
 	err = afero.WriteFile(storage, "foo", content, 0644)
 	assert.NoError(t, err)
-	storage = instance.FS()
+	storage = instance.VFS()
 	assert.NotNil(t, storage, "the instance should have a memory storage provider")
 	buf, err := afero.ReadFile(storage, "foo")
 	assert.NoError(t, err)

--- a/pkg/instance/instance_test.go
+++ b/pkg/instance/instance_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cozy/cozy-stack/pkg/crypto"
 	"github.com/cozy/cozy-stack/pkg/vfs"
 	jwt "github.com/dgrijalva/jwt-go"
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -370,18 +369,8 @@ func TestGetFs(t *testing.T) {
 		Domain:     "test-provider.cozycloud.cc",
 		StorageURL: "mem://test",
 	}
-	content := []byte{'b', 'a', 'r'}
-	err := instance.makeStorageFs()
-	assert.NoError(t, err)
 	storage := instance.VFS()
 	assert.NotNil(t, storage, "the instance should have a memory storage provider")
-	err = afero.WriteFile(storage, "foo", content, 0644)
-	assert.NoError(t, err)
-	storage = instance.VFS()
-	assert.NotNil(t, storage, "the instance should have a memory storage provider")
-	buf, err := afero.ReadFile(storage, "foo")
-	assert.NoError(t, err)
-	assert.Equal(t, content, buf, "the storage should have persist the content of the foo file")
 }
 
 func TestTranslate(t *testing.T) {

--- a/pkg/vfs/directory.go
+++ b/pkg/vfs/directory.go
@@ -67,7 +67,13 @@ func (d *DirDoc) Path(fs VFS) (string, error) {
 }
 
 // Parent returns the parent directory document
-func (d *DirDoc) Parent(fs VFS) (*DirDoc, error) { return fs.DirByID(d.DirID) }
+func (d *DirDoc) Parent(fs VFS) (*DirDoc, error) {
+	parent, err := fs.DirByID(d.DirID)
+	if os.IsNotExist(err) {
+		err = ErrParentDoesNotExist
+	}
+	return parent, err
+}
 
 // Name returns base name of the file
 func (d *DirDoc) Name() string { return d.DocName }

--- a/pkg/vfs/directory.go
+++ b/pkg/vfs/directory.go
@@ -1,7 +1,6 @@
 package vfs
 
 import (
-	"fmt"
 	"os"
 	"path"
 	"strings"
@@ -9,7 +8,6 @@ import (
 
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
-	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
 )
 
 // DirDoc is a struct containing all the informations about a
@@ -24,7 +22,7 @@ type DirDoc struct {
 	// Directory revision
 	DocRev string `json:"_rev,omitempty"`
 	// Directory name
-	Name string `json:"name"`
+	DocName string `json:"name"`
 	// Parent directory identifier
 	DirID       string `json:"dir_id"`
 	RestorePath string `json:"restore_path,omitempty"`
@@ -53,35 +51,45 @@ func (d *DirDoc) SetID(id string) { d.DocID = id }
 func (d *DirDoc) SetRev(rev string) { d.DocRev = rev }
 
 // Path is used to generate the file path
-func (d *DirDoc) Path(c Context) (string, error) {
+func (d *DirDoc) Path(fs VFS) (string, error) {
 	if d.Fullpath == "" {
-		parent, err := d.Parent(c)
+		parent, err := d.Parent(fs)
 		if err != nil {
 			return "", err
 		}
-		parentPath, err := parent.Path(c)
+		parentPath, err := parent.Path(fs)
 		if err != nil {
 			return "", err
 		}
-		d.Fullpath = path.Join(parentPath, d.Name)
+		d.Fullpath = path.Join(parentPath, d.DocName)
 	}
 	return d.Fullpath, nil
 }
 
 // Parent returns the parent directory document
-func (d *DirDoc) Parent(c Context) (*DirDoc, error) {
-	return GetDirDoc(c, d.DirID)
-}
+func (d *DirDoc) Parent(fs VFS) (*DirDoc, error) { return fs.DirByID(d.DirID) }
 
-// ChildrenIterator returns an iterator to iterate over the children of
-// the directory.
-func (d *DirDoc) ChildrenIterator(c Context, opts *IteratorOptions) *Iterator {
-	return NewIterator(c, mango.Equal("dir_id", d.DocID), opts)
-}
+// Name returns base name of the file
+func (d *DirDoc) Name() string { return d.DocName }
+
+// Size returns the length in bytes for regular files; system-dependent for others
+func (d *DirDoc) Size() int64 { return 0 }
+
+// Mode returns the file mode bits
+func (d *DirDoc) Mode() os.FileMode { return 0755 }
+
+// ModTime returns the modification time
+func (d *DirDoc) ModTime() time.Time { return d.UpdatedAt }
+
+// IsDir returns the abbreviation for Mode().IsDir()
+func (d *DirDoc) IsDir() bool { return true }
+
+// Sys returns the underlying data source (can return nil)
+func (d *DirDoc) Sys() interface{} { return nil }
 
 // IsEmpty returns whether or not the directory has at least one child.
-func (d *DirDoc) IsEmpty(c Context) (bool, error) {
-	iter := d.ChildrenIterator(c, &IteratorOptions{ByFetch: 1})
+func (d *DirDoc) IsEmpty(fs VFS) (bool, error) {
+	iter := fs.DirIterator(d, &IteratorOptions{ByFetch: 1})
 	_, _, err := iter.Next()
 	if err == ErrIteratorDone {
 		return true, nil
@@ -103,9 +111,9 @@ func NewDirDoc(name, dirID string, tags []string) (*DirDoc, error) {
 
 	createDate := time.Now()
 	doc := &DirDoc{
-		Type:  consts.DirType,
-		Name:  name,
-		DirID: dirID,
+		Type:    consts.DirType,
+		DocName: name,
+		DirID:   dirID,
 
 		CreatedAt: createDate,
 		UpdatedAt: createDate,
@@ -115,112 +123,9 @@ func NewDirDoc(name, dirID string, tags []string) (*DirDoc, error) {
 	return doc, nil
 }
 
-// GetDirDoc is used to fetch directory document information
-// form the database.
-func GetDirDoc(c Context, fileID string) (*DirDoc, error) {
-	doc := &DirDoc{}
-	err := couchdb.GetDoc(c, consts.Files, fileID, doc)
-	if couchdb.IsNotFoundError(err) {
-		err = ErrParentDoesNotExist
-	}
-	if err != nil {
-		if fileID == consts.RootDirID {
-			panic("Root directory is not in database")
-		}
-		if fileID == consts.TrashDirID {
-			panic("Trash directory is not in database")
-		}
-		return nil, err
-	}
-	if doc.Type != consts.DirType {
-		return nil, os.ErrNotExist
-	}
-	return doc, err
-}
-
-// GetDirDocFromPath is used to fetch directory document information from
-// the database from its path.
-func GetDirDocFromPath(c Context, name string) (*DirDoc, error) {
-	if !path.IsAbs(name) {
-		return nil, ErrNonAbsolutePath
-	}
-
-	var doc *DirDoc
-	var err error
-
-	var docs []*DirDoc
-	sel := mango.Equal("path", path.Clean(name))
-	req := &couchdb.FindRequest{
-		UseIndex: "dir-by-path",
-		Selector: sel,
-		Limit:    1,
-	}
-	err = couchdb.FindDocs(c, consts.Files, req, &docs)
-	if err != nil {
-		return nil, err
-	}
-	if len(docs) == 0 {
-		if name == "/" {
-			panic("Root directory is not in database")
-		}
-		return nil, os.ErrNotExist
-	}
-	doc = docs[0]
-	return doc, err
-}
-
-// CreateDir is the method for creating a new directory
-func CreateDir(c Context, doc *DirDoc) error {
-	pth, err := doc.Path(c)
-	if err != nil {
-		return err
-	}
-
-	err = c.FS().Mkdir(pth, 0755)
-	if err != nil {
-		return err
-	}
-
-	err = couchdb.CreateDoc(c, doc)
-	if err != nil {
-		c.FS().Remove(pth)
-	}
-	return err
-}
-
-// CreateRootDirDoc creates the root directory document for this context
-func CreateRootDirDoc(c Context) error {
-	return couchdb.CreateNamedDocWithDB(c, &DirDoc{
-		Name:     "",
-		Type:     consts.DirType,
-		DocID:    consts.RootDirID,
-		Fullpath: "/",
-		DirID:    "",
-	})
-}
-
-// CreateTrashDir creates the trash directory for this context
-func CreateTrashDir(c Context) error {
-	err := c.FS().Mkdir(TrashDirName, 0755)
-	if err != nil && !os.IsExist(err) {
-		return err
-	}
-	err = couchdb.CreateNamedDocWithDB(c, &DirDoc{
-		Name:     path.Base(TrashDirName),
-		Type:     consts.DirType,
-		DocID:    consts.TrashDirID,
-		Fullpath: TrashDirName,
-		DirID:    consts.RootDirID,
-	})
-	if err != nil && !couchdb.IsConflictError(err) {
-		return err
-	}
-	return nil
-}
-
 // ModifyDirMetadata modify the metadata associated to a directory. It
 // can be used to rename or move the directory in the VFS.
-func ModifyDirMetadata(c Context, olddoc *DirDoc, patch *DocPatch) (*DirDoc, error) {
+func ModifyDirMetadata(fs VFS, olddoc *DirDoc, patch *DocPatch) (*DirDoc, error) {
 	id := olddoc.ID()
 	if id == consts.RootDirID || id == consts.TrashDirID {
 		return nil, os.ErrInvalid
@@ -229,7 +134,7 @@ func ModifyDirMetadata(c Context, olddoc *DirDoc, patch *DocPatch) (*DirDoc, err
 	var err error
 	cdate := olddoc.CreatedAt
 	patch, err = normalizeDocPatch(&DocPatch{
-		Name:        &olddoc.Name,
+		Name:        &olddoc.DocName,
 		DirID:       &olddoc.DirID,
 		RestorePath: &olddoc.RestorePath,
 		Tags:        &olddoc.Tags,
@@ -246,74 +151,17 @@ func ModifyDirMetadata(c Context, olddoc *DirDoc, patch *DocPatch) (*DirDoc, err
 	}
 
 	newdoc.RestorePath = *patch.RestorePath
-
-	newdoc.SetID(olddoc.ID())
-	newdoc.SetRev(olddoc.Rev())
 	newdoc.CreatedAt = cdate
 	newdoc.UpdatedAt = *patch.UpdatedAt
-
-	oldpath, err := olddoc.Path(c)
-	if err != nil {
+	if err = fs.UpdateDir(olddoc, newdoc); err != nil {
 		return nil, err
 	}
-	newpath, err := newdoc.Path(c)
-	if err != nil {
-		return nil, err
-	}
-
-	if oldpath != newpath {
-		err = safeRenameDir(c, oldpath, newpath)
-		if err != nil {
-			return nil, err
-		}
-		err = bulkUpdateDocsPath(c, oldpath, newpath)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	err = couchdb.UpdateDoc(c, newdoc)
-	return newdoc, err
-}
-
-// @TODO remove this method and use couchdb bulk updates instead
-func bulkUpdateDocsPath(c Context, oldpath, newpath string) error {
-	var children []*DirDoc
-	sel := mango.StartWith("path", oldpath+"/")
-	req := &couchdb.FindRequest{
-		UseIndex: "dir-by-path",
-		Selector: sel,
-	}
-	err := couchdb.FindDocs(c, consts.Files, req, &children)
-	if err != nil || len(children) == 0 {
-		return err
-	}
-
-	errc := make(chan error)
-
-	for _, child := range children {
-		go func(child *DirDoc) {
-			if !strings.HasPrefix(child.Fullpath, oldpath+"/") {
-				errc <- fmt.Errorf("Child has wrong base directory")
-			} else {
-				child.Fullpath = path.Join(newpath, child.Fullpath[len(oldpath)+1:])
-				errc <- couchdb.UpdateDoc(c, child)
-			}
-		}(child)
-	}
-
-	for range children {
-		if e := <-errc; e != nil {
-			err = e
-		}
-	}
-
-	return err
+	return newdoc, nil
 }
 
 // TrashDir is used to delete a directory given its document
-func TrashDir(c Context, olddoc *DirDoc) (*DirDoc, error) {
-	oldpath, err := olddoc.Path(c)
+func TrashDir(fs VFS, olddoc *DirDoc) (*DirDoc, error) {
+	oldpath, err := olddoc.Path(fs)
 	if err != nil {
 		return nil, err
 	}
@@ -325,8 +173,8 @@ func TrashDir(c Context, olddoc *DirDoc) (*DirDoc, error) {
 	restorePath := path.Dir(oldpath)
 
 	var newdoc *DirDoc
-	tryOrUseSuffix(olddoc.Name, conflictFormat, func(name string) error {
-		newdoc, err = ModifyDirMetadata(c, olddoc, &DocPatch{
+	tryOrUseSuffix(olddoc.DocName, conflictFormat, func(name string) error {
+		newdoc, err = ModifyDirMetadata(fs, olddoc, &DocPatch{
 			DirID:       &trashDirID,
 			RestorePath: &restorePath,
 			Name:        &name,
@@ -337,20 +185,20 @@ func TrashDir(c Context, olddoc *DirDoc) (*DirDoc, error) {
 }
 
 // RestoreDir is used to restore a trashed directory given its document
-func RestoreDir(c Context, olddoc *DirDoc) (*DirDoc, error) {
-	oldpath, err := olddoc.Path(c)
+func RestoreDir(fs VFS, olddoc *DirDoc) (*DirDoc, error) {
+	oldpath, err := olddoc.Path(fs)
 	if err != nil {
 		return nil, err
 	}
-	restoreDir, err := getRestoreDir(c, oldpath, olddoc.RestorePath)
+	restoreDir, err := getRestoreDir(fs, oldpath, olddoc.RestorePath)
 	if err != nil {
 		return nil, err
 	}
 	var newdoc *DirDoc
 	var emptyStr string
-	name := stripSuffix(olddoc.Name, conflictSuffix)
+	name := stripSuffix(olddoc.DocName, conflictSuffix)
 	tryOrUseSuffix(name, "%s (%s)", func(name string) error {
-		newdoc, err = ModifyDirMetadata(c, olddoc, &DocPatch{
+		newdoc, err = ModifyDirMetadata(fs, olddoc, &DocPatch{
 			DirID:       &restoreDir.DocID,
 			RestorePath: &emptyStr,
 			Name:        &name,
@@ -360,67 +208,7 @@ func RestoreDir(c Context, olddoc *DirDoc) (*DirDoc, error) {
 	return newdoc, err
 }
 
-// DestroyDirContent destroy all directories and files contained in a directory.
-func DestroyDirContent(c Context, doc *DirDoc) error {
-	iter := doc.ChildrenIterator(c, nil)
-	for {
-		d, f, err := iter.Next()
-		if err == ErrIteratorDone {
-			break
-		}
-		if d != nil {
-			err = DestroyDirAndContent(c, d)
-		} else {
-			err = DestroyFile(c, f)
-		}
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// DestroyDirAndContent destroy a directory and its content
-func DestroyDirAndContent(c Context, doc *DirDoc) error {
-	err := DestroyDirContent(c, doc)
-	if err != nil {
-		return err
-	}
-	dirpath, err := doc.Path(c)
-	if err != nil {
-		return err
-	}
-	err = c.FS().RemoveAll(dirpath)
-	if err != nil {
-		return err
-	}
-	err = couchdb.DeleteDoc(c, doc)
-	return err
-}
-
-func safeRenameDir(c Context, oldpath, newpath string) error {
-	newpath = path.Clean(newpath)
-	oldpath = path.Clean(oldpath)
-
-	if !path.IsAbs(newpath) || !path.IsAbs(oldpath) {
-		return ErrNonAbsolutePath
-	}
-
-	if strings.HasPrefix(newpath, oldpath+"/") {
-		return ErrForbiddenDocMove
-	}
-
-	_, err := c.FS().Stat(newpath)
-	if err == nil {
-		return os.ErrExist
-	}
-	if err != nil && !os.IsNotExist(err) {
-		return err
-	}
-
-	return c.FS().Rename(oldpath, newpath)
-}
-
 var (
 	_ couchdb.Doc = &DirDoc{}
+	_ os.FileInfo = &DirDoc{}
 )

--- a/pkg/vfs/download_store.go
+++ b/pkg/vfs/download_store.go
@@ -23,6 +23,9 @@ type fileRef struct {
 
 // downloadStoreTTL is the time an Archive stay alive
 const downloadStoreTTL = 1 * time.Hour
+
+// downloadStoreCleanInterval is the time interval between each download
+// cleanup.
 const downloadStoreCleanInterval = 1 * time.Hour
 
 var storeStoreMutex sync.Mutex

--- a/pkg/vfs/download_store_test.go
+++ b/pkg/vfs/download_store_test.go
@@ -1,0 +1,53 @@
+package vfs
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDonwloadStore(t *testing.T) {
+	domainA := "alice.cozycloud.local"
+	domainB := "bob.cozycloud.local"
+	storeA := GetStore(domainA)
+	storeB := GetStore(domainB)
+
+	path := "/test/random/path.txt"
+	key1, err := storeA.AddFile(path)
+	assert.NoError(t, err)
+
+	path2, err := storeB.GetFile(key1)
+	assert.NoError(t, err)
+	assert.Zero(t, path2, "Inter-instances store leaking")
+
+	path3, err := storeA.GetFile(key1)
+	assert.NoError(t, err)
+	assert.Equal(t, path, path3)
+
+	storeStore[domainA].Files[key1].ExpiresAt = time.Now().Add(-2 * downloadStoreTTL)
+
+	path4, err := storeA.GetFile(key1)
+	assert.NoError(t, err)
+	assert.Zero(t, path4, "no expiration")
+
+	a := &Archive{
+		Name: "test",
+		Files: []string{
+			"/archive/foo.jpg",
+			"/archive/bar",
+		},
+	}
+	key2, err := storeA.AddArchive(a)
+	assert.NoError(t, err)
+
+	a2, err := storeA.GetArchive(key2)
+	assert.NoError(t, err)
+	assert.Equal(t, a, a2)
+
+	storeStore[domainA].Archives[key2].ExpiresAt = time.Now().Add(-2 * downloadStoreTTL)
+
+	a3, err := storeA.GetArchive(key2)
+	assert.NoError(t, err)
+	assert.Nil(t, a3, "no expiration")
+}

--- a/pkg/vfs/file.go
+++ b/pkg/vfs/file.go
@@ -80,7 +80,13 @@ func (f *FileDoc) Path(fs VFS) (string, error) {
 }
 
 // Parent returns the parent directory document
-func (f *FileDoc) Parent(fs VFS) (*DirDoc, error) { return fs.DirByID(f.DirID) }
+func (f *FileDoc) Parent(fs VFS) (*DirDoc, error) {
+	parent, err := fs.DirByID(f.DirID)
+	if os.IsNotExist(err) {
+		err = ErrParentDoesNotExist
+	}
+	return parent, err
+}
 
 // Name returns base name of the file
 func (f *FileDoc) Name() string { return f.DocName }

--- a/pkg/vfs/file.go
+++ b/pkg/vfs/file.go
@@ -1,11 +1,9 @@
 package vfs
 
 import (
-	"bytes"
-	"crypto/md5" // #nosec
+
+	// #nosec
 	"encoding/base64"
-	"fmt"
-	"hash"
 	"net/http"
 	"os"
 	"path"
@@ -14,9 +12,7 @@ import (
 
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
-	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
 	"github.com/cozy/cozy-stack/web/jsonapi"
-	"github.com/spf13/afero"
 )
 
 // FileDoc is a struct containing all the informations about a file.
@@ -30,7 +26,7 @@ type FileDoc struct {
 	// File revision
 	DocRev string `json:"_rev,omitempty"`
 	// File name
-	Name string `json:"name"`
+	DocName string `json:"name"`
 	// Parent directory identifier
 	DirID       string `json:"dir_id,omitempty"`
 	RestorePath string `json:"restore_path,omitempty"`
@@ -38,7 +34,7 @@ type FileDoc struct {
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 
-	Size       int64    `json:"size,string"` // Serialized in JSON as a string, because JS has some issues with big numbers
+	ByteSize   int64    `json:"size,string"` // Serialized in JSON as a string, because JS has some issues with big numbers
 	MD5Sum     []byte   `json:"md5sum"`
 	Mime       string   `json:"mime"`
 	Class      string   `json:"class"`
@@ -66,27 +62,43 @@ func (f *FileDoc) SetID(id string) { f.DocID = id }
 func (f *FileDoc) SetRev(rev string) { f.DocRev = rev }
 
 // Path is used to generate the file path
-func (f *FileDoc) Path(c Context) (string, error) {
+func (f *FileDoc) Path(fs VFS) (string, error) {
 	var parentPath string
 	if f.DirID == consts.RootDirID {
 		parentPath = "/"
 	} else {
-		parent, err := f.Parent(c)
+		parent, err := f.Parent(fs)
 		if err != nil {
 			return "", err
 		}
-		parentPath, err = parent.Path(c)
+		parentPath, err = parent.Path(fs)
 		if err != nil {
 			return "", err
 		}
 	}
-	return path.Join(parentPath, f.Name), nil
+	return path.Join(parentPath, f.DocName), nil
 }
 
 // Parent returns the parent directory document
-func (f *FileDoc) Parent(c Context) (*DirDoc, error) {
-	return GetDirDoc(c, f.DirID)
-}
+func (f *FileDoc) Parent(fs VFS) (*DirDoc, error) { return fs.DirByID(f.DirID) }
+
+// Name returns base name of the file
+func (f *FileDoc) Name() string { return f.DocName }
+
+// Size returns the length in bytes for regular files; system-dependent for others
+func (f *FileDoc) Size() int64 { return f.ByteSize }
+
+// Mode returns the file mode bits
+func (f *FileDoc) Mode() os.FileMode { return getFileMode(f.Executable) }
+
+// ModTime returns the modification time
+func (f *FileDoc) ModTime() time.Time { return f.UpdatedAt }
+
+// IsDir returns the abbreviation for Mode().IsDir()
+func (f *FileDoc) IsDir() bool { return false }
+
+// Sys returns the underlying data source (can return nil)
+func (f *FileDoc) Sys() interface{} { return nil }
 
 // AddReferencedBy adds referenced_by to the file
 func (f *FileDoc) AddReferencedBy(ri ...jsonapi.ResourceIdentifier) {
@@ -127,13 +139,13 @@ func NewFileDoc(name, dirID string, size int64, md5Sum []byte, mime, class strin
 	tags = uniqueTags(tags)
 
 	doc := &FileDoc{
-		Type:  consts.FileType,
-		Name:  name,
-		DirID: dirID,
+		Type:    consts.FileType,
+		DocName: name,
+		DirID:   dirID,
 
 		CreatedAt:  cdate,
 		UpdatedAt:  cdate,
-		Size:       size,
+		ByteSize:   size,
 		MD5Sum:     md5Sum,
 		Mime:       mime,
 		Class:      class,
@@ -142,61 +154,6 @@ func NewFileDoc(name, dirID string, size int64, md5Sum []byte, mime, class strin
 	}
 
 	return doc, nil
-}
-
-// GetFileDoc is used to fetch file document information form the
-// database.
-func GetFileDoc(c Context, fileID string) (*FileDoc, error) {
-	doc := &FileDoc{}
-	err := couchdb.GetDoc(c, consts.Files, fileID, doc)
-	if err != nil {
-		return nil, err
-	}
-	if doc.Type != consts.FileType {
-		return nil, os.ErrNotExist
-	}
-	return doc, nil
-}
-
-// GetFileDocFromPath is used to fetch file document information from
-// the database from its path.
-func GetFileDocFromPath(c Context, name string) (*FileDoc, error) {
-	if !path.IsAbs(name) {
-		return nil, ErrNonAbsolutePath
-	}
-
-	var err error
-	dirpath := path.Dir(name)
-	var parent *DirDoc
-	parent, err = GetDirDocFromPath(c, dirpath)
-
-	if err != nil {
-		return nil, err
-	}
-
-	dirID := parent.ID()
-	selector := mango.Map{
-		"dir_id": dirID,
-		"name":   path.Base(name),
-		"type":   consts.FileType,
-	}
-
-	var docs []*FileDoc
-	req := &couchdb.FindRequest{
-		UseIndex: "dir-file-child",
-		Selector: selector,
-		Limit:    1,
-	}
-	err = couchdb.FindDocs(c, consts.Files, req, &docs)
-	if err != nil {
-		return nil, err
-	}
-	if len(docs) == 0 {
-		return nil, os.ErrNotExist
-	}
-
-	fileDoc := docs[0]
-	return fileDoc, nil
 }
 
 // ServeFileContent replies to a http request using the content of a
@@ -208,11 +165,11 @@ func GetFileDocFromPath(c Context, name string) (*FileDoc, error) {
 // non-ranged requests
 //
 // The content disposition is inlined.
-func ServeFileContent(c Context, doc *FileDoc, disposition string, req *http.Request, w http.ResponseWriter) error {
+func ServeFileContent(fs VFS, doc *FileDoc, disposition string, req *http.Request, w http.ResponseWriter) error {
 	header := w.Header()
 	header.Set("Content-Type", doc.Mime)
 	if disposition != "" {
-		header.Set("Content-Disposition", ContentDisposition(disposition, doc.Name))
+		header.Set("Content-Disposition", ContentDisposition(disposition, doc.DocName))
 	}
 
 	if header.Get("Range") == "" {
@@ -220,236 +177,25 @@ func ServeFileContent(c Context, doc *FileDoc, disposition string, req *http.Req
 		header.Set("Etag", eTag)
 	}
 
-	name, err := doc.Path(c)
-	if err != nil {
-		return err
-	}
-
-	content, err := c.FS().Open(name)
+	content, err := fs.OpenFile(doc)
 	if err != nil {
 		return err
 	}
 	defer content.Close()
 
-	http.ServeContent(w, req, doc.Name, doc.UpdatedAt, content)
+	http.ServeContent(w, req, doc.DocName, doc.UpdatedAt, content)
 	return nil
-}
-
-// File represents a file handle. It can be used either for writing OR
-// reading, but not both at the same time.
-type File struct {
-	c  Context       // vfs context
-	f  afero.File    // file handle
-	fc *fileCreation // file creation handle
-}
-
-// fileCreation represents a file open for writing. It is used to
-// create of file or to modify the content of a file.
-//
-// fileCreation implements io.WriteCloser.
-type fileCreation struct {
-	w       int64          // total size written
-	newdoc  *FileDoc       // new document
-	olddoc  *FileDoc       // old document if any
-	newpath string         // file new path
-	bakpath string         // backup file path in case of modifying an existing file
-	hash    hash.Hash      // hash we build up along the file
-	meta    *MetaExtractor // extracts metadata from the content
-	err     error          // write error
-}
-
-// Open returns a file handle that can be used to read form the file
-// specified by the given document.
-func Open(c Context, doc *FileDoc) (*File, error) {
-	name, err := doc.Path(c)
-	if err != nil {
-		return nil, err
-	}
-	f, err := c.FS().Open(name)
-	if err != nil {
-		return nil, err
-	}
-	return &File{c, f, nil}, nil
-}
-
-// CreateFile is used to create file or modify an existing file
-// content. It returns a fileCreation handle. Along with the vfs
-// context, it receives the new file document that you want to create.
-// It can also receive the old document, representing the current
-// revision of the file. In this case it will try to modify the file,
-// otherwise it will create it.
-//
-// Warning: you MUST call the Close() method and check for its error.
-// The Close() method will actually create or update the document in
-// couchdb. It will also check the md5 hash if required.
-func CreateFile(c Context, newdoc, olddoc *FileDoc) (*File, error) {
-	newpath, err := newdoc.Path(c)
-	if err != nil {
-		return nil, err
-	}
-
-	var bakpath string
-	if olddoc != nil {
-		bakpath = fmt.Sprintf("/.%s_%s", olddoc.ID(), olddoc.Rev())
-		if err = safeRenameFile(c, newpath, bakpath); err != nil {
-			// in case of a concurrent access to this method, it can happened
-			// that the file has already been renamed. In this case the
-			// safeRenameFile will return an os.ErrNotExist error. But this
-			// error is misleading since it does not reflect the conflict.
-			if os.IsNotExist(err) {
-				err = ErrConflict
-			}
-			return nil, err
-		}
-	}
-
-	if olddoc != nil {
-		newdoc.SetID(olddoc.ID())
-		newdoc.SetRev(olddoc.Rev())
-		newdoc.CreatedAt = olddoc.CreatedAt
-	}
-
-	f, err := safeCreateFile(newpath, newdoc.Executable, c.FS())
-	if err != nil {
-		return nil, err
-	}
-
-	hash := md5.New() // #nosec
-	extractor := NewMetaExtractor(newdoc)
-
-	fc := &fileCreation{
-		w: 0,
-
-		newdoc:  newdoc,
-		olddoc:  olddoc,
-		bakpath: bakpath,
-		newpath: newpath,
-
-		hash: hash,
-		meta: extractor,
-	}
-
-	return &File{c, f, fc}, nil
-}
-
-// Read bytes from the file into given buffer - part of io.Reader
-// This method can be called on read mode only
-func (f *File) Read(p []byte) (int, error) {
-	if f.fc != nil {
-		return 0, os.ErrInvalid
-	}
-	return f.f.Read(p)
-}
-
-// Seek into the file - part of io.Reader
-// This method can be called on read mode only
-func (f *File) Seek(offset int64, whence int) (int64, error) {
-	if f.fc != nil {
-		return 0, os.ErrInvalid
-	}
-	return f.f.Seek(offset, whence)
-}
-
-// Write bytes to the file - part of io.WriteCloser
-// This method can be called in write mode only
-func (f *File) Write(p []byte) (int, error) {
-	if f.fc == nil {
-		return 0, os.ErrInvalid
-	}
-
-	n, err := f.f.Write(p)
-	if err != nil {
-		f.fc.err = err
-		return n, err
-	}
-
-	f.fc.w += int64(n)
-
-	if f.fc.meta != nil {
-		(*f.fc.meta).Write(p)
-	}
-
-	_, err = f.fc.hash.Write(p)
-	return n, err
-}
-
-// Close the handle and commit the document in database if all checks
-// are OK. It is important to check errors returned by this method.
-func (f *File) Close() error {
-	if f.fc == nil {
-		return f.f.Close()
-	}
-
-	var err error
-	fc, c := f.fc, f.c
-
-	defer func() {
-		werr := fc.err
-		if fc.olddoc != nil {
-			// put back backup file revision in case on error occurred while
-			// modifying file content or remove the backup file otherwise
-			if err != nil || werr != nil {
-				c.FS().Rename(fc.bakpath, fc.newpath)
-			} else {
-				c.FS().Remove(fc.bakpath)
-			}
-		} else if err != nil || werr != nil {
-			// remove file if an error occurred while file creation
-			c.FS().Remove(fc.newpath)
-		}
-	}()
-
-	err = f.f.Close()
-	if err != nil {
-		if f.fc.meta != nil {
-			(*f.fc.meta).Abort(err)
-		}
-		return err
-	}
-
-	newdoc, olddoc, written := fc.newdoc, fc.olddoc, fc.w
-
-	if f.fc.meta != nil {
-		(*f.fc.meta).Close()
-		newdoc.Metadata = (*f.fc.meta).Result()
-	}
-
-	md5sum := fc.hash.Sum(nil)
-	if newdoc.MD5Sum == nil {
-		newdoc.MD5Sum = md5sum
-	}
-
-	if !bytes.Equal(newdoc.MD5Sum, md5sum) {
-		err = ErrInvalidHash
-		return err
-	}
-
-	if newdoc.Size < 0 {
-		newdoc.Size = written
-	}
-
-	if newdoc.Size != written {
-		err = ErrContentLengthMismatch
-		return err
-	}
-
-	if olddoc != nil {
-		err = couchdb.UpdateDoc(c, newdoc)
-	} else {
-		err = couchdb.CreateDoc(c, newdoc)
-	}
-
-	return err
 }
 
 // ModifyFileMetadata modify the metadata associated to a file. It can
 // be used to rename or move the file in the VFS.
-func ModifyFileMetadata(c Context, olddoc *FileDoc, patch *DocPatch) (*FileDoc, error) {
+func ModifyFileMetadata(fs VFS, olddoc *FileDoc, patch *DocPatch) (*FileDoc, error) {
 	var err error
 	rename := patch.Name != nil
 	cdate := olddoc.CreatedAt
+	oname := olddoc.DocName
 	patch, err = normalizeDocPatch(&DocPatch{
-		Name:        &olddoc.Name,
+		Name:        &oname,
 		DirID:       &olddoc.DirID,
 		RestorePath: &olddoc.RestorePath,
 		Tags:        &olddoc.Tags,
@@ -464,7 +210,7 @@ func ModifyFileMetadata(c Context, olddoc *FileDoc, patch *DocPatch) (*FileDoc, 
 	// changed, we consider recalculating the mime and class attributes, using
 	// the new extension.
 	newname := *patch.Name
-	oldname := olddoc.Name
+	oldname := olddoc.DocName
 	var mime, class string
 	if rename && path.Ext(newname) != path.Ext(oldname) {
 		mime, class = ExtractMimeAndClassFromFilename(newname)
@@ -475,7 +221,7 @@ func ModifyFileMetadata(c Context, olddoc *FileDoc, patch *DocPatch) (*FileDoc, 
 	newdoc, err := NewFileDoc(
 		newname,
 		*patch.DirID,
-		olddoc.Size,
+		olddoc.Size(),
 		olddoc.MD5Sum,
 		mime,
 		class,
@@ -488,40 +234,16 @@ func ModifyFileMetadata(c Context, olddoc *FileDoc, patch *DocPatch) (*FileDoc, 
 	}
 
 	newdoc.RestorePath = *patch.RestorePath
-	newdoc.SetID(olddoc.ID())
-	newdoc.SetRev(olddoc.Rev())
 	newdoc.UpdatedAt = *patch.UpdatedAt
-
-	oldpath, err := olddoc.Path(c)
-	if err != nil {
+	if err = fs.UpdateFile(olddoc, newdoc); err != nil {
 		return nil, err
 	}
-	newpath, err := newdoc.Path(c)
-	if err != nil {
-		return nil, err
-	}
-
-	if newpath != oldpath {
-		err = safeRenameFile(c, oldpath, newpath)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if newdoc.Executable != olddoc.Executable {
-		err = c.FS().Chmod(newpath, getFileMode(newdoc.Executable))
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	err = couchdb.UpdateDoc(c, newdoc)
-	return newdoc, err
+	return newdoc, nil
 }
 
 // TrashFile is used to delete a file given its document
-func TrashFile(c Context, olddoc *FileDoc) (*FileDoc, error) {
-	oldpath, err := olddoc.Path(c)
+func TrashFile(fs VFS, olddoc *FileDoc) (*FileDoc, error) {
+	oldpath, err := olddoc.Path(fs)
 	if err != nil {
 		return nil, err
 	}
@@ -533,8 +255,8 @@ func TrashFile(c Context, olddoc *FileDoc) (*FileDoc, error) {
 	restorePath := path.Dir(oldpath)
 
 	var newdoc *FileDoc
-	tryOrUseSuffix(olddoc.Name, conflictFormat, func(name string) error {
-		newdoc, err = ModifyFileMetadata(c, olddoc, &DocPatch{
+	tryOrUseSuffix(olddoc.DocName, conflictFormat, func(name string) error {
+		newdoc, err = ModifyFileMetadata(fs, olddoc, &DocPatch{
 			DirID:       &trashDirID,
 			RestorePath: &restorePath,
 			Name:        &name,
@@ -545,20 +267,20 @@ func TrashFile(c Context, olddoc *FileDoc) (*FileDoc, error) {
 }
 
 // RestoreFile is used to restore a trashed file given its document
-func RestoreFile(c Context, olddoc *FileDoc) (*FileDoc, error) {
-	oldpath, err := olddoc.Path(c)
+func RestoreFile(fs VFS, olddoc *FileDoc) (*FileDoc, error) {
+	oldpath, err := olddoc.Path(fs)
 	if err != nil {
 		return nil, err
 	}
-	restoreDir, err := getRestoreDir(c, oldpath, olddoc.RestorePath)
+	restoreDir, err := getRestoreDir(fs, oldpath, olddoc.RestorePath)
 	if err != nil {
 		return nil, err
 	}
 	var newdoc *FileDoc
 	var emptyStr string
-	name := stripSuffix(olddoc.Name, conflictSuffix)
+	name := stripSuffix(olddoc.DocName, conflictSuffix)
 	tryOrUseSuffix(name, "%s (%s)", func(name string) error {
-		newdoc, err = ModifyFileMetadata(c, olddoc, &DocPatch{
+		newdoc, err = ModifyFileMetadata(fs, olddoc, &DocPatch{
 			DirID:       &restoreDir.DocID,
 			RestorePath: &emptyStr,
 			Name:        &name,
@@ -566,48 +288,6 @@ func RestoreFile(c Context, olddoc *FileDoc) (*FileDoc, error) {
 		return err
 	})
 	return newdoc, err
-}
-
-// DestroyFile definitively destroy a file from the trash.
-func DestroyFile(c Context, doc *FileDoc) error {
-	path, err := doc.Path(c)
-	if err != nil {
-		return err
-	}
-
-	err = c.FS().Remove(path)
-	if err != nil {
-		return err
-	}
-
-	return couchdb.DeleteDoc(c, doc)
-}
-
-func safeCreateFile(name string, executable bool, fs afero.Fs) (afero.File, error) {
-	// write only (O_WRONLY), try to create the file and check that it
-	// does not already exist (O_CREATE|O_EXCL).
-	flag := os.O_WRONLY | os.O_CREATE | os.O_EXCL
-	mode := getFileMode(executable)
-	return fs.OpenFile(name, flag, mode)
-}
-
-func safeRenameFile(c Context, oldpath, newpath string) error {
-	newpath = path.Clean(newpath)
-	oldpath = path.Clean(oldpath)
-
-	if !path.IsAbs(newpath) || !path.IsAbs(oldpath) {
-		return ErrNonAbsolutePath
-	}
-
-	_, err := c.FS().Stat(newpath)
-	if err == nil {
-		return os.ErrExist
-	}
-	if err != nil && !os.IsNotExist(err) {
-		return err
-	}
-
-	return c.FS().Rename(oldpath, newpath)
 }
 
 func getFileMode(executable bool) os.FileMode {
@@ -619,4 +299,5 @@ func getFileMode(executable bool) os.FileMode {
 
 var (
 	_ couchdb.Doc = &FileDoc{}
+	_ os.FileInfo = &FileDoc{}
 )

--- a/pkg/vfs/permissions_test.go
+++ b/pkg/vfs/permissions_test.go
@@ -1,10 +1,11 @@
-package vfs
+package vfs_test
 
 import (
 	"testing"
 
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/permissions"
+	"github.com/cozy/cozy-stack/pkg/vfs"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -41,7 +42,7 @@ func TestPermissions(t *testing.T) {
 	if !assert.NoError(t, err) {
 		return
 	}
-	ModifyDirMetadata(fs, B, &DocPatch{
+	vfs.ModifyDirMetadata(fs, B, &vfs.DocPatch{
 		Tags: &[]string{"testtagparent"},
 	})
 
@@ -54,7 +55,7 @@ func TestPermissions(t *testing.T) {
 	if !assert.NoError(t, err) {
 		return
 	}
-	ModifyFileMetadata(fs, f, &DocPatch{
+	vfs.ModifyFileMetadata(fs, f, &vfs.DocPatch{
 		Tags: &[]string{"testtag"},
 	})
 	// reload
@@ -71,7 +72,7 @@ func TestPermissions(t *testing.T) {
 			Verbs: permissions.ALL,
 		},
 	}
-	assert.NoError(t, Allows(fs, psetWholeType, permissions.GET, f))
+	assert.NoError(t, vfs.Allows(fs, psetWholeType, permissions.GET, f))
 
 	psetSelfID := permissions.Set{
 		permissions.Rule{
@@ -80,7 +81,7 @@ func TestPermissions(t *testing.T) {
 			Values: []string{f.ID()},
 		},
 	}
-	assert.NoError(t, Allows(fs, psetSelfID, permissions.GET, f))
+	assert.NoError(t, vfs.Allows(fs, psetSelfID, permissions.GET, f))
 
 	psetSelfAttributes := permissions.Set{
 		permissions.Rule{
@@ -90,7 +91,7 @@ func TestPermissions(t *testing.T) {
 			Values:   []string{"superfile"},
 		},
 	}
-	assert.NoError(t, Allows(fs, psetSelfAttributes, permissions.GET, f))
+	assert.NoError(t, vfs.Allows(fs, psetSelfAttributes, permissions.GET, f))
 
 	psetOnlyFiles := permissions.Set{
 		permissions.Rule{
@@ -100,7 +101,7 @@ func TestPermissions(t *testing.T) {
 			Values:   []string{"file"},
 		},
 	}
-	assert.NoError(t, Allows(fs, psetOnlyFiles, permissions.GET, f))
+	assert.NoError(t, vfs.Allows(fs, psetOnlyFiles, permissions.GET, f))
 
 	psetOnlyDirs := permissions.Set{
 		permissions.Rule{
@@ -110,7 +111,7 @@ func TestPermissions(t *testing.T) {
 			Values:   []string{"directory"},
 		},
 	}
-	assert.NoError(t, Allows(fs, psetOnlyDirs, permissions.GET, B))
+	assert.NoError(t, vfs.Allows(fs, psetOnlyDirs, permissions.GET, B))
 
 	psetMime := permissions.Set{
 		permissions.Rule{
@@ -121,7 +122,7 @@ func TestPermissions(t *testing.T) {
 		},
 	}
 	f.Mime = "text/plain"
-	assert.NoError(t, Allows(fs, psetMime, permissions.GET, f))
+	assert.NoError(t, vfs.Allows(fs, psetMime, permissions.GET, f))
 
 	psetName := permissions.Set{
 		permissions.Rule{
@@ -131,7 +132,7 @@ func TestPermissions(t *testing.T) {
 			Values:   []string{"b1.txt"},
 		},
 	}
-	assert.NoError(t, Allows(fs, psetName, permissions.GET, f))
+	assert.NoError(t, vfs.Allows(fs, psetName, permissions.GET, f))
 
 	psetSelfTag := permissions.Set{
 		permissions.Rule{
@@ -141,7 +142,7 @@ func TestPermissions(t *testing.T) {
 			Values:   []string{"testtag"},
 		},
 	}
-	assert.NoError(t, Allows(fs, psetSelfTag, permissions.GET, f))
+	assert.NoError(t, vfs.Allows(fs, psetSelfTag, permissions.GET, f))
 
 	psetParentID := permissions.Set{
 		permissions.Rule{
@@ -150,7 +151,7 @@ func TestPermissions(t *testing.T) {
 			Values: []string{O.ID()},
 		},
 	}
-	assert.NoError(t, Allows(fs, psetParentID, permissions.GET, f))
+	assert.NoError(t, vfs.Allows(fs, psetParentID, permissions.GET, f))
 
 	psetSelfParentTag := permissions.Set{
 		permissions.Rule{
@@ -160,7 +161,7 @@ func TestPermissions(t *testing.T) {
 			Values:   []string{"testtagparent"},
 		},
 	}
-	assert.NoError(t, Allows(fs, psetSelfParentTag, permissions.GET, f))
+	assert.NoError(t, vfs.Allows(fs, psetSelfParentTag, permissions.GET, f))
 
 	psetWrongType := permissions.Set{
 		permissions.Rule{
@@ -169,7 +170,7 @@ func TestPermissions(t *testing.T) {
 			Values: []string{A.ID()},
 		},
 	}
-	assert.Error(t, Allows(fs, psetWrongType, permissions.GET, f))
+	assert.Error(t, vfs.Allows(fs, psetWrongType, permissions.GET, f))
 
 	psetWrongVerb := permissions.Set{
 		permissions.Rule{
@@ -178,7 +179,7 @@ func TestPermissions(t *testing.T) {
 			Values: []string{A.ID()},
 		},
 	}
-	assert.Error(t, Allows(fs, psetWrongVerb, permissions.GET, f))
+	assert.Error(t, vfs.Allows(fs, psetWrongVerb, permissions.GET, f))
 
 	psetUncleID := permissions.Set{
 		permissions.Rule{
@@ -187,7 +188,7 @@ func TestPermissions(t *testing.T) {
 			Values: []string{B.ID()},
 		},
 	}
-	assert.Error(t, Allows(fs, psetUncleID, permissions.GET, B2))
+	assert.Error(t, vfs.Allows(fs, psetUncleID, permissions.GET, B2))
 
 	psetUnclePrefixID := permissions.Set{
 		permissions.Rule{
@@ -196,6 +197,6 @@ func TestPermissions(t *testing.T) {
 			Values: []string{A.ID()},
 		},
 	}
-	assert.Error(t, Allows(fs, psetUnclePrefixID, permissions.GET, f))
+	assert.Error(t, vfs.Allows(fs, psetUnclePrefixID, permissions.GET, f))
 
 }

--- a/pkg/vfs/permissions_test.go
+++ b/pkg/vfs/permissions_test.go
@@ -32,33 +32,33 @@ func TestPermissions(t *testing.T) {
 		return
 	}
 
-	A, err := GetDirDocFromPath(vfsC, "/O/A")
+	A, err := fs.DirByPath("/O/A")
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	B, err := GetDirDocFromPath(vfsC, "/O/B")
+	B, err := fs.DirByPath("/O/B")
 	if !assert.NoError(t, err) {
 		return
 	}
-	ModifyDirMetadata(vfsC, B, &DocPatch{
+	ModifyDirMetadata(fs, B, &DocPatch{
 		Tags: &[]string{"testtagparent"},
 	})
 
-	B2, err := GetDirDocFromPath(vfsC, "/O/B2")
+	B2, err := fs.DirByPath("/O/B2")
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	f, err := GetFileDocFromPath(vfsC, "/O/B/b1.txt")
+	f, err := fs.FileByPath("/O/B/b1.txt")
 	if !assert.NoError(t, err) {
 		return
 	}
-	ModifyFileMetadata(vfsC, f, &DocPatch{
+	ModifyFileMetadata(fs, f, &DocPatch{
 		Tags: &[]string{"testtag"},
 	})
 	// reload
-	f, err = GetFileDocFromPath(vfsC, "/O/B/b1.txt")
+	f, err = fs.FileByPath("/O/B/b1.txt")
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -71,7 +71,7 @@ func TestPermissions(t *testing.T) {
 			Verbs: permissions.ALL,
 		},
 	}
-	assert.NoError(t, Allows(vfsC, psetWholeType, permissions.GET, f))
+	assert.NoError(t, Allows(fs, psetWholeType, permissions.GET, f))
 
 	psetSelfID := permissions.Set{
 		permissions.Rule{
@@ -80,7 +80,7 @@ func TestPermissions(t *testing.T) {
 			Values: []string{f.ID()},
 		},
 	}
-	assert.NoError(t, Allows(vfsC, psetSelfID, permissions.GET, f))
+	assert.NoError(t, Allows(fs, psetSelfID, permissions.GET, f))
 
 	psetSelfAttributes := permissions.Set{
 		permissions.Rule{
@@ -90,7 +90,7 @@ func TestPermissions(t *testing.T) {
 			Values:   []string{"superfile"},
 		},
 	}
-	assert.NoError(t, Allows(vfsC, psetSelfAttributes, permissions.GET, f))
+	assert.NoError(t, Allows(fs, psetSelfAttributes, permissions.GET, f))
 
 	psetOnlyFiles := permissions.Set{
 		permissions.Rule{
@@ -100,7 +100,7 @@ func TestPermissions(t *testing.T) {
 			Values:   []string{"file"},
 		},
 	}
-	assert.NoError(t, Allows(vfsC, psetOnlyFiles, permissions.GET, f))
+	assert.NoError(t, Allows(fs, psetOnlyFiles, permissions.GET, f))
 
 	psetOnlyDirs := permissions.Set{
 		permissions.Rule{
@@ -110,7 +110,7 @@ func TestPermissions(t *testing.T) {
 			Values:   []string{"directory"},
 		},
 	}
-	assert.NoError(t, Allows(vfsC, psetOnlyDirs, permissions.GET, B))
+	assert.NoError(t, Allows(fs, psetOnlyDirs, permissions.GET, B))
 
 	psetMime := permissions.Set{
 		permissions.Rule{
@@ -121,7 +121,7 @@ func TestPermissions(t *testing.T) {
 		},
 	}
 	f.Mime = "text/plain"
-	assert.NoError(t, Allows(vfsC, psetMime, permissions.GET, f))
+	assert.NoError(t, Allows(fs, psetMime, permissions.GET, f))
 
 	psetName := permissions.Set{
 		permissions.Rule{
@@ -131,7 +131,7 @@ func TestPermissions(t *testing.T) {
 			Values:   []string{"b1.txt"},
 		},
 	}
-	assert.NoError(t, Allows(vfsC, psetName, permissions.GET, f))
+	assert.NoError(t, Allows(fs, psetName, permissions.GET, f))
 
 	psetSelfTag := permissions.Set{
 		permissions.Rule{
@@ -141,7 +141,7 @@ func TestPermissions(t *testing.T) {
 			Values:   []string{"testtag"},
 		},
 	}
-	assert.NoError(t, Allows(vfsC, psetSelfTag, permissions.GET, f))
+	assert.NoError(t, Allows(fs, psetSelfTag, permissions.GET, f))
 
 	psetParentID := permissions.Set{
 		permissions.Rule{
@@ -150,7 +150,7 @@ func TestPermissions(t *testing.T) {
 			Values: []string{O.ID()},
 		},
 	}
-	assert.NoError(t, Allows(vfsC, psetParentID, permissions.GET, f))
+	assert.NoError(t, Allows(fs, psetParentID, permissions.GET, f))
 
 	psetSelfParentTag := permissions.Set{
 		permissions.Rule{
@@ -160,7 +160,7 @@ func TestPermissions(t *testing.T) {
 			Values:   []string{"testtagparent"},
 		},
 	}
-	assert.NoError(t, Allows(vfsC, psetSelfParentTag, permissions.GET, f))
+	assert.NoError(t, Allows(fs, psetSelfParentTag, permissions.GET, f))
 
 	psetWrongType := permissions.Set{
 		permissions.Rule{
@@ -169,7 +169,7 @@ func TestPermissions(t *testing.T) {
 			Values: []string{A.ID()},
 		},
 	}
-	assert.Error(t, Allows(vfsC, psetWrongType, permissions.GET, f))
+	assert.Error(t, Allows(fs, psetWrongType, permissions.GET, f))
 
 	psetWrongVerb := permissions.Set{
 		permissions.Rule{
@@ -178,7 +178,7 @@ func TestPermissions(t *testing.T) {
 			Values: []string{A.ID()},
 		},
 	}
-	assert.Error(t, Allows(vfsC, psetWrongVerb, permissions.GET, f))
+	assert.Error(t, Allows(fs, psetWrongVerb, permissions.GET, f))
 
 	psetUncleID := permissions.Set{
 		permissions.Rule{
@@ -187,7 +187,7 @@ func TestPermissions(t *testing.T) {
 			Values: []string{B.ID()},
 		},
 	}
-	assert.Error(t, Allows(vfsC, psetUncleID, permissions.GET, B2))
+	assert.Error(t, Allows(fs, psetUncleID, permissions.GET, B2))
 
 	psetUnclePrefixID := permissions.Set{
 		permissions.Rule{
@@ -196,6 +196,6 @@ func TestPermissions(t *testing.T) {
 			Values: []string{A.ID()},
 		},
 	}
-	assert.Error(t, Allows(vfsC, psetUnclePrefixID, permissions.GET, f))
+	assert.Error(t, Allows(fs, psetUnclePrefixID, permissions.GET, f))
 
 }

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -49,26 +49,26 @@ var ErrSkipDir = errors.New("skip directories")
 // architecture.
 type VFS interface {
 	Init() error
-	Destroy() error
+	Delete() error
+
 	DiskUsage() (int64, error)
 
-	CreateDir(doc *DirDoc) error
-	UpdateDir(olddoc, newdoc *DirDoc) error
-	DestroyDirContent(doc *DirDoc) error
-	DestroyDirAndContent(doc *DirDoc) error
 	DirByID(fileID string) (*DirDoc, error)
 	DirByPath(name string) (*DirDoc, error)
-	DirIterator(doc *DirDoc, opts *IteratorOptions) DirIterator
-
-	CreateFile(newdoc, olddoc *FileDoc) (File, error)
-	OpenFile(doc *FileDoc) (File, error)
-	UpdateFile(olddoc, newdoc *FileDoc) error
-	DestroyFile(doc *FileDoc) error
 	FileByID(fileID string) (*FileDoc, error)
 	FileByPath(name string) (*FileDoc, error)
-
 	DirOrFileByID(fileID string) (*DirDoc, *FileDoc, error)
 	DirOrFileByPath(name string) (*DirDoc, *FileDoc, error)
+	DirIterator(doc *DirDoc, opts *IteratorOptions) DirIterator
+
+	CreateDir(doc *DirDoc) error
+	CreateFile(newdoc, olddoc *FileDoc) (File, error)
+	UpdateDir(olddoc, newdoc *DirDoc) error
+	UpdateFile(olddoc, newdoc *FileDoc) error
+	DestroyDirContent(doc *DirDoc) error
+	DestroyDirAndContent(doc *DirDoc) error
+	DestroyFile(doc *FileDoc) error
+	OpenFile(doc *FileDoc) (File, error)
 }
 
 // File is a reader, writer, seeker, closer iterface reprsenting an opened
@@ -83,10 +83,6 @@ type File interface {
 // ErrIteratorDone is returned by the Next() method of the iterator when
 // the iterator is actually done.
 var ErrIteratorDone = errors.New("No more element in the iterator")
-
-// IteratorDefaultFetchSize is the default number of elements fetched from
-// couchdb on each iteration.
-const IteratorDefaultFetchSize = 100
 
 // IteratorOptions contains the options of the iterator.
 type IteratorOptions struct {

--- a/pkg/vfs/vfs_afero.go
+++ b/pkg/vfs/vfs_afero.go
@@ -1,0 +1,674 @@
+package vfs
+
+// #nosec
+import (
+	"bytes"
+	"crypto/md5"
+	"errors"
+	"fmt"
+	"hash"
+	"net/url"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/cozy/cozy-stack/pkg/config"
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
+	"github.com/labstack/gommon/log"
+	"github.com/spf13/afero"
+)
+
+type AferoVFS struct {
+	db  couchdb.Database
+	fs  afero.Fs
+	url *url.URL
+
+	// whether or not the localfilesystem requires an initialisation of its root
+	// directory
+	rootInit bool
+}
+
+func NewAferoVFS(db couchdb.Database, storageURL string) (*AferoVFS, error) {
+	u, err := url.Parse(storageURL)
+	if err != nil {
+		return nil, err
+	}
+	fs, err := createFS(u)
+	if err != nil {
+		return nil, err
+	}
+	return &AferoVFS{
+		db:  db,
+		fs:  fs,
+		url: u,
+		// for now, only the file:// scheme needs a specific initialisation of its
+		// root directory.
+		rootInit: u.Scheme == "file",
+	}, nil
+}
+
+func createFS(u *url.URL) (afero.Fs, error) {
+	switch u.Scheme {
+	case "file":
+		return afero.NewBasePathFs(afero.NewOsFs(), u.Path), nil
+	case "mem":
+		return afero.NewMemMapFs(), nil
+	}
+	return nil, errors.New("vfs_afero: non supported type")
+}
+
+// Init creates the root directory document and the trash directory for this
+// file system.
+func (afs *AferoVFS) Init() error {
+	var err error
+	// for a file:// fs, we need to create the root directory container
+	if afs.rootInit {
+		var rootFs afero.Fs
+		rootFsURL := config.BuildAbsFsURL("/")
+		rootFs, err = createFS(rootFsURL)
+		if err != nil {
+			return err
+		}
+		if err = rootFs.MkdirAll(afs.url.Path, 0755); err != nil {
+			return err
+		}
+
+		defer func() {
+			if err != nil {
+				if rmerr := rootFs.RemoveAll(afs.url.Path); rmerr != nil {
+					log.Warn("[instance] Could not remove the instance directory")
+				}
+			}
+		}()
+	}
+
+	err = couchdb.CreateNamedDocWithDB(afs.db, &DirDoc{
+		DocName:  "",
+		Type:     consts.DirType,
+		DocID:    consts.RootDirID,
+		Fullpath: "/",
+		DirID:    "",
+	})
+	if err != nil {
+		return err
+	}
+
+	err = couchdb.CreateNamedDocWithDB(afs.db, &DirDoc{
+		DocName:  path.Base(TrashDirName),
+		Type:     consts.DirType,
+		DocID:    consts.TrashDirID,
+		Fullpath: TrashDirName,
+		DirID:    consts.RootDirID,
+	})
+	if err != nil && !couchdb.IsConflictError(err) {
+		return err
+	}
+
+	err = afs.fs.Mkdir(TrashDirName, 0755)
+	if err != nil && !os.IsExist(err) {
+		return err
+	}
+	return nil
+}
+
+func (afs *AferoVFS) Destroy() error {
+	if !afs.rootInit {
+		return nil
+	}
+	rootFsURL := config.BuildAbsFsURL("/")
+	rootFs, err := createFS(rootFsURL)
+	if err != nil {
+		return err
+	}
+	return rootFs.RemoveAll(afs.url.Path)
+}
+
+// CreateDir is the method for creating a new directory
+func (afs *AferoVFS) CreateDir(doc *DirDoc) error {
+	pth, err := doc.Path(afs)
+	if err != nil {
+		return err
+	}
+	err = afs.fs.Mkdir(pth, 0755)
+	if err != nil {
+		return err
+	}
+	err = couchdb.CreateDoc(afs.db, doc)
+	if err != nil {
+		afs.fs.Remove(pth)
+	}
+	return err
+}
+
+// UpdateDir
+func (afs *AferoVFS) UpdateDir(olddoc, newdoc *DirDoc) error {
+	newdoc.SetID(olddoc.ID())
+	newdoc.SetRev(olddoc.Rev())
+	oldpath, err := olddoc.Path(afs)
+	if err != nil {
+		return err
+	}
+	newpath, err := newdoc.Path(afs)
+	if err != nil {
+		return err
+	}
+	if oldpath != newpath {
+		err = safeRenameDir(afs, oldpath, newpath)
+		if err != nil {
+			return err
+		}
+		err = bulkUpdateDocsPath(afs.db, oldpath, newpath)
+		if err != nil {
+			return err
+		}
+	}
+	return couchdb.UpdateDoc(afs.db, newdoc)
+}
+
+// DestroyDirContent destroy all directories and files contained in a directory.
+func (afs *AferoVFS) DestroyDirContent(doc *DirDoc) error {
+	iter := afs.DirIterator(doc, nil)
+	for {
+		d, f, err := iter.Next()
+		if err == ErrIteratorDone {
+			break
+		}
+		if d != nil {
+			err = afs.DestroyDirAndContent(d)
+		} else {
+			err = afs.DestroyFile(f)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// DestroyDirAndContent destroy all directories and files contained in a
+// directory and the directory itself.
+func (afs *AferoVFS) DestroyDirAndContent(doc *DirDoc) error {
+	err := afs.DestroyDirContent(doc)
+	if err != nil {
+		return err
+	}
+	dirpath, err := doc.Path(afs)
+	if err != nil {
+		return err
+	}
+	err = afs.fs.RemoveAll(dirpath)
+	if err != nil {
+		return err
+	}
+	err = couchdb.DeleteDoc(afs.db, doc)
+	return err
+}
+
+// DirByID is used to fetch directory document information form the database.
+func (afs *AferoVFS) DirByID(fileID string) (*DirDoc, error) {
+	doc := &DirDoc{}
+	err := couchdb.GetDoc(afs.db, consts.Files, fileID, doc)
+	if couchdb.IsNotFoundError(err) {
+		err = ErrParentDoesNotExist
+	}
+	if err != nil {
+		if fileID == consts.RootDirID {
+			panic("Root directory is not in database")
+		}
+		if fileID == consts.TrashDirID {
+			panic("Trash directory is not in database")
+		}
+		return nil, err
+	}
+	if doc.Type != consts.DirType {
+		return nil, os.ErrNotExist
+	}
+	return doc, err
+}
+
+// DirByPath is used to fetch directory document information from the database
+// from its path.
+func (afs *AferoVFS) DirByPath(name string) (*DirDoc, error) {
+	if !path.IsAbs(name) {
+		return nil, ErrNonAbsolutePath
+	}
+	var docs []*DirDoc
+	sel := mango.Equal("path", path.Clean(name))
+	req := &couchdb.FindRequest{
+		UseIndex: "dir-by-path",
+		Selector: sel,
+		Limit:    1,
+	}
+	err := couchdb.FindDocs(afs.db, consts.Files, req, &docs)
+	if err != nil {
+		return nil, err
+	}
+	if len(docs) == 0 {
+		if name == "/" {
+			panic("Root directory is not in database")
+		}
+		return nil, os.ErrNotExist
+	}
+	return docs[0], nil
+}
+
+func (afs *AferoVFS) DirIterator(doc *DirDoc, opts *IteratorOptions) DirIterator {
+	return NewLocalIterator(afs.db, doc, opts)
+}
+
+// -- Files
+
+// CreateFile is used to create file or modify an existing file
+// content. It returns a localFileCreation handle. Along with the vfs
+// context, it receives the new file document that you want to create.
+// It can also receive the old document, representing the current
+// revision of the file. In this case it will try to modify the file,
+// otherwise it will create it.
+//
+// Warning: you MUST call the Close() method and check for its error.
+// The Close() method will actually create or update the document in
+// couchdb. It will also check the md5 hash if required.
+func (afs *AferoVFS) CreateFile(newdoc, olddoc *FileDoc) (File, error) {
+	newpath, err := newdoc.Path(afs)
+	if err != nil {
+		return nil, err
+	}
+
+	var bakpath string
+	if olddoc != nil {
+		bakpath = fmt.Sprintf("/.%s_%s", olddoc.ID(), olddoc.Rev())
+		if err = safeRenameFile(afs, newpath, bakpath); err != nil {
+			// in case of a concurrent access to this method, it can happened
+			// that the file has already been renamed. In this case the
+			// safeRenameFile will return an os.ErrNotExist error. But this
+			// error is misleading since it does not reflect the conflict.
+			if os.IsNotExist(err) {
+				err = ErrConflict
+			}
+			return nil, err
+		}
+	}
+
+	if olddoc != nil {
+		newdoc.SetID(olddoc.ID())
+		newdoc.SetRev(olddoc.Rev())
+		newdoc.CreatedAt = olddoc.CreatedAt
+	}
+
+	f, err := safeCreateFile(newpath, newdoc.Executable, afs.fs)
+	if err != nil {
+		return nil, err
+	}
+
+	hash := md5.New() // #nosec
+	extractor := NewMetaExtractor(newdoc)
+
+	fc := &localFileCreation{
+		w: 0,
+
+		newdoc:  newdoc,
+		olddoc:  olddoc,
+		bakpath: bakpath,
+		newpath: newpath,
+
+		hash: hash,
+		meta: extractor,
+	}
+
+	return &localFile{afs: afs, f: f, fc: fc}, nil
+}
+
+func (afs *AferoVFS) OpenFile(doc *FileDoc) (File, error) {
+	name, err := doc.Path(afs)
+	if err != nil {
+		return nil, err
+	}
+	f, err := afs.fs.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	return &localFile{afs: afs, f: f, fc: nil}, nil
+}
+
+// DestroyFile definitively destroy a file from the trash.
+func (afs *AferoVFS) DestroyFile(doc *FileDoc) error {
+	path, err := doc.Path(afs)
+	if err != nil {
+		return err
+	}
+	err = afs.fs.Remove(path)
+	if err != nil {
+		return err
+	}
+	return couchdb.DeleteDoc(afs.db, doc)
+}
+
+func (afs *AferoVFS) UpdateFile(olddoc, newdoc *FileDoc) error {
+	newdoc.SetID(olddoc.ID())
+	newdoc.SetRev(olddoc.Rev())
+
+	oldpath, err := olddoc.Path(afs)
+	if err != nil {
+		return err
+	}
+	newpath, err := newdoc.Path(afs)
+	if err != nil {
+		return err
+	}
+	if newpath != oldpath {
+		err = safeRenameFile(afs, oldpath, newpath)
+		if err != nil {
+			return err
+		}
+	}
+
+	if newdoc.Executable != olddoc.Executable {
+		err = afs.fs.Chmod(newpath, getFileMode(newdoc.Executable))
+		if err != nil {
+			return err
+		}
+	}
+	return couchdb.UpdateDoc(afs.db, newdoc)
+}
+
+// GetFileDoc is used to fetch file document information form the
+// database.
+func (afs *AferoVFS) FileByID(fileID string) (*FileDoc, error) {
+	doc := &FileDoc{}
+	err := couchdb.GetDoc(afs.db, consts.Files, fileID, doc)
+	if err != nil {
+		return nil, err
+	}
+	if doc.Type != consts.FileType {
+		return nil, os.ErrNotExist
+	}
+	return doc, nil
+}
+
+// GetFileDocFromPath is used to fetch file document information from
+// the database from its path.
+func (afs *AferoVFS) FileByPath(name string) (*FileDoc, error) {
+	if !path.IsAbs(name) {
+		return nil, ErrNonAbsolutePath
+	}
+	parent, err := afs.DirByPath(path.Dir(name))
+	if err != nil {
+		return nil, err
+	}
+	selector := mango.Map{
+		"dir_id": parent.DocID,
+		"name":   path.Base(name),
+		"type":   consts.FileType,
+	}
+	var docs []*FileDoc
+	req := &couchdb.FindRequest{
+		UseIndex: "dir-file-child",
+		Selector: selector,
+		Limit:    1,
+	}
+	err = couchdb.FindDocs(afs.db, consts.Files, req, &docs)
+	if err != nil {
+		return nil, err
+	}
+	if len(docs) == 0 {
+		return nil, os.ErrNotExist
+	}
+	return docs[0], nil
+}
+
+// GetDirOrFileDoc is used to fetch a document from its identifier
+// without knowing in advance its type.
+func (afs *AferoVFS) DirOrFileByID(fileID string) (*DirDoc, *FileDoc, error) {
+	dirOrFile := &DirOrFileDoc{}
+	err := couchdb.GetDoc(afs.db, consts.Files, fileID, dirOrFile)
+	if err != nil {
+		return nil, nil, err
+	}
+	dirDoc, fileDoc := dirOrFile.Refine()
+	return dirDoc, fileDoc, nil
+}
+
+// GetDirOrFileDocFromPath is used to fetch a document from its path
+// without knowning in advance its type.
+func (afs *AferoVFS) DirOrFileByPath(name string) (*DirDoc, *FileDoc, error) {
+	dirDoc, err := afs.DirByPath(name)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, nil, err
+	}
+	if err == nil {
+		return dirDoc, nil, nil
+	}
+
+	fileDoc, err := afs.FileByPath(name)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, nil, err
+	}
+	if err == nil {
+		return nil, fileDoc, nil
+	}
+
+	return nil, nil, err
+}
+
+// localFile represents a file handle. It can be used either for writing OR
+// reading, but not both at the same time.
+type localFile struct {
+	afs *AferoVFS          // afero file system
+	f   afero.File         // file handle
+	fc  *localFileCreation // file creation handle
+}
+
+// localFileCreation represents a file open for writing. It is used to
+// create of file or to modify the content of a file.
+//
+// localFileCreation implements io.WriteCloser.
+type localFileCreation struct {
+	w       int64          // total size written
+	newdoc  *FileDoc       // new document
+	olddoc  *FileDoc       // old document if any
+	newpath string         // file new path
+	bakpath string         // backup file path in case of modifying an existing file
+	hash    hash.Hash      // hash we build up along the file
+	meta    *MetaExtractor // extracts metadata from the content
+	err     error          // write error
+}
+
+// Read bytes from the file into given buffer - part of io.Reader
+// This method can be called on read mode only
+func (f *localFile) Read(p []byte) (int, error) {
+	if f.fc != nil {
+		return 0, os.ErrInvalid
+	}
+	return f.f.Read(p)
+}
+
+// Seek into the file - part of io.Reader
+// This method can be called on read mode only
+func (f *localFile) Seek(offset int64, whence int) (int64, error) {
+	if f.fc != nil {
+		return 0, os.ErrInvalid
+	}
+	return f.f.Seek(offset, whence)
+}
+
+// Write bytes to the file - part of io.WriteCloser
+// This method can be called in write mode only
+func (f *localFile) Write(p []byte) (int, error) {
+	if f.fc == nil {
+		return 0, os.ErrInvalid
+	}
+
+	n, err := f.f.Write(p)
+	if err != nil {
+		f.fc.err = err
+		return n, err
+	}
+
+	f.fc.w += int64(n)
+
+	if f.fc.meta != nil {
+		(*f.fc.meta).Write(p)
+	}
+
+	_, err = f.fc.hash.Write(p)
+	return n, err
+}
+
+// Close the handle and commit the document in database if all checks
+// are OK. It is important to check errors returned by this method.
+func (f *localFile) Close() error {
+	if f.fc == nil {
+		return f.f.Close()
+	}
+
+	var err error
+	fc := f.fc
+
+	defer func() {
+		werr := fc.err
+		if fc.olddoc != nil {
+			// put back backup file revision in case on error occurred while
+			// modifying file content or remove the backup file otherwise
+			if err != nil || werr != nil {
+				f.afs.fs.Rename(fc.bakpath, fc.newpath)
+			} else {
+				f.afs.fs.Remove(fc.bakpath)
+			}
+		} else if err != nil || werr != nil {
+			// remove file if an error occurred while file creation
+			f.afs.fs.Remove(fc.newpath)
+		}
+	}()
+
+	err = f.f.Close()
+	if err != nil {
+		if f.fc.meta != nil {
+			(*f.fc.meta).Abort(err)
+		}
+		return err
+	}
+
+	newdoc, olddoc, written := fc.newdoc, fc.olddoc, fc.w
+
+	if f.fc.meta != nil {
+		(*f.fc.meta).Close()
+		newdoc.Metadata = (*f.fc.meta).Result()
+	}
+
+	md5sum := fc.hash.Sum(nil)
+	if newdoc.MD5Sum == nil {
+		newdoc.MD5Sum = md5sum
+	}
+
+	if !bytes.Equal(newdoc.MD5Sum, md5sum) {
+		err = ErrInvalidHash
+		return err
+	}
+
+	if newdoc.ByteSize < 0 {
+		newdoc.ByteSize = written
+	}
+
+	if newdoc.ByteSize != written {
+		err = ErrContentLengthMismatch
+		return err
+	}
+
+	if olddoc != nil {
+		err = couchdb.UpdateDoc(f.afs.db, newdoc)
+	} else {
+		err = couchdb.CreateDoc(f.afs.db, newdoc)
+	}
+	return err
+}
+
+func safeCreateFile(name string, executable bool, fs afero.Fs) (afero.File, error) {
+	// write only (O_WRONLY), try to create the file and check that it
+	// does not already exist (O_CREATE|O_EXCL).
+	flag := os.O_WRONLY | os.O_CREATE | os.O_EXCL
+	mode := getFileMode(executable)
+	return fs.OpenFile(name, flag, mode)
+}
+
+func safeRenameFile(afs *AferoVFS, oldpath, newpath string) error {
+	newpath = path.Clean(newpath)
+	oldpath = path.Clean(oldpath)
+
+	if !path.IsAbs(newpath) || !path.IsAbs(oldpath) {
+		return ErrNonAbsolutePath
+	}
+
+	_, err := afs.fs.Stat(newpath)
+	if err == nil {
+		return os.ErrExist
+	}
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	return afs.fs.Rename(oldpath, newpath)
+}
+
+func safeRenameDir(afs *AferoVFS, oldpath, newpath string) error {
+	newpath = path.Clean(newpath)
+	oldpath = path.Clean(oldpath)
+
+	if !path.IsAbs(newpath) || !path.IsAbs(oldpath) {
+		return ErrNonAbsolutePath
+	}
+
+	if strings.HasPrefix(newpath, oldpath+"/") {
+		return ErrForbiddenDocMove
+	}
+
+	_, err := afs.fs.Stat(newpath)
+	if err == nil {
+		return os.ErrExist
+	}
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	return afs.fs.Rename(oldpath, newpath)
+}
+
+// @TODO remove this method and use couchdb bulk updates instead
+func bulkUpdateDocsPath(db couchdb.Database, oldpath, newpath string) error {
+	var children []*DirDoc
+	sel := mango.StartWith("path", oldpath+"/")
+	req := &couchdb.FindRequest{
+		UseIndex: "dir-by-path",
+		Selector: sel,
+	}
+	err := couchdb.FindDocs(db, consts.Files, req, &children)
+	if err != nil || len(children) == 0 {
+		return err
+	}
+
+	errc := make(chan error)
+
+	for _, child := range children {
+		go func(child *DirDoc) {
+			if !strings.HasPrefix(child.Fullpath, oldpath+"/") {
+				errc <- fmt.Errorf("Child has wrong base directory")
+			} else {
+				child.Fullpath = path.Join(newpath, child.Fullpath[len(oldpath)+1:])
+				errc <- couchdb.UpdateDoc(db, child)
+			}
+		}(child)
+	}
+
+	for range children {
+		if e := <-errc; e != nil {
+			err = e
+		}
+	}
+
+	return err
+}
+
+var (
+	_ VFS = &AferoVFS{}
+)

--- a/pkg/vfs/vfs_test.go
+++ b/pkg/vfs/vfs_test.go
@@ -104,7 +104,7 @@ func fetchTree(root string) (H, error) {
 
 func recFetchTree(parent *DirDoc, name string) (H, error) {
 	h := make(H)
-	iter := parent.ChildrenIterator(vfsC, nil)
+	iter := vfsC.DirIterator(parent, nil)
 	for {
 		d, f, err := iter.Next()
 		if err == ErrIteratorDone {
@@ -454,7 +454,7 @@ func TestIterator(t *testing.T) {
 		return
 	}
 
-	iter1 := iterDir.ChildrenIterator(vfsC, &IteratorOptions{ByFetch: 4})
+	iter1 := vfsC.DirIterator(iterDir, &IteratorOptions{ByFetch: 4})
 	iterTree2 := H{}
 	var children1 []string
 	var nextKey string
@@ -484,7 +484,7 @@ func TestIterator(t *testing.T) {
 	}
 	assert.EqualValues(t, iterTree["iter/"], iterTree2)
 
-	iter2 := iterDir.ChildrenIterator(vfsC, &IteratorOptions{
+	iter2 := vfsC.DirIterator(iterDir, &IteratorOptions{
 		ByFetch: 4,
 		AfterID: nextKey,
 	})

--- a/tests/testutils/test_utils.go
+++ b/tests/testutils/test_utils.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cozy/cozy-stack/pkg/utils"
 	"github.com/cozy/cozy-stack/web/errors"
 	"github.com/labstack/echo"
-	"github.com/spf13/afero"
 )
 
 // Fatal prints a message and immediately exit the process
@@ -206,28 +205,6 @@ func (c *TestSetup) GetCookieJar() http.CookieJar {
 		Jar: j,
 		URL: instanceURL,
 	}
-}
-
-// VFSContext implements vfs.Context
-type VFSContext struct {
-	prefix string
-	fs     afero.Fs
-}
-
-// Prefix implements vfs.Context
-func (c VFSContext) Prefix() string { return c.prefix }
-
-// FS implements vfs.Context
-func (c VFSContext) FS() afero.Fs { return c.fs }
-
-// GetVFSContext gives a tmp dir backed vfs.Context
-// The temporary folder will be erased on container cleanup
-func (c *TestSetup) GetVFSContext() VFSContext {
-	tempdir := c.GetTmpDirectory()
-	var vfsC VFSContext
-	vfsC.prefix = "dev/"
-	vfsC.fs = afero.NewBasePathFs(afero.NewOsFs(), tempdir)
-	return vfsC
 }
 
 // func resetDBAndViews(db couchdb.Database, doctype string) error {

--- a/web/apps/apps.go
+++ b/web/apps/apps.go
@@ -34,7 +34,7 @@ func installHandler(c echo.Context) error {
 	if err := permissions.AllowInstallApp(c, permissions.POST); err != nil {
 		return err
 	}
-	inst, err := apps.NewInstaller(instance, &apps.InstallerOptions{
+	inst, err := apps.NewInstaller(instance, instance.VFS(), &apps.InstallerOptions{
 		SourceURL: c.QueryParam("Source"),
 		Slug:      slug,
 	})
@@ -53,7 +53,7 @@ func updateHandler(c echo.Context) error {
 	if err := permissions.AllowInstallApp(c, permissions.POST); err != nil {
 		return err
 	}
-	inst, err := apps.NewInstaller(instance, &apps.InstallerOptions{
+	inst, err := apps.NewInstaller(instance, instance.VFS(), &apps.InstallerOptions{
 		Slug: slug,
 	})
 	if err != nil {
@@ -71,7 +71,7 @@ func deleteHandler(c echo.Context) error {
 	if err := permissions.AllowInstallApp(c, permissions.DELETE); err != nil {
 		return err
 	}
-	inst, err := apps.NewInstaller(instance, &apps.InstallerOptions{Slug: slug})
+	inst, err := apps.NewInstaller(instance, instance.VFS(), &apps.InstallerOptions{Slug: slug})
 	if err != nil {
 		return wrapAppsError(err)
 	}
@@ -175,7 +175,12 @@ func iconHandler(c echo.Context) error {
 	}
 
 	filepath := path.Join(vfs.AppsDirName, slug, app.Icon)
-	r, err := instance.FS().Open(filepath)
+	file, err := instance.VFS().FileByPath(filepath)
+	if err != nil {
+		return err
+	}
+
+	r, err := instance.VFS().OpenFile(file)
 	if err != nil {
 		return err
 	}

--- a/web/apps/apps_test.go
+++ b/web/apps/apps_test.go
@@ -44,7 +44,7 @@ var client *http.Client
 
 func createFile(dir, filename, content string) error {
 	abs := path.Join(dir, filename)
-	file, err := vfs.Create(testInstance, abs)
+	file, err := vfs.Create(testInstance.VFS(), abs)
 	if err != nil {
 		return err
 	}
@@ -85,17 +85,17 @@ func installMiniApp() error {
 	}
 
 	appdir := path.Join(vfs.AppsDirName, slug)
-	_, err = vfs.MkdirAll(testInstance, appdir, nil)
+	_, err = vfs.MkdirAll(testInstance.VFS(), appdir, nil)
 	if err != nil {
 		return err
 	}
 	bardir := path.Join(appdir, "bar")
-	_, err = vfs.Mkdir(testInstance, bardir, nil)
+	_, err = vfs.Mkdir(testInstance.VFS(), bardir, nil)
 	if err != nil {
 		return err
 	}
 	pubdir := path.Join(appdir, "public")
-	_, err = vfs.Mkdir(testInstance, pubdir, nil)
+	_, err = vfs.Mkdir(testInstance.VFS(), pubdir, nil)
 	if err != nil {
 		return err
 	}

--- a/web/data/references.go
+++ b/web/data/references.go
@@ -48,7 +48,7 @@ func addReferencesHandler(c echo.Context) error {
 	}
 
 	for _, fRef := range references {
-		file, err := vfs.GetFileDoc(instance, fRef.ID)
+		file, err := instance.VFS().FileByID(fRef.ID)
 		if err != nil {
 			return err
 		}
@@ -82,7 +82,7 @@ func removeReferencesHandler(c echo.Context) error {
 	}
 
 	for _, fRef := range references {
-		file, err := vfs.GetFileDoc(instance, fRef.ID)
+		file, err := instance.VFS().FileByID(fRef.ID)
 		if err != nil {
 			return err
 		}

--- a/web/data/references_test.go
+++ b/web/data/references_test.go
@@ -50,7 +50,7 @@ func TestAddReferencesHandler(t *testing.T) {
 		return
 	}
 
-	f, err := vfs.CreateFile(testInstance, filedoc, nil)
+	f, err := testInstance.VFS().CreateFile(filedoc, nil)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -76,7 +76,7 @@ func TestAddReferencesHandler(t *testing.T) {
 	defer res.Body.Close()
 	assert.Equal(t, 204, res.StatusCode)
 
-	fdoc, err := vfs.GetFileDoc(testInstance, filedoc.ID())
+	fdoc, err := testInstance.VFS().FileByID(filedoc.ID())
 	assert.NoError(t, err)
 	assert.Len(t, fdoc.ReferencedBy, 1)
 }
@@ -108,17 +108,17 @@ func TestRemoveReferencesHandler(t *testing.T) {
 	defer res.Body.Close()
 	assert.Equal(t, 204, res.StatusCode)
 
-	fdoc6, err := vfs.GetFileDoc(testInstance, f6)
+	fdoc6, err := testInstance.VFS().FileByID(f6)
 	assert.NoError(t, err)
 	assert.Len(t, fdoc6.ReferencedBy, 0)
-	fdoc8, err := vfs.GetFileDoc(testInstance, f8)
+	fdoc8, err := testInstance.VFS().FileByID(f8)
 	assert.NoError(t, err)
 	assert.Len(t, fdoc8.ReferencedBy, 0)
 
-	fdoc7, err := vfs.GetFileDoc(testInstance, f7)
+	fdoc7, err := testInstance.VFS().FileByID(f7)
 	assert.NoError(t, err)
 	assert.Len(t, fdoc7.ReferencedBy, 1)
-	fdoc9, err := vfs.GetFileDoc(testInstance, f9)
+	fdoc9, err := testInstance.VFS().FileByID(f9)
 	assert.NoError(t, err)
 	assert.Len(t, fdoc9.ReferencedBy, 1)
 }
@@ -137,7 +137,7 @@ func makeReferencedTestFile(t *testing.T, doc couchdb.Doc, name string) string {
 		},
 	}
 
-	f, err := vfs.CreateFile(testInstance, filedoc, nil)
+	f, err := testInstance.VFS().CreateFile(filedoc, nil)
 	if !assert.NoError(t, err) {
 		return ""
 	}

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -252,7 +252,7 @@ func TestCreateDirRootSuccess(t *testing.T) {
 	res, _ := createDir(t, "/files/?Name=coucou&Type=directory")
 	assert.Equal(t, 201, res.StatusCode)
 
-	storage := testInstance.FS()
+	storage := testInstance.VFS()
 	exists, err := afero.DirExists(storage, "/coucou")
 	assert.NoError(t, err)
 	assert.True(t, exists)
@@ -291,7 +291,7 @@ func TestCreateDirWithParentSuccess(t *testing.T) {
 	res2, _ := createDir(t, "/files/"+parentID+"?Name=child&Type=directory")
 	assert.Equal(t, 201, res2.StatusCode)
 
-	storage := testInstance.FS()
+	storage := testInstance.VFS()
 	exists, err := afero.DirExists(storage, "/dirparent/child")
 	assert.NoError(t, err)
 	assert.True(t, exists)
@@ -352,7 +352,7 @@ func TestUploadBadHash(t *testing.T) {
 	res, _ := upload(t, "/files/?Type=file&Name=badhash", "text/plain", body, "3FbbMXfH+PdjAlWFfVb1dQ==")
 	assert.Equal(t, 412, res.StatusCode)
 
-	storage := testInstance.FS()
+	storage := testInstance.VFS()
 	_, err := afero.ReadFile(storage, "/badhash")
 	assert.Error(t, err)
 }
@@ -362,7 +362,7 @@ func TestUploadAtRootSuccess(t *testing.T) {
 	res, _ := upload(t, "/files/?Type=file&Name=goodhash", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
 	assert.Equal(t, 201, res.StatusCode)
 
-	storage := testInstance.FS()
+	storage := testInstance.VFS()
 	buf, err := afero.ReadFile(storage, "/goodhash")
 	assert.NoError(t, err)
 	assert.Equal(t, body, string(buf))
@@ -415,7 +415,7 @@ func TestUploadWithParentSuccess(t *testing.T) {
 	res2, _ := upload(t, "/files/"+parentID+"?Type=file&Name=goodhash", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
 	assert.Equal(t, 201, res2.StatusCode)
 
-	storage := testInstance.FS()
+	storage := testInstance.VFS()
 	buf, err := afero.ReadFile(storage, "/fileparent/goodhash")
 	assert.NoError(t, err)
 	assert.Equal(t, body, string(buf))
@@ -572,7 +572,7 @@ func TestModifyMetadataDirMove(t *testing.T) {
 	res3, _ := patchFile(t, "/files/"+dir1ID, "directory", dir1ID, attrs1, nil)
 	assert.Equal(t, 200, res3.StatusCode)
 
-	storage := testInstance.FS()
+	storage := testInstance.VFS()
 	exists, err := afero.DirExists(storage, "/dirmodmemoveinme/renamed")
 	assert.NoError(t, err)
 	assert.True(t, exists)
@@ -619,7 +619,7 @@ func TestModifyMetadataDirMoveWithRel(t *testing.T) {
 	res3, _ := patchFile(t, "/files/"+dir1ID, "directory", dir1ID, nil, parent)
 	assert.Equal(t, 200, res3.StatusCode)
 
-	storage := testInstance.FS()
+	storage := testInstance.VFS()
 	exists, err := afero.DirExists(storage, "/dirmodmemoveinmewithrel/dirmodmewithrel")
 	assert.NoError(t, err)
 	assert.True(t, exists)
@@ -688,7 +688,7 @@ func TestModifyContentSuccess(t *testing.T) {
 	var buf []byte
 	var fileInfo os.FileInfo
 
-	storage := testInstance.FS()
+	storage := testInstance.VFS()
 	res1, data1 := upload(t, "/files/?Type=file&Name=willbemodified&Executable=true", "text/plain", "foo", "")
 	assert.Equal(t, 201, res1.StatusCode)
 
@@ -829,7 +829,7 @@ func TestModifyContentConcurrently(t *testing.T) {
 		assert.True(t, strings.HasPrefix(s.rev, strconv.Itoa(i+2)+"-"))
 	}
 
-	storage := testInstance.FS()
+	storage := testInstance.VFS()
 	buf, err := afero.ReadFile(storage, "/willbemodifiedconcurrently")
 	assert.NoError(t, err)
 

--- a/web/files/paginated.go
+++ b/web/files/paginated.go
@@ -41,15 +41,11 @@ func paginationConfig(c echo.Context) (int, *vfs.IteratorOptions, error) {
 	} else {
 		count = defPerPage
 	}
-	var byFetch int
-	if count < vfs.IteratorDefaultFetchSize {
-		byFetch = int(count)
-	}
 	if count > maxPerPage {
 		count = maxPerPage
 	}
 	return int(count), &vfs.IteratorOptions{
-		ByFetch: byFetch,
+		ByFetch: int(count),
 		AfterID: cursorQuery,
 	}, nil
 }

--- a/web/files/paginated.go
+++ b/web/files/paginated.go
@@ -70,7 +70,7 @@ func dirData(c echo.Context, statusCode int, doc *vfs.DirDoc) error {
 	hasNext := true
 
 	i := middlewares.GetInstance(c)
-	iter := doc.ChildrenIterator(i, iterOpts)
+	iter := i.VFS().DirIterator(doc, iterOpts)
 	for i := 0; i < count; i++ {
 		d, f, err := iter.Next()
 		if err == vfs.ErrIteratorDone {
@@ -135,7 +135,7 @@ func dirDataList(c echo.Context, statusCode int, doc *vfs.DirDoc) error {
 	}
 
 	i := middlewares.GetInstance(c)
-	iter := doc.ChildrenIterator(i, iterOpts)
+	iter := i.VFS().DirIterator(doc, iterOpts)
 	for i := 0; i < count; i++ {
 		d, f, err := iter.Next()
 		if err == vfs.ErrIteratorDone {

--- a/web/files/referencedby.go
+++ b/web/files/referencedby.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/permissions"
-	"github.com/cozy/cozy-stack/pkg/vfs"
 	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/labstack/echo"
@@ -19,7 +18,7 @@ func AddReferencedHandler(c echo.Context) error {
 
 	fileID := c.Param("file-id")
 
-	dir, file, err := vfs.GetDirOrFileDoc(instance, fileID)
+	dir, file, err := instance.VFS().DirOrFileByID(fileID)
 	if err != nil {
 		return wrapVfsError(err)
 	}
@@ -59,7 +58,7 @@ func RemoveReferencedHandler(c echo.Context) error {
 
 	fileID := c.Param("file-id")
 
-	file, err := vfs.GetFileDoc(instance, fileID)
+	file, err := instance.VFS().FileByID(fileID)
 	if err != nil {
 		return wrapVfsError(err)
 	}

--- a/web/files/referencedby_test.go
+++ b/web/files/referencedby_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/cozy/cozy-stack/pkg/vfs"
 	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/labstack/echo"
 	"github.com/stretchr/testify/assert"
@@ -46,7 +45,7 @@ func TestAddReferencedByOneRelation(t *testing.T) {
 	}
 	assert.Equal(t, 204, res.StatusCode)
 
-	doc, err := vfs.GetFileDoc(testInstance, fileID1)
+	doc, err := testInstance.VFS().FileByID(fileID1)
 	assert.NoError(t, err)
 	assert.Len(t, doc.ReferencedBy, 1)
 }
@@ -84,7 +83,7 @@ func TestAddReferencedByMultipleRelation(t *testing.T) {
 	}
 	assert.Equal(t, 204, res.StatusCode)
 
-	doc, err := vfs.GetFileDoc(testInstance, fileID2)
+	doc, err := testInstance.VFS().FileByID(fileID2)
 	assert.NoError(t, err)
 	assert.Len(t, doc.ReferencedBy, 3)
 }
@@ -106,7 +105,7 @@ func TestRemoveReferencedByOneRelation(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 204, res.StatusCode)
 
-	doc, err := vfs.GetFileDoc(testInstance, fileID1)
+	doc, err := testInstance.VFS().FileByID(fileID1)
 	assert.NoError(t, err)
 	assert.Len(t, doc.ReferencedBy, 0)
 }
@@ -129,7 +128,7 @@ func TestRemoveReferencedByMultipleRelation(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 204, res.StatusCode)
 
-	doc, err := vfs.GetFileDoc(testInstance, fileID2)
+	doc, err := testInstance.VFS().FileByID(fileID2)
 	assert.NoError(t, err)
 	assert.Len(t, doc.ReferencedBy, 1)
 	assert.Equal(t, "fooalbumid2", doc.ReferencedBy[0].ID)

--- a/web/permissions/allow.go
+++ b/web/permissions/allow.go
@@ -56,7 +56,7 @@ func AllowVFS(c echo.Context, v permissions.Verb, o vfs.Validable) error {
 	if err != nil {
 		return err
 	}
-	err = vfs.Allows(instance, pdoc.Permissions, v, o)
+	err = vfs.Allows(instance.VFS(), pdoc.Permissions, v, o)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusForbidden)
 	}

--- a/web/settings/disk_usage.go
+++ b/web/settings/disk_usage.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 
 	"github.com/cozy/cozy-stack/pkg/consts"
-	"github.com/cozy/cozy-stack/pkg/vfs"
 	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/cozy/cozy-stack/web/permissions"
@@ -44,7 +43,7 @@ func diskUsage(c echo.Context) error {
 		}
 	}
 
-	used, err := vfs.DiskUsage(instance)
+	used, err := instance.VFS().DiskUsage()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR is mostly a refactoring (it does not add or remove functionalities) to put our abstraction layer of the VFS at a higher level, closer to our data model.

Instead of relying on the `afero.Fs` interface, which mostly works on `path: string, data: io.ReadWriteCloser` data-structures, this PR introduces a `vfs.VFS` interface working on `dir: *DirDoc, file: *FileDoc, data: io.ReadWriteCloser`.

In the VFS, files and directories are both indexed by path (hierarchically) and by a unique ID.

The interface is defined as follow:

```go
type VFS interface {
	Init() error
	Delete() error

	DiskUsage() (int64, error)

	DirByID(fileID string) (*DirDoc, error)
	DirByPath(name string) (*DirDoc, error)
	FileByID(fileID string) (*FileDoc, error)
	FileByPath(name string) (*FileDoc, error)
	DirOrFileByID(fileID string) (*DirDoc, *FileDoc, error)
	DirOrFileByPath(name string) (*DirDoc, *FileDoc, error)
	DirIterator(doc *DirDoc, opts *IteratorOptions) DirIterator

	CreateDir(doc *DirDoc) error
	CreateFile(newdoc, olddoc *FileDoc) (File, error)
	UpdateDir(olddoc, newdoc *DirDoc) error
	UpdateFile(olddoc, newdoc *FileDoc) error
	DestroyDirContent(doc *DirDoc) error
	DestroyDirAndContent(doc *DirDoc) error
	DestroyFile(doc *FileDoc) error
	OpenFile(doc *FileDoc) (File, error)
}

type File interface {
	io.Reader
	io.Seeker
	io.Writer
	io.Closer
}

type DirIterator interface {
	Next() (*DirDoc, *FileDoc, error)
}
```