### PR TITLE
Fix cozy-app-dev docker image

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -70,6 +70,7 @@ EXPOSE 8080 8025 5984
 
 CMD couchdb 2>/dev/null 1>/dev/null & \
     MailHog 2>/dev/null 1>/dev/null & \
+    echo "0.0.0.0 cozy.tools" >> /etc/hosts && \
     /usr/bin/cozy-app-dev.sh \
       -d /data/cozy-app \
       -f /data/cozy-storage

--- a/scripts/cozy-app-dev.sh
+++ b/scripts/cozy-app-dev.sh
@@ -73,7 +73,6 @@ do_start() {
 
 	check_not_running ":${COZY_STACK_PORT}" "cozy-stack"
 	do_check_couchdb
-	check_hosts
 
 	if [ -f "${appdir}/manifest.webapp" ]; then
 		slug="app"
@@ -202,17 +201,6 @@ check_not_running() {
 		exit 1
 	fi
 	echo "ok"
-}
-
-check_hosts() {
-	devhost=$(grep ${COZY_STACK_HOST} /etc/hosts || echo "")
-	apphost=$(grep app.${COZY_STACK_HOST} /etc/hosts || echo "")
-	if [ -z "${devhost}" ] || [ -z "${apphost}" ]; then
-		echo -e ""
-		echo -e "You should have the following line in your /etc/hosts file:"
-		echo -e "127.0.0.1\t${COZY_STACK_HOST} app.${COZY_STACK_HOST}"
-		echo -e ""
-	fi
 }
 
 update=false


### PR DESCRIPTION
We need to make cozy-stack listens on 0.0.0.0 inside docker to be accessible from outside the docker image