### PR TITLE
Improve error handling of apps install/update

### DIFF
--- a/client/request/request.go
+++ b/client/request/request.go
@@ -234,7 +234,7 @@ func ReadSSE(r io.ReadCloser, ch chan *SSEEvent) {
 			ev = nil
 			continue
 		}
-		spl := bytes.Split(bs, []byte(": "))
+		spl := bytes.SplitN(bs, []byte(": "), 2)
 		if len(spl) != 2 {
 			err = ErrSSEParse
 			return

--- a/cmd/apps.go
+++ b/cmd/apps.go
@@ -63,7 +63,7 @@ var installAppCmd = &cobra.Command{
 					}
 					return err
 				}
-				log.Infof("Application installed successfuly on %s", in.Attrs.Domain)
+				log.Infof("Application installed successfully on %s", in.Attrs.Domain)
 				return nil
 			})
 		}
@@ -106,7 +106,7 @@ var updateAppCmd = &cobra.Command{
 					}
 					return err
 				}
-				log.Infof("Application updated successfuly on %s", in.Attrs.Domain)
+				log.Infof("Application updated successfully on %s", in.Attrs.Domain)
 				return nil
 			})
 		}

--- a/cmd/apps.go
+++ b/cmd/apps.go
@@ -57,7 +57,14 @@ var installAppCmd = &cobra.Command{
 					Slug:      slug,
 					SourceURL: source,
 				})
