### PR TITLE
Add sharer structure

### DIFF
--- a/pkg/sharings/sharings.go
+++ b/pkg/sharings/sharings.go
@@ -28,6 +28,7 @@ type Sharing struct {
 
 	Permissions      permissions.Set    `json:"permissions,omitempty"`
 	RecipientsStatus []*RecipientStatus `json:"recipients,omitempty"`
+	Sharer           *Sharer            `json:"sharer,omitempty"`
 }
 
 // RecipientStatus contains the information about a recipient for a sharing
@@ -39,6 +40,17 @@ type RecipientStatus struct {
 	RefRecipient jsonapi.ResourceIdentifier `json:"recipient,omitempty"`
 
 	recipient *Recipient
+}
+
+// Sharer contains the information about the sharer from the recipient's
+// perspective.
+//
+// ATTENTION: This structure will only be filled by the recipients as it is
+// recipient specific. The `ClientID` is different for each recipient and only
+// known by them.
+type Sharer struct {
+	ClientID string `json:"client_id"`
+	URL      string `json:"url"`
 }
 
 // SharingAnswer contains the necessary information to answer a sharing
@@ -231,7 +243,7 @@ func SharingRefused(db couchdb.Database, state, clientID string) (string, error)
 
 // RecipientRefusedSharing executes all the actions induced by a refusal from
 // the recipient: the sharing document is deleted and the sharer is informed.
