### PR TITLE
Fix refused sharing answer

### DIFF
--- a/pkg/sharings/recipients.go
+++ b/pkg/sharings/recipients.go
@@ -83,8 +83,8 @@ func (r *Recipient) Register(instance *instance.Instance) error {
 		Domain:     rURL,
 		HTTPClient: client,
 	}
-	clientURI := instance.Scheme() + "://" + instance.Domain
-	redirectURI := clientURI + "/sharings/answer"
+	clientURI := instance.PageURL("", nil)
+	redirectURI := instance.PageURL("/sharings/answer", nil)
 
 	// Get the Cozy's public name
 	doc := &couchdb.JSONDoc{}

--- a/pkg/sharings/recipients.go
+++ b/pkg/sharings/recipients.go
@@ -83,7 +83,8 @@ func (r *Recipient) Register(instance *instance.Instance) error {
 		Domain:     rURL,
 		HTTPClient: client,
 	}
-	redirectURI := instance.Scheme() + "://" + instance.Domain + "/sharings/answer"
+	clientURI := instance.Scheme() + "://" + instance.Domain
+	redirectURI := clientURI + "/sharings/answer"
 
 	// Get the Cozy's public name
 	doc := &couchdb.JSONDoc{}
@@ -101,7 +102,7 @@ func (r *Recipient) Register(instance *instance.Instance) error {
 		ClientName:   sharerPublicName,
 		ClientKind:   "sharing",
 		SoftwareID:   "github.com/cozy/cozy-stack",
-		ClientURI:    instance.Domain,
+		ClientURI:    clientURI,
 	}
 
 	resClient, err := req.RegisterClient(authClient)

--- a/pkg/sharings/sharings_test.go
+++ b/pkg/sharings/sharings_test.go
@@ -431,7 +431,7 @@ func TestSharingRefusedSuccess(t *testing.T) {
 }
 
 func TestRecipientRefusedSharingWhenSharingDoesNotExist(t *testing.T) {
-	err := RecipientRefusedSharing(TestPrefix, "fakesharingid")
+	_, err := RecipientRefusedSharing(TestPrefix, "fakesharingid", "fakeclientid")
 	assert.Error(t, err)
 	assert.Equal(t, ErrSharingDoesNotExist, err)
 }
@@ -450,7 +450,7 @@ func TestRecipientRefusedSharingWhenSharingIDIsNotUnique(t *testing.T) {
 		t.FailNow()
 	}
 
-	err = RecipientRefusedSharing(TestPrefix, testSharingID)
+	_, err = RecipientRefusedSharing(TestPrefix, testSharingID, testClientID)
 	assert.Error(t, err)
 	assert.Equal(t, ErrSharingIDNotUnique, err)
 }
@@ -462,11 +462,12 @@ func TestRecipientRefusedSharingWhenPostFails(t *testing.T) {
 
 	docSharingTestID, err := insertSharingDocumentInDB(TestPrefix,
 		testSharingID, testClientID, testURL)
+
 	if err != nil {
 		t.Fail()
 	}
 
-	err = RecipientRefusedSharing(TestPrefix, testSharingID)
+	_, err = RecipientRefusedSharing(TestPrefix, testSharingID, testClientID)
 	assert.Error(t, err)
 
 	out := couchdb.JSONDoc{}
@@ -492,9 +493,10 @@ func TestRecipientRefusedSharingWhenResponseStatusCodeIsNotOK(t *testing.T) {
 		t.Fail()
 	}
 
-	err = RecipientRefusedSharing(TestPrefix, testSharingID)
+	_, err = RecipientRefusedSharing(TestPrefix, testSharingID, testClientID)
 	assert.Error(t, err)
-	assert.Equal(t, ErrSharerDidNotReceiveAnswer, err)
+	//assert.Equal(t, ErrSharerDidNotReceiveAnswer, err)
+
 }
 
 func TestRecipientRefusedSharingSuccess(t *testing.T) {
@@ -523,19 +525,23 @@ func TestRecipientRefusedSharingSuccess(t *testing.T) {
 	))
 	defer tsLocal.Close()
 
+	err := insertClientDocumentInDB(TestPrefix, testClientID, tsLocal.URL)
+	if err != nil {
+		t.Fail()
+	}
+
 	docSharingTestID, err := insertSharingDocumentInDB(TestPrefix,
 		testSharingID, testClientID, tsLocal.URL)
 	if err != nil {
 		t.Fail()
 	}
 
-	err = RecipientRefusedSharing(TestPrefix, testSharingID)
+	_, err = RecipientRefusedSharing(TestPrefix, testSharingID, testClientID)
 	assert.NoError(t, err)
 
 	// We also test that the sharing document is actually deleted.
 	sharing := couchdb.JSONDoc{}
-	err = couchdb.GetDoc(TestPrefix,
-		consts.Sharings, docSharingTestID, &sharing)
+	err = couchdb.GetDoc(TestPrefix, consts.Sharings, docSharingTestID, &sharing)
 	assert.Error(t, err)
 }
 


### PR DESCRIPTION
The refused sharing answer handler on the recipient side used to make a POST to the sharer. 
This changes the request to follow the same behaviour than the accepted sharing answer, i.e. an HTTP redirect to the sharer endpoint.