### PR TITLE
Move apps/konnectors data out of the VFS

### DIFF
--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -200,6 +200,7 @@ func (i *Instance) hiddenFS(dirname string) afero.Fs {
 	case "swift":
 		panic("Not implemented")
 	}
+	return nil
 }
 
 // StartJobSystem creates all the resources necessary for the instance's job

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 
@@ -25,6 +26,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/vfs/vfsswift"
 	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/leonelquinteros/gotext"
+	"github.com/spf13/afero"
 	jwt "gopkg.in/dgrijalva/jwt-go.v3"
 )
 
@@ -177,6 +179,29 @@ func (i *Instance) makeVFS() error {
 	return err
 }
 
+// AppsFS returns the hidden filesystem associated with the specified
+// application type
+func (i *Instance) AppsFS(appsType apps.AppType) afero.Fs {
+	switch appsType {
+	case apps.Webapp:
+		return i.hiddenFS(vfs.WebappsDirName)
+	case apps.Konnector:
+		return i.hiddenFS(vfs.KonnectorsDirName)
+	}
+	panic(fmt.Errorf("Unknown application type %s", string(appsType)))
+}
+
+func (i *Instance) hiddenFS(dirname string) afero.Fs {
+	fsURL := config.FsURL()
+	switch fsURL.Scheme {
+	case "file", "mem":
+		return afero.NewBasePathFs(afero.NewOsFs(),
+			path.Join(fsURL.Path, i.Domain, dirname))
+	case "swift":
+		panic("Not implemented")
+	}
+}
+
 // StartJobSystem creates all the resources necessary for the instance's job
 // system to work properly.
 func (i *Instance) StartJobSystem() error {
@@ -260,7 +285,7 @@ func (i *Instance) installApp(slug string) error {
 	if !ok {
 		return errors.New("Unknown app")
 	}
-	inst, err := apps.NewInstaller(i, i.VFS(), &apps.InstallerOptions{
+	inst, err := apps.NewInstaller(i, i.AppsFS(apps.Webapp), &apps.InstallerOptions{
 		Operation: apps.Install,
 		Type:      apps.Webapp,
 		SourceURL: source,

--- a/web/apps/apps.go
+++ b/web/apps/apps.go
@@ -14,7 +14,6 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/cozy/cozy-stack/pkg/apps"
 	"github.com/cozy/cozy-stack/pkg/consts"
-	"github.com/cozy/cozy-stack/pkg/vfs"
 	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/cozy/cozy-stack/web/permissions"
@@ -222,7 +221,7 @@ func iconHandler(c echo.Context) error {
 		return err
 	}
 
-	filepath := path.Join(vfs.WebappsDirName, slug, app.Icon)
+	filepath := path.Join("/", slug, app.Icon)
 	fs := instance.AppsFS(apps.Webapp)
 	s, err := fs.Stat(filepath)
 	if err != nil {

--- a/web/apps/apps.go
+++ b/web/apps/apps.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
-	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/cozy/cozy-stack/pkg/apps"
@@ -43,7 +43,7 @@ func installHandler(installerType apps.AppType) echo.HandlerFunc {
 			w.WriteHeader(200)
 		}
 
-		inst, err := apps.NewInstaller(instance, instance.VFS(),
+		inst, err := apps.NewInstaller(instance, instance.AppsFS(installerType),
 			&apps.InstallerOptions{
 				Operation: apps.Install,
 				Type:      installerType,
@@ -84,7 +84,7 @@ func updateHandler(installerType apps.AppType) echo.HandlerFunc {
 			w.WriteHeader(200)
 		}
 
-		inst, err := apps.NewInstaller(instance, instance.VFS(),
+		inst, err := apps.NewInstaller(instance, instance.AppsFS(installerType),
 			&apps.InstallerOptions{
 				Operation: apps.Update,
 				Type:      installerType,
@@ -116,7 +116,7 @@ func deleteHandler(installerType apps.AppType) echo.HandlerFunc {
 		if err := permissions.AllowInstallApp(c, installerType, permissions.DELETE); err != nil {
 			return err
 		}
-		inst, err := apps.NewInstaller(instance, instance.VFS(),
+		inst, err := apps.NewInstaller(instance, instance.AppsFS(installerType),
 			&apps.InstallerOptions{
 				Operation: apps.Delete,
 				Type:      installerType,
@@ -223,17 +223,21 @@ func iconHandler(c echo.Context) error {
 	}
 
 	filepath := path.Join(vfs.WebappsDirName, slug, app.Icon)
-	file, err := instance.VFS().FileByPath(filepath)
+	fs := instance.AppsFS(apps.Webapp)
+	s, err := fs.Stat(filepath)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return echo.NewHTTPError(http.StatusNotFound, err)
+		}
 		return err
 	}
 
-	r, err := instance.VFS().OpenFile(file)
+	r, err := fs.Open(filepath)
 	if err != nil {
 		return err
 	}
 	defer r.Close()
-	http.ServeContent(c.Response(), c.Request(), filepath, time.Time{}, r)
+	http.ServeContent(c.Response(), c.Request(), filepath, s.ModTime(), r)
 	return nil
 }
 

--- a/web/apps/serve.go
+++ b/web/apps/serve.go
@@ -133,6 +133,12 @@ func ServeAppFile(c echo.Context, i *instance.Instance, fs AppFileServer, app *a
 		return err
 	}
 	defer content.Close()
+
+	ext := path.Ext(file)
+	if ext != ".html" && ext != ".htm" {
+		return fs.ServeFileContent(c.Response(), c.Request(), modtime, slug, route.Folder, file)
+	}
+
 	buf, err := ioutil.ReadAll(content)
 	if err != nil {
 		return err

--- a/web/apps/serve.go
+++ b/web/apps/serve.go
@@ -133,12 +133,6 @@ func ServeAppFile(c echo.Context, i *instance.Instance, fs AppFileServer, app *a
 		return err
 	}
 	defer content.Close()
-
-	ext := path.Ext(file)
-	if ext != ".html" && ext != ".htm" {
-		return fs.ServeFileContent(c.Response(), c.Request(), modtime, slug, route.Folder, file)
-	}
-
 	buf, err := ioutil.ReadAll(content)
 	if err != nil {
 		return err

--- a/web/server.go
+++ b/web/server.go
@@ -116,7 +116,7 @@ func ListenAndServeWithAppDir(appsdir map[string]string) error {
 				apps.WebappManifestName, err.Error())
 		}
 		i := middlewares.GetInstance(c)
-		f := webapps.NewAferoServer(fs, func(_, folder, file string) string {
+		f := webapps.NewServer(fs, func(_, folder, file string) string {
 			return path.Join(folder, file)
 		})
 		// Save permissions in couchdb before loading an index page


### PR DESCRIPTION
This PR moves the apps and konnectors storage out of the VFS index.

For retro-compatibility reason, the `.cozy-apps` and `.cozy-konnectors` are stilled used and stored in the VFS directory of the user.

The `swift` filesystem is not yet implemented.