### PR TITLE
Decrease iframe security policy to allow intents

### DIFF
--- a/web/routing.go
+++ b/web/routing.go
@@ -115,8 +115,8 @@ func SetupAppsHandler(appsHandler echo.HandlerFunc) echo.HandlerFunc {
 		CSPDefaultSrc: []middlewares.CSPSource{middlewares.CSPSrcSelf, middlewares.CSPSrcParent},
 		CSPFontSrc:    []middlewares.CSPSource{middlewares.CSPSrcSelf, middlewares.CSPSrcData, middlewares.CSPSrcParent},
 		CSPImgSrc:     []middlewares.CSPSource{middlewares.CSPSrcSelf, middlewares.CSPSrcData, middlewares.CSPSrcBlob, middlewares.CSPSrcParent},
-		CSPFrameSrc:   []middlewares.CSPSource{middlewares.CSPSrcParent},
-		XFrameOptions: middlewares.XFrameDeny,
+		CSPFrameSrc:   []middlewares.CSPSource{middlewares.CSPSrcParentSubdomains},
+		XFrameOptions: middlewares.XFrameSameOrigin,
 	})
 
 	return middlewares.Compose(appsHandler, secure, middlewares.LoadSession)


### PR DESCRIPTION
To allow intents we need to be able to display iframes providing resource from another subdomain of the same domain. Example : onboarding.cozy.tools may display an intent from konnectors.cozy.tools.