### PR TITLE
Add supports for skip pagination on /files/

### DIFF
--- a/cmd/instances.go
+++ b/cmd/instances.go
@@ -49,7 +49,6 @@ create its CouchDB databases.
 var cleanInstanceCmd = &cobra.Command{
 	Use:   "clean [domain]",
 	Short: "Clean badly removed instances",
-	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			return cmd.Help()

--- a/cmd/instances.go
+++ b/cmd/instances.go
@@ -10,6 +10,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/cozy/cozy-stack/client"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/instance"
 	humanize "github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
@@ -42,6 +43,22 @@ create its CouchDB databases.
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return cmd.Help()
+	},
+}
+
+var cleanInstanceCmd = &cobra.Command{
+	Use:   "clean [domain]",
+	Short: "Clean badly removed instances",
+	Long:  ``,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 0 {
+			return cmd.Help()
+		}
+
+		domain := args[0]
+		i := couchdb.SimpleDatabasePrefix(domain)
+		return couchdb.DeleteAllDBs(i)
+
 	},
 }
 
@@ -238,6 +255,7 @@ var oauthClientInstanceCmd = &cobra.Command{
 
 func init() {
 	instanceCmdGroup.AddCommand(addInstanceCmd)
+	instanceCmdGroup.AddCommand(cleanInstanceCmd)
 	instanceCmdGroup.AddCommand(lsInstanceCmd)
 	instanceCmdGroup.AddCommand(destroyInstanceCmd)
 	instanceCmdGroup.AddCommand(appTokenInstanceCmd)

--- a/pkg/consts/views.go
+++ b/pkg/consts/views.go
@@ -57,7 +57,6 @@ function(doc) {
 
 // FilesByParentView is the view used for fetching files referenced by a
 // given document
-// TODO change me for flag hidden
 var FilesByParentView = &couchdb.View{
 	Name:    "by-parent-type-name",
 	Doctype: Files,

--- a/pkg/consts/views.go
+++ b/pkg/consts/views.go
@@ -5,6 +5,10 @@ import (
 	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
 )
 
+// IndexViewsVersion is the version of current definition of views & indexes.
+// This number should be incremented when this file changes.
+const IndexViewsVersion int = 1
+
 // GlobalIndexes is the index list required on the global databases to run
 // properly.
 var GlobalIndexes = []*mango.Index{

--- a/pkg/consts/views.go
+++ b/pkg/consts/views.go
@@ -55,6 +55,19 @@ function(doc) {
 }`,
 }
 
+// FilesByParentView is the view used for fetching files referenced by a
+// given document
+// TODO change me for flag hidden
+var FilesByParentView = &couchdb.View{
+	Name:    "by-parent-type-name",
+	Doctype: Files,
+	Map: `
+function(doc) {
+  emit([doc.dir_id, doc.type, doc.name])
+}`,
+	Reduce: "_count",
+}
+
 // PermissionsShareByCView is the view for fetching the permissions associated
 // to a document via a token code.
 var PermissionsShareByCView = &couchdb.View{
@@ -93,6 +106,7 @@ function(doc){
 var Views = []*couchdb.View{
 	DiskUsageView,
 	FilesReferencedByView,
+	FilesByParentView,
 	PermissionsShareByCView,
 	PermissionsShareByDocView,
 }

--- a/pkg/couchdb/couchdb.go
+++ b/pkg/couchdb/couchdb.go
@@ -503,7 +503,7 @@ func DefineViews(db Database, views []*View) error {
 
 // ExecView executes the specified view function
 func ExecView(db Database, view *View, req *ViewRequest, results interface{}) error {
-	viewurl := fmt.Sprintf("%s/_design/%s/_view/%s", makeDBName(db, view.Doctype), view.Doctype, view.Name)
+	viewurl := fmt.Sprintf("%s/_design/%s/_view/%s", makeDBName(db, view.Doctype), view.Name, view.Name)
 	// Keys request
 	if req.Keys != nil {
 		return makeRequest("POST", viewurl, req, &results)

--- a/pkg/couchdb/couchdb.go
+++ b/pkg/couchdb/couchdb.go
@@ -696,15 +696,18 @@ type ViewRequest struct {
 	GroupLevel int  `json:"group_level,omitempty" url:"group_level,omitempty"`
 }
 
+// ViewResponseRow is a row in a ViewResponse
+type ViewResponseRow struct {
+	ID    string           `json:"id"`
+	Key   interface{}      `json:"key"`
+	Value interface{}      `json:"value"`
+	Doc   *json.RawMessage `json:"doc"`
+}
+
 // ViewResponse is the response we receive when executing a view
 type ViewResponse struct {
-	Total int `json:"total_rows"`
-	Rows  []struct {
-		ID    string           `json:"id"`
-		Key   interface{}      `json:"key"`
-		Value interface{}      `json:"value"`
-		Doc   *json.RawMessage `json:"doc"`
-	} `json:"rows"`
+	Total int                `json:"total_rows"`
+	Rows  []*ViewResponseRow `json:"rows"`
 }
 
 // DBStatusResponse is the response from DBStatus

--- a/pkg/couchdb/cursor.go
+++ b/pkg/couchdb/cursor.go
@@ -3,7 +3,7 @@ package couchdb
 // A Cursor holds a reference to a page in a couchdb View
 type Cursor interface {
 	HasMore() bool
-	ApplyTo(req *ViewRequest) *ViewRequest
+	ApplyTo(req *ViewRequest)
 	UpdateFrom(res *ViewResponse)
 }
 
@@ -58,14 +58,13 @@ type SkipCursor struct {
 // the transformed ViewRequest will retrieve elements from Cursor to
 // Limit or EndKey whichever comes first
 // /!\ Mutates req
-func (c *SkipCursor) ApplyTo(req *ViewRequest) *ViewRequest {
+func (c *SkipCursor) ApplyTo(req *ViewRequest) {
 	if c.Skip != 0 {
 		req.Skip = c.Skip
 	}
 	if c.Limit != 0 {
 		req.Limit = c.Limit + 1
 	}
-	return req
 }
 
 // UpdateFrom change the cursor status depending on information from
@@ -89,7 +88,7 @@ type StartKeyCursor struct {
 // the transformed ViewRequest will retrieve elements from Cursor to
 // Limit or EndKey whichever comes first
 // /!\ Mutates req
-func (c *StartKeyCursor) ApplyTo(req *ViewRequest) *ViewRequest {
+func (c *StartKeyCursor) ApplyTo(req *ViewRequest) {
 	if c.NextKey != "" && c.NextKey != nil {
 		if req.Key != nil && req.StartKey == nil {
 			req.StartKey = req.Key
@@ -108,7 +107,6 @@ func (c *StartKeyCursor) ApplyTo(req *ViewRequest) *ViewRequest {
 		req.Limit = c.Limit + 1
 	}
 
-	return req
 }
 
 // UpdateFrom change the cursor status depending on information from

--- a/pkg/couchdb/cursor.go
+++ b/pkg/couchdb/cursor.go
@@ -1,19 +1,96 @@
 package couchdb
 
-// Cursor holds a pointer in a couchdb map reduce results
-type Cursor struct {
-	Limit     int
-	Done      bool
+// A Cursor holds a reference to a page in a couchdb View
+type Cursor interface {
+	HasMore() bool
+	ApplyTo(req *ViewRequest) *ViewRequest
+	UpdateFrom(res *ViewResponse)
+}
+
+// NewKeyCursor returns a new key based Cursor pointing to
+// the given start_key & startkey_docid
+func NewKeyCursor(limit int, key interface{}, id string) Cursor {
+	return &StartKeyCursor{
+		baseCursor: &baseCursor{Limit: limit},
+		NextKey:    key,
+		NextDocID:  id,
+	}
+}
+
+// NewSkipCursor returns a new skip based Cursor pointing to
+// the page after skip items
+func NewSkipCursor(limit, skip int) Cursor {
+	return &SkipCursor{
+		baseCursor: &baseCursor{Limit: limit},
+		Skip:       skip,
+	}
+}
+
+type baseCursor struct {
+	// Done will be true if there is no more result after last fetch
+	Done bool
+
+	// Limit is maximum number of items retrieved from a request
+	Limit int
+}
+
+// HasMore returns true if there is more document after the current batch.
+// This value is meaning full only after UpdateFrom
+func (c *baseCursor) HasMore() bool { return !c.Done }
+func (c *baseCursor) updateFrom(res *ViewResponse) {
+	lrows := len(res.Rows)
+	if lrows <= c.Limit {
+		c.Done = true
+	} else {
+		res.Rows = res.Rows[:lrows-1]
+		c.Done = false
+	}
+}
+
+// SkipCursor is a Cursor using Skip to know how deep in the request it is.
+type SkipCursor struct {
+	*baseCursor
+	// Skip is the number of elements to start from
+	Skip int
+}
+
+// ApplyTo applies the cursor to a ViewRequest
+// the transformed ViewRequest will retrieve elements from Cursor to
+// Limit or EndKey whichever comes first
+// /!\ Mutates req
+func (c *SkipCursor) ApplyTo(req *ViewRequest) *ViewRequest {
+	if c.Skip != 0 {
+		req.Skip = c.Skip
+	}
+	if c.Limit != 0 {
+		req.Limit = c.Limit + 1
+	}
+	return req
+}
+
+// UpdateFrom change the cursor status depending on information from
+// the view's response
+func (c *SkipCursor) UpdateFrom(res *ViewResponse) {
+	c.baseCursor.updateFrom(res)
+	c.Skip += c.Limit
+}
+
+// StartKeyCursor is a Cursor using start_key, ie a reference to the
+// last fetched item to keep pagination
+type StartKeyCursor struct {
+	*baseCursor
+	// NextKey & NextDocID contains a reference to the document
+	// right after the last fetched one
 	NextKey   interface{}
 	NextDocID string
 }
 
 // ApplyTo applies the cursor to a ViewRequest
-// the transformed ViewRequest will retrive elements from Cursor to
-// Limit or StartKey whichever comes first
-// Mutates req
-func (c *Cursor) ApplyTo(req *ViewRequest) *ViewRequest {
-	if c.NextKey != "" {
+// the transformed ViewRequest will retrieve elements from Cursor to
+// Limit or EndKey whichever comes first
+// /!\ Mutates req
+func (c *StartKeyCursor) ApplyTo(req *ViewRequest) *ViewRequest {
+	if c.NextKey != "" && c.NextKey != nil {
 		if req.Key != nil && req.StartKey == nil {
 			req.StartKey = req.Key
 			req.EndKey = req.Key
@@ -36,32 +113,18 @@ func (c *Cursor) ApplyTo(req *ViewRequest) *ViewRequest {
 
 // UpdateFrom change the cursor status depending on information from
 // the view's response
-func (c *Cursor) UpdateFrom(res *ViewResponse) {
+func (c *StartKeyCursor) UpdateFrom(res *ViewResponse) {
+	var next *ViewResponseRow
 	lrows := len(res.Rows)
-	if lrows <= c.Limit {
-		c.Done = true
-		c.NextKey = nil
-		c.NextDocID = ""
-	} else {
-		c.Done = false
-		next := res.Rows[lrows-1]
-		res.Rows = res.Rows[:lrows-1]
+	if lrows > 0 {
+		next = res.Rows[lrows-1]
+	}
+	c.baseCursor.updateFrom(res)
+	if !c.Done {
 		c.NextKey = next.Key
 		c.NextDocID = next.ID
-	}
-}
-
-// GetNextCursor returns a cursor to the end of a ViewResponse
-// it removes the last item from the response to create a Cursor
-func GetNextCursor(res *ViewResponse) *Cursor {
-	if len(res.Rows) == 0 {
-		return &Cursor{}
-	}
-	next := res.Rows[len(res.Rows)-1]
-	res.Rows = res.Rows[:len(res.Rows)-1]
-
-	return &Cursor{
-		NextKey:   next.Key,
-		NextDocID: next.ID,
+	} else {
+		c.NextKey = nil
+		c.NextDocID = ""
 	}
 }

--- a/pkg/couchdb/cursor_test.go
+++ b/pkg/couchdb/cursor_test.go
@@ -1,23 +1,18 @@
 package couchdb
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCursor(t *testing.T) {
+func TestStartKeyCursor(t *testing.T) {
 
 	req1 := &ViewRequest{
 		Key: []string{"A", "B"},
 	}
 
-	c1 := &Cursor{
-		Limit:     10,
-		NextKey:   []string{"A", "B"},
-		NextDocID: "last-result-id",
-	}
+	c1 := NewKeyCursor(10, []string{"A", "B"}, "last-result-id")
 
 	req2 := c1.ApplyTo(req1)
 	assert.Nil(t, req2.Key)
@@ -25,17 +20,10 @@ func TestCursor(t *testing.T) {
 	assert.Equal(t, "last-result-id", req2.StartKeyDocID)
 	assert.Equal(t, 11, req2.Limit)
 
-	c2 := &Cursor{
-		Limit: 3,
-	}
+	c2 := NewKeyCursor(3, nil, "")
 
 	res := &ViewResponse{
-		Rows: []struct {
-			ID    string           `json:"id"`
-			Key   interface{}      `json:"key"`
-			Value interface{}      `json:"value"`
-			Doc   *json.RawMessage `json:"doc"`
-		}{
+		Rows: []*ViewResponseRow{
 			{Key: []string{"A", "B"}, ID: "resultA"},
 			{Key: []string{"A", "B"}, ID: "resultB"},
 			{Key: []string{"A", "B"}, ID: "resultC"},
@@ -45,7 +33,7 @@ func TestCursor(t *testing.T) {
 
 	c2.UpdateFrom(res)
 	assert.Len(t, res.Rows, 3)
-	assert.Equal(t, []string{"A", "B"}, c2.NextKey)
-	assert.Equal(t, "resultD", c2.NextDocID)
+	assert.Equal(t, []string{"A", "B"}, c2.(*StartKeyCursor).NextKey)
+	assert.Equal(t, "resultD", c2.(*StartKeyCursor).NextDocID)
 
 }

--- a/pkg/couchdb/cursor_test.go
+++ b/pkg/couchdb/cursor_test.go
@@ -14,11 +14,11 @@ func TestStartKeyCursor(t *testing.T) {
 
 	c1 := NewKeyCursor(10, []string{"A", "B"}, "last-result-id")
 
-	req2 := c1.ApplyTo(req1)
-	assert.Nil(t, req2.Key)
-	assert.Equal(t, []string{"A", "B"}, req2.StartKey)
-	assert.Equal(t, "last-result-id", req2.StartKeyDocID)
-	assert.Equal(t, 11, req2.Limit)
+	c1.ApplyTo(req1)
+	assert.Nil(t, req1.Key)
+	assert.Equal(t, []string{"A", "B"}, req1.StartKey)
+	assert.Equal(t, "last-result-id", req1.StartKeyDocID)
+	assert.Equal(t, 11, req1.Limit)
 
 	c2 := NewKeyCursor(3, nil, "")
 

--- a/pkg/instance/cache_test.go
+++ b/pkg/instance/cache_test.go
@@ -3,12 +3,14 @@ package instance
 import (
 	"testing"
 
+	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGetFs(t *testing.T) {
 	instance := &Instance{
-		Domain: "test-provider.cozycloud.cc",
+		IndexViewsVersion: consts.IndexViewsVersion,
+		Domain:            "test-provider.cozycloud.cc",
 	}
 	err := instance.makeVFS()
 	if !assert.NoError(t, err) {
@@ -25,9 +27,10 @@ func TestCache(t *testing.T) {
 	}()
 
 	i := &Instance{
-		DocID:  "fake-instance",
-		Domain: "cached.cozy.tools",
-		Locale: "zh",
+		IndexViewsVersion: consts.IndexViewsVersion,
+		DocID:             "fake-instance",
+		Domain:            "cached.cozy.tools",
+		Locale:            "zh",
 	}
 	getCache().Set("cached.cozy.tools", i)
 

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -72,6 +72,8 @@ type Instance struct {
 
 	BytesDiskQuota int64 `json:"disk_quota,string,omitempty"` // The total size in bytes allowed to the user
 
+	IndexViewsVersion int `json:"indexes_version"`
+
 	// PassphraseHash is a hash of the user's passphrase. For more informations,
 	// see crypto.GenerateFromPassphrase.
 	PassphraseHash       []byte    `json:"passphrase_hash,omitempty"`
@@ -310,6 +312,17 @@ func (i *Instance) installApp(slug string) error {
 	return nil
 }
 
+func (i *Instance) defineViewsAndIndex() error {
+	if err := couchdb.DefineIndexes(i, consts.Indexes); err != nil {
+		return err
+	}
+	if err := couchdb.DefineViews(i, consts.Views); err != nil {
+		return err
+	}
+	i.IndexViewsVersion = consts.IndexViewsVersion
+	return nil
+}
+
 // Create builds an instance and initializes it
 func Create(opts *Options) (*Instance, error) {
 	domain := strings.TrimSpace(opts.Domain)
@@ -404,10 +417,7 @@ func Create(opts *Options) (*Instance, error) {
 	if err := couchdb.CreateNamedDoc(i, settingsDoc); err != nil {
 		return nil, err
 	}
-	if err := couchdb.DefineIndexes(i, consts.Indexes); err != nil {
-		return nil, err
-	}
-	if err := couchdb.DefineViews(i, consts.Views); err != nil {
+	if err := i.defineViewsAndIndex(); err != nil {
 		return nil, err
 	}
 	if err := i.StartJobSystem(); err != nil {
@@ -442,6 +452,15 @@ func Get(domain string) (*Instance, error) {
 			return nil, err
 		}
 		cache.Set(domain, i)
+	}
+
+	if i.IndexViewsVersion != consts.IndexViewsVersion {
+		if err = i.defineViewsAndIndex(); err != nil {
+			return nil, err
+		}
+		if err = Update(i); err != nil {
+			return nil, err
+		}
 	}
 
 	if err = i.makeVFS(); err != nil {

--- a/pkg/permissions/permissions.go
+++ b/pkg/permissions/permissions.go
@@ -339,7 +339,7 @@ func GetPermissionsForIDs(db couchdb.Database, doctype string, ids []string) (ma
 
 // GetPermissionsByType gets all share permissions for a given doctype.
 // The passed Cursor will be modified in place
-func GetPermissionsByType(db couchdb.Database, doctype string, cursor *couchdb.Cursor) ([]*Permission, error) {
+func GetPermissionsByType(db couchdb.Database, doctype string, cursor couchdb.Cursor) ([]*Permission, error) {
 
 	var req = &couchdb.ViewRequest{
 		StartKey:    []string{doctype},

--- a/pkg/vfs/couchdb_indexer.go
+++ b/pkg/vfs/couchdb_indexer.go
@@ -276,7 +276,6 @@ func (c *couchdbIndexer) DirIterator(doc *DirDoc, opts *IteratorOptions) DirIter
 func (c *couchdbIndexer) DirBatch(doc *DirDoc, cursor couchdb.Cursor) ([]DirOrFileDoc, error) {
 
 	// consts.FilesByParentView keys are [parentID, type, name]
-	// TODO change me for flag hidden, depending if doc is Trash
 	req := couchdb.ViewRequest{
 		StartKey:    []string{doc.DocID, ""},
 		EndKey:      []string{doc.DocID, couchdb.MaxString},
@@ -305,7 +304,6 @@ func (c *couchdbIndexer) DirBatch(doc *DirDoc, cursor couchdb.Cursor) ([]DirOrFi
 
 func (c *couchdbIndexer) DirLength(doc *DirDoc) (int, error) {
 
-	// TODO change me for flag hidden, depending if doc is Trash
 	req := couchdb.ViewRequest{
 		StartKey:   []string{doc.DocID, ""},
 		EndKey:     []string{doc.DocID, couchdb.MaxString},

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
 )
 
 // DefaultContentType is used for files uploaded with no content-type
@@ -135,6 +136,10 @@ type Indexer interface {
 	// DirIterator returns an iterator over the children of the specified
 	// directory.
 	DirIterator(doc *DirDoc, opts *IteratorOptions) DirIterator
+
+	// DirBatch returns a batch of documents
+	DirBatch(*DirDoc, couchdb.Cursor) ([]DirOrFileDoc, error)
+	DirLength(*DirDoc) (int, error)
 }
 
 // Locker interface provides a Read/Write mutex interface that can be used

--- a/web/data/references.go
+++ b/web/data/references.go
@@ -43,7 +43,7 @@ func listReferencesHandler(c echo.Context) error {
 	cursor.UpdateFrom(&res)
 
 	var links = &jsonapi.LinksList{}
-	if !cursor.Done {
+	if cursor.HasMore() {
 		params, err := jsonapi.PaginationCursorToParams(cursor)
 		if err != nil {
 			return err

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -302,6 +302,24 @@ func ReadMetadataFromIDHandler(c echo.Context) error {
 	return fileData(c, http.StatusOK, file, nil)
 }
 
+// GetChildrenHandler returns a list of children of a folder
+func GetChildrenHandler(c echo.Context) error {
+	instance := middlewares.GetInstance(c)
+
+	fileID := c.Param("file-id")
+
+	dir, file, err := instance.VFS().DirOrFileByID(fileID)
+	if err != nil {
+		return wrapVfsError(err)
+	}
+
+	if file != nil {
+		return jsonapi.NewError(400, "cant read children of file "+fileID)
+	}
+
+	return dirDataList(c, http.StatusOK, dir)
+}
+
 // ReadMetadataFromPathHandler handles all GET requests on
 // /files/metadata aiming at getting file metadata from its path.
 func ReadMetadataFromPathHandler(c echo.Context) error {
@@ -679,6 +697,7 @@ func Routes(router *echo.Group) {
 
 	router.GET("/metadata", ReadMetadataFromPathHandler)
 	router.GET("/:file-id", ReadMetadataFromIDHandler)
+	router.GET("/:file-id/relationships/contents", GetChildrenHandler)
 
 	router.PATCH("/metadata", ModifyMetadataByPathHandler)
 	router.PATCH("/:file-id", ModifyMetadataByIDHandler)

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -1479,7 +1479,7 @@ func TestTrashList(t *testing.T) {
 		return
 	}
 
-	assert.True(t, len(v.Data) >= 2)
+	assert.True(t, len(v.Data) >= 2, "response should contains at least 2 items")
 }
 
 func TestTrashClear(t *testing.T) {

--- a/web/files/paginated.go
+++ b/web/files/paginated.go
@@ -36,19 +36,19 @@ func newDir(doc *vfs.DirDoc) *dir {
 
 func dirData(c echo.Context, statusCode int, doc *vfs.DirDoc) error {
 
-	inst := middlewares.GetInstance(c)
+	fs := middlewares.GetInstance(c).VFS()
 
 	cursor, err := jsonapi.ExtractPaginationCursor(c, defPerPage)
 	if err != nil {
 		return err
 	}
 
-	count, err := inst.VFS().DirLength(doc)
+	count, err := fs.DirLength(doc)
 	if err != nil {
 		return err
 	}
 
-	children, err := inst.VFS().DirBatch(doc, cursor)
+	children, err := fs.DirBatch(doc, cursor)
 	if err != nil {
 		return err
 	}
@@ -113,14 +113,14 @@ func dirDataList(c echo.Context, statusCode int, doc *vfs.DirDoc) error {
 		return err
 	}
 
-	inst := middlewares.GetInstance(c)
+	fs := middlewares.GetInstance(c).VFS()
 
-	count, err := inst.VFS().DirLength(doc)
+	count, err := fs.DirLength(doc)
 	if err != nil {
 		return err
 	}
 
-	children, err := inst.VFS().DirBatch(doc, cursor)
+	children, err := fs.DirBatch(doc, cursor)
 	if err != nil {
 		return err
 	}

--- a/web/files/paginated.go
+++ b/web/files/paginated.go
@@ -14,7 +14,6 @@ import (
 
 const (
 	defPerPage = 30
-	maxPerPage = 100
 )
 
 type dir struct {

--- a/web/files/paginated.go
+++ b/web/files/paginated.go
@@ -3,8 +3,6 @@ package files
 // Links is used to generate a JSON-API link for the directory (part of
 import (
 	"encoding/json"
-	"fmt"
-	"strconv"
 
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
@@ -33,73 +31,47 @@ type apiArchive struct {
 	*vfs.Archive
 }
 
-func paginationConfig(c echo.Context) (int, *vfs.IteratorOptions, error) {
-	var count int64
-	var err error
-	cursorQuery := c.QueryParam("page[cursor]")
-	limitQuery := c.QueryParam("page[limit]")
-	if limitQuery != "" {
-		count, err = strconv.ParseInt(limitQuery, 10, 32)
-		if err != nil {
-			return 0, nil, err
-		}
-	} else {
-		count = defPerPage
-	}
-	if count > maxPerPage {
-		count = maxPerPage
-	}
-	return int(count), &vfs.IteratorOptions{
-		ByFetch: int(count),
-		AfterID: cursorQuery,
-	}, nil
-}
-
 func newDir(doc *vfs.DirDoc) *dir {
 	return &dir{doc: doc}
 }
 
 func dirData(c echo.Context, statusCode int, doc *vfs.DirDoc) error {
-	relsData := make([]couchdb.DocReference, 0)
-	included := make([]jsonapi.Object, 0)
 
-	count, iterOpts, err := paginationConfig(c)
+	inst := middlewares.GetInstance(c)
+
+	cursor, err := jsonapi.ExtractPaginationCursor(c, defPerPage)
 	if err != nil {
 		return err
 	}
 
-	hasNext := true
+	count, err := inst.VFS().DirLength(doc)
+	if err != nil {
+		return err
+	}
 
-	i := middlewares.GetInstance(c)
-	iter := i.VFS().DirIterator(doc, iterOpts)
-	for i := 0; i < count; i++ {
-		d, f, err := iter.Next()
-		if err == vfs.ErrIteratorDone {
-			hasNext = false
-			break
-		}
-		if err != nil {
-			return err
-		}
+	children, err := inst.VFS().DirBatch(doc, cursor)
+	if err != nil {
+		return err
+	}
+
+	relsData := make([]couchdb.DocReference, len(children))
+	included := make([]jsonapi.Object, len(children))
+
+	for i, child := range children {
+		relsData[i] = couchdb.DocReference{ID: child.ID(), Type: child.DocType()}
+		d, f := child.Refine()
 		if d != nil {
-			included = append(included, newDir(d))
+			included[i] = newDir(d)
 		} else {
-			included = append(included, newFile(f))
+			included[i] = newFile(f)
 		}
-		var ri couchdb.DocReference
-		if d != nil {
-			ri = couchdb.DocReference{ID: d.ID(), Type: d.DocType()}
-		} else {
-			ri = couchdb.DocReference{ID: f.ID(), Type: f.DocType()}
-		}
-		relsData = append(relsData, ri)
 	}
 
 	var parent jsonapi.Relationship
 	if doc.ID() != consts.RootDirID {
 		parent = jsonapi.Relationship{
 			Links: &jsonapi.LinksList{
-				Related: "/files/" + doc.DirID,
+				Self: "/files/" + doc.DirID,
 			},
 			Data: couchdb.DocReference{
 				ID:   doc.DirID,
@@ -108,15 +80,23 @@ func dirData(c echo.Context, statusCode int, doc *vfs.DirDoc) error {
 		}
 	}
 	rel := jsonapi.RelationshipMap{
-		"parent":   parent,
-		"contents": jsonapi.Relationship{Data: relsData},
+		"parent": parent,
+		"contents": jsonapi.Relationship{
+			Meta: &jsonapi.RelationshipMeta{Count: count},
+			Links: &jsonapi.LinksList{
+				Self: "/files/" + doc.DocID + "/relationships/contents",
+			},
+			Data: relsData},
 	}
 
-	var links *jsonapi.LinksList
-	if hasNext && len(included) > 0 {
-		next := fmt.Sprintf("/files/%s?page[cursor]=%s&page[limit]=%d",
-			doc.DocID, included[len(included)-1].ID(), count)
-		links = &jsonapi.LinksList{Next: next}
+	var links jsonapi.LinksList
+	if cursor.HasMore() {
+		params, err := jsonapi.PaginationCursorToParams(cursor)
+		if err != nil {
+			return err
+		}
+		next := "/files/" + doc.DocID + "/relationships/contents?" + params.Encode()
+		rel["contents"].Links.Next = next
 	}
 
 	dir := &dir{
@@ -124,34 +104,49 @@ func dirData(c echo.Context, statusCode int, doc *vfs.DirDoc) error {
 		rel:      rel,
 		included: included,
 	}
-	return jsonapi.Data(c, statusCode, dir, links)
+	return jsonapi.Data(c, statusCode, dir, &links)
 }
 
 func dirDataList(c echo.Context, statusCode int, doc *vfs.DirDoc) error {
-	included := make([]jsonapi.Object, 0)
 
-	count, iterOpts, err := paginationConfig(c)
+	cursor, err := jsonapi.ExtractPaginationCursor(c, defPerPage)
 	if err != nil {
 		return err
 	}
 
-	i := middlewares.GetInstance(c)
-	iter := i.VFS().DirIterator(doc, iterOpts)
-	for i := 0; i < count; i++ {
-		d, f, err := iter.Next()
-		if err == vfs.ErrIteratorDone {
-			break
+	inst := middlewares.GetInstance(c)
+
+	count, err := inst.VFS().DirLength(doc)
+	if err != nil {
+		return err
+	}
+
+	children, err := inst.VFS().DirBatch(doc, cursor)
+	if err != nil {
+		return err
+	}
+
+	included := make([]jsonapi.Object, len(children))
+	for i, child := range children {
+		d, f := child.Refine()
+		if d != nil {
+			included[i] = newDir(d)
+		} else {
+			included[i] = newFile(f)
 		}
+	}
+
+	var links jsonapi.LinksList
+	if cursor.HasMore() {
+		params, err := jsonapi.PaginationCursorToParams(cursor)
 		if err != nil {
 			return err
 		}
-		if d != nil {
-			included = append(included, newDir(d))
-		} else {
-			included = append(included, newFile(f))
-		}
+		next := c.Request().URL.Path + "?" + params.Encode()
+		links.Next = next
 	}
-	return jsonapi.DataList(c, statusCode, included, nil)
+
+	return jsonapi.DataListWithTotal(c, statusCode, count, included, &links)
 }
 
 // newFile creates an instance of file struct from a vfs.FileDoc document.

--- a/web/files/pagination_test.go
+++ b/web/files/pagination_test.go
@@ -1,0 +1,185 @@
+package files
+
+import (
+	"encoding/json"
+	"net/url"
+	"strconv"
+	"testing"
+
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/web/jsonapi"
+	"github.com/stretchr/testify/assert"
+)
+
+type getDirRes struct {
+	Meta struct {
+		Count int
+	}
+	Included []interface{}
+}
+
+func getJSON(t *testing.T, url string, out interface{}) error {
+	res, err := httpGet(ts.URL + url)
+	assert.NoError(t, err)
+	defer res.Body.Close()
+
+	assert.Equal(t, 200, res.StatusCode)
+	return json.NewDecoder(res.Body).Decode(&out)
+
+}
+
+func TestListDirPaginated(t *testing.T) {
+
+	_, dirdata := createDir(t, "/files/?Type=directory&Name=paginationcontainer")
+
+	dirdata, ok := dirdata["data"].(map[string]interface{})
+	assert.True(t, ok)
+
+	parentID, ok := dirdata["id"].(string)
+	assert.True(t, ok)
+
+	nb := 15
+
+	body := "foo"
+	for i := 0; i < nb; i++ {
+		name := "file" + strconv.Itoa(i)
+		upload(t, "/files/"+parentID+"?Type=file&Name="+name, "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
+	}
+
+	var opts = &url.Values{}
+	opts.Add("page[limit]", "7")
+	var result struct {
+		Data struct {
+			Relationships struct {
+				Contents struct {
+					Meta struct {
+						Count int
+					}
+					Links *jsonapi.LinksList
+					Data  []couchdb.DocReference
+				}
+			}
+		}
+		Included []interface{}
+	}
+	getJSON(t, "/files/"+parentID+"?"+opts.Encode(), &result)
+
+	assert.Len(t, result.Data.Relationships.Contents.Data, 7)
+	assert.Len(t, result.Included, 7)
+	assert.Equal(t, result.Data.Relationships.Contents.Meta.Count, 15)
+	next := result.Data.Relationships.Contents.Links.Next
+	assert.NotEmpty(t, next)
+
+	var result2 struct {
+		Links *jsonapi.LinksList
+		Meta  struct {
+			Count int
+		}
+		Data []interface{}
+	}
+	getJSON(t, next, &result2)
+	assert.Len(t, result2.Data, 7)
+	assert.Equal(t, result2.Meta.Count, 15)
+
+	assert.NotEqual(t, result.Data.Relationships.Contents.Data[0].ID,
+		result2.Data[0].(map[string]interface{})["id"])
+
+	next = result2.Links.Next
+	assert.NotEmpty(t, next)
+
+	var result3 struct {
+		Lins *jsonapi.LinksList
+		Meta struct {
+			Count int
+		}
+		Data []interface{}
+	}
+	getJSON(t, next, &result3)
+	assert.Len(t, result3.Data, 1)
+	assert.Equal(t, result3.Meta.Count, 15)
+
+	assert.NotEqual(t, result.Data.Relationships.Contents.Data[0].ID,
+		result3.Data[0].(map[string]interface{})["id"])
+
+	trash(t, "/files/"+parentID)
+
+}
+
+func TestListDirPaginatedSkip(t *testing.T) {
+
+	_, dirdata := createDir(t, "/files/?Type=directory&Name=paginationcontainerskip")
+
+	dirdata, ok := dirdata["data"].(map[string]interface{})
+	assert.True(t, ok)
+
+	parentID, ok := dirdata["id"].(string)
+	assert.True(t, ok)
+
+	nb := 15
+
+	body := "foo"
+	for i := 0; i < nb; i++ {
+		name := "file" + strconv.Itoa(i)
+		upload(t, "/files/"+parentID+"?Type=file&Name="+name, "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
+	}
+
+	var opts = &url.Values{}
+	opts.Add("page[limit]", "7")
+	opts.Add("page[skip]", "0")
+	var result struct {
+		Data struct {
+			Relationships struct {
+				Contents struct {
+					Meta struct {
+						Count int
+					}
+					Links *jsonapi.LinksList
+					Data  []couchdb.DocReference
+				}
+			}
+		}
+		Included []interface{}
+	}
+	getJSON(t, "/files/"+parentID+"?"+opts.Encode(), &result)
+
+	assert.Len(t, result.Data.Relationships.Contents.Data, 7)
+	assert.Len(t, result.Included, 7)
+	assert.Equal(t, result.Data.Relationships.Contents.Meta.Count, 15)
+	next := result.Data.Relationships.Contents.Links.Next
+	assert.NotEmpty(t, next)
+	assert.Contains(t, next, "skip")
+
+	var result2 struct {
+		Links *jsonapi.LinksList
+		Meta  struct {
+			Count int
+		}
+		Data []interface{}
+	}
+	getJSON(t, next, &result2)
+	assert.Len(t, result2.Data, 7)
+	assert.Equal(t, result2.Meta.Count, 15)
+
+	assert.NotEqual(t, result.Data.Relationships.Contents.Data[0].ID,
+		result2.Data[0].(map[string]interface{})["id"])
+
+	next = result2.Links.Next
+	assert.NotEmpty(t, next)
+
+	var result3 struct {
+		Lins *jsonapi.LinksList
+		Meta struct {
+			Count int
+		}
+		Data []interface{}
+	}
+	getJSON(t, next, &result3)
+	assert.Len(t, result3.Data, 1)
+	assert.Equal(t, result3.Meta.Count, 15)
+
+	assert.NotEqual(t, result.Data.Relationships.Contents.Data[0].ID,
+		result3.Data[0].(map[string]interface{})["id"])
+
+	trash(t, "/files/"+parentID)
+
+}

--- a/web/jsonapi/data.go
+++ b/web/jsonapi/data.go
@@ -19,6 +19,11 @@ type Meta struct {
 	Rev string `json:"rev,omitempty"`
 }
 
+// RelationshipMeta is a container for the total number of elements
+type RelationshipMeta struct {
+	Count int `json:"count,omitempty"`
+}
+
 // LinksList is the common links used in JSON-API for the top-level or a
 // resource object
 // See http://jsonapi.org/format/#document-links
@@ -37,8 +42,9 @@ type LinksList struct {
 // Data can be a single ResourceIdentifier for to-one relationships,
 // or an array of them for to-many relationships.
 type Relationship struct {
-	Links *LinksList  `json:"links,omitempty"`
-	Data  interface{} `json:"data"`
+	Links *LinksList        `json:"links,omitempty"`
+	Meta  *RelationshipMeta `json:"meta,omitempty"`
+	Data  interface{}       `json:"data"`
 }
 
 // ResourceIdentifier returns the resource identifier of the relationship.

--- a/web/jsonapi/jsonapi.go
+++ b/web/jsonapi/jsonapi.go
@@ -20,10 +20,11 @@ const ContentType = "application/vnd.api+json"
 // application/vnd.api+json
 // See http://jsonapi.org/format/#document-structure
 type Document struct {
-	Data     *json.RawMessage `json:"data,omitempty"`
-	Errors   ErrorList        `json:"errors,omitempty"`
-	Links    *LinksList       `json:"links,omitempty"`
-	Included []interface{}    `json:"included,omitempty"`
+	Data     *json.RawMessage  `json:"data,omitempty"`
+	Errors   ErrorList         `json:"errors,omitempty"`
+	Links    *LinksList        `json:"links,omitempty"`
+	Meta     *RelationshipMeta `json:"meta,omitempty"`
+	Included []interface{}     `json:"included,omitempty"`
 }
 
 // WriteData can be called to write an answer with a JSON-API document
@@ -61,6 +62,12 @@ func Data(c echo.Context, statusCode int, o Object, links *LinksList) error {
 // DataList can be called to send an multiple-value answer with a
 // JSON-API document contains multiple objects.
 func DataList(c echo.Context, statusCode int, objs []Object, links *LinksList) error {
+	return DataListWithTotal(c, statusCode, len(objs), objs, links)
+}
+
+// DataListWithTotal can be called to send a list of Object with a different
+// meta:count, useful to indicate total number of results with pagination.
+func DataListWithTotal(c echo.Context, statusCode, total int, objs []Object, links *LinksList) error {
 	objsMarshaled := make([]json.RawMessage, len(objs))
 	for i, o := range objs {
 		j, err := MarshalObject(o)
@@ -77,6 +84,7 @@ func DataList(c echo.Context, statusCode int, objs []Object, links *LinksList) e
 
 	doc := Document{
 		Data:  (*json.RawMessage)(&data),
+		Meta:  &RelationshipMeta{Count: total},
 		Links: links,
 	}
 

--- a/web/permissions/permissions.go
+++ b/web/permissions/permissions.go
@@ -144,7 +144,7 @@ func listPermissionsByDoctype(c echo.Context) error {
 	}
 
 	links := &jsonapi.LinksList{}
-	if !cursor.Done {
+	if cursor.HasMore() {
 		params, err := jsonapi.PaginationCursorToParams(cursor)
 		if err != nil {
 			return err


### PR DESCRIPTION
This adds a meta:count to the contents  relationships of a folder. 

We also introduce a separate route to fetch more of this relationships.

Improved couchdb.Cursor to  support both skip & cursor, this will allows supporting both kind of pagination for all routes using couchdb.Cursor.

Note @nono I added a couple "TODO change me for flag hidden" which will require revision when introducing `hidden` flag.