-func RecipientRefusedSharing(db couchdb.Database, sharingID, clientID string) error {
+func RecipientRefusedSharing(db couchdb.Database, sharingID string) error {
 	// We get the sharing document through its sharing id…
 	var res []Sharing
 	err := couchdb.FindDocs(db, consts.Sharings, &couchdb.FindRequest{
@@ -252,22 +264,14 @@ func RecipientRefusedSharing(db couchdb.Database, sharingID, clientID string) er
 		return err
 	}
 
-	// We get the sharer's oauth client so that we can get her Cozy's url
-	// through the `ClientURI`.
-	sharer := &oauth.Client{}
-	err = couchdb.GetDoc(db, consts.OAuthClients, clientID, sharer)
-	if err != nil {
-		return ErrNoOAuthClient
-	}
-
 	// We send the refusal.
 	bodyRaw := &SharingAnswer{
-		ClientID:  clientID,
+		ClientID:  sharing.Sharer.ClientID,
 		SharingID: sharingID,
 	}
 	body, _ := json.Marshal(bodyRaw)
 
-	url := fmt.Sprintf("%s/sharings/answer", sharer.ClientURI)
+	url := fmt.Sprintf("%s/sharings/answer", sharing.Sharer.URL)
 	resp, err := http.Post(url, "application/json", bytes.NewReader(body))
 	if err != nil {
 		return err
@@ -284,7 +288,7 @@ func RecipientRefusedSharing(db couchdb.Database, sharingID, clientID string) er
 
 // CreateSharingRequest checks fields integrity and creates a sharing document
 // for an incoming sharing request
-func CreateSharingRequest(db couchdb.Database, desc, state, sharingType, scope string) (*Sharing, error) {
+func CreateSharingRequest(db couchdb.Database, desc, state, sharingType, scope, clientID string) (*Sharing, error) {
 	if state == "" {
 		return nil, ErrMissingState
 	}
@@ -294,9 +298,23 @@ func CreateSharingRequest(db couchdb.Database, desc, state, sharingType, scope s
 	if scope == "" {
 		return nil, ErrMissingScope
 	}
+	if clientID == "" {
+		return nil, ErrNoOAuthClient
+	}
 	permissions, err := permissions.UnmarshalScopeString(scope)
 	if err != nil {
 		return nil, err
+	}
+
+	sharerClient := &oauth.Client{}
+	err = couchdb.GetDoc(db, consts.OAuthClients, clientID, sharerClient)
+	if err != nil {
+		return nil, ErrNoOAuthClient
+	}
+
+	sharer := &Sharer{
+		ClientID: clientID,
+		URL:      sharerClient.ClientURI,
 	}
 
 	sharing := &Sharing{
@@ -305,6 +323,7 @@ func CreateSharingRequest(db couchdb.Database, desc, state, sharingType, scope s
 		Permissions: permissions,
 		Owner:       false,
 		Desc:        desc,
+		Sharer:      sharer,
 	}
 
 	err = Create(db, sharing)

--- a/pkg/sharings/sharings_test.go
+++ b/pkg/sharings/sharings_test.go
@@ -397,59 +397,42 @@ func TestSharingRefusedSuccess(t *testing.T) {
 }
 
 func TestRecipientRefusedSharingWhenSharingDoesNotExist(t *testing.T) {
-	err := RecipientRefusedSharing(TestPrefix, "fakesharingid", "fakeclientid")
+	err := RecipientRefusedSharing(TestPrefix, "fakesharingid")
 	assert.Error(t, err)
 	assert.Equal(t, ErrSharingDoesNotExist, err)
 }
 
 func TestRecipientRefusedSharingWhenSharingIDIsNotUnique(t *testing.T) {
 	testSharingID := "sameid"
-	testClientID := "notused"
+	testClientID := "notUsedClientID"
+	testURL := "notUsedURL"
 
-	_, err := insertSharingDocumentInDB(TestPrefix, testSharingID, testClientID)
+	_, err := insertSharingDocumentInDB(TestPrefix, testSharingID, testClientID, testURL)
 	if err != nil {
 		t.FailNow()
 	}
-	_, err = insertSharingDocumentInDB(TestPrefix, testSharingID, testClientID)
+	_, err = insertSharingDocumentInDB(TestPrefix, testSharingID, testClientID, testURL)
 	if err != nil {
 		t.FailNow()
 	}
 
-	err = RecipientRefusedSharing(TestPrefix, testSharingID, testClientID)
+	err = RecipientRefusedSharing(TestPrefix, testSharingID)
 	assert.Error(t, err)
 	assert.Equal(t, ErrSharingIDNotUnique, err)
-}
-
-func TestRecipientRefusedSharingWhenOAuthClientDoesNotExist(t *testing.T) {
-	testSharingID := "SharingNoOAuthClient"
-	testClientID := "ClientNoOAuthClient"
-
-	_, err := insertSharingDocumentInDB(TestPrefix, testSharingID, testClientID)
-	if err != nil {
-		t.Fail()
-	}
-
-	err = RecipientRefusedSharing(TestPrefix, testSharingID, testClientID)
-	assert.Error(t, err)
-	assert.Equal(t, ErrNoOAuthClient, err)
 }
 
 func TestRecipientRefusedSharingWhenPostFails(t *testing.T) {
 	testSharingID := "testPostFails"
 	testClientID := "clientPostFails"
+	testURL := "urlPostFails"
 
 	docSharingTestID, err := insertSharingDocumentInDB(TestPrefix,
-		testSharingID, testClientID)
+		testSharingID, testClientID, testURL)
 	if err != nil {
 		t.Fail()
 	}
 
-	err = insertClientDocumentInDB(TestPrefix, testClientID, "nourl")
-	if err != nil {
-		t.Fail()
-	}
-
-	err = RecipientRefusedSharing(TestPrefix, testSharingID, testClientID)
+	err = RecipientRefusedSharing(TestPrefix, testSharingID)
 	assert.Error(t, err)
 
 	out := couchdb.JSONDoc{}
@@ -469,24 +452,20 @@ func TestRecipientRefusedSharingWhenResponseStatusCodeIsNotOK(t *testing.T) {
 	))
 	defer tsLocal.Close()
 
-	err := insertClientDocumentInDB(TestPrefix, testClientID, tsLocal.URL)
+	_, err := insertSharingDocumentInDB(TestPrefix,
+		testSharingID, testClientID, tsLocal.URL)
 	if err != nil {
 		t.Fail()
 	}
 
-	_, err = insertSharingDocumentInDB(TestPrefix, testSharingID, testClientID)
-	if err != nil {
-		t.Fail()
-	}
-
-	err = RecipientRefusedSharing(TestPrefix, testSharingID, testClientID)
+	err = RecipientRefusedSharing(TestPrefix, testSharingID)
 	assert.Error(t, err)
 	assert.Equal(t, ErrSharerDidNotReceiveAnswer, err)
 }
 
 func TestRecipientRefusedSharingSuccess(t *testing.T) {
 	testSharingID := "SharingSuccess"
-	testClientID := "ClientSucess"
+	testClientID := "ClientSuccess"
 
 	tsLocal := httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
@@ -510,37 +489,38 @@ func TestRecipientRefusedSharingSuccess(t *testing.T) {
 	))
 	defer tsLocal.Close()
 
-	err := insertClientDocumentInDB(TestPrefix, testClientID, tsLocal.URL)
+	docSharingTestID, err := insertSharingDocumentInDB(TestPrefix,
+		testSharingID, testClientID, tsLocal.URL)
 	if err != nil {
 		t.Fail()
 	}
 
-	docSharingTestID, err := insertSharingDocumentInDB(TestPrefix, testSharingID, testClientID)
-	if err != nil {
-		t.Fail()
-	}
-
-	err = RecipientRefusedSharing(TestPrefix, testSharingID, testClientID)
+	err = RecipientRefusedSharing(TestPrefix, testSharingID)
 	assert.NoError(t, err)
 
 	// We also test that the sharing document is actually deleted.
 	sharing := couchdb.JSONDoc{}
-	err = couchdb.GetDoc(TestPrefix, consts.Sharings, docSharingTestID, &sharing)
+	err = couchdb.GetDoc(TestPrefix,
+		consts.Sharings, docSharingTestID, &sharing)
 	assert.Error(t, err)
 }
 
 func TestCreateSharingRequestBadParams(t *testing.T) {
-	_, err := CreateSharingRequest(TestPrefix, "", "", "", "")
+	_, err := CreateSharingRequest(TestPrefix, "", "", "", "", "")
 	assert.Error(t, err)
 
 	state := "1234"
-	_, err = CreateSharingRequest(TestPrefix, "", state, "", "")
+	_, err = CreateSharingRequest(TestPrefix, "", state, "", "", "")
 	assert.Error(t, err)
 
 	sharingType := consts.OneShotSharing
-	_, err = CreateSharingRequest(TestPrefix, "", state, sharingType, "")
+	_, err = CreateSharingRequest(TestPrefix, "", state, sharingType, "", "")
 	assert.Error(t, err)
 
+	scope := "io.cozy.sharings"
+	_, err = CreateSharingRequest(TestPrefix, "", state, sharingType, scope, "")
+	assert.Error(t, err)
+	assert.Equal(t, ErrNoOAuthClient, err)
 }
 
 func TestCreateSharingRequestSuccess(t *testing.T) {
@@ -554,11 +534,18 @@ func TestCreateSharingRequestSuccess(t *testing.T) {
 		Values: []string{"1234"},
 	}
 
+	// TODO insert a client document in the database.
+	clientID := "clientIDTestCreateSharingRequestSuccess"
+	err := insertClientDocumentInDB(TestPrefix, clientID, "https://cozy.rocks")
+	if err != nil {
+		t.FailNow()
+	}
+
 	set := permissions.Set{rule}
 	scope, err := set.MarshalScopeString()
 	assert.NoError(t, err)
 
-	sharing, err := CreateSharingRequest(TestPrefix, desc, state, sharingType, scope)
+	sharing, err := CreateSharingRequest(TestPrefix, desc, state, sharingType, scope, clientID)
 	assert.NoError(t, err)
 	assert.Equal(t, state, sharing.SharingID)
 	assert.Equal(t, sharingType, sharing.SharingType)
@@ -683,13 +670,17 @@ func TestMain(m *testing.M) {
 	os.Exit(res)
 }
 
-func insertSharingDocumentInDB(db couchdb.Database, sharingID, clientID string) (string, error) {
+func insertSharingDocumentInDB(db couchdb.Database, sharingID, clientID, URL string) (string, error) {
 	sharing := couchdb.JSONDoc{
 		Type: consts.Sharings,
-		M:    make(map[string]interface{}),
+		M: map[string]interface{}{
+			"sharing_id": sharingID,
+			"sharer": map[string]interface{}{
+				"client_id": clientID,
+				"url":       URL,
+			},
+		},
 	}
-	sharing.M["sharing_id"] = sharingID
-	sharing.M["client_id"] = clientID
 	err := couchdb.CreateDoc(db, sharing)
 	if err != nil {
 		fmt.Printf("Error occurred while trying to insert document: %v\n", err)
@@ -702,10 +693,11 @@ func insertSharingDocumentInDB(db couchdb.Database, sharingID, clientID string) 
 func insertClientDocumentInDB(db couchdb.Database, clientID, url string) error {
 	client := couchdb.JSONDoc{
 		Type: consts.OAuthClients,
-		M:    make(map[string]interface{}),
+		M: map[string]interface{}{
+			"_id":        clientID,
+			"client_uri": url,
+		},
 	}
-	client.SetID(clientID)
-	client.M["client_uri"] = url
 
 	return couchdb.CreateNamedDocWithDB(db, client)
 }

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -57,16 +57,17 @@ func AddRecipient(c echo.Context) error {
 }
 
 // SharingRequest handles a sharing request from the recipient side
-// It creates a tempory sharing document and redirect to the authorize page
+// It creates a temporary sharing document and redirects to the authorize page
 func SharingRequest(c echo.Context) error {
 	scope := c.QueryParam("scope")
 	state := c.QueryParam("state")
 	sharingType := c.QueryParam("sharing_type")
 	desc := c.QueryParam("desc")
+	clientID := c.QueryParam("client_id")
 
 	instance := middlewares.GetInstance(c)
 
-	_, err := sharings.CreateSharingRequest(instance, desc, state, sharingType, scope)
+	_, err := sharings.CreateSharingRequest(instance, desc, state, sharingType, scope, clientID)
 	if err != nil {
 		return wrapErrors(err)
 	}
@@ -125,6 +126,7 @@ func SendSharingMails(c echo.Context) error {
 }
 
 // RecipientRefusedSharing is called when the recipient refused the sharing.
+//
 // This function will delete the sharing document and inform the sharer by
 // returning her the sharing id, the client id (oauth) and nothing else (more
 // especially no scope and no access code).
@@ -137,12 +139,8 @@ func RecipientRefusedSharing(c echo.Context) error {
 	if sharingID == "" {
 		return wrapErrors(sharings.ErrMissingState)
 	}
-	clientID := c.FormValue("client_id")
-	if clientID == "" {
-		return wrapErrors(sharings.ErrNoOAuthClient)
-	}
 
-	return sharings.RecipientRefusedSharing(instance, sharingID, clientID)
+	return sharings.RecipientRefusedSharing(instance, sharingID)
 }
 
 // Routes sets the routing for the sharing service

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -152,7 +152,10 @@ func TestSharingAnswerSuccess(t *testing.T) {
 }
 
 func TestSharingRequestNoScope(t *testing.T) {
-	urlVal := url.Values{}
+	urlVal := url.Values{
+		"state":        {"dummystate"},
+		"sharing_type": {consts.OneShotSharing},
+	}
 	res, err := requestGET("/sharings/request", urlVal)
 	assert.NoError(t, err)
 	assert.Equal(t, 400, res.StatusCode)
@@ -160,7 +163,9 @@ func TestSharingRequestNoScope(t *testing.T) {
 
 func TestSharingRequestNoState(t *testing.T) {
 	urlVal := url.Values{
-		"scope": {"dummyscope"},
+		"scope":        {"dummyscope"},
+		"sharing_type": {consts.OneShotSharing},
+		"client_id":    {"dummyclientid"},
 	}
 	res, err := requestGET("/sharings/request", urlVal)
 	assert.NoError(t, err)
@@ -169,8 +174,9 @@ func TestSharingRequestNoState(t *testing.T) {
 
 func TestSharingRequestNoSharingType(t *testing.T) {
 	urlVal := url.Values{
-		"scope": {"dummyscope"},
-		"state": {"dummystate"},
+		"scope":     {"dummyscope"},
+		"state":     {"dummystate"},
+		"client_id": {"dummyclientid"},
 	}
 	res, err := requestGET("/sharings/request", urlVal)
 	assert.NoError(t, err)
@@ -182,10 +188,34 @@ func TestSharingRequestBadScope(t *testing.T) {
 		"scope":        []string{":"},
 		"state":        {"dummystate"},
 		"sharing_type": {consts.OneShotSharing},
+		"client_id":    {"dummyclientid"},
 	}
 	res, err := requestGET("/sharings/request", urlVal)
 	assert.NoError(t, err)
 	assert.Equal(t, 500, res.StatusCode)
+}
+
+func TestSharingRequestNoClientID(t *testing.T) {
+	urlVal := url.Values{
+		"scope":        {"dummyscope"},
+		"state":        {"dummystate"},
+		"sharing_type": {consts.OneShotSharing},
+	}
+	res, err := requestGET("/sharings/request", urlVal)
+	assert.NoError(t, err)
+	assert.Equal(t, 400, res.StatusCode)
+}
+
+func TestSharingRequestBadClientID(t *testing.T) {
+	urlVal := url.Values{
+		"scope":        {"dummyscope"},
+		"state":        {"dummystate"},
+		"sharing_type": {consts.OneShotSharing},
+		"client_id":    {"badclientid"},
+	}
+	res, err := requestGET("/sharings/request", urlVal)
+	assert.NoError(t, err)
+	assert.Equal(t, 400, res.StatusCode)
 }
 
 func TestSharingRequestSuccess(t *testing.T) {


### PR DESCRIPTION
We need to be able to access the sharer's information from the sharing
document: this is what this PR adds.

The `sharer` structure is filled when a sharing request is received by a
recipient. It is composed of the id of the sharer's OAuth Client (at the
recipient's) and of the sharer's URL of her Cozy.

Tests where updated accordingly.