-				return err
+				if err != nil {
+					if err.Error() == "Application with same slug already exists" {
+						return nil
+					}
+					return err
+				}
+				log.Infof("Application installed successfuly on %s", in.Attrs.Domain)
+				return nil
 			})
 		}
 		if flagAppsDomain == "" {
@@ -93,7 +100,14 @@ var updateAppCmd = &cobra.Command{
 			return foreachDomains(func(in *client.Instance) error {
 				c := newClient(in.Attrs.Domain, consts.Apps)
 				_, err := c.UpdateApp(&client.AppOptions{Slug: args[0]})
-				return err
+				if err != nil {
+					if err.Error() == "Application is not installed" {
+						return nil
+					}
+					return err
+				}
+				log.Infof("Application updated successfuly on %s", in.Attrs.Domain)
+				return nil
 			})
 		}
 		if flagAppsDomain == "" {

--- a/pkg/apps/installer.go
+++ b/pkg/apps/installer.go
@@ -14,6 +14,14 @@ import (
 
 var slugReg = regexp.MustCompile(`^[A-Za-z0-9\-]+$`)
 
+type Operation int
+
+const (
+	Install Operation = iota + 1
+	Update
+	Delete
+)
+
 // Installer is used to install or update applications.
 type Installer struct {
 	fetcher Fetcher
@@ -35,6 +43,7 @@ type Installer struct {
 // source URL.
 type InstallerOptions struct {
 	Type      AppType
+	Operation Operation
 	Slug      string
 	SourceURL string
 }
@@ -52,6 +61,10 @@ type Fetcher interface {
 
 // NewInstaller creates a new Installer
 func NewInstaller(db couchdb.Database, fs vfs.VFS, opts *InstallerOptions) (*Installer, error) {
+	if opts.Operation == 0 {
+		panic("Missing installer operation")
+	}
+
 	slug := opts.Slug
 	if slug == "" || !slugReg.MatchString(slug) {
 		return nil, ErrInvalidSlugName
@@ -68,17 +81,35 @@ func NewInstaller(db couchdb.Database, fs vfs.VFS, opts *InstallerOptions) (*Ins
 	}
 
 	man, err := GetBySlug(db, slug, opts.Type)
-	if err != nil && !couchdb.IsNotFoundError(err) {
+	if opts.Operation == Install {
+		if err == nil {
+			return nil, ErrAlreadyExists
+		}
+		if !couchdb.IsNotFoundError(err) {
+			return nil, err
+		}
+		err = nil
+		switch opts.Type {
+		case Webapp:
+			man = &WebappManifest{}
+		case Konnector:
+			man = &konnManifest{}
+		}
+	} else if couchdb.IsNotFoundError(err) {
+		return nil, ErrNotFound
+	} else if err != nil {
 		return nil, err
 	}
 
 	var src *url.URL
-	if man != nil {
-		src, err = url.Parse(man.Source())
-	} else if opts.SourceURL != "" {
+	switch opts.Operation {
+	case Install:
+		if opts.SourceURL == "" {
+			return nil, ErrMissingSource
+		}
 		src, err = url.Parse(opts.SourceURL)
-	} else {
-		err = ErrMissingSource
+	case Update, Delete:
+		src, err = url.Parse(man.Source())
 	}
 	if err != nil {
 		return nil, err
@@ -97,11 +128,10 @@ func NewInstaller(db couchdb.Database, fs vfs.VFS, opts *InstallerOptions) (*Ins
 		db:      db,
 		fs:      fs,
 
-		appType: opts.Type,
-		man:     man,
-		src:     src,
-		slug:    slug,
-		base:    base,
+		man:  man,
+		src:  src,
+		slug: slug,
+		base: base,
 
 		errc: make(chan error, 1),
 		manc: make(chan Manifest, 2),
@@ -112,11 +142,7 @@ func NewInstaller(db couchdb.Database, fs vfs.VFS, opts *InstallerOptions) (*Ins
 // report its progress or error (see Poll method).
 func (i *Installer) Install() {
 	defer i.endOfProc()
-	if i.man != nil {
-		i.man, i.err = nil, ErrAlreadyExists
-	} else {
-		i.man, i.err = i.install()
-	}
+	i.man, i.err = i.install()
 	return
 }
 
@@ -124,10 +150,6 @@ func (i *Installer) Install() {
 // report its progress or error (see Poll method).
 func (i *Installer) Update() {
 	defer i.endOfProc()
-	if i.man == nil {
-		i.err = ErrNotFound
-		return
-	}
 	if state := i.man.State(); state != Ready && state != Errored {
 		i.man, i.err = nil, ErrBadState
 	} else {
@@ -138,9 +160,6 @@ func (i *Installer) Update() {
 
 // Delete will remove the application linked to the installer.
 func (i *Installer) Delete() (Manifest, error) {
-	if i.man == nil {
-		return nil, ErrNotFound
-	}
 	if state := i.man.State(); state != Ready && state != Errored {
 		return nil, ErrBadState
 	}
@@ -178,7 +197,7 @@ func (i *Installer) endOfProc() {
 // Note that the fetched manifest is returned even if an error occurred while
 // upgrading.
 func (i *Installer) install() (Manifest, error) {
-	man := i.createManifest()
+	man := i.man
 	if err := i.ReadManifest(Installing, man); err != nil {
 		return nil, err
 	}
@@ -242,16 +261,6 @@ func (i *Installer) ReadManifest(state State, man Manifest) error {
 	defer r.Close()
 	man.SetState(state)
 	return man.ReadManifest(io.LimitReader(r, ManifestMaxSize), i.slug, i.src.String())
-}
-
-func (i *Installer) createManifest() Manifest {
-	switch i.appType {
-	case Webapp:
-		return &WebappManifest{}
-	case Konnector:
-		return &konnManifest{}
-	}
-	return nil
 }
 
 // Poll should be used to monitor the progress of the Installer.

--- a/pkg/apps/installer.go
+++ b/pkg/apps/installer.go
@@ -14,11 +14,15 @@ import (
 
 var slugReg = regexp.MustCompile(`^[A-Za-z0-9\-]+$`)
 
+// Operation is the type of operation the installer is created for.
 type Operation int
 
 const (
+	// Install operation for installing an application
 	Install Operation = iota + 1
+	// Update operation for updating an application
 	Update
+	// Delete operation for deleting an application
 	Delete
 )
 
@@ -28,11 +32,10 @@ type Installer struct {
 	fs      vfs.VFS
 	db      couchdb.Database
 
-	appType AppType
-	man     Manifest
-	src     *url.URL
-	slug    string
-	base    string
+	man  Manifest
+	src  *url.URL
+	slug string
+	base string
 
 	err  error
 	errc chan error

--- a/pkg/apps/installer_test.go
+++ b/pkg/apps/installer_test.go
@@ -179,6 +179,16 @@ func TestInstallBadAppsSource(t *testing.T) {
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "invalid character")
 	}
+
+	_, err = NewInstaller(db, fs, &InstallerOptions{
+		Operation: Install,
+		Type:      installerType,
+		Slug:      "app5",
+		SourceURL: "",
+	})
+	if assert.Error(t, err) {
+		assert.Equal(t, ErrMissingSource, err)
+	}
 }
 
 func TestInstallSuccessful(t *testing.T) {

--- a/pkg/apps/installer_test.go
+++ b/pkg/apps/installer_test.go
@@ -140,6 +140,7 @@ var fs vfs.VFS
 
 func TestInstallBadSlug(t *testing.T) {
 	_, err := NewInstaller(db, fs, &InstallerOptions{
+		Operation: Install,
 		Type:      installerType,
 		SourceURL: "git://foo.bar",
 	})
@@ -148,6 +149,7 @@ func TestInstallBadSlug(t *testing.T) {
 	}
 
 	_, err = NewInstaller(db, fs, &InstallerOptions{
+		Operation: Install,
 		Type:      installerType,
 		Slug:      "coucou/",
 		SourceURL: "git://foo.bar",
@@ -159,6 +161,7 @@ func TestInstallBadSlug(t *testing.T) {
 
 func TestInstallBadAppsSource(t *testing.T) {
 	_, err := NewInstaller(db, fs, &InstallerOptions{
+		Operation: Install,
 		Type:      installerType,
 		Slug:      "app3",
 		SourceURL: "foo://bar.baz",
@@ -168,6 +171,7 @@ func TestInstallBadAppsSource(t *testing.T) {
 	}
 
 	_, err = NewInstaller(db, fs, &InstallerOptions{
+		Operation: Install,
 		Type:      installerType,
 		Slug:      "app4",
 		SourceURL: "git://bar  .baz",
@@ -179,6 +183,7 @@ func TestInstallBadAppsSource(t *testing.T) {
 
 func TestInstallSuccessful(t *testing.T) {
 	inst, err := NewInstaller(db, fs, &InstallerOptions{
+		Operation: Install,
 		Type:      installerType,
 		Slug:      "local-cozy-mini",
 		SourceURL: "git://localhost/",
@@ -220,48 +225,40 @@ func TestInstallSuccessful(t *testing.T) {
 	ok, err = fileContainsBytes(fs, installDir+"/local-cozy-mini/"+manifestName, []byte("1.0.0"))
 	assert.NoError(t, err)
 	assert.True(t, ok, "The manifest has the right version")
+
+	inst2, err := NewInstaller(db, fs, &InstallerOptions{
+		Operation: Install,
+		Type:      installerType,
+		Slug:      "local-cozy-mini",
+		SourceURL: "git://localhost/",
+	})
+	assert.Nil(t, inst2)
+	assert.Equal(t, ErrAlreadyExists, err)
 }
 
-func TestInstallAldreadyExist(t *testing.T) {
+func TestUpgradeNotExist(t *testing.T) {
 	inst, err := NewInstaller(db, fs, &InstallerOptions{
+		Operation: Update,
 		Type:      installerType,
-		Slug:      "cozy-app-a",
+		Slug:      "cozy-app-not-exist",
 		SourceURL: "git://localhost/",
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
-
-	go inst.Install()
-
-	for {
-		var done bool
-		_, done, err = inst.Poll()
-		if !assert.NoError(t, err) {
-			return
-		}
-		if done {
-			break
-		}
-	}
+	assert.Nil(t, inst)
+	assert.Equal(t, ErrNotFound, err)
 
 	inst, err = NewInstaller(db, fs, &InstallerOptions{
+		Operation: Delete,
 		Type:      installerType,
-		Slug:      "cozy-app-a",
+		Slug:      "cozy-app-not-exist",
 		SourceURL: "git://localhost/",
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
-
-	go inst.Install()
-
-	_, _, err = inst.Poll()
-	assert.Equal(t, ErrAlreadyExists, err)
+	assert.Nil(t, inst)
+	assert.Equal(t, ErrNotFound, err)
 }
 
 func TestInstallWithUpgrade(t *testing.T) {
 	inst, err := NewInstaller(db, fs, &InstallerOptions{
+		Operation: Install,
 		Type:      installerType,
 		Slug:      "cozy-app-b",
 		SourceURL: "git://localhost/",
@@ -293,6 +290,7 @@ func TestInstallWithUpgrade(t *testing.T) {
 	doUpgrade(2)
 
 	inst, err = NewInstaller(db, fs, &InstallerOptions{
+		Operation: Update,
 		Type:      installerType,
 		Slug:      "cozy-app-b",
 		SourceURL: "git://localhost/",
@@ -340,6 +338,7 @@ func TestInstallAndUpgradeWithBranch(t *testing.T) {
 	doUpgrade(3)
 
 	inst, err := NewInstaller(db, fs, &InstallerOptions{
+		Operation: Install,
 		Type:      installerType,
 		Slug:      "local-cozy-mini-branch",
 		SourceURL: "git://localhost/#branch",
@@ -388,6 +387,7 @@ func TestInstallAndUpgradeWithBranch(t *testing.T) {
 	doUpgrade(4)
 
 	inst, err = NewInstaller(db, fs, &InstallerOptions{
+		Operation: Update,
 		Type:      installerType,
 		Slug:      "local-cozy-mini-branch",
 		SourceURL: "git://localhost/#branch",
@@ -436,6 +436,7 @@ func TestInstallAndUpgradeWithBranch(t *testing.T) {
 
 func TestInstallFromGithub(t *testing.T) {
 	inst, err := NewInstaller(db, fs, &InstallerOptions{
+		Operation: Install,
 		Type:      installerType,
 		Slug:      "github-cozy-mini",
 		SourceURL: "git://github.com/nono/cozy-mini.git",
@@ -474,6 +475,7 @@ func TestInstallFromGithub(t *testing.T) {
 
 func TestInstallFromGitlab(t *testing.T) {
 	inst, err := NewInstaller(db, fs, &InstallerOptions{
+		Operation: Install,
 		Type:      installerType,
 		Slug:      "gitlab-cozy-mini",
 		SourceURL: "git://framagit.org/nono/cozy-mini.git",
@@ -512,6 +514,7 @@ func TestInstallFromGitlab(t *testing.T) {
 
 func TestUninstall(t *testing.T) {
 	inst1, err := NewInstaller(db, fs, &InstallerOptions{
+		Operation: Install,
 		Type:      installerType,
 		Slug:      "github-cozy-delete",
 		SourceURL: "git://localhost/",
@@ -531,8 +534,9 @@ func TestUninstall(t *testing.T) {
 		}
 	}
 	inst2, err := NewInstaller(db, fs, &InstallerOptions{
-		Type: installerType,
-		Slug: "github-cozy-delete",
+		Operation: Delete,
+		Type:      installerType,
+		Slug:      "github-cozy-delete",
 	})
 	if !assert.NoError(t, err) {
 		return
@@ -542,16 +546,13 @@ func TestUninstall(t *testing.T) {
 		return
 	}
 	inst3, err := NewInstaller(db, fs, &InstallerOptions{
+		Operation: Delete,
 		Type:      installerType,
 		Slug:      "github-cozy-delete",
 		SourceURL: "git://localhost/",
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
-	go inst3.Update()
-	_, _, err = inst3.Poll()
-	assert.Error(t, err)
+	assert.Nil(t, inst3)
+	assert.Equal(t, ErrNotFound, err)
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -261,6 +261,7 @@ func (i *Instance) installApp(slug string) error {
 		return errors.New("Unknown app")
 	}
 	inst, err := apps.NewInstaller(i, i.VFS(), &apps.InstallerOptions{
+		Operation: apps.Install,
 		Type:      apps.Webapp,
 		SourceURL: source,
 		Slug:      slug,


### PR DESCRIPTION
This PR improves the error handling of the installation / update of applications. On the server-side the installer is given on "Operation" type to better check the manifest existence only if necessary (update/delete). On the API/Client side, the error are always returned in a `text/event-stream` format if required by the client.