### PR TITLE
Handle no-database error from couch as notfound errors

### DIFF
--- a/pkg/apps/installer.go
+++ b/pkg/apps/installer.go
@@ -279,7 +279,7 @@ func updateManifest(db couchdb.Database, man Manifest) error {
 }
 
 func createManifest(db couchdb.Database, man Manifest) error {
-	if err := couchdb.CreateNamedDoc(db, man); err != nil {
+	if err := couchdb.CreateNamedDocWithDB(db, man); err != nil {
 		return err
 	}
 	_, err := permissions.CreateAppSet(db, man.Slug(), man.Permissions())

--- a/pkg/couchdb/errors.go
+++ b/pkg/couchdb/errors.go
@@ -106,7 +106,9 @@ func IsNotFoundError(err error) bool {
 	if !isCouchErr {
 		return false
 	}
-	return couchErr.Name == "not_found"
+	return (couchErr.Name == "not_found" ||
+		couchErr.Reason == "no_db_file" ||
+		couchErr.Reason == "Database does not exist.")
 }
 
 // IsFileExists checks if the given error is a couch conflict error

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -340,6 +340,9 @@ func Create(opts *Options) (*Instance, error) {
 	if err := couchdb.CreateDB(i, consts.Apps); err != nil {
 		return nil, err
 	}
+	if err := couchdb.CreateDB(i, consts.Konnectors); err != nil {
+		return nil, err
+	}
 	if err := couchdb.CreateDB(i, consts.OAuthClients); err != nil {
 		return nil, err
 	}

--- a/web/data/data_test.go
+++ b/web/data/data_test.go
@@ -128,6 +128,7 @@ func TestAllDoctypes(t *testing.T) {
 		"io.cozy.apps",
 		"io.cozy.events",
 		"io.cozy.files",
+		"io.cozy.konnectors",
 		"io.cozy.settings",
 		"io.cozy.sharings",
 	}


### PR DESCRIPTION
To facilitate retro-compatibility when adding new doctypes, the `couchdb.IsNotFoundError` now also returns true when the database does not exist.

It fixes the konnectors installation with no created `io.cozy.konnectors` database on instance creation.