### PR TITLE
Create index on get

### DIFF
--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -438,7 +438,7 @@ func (i *Instance) makeStorageFs() error {
 func Get(domain string) (*Instance, error) {
 	// FIXME temporary workaround to delete instances with no named indexes
 	errindex := couchdb.DefineIndexes(couchdb.GlobalDB, consts.GlobalIndexes)
-	if errindex != nil {
+	if errindex != nil && !couchdb.IsNotFoundError(errindex) {
 		log.Error("[instance] could not define global indexes:", errindex)
 	}
 	// ---

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -436,6 +436,13 @@ func (i *Instance) makeStorageFs() error {
 
 // Get retrieves the instance for a request by its host.
 func Get(domain string) (*Instance, error) {
+	// FIXME temporary workaround to delete instances with no named indexes
+	errindex := couchdb.DefineIndexes(couchdb.GlobalDB, consts.GlobalIndexes)
+	if errindex != nil {
+		log.Error("[instance] could not define global indexes:", errindex)
+	}
+	// ---
+
 	var instances []*Instance
 	req := &couchdb.FindRequest{
 		UseIndex: "by-domain",

--- a/web/files/paginated.go
+++ b/web/files/paginated.go
@@ -59,8 +59,8 @@ func newDir(doc *vfs.DirDoc) *dir {
 }
 
 func dirData(c echo.Context, statusCode int, doc *vfs.DirDoc) error {
-	var relsData []jsonapi.ResourceIdentifier
-	var included []jsonapi.Object
+	relsData := make([]jsonapi.ResourceIdentifier, 0)
+	included := make([]jsonapi.Object, 0)
 
 	count, iterOpts, err := paginationConfig(c)
 	if err != nil {
@@ -127,7 +127,7 @@ func dirData(c echo.Context, statusCode int, doc *vfs.DirDoc) error {
 }
 
 func dirDataList(c echo.Context, statusCode int, doc *vfs.DirDoc) error {
-	var included []jsonapi.Object
+	included := make([]jsonapi.Object, 0)
 
 	count, iterOpts, err := paginationConfig(c)
 	if err != nil {


### PR DESCRIPTION
This PR fixes (like #400) contains a temporary fix for the migration to our new index naming system in couchdb.

It also fixes a null value returned by the data relationship in the jsonapi representation of a directory.