### PR TITLE
Centralized FS for storing applications and konnectors

### DIFF
--- a/pkg/apps/apps.go
+++ b/pkg/apps/apps.go
@@ -65,13 +65,20 @@ type Manifest interface {
 	couchdb.Doc
 	Valid(field, expected string) bool
 	ReadManifest(i io.Reader, slug, sourceURL string) error
+
+	Create(db couchdb.Database) error
+	Update(db couchdb.Database) error
+	Delete(db couchdb.Database) error
+
 	Permissions() permissions.Set
 	Source() string
 	Version() string
 	Slug() string
 	State() State
 	Error() error
+
 	SetState(state State)
+	SetVersion(version string)
 	SetError(err error)
 }
 

--- a/pkg/apps/apps.go
+++ b/pkg/apps/apps.go
@@ -67,6 +67,7 @@ type Manifest interface {
 	ReadManifest(i io.Reader, slug, sourceURL string) error
 	Permissions() permissions.Set
 	Source() string
+	Version() string
 	Slug() string
 	State() State
 	Error() error

--- a/pkg/apps/copier.go
+++ b/pkg/apps/copier.go
@@ -1,7 +1,6 @@
 package apps
 
 import (
-	"errors"
 	"io"
 	"os"
 	"path"
@@ -58,7 +57,7 @@ func (f *swiftCopier) Start(slug, version string) (bool, error) {
 
 func (f *swiftCopier) Copy(name string, src io.Reader) (err error) {
 	if !f.started {
-		return errors.New("copier should call Start() before Copy()")
+		panic("copier should call Start() before Copy()")
 	}
 	defer func() {
 		if err != nil {
@@ -101,7 +100,7 @@ func (f *aferoCopier) Start(slug, version string) (bool, error) {
 
 func (f *aferoCopier) Copy(name string, src io.Reader) (err error) {
 	if !f.started {
-		return errors.New("copier should call Start() before Copy()")
+		panic("copier should call Start() before Copy()")
 	}
 	fullpath := path.Join(f.appDir, name)
 	dir := path.Dir(fullpath)

--- a/pkg/apps/copier.go
+++ b/pkg/apps/copier.go
@@ -10,6 +10,8 @@ import (
 	"github.com/spf13/afero"
 )
 
+// Copier is an interface defining a common set of functions for the installer
+// to copy the application into an unknown storage.
 type Copier interface {
 	Start(slug, version string) (exists bool, err error)
 	Copy(name string, src io.Reader) error
@@ -28,6 +30,7 @@ type aferoCopier struct {
 	started bool
 }
 
+// NewSwiftCopier defines a Copier storing data into a swift container.
 func NewSwiftCopier(conn *swift.Connection, container string) (Copier, error) {
 	if container[0] == '/' {
 		container = container[1:]
@@ -76,6 +79,8 @@ func (f *swiftCopier) Copy(name string, src io.Reader) (err error) {
 	return err
 }
 
+// NewAferoCopier defines a copier using an afero.Fs filesystem to store the
+// application data.
 func NewAferoCopier(fs afero.Fs) Copier {
 	return &aferoCopier{fs: fs}
 }

--- a/pkg/apps/copier.go
+++ b/pkg/apps/copier.go
@@ -1,0 +1,134 @@
+package apps
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path"
+
+	"github.com/ncw/swift"
+	"github.com/spf13/afero"
+)
+
+type Copier interface {
+	Start(slug, version string) (exists bool, err error)
+	Copy(slug, version, name string, src io.Reader) error
+	Close() error
+}
+
+type swiftCopier struct {
+	c         *swift.Connection
+	container string
+	started   bool
+}
+
+type aferoCopier struct {
+	fs      afero.Fs
+	started bool
+}
+
+func NewSwiftCopier(conn *swift.Connection, container string) (Copier, error) {
+	if container[0] == '/' {
+		container = container[1:]
+	}
+	if err := conn.ContainerCreate(container, nil); err != nil {
+		return nil, err
+	}
+	return &swiftCopier{c: conn, container: container}, nil
+}
+
+func (f *swiftCopier) Start(slug, version string) (bool, error) {
+	objName := path.Join(slug, version)
+	_, _, err := f.c.Object(f.container, objName)
+	if err == nil {
+		return true, nil
+	}
+	o, err := f.c.ObjectCreate(f.container, objName, false, "", "", nil)
+	if err != nil {
+		return false, err
+	}
+	err = o.Close()
+	f.started = err == nil
+	return false, err
+}
+
+func (f *swiftCopier) Copy(slug, version, name string, src io.Reader) (err error) {
+	if !f.started {
+		return errors.New("copier should call Start() before Copy()")
+	}
+	defer func() {
+		if err != nil {
+			// TODO: retries on this important delete
+			f.c.ObjectDelete(f.container, path.Join(slug, version)) // #nosec
+		}
+	}()
+	objName := path.Join(slug, version, name)
+	file, err := f.c.ObjectCreate(f.container, objName, false, "", "", nil)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if errc := file.Close(); errc != nil {
+			err = errc
+		}
+	}()
+	_, err = io.Copy(file, src)
+	return err
+}
+
+func (f *swiftCopier) Close() error {
+	return nil
+}
+
+func NewAferoCopier(fs afero.Fs) Copier {
+	return &aferoCopier{fs: fs}
+}
+
+func (f *aferoCopier) Start(slug, version string) (bool, error) {
+	appDir := path.Join("/", slug, version)
+	exists, err := afero.DirExists(f.fs, appDir)
+	if err != nil {
+		return false, err
+	}
+	if exists {
+		return true, nil
+	}
+	err = f.fs.MkdirAll(appDir, 0755)
+	f.started = err == nil
+	return false, err
+}
+
+func (f *aferoCopier) Copy(slug, version, name string, src io.Reader) (err error) {
+	if !f.started {
+		return errors.New("copier should call Start() before Copy()")
+	}
+	dir := path.Dir(name)
+	if err = f.fs.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	dst, err := f.fs.Create(name)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if errc := dst.Close(); errc != nil {
+			err = errc
+		}
+	}()
+	_, err = io.Copy(dst, src)
+	return err
+}
+
+func (f *aferoCopier) Close() error {
+	return nil
+}
+
+func wrapSwiftErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	if err == swift.ObjectNotFound {
+		return os.ErrNotExist
+	}
+	return nil
+}

--- a/pkg/apps/installer.go
+++ b/pkg/apps/installer.go
@@ -4,12 +4,10 @@ import (
 	"fmt"
 	"io"
 	"net/url"
-	"path"
 	"regexp"
 
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/permissions"
-	"github.com/spf13/afero"
 )
 
 var slugReg = regexp.MustCompile(`^[A-Za-z0-9\-]+$`)
@@ -29,7 +27,8 @@ const (
 // Installer is used to install or update applications.
 type Installer struct {
 	fetcher Fetcher
-	fs      afero.Fs
+	op      Operation
+	fs      Copier
 	db      couchdb.Database
 
 	man  Manifest
@@ -58,11 +57,11 @@ type Fetcher interface {
 	FetchManifest(src *url.URL) (io.ReadCloser, error)
 	// Fetch should download the application and install it in the given
 	// directory.
-	Fetch(src *url.URL, appDir string) error
+	Fetch(src *url.URL, fs Copier, slug, version string) error
 }
 
 // NewInstaller creates a new Installer
-func NewInstaller(db couchdb.Database, fs afero.Fs, opts *InstallerOptions) (*Installer, error) {
+func NewInstaller(db couchdb.Database, fs Copier, opts *InstallerOptions) (*Installer, error) {
 	if opts.Operation == 0 {
 		panic("Missing installer operation")
 	}
@@ -120,13 +119,14 @@ func NewInstaller(db couchdb.Database, fs afero.Fs, opts *InstallerOptions) (*In
 	var fetcher Fetcher
 	switch src.Scheme {
 	case "git":
-		fetcher = newGitFetcher(fs, manFilename)
+		fetcher = newGitFetcher(manFilename, opts.Type == Konnector)
 	default:
 		return nil, ErrNotSupportedSource
 	}
 
 	return &Installer{
 		fetcher: fetcher,
+		op:      opts.Operation,
 		db:      db,
 		fs:      fs,
 
@@ -139,38 +139,36 @@ func NewInstaller(db couchdb.Database, fs afero.Fs, opts *InstallerOptions) (*In
 	}, nil
 }
 
-// Install will install the application linked to the installer. It will
-// report its progress or error (see Poll method).
-func (i *Installer) Install() {
+// Run will install, update or delete the application linked to the installer,
+// depending on specified operation. It will report its progress or error (see
+// Poll method) and should be run asynchronously.
+func (i *Installer) Run() {
 	defer i.endOfProc()
-	i.man, i.err = i.install()
-	return
-}
-
-// Update will update the application linked to the installer. It will
-// report its progress or error (see Poll method).
-func (i *Installer) Update() {
-	defer i.endOfProc()
-	if state := i.man.State(); state != Ready && state != Errored {
-		i.man, i.err = nil, ErrBadState
-	} else {
+	switch i.op {
+	case Install:
+		i.man, i.err = i.install()
+	case Update:
 		i.man, i.err = i.update()
+	case Delete:
+		i.man, i.err = i.delete()
 	}
 	return
 }
 
-// Delete will remove the application linked to the installer.
-func (i *Installer) Delete() (Manifest, error) {
-	if state := i.man.State(); state != Ready && state != Errored {
-		return nil, ErrBadState
+// RunSync does the same work as Run but can be used synchronously.
+func (i *Installer) RunSync() (Manifest, error) {
+	go i.Run()
+	for {
+		man, done, err := i.Poll()
+		if err != nil {
+			return nil, err
+		}
+		if done {
+			return man, nil
+		}
 	}
-	if err := deleteManifest(i.db, i.man); err != nil {
-		return nil, err
-	}
-	if err := i.fs.RemoveAll(i.baseDirName()); err != nil {
-		return nil, err
-	}
-	return i.man, nil
+	// unreachable
+	return nil, nil
 }
 
 func (i *Installer) endOfProc() {
@@ -202,20 +200,11 @@ func (i *Installer) install() (Manifest, error) {
 	if err := i.ReadManifest(Installing, man); err != nil {
 		return nil, err
 	}
-
 	if err := createManifest(i.db, man); err != nil {
 		return man, err
 	}
-
 	i.manc <- man
-
-	err := i.fs.MkdirAll(i.baseDirName(), 0755)
-	if err != nil {
-		return man, err
-	}
-
-	err = i.fetcher.Fetch(i.src, i.baseDirName())
-	return man, err
+	return man, i.fetcher.Fetch(i.src, i.fs, i.slug, man.Version())
 }
 
 // update will perform the update of an already installed application. It
@@ -226,23 +215,25 @@ func (i *Installer) install() (Manifest, error) {
 // upgrading.
 func (i *Installer) update() (Manifest, error) {
 	man := i.man
-
+	if state := man.State(); state != Ready && state != Errored {
+		return nil, ErrBadState
+	}
 	if err := i.ReadManifest(Upgrading, man); err != nil {
 		return man, err
 	}
-
 	if err := updateManifest(i.db, man); err != nil {
 		return man, err
 	}
-
 	i.manc <- man
-
-	err := i.fetcher.Fetch(i.src, i.baseDirName())
-	return man, err
+	return man, i.fetcher.Fetch(i.src, i.fs, i.slug, man.Version())
 }
 
-func (i *Installer) baseDirName() string {
-	return path.Join("/", i.slug)
+func (i *Installer) delete() (Manifest, error) {
+	if state := i.man.State(); state != Ready && state != Errored {
+		return nil, ErrBadState
+	}
+	i.manc <- i.man
+	return i.man, deleteManifest(i.db, i.man)
 }
 
 // ReadManifest will fetch the manifest and read its JSON content into the

--- a/pkg/apps/installer_konnector_test.go
+++ b/pkg/apps/installer_konnector_test.go
@@ -1,0 +1,320 @@
+package apps
+
+import (
+	"path"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKonnectorInstallSuccessful(t *testing.T) {
+	manGen = manifestKonnector
+	manName = KonnectorManifestName
+
+	doUpgrade(1)
+
+	inst, err := NewInstaller(db, fs, &InstallerOptions{
+		Operation: Install,
+		Type:      Konnector,
+		Slug:      "local-konnector",
+		SourceURL: "git://localhost/",
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	go inst.Run()
+
+	var state State
+	var man Manifest
+	for {
+		var done bool
+		var err2 error
+		man, done, err2 = inst.Poll()
+		if !assert.NoError(t, err2) {
+			return
+		}
+		if state == "" {
+			if !assert.EqualValues(t, Installing, man.State()) {
+				return
+			}
+		} else if state == Installing {
+			if !assert.EqualValues(t, Ready, man.State()) {
+				return
+			}
+			if !assert.True(t, done) {
+				return
+			}
+			break
+		} else {
+			t.Fatalf("invalid state")
+			return
+		}
+		state = man.State()
+	}
+
+	ok, err := afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), "app.tar"))
+	assert.NoError(t, err)
+	assert.True(t, ok, "The manifest is present")
+	ok, err = afero.FileContainsBytes(baseFS, path.Join("/", man.Slug(), man.Version(), "app.tar"), []byte("1.0.0"))
+	assert.NoError(t, err)
+	assert.True(t, ok, "The manifest has the right version")
+
+	inst2, err := NewInstaller(db, fs, &InstallerOptions{
+		Operation: Install,
+		Type:      Konnector,
+		Slug:      "local-konnector",
+		SourceURL: "git://localhost/",
+	})
+	assert.Nil(t, inst2)
+	assert.Equal(t, ErrAlreadyExists, err)
+}
+
+func TestKonnectorUpgradeNotExist(t *testing.T) {
+	manGen = manifestKonnector
+	manName = KonnectorManifestName
+	inst, err := NewInstaller(db, fs, &InstallerOptions{
+		Operation: Update,
+		Type:      Konnector,
+		Slug:      "cozy-konnector-not-exist",
+	})
+	assert.Nil(t, inst)
+	assert.Equal(t, ErrNotFound, err)
+
+	inst, err = NewInstaller(db, fs, &InstallerOptions{
+		Operation: Delete,
+		Type:      Konnector,
+		Slug:      "cozy-konnector-not-exist",
+	})
+	assert.Nil(t, inst)
+	assert.Equal(t, ErrNotFound, err)
+}
+
+func TestKonnectorInstallWithUpgrade(t *testing.T) {
+	manGen = manifestKonnector
+	manName = KonnectorManifestName
+
+	doUpgrade(1)
+
+	inst, err := NewInstaller(db, fs, &InstallerOptions{
+		Operation: Install,
+		Type:      Konnector,
+		Slug:      "cozy-konnector-b",
+		SourceURL: "git://localhost/",
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	go inst.Run()
+
+	var man Manifest
+	for {
+		var done bool
+		man, done, err = inst.Poll()
+		if !assert.NoError(t, err) {
+			return
+		}
+		if done {
+			break
+		}
+	}
+
+	ok, err := afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), "app.tar"))
+	assert.NoError(t, err)
+	assert.True(t, ok, "The manifest is present")
+	ok, err = afero.FileContainsBytes(baseFS, path.Join("/", man.Slug(), man.Version(), "app.tar"), []byte("1.0.0"))
+	assert.NoError(t, err)
+	assert.True(t, ok, "The manifest has the right version")
+
+	doUpgrade(2)
+
+	inst, err = NewInstaller(db, fs, &InstallerOptions{
+		Operation: Update,
+		Type:      Konnector,
+		Slug:      "cozy-konnector-b",
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	go inst.Run()
+
+	var state State
+	for {
+		var done bool
+		man, done, err = inst.Poll()
+		if !assert.NoError(t, err) {
+			return
+		}
+		if state == "" {
+			if !assert.EqualValues(t, Upgrading, man.State()) {
+				return
+			}
+		} else if state == Upgrading {
+			if !assert.EqualValues(t, Ready, man.State()) {
+				return
+			}
+			if !assert.True(t, done) {
+				return
+			}
+			break
+		} else {
+			t.Fatalf("invalid state")
+			return
+		}
+		state = man.State()
+	}
+
+	ok, err = afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), "app.tar"))
+	assert.NoError(t, err)
+	assert.True(t, ok, "The manifest is present")
+	ok, err = afero.FileContainsBytes(baseFS, path.Join("/", man.Slug(), man.Version(), "app.tar"), []byte("2.0.0"))
+	assert.NoError(t, err)
+	assert.True(t, ok, "The manifest has the right version")
+}
+
+func TestKonnectorInstallAndUpgradeWithBranch(t *testing.T) {
+	manGen = manifestKonnector
+	manName = KonnectorManifestName
+	doUpgrade(3)
+
+	inst, err := NewInstaller(db, fs, &InstallerOptions{
+		Operation: Install,
+		Type:      Konnector,
+		Slug:      "local-konnector-branch",
+		SourceURL: "git://localhost/#branch",
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	go inst.Run()
+
+	var state State
+	var man Manifest
+	for {
+		var done bool
+		var err2 error
+		man, done, err2 = inst.Poll()
+		if !assert.NoError(t, err2) {
+			return
+		}
+		if state == "" {
+			if !assert.EqualValues(t, Installing, man.State()) {
+				return
+			}
+		} else if state == Installing {
+			if !assert.EqualValues(t, Ready, man.State()) {
+				return
+			}
+			if !assert.True(t, done) {
+				return
+			}
+			break
+		} else {
+			t.Fatalf("invalid state")
+			return
+		}
+		state = man.State()
+	}
+
+	ok, err := afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), "app.tar"))
+	assert.NoError(t, err)
+	assert.True(t, ok, "The manifest is present")
+	ok, err = afero.FileContainsBytes(baseFS, path.Join("/", man.Slug(), man.Version(), "app.tar"), []byte("3.0.0"))
+	assert.NoError(t, err)
+	assert.True(t, ok, "The manifest has the right version")
+
+	doUpgrade(4)
+
+	inst, err = NewInstaller(db, fs, &InstallerOptions{
+		Operation: Update,
+		Type:      Konnector,
+		Slug:      "local-konnector-branch",
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	go inst.Run()
+
+	state = ""
+	for {
+		var done bool
+		var err2 error
+		man, done, err2 = inst.Poll()
+		if !assert.NoError(t, err2) {
+			return
+		}
+		if state == "" {
+			if !assert.EqualValues(t, Upgrading, man.State()) {
+				return
+			}
+		} else if state == Upgrading {
+			if !assert.EqualValues(t, Ready, man.State()) {
+				return
+			}
+			if !assert.True(t, done) {
+				return
+			}
+			break
+		} else {
+			t.Fatalf("invalid state")
+			return
+		}
+		state = man.State()
+	}
+
+	ok, err = afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), "app.tar"))
+	assert.NoError(t, err)
+	assert.True(t, ok, "The manifest is present")
+	ok, err = afero.FileContainsBytes(baseFS, path.Join("/", man.Slug(), man.Version(), "app.tar"), []byte("4.0.0"))
+	assert.NoError(t, err)
+	assert.True(t, ok, "The manifest has the right version")
+}
+
+func TestKonnectorUninstall(t *testing.T) {
+	manGen = manifestKonnector
+	manName = KonnectorManifestName
+	inst1, err := NewInstaller(db, fs, &InstallerOptions{
+		Operation: Install,
+		Type:      Konnector,
+		Slug:      "konnector-delete",
+		SourceURL: "git://localhost/",
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+	go inst1.Run()
+	for {
+		var done bool
+		_, done, err = inst1.Poll()
+		if !assert.NoError(t, err) {
+			return
+		}
+		if done {
+			break
+		}
+	}
+	inst2, err := NewInstaller(db, fs, &InstallerOptions{
+		Operation: Delete,
+		Type:      Konnector,
+		Slug:      "konnector-delete",
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+	_, err = inst2.RunSync()
+	if !assert.NoError(t, err) {
+		return
+	}
+	inst3, err := NewInstaller(db, fs, &InstallerOptions{
+		Operation: Delete,
+		Type:      Konnector,
+		Slug:      "konnector-delete",
+	})
+	assert.Nil(t, inst3)
+	assert.Equal(t, ErrNotFound, err)
+}

--- a/pkg/apps/installer_webapp_test.go
+++ b/pkg/apps/installer_webapp_test.go
@@ -1,0 +1,458 @@
+package apps
+
+import (
+	"fmt"
+	"path"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWebappInstallBadSlug(t *testing.T) {
+	manGen = manifestWebapp
+	manName = WebappManifestName
+	_, err := NewInstaller(db, fs, &InstallerOptions{
+		Operation: Install,
+		Type:      Webapp,
+		SourceURL: "git://foo.bar",
+	})
+	if assert.Error(t, err) {
+		assert.Equal(t, ErrInvalidSlugName, err)
+	}
+
+	_, err = NewInstaller(db, fs, &InstallerOptions{
+		Operation: Install,
+		Type:      Webapp,
+		Slug:      "coucou/",
+		SourceURL: "git://foo.bar",
+	})
+	if assert.Error(t, err) {
+		assert.Equal(t, ErrInvalidSlugName, err)
+	}
+}
+
+func TestWebappInstallBadAppsSource(t *testing.T) {
+	manGen = manifestWebapp
+	manName = WebappManifestName
+	_, err := NewInstaller(db, fs, &InstallerOptions{
+		Operation: Install,
+		Type:      Webapp,
+		Slug:      "app3",
+		SourceURL: "foo://bar.baz",
+	})
+	if assert.Error(t, err) {
+		assert.Equal(t, ErrNotSupportedSource, err)
+	}
+
+	_, err = NewInstaller(db, fs, &InstallerOptions{
+		Operation: Install,
+		Type:      Webapp,
+		Slug:      "app4",
+		SourceURL: "git://bar  .baz",
+	})
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "invalid character")
+	}
+
+	_, err = NewInstaller(db, fs, &InstallerOptions{
+		Operation: Install,
+		Type:      Webapp,
+		Slug:      "app5",
+		SourceURL: "",
+	})
+	if assert.Error(t, err) {
+		assert.Equal(t, ErrMissingSource, err)
+	}
+}
+
+func TestWebappInstallSuccessful(t *testing.T) {
+	manGen = manifestWebapp
+	manName = WebappManifestName
+
+	doUpgrade(1)
+
+	inst, err := NewInstaller(db, fs, &InstallerOptions{
+		Operation: Install,
+		Type:      Webapp,
+		Slug:      "local-cozy-mini",
+		SourceURL: "git://localhost/",
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	go inst.Run()
+
+	var state State
+	var man Manifest
+	for {
+		var done bool
+		var err2 error
+		man, done, err2 = inst.Poll()
+		if !assert.NoError(t, err2) {
+			return
+		}
+		if state == "" {
+			if !assert.EqualValues(t, Installing, man.State()) {
+				return
+			}
+		} else if state == Installing {
+			if !assert.EqualValues(t, Ready, man.State()) {
+				return
+			}
+			if !assert.True(t, done) {
+				return
+			}
+			break
+		} else {
+			t.Fatalf("invalid state")
+			return
+		}
+		state = man.State()
+	}
+
+	ok, err := afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), WebappManifestName))
+	assert.NoError(t, err)
+	assert.True(t, ok, "The manifest is present")
+	ok, err = afero.FileContainsBytes(baseFS, path.Join("/", man.Slug(), man.Version(), WebappManifestName), []byte("1.0.0"))
+	assert.NoError(t, err)
+	assert.True(t, ok, "The manifest has the right version")
+
+	inst2, err := NewInstaller(db, fs, &InstallerOptions{
+		Operation: Install,
+		Type:      Webapp,
+		Slug:      "local-cozy-mini",
+		SourceURL: "git://localhost/",
+	})
+	assert.Nil(t, inst2)
+	assert.Equal(t, ErrAlreadyExists, err)
+}
+
+func TestWebappUpgradeNotExist(t *testing.T) {
+	manGen = manifestWebapp
+	manName = WebappManifestName
+	inst, err := NewInstaller(db, fs, &InstallerOptions{
+		Operation: Update,
+		Type:      Webapp,
+		Slug:      "cozy-app-not-exist",
+	})
+	assert.Nil(t, inst)
+	assert.Equal(t, ErrNotFound, err)
+
+	inst, err = NewInstaller(db, fs, &InstallerOptions{
+		Operation: Delete,
+		Type:      Webapp,
+		Slug:      "cozy-app-not-exist",
+	})
+	assert.Nil(t, inst)
+	assert.Equal(t, ErrNotFound, err)
+}
+
+func TestWebappInstallWithUpgrade(t *testing.T) {
+	manGen = manifestWebapp
+	manName = WebappManifestName
+
+	doUpgrade(1)
+
+	inst, err := NewInstaller(db, fs, &InstallerOptions{
+		Operation: Install,
+		Type:      Webapp,
+		Slug:      "cozy-app-b",
+		SourceURL: "git://localhost/",
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	man, err := inst.RunSync()
+
+	ok, err := afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), WebappManifestName))
+	assert.NoError(t, err)
+	assert.True(t, ok, "The manifest is present")
+	ok, err = afero.FileContainsBytes(baseFS, path.Join("/", man.Slug(), man.Version(), WebappManifestName), []byte("1.0.0"))
+	assert.NoError(t, err)
+	assert.True(t, ok, "The manifest has the right version")
+	version1 := man.Version()
+
+	doUpgrade(2)
+
+	inst, err = NewInstaller(db, fs, &InstallerOptions{
+		Operation: Update,
+		Type:      Webapp,
+		Slug:      "cozy-app-b",
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	go inst.Run()
+
+	var state State
+	for {
+		var done bool
+		man, done, err = inst.Poll()
+		if !assert.NoError(t, err) {
+			return
+		}
+		if state == "" {
+			if !assert.EqualValues(t, Upgrading, man.State()) {
+				return
+			}
+		} else if state == Upgrading {
+			if !assert.EqualValues(t, Ready, man.State()) {
+				return
+			}
+			if !assert.True(t, done) {
+				return
+			}
+			break
+		} else {
+			t.Fatalf("invalid state")
+			return
+		}
+		state = man.State()
+	}
+	version2 := man.Version()
+
+	fmt.Println("versions:", version1, version2)
+
+	ok, err = afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), WebappManifestName))
+	assert.NoError(t, err)
+	assert.True(t, ok, "The manifest is present")
+	ok, err = afero.FileContainsBytes(baseFS, path.Join("/", man.Slug(), man.Version(), WebappManifestName), []byte("2.0.0"))
+	assert.NoError(t, err)
+	assert.True(t, ok, "The manifest has the right version")
+}
+
+func TestWebappInstallAndUpgradeWithBranch(t *testing.T) {
+	manGen = manifestWebapp
+	manName = WebappManifestName
+	doUpgrade(3)
+
+	inst, err := NewInstaller(db, fs, &InstallerOptions{
+		Operation: Install,
+		Type:      Webapp,
+		Slug:      "local-cozy-mini-branch",
+		SourceURL: "git://localhost/#branch",
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	go inst.Run()
+
+	var state State
+	var man Manifest
+	for {
+		var done bool
+		var err2 error
+		man, done, err2 = inst.Poll()
+		if !assert.NoError(t, err2) {
+			return
+		}
+		if state == "" {
+			if !assert.EqualValues(t, Installing, man.State()) {
+				return
+			}
+		} else if state == Installing {
+			if !assert.EqualValues(t, Ready, man.State()) {
+				return
+			}
+			if !assert.True(t, done) {
+				return
+			}
+			break
+		} else {
+			t.Fatalf("invalid state")
+			return
+		}
+		state = man.State()
+	}
+
+	ok, err := afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), WebappManifestName))
+	assert.NoError(t, err)
+	assert.True(t, ok, "The manifest is present")
+	ok, err = afero.FileContainsBytes(baseFS, path.Join("/", man.Slug(), man.Version(), WebappManifestName), []byte("3.0.0"))
+	assert.NoError(t, err)
+	assert.True(t, ok, "The manifest has the right version")
+	ok, err = afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), "branch"))
+	assert.NoError(t, err)
+	assert.True(t, ok, "The good branch was checked out")
+
+	doUpgrade(4)
+
+	inst, err = NewInstaller(db, fs, &InstallerOptions{
+		Operation: Update,
+		Type:      Webapp,
+		Slug:      "local-cozy-mini-branch",
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	go inst.Run()
+
+	state = ""
+	for {
+		var done bool
+		var err2 error
+		man, done, err2 = inst.Poll()
+		if !assert.NoError(t, err2) {
+			return
+		}
+		if state == "" {
+			if !assert.EqualValues(t, Upgrading, man.State()) {
+				return
+			}
+		} else if state == Upgrading {
+			if !assert.EqualValues(t, Ready, man.State()) {
+				return
+			}
+			if !assert.True(t, done) {
+				return
+			}
+			break
+		} else {
+			t.Fatalf("invalid state")
+			return
+		}
+		state = man.State()
+	}
+
+	ok, err = afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), WebappManifestName))
+	assert.NoError(t, err)
+	assert.True(t, ok, "The manifest is present")
+	ok, err = afero.FileContainsBytes(baseFS, path.Join("/", man.Slug(), man.Version(), WebappManifestName), []byte("4.0.0"))
+	assert.NoError(t, err)
+	assert.True(t, ok, "The manifest has the right version")
+	ok, err = afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), "branch"))
+	assert.NoError(t, err)
+	assert.True(t, ok, "The good branch was checked out")
+}
+
+func TestWebappInstallFromGithub(t *testing.T) {
+	manGen = manifestWebapp
+	manName = WebappManifestName
+	inst, err := NewInstaller(db, fs, &InstallerOptions{
+		Operation: Install,
+		Type:      Webapp,
+		Slug:      "github-cozy-mini",
+		SourceURL: "git://github.com/nono/cozy-mini.git",
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	go inst.Run()
+
+	var state State
+	for {
+		man, done, err := inst.Poll()
+		if !assert.NoError(t, err) {
+			return
+		}
+		if state == "" {
+			if !assert.EqualValues(t, Installing, man.State()) {
+				return
+			}
+		} else if state == Installing {
+			if !assert.EqualValues(t, Ready, man.State()) {
+				return
+			}
+			if !assert.True(t, done) {
+				return
+			}
+			break
+		} else {
+			t.Fatalf("invalid state")
+			return
+		}
+		state = man.State()
+	}
+}
+
+func TestWebappInstallFromGitlab(t *testing.T) {
+	manGen = manifestWebapp
+	manName = WebappManifestName
+	inst, err := NewInstaller(db, fs, &InstallerOptions{
+		Operation: Install,
+		Type:      Webapp,
+		Slug:      "gitlab-cozy-mini",
+		SourceURL: "git://framagit.org/nono/cozy-mini.git",
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	go inst.Run()
+
+	var state State
+	for {
+		man, done, err := inst.Poll()
+		if !assert.NoError(t, err) {
+			return
+		}
+		if state == "" {
+			if !assert.EqualValues(t, Installing, man.State()) {
+				return
+			}
+		} else if state == Installing {
+			if !assert.EqualValues(t, Ready, man.State()) {
+				return
+			}
+			if !assert.True(t, done) {
+				return
+			}
+			break
+		} else {
+			t.Fatalf("invalid state")
+			return
+		}
+		state = man.State()
+	}
+}
+
+func TestWebappUninstall(t *testing.T) {
+	manGen = manifestWebapp
+	manName = WebappManifestName
+	inst1, err := NewInstaller(db, fs, &InstallerOptions{
+		Operation: Install,
+		Type:      Webapp,
+		Slug:      "github-cozy-delete",
+		SourceURL: "git://localhost/",
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+	go inst1.Run()
+	for {
+		var done bool
+		_, done, err = inst1.Poll()
+		if !assert.NoError(t, err) {
+			return
+		}
+		if done {
+			break
+		}
+	}
+	inst2, err := NewInstaller(db, fs, &InstallerOptions{
+		Operation: Delete,
+		Type:      Webapp,
+		Slug:      "github-cozy-delete",
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+	_, err = inst2.RunSync()
+	if !assert.NoError(t, err) {
+		return
+	}
+	inst3, err := NewInstaller(db, fs, &InstallerOptions{
+		Operation: Delete,
+		Type:      Webapp,
+		Slug:      "github-cozy-delete",
+	})
+	assert.Nil(t, inst3)
+	assert.Equal(t, ErrNotFound, err)
+}

--- a/pkg/apps/installer_webapp_test.go
+++ b/pkg/apps/installer_webapp_test.go
@@ -166,6 +166,7 @@ func TestWebappInstallWithUpgrade(t *testing.T) {
 	}
 
 	man, err := inst.RunSync()
+	assert.NoError(t, err)
 
 	ok, err := afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), WebappManifestName))
 	assert.NoError(t, err)

--- a/pkg/apps/konnector.go
+++ b/pkg/apps/konnector.go
@@ -51,8 +51,9 @@ func (m *konnManifest) Error() error {
 	return errors.New(m.DocError)
 }
 
-func (m *konnManifest) SetState(state State) { m.DocState = state }
-func (m *konnManifest) SetError(err error)   { m.DocError = err.Error() }
+func (m *konnManifest) SetState(state State)      { m.DocState = state }
+func (m *konnManifest) SetError(err error)        { m.DocError = err.Error() }
+func (m *konnManifest) SetVersion(version string) { m.DocVersion = version }
 func (m *konnManifest) Permissions() permissions.Set {
 	return m.DocPermissions
 }
@@ -77,6 +78,35 @@ func (m *konnManifest) ReadManifest(r io.Reader, slug, sourceURL string) error {
 	m.DocSlug = slug
 	m.DocSource = sourceURL
 	return nil
+}
+
+func (m *konnManifest) Create(db couchdb.Database) error {
+	if err := couchdb.CreateNamedDocWithDB(db, m); err != nil {
+		return err
+	}
+	_, err := permissions.CreateKonnectorSet(db, m.Slug(), m.Permissions())
+	return err
+}
+
+func (m *konnManifest) Update(db couchdb.Database) error {
+	err := permissions.DestroyKonnector(db, m.Slug())
+	if err != nil && !couchdb.IsNotFoundError(err) {
+		return err
+	}
+	err = couchdb.UpdateDoc(db, m)
+	if err != nil {
+		return err
+	}
+	_, err = permissions.CreateKonnectorSet(db, m.Slug(), m.Permissions())
+	return err
+}
+
+func (m *konnManifest) Delete(db couchdb.Database) error {
+	err := permissions.DestroyKonnector(db, m.Slug())
+	if err != nil && !couchdb.IsNotFoundError(err) {
+		return err
+	}
+	return couchdb.DeleteDoc(db, m)
 }
 
 // GetKonnectorBySlug fetch the manifest of a konnector from the database given

--- a/pkg/apps/konnector.go
+++ b/pkg/apps/konnector.go
@@ -28,7 +28,7 @@ type konnManifest struct {
 		Description string `json:"description"`
 	} `json:"locales"`
 
-	Version        string          `json:"version"`
+	DocVersion     string          `json:"version"`
 	License        string          `json:"license"`
 	DocPermissions permissions.Set `json:"permissions"`
 }
@@ -40,6 +40,7 @@ func (m *konnManifest) Clone() couchdb.Doc { cloned := *m; return &cloned }
 func (m *konnManifest) SetID(id string)    {}
 func (m *konnManifest) SetRev(rev string)  { m.DocRev = rev }
 func (m *konnManifest) Source() string     { return m.DocSource }
+func (m *konnManifest) Version() string    { return m.DocVersion }
 func (m *konnManifest) Slug() string       { return m.DocSlug }
 
 func (m *konnManifest) State() State { return m.DocState }

--- a/pkg/apps/server.go
+++ b/pkg/apps/server.go
@@ -117,6 +117,8 @@ func defaultMakePath(slug, version, file string) string {
 	return path.Join("/", slug, version, file)
 }
 
+// FIXME: retro-compatibility code to serve application that were not installed
+// in a versioned directory.
 func retroCompatMakePath(slug, version, file string) string {
 	return path.Join("/", slug, file)
 }

--- a/pkg/apps/server.go
+++ b/pkg/apps/server.go
@@ -1,0 +1,137 @@
+package apps
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"time"
+
+	"github.com/ncw/swift"
+	"github.com/spf13/afero"
+)
+
+// FileServer interface defines a way to access and serve the application's
+// data files.
+type FileServer interface {
+	Stat(slug, version, file string) (os.FileInfo, error)
+	Open(slug, version, file string) (File, error)
+	ServeFileContent(w http.ResponseWriter, req *http.Request,
+		modtime time.Time, slug, version, file string) error
+}
+
+type File interface {
+	io.ReadCloser
+	io.Seeker
+}
+
+type swiftServer struct {
+	c         *swift.Connection
+	container string
+}
+
+type aferoServer struct {
+	mkPath func(slug, version, file string) string
+	fs     afero.Fs
+}
+
+type fileStat struct {
+	name    string
+	size    int64
+	modtime time.Time
+	isDir   bool
+}
+
+// NewSwiftFileServer returns provides the apps.FileServer implementation
+// using the swift backend as file server.
+func NewSwiftFileServer(conn *swift.Connection) FileServer {
+	return &swiftServer{
+		c: conn,
+	}
+}
+
+func (s *swiftServer) Stat(slug, version, file string) (os.FileInfo, error) {
+	objName := s.makeObjectName(slug, version, file)
+	o, _, err := s.c.Object(s.container, objName)
+	if err != nil {
+		return nil, wrapSwiftErr(err)
+	}
+	return &fileStat{
+		name:    objName,
+		size:    o.Bytes,
+		modtime: o.LastModified,
+		isDir:   false,
+	}, nil
+}
+
+func (s *swiftServer) Open(slug, version, file string) (File, error) {
+	objName := s.makeObjectName(slug, version, file)
+	f, _, err := s.c.ObjectOpen(s.container, objName, false, nil)
+	if err != nil {
+		return nil, wrapSwiftErr(err)
+	}
+	return f, nil
+}
+
+func (s *swiftServer) ServeFileContent(w http.ResponseWriter, req *http.Request, modtime time.Time, slug, version, file string) error {
+	objName := s.makeObjectName(slug, version, file)
+	f, o, err := s.c.ObjectOpen(s.container, objName, false, nil)
+	if err != nil {
+		return wrapSwiftErr(err)
+	}
+	defer f.Close()
+	lastModified, _ := time.Parse(http.TimeFormat, o["Last-Modified"])
+	w.Header().Set("Etag", o["Etag"])
+	http.ServeContent(w, req, objName, lastModified, f)
+	return nil
+}
+
+func (s *swiftServer) makeObjectName(slug, version, file string) string {
+	return path.Join(slug, version, file)
+}
+
+// NewAferoFileServer returns a simple wrapper of the afero.Fs interface that
+// provides the apps.FileServer interface.
+//
+// You can provide a makePath method to define how the file name should be
+// created from the application's slug, version and file name. If not provided,
+// the standard VFS concatenation (starting with vfs.WebappsDirName) is used.
+func NewAferoFileServer(fs afero.Fs, makePath func(slug, version, file string) string) FileServer {
+	if makePath == nil {
+		makePath = defaultMakePath
+	}
+	return &aferoServer{
+		mkPath: makePath,
+		fs:     fs,
+	}
+}
+
+func (s *aferoServer) Stat(slug, version, file string) (os.FileInfo, error) {
+	return s.fs.Stat(s.mkPath(slug, version, file))
+}
+
+func (s *aferoServer) Open(slug, version, file string) (File, error) {
+	return s.fs.Open(s.mkPath(slug, version, file))
+}
+
+func (s *aferoServer) ServeFileContent(w http.ResponseWriter, req *http.Request, modtime time.Time, slug, version, file string) error {
+	filepath := s.mkPath(slug, version, file)
+	r, err := s.fs.Open(filepath)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+	http.ServeContent(w, req, filepath, modtime, r)
+	return nil
+}
+
+func defaultMakePath(slug, version, file string) string {
+	return path.Join("/", slug, version, file)
+}
+
+func (f *fileStat) IsDir() bool        { return f.isDir }
+func (f *fileStat) ModTime() time.Time { return f.modtime }
+func (f *fileStat) Mode() os.FileMode  { return 0 }
+func (f *fileStat) Name() string       { return f.name }
+func (f *fileStat) Size() int64        { return f.size }
+func (f *fileStat) Sys() interface{}   { return nil }

--- a/pkg/apps/webapp.go
+++ b/pkg/apps/webapp.go
@@ -106,6 +106,9 @@ func (m *WebappManifest) SetState(state State) { m.DocState = state }
 // SetError is part of the Manifest interface
 func (m *WebappManifest) SetError(err error) { m.DocError = err.Error() }
 
+// SetVersion is part of the Manifest interface
+func (m *WebappManifest) SetVersion(version string) { m.DocVersion = version }
+
 // Permissions is part of the Manifest interface
 func (m *WebappManifest) Permissions() permissions.Set {
 	return m.DocPermissions
@@ -122,7 +125,7 @@ func (m *WebappManifest) Valid(field, value string) bool {
 	return false
 }
 
-// ReadManifest  is part of the Manifest interface
+// ReadManifest is part of the Manifest interface
 func (m *WebappManifest) ReadManifest(r io.Reader, slug, sourceURL string) error {
 	if err := json.NewDecoder(r).Decode(&m); err != nil {
 		return ErrBadManifest
@@ -140,6 +143,38 @@ func (m *WebappManifest) ReadManifest(r io.Reader, slug, sourceURL string) error
 		}
 	}
 	return nil
+}
+
+// Create is part of the Manifest interface
+func (m *WebappManifest) Create(db couchdb.Database) error {
+	if err := couchdb.CreateNamedDocWithDB(db, m); err != nil {
+		return err
+	}
+	_, err := permissions.CreateAppSet(db, m.Slug(), m.Permissions())
+	return err
+}
+
+// Update is part of the Manifest interface
+func (m *WebappManifest) Update(db couchdb.Database) error {
+	err := permissions.DestroyApp(db, m.Slug())
+	if err != nil && !couchdb.IsNotFoundError(err) {
+		return err
+	}
+	err = couchdb.UpdateDoc(db, m)
+	if err != nil {
+		return err
+	}
+	_, err = permissions.CreateAppSet(db, m.Slug(), m.Permissions())
+	return err
+}
+
+// Delete is part of the Manifest interface
+func (m *WebappManifest) Delete(db couchdb.Database) error {
+	err := permissions.DestroyApp(db, m.Slug())
+	if err != nil && !couchdb.IsNotFoundError(err) {
+		return err
+	}
+	return couchdb.DeleteDoc(db, m)
 }
 
 // FindRoute takes a path, returns the route which matches the best,

--- a/pkg/apps/webapp.go
+++ b/pkg/apps/webapp.go
@@ -53,7 +53,7 @@ type WebappManifest struct {
 		Description string `json:"description"`
 	} `json:"locales"`
 
-	Version        string          `json:"version"`
+	DocVersion     string          `json:"version"`
 	License        string          `json:"license"`
 	DocPermissions permissions.Set `json:"permissions"`
 	Intents        []Intent        `json:"intents"`
@@ -82,6 +82,9 @@ func (m *WebappManifest) SetRev(rev string) { m.DocRev = rev }
 
 // Source is part of the Manifest interface
 func (m *WebappManifest) Source() string { return m.DocSource }
+
+// Version is part of the Manifest interface
+func (m *WebappManifest) Version() string { return m.DocVersion }
 
 // Slug is part of the Manifest interface
 func (m *WebappManifest) Slug() string { return m.DocSlug }

--- a/pkg/couchdb/couchdb.go
+++ b/pkg/couchdb/couchdb.go
@@ -65,6 +65,11 @@ func rtevent(db Database, evtype string, doc Doc) {
 // GlobalDB is the prefix used for stack-scoped db
 var GlobalDB = SimpleDatabasePrefix("global")
 
+// GlobalTriggersDB is the database prefix used for triggers that may be stored
+// globally on self-hosted instances where we need to store them in the same
+// database.
+var GlobalTriggersDB = SimpleDatabasePrefix("triggers")
+
 // View is the map/reduce thing in CouchDB
 type View struct {
 	Name    string `json:"-"`

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -157,18 +157,39 @@ func (i *Instance) makeVFS() error {
 // AppsCopier returns the application copier associated with the specified
 // application type
 func (i *Instance) AppsCopier(appsType apps.AppType) apps.Copier {
-	// switch appsType {
-	// case apps.Webapp:
-	// 	return i.hiddenFS(vfs.WebappsDirName)
-	// case apps.Konnector:
-	// 	return i.hiddenFS(vfs.KonnectorsDirName)
-	// }
-	// panic(fmt.Errorf("Unknown application type %s", string(appsType)))
-	return nil
+	fsURL := config.FsURL()
+	switch fsURL.Scheme {
+	case "file", "mem":
+		var baseDirName string
+		switch appsType {
+		case apps.Webapp:
+			baseDirName = vfs.WebappsDirName
+		case apps.Konnector:
+			baseDirName = vfs.KonnectorsDirName
+		}
+		baseFS := afero.NewBasePathFs(afero.NewOsFs(),
+			path.Join(fsURL.Path, i.Domain, baseDirName))
+		return apps.NewAferoCopier(baseFS)
+	}
+	panic("unreachable")
 }
 
 func (i *Instance) AppsFileServer(appsType apps.AppType) apps.FileServer {
-	return nil
+	fsURL := config.FsURL()
+	switch fsURL.Scheme {
+	case "file", "mem":
+		var baseDirName string
+		switch appsType {
+		case apps.Webapp:
+			baseDirName = vfs.WebappsDirName
+		case apps.Konnector:
+			baseDirName = vfs.KonnectorsDirName
+		}
+		baseFS := afero.NewBasePathFs(afero.NewOsFs(),
+			path.Join(fsURL.Path, i.Domain, baseDirName))
+		return apps.NewAferoFileServer(baseFS, nil)
+	}
+	panic("unreachable")
 }
 
 // ThumbsFS returns the hidden filesystem for storing the thumbnails of the

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -26,9 +26,6 @@ import (
 	"github.com/leonelquinteros/gotext"
 	"github.com/spf13/afero"
 	jwt "gopkg.in/dgrijalva/jwt-go.v3"
-
-	// import the mail worker to test passphrase reset
-	_ "github.com/cozy/cozy-stack/pkg/jobs/workers/mails"
 )
 
 /* #nosec */

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -26,6 +26,9 @@ import (
 	"github.com/leonelquinteros/gotext"
 	"github.com/spf13/afero"
 	jwt "gopkg.in/dgrijalva/jwt-go.v3"
+
+	// import the mail worker to test passphrase reset
+	_ "github.com/cozy/cozy-stack/pkg/jobs/workers/mails"
 )
 
 /* #nosec */
@@ -361,7 +364,7 @@ func Create(opts *Options) (*Instance, error) {
 		return nil, err
 	}
 	scheduler := jobs.GetScheduler()
-	for _, trigger := range Triggers {
+	for _, trigger := range Triggers(i.Domain) {
 		t, err := jobs.NewTrigger(&trigger)
 		if err != nil {
 			return nil, err

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -158,52 +158,33 @@ func (i *Instance) makeVFS() error {
 // application type
 func (i *Instance) AppsCopier(appsType apps.AppType) apps.Copier {
 	fsURL := config.FsURL()
-	switch fsURL.Scheme {
-	case "file", "mem":
-		var baseDirName string
-		switch appsType {
-		case apps.Webapp:
-			baseDirName = vfs.WebappsDirName
-		case apps.Konnector:
-			baseDirName = vfs.KonnectorsDirName
-		}
-		baseFS := afero.NewBasePathFs(afero.NewOsFs(),
-			path.Join(fsURL.Path, i.Domain, baseDirName))
-		return apps.NewAferoCopier(baseFS)
+	var baseDirName string
+	switch appsType {
+	case apps.Webapp:
+		baseDirName = vfs.WebappsDirName
+	case apps.Konnector:
+		baseDirName = vfs.KonnectorsDirName
 	}
-	panic("unreachable")
+	baseFS := afero.NewBasePathFs(afero.NewOsFs(),
+		path.Join(fsURL.Path, i.Domain, baseDirName))
+	return apps.NewAferoCopier(baseFS)
 }
 
-func (i *Instance) AppsFileServer(appsType apps.AppType) apps.FileServer {
+// AppsFileServer returns the web-application file server associated to this
+// instance.
+func (i *Instance) AppsFileServer() apps.FileServer {
 	fsURL := config.FsURL()
-	switch fsURL.Scheme {
-	case "file", "mem":
-		var baseDirName string
-		switch appsType {
-		case apps.Webapp:
-			baseDirName = vfs.WebappsDirName
-		case apps.Konnector:
-			baseDirName = vfs.KonnectorsDirName
-		}
-		baseFS := afero.NewBasePathFs(afero.NewOsFs(),
-			path.Join(fsURL.Path, i.Domain, baseDirName))
-		return apps.NewAferoFileServer(baseFS, nil)
-	}
-	panic("unreachable")
+	baseFS := afero.NewBasePathFs(afero.NewOsFs(),
+		path.Join(fsURL.Path, i.Domain, vfs.WebappsDirName))
+	return apps.NewAferoFileServer(baseFS, nil)
 }
 
 // ThumbsFS returns the hidden filesystem for storing the thumbnails of the
 // photos/image
 func (i *Instance) ThumbsFS() afero.Fs {
 	fsURL := config.FsURL()
-	switch fsURL.Scheme {
-	case "file", "mem":
-		return afero.NewBasePathFs(afero.NewOsFs(),
-			path.Join(fsURL.Path, i.Domain, vfs.ThumbsDirName))
-	case "swift":
-		panic("Not implemented")
-	}
-	return nil
+	return afero.NewBasePathFs(afero.NewOsFs(),
+		path.Join(fsURL.Path, i.Domain, vfs.ThumbsDirName))
 }
 
 // DiskQuota returns the number of bytes allowed on the disk to the user.

--- a/pkg/instance/instance_test.go
+++ b/pkg/instance/instance_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
 	"github.com/cozy/cozy-stack/pkg/crypto"
 	"github.com/cozy/cozy-stack/pkg/instance"
+	"github.com/cozy/cozy-stack/pkg/jobs"
 	_ "github.com/cozy/cozy-stack/pkg/jobs/workers"
 	"github.com/cozy/cozy-stack/pkg/vfs"
 	jwt "github.com/dgrijalva/jwt-go"
@@ -403,6 +404,11 @@ func TestMain(m *testing.M) {
 	instance.Destroy("test.cozycloud.cc")
 	instance.Destroy("test2.cozycloud.cc")
 	instance.Destroy("test.cozycloud.cc.duplicate")
+
+	if err = jobs.StartSystem(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 
 	os.RemoveAll("/usr/local/var/cozy2/")
 

--- a/pkg/instance/instance_test.go
+++ b/pkg/instance/instance_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/crypto"
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/pkg/jobs"
-	_ "github.com/cozy/cozy-stack/pkg/jobs/workers"
+	_ "github.com/cozy/cozy-stack/pkg/jobs/workers/mails"
 	"github.com/cozy/cozy-stack/pkg/vfs"
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/stretchr/testify/assert"

--- a/pkg/instance/triggers.go
+++ b/pkg/instance/triggers.go
@@ -2,12 +2,15 @@ package instance
 
 import "github.com/cozy/cozy-stack/pkg/jobs"
 
-// Triggers is the list of the triggers to add when an instance is created
-var Triggers = []jobs.TriggerInfos{
+// Triggers returns the list of the triggers to add when an instance is created
+func Triggers(domain string) []jobs.TriggerInfos {
 	// Create/update/remove thumbnails when an image is created/updated/removed
-	jobs.TriggerInfos{
-		Type:       "@event",
-		WorkerType: "thumbnail",
-		Arguments:  "io.cozy.files:CREATED,UPDATED,DELETED:image:class",
-	},
+	return []jobs.TriggerInfos{
+		{
+			Domain:     domain,
+			Type:       "@event",
+			WorkerType: "thumbnail",
+			Arguments:  "io.cozy.files:CREATED,UPDATED,DELETED:image:class",
+		},
+	}
 }

--- a/pkg/jobs/couch_storage.go
+++ b/pkg/jobs/couch_storage.go
@@ -21,12 +21,12 @@ func (t triggerDoc) MarshalJSON() ([]byte, error) {
 	return json.Marshal(t.t.Infos())
 }
 
-// CouchStorage cmplements the TriggerStorage interface and uses CouchDB as the
+// CouchStorage implements the TriggerStorage interface and uses CouchDB as the
 // underlying storage for triggers.
 type couchStorage struct {
 }
 
-// NewTriggerCouchStorage ceturns a new instance of CouchStorage using the
+// NewTriggerCouchStorage returns a new instance of CouchStorage using the
 // specified database.
 func NewTriggerCouchStorage() TriggerStorage {
 	return &couchStorage{}

--- a/pkg/jobs/couch_storage.go
+++ b/pkg/jobs/couch_storage.go
@@ -36,7 +36,8 @@ func (s *couchStorage) GetAll() ([]*TriggerInfos, error) {
 	var infos []*TriggerInfos
 	// TODO(pagination): use a sort of couchdb.WalkDocs function when available.
 	req := &couchdb.AllDocsRequest{Limit: 1000}
-	if err := couchdb.GetAllDocs(couchdb.GlobalDB, consts.Triggers, req, &infos); err != nil {
+	err := couchdb.GetAllDocs(couchdb.GlobalTriggersDB, consts.Triggers, req, &infos)
+	if err != nil {
 		if couchdb.IsNoDatabaseError(err) {
 			return infos, nil
 		}
@@ -46,9 +47,9 @@ func (s *couchStorage) GetAll() ([]*TriggerInfos, error) {
 }
 
 func (s *couchStorage) Add(trigger Trigger) error {
-	return couchdb.CreateDoc(couchdb.GlobalDB, &triggerDoc{trigger})
+	return couchdb.CreateDoc(couchdb.GlobalTriggersDB, &triggerDoc{trigger})
 }
 
 func (s *couchStorage) Delete(trigger Trigger) error {
-	return couchdb.DeleteDoc(couchdb.GlobalDB, &triggerDoc{trigger})
+	return couchdb.DeleteDoc(couchdb.GlobalTriggersDB, &triggerDoc{trigger})
 }

--- a/pkg/jobs/couch_storage.go
+++ b/pkg/jobs/couch_storage.go
@@ -21,24 +21,22 @@ func (t triggerDoc) MarshalJSON() ([]byte, error) {
 	return json.Marshal(t.t.Infos())
 }
 
-// CouchStorage implements the TriggerStorage interface and uses CouchDB as the
+// CouchStorage cmplements the TriggerStorage interface and uses CouchDB as the
 // underlying storage for triggers.
-type CouchStorage struct {
-	db couchdb.Database
+type couchStorage struct {
 }
 
-// NewTriggerCouchStorage returns a new instance of CouchStorage using the
+// NewTriggerCouchStorage ceturns a new instance of CouchStorage using the
 // specified database.
-func NewTriggerCouchStorage(db couchdb.Database) *CouchStorage {
-	return &CouchStorage{db}
+func NewTriggerCouchStorage() TriggerStorage {
+	return &couchStorage{}
 }
 
-// GetAll implements the GetAll method of the TriggerStorage.
-func (s *CouchStorage) GetAll() ([]*TriggerInfos, error) {
+func (s *couchStorage) GetAll() ([]*TriggerInfos, error) {
 	var infos []*TriggerInfos
 	// TODO(pagination): use a sort of couchdb.WalkDocs function when available.
-	req := &couchdb.AllDocsRequest{Limit: 100}
-	if err := couchdb.GetAllDocs(s.db, consts.Triggers, req, &infos); err != nil {
+	req := &couchdb.AllDocsRequest{Limit: 1000}
+	if err := couchdb.GetAllDocs(couchdb.GlobalDB, consts.Triggers, req, &infos); err != nil {
 		if couchdb.IsNoDatabaseError(err) {
 			return infos, nil
 		}
@@ -47,12 +45,10 @@ func (s *CouchStorage) GetAll() ([]*TriggerInfos, error) {
 	return infos, nil
 }
 
-// Add implements the Add method of the TriggerStorage.
-func (s *CouchStorage) Add(trigger Trigger) error {
-	return couchdb.CreateDoc(s.db, &triggerDoc{trigger})
+func (s *couchStorage) Add(trigger Trigger) error {
+	return couchdb.CreateDoc(couchdb.GlobalDB, &triggerDoc{trigger})
 }
 
-// Delete implements the Delete method of the TriggerStorage.
-func (s *CouchStorage) Delete(trigger Trigger) error {
-	return couchdb.DeleteDoc(s.db, &triggerDoc{trigger})
+func (s *couchStorage) Delete(trigger Trigger) error {
+	return couchdb.DeleteDoc(couchdb.GlobalDB, &triggerDoc{trigger})
 }

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -207,11 +207,17 @@ func StartSystem() error {
 
 // GetScheduler returns the global job scheduler.
 func GetScheduler() Scheduler {
+	if scheduler == nil {
+		panic("Job system not initialized")
+	}
 	return scheduler
 }
 
 // GetBroker returns the global job broker.
 func GetBroker() Broker {
+	if broker == nil {
+		panic("Job system not initialized")
+	}
 	return broker
 }
 

--- a/pkg/jobs/mem_jobs.go
+++ b/pkg/jobs/mem_jobs.go
@@ -9,17 +9,9 @@ import (
 	log "github.com/Sirupsen/logrus"
 )
 
-var (
-	memBrokers   map[string]*MemBroker
-	memBrokersMu sync.RWMutex
-
-	memSchedulers   map[string]*MemScheduler
-	memSchedulersMu sync.Mutex
-)
-
 type (
-	// MemQueue is a queue in-memory implementation of the Queue interface.
-	MemQueue struct {
+	// memQueue is a queue in-memory implementation of the Queue interface.
+	memQueue struct {
 		MaxCapacity int
 
 		jobs *list.List
@@ -30,15 +22,14 @@ type (
 		cl chan bool
 	}
 
-	// MemBroker is an in-memory broker implementation of the Broker interface.
-	MemBroker struct {
-		domain string
-		queues map[string]*MemQueue
+	// memBroker is an in-memory broker implementation of the Broker interface.
+	memBroker struct {
+		queues map[string]*memQueue
 	}
 
-	// MemScheduler is a centralized scheduler of many triggers. It stars all of
+	// memScheduler is a centralized scheduler of many triggers. It stars all of
 	// them and schedules jobs accordingly.
-	MemScheduler struct {
+	memScheduler struct {
 		broker  Broker
 		storage TriggerStorage
 
@@ -54,9 +45,9 @@ type (
 	}
 )
 
-// NewMemQueue creates and a new in-memory queue.
-func NewMemQueue(domain, workerType string) *MemQueue {
-	return &MemQueue{
+// newMemQueue creates and a new in-memory queue.
+func newMemQueue(workerType string) *memQueue {
+	return &memQueue{
 		jobs: list.New(),
 		ch:   make(chan Job),
 		cl:   make(chan bool),
@@ -64,7 +55,7 @@ func NewMemQueue(domain, workerType string) *MemQueue {
 }
 
 // Enqueue into the queue
-func (q *MemQueue) Enqueue(job Job) error {
+func (q *memQueue) Enqueue(job Job) error {
 	q.jmu.Lock()
 	defer q.jmu.Unlock()
 	q.jobs.PushBack(job)
@@ -75,7 +66,7 @@ func (q *MemQueue) Enqueue(job Job) error {
 	return nil
 }
 
-func (q *MemQueue) send() {
+func (q *memQueue) send() {
 	for {
 		q.jmu.Lock()
 		e := q.jobs.Front()
@@ -96,7 +87,7 @@ func (q *MemQueue) send() {
 }
 
 // Consume from the queue
-func (q *MemQueue) Consume() (Job, error) {
+func (q *memQueue) Consume() (Job, error) {
 	select {
 	case job := <-q.ch:
 		return job, nil
@@ -106,66 +97,38 @@ func (q *MemQueue) Consume() (Job, error) {
 }
 
 // Len returns the length of the queue
-func (q *MemQueue) Len() int {
+func (q *memQueue) Len() int {
 	q.jmu.RLock()
 	defer q.jmu.RUnlock()
 	return q.jobs.Len()
 }
 
 // Close closes the queue
-func (q *MemQueue) Close() {
+func (q *memQueue) Close() {
 	close(q.cl)
 }
 
-// NewMemBroker creates a new in-memory broker system.
+// newMemBroker creates a new in-memory broker system.
 //
 // The in-memory implementation of the job system has the specifity that
 // workers are actually launched by the broker at its creation.
-func NewMemBroker(domain string, ws WorkersList) Broker {
-	memBrokersMu.Lock()
-	defer memBrokersMu.Unlock()
-	if memBrokers == nil {
-		memBrokers = make(map[string]*MemBroker)
-	}
-	b, ok := memBrokers[domain]
-	if ok {
-		return b
-	}
-	queues := make(map[string]*MemQueue)
+func newMemBroker(ws WorkersList) Broker {
+	queues := make(map[string]*memQueue)
 	for workerType, conf := range ws {
-		q := NewMemQueue(domain, workerType)
+		q := newMemQueue(workerType)
 		queues[workerType] = q
 		w := &Worker{
-			Domain: domain,
-			Type:   workerType,
-			Conf:   conf,
+			Type: workerType,
+			Conf: conf,
 		}
 		w.Start(q)
 	}
-	b = &MemBroker{
-		domain: domain,
-		queues: queues,
-	}
-	memBrokers[domain] = b
-	return b
-}
-
-// GetMemBroker returns the in-memory broker associated with the specified
-// domain.
-func GetMemBroker(domain string) Broker {
-	memBrokersMu.RLock()
-	defer memBrokersMu.RUnlock()
-	return memBrokers[domain]
-}
-
-// Domain returns the broker's domain
-func (b *MemBroker) Domain() string {
-	return b.domain
+	return &memBroker{queues: queues}
 }
 
 // PushJob will produce a new Job with the given options and enqueue the job in
 // the proper queue.
-func (b *MemBroker) PushJob(req *JobRequest) (*JobInfos, <-chan *JobInfos, error) {
+func (b *memBroker) PushJob(req *JobRequest) (*JobInfos, <-chan *JobInfos, error) {
 	workerType := req.WorkerType
 	q, ok := b.queues[workerType]
 	if !ok {
@@ -185,12 +148,19 @@ func (b *MemBroker) PushJob(req *JobRequest) (*JobInfos, <-chan *JobInfos, error
 
 // QueueLen returns the size of the number of elements in queue of the
 // specified worker type.
-func (b *MemBroker) QueueLen(workerType string) (int, error) {
+func (b *memBroker) QueueLen(workerType string) (int, error) {
 	q, ok := b.queues[workerType]
 	if !ok {
 		return 0, ErrUnknownWorker
 	}
 	return q.Len(), nil
+}
+
+// Domain returns the associated domain
+func (j *MemJob) Domain() string {
+	j.infmu.RLock()
+	defer j.infmu.RUnlock()
+	return j.infos.Domain
 }
 
 // Infos returns the associated job infos
@@ -256,34 +226,19 @@ func (j *MemJob) Unmarshal() error {
 	return errors.New("should not be unmarshaled")
 }
 
-// NewMemScheduler creates a new in-memory scheduler that will load all
+// newMemScheduler creates a new in-memory scheduler that will load all
 // registered triggers and schedule their work.
-func NewMemScheduler(domain string, storage TriggerStorage) *MemScheduler {
-	memSchedulersMu.Lock()
-	defer memSchedulersMu.Unlock()
-	if memSchedulers == nil {
-		memSchedulers = make(map[string]*MemScheduler)
-	}
-	s := &MemScheduler{
+func newMemScheduler(storage TriggerStorage) *memScheduler {
+	return &memScheduler{
 		storage: storage,
 		ts:      make(map[string]Trigger),
 	}
-	memSchedulers[domain] = s
-	return s
-}
-
-// GetMemScheduler returns the in-memory scheduler associated with the
-// specified domain.
-func GetMemScheduler(domain string) Scheduler {
-	memSchedulersMu.Lock()
-	defer memSchedulersMu.Unlock()
-	return memSchedulers[domain]
 }
 
 // Start will start the scheduler by actually loading all triggers from the
 // scheduler's storage and associate for each of them a go routine in which
 // they wait for the trigger send job requests.
-func (s *MemScheduler) Start(b Broker) error {
+func (s *memScheduler) Start(b Broker) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	ts, err := s.storage.GetAll()
@@ -307,7 +262,7 @@ func (s *MemScheduler) Start(b Broker) error {
 
 // Add will add a new trigger to the scheduler. The trigger is persisted in
 // storage.
-func (s *MemScheduler) Add(t Trigger) error {
+func (s *memScheduler) Add(t Trigger) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if err := s.storage.Add(t); err != nil {
@@ -319,11 +274,11 @@ func (s *MemScheduler) Add(t Trigger) error {
 }
 
 // Get returns the trigger with the specified ID.
-func (s *MemScheduler) Get(id string) (Trigger, error) {
+func (s *memScheduler) Get(domain, id string) (Trigger, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	t, ok := s.ts[id]
-	if !ok {
+	if !ok || t.Infos().Domain != domain {
 		return nil, ErrNotFoundTrigger
 	}
 	return t, nil
@@ -331,11 +286,11 @@ func (s *MemScheduler) Get(id string) (Trigger, error) {
 
 // Delete removes the trigger with the specified ID. The trigger is unscheduled
 // and remove from the storage.
-func (s *MemScheduler) Delete(id string) error {
+func (s *memScheduler) Delete(domain, id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	t, ok := s.ts[id]
-	if !ok {
+	if !ok || t.Infos().Domain != domain {
 		return ErrNotFoundTrigger
 	}
 	if err := s.storage.Delete(t); err != nil {
@@ -347,33 +302,35 @@ func (s *MemScheduler) Delete(id string) error {
 }
 
 // GetAll returns all the running in-memory triggers.
-func (s *MemScheduler) GetAll() ([]Trigger, error) {
+func (s *memScheduler) GetAll(domain string) ([]Trigger, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	v := make([]Trigger, 0, len(s.ts))
+	v := make([]Trigger, 0)
 	for _, t := range s.ts {
-		v = append(v, t)
+		if t.Infos().Domain == domain {
+			v = append(v, t)
+		}
 	}
 	return v, nil
 }
 
-func (s *MemScheduler) schedule(t Trigger) {
+func (s *memScheduler) schedule(t Trigger) {
 	log.Debugf("[jobs] trigger %s(%s): Starting trigger", t.Type(), t.Infos().ID)
-	for req := range t.Schedule(s.broker.Domain()) {
+	for req := range t.Schedule() {
 		log.Debugf("[jobs] trigger %s(%s): Pushing new job", t.Type(), t.Infos().ID)
 		if _, _, err := s.broker.PushJob(req); err != nil {
 			log.Errorf("[jobs] trigger %s(%s): Could not schedule a new job: %s", t.Type(), t.Infos().ID, err.Error())
 		}
 	}
 	log.Debugf("[jobs] trigger %s(%s): Closing trigger", t.Type(), t.Infos().ID)
-	if err := s.Delete(t.Infos().ID); err != nil {
+	if err := s.Delete(t.Infos().Domain, t.Infos().ID); err != nil {
 		log.Errorf("[jobs] trigger %s(%s): Could not delete trigger: %s", t.Type(), t.Infos().ID, err.Error())
 	}
 }
 
 var (
-	_ Queue     = &MemQueue{}
-	_ Broker    = &MemBroker{}
+	_ Queue     = &memQueue{}
+	_ Broker    = &memBroker{}
 	_ Job       = &MemJob{}
-	_ Scheduler = &MemScheduler{}
+	_ Scheduler = &memScheduler{}
 )

--- a/pkg/jobs/trigger_at.go
+++ b/pkg/jobs/trigger_at.go
@@ -72,7 +72,7 @@ func (a *AtTrigger) Valid(key, value string) bool {
 }
 
 // Schedule implements the Schedule method of the Trigger interface.
-func (a *AtTrigger) Schedule(domain string) <-chan *JobRequest {
+func (a *AtTrigger) Schedule() <-chan *JobRequest {
 	at := a.at
 	ch := make(chan *JobRequest)
 	duration := time.Since(at)

--- a/pkg/jobs/trigger_at.go
+++ b/pkg/jobs/trigger_at.go
@@ -97,6 +97,7 @@ func (a *AtTrigger) Schedule() <-chan *JobRequest {
 
 func (a *AtTrigger) trigger(ch chan *JobRequest) {
 	ch <- &JobRequest{
+		Domain:     a.in.Domain,
 		WorkerType: a.in.WorkerType,
 		Message:    a.in.Message,
 		Options:    a.in.Options,

--- a/pkg/jobs/trigger_cron.go
+++ b/pkg/jobs/trigger_cron.go
@@ -67,7 +67,7 @@ func (c *CronTrigger) Valid(key, value string) bool {
 }
 
 // Schedule implements the Schedule method of the Trigger interface.
-func (c *CronTrigger) Schedule(domain string) <-chan *JobRequest {
+func (c *CronTrigger) Schedule() <-chan *JobRequest {
 	ch := make(chan *JobRequest)
 	go func() {
 		for next := time.Now(); true; next = c.sched.Next(next) {

--- a/pkg/jobs/trigger_cron.go
+++ b/pkg/jobs/trigger_cron.go
@@ -74,6 +74,7 @@ func (c *CronTrigger) Schedule() <-chan *JobRequest {
 			select {
 			case <-time.After(-time.Since(next)):
 				ch <- &JobRequest{
+					Domain:     c.infos.Domain,
 					WorkerType: c.infos.WorkerType,
 					Message:    c.infos.Message,
 					Options:    c.infos.Options,
@@ -89,6 +90,7 @@ func (c *CronTrigger) Schedule() <-chan *JobRequest {
 
 func (c *CronTrigger) trigger(ch chan *JobRequest) {
 	ch <- &JobRequest{
+		Domain:     c.infos.Domain,
 		WorkerType: c.infos.WorkerType,
 		Message:    c.infos.Message,
 		Options:    c.infos.Options,

--- a/pkg/jobs/trigger_event.go
+++ b/pkg/jobs/trigger_event.go
@@ -86,10 +86,10 @@ func addEventToMessage(e *realtime.Event, base *Message) (*Message, error) {
 }
 
 // Schedule implements the Schedule method of the Trigger interface.
-func (t *EventTrigger) Schedule(domain string) <-chan *JobRequest {
+func (t *EventTrigger) Schedule() <-chan *JobRequest {
 	ch := make(chan *JobRequest)
 	go func() {
-		c := realtime.InstanceHub(domain).Subscribe(t.mask.Type)
+		c := realtime.InstanceHub(t.infos.Domain).Subscribe(t.mask.Type)
 		for {
 			select {
 			case e := <-c.Read():

--- a/pkg/jobs/trigger_event.go
+++ b/pkg/jobs/trigger_event.go
@@ -99,8 +99,8 @@ func (t *EventTrigger) Schedule() <-chan *JobRequest {
 						log.Error(err)
 						continue
 					}
-
 					ch <- &JobRequest{
+						Domain:     t.infos.Domain,
 						WorkerType: t.infos.WorkerType,
 						Message:    msg,
 						Options:    t.infos.Options,

--- a/pkg/jobs/trigger_event_test.go
+++ b/pkg/jobs/trigger_event_test.go
@@ -23,7 +23,7 @@ func TestTriggerEvent(t *testing.T) {
 	var wg sync.WaitGroup
 	var called = make(map[string]bool)
 
-	NewMemBroker("test2.scheduler.io", WorkersList{
+	bro := newMemBroker(WorkersList{
 		"worker_event": {
 			Concurrency:  1,
 			MaxExecCount: 1,
@@ -52,6 +52,7 @@ func TestTriggerEvent(t *testing.T) {
 		{
 			ID:         utils.RandomString(10),
 			Type:       "@event",
+			Domain:     "cozy.local",
 			Arguments:  "io.cozy.testeventobject:DELETED",
 			WorkerType: "worker_event",
 			Message:    makeMessage(t, "message-bad-verb"),
@@ -59,6 +60,7 @@ func TestTriggerEvent(t *testing.T) {
 		{
 			ID:         utils.RandomString(10),
 			Type:       "@event",
+			Domain:     "cozy.local",
 			Arguments:  "io.cozy.testeventobject:CREATED:value:test",
 			WorkerType: "worker_event",
 			Message:    makeMessage(t, "message-correct-verb-correct-value"),
@@ -66,6 +68,7 @@ func TestTriggerEvent(t *testing.T) {
 		{
 			ID:         utils.RandomString(10),
 			Type:       "@event",
+			Domain:     "cozy.local",
 			Arguments:  "io.cozy.testeventobject:CREATED",
 			WorkerType: "worker_event",
 			Message:    makeMessage(t, "message-correct-verb"),
@@ -73,6 +76,7 @@ func TestTriggerEvent(t *testing.T) {
 		{
 			ID:         utils.RandomString(10),
 			Type:       "@event",
+			Domain:     "cozy.local",
 			Arguments:  "io.cozy.testeventobject:CREATED:notvalue:test",
 			WorkerType: "worker_event",
 			Message:    makeMessage(t, "message-correct-verb-bad-value"),
@@ -80,15 +84,14 @@ func TestTriggerEvent(t *testing.T) {
 		{
 			ID:         utils.RandomString(10),
 			Type:       "@event",
+			Domain:     "cozy.local",
 			Arguments:  "io.cozy.testeventobject",
 			WorkerType: "worker_event",
 			Message:    makeMessage(t, "message-wholetype"),
 		},
 	}}
 	wg.Add(3)
-	NewMemScheduler("test2.scheduler.io", storage)
-	bro := GetMemBroker("test2.scheduler.io")
-	sch := GetMemScheduler("test2.scheduler.io")
+	sch := newMemScheduler(storage)
 	sch.Start(bro)
 
 	time.AfterFunc(1*time.Millisecond, func() {
@@ -100,7 +103,7 @@ func TestTriggerEvent(t *testing.T) {
 				"test": "value",
 			},
 		}
-		realtime.InstanceHub("test2.scheduler.io").Publish(&realtime.Event{
+		realtime.InstanceHub("cozy.local").Publish(&realtime.Event{
 			Type: realtime.EventCreate,
 			Doc:  &doc,
 		})
@@ -115,7 +118,6 @@ func TestTriggerEvent(t *testing.T) {
 	assert.False(t, called["message-correct-verb-bad-value"])
 
 	for _, t := range storage.ts {
-		sch.Delete(t.ID)
+		sch.Delete("cozy.local", t.ID)
 	}
-
 }

--- a/pkg/jobs/worker.go
+++ b/pkg/jobs/worker.go
@@ -72,6 +72,7 @@ func (w *Worker) work(workerID string) {
 		domain := job.Domain()
 		if domain == "" {
 			log.Errorf("[job] %s: missing domain from job request", workerID)
+			continue
 		}
 		parentCtx := NewWorkerContext(domain)
 		infos := job.Infos()

--- a/pkg/jobs/workers/sharings/share_data_test.go
+++ b/pkg/jobs/workers/sharings/share_data_test.go
@@ -108,13 +108,18 @@ func TestMain(m *testing.M) {
 	config.UseTestFile()
 
 	var err error
+	err = jobs.StartSystem()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
 	_, _ = instance.Destroy(domainSharer)
 	in, err = createInstance(domainSharer, "Alice")
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-
 	err = couchdb.ResetDB(in, testDocType)
 	if err != nil {
 		fmt.Println(err)

--- a/pkg/jobs/workers/sharings/share_data_test.go
+++ b/pkg/jobs/workers/sharings/share_data_test.go
@@ -107,8 +107,7 @@ func TestSendDataBadRecipient(t *testing.T) {
 func TestMain(m *testing.M) {
 	config.UseTestFile()
 
-	var err error
-	err = jobs.StartSystem()
+	err := jobs.StartSystem()
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/pkg/permissions/permissions.go
+++ b/pkg/permissions/permissions.go
@@ -222,7 +222,7 @@ func CreateAppSet(db couchdb.Database, slug string, set Set) (*Permission, error
 	return createAppSet(db, TypeApplication, consts.Apps, slug, set)
 }
 
-// CreateAppSet creates a Permission doc for a konnector
+// CreateKonnectorSet creates a Permission doc for a konnector
 func CreateKonnectorSet(db couchdb.Database, slug string, set Set) (*Permission, error) {
 	return createAppSet(db, TypeKonnector, consts.Konnectors, slug, set)
 }
@@ -308,7 +308,7 @@ func DestroyApp(db couchdb.Database, slug string) error {
 	return destroyApp(db, consts.Apps, slug)
 }
 
-// DestroyApp remove all Permission docs for a given konnector
+// DestroyKonnector remove all Permission docs for a given konnector
 func DestroyKonnector(db couchdb.Database, slug string) error {
 	return destroyApp(db, consts.Konnectors, slug)
 }

--- a/pkg/sharings/send_mails.go
+++ b/pkg/sharings/send_mails.go
@@ -78,7 +78,8 @@ func SendSharingMails(instance *instance.Instance, s *Sharing) error {
 		// are of no use in this situation.
 		// FI: they correspond to the job information and to a channel with
 		// which we can check the advancement of said job.
-		_, _, errJobs := instance.JobsBroker().PushJob(&jobs.JobRequest{
+		_, _, errJobs := jobs.GetBroker().PushJob(&jobs.JobRequest{
+			Domain:     instance.Domain,
 			WorkerType: "sendmail",
 			Options:    nil,
 			Message:    sharingMessage,

--- a/pkg/sharings/sharings.go
+++ b/pkg/sharings/sharings.go
@@ -155,7 +155,7 @@ func findSharingRecipient(db couchdb.Database, sharingID, clientID string) (*Sha
 
 // addTrigger creates a new trigger on the updates of the shared documents
 func addTrigger(instance *instance.Instance, rule permissions.Rule, sharingID string) error {
-	scheduler := instance.JobsScheduler()
+	scheduler := jobs.GetScheduler()
 
 	var eventArgs string
 	if rule.Selector != "" {
@@ -175,6 +175,7 @@ func addTrigger(instance *instance.Instance, rule permissions.Rule, sharingID st
 	t, err := jobs.NewTrigger(&jobs.TriggerInfos{
 		Type:       "@event",
 		WorkerType: "sharingupdates",
+		Domain:     instance.Domain,
 		Arguments:  eventArgs,
 		Message: &jobs.Message{
 			Type: jobs.JSONEncoding,
@@ -224,7 +225,8 @@ func ShareDoc(instance *instance.Instance, sharing *Sharing, recStatus *Recipien
 			if err != nil {
 				return err
 			}
-			_, _, err = instance.JobsBroker().PushJob(&jobs.JobRequest{
+			_, _, err = jobs.GetBroker().PushJob(&jobs.JobRequest{
+				Domain:     instance.Domain,
 				WorkerType: "sharedata",
 				Options:    nil,
 				Message:    workerMsg,

--- a/pkg/sharings/sharings_test.go
+++ b/pkg/sharings/sharings_test.go
@@ -728,6 +728,12 @@ func TestMain(m *testing.M) {
 	}
 	config.GetConfig().Fs.URL = fmt.Sprintf("file://localhost%s", tempdir)
 
+	err = jobs.StartSystem()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
 	// The instance must be created in db in order to retrieve it from
 	// the share_data worker
 	_, _ = instance.Destroy(domainSharer)

--- a/pkg/sharings/sharings_test.go
+++ b/pkg/sharings/sharings_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
 	"github.com/cozy/cozy-stack/pkg/instance"
+	"github.com/cozy/cozy-stack/pkg/jobs"
 	"github.com/cozy/cozy-stack/pkg/oauth"
 	"github.com/cozy/cozy-stack/pkg/permissions"
 	"github.com/cozy/cozy-stack/pkg/vfs"
@@ -794,7 +795,7 @@ func TestMain(m *testing.M) {
 	}
 
 	createSettings(in)
-	err = in.StartJobSystem()
+	err = jobs.StartSystem()
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/pkg/stack/main.go
+++ b/pkg/stack/main.go
@@ -2,24 +2,14 @@ package stack
 
 import (
 	"github.com/cozy/cozy-stack/pkg/config"
-	"github.com/cozy/cozy-stack/pkg/couchdb"
-	"github.com/cozy/cozy-stack/pkg/instance"
+	"github.com/cozy/cozy-stack/pkg/jobs"
 	"github.com/cozy/cozy-stack/pkg/vfs/vfsswift"
 )
 
 // Start is used to initialize all the
 func Start() error {
-	// StartJobs is used to start the job system for all the instances.
-	// TODO: on distributed stacks, we should not have to iterate over all
-	// instances on each startup
-	instances, err := instance.List()
-	if err != nil && !couchdb.IsNoDatabaseError(err) {
+	if err := jobs.StartSystem(); err != nil {
 		return err
-	}
-	for _, in := range instances {
-		if err := in.StartJobSystem(); err != nil {
-			return err
-		}
 	}
 
 	// Init the main global connection to the swift server

--- a/pkg/vfs/vfsswift/impl.go
+++ b/pkg/vfs/vfsswift/impl.go
@@ -17,7 +17,7 @@ import (
 
 const versionSuffix = "-version"
 
-var conn *swift.Connection
+var Conn *swift.Connection
 
 type swiftVFS struct {
 	vfs.Indexer
@@ -34,14 +34,14 @@ type swiftVFS struct {
 //
 // This function is not thread-safe.
 func InitConnection(fsURL *url.URL) (err error) {
-	conn, err = config.NewSwiftConnection(fsURL)
+	Conn, err = config.NewSwiftConnection(fsURL)
 	if err != nil {
 		return err
 	}
-	log.Debugf("[vfsswift] Starting authentication with server %s", conn.AuthUrl)
-	if err = conn.Authenticate(); err != nil {
+	log.Debugf("[vfsswift] Starting authentication with server %s", Conn.AuthUrl)
+	if err = Conn.Authenticate(); err != nil {
 		log.Errorf("[vfsswift] Authentication failed with the OpenStack Swift server on %s",
-			conn.AuthUrl)
+			Conn.AuthUrl)
 		return err
 	}
 	return nil
@@ -50,7 +50,7 @@ func InitConnection(fsURL *url.URL) (err error) {
 // New returns a vfs.VFS instance associated with the specified indexer and the
 // swift storage url.
 func New(index vfs.Indexer, disk vfs.DiskThresholder, mu vfs.Locker, domain string) (vfs.VFS, error) {
-	if conn == nil {
+	if Conn == nil {
 		return nil, errors.New("vfsswift: global connection is not initialized")
 	}
 	if domain == "" {
@@ -60,7 +60,7 @@ func New(index vfs.Indexer, disk vfs.DiskThresholder, mu vfs.Locker, domain stri
 		Indexer:         index,
 		DiskThresholder: disk,
 
-		c:         conn,
+		c:         Conn,
 		container: domain,
 		version:   domain + versionSuffix,
 		versionOk: true,

--- a/pkg/vfs/vfsswift/impl.go
+++ b/pkg/vfs/vfsswift/impl.go
@@ -17,7 +17,7 @@ import (
 
 const versionSuffix = "-version"
 
-var Conn *swift.Connection
+var conn *swift.Connection
 
 type swiftVFS struct {
 	vfs.Indexer
@@ -34,14 +34,14 @@ type swiftVFS struct {
 //
 // This function is not thread-safe.
 func InitConnection(fsURL *url.URL) (err error) {
-	Conn, err = config.NewSwiftConnection(fsURL)
+	conn, err = config.NewSwiftConnection(fsURL)
 	if err != nil {
 		return err
 	}
-	log.Debugf("[vfsswift] Starting authentication with server %s", Conn.AuthUrl)
-	if err = Conn.Authenticate(); err != nil {
+	log.Debugf("[vfsswift] Starting authentication with server %s", conn.AuthUrl)
+	if err = conn.Authenticate(); err != nil {
 		log.Errorf("[vfsswift] Authentication failed with the OpenStack Swift server on %s",
-			Conn.AuthUrl)
+			conn.AuthUrl)
 		return err
 	}
 	return nil
@@ -50,7 +50,7 @@ func InitConnection(fsURL *url.URL) (err error) {
 // New returns a vfs.VFS instance associated with the specified indexer and the
 // swift storage url.
 func New(index vfs.Indexer, disk vfs.DiskThresholder, mu vfs.Locker, domain string) (vfs.VFS, error) {
-	if Conn == nil {
+	if conn == nil {
 		return nil, errors.New("vfsswift: global connection is not initialized")
 	}
 	if domain == "" {
@@ -60,7 +60,7 @@ func New(index vfs.Indexer, disk vfs.DiskThresholder, mu vfs.Locker, domain stri
 		Indexer:         index,
 		DiskThresholder: disk,
 
-		c:         Conn,
+		c:         conn,
 		container: domain,
 		version:   domain + versionSuffix,
 		versionOk: true,

--- a/scripts/cozy-app-dev.sh
+++ b/scripts/cozy-app-dev.sh
@@ -103,8 +103,8 @@ do_start() {
 		--couchdb-url "${COUCHDB_URL}" \
 		--mail-host "${COZY_STACK_HOST}" \
 		--mail-port 1025 \
-		--mail-disable-tls & # \
-		# --fs-url "file://localhost${vfsdir}" &
+		--mail-disable-tls \
+		--fs-url "file://localhost${vfsdir}" &
 
 	wait_for "${COZY_STACK_HOST}:${COZY_STACK_PORT}/version/" "cozy-stack"
 

--- a/scripts/cozy-app-dev.sh
+++ b/scripts/cozy-app-dev.sh
@@ -103,8 +103,8 @@ do_start() {
 		--couchdb-url "${COUCHDB_URL}" \
 		--mail-host "${COZY_STACK_HOST}" \
 		--mail-port 1025 \
-		--mail-disable-tls \
-		--fs-url "file://localhost${vfsdir}" &
+		--mail-disable-tls & # \
+		# --fs-url "file://localhost${vfsdir}" &
 
 	wait_for "${COZY_STACK_HOST}:${COZY_STACK_PORT}/version/" "cozy-stack"
 

--- a/tests/testutils/test_utils.go
+++ b/tests/testutils/test_utils.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cozy/checkup"
 	"github.com/cozy/cozy-stack/pkg/config"
 	"github.com/cozy/cozy-stack/pkg/instance"
+	"github.com/cozy/cozy-stack/pkg/jobs"
 	"github.com/cozy/cozy-stack/pkg/oauth"
 	"github.com/cozy/cozy-stack/pkg/permissions"
 	"github.com/cozy/cozy-stack/pkg/utils"
@@ -100,6 +101,10 @@ func (c *TestSetup) GetTestInstance(opts ...*instance.Options) *instance.Instanc
 	if c.inst != nil {
 		return c.inst
 	}
+	err := jobs.StartSystem()
+	if err != nil {
+		c.CleanupAndDie("Error while starting job system", err)
+	}
 	if len(opts) == 0 {
 		opts = []*instance.Options{{}}
 	}
@@ -108,7 +113,7 @@ func (c *TestSetup) GetTestInstance(opts ...*instance.Options) *instance.Instanc
 	} else {
 		c.host = opts[0].Domain
 	}
-	_, err := instance.Destroy(c.host)
+	_, err = instance.Destroy(c.host)
 	if err != nil && err != instance.ErrNotFound {
 		c.CleanupAndDie("Error while destroying instance", err)
 	}

--- a/web/apps/apps.go
+++ b/web/apps/apps.go
@@ -270,22 +270,15 @@ func iconHandler(c echo.Context) error {
 		return err
 	}
 
-	filepath := path.Join("/", slug, app.Icon)
+	filepath := path.Join("/", app.Icon)
 	fs := instance.AppsFileServer(apps.Webapp)
-	s, err := fs.Stat(app.Slug(), app.Version(), filepath)
+	err = fs.ServeFileContent(c.Response(), c.Request(), app.Slug(), app.Version(), filepath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return echo.NewHTTPError(http.StatusNotFound, err)
 		}
 		return err
 	}
-
-	r, err := fs.Open(app.Slug(), app.Version(), filepath)
-	if err != nil {
-		return err
-	}
-	defer r.Close()
-	http.ServeContent(c.Response(), c.Request(), filepath, s.ModTime(), r)
 	return nil
 }
 

--- a/web/apps/apps.go
+++ b/web/apps/apps.go
@@ -271,7 +271,7 @@ func iconHandler(c echo.Context) error {
 	}
 
 	filepath := path.Join("/", app.Icon)
-	fs := instance.AppsFileServer(apps.Webapp)
+	fs := instance.AppsFileServer()
 	err = fs.ServeFileContent(c.Response(), c.Request(), app.Slug(), app.Version(), filepath)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/web/apps/serve.go
+++ b/web/apps/serve.go
@@ -46,7 +46,7 @@ func Serve(c echo.Context) error {
 	if app.State() != apps.Ready {
 		return echo.NewHTTPError(http.StatusServiceUnavailable, "Application is not ready")
 	}
-	return ServeAppFile(c, i, i.AppsFileServer(apps.Webapp), app)
+	return ServeAppFile(c, i, i.AppsFileServer(), app)
 }
 
 func onboarding(c echo.Context) bool {

--- a/web/data/data_test.go
+++ b/web/data/data_test.go
@@ -130,7 +130,6 @@ func TestAllDoctypes(t *testing.T) {
 		"io.cozy.files",
 		"io.cozy.konnectors",
 		"io.cozy.settings",
-		"io.cozy.triggers",
 	}
 	assert.Equal(t, expected, dbs)
 }

--- a/web/jobs/jobs_test.go
+++ b/web/jobs/jobs_test.go
@@ -422,7 +422,7 @@ func TestMain(m *testing.M) {
 	setup := testutils.NewSetup(m, "jobs_test")
 	testInstance = setup.GetTestInstance()
 
-	if err := testInstance.StartJobSystem(); err != nil {
+	if err := jobs.StartSystem(); err != nil {
 		testutils.Fatal(err)
 	}
 

--- a/web/jobs/jobs_test.go
+++ b/web/jobs/jobs_test.go
@@ -374,10 +374,16 @@ func TestGetAllJobs(t *testing.T) {
 	}
 
 	if assert.Len(t, v.Data, 2) {
-		assert.Equal(t, consts.Triggers, v.Data[1].Type)
-		assert.Equal(t, "@in", v.Data[1].Attributes.Type)
-		assert.Equal(t, "10s", v.Data[1].Attributes.Arguments)
-		assert.Equal(t, "print", v.Data[1].Attributes.WorkerType)
+		var index int
+		if v.Data[1].Attributes.Type == "@in" {
+			index = 1
+		} else {
+			index = 0
+		}
+		assert.Equal(t, consts.Triggers, v.Data[index].Type)
+		assert.Equal(t, "@in", v.Data[index].Attributes.Type)
+		assert.Equal(t, "10s", v.Data[index].Attributes.Arguments)
+		assert.Equal(t, "print", v.Data[index].Attributes.WorkerType)
 	}
 }
 

--- a/web/server.go
+++ b/web/server.go
@@ -116,7 +116,7 @@ func ListenAndServeWithAppDir(appsdir map[string]string) error {
 				apps.WebappManifestName, err.Error())
 		}
 		i := middlewares.GetInstance(c)
-		f := webapps.NewServer(fs, func(_, folder, file string) string {
+		f := apps.NewAferoFileServer(fs, func(_, folder, file string) string {
 			return path.Join(folder, file)
 		})
 		// Save permissions in couchdb before loading an index page

--- a/web/server.go
+++ b/web/server.go
@@ -116,8 +116,8 @@ func ListenAndServeWithAppDir(appsdir map[string]string) error {
 				apps.WebappManifestName, err.Error())
 		}
 		i := middlewares.GetInstance(c)
-		f := apps.NewAferoFileServer(fs, func(_, folder, file string) string {
-			return path.Join(folder, file)
+		f := apps.NewAferoFileServer(fs, func(_, _, file string) string {
+			return path.Join("/", file)
 		})
 		// Save permissions in couchdb before loading an index page
 		if _, file := app.FindRoute(path.Clean(c.Request().URL.Path)); file == "" {


### PR DESCRIPTION
This PR is an intermediate work into making complete execution pipeline for konnectors working. Since the code change is already quite important, I'm making this PR right now.

What it contains:

--------------------

1/ The first commit make the job system independent from the "domain" of the instance.

For now, we had one "job system" for each instance: each (domain, worker) couple had its own queue. This was mainly done because we had only one "in-memory" model of this job system for single nodes. In the case of multiple nodes, it will be more useful to have shared queues for workers where the domain information is stored on the job message, rather that having as many queues as users.

It also removes the code that had to iterate over all the instances on startup to initiate all the queues.

--------------------

2/ The second part of the commits implement a centralized/versioned storage for applications and konnectors

The implementation is not yet complete, and the swift storage is not yet tested.

It contains two new interfaces to abstract how application files are copied and served (for a webapp): `apps.Copier` and `app.FileServer`.

The Copier implementation copy application in a `${slug}/${version}/${file}` path so that we can de-duplicate application data by version. In the git fetcher, the version is patched with the shasum of the current commit: `${slug}/${version}-${shasum}/${file}`. I removed the storage of the `.git` directory which is now only temporary and always recreated with a fresh clone which simplify many things.

For konnectors, a tarball is created containing all the file and then copied on the application storage.

The `Installer` methods have been cleaned up also, by using a single `Run` method, rather that `Install/Update/Delete`