### PR TITLE
[refacto] Clean package graph 

### DIFF
--- a/pkg/apps/apps.go
+++ b/pkg/apps/apps.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/permissions"
-	"github.com/cozy/cozy-stack/web/jsonapi"
 )
 
 const (
@@ -63,7 +62,7 @@ type SubDomainer interface {
 // Manifest interface is used by installer to encapsulate the manifest metadata
 // that can represent either a webapp or konnector manifest
 type Manifest interface {
-	jsonapi.Object
+	couchdb.Doc
 	Valid(field, expected string) bool
 	ReadManifest(i io.Reader, slug, sourceURL string) error
 	Permissions() permissions.Set

--- a/pkg/apps/konnector.go
+++ b/pkg/apps/konnector.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/permissions"
-	"github.com/cozy/cozy-stack/web/jsonapi"
 )
 
 type konnManifest struct {
@@ -54,20 +53,6 @@ func (m *konnManifest) SetState(state State) { m.DocState = state }
 func (m *konnManifest) SetError(err error)   { m.DocError = err.Error() }
 func (m *konnManifest) Permissions() permissions.Set {
 	return m.DocPermissions
-}
-
-func (m *konnManifest) Links() *jsonapi.LinksList {
-	return &jsonapi.LinksList{
-		Self: "/konnectors/" + m.DocSlug,
-	}
-}
-
-func (m *konnManifest) Relationships() jsonapi.RelationshipMap {
-	return jsonapi.RelationshipMap{}
-}
-
-func (m *konnManifest) Included() []jsonapi.Object {
-	return []jsonapi.Object{}
 }
 
 func (m *konnManifest) Valid(field, value string) bool {

--- a/pkg/apps/webapp.go
+++ b/pkg/apps/webapp.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/permissions"
-	"github.com/cozy/cozy-stack/web/jsonapi"
 )
 
 // Route is a struct to serve a folder inside an app
@@ -104,30 +103,6 @@ func (m *WebappManifest) SetError(err error) { m.DocError = err.Error() }
 // Permissions is part of the Manifest interface
 func (m *WebappManifest) Permissions() permissions.Set {
 	return m.DocPermissions
-}
-
-// Links is part of the Manifest interface
-func (m *WebappManifest) Links() *jsonapi.LinksList {
-	links := jsonapi.LinksList{
-		Self: "/apps/" + m.DocSlug,
-	}
-	if m.Icon != "" {
-		links.Icon = "/apps/" + m.DocSlug + "/icon"
-	}
-	if m.DocState == Ready && m.Instance != nil {
-		links.Related = m.Instance.SubDomain(m.DocSlug).String()
-	}
-	return &links
-}
-
-// Relationships is part of the Manifest interface
-func (m *WebappManifest) Relationships() jsonapi.RelationshipMap {
-	return jsonapi.RelationshipMap{}
-}
-
-// Included is part of the Manifest interface
-func (m *WebappManifest) Included() []jsonapi.Object {
-	return []jsonapi.Object{}
 }
 
 // Valid is part of the Manifest interface

--- a/pkg/couchdb/reference.go
+++ b/pkg/couchdb/reference.go
@@ -1,0 +1,7 @@
+package couchdb
+
+// DocReference is a reference to a document
+type DocReference struct {
+	ID   string `json:"id"`
+	Type string `json:"type"`
+}

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cozy/cozy-stack/pkg/vfs"
 	"github.com/cozy/cozy-stack/pkg/vfs/vfsafero"
 	"github.com/cozy/cozy-stack/pkg/vfs/vfsswift"
-	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/leonelquinteros/gotext"
 	"github.com/spf13/afero"
 	jwt "gopkg.in/dgrijalva/jwt-go.v3"
@@ -119,21 +118,6 @@ func (i *Instance) Rev() string { return i.DocRev }
 
 // SetRev implements couchdb.Doc
 func (i *Instance) SetRev(v string) { i.DocRev = v }
-
-// Links is used to generate a JSON-API link for the instance
-func (i *Instance) Links() *jsonapi.LinksList {
-	return &jsonapi.LinksList{Self: "/instances/" + i.DocID}
-}
-
-// Relationships is used to generate the content relationship in JSON-API format
-func (i *Instance) Relationships() jsonapi.RelationshipMap {
-	return jsonapi.RelationshipMap{}
-}
-
-// Included is part of the jsonapi.Object interface
-func (i *Instance) Included() []jsonapi.Object {
-	return nil
-}
 
 // settings is a struct used for the settings of an instance
 type instanceSettings struct {

--- a/pkg/jobs/errors.go
+++ b/pkg/jobs/errors.go
@@ -1,6 +1,11 @@
 package jobs
 
-import "errors"
+import (
+	"errors"
+	"net/http"
+
+	"github.com/labstack/echo"
+)
 
 var (
 	// ErrQueueClosed is used to indicate the queue is closed
@@ -13,4 +18,6 @@ var (
 	ErrUnknownTrigger = errors.New("Unknown trigger type")
 	// ErrNotFoundTrigger is used when the trigger was not found
 	ErrNotFoundTrigger = errors.New("Trigger with specified ID does not exist")
+	// ErrMalformedTigger is used to indicate the trigger is unparsable
+	ErrMalformedTigger = echo.NewHTTPError(http.StatusBadRequest, "Trigger unparsable")
 )

--- a/pkg/jobs/errors.go
+++ b/pkg/jobs/errors.go
@@ -18,6 +18,6 @@ var (
 	ErrUnknownTrigger = errors.New("Unknown trigger type")
 	// ErrNotFoundTrigger is used when the trigger was not found
 	ErrNotFoundTrigger = errors.New("Trigger with specified ID does not exist")
-	// ErrMalformedTigger is used to indicate the trigger is unparsable
-	ErrMalformedTigger = echo.NewHTTPError(http.StatusBadRequest, "Trigger unparsable")
+	// ErrMalformedTrigger is used to indicate the trigger is unparsable
+	ErrMalformedTrigger = echo.NewHTTPError(http.StatusBadRequest, "Trigger unparsable")
 )

--- a/pkg/jobs/trigger_at.go
+++ b/pkg/jobs/trigger_at.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/cozy/cozy-stack/pkg/consts"
-	"github.com/cozy/cozy-stack/web/jsonapi"
 )
 
 // maxPastTriggerTime is the maximum duration in the past for which the at
@@ -24,7 +23,7 @@ type AtTrigger struct {
 func NewAtTrigger(infos *TriggerInfos) (*AtTrigger, error) {
 	at, err := time.Parse(time.RFC3339, infos.Arguments)
 	if err != nil {
-		return nil, jsonapi.BadRequest(err)
+		return nil, ErrMalformedTigger
 	}
 	return &AtTrigger{
 		at:   at,
@@ -38,7 +37,7 @@ func NewAtTrigger(infos *TriggerInfos) (*AtTrigger, error) {
 func NewInTrigger(infos *TriggerInfos) (*AtTrigger, error) {
 	d, err := time.ParseDuration(infos.Arguments)
 	if err != nil {
-		return nil, jsonapi.BadRequest(err)
+		return nil, ErrMalformedTigger
 	}
 	at := time.Now().Add(d)
 	return &AtTrigger{

--- a/pkg/jobs/trigger_at.go
+++ b/pkg/jobs/trigger_at.go
@@ -23,7 +23,7 @@ type AtTrigger struct {
 func NewAtTrigger(infos *TriggerInfos) (*AtTrigger, error) {
 	at, err := time.Parse(time.RFC3339, infos.Arguments)
 	if err != nil {
-		return nil, ErrMalformedTigger
+		return nil, ErrMalformedTrigger
 	}
 	return &AtTrigger{
 		at:   at,
@@ -37,7 +37,7 @@ func NewAtTrigger(infos *TriggerInfos) (*AtTrigger, error) {
 func NewInTrigger(infos *TriggerInfos) (*AtTrigger, error) {
 	d, err := time.ParseDuration(infos.Arguments)
 	if err != nil {
-		return nil, ErrMalformedTigger
+		return nil, ErrMalformedTrigger
 	}
 	at := time.Now().Add(d)
 	return &AtTrigger{

--- a/pkg/jobs/trigger_cron.go
+++ b/pkg/jobs/trigger_cron.go
@@ -19,7 +19,7 @@ type CronTrigger struct {
 func NewCronTrigger(infos *TriggerInfos) (*CronTrigger, error) {
 	schedule, err := cron.Parse(infos.Arguments)
 	if err != nil {
-		return nil, ErrMalformedTigger
+		return nil, ErrMalformedTrigger
 	}
 	return &CronTrigger{
 		sched: schedule,
@@ -33,7 +33,7 @@ func NewCronTrigger(infos *TriggerInfos) (*CronTrigger, error) {
 func NewEveryTrigger(infos *TriggerInfos) (*CronTrigger, error) {
 	schedule, err := cron.Parse("@every " + infos.Arguments)
 	if err != nil {
-		return nil, ErrMalformedTigger
+		return nil, ErrMalformedTrigger
 	}
 	return &CronTrigger{
 		sched: schedule,

--- a/pkg/jobs/trigger_cron.go
+++ b/pkg/jobs/trigger_cron.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/cozy/cozy-stack/pkg/consts"
-	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/robfig/cron"
 )
 
@@ -20,7 +19,7 @@ type CronTrigger struct {
 func NewCronTrigger(infos *TriggerInfos) (*CronTrigger, error) {
 	schedule, err := cron.Parse(infos.Arguments)
 	if err != nil {
-		return nil, jsonapi.BadRequest(err)
+		return nil, ErrMalformedTigger
 	}
 	return &CronTrigger{
 		sched: schedule,
@@ -34,7 +33,7 @@ func NewCronTrigger(infos *TriggerInfos) (*CronTrigger, error) {
 func NewEveryTrigger(infos *TriggerInfos) (*CronTrigger, error) {
 	schedule, err := cron.Parse("@every " + infos.Arguments)
 	if err != nil {
-		return nil, jsonapi.BadRequest(err)
+		return nil, ErrMalformedTigger
 	}
 	return &CronTrigger{
 		sched: schedule,

--- a/pkg/oauth/client.go
+++ b/pkg/oauth/client.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cozy/cozy-stack/pkg/crypto"
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/pkg/permissions"
-	"github.com/cozy/cozy-stack/web/jsonapi"
 	jwt "gopkg.in/dgrijalva/jwt-go.v3"
 )
 
@@ -62,23 +61,6 @@ func (c *Client) SetID(id string) { c.CouchID = id }
 
 // SetRev changes the client revision
 func (c *Client) SetRev(rev string) { c.CouchRev = rev }
-
-// Links is used to generate a JSON-API link for the client - see
-// jsonapi.Object interface
-func (c *Client) Links() *jsonapi.LinksList {
-	return &jsonapi.LinksList{Self: "/settings/clients/" + c.ID()}
-}
-
-// Relationships is used to generate the parent relationship in JSON-API format
-// - see jsonapi.Object interface
-func (c *Client) Relationships() jsonapi.RelationshipMap {
-	return jsonapi.RelationshipMap{}
-}
-
-// Included is part of the jsonapi.Object interface
-func (c *Client) Included() []jsonapi.Object {
-	return []jsonapi.Object{}
-}
 
 // TransformIDAndRev makes the translation from the JSON of CouchDB to the
 // one used in the dynamic client registration protocol

--- a/pkg/permissions/permissions.go
+++ b/pkg/permissions/permissions.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
-	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/labstack/echo"
 )
 
@@ -66,17 +65,6 @@ func (p *Permission) SetID(id string) { p.PID = id }
 
 // SetRev implements jsonapi.Doc
 func (p *Permission) SetRev(rev string) { p.PRev = rev }
-
-// Relationships implements jsonapi.Doc
-func (p *Permission) Relationships() jsonapi.RelationshipMap { return nil }
-
-// Included implements jsonapi.Doc
-func (p *Permission) Included() []jsonapi.Object { return nil }
-
-// Links implements jsonapi.Doc
-func (p *Permission) Links() *jsonapi.LinksList {
-	return &jsonapi.LinksList{Self: "/permissions/" + p.PID}
-}
 
 // AddRules add some rules to the permission doc
 func (p *Permission) AddRules(rules ...Rule) {

--- a/pkg/sharings/recipients.go
+++ b/pkg/sharings/recipients.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/instance"
-	"github.com/cozy/cozy-stack/web/jsonapi"
 )
 
 // Recipient is a struct describing a sharing recipient
@@ -24,7 +23,7 @@ type RecipientStatus struct {
 	Status string `json:"status,omitempty"`
 
 	// Reference on the recipient.
-	RefRecipient jsonapi.ResourceIdentifier `json:"recipient,omitempty"`
+	RefRecipient couchdb.DocReference `json:"recipient,omitempty"`
 	recipient    *Recipient
 
 	// The sharer is the "client", in the OAuth2 protocol, we keep here the
@@ -47,17 +46,6 @@ func (r *Recipient) SetID(id string) { r.RID = id }
 
 // SetRev changes the recipient revision
 func (r *Recipient) SetRev(rev string) { r.RRev = rev }
-
-// Relationships implements jsonapi.Doc
-func (r *Recipient) Relationships() jsonapi.RelationshipMap { return nil }
-
-// Included implements jsonapi.Doc
-func (r *Recipient) Included() []jsonapi.Object { return nil }
-
-// Links implements jsonapi.Doc
-func (r *Recipient) Links() *jsonapi.LinksList {
-	return &jsonapi.LinksList{Self: "/recipients/" + r.RID}
-}
 
 // ExtractDomain returns the recipient's domain without the scheme
 func (r *Recipient) ExtractDomain() (string, error) {
@@ -92,6 +80,12 @@ func GetRecipient(db couchdb.Database, recID string) (*Recipient, error) {
 		err = ErrRecipientDoesNotExist
 	}
 	return doc, err
+}
+
+// GetCachedRecipient returns the recipient cached in memory within
+// the RecipientStatus. CAN BE NIL, Used by jsonapi
+func (rs *RecipientStatus) GetCachedRecipient() *Recipient {
+	return rs.recipient
 }
 
 // getAccessToken sends an "access_token" request to the recipient using the
@@ -195,6 +189,5 @@ func (rs *RecipientStatus) Register(instance *instance.Instance) error {
 }
 
 var (
-	_ couchdb.Doc    = &Recipient{}
-	_ jsonapi.Object = &Recipient{}
+	_ couchdb.Doc = &Recipient{}
 )

--- a/pkg/sharings/send_mails_test.go
+++ b/pkg/sharings/send_mails_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/permissions"
-	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,7 +17,7 @@ var rec = &Recipient{
 }
 
 var recStatus = &RecipientStatus{
-	RefRecipient: jsonapi.ResourceIdentifier{
+	RefRecipient: couchdb.DocReference{
 		Type: consts.Recipients,
 	},
 	Client: &auth.Client{

--- a/pkg/sharings/sharings.go
+++ b/pkg/sharings/sharings.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cozy/cozy-stack/pkg/oauth"
 	"github.com/cozy/cozy-stack/pkg/permissions"
 	"github.com/cozy/cozy-stack/pkg/utils"
-	"github.com/cozy/cozy-stack/web/jsonapi"
 )
 
 // Sharing contains all the information about a sharing
@@ -70,11 +69,6 @@ func (s *Sharing) SetID(id string) { s.SID = id }
 // SetRev changes the sharing revision
 func (s *Sharing) SetRev(rev string) { s.SRev = rev }
 
-// Links implements jsonapi.Doc
-func (s *Sharing) Links() *jsonapi.LinksList {
-	return &jsonapi.LinksList{Self: "/sharings/" + s.SID}
-}
-
 // RecStatus returns the sharing recipients status
 func (s *Sharing) RecStatus(db couchdb.Database) ([]*RecipientStatus, error) {
 	var rStatus []*RecipientStatus
@@ -106,32 +100,6 @@ func (s *Sharing) Recipients(db couchdb.Database) ([]*Recipient, error) {
 	}
 
 	return recipients, nil
-}
-
-// Relationships is part of the jsonapi.Object interface
-// It is used to generate the recipients relationships
-func (s *Sharing) Relationships() jsonapi.RelationshipMap {
-	l := len(s.RecipientsStatus)
-	i := 0
-
-	data := make([]jsonapi.ResourceIdentifier, l)
-	for _, rec := range s.RecipientsStatus {
-		r := rec.recipient
-		data[i] = jsonapi.ResourceIdentifier{ID: r.ID(), Type: r.DocType()}
-		i++
-	}
-	contents := jsonapi.Relationship{Data: data}
-	return jsonapi.RelationshipMap{"recipients": contents}
-}
-
-// Included is part of the jsonapi.Object interface
-func (s *Sharing) Included() []jsonapi.Object {
-	var included []jsonapi.Object
-	for _, rec := range s.RecipientsStatus {
-		r := rec.recipient
-		included = append(included, r)
-	}
-	return included
 }
 
 // GetSharingRecipientFromClientID returns the Recipient associated with the
@@ -443,6 +411,5 @@ func CreateSharingAndRegisterSharer(instance *instance.Instance, sharing *Sharin
 }
 
 var (
-	_ couchdb.Doc    = &Sharing{}
-	_ jsonapi.Object = &Sharing{}
+	_ couchdb.Doc = &Sharing{}
 )

--- a/pkg/sharings/sharings_test.go
+++ b/pkg/sharings/sharings_test.go
@@ -20,7 +20,6 @@ import (
 	webAuth "github.com/cozy/cozy-stack/web/auth"
 	"github.com/cozy/cozy-stack/web/data"
 	"github.com/cozy/cozy-stack/web/errors"
-	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/labstack/echo"
 	"github.com/stretchr/testify/assert"
 )
@@ -105,7 +104,7 @@ func createSharing(t *testing.T, doc *couchdb.JSONDoc) (*Sharing, error) {
 	assert.NoError(t, err)
 
 	recStatus := &RecipientStatus{
-		RefRecipient: jsonapi.ResourceIdentifier{
+		RefRecipient: couchdb.DocReference{
 			ID:   recipient.RID,
 			Type: consts.Recipients,
 		},
@@ -262,7 +261,7 @@ func TestGetSharingRecipientFromClientIDNoClient(t *testing.T) {
 	clientID := "fake client"
 
 	rStatus := &RecipientStatus{
-		RefRecipient: jsonapi.ResourceIdentifier{ID: "id", Type: "type"},
+		RefRecipient: couchdb.DocReference{ID: "id", Type: "type"},
 		Client: &auth.Client{
 			ClientID: "fakeid",
 		},
@@ -440,7 +439,7 @@ func TestSharingRefusedSuccess(t *testing.T) {
 	assert.NoError(t, err)
 
 	rStatus := &RecipientStatus{
-		RefRecipient: jsonapi.ResourceIdentifier{ID: recipient.RID},
+		RefRecipient: couchdb.DocReference{ID: recipient.RID},
 		Client: &auth.Client{
 			ClientID: clientID,
 		},
@@ -554,7 +553,7 @@ func TestCreateSharingAndRegisterSharer(t *testing.T) {
 	}
 
 	recStatus := &RecipientStatus{
-		RefRecipient: jsonapi.ResourceIdentifier{
+		RefRecipient: couchdb.DocReference{
 			ID:   "123",
 			Type: consts.Recipients,
 		},

--- a/pkg/vfs/archive.go
+++ b/pkg/vfs/archive.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/cozy/cozy-stack/pkg/consts"
-	"github.com/cozy/cozy-stack/web/jsonapi"
 )
 
 // ZipMime is the content-type for zip archives
@@ -143,18 +142,3 @@ func (a *Archive) SetID(_ string) {}
 
 // SetRev makes Archive a jsonapi.Object
 func (a *Archive) SetRev(_ string) {}
-
-// Relationships makes Archive a jsonapi.Object
-func (a *Archive) Relationships() jsonapi.RelationshipMap { return nil }
-
-// Included makes Archive a jsonapi.Object
-func (a *Archive) Included() []jsonapi.Object { return nil }
-
-// Links makes Archive a jsonapi.Object
-func (a *Archive) Links() *jsonapi.LinksList {
-	return &jsonapi.LinksList{Self: "/files/archive/" + a.Secret}
-}
-
-var (
-	_ jsonapi.Object = &Archive{}
-)

--- a/pkg/vfs/file.go
+++ b/pkg/vfs/file.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
-	"github.com/cozy/cozy-stack/web/jsonapi"
 )
 
 // FileDoc is a struct containing all the informations about a file.
@@ -43,7 +42,7 @@ type FileDoc struct {
 
 	Metadata Metadata `json:"metadata,omitempty"`
 
-	ReferencedBy []jsonapi.ResourceIdentifier `json:"referenced_by,omitempty"`
+	ReferencedBy []couchdb.DocReference `json:"referenced_by,omitempty"`
 
 	// Cache of the fullpath of the file. Should not have to be invalidated since
 	// we use FileDoc as immutable data-structures.
@@ -103,11 +102,11 @@ func (f *FileDoc) IsDir() bool { return false }
 func (f *FileDoc) Sys() interface{} { return nil }
 
 // AddReferencedBy adds referenced_by to the file
-func (f *FileDoc) AddReferencedBy(ri ...jsonapi.ResourceIdentifier) {
+func (f *FileDoc) AddReferencedBy(ri ...couchdb.DocReference) {
 	f.ReferencedBy = append(f.ReferencedBy, ri...)
 }
 
-func containsReferencedBy(haystack []jsonapi.ResourceIdentifier, needle jsonapi.ResourceIdentifier) bool {
+func containsReferencedBy(haystack []couchdb.DocReference, needle couchdb.DocReference) bool {
 	for _, ref := range haystack {
 		if ref.ID == needle.ID && ref.Type == needle.Type {
 			return true
@@ -117,7 +116,7 @@ func containsReferencedBy(haystack []jsonapi.ResourceIdentifier, needle jsonapi.
 }
 
 // RemoveReferencedBy adds referenced_by to the file
-func (f *FileDoc) RemoveReferencedBy(ri ...jsonapi.ResourceIdentifier) {
+func (f *FileDoc) RemoveReferencedBy(ri ...couchdb.DocReference) {
 	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
 	referenced := f.ReferencedBy[:0]
 	for _, ref := range f.ReferencedBy {

--- a/web/data/references.go
+++ b/web/data/references.go
@@ -52,9 +52,9 @@ func listReferencesHandler(c echo.Context) error {
 			c.Request().URL.Path, params.Encode())
 	}
 
-	var out = make([]jsonapi.ResourceIdentifier, len(res.Rows))
+	var out = make([]couchdb.DocReference, len(res.Rows))
 	for i, row := range res.Rows {
-		out[i] = jsonapi.ResourceIdentifier{
+		out[i] = couchdb.DocReference{
 			ID:   row.ID,
 			Type: consts.Files,
 		}
@@ -73,7 +73,7 @@ func addReferencesHandler(c echo.Context) error {
 		return err
 	}
 
-	docRef := jsonapi.ResourceIdentifier{
+	docRef := couchdb.DocReference{
 		Type: doctype,
 		ID:   id,
 	}
@@ -107,7 +107,7 @@ func removeReferencesHandler(c echo.Context) error {
 		return err
 	}
 
-	docRef := jsonapi.ResourceIdentifier{
+	docRef := couchdb.DocReference{
 		Type: doctype,
 		ID:   id,
 	}

--- a/web/data/references_test.go
+++ b/web/data/references_test.go
@@ -28,7 +28,7 @@ func TestListReferencesHandler(t *testing.T) {
 
 	var result struct {
 		Links jsonapi.LinksList
-		Data  []jsonapi.ResourceIdentifier `json:"data"`
+		Data  []couchdb.DocReference `json:"data"`
 	}
 	_, res, err := doRequest(req, &result)
 
@@ -39,7 +39,7 @@ func TestListReferencesHandler(t *testing.T) {
 
 	var result2 struct {
 		Links jsonapi.LinksList
-		Data  []jsonapi.ResourceIdentifier `json:"data"`
+		Data  []couchdb.DocReference `json:"data"`
 	}
 	req2, _ := http.NewRequest("GET", url+"?page[limit]=3", nil)
 	req2.Header.Add("Authorization", "Bearer "+token)
@@ -52,7 +52,7 @@ func TestListReferencesHandler(t *testing.T) {
 
 	var result3 struct {
 		Links jsonapi.LinksList
-		Data  []jsonapi.ResourceIdentifier `json:"data"`
+		Data  []couchdb.DocReference `json:"data"`
 	}
 	req3, _ := http.NewRequest("GET", ts.URL+result2.Links.Next, nil)
 	req3.Header.Add("Authorization", "Bearer "+token)
@@ -87,7 +87,7 @@ func TestAddReferencesHandler(t *testing.T) {
 
 	// update it
 	var in = jsonReader(jsonapi.Relationship{
-		Data: []jsonapi.ResourceIdentifier{
+		Data: []couchdb.DocReference{
 			{
 				ID:   filedoc.ID(),
 				Type: filedoc.DocType(),
@@ -121,7 +121,7 @@ func TestRemoveReferencesHandler(t *testing.T) {
 
 	// update it
 	var in = jsonReader(jsonapi.Relationship{
-		Data: []jsonapi.ResourceIdentifier{
+		Data: []couchdb.DocReference{
 			{ID: f8, Type: consts.Files},
 			{ID: f6, Type: consts.Files},
 		},
@@ -157,7 +157,7 @@ func makeReferencedTestFile(t *testing.T, doc couchdb.Doc, name string) string {
 		return ""
 	}
 
-	filedoc.ReferencedBy = []jsonapi.ResourceIdentifier{
+	filedoc.ReferencedBy = []couchdb.DocReference{
 		{
 			ID:   doc.ID(),
 			Type: doc.DocType(),

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -432,7 +432,7 @@ func ArchiveDownloadCreateHandler(c echo.Context) error {
 		Related: "/files/archive/" + secret + "/" + fakeName + ".zip",
 	}
 
-	return jsonapi.Data(c, http.StatusOK, archive, links)
+	return jsonapi.Data(c, http.StatusOK, &apiArchive{archive}, links)
 }
 
 // FileDownloadCreateHandler stores the required path into a secret

--- a/web/files/paginated.go
+++ b/web/files/paginated.go
@@ -29,6 +29,10 @@ type file struct {
 	doc *vfs.FileDoc
 }
 
+type apiArchive struct {
+	*vfs.Archive
+}
+
 func paginationConfig(c echo.Context) (int, *vfs.IteratorOptions, error) {
 	var count int64
 	var err error
@@ -159,6 +163,12 @@ func fileData(c echo.Context, statusCode int, doc *vfs.FileDoc, links *jsonapi.L
 	return jsonapi.Data(c, statusCode, newFile(doc), links)
 }
 
+var (
+	_ jsonapi.Object = (*apiArchive)(nil)
+	_ jsonapi.Object = (*dir)(nil)
+	_ jsonapi.Object = (*file)(nil)
+)
+
 func (d *dir) ID() string                             { return d.doc.ID() }
 func (d *dir) Rev() string                            { return d.doc.Rev() }
 func (d *dir) SetID(id string)                        { d.doc.SetID(id) }
@@ -169,6 +179,13 @@ func (d *dir) Included() []jsonapi.Object             { return d.included }
 func (d *dir) MarshalJSON() ([]byte, error)           { return json.Marshal(d.doc) }
 func (d *dir) Links() *jsonapi.LinksList {
 	return &jsonapi.LinksList{Self: "/files/" + d.doc.DocID}
+}
+
+func (a *apiArchive) Relationships() jsonapi.RelationshipMap { return nil }
+func (a *apiArchive) Included() []jsonapi.Object             { return nil }
+func (a *apiArchive) MarshalJSON() ([]byte, error)           { return json.Marshal(a.Archive) }
+func (a *apiArchive) Links() *jsonapi.LinksList {
+	return &jsonapi.LinksList{Self: "/files/archive/" + a.Secret}
 }
 
 func (f *file) ID() string        { return f.doc.ID() }

--- a/web/files/paginated.go
+++ b/web/files/paginated.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/vfs"
 	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/cozy/cozy-stack/web/middlewares"
@@ -55,7 +56,7 @@ func newDir(doc *vfs.DirDoc) *dir {
 }
 
 func dirData(c echo.Context, statusCode int, doc *vfs.DirDoc) error {
-	relsData := make([]jsonapi.ResourceIdentifier, 0)
+	relsData := make([]couchdb.DocReference, 0)
 	included := make([]jsonapi.Object, 0)
 
 	count, iterOpts, err := paginationConfig(c)
@@ -81,11 +82,11 @@ func dirData(c echo.Context, statusCode int, doc *vfs.DirDoc) error {
 		} else {
 			included = append(included, newFile(f))
 		}
-		var ri jsonapi.ResourceIdentifier
+		var ri couchdb.DocReference
 		if d != nil {
-			ri = jsonapi.ResourceIdentifier{ID: d.ID(), Type: d.DocType()}
+			ri = couchdb.DocReference{ID: d.ID(), Type: d.DocType()}
 		} else {
-			ri = jsonapi.ResourceIdentifier{ID: f.ID(), Type: f.DocType()}
+			ri = couchdb.DocReference{ID: f.ID(), Type: f.DocType()}
 		}
 		relsData = append(relsData, ri)
 	}
@@ -96,7 +97,7 @@ func dirData(c echo.Context, statusCode int, doc *vfs.DirDoc) error {
 			Links: &jsonapi.LinksList{
 				Related: "/files/" + doc.DirID,
 			},
-			Data: jsonapi.ResourceIdentifier{
+			Data: couchdb.DocReference{
 				ID:   doc.DirID,
 				Type: consts.Files,
 			},
@@ -181,7 +182,7 @@ func (f *file) Relationships() jsonapi.RelationshipMap {
 			Links: &jsonapi.LinksList{
 				Related: "/files/" + f.doc.DirID,
 			},
-			Data: jsonapi.ResourceIdentifier{
+			Data: couchdb.DocReference{
 				ID:   f.doc.DirID,
 				Type: consts.Files,
 			},

--- a/web/files/referencedby_test.go
+++ b/web/files/referencedby_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/labstack/echo"
 	"github.com/stretchr/testify/assert"
@@ -24,7 +25,7 @@ func TestAddReferencedByOneRelation(t *testing.T) {
 
 	path := "/files/" + fileID1 + "/relationships/referenced_by"
 	content, err := json.Marshal(&jsonapi.Relationship{
-		Data: jsonapi.ResourceIdentifier{
+		Data: couchdb.DocReference{
 			ID:   "fooalbumid",
 			Type: "io.cozy.photos.albums",
 		},
@@ -61,7 +62,7 @@ func TestAddReferencedByMultipleRelation(t *testing.T) {
 
 	path := "/files/" + fileID2 + "/relationships/referenced_by"
 	content, err := json.Marshal(&jsonapi.Relationship{
-		Data: []jsonapi.ResourceIdentifier{
+		Data: []couchdb.DocReference{
 			{ID: "fooalbumid1", Type: "io.cozy.photos.albums"},
 			{ID: "fooalbumid2", Type: "io.cozy.photos.albums"},
 			{ID: "fooalbumid3", Type: "io.cozy.photos.albums"},
@@ -91,7 +92,7 @@ func TestAddReferencedByMultipleRelation(t *testing.T) {
 func TestRemoveReferencedByOneRelation(t *testing.T) {
 	path := "/files/" + fileID1 + "/relationships/referenced_by"
 	content, err := json.Marshal(&jsonapi.Relationship{
-		Data: jsonapi.ResourceIdentifier{
+		Data: couchdb.DocReference{
 			ID:   "fooalbumid",
 			Type: "io.cozy.photos.albums",
 		},
@@ -113,7 +114,7 @@ func TestRemoveReferencedByOneRelation(t *testing.T) {
 func TestRemoveReferencedByMultipleRelation(t *testing.T) {
 	path := "/files/" + fileID2 + "/relationships/referenced_by"
 	content, err := json.Marshal(&jsonapi.Relationship{
-		Data: []jsonapi.ResourceIdentifier{
+		Data: []couchdb.DocReference{
 			{ID: "fooalbumid3", Type: "io.cozy.photos.albums"},
 			{ID: "fooalbumid5", Type: "io.cozy.photos.albums"},
 			{ID: "fooalbumid1", Type: "io.cozy.photos.albums"},

--- a/web/jsonapi/data.go
+++ b/web/jsonapi/data.go
@@ -31,14 +31,6 @@ type LinksList struct {
 	Perms   string `json:"permissions,omitempty"`
 }
 
-// ResourceIdentifier is an object, used in relationships, to identify an
-// individual resource
-// See http://jsonapi.org/format/#document-resource-identifier-objects
-type ResourceIdentifier struct {
-	ID   string `json:"id"`
-	Type string `json:"type"`
-}
-
 // Relationship is a resource linkage, as described in JSON-API
 // See http://jsonapi.org/format/#document-resource-object-relationships
 //
@@ -50,11 +42,11 @@ type Relationship struct {
 }
 
 // ResourceIdentifier returns the resource identifier of the relationship.
-func (r *Relationship) ResourceIdentifier() (*ResourceIdentifier, bool) {
+func (r *Relationship) ResourceIdentifier() (*couchdb.DocReference, bool) {
 	if m, ok := r.Data.(map[string]interface{}); ok {
 		idd, _ := m["id"].(string)
 		typ, _ := m["type"].(string)
-		return &ResourceIdentifier{ID: idd, Type: typ}, true
+		return &couchdb.DocReference{ID: idd, Type: typ}, true
 	}
 	return nil, false
 }

--- a/web/jsonapi/jsonapi.go
+++ b/web/jsonapi/jsonapi.go
@@ -88,7 +88,7 @@ func DataList(c echo.Context, statusCode int, objs []Object, links *LinksList) e
 
 // DataRelations can be called to send a Relations page,
 // a list of ResourceIdentifier
-func DataRelations(c echo.Context, statusCode int, refs []ResourceIdentifier, links *LinksList) error {
+func DataRelations(c echo.Context, statusCode int, refs []couchdb.DocReference, links *LinksList) error {
 	data, err := json.Marshal(refs)
 	if err != nil {
 		return InternalServerError(err)
@@ -151,8 +151,8 @@ func Bind(req *http.Request, attrs interface{}) (*ObjectMarshalling, error) {
 }
 
 // BindRelations extracts a Relationships request ( a list of ResourceIdentifier)
-func BindRelations(req *http.Request) ([]ResourceIdentifier, error) {
-	var out []ResourceIdentifier
+func BindRelations(req *http.Request) ([]couchdb.DocReference, error) {
+	var out []couchdb.DocReference
 	decoder := json.NewDecoder(req.Body)
 	var doc *Document
 	if err := decoder.Decode(&doc); err != nil {
@@ -163,11 +163,11 @@ func BindRelations(req *http.Request) ([]ResourceIdentifier, error) {
 	}
 	// Attempt Unmarshaling either as ResourceIdentifier or []ResourceIdentifier
 	if err := json.Unmarshal(*doc.Data, &out); err != nil {
-		var ri ResourceIdentifier
+		var ri couchdb.DocReference
 		if err = json.Unmarshal(*doc.Data, &ri); err != nil {
 			return nil, err
 		}
-		out = []ResourceIdentifier{ri}
+		out = []couchdb.DocReference{ri}
 		return out, nil
 	}
 	return out, nil

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -12,13 +12,13 @@ import (
 
 	"github.com/cozy/cozy-stack/pkg/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/pkg/oauth"
 	"github.com/cozy/cozy-stack/pkg/permissions"
 	"github.com/cozy/cozy-stack/pkg/sharings"
 	"github.com/cozy/cozy-stack/tests/testutils"
 	"github.com/cozy/cozy-stack/web/auth"
-	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/labstack/echo"
 	"github.com/stretchr/testify/assert"
 )
@@ -45,7 +45,7 @@ func createRecipient(t *testing.T) (*sharings.Recipient, error) {
 
 func createSharing(t *testing.T, recipient *sharings.Recipient) (*sharings.Sharing, error) {
 	recStatus := &sharings.RecipientStatus{
-		RefRecipient: jsonapi.ResourceIdentifier{
+		RefRecipient: couchdb.DocReference{
 			ID:   recipient.RID,
 			Type: consts.Recipients,
 		},


### PR DESCRIPTION
Remove almost all dependency from "/pkg" to "/web".

Only remaining dependency is in pkg/sharings which needs to setup a fake remote cozy to communicate with.

Use the apiXXX technique to remove dependency to jsonapi & a new couchdb.DocReference which replace jsonapi.ResourceIdentifier.