### PR TITLE
Docs retrieval at dynamic sharing creation

### DIFF
--- a/pkg/sharings/sharings.go
+++ b/pkg/sharings/sharings.go
@@ -190,9 +190,7 @@ func addTrigger(instance *instance.Instance, rule permissions.Rule, sharingID st
 // ShareDoc shares the documents specified in the Sharing structure to the
 // specified recipient
 func ShareDoc(instance *instance.Instance, sharing *Sharing, recStatus *RecipientStatus) error {
-	// Lookup all the sharing permissions
 	for _, rule := range sharing.Permissions {
-		// Only static values are supported yet
 		if len(rule.Values) == 0 {
 			return nil
 		}
@@ -204,8 +202,39 @@ func ShareDoc(instance *instance.Instance, sharing *Sharing, recStatus *Recipien
 			}
 		}
 
+		var values []string
+
+		// Dynamic sharing
+		if rule.Selector != "" {
+			// Create index based on selector to retrieve documents to share
+			index := mango.IndexOnFields(docType, sharing.ID(), []string{rule.Selector})
+			err := couchdb.DefineIndex(instance, index)
+			if err != nil {
+				return err
+			}
+
+			var docs []couchdb.JSONDoc
+
+			// Request the index for all values
+			for _, val := range rule.Values {
+				err = couchdb.FindDocs(instance, docType, &couchdb.FindRequest{
+					UseIndex: sharing.ID(),
+					Selector: mango.Equal(rule.Selector, val),
+				}, &docs)
+				if err != nil {
+					return err
+				}
+				// Save returned doc ids
+				for _, d := range docs {
+					values = append(values, d.ID())
+				}
+			}
+		} else {
+			values = rule.Values
+		}
+
 		// Create a sharedata worker for each doc to send
-		for _, val := range rule.Values {
+		for _, val := range values {
 			domain, err := recStatus.recipient.ExtractDomain()
 			if err != nil {
 				return err

--- a/pkg/sharings/sharings_test.go
+++ b/pkg/sharings/sharings_test.go
@@ -94,13 +94,15 @@ func createRecipient(t *testing.T) (*Recipient, error) {
 	return recipient, err
 }
 
-func createTestDoc(t *testing.T) (*couchdb.JSONDoc, error) {
+func createTestDoc(t *testing.T, withSelector bool) (*couchdb.JSONDoc, error) {
 	doc := &couchdb.JSONDoc{
 		Type: testDocType,
 		M:    make(map[string]interface{}),
 	}
 	doc.M["test"] = "hello there"
-	doc.M["dyn"] = "amic"
+	if withSelector {
+		doc.M["dyn"] = "amic"
+	}
 	err := couchdb.CreateDoc(in, doc)
 	assert.NoError(t, err)
 	return doc, err
@@ -226,7 +228,7 @@ func acceptedSharing(t *testing.T, sharingType string, isFile, withSelector bool
 
 	// share doc
 	if !isFile {
-		testDoc, err = createTestDoc(t)
+		testDoc, err = createTestDoc(t, withSelector)
 		assert.NoError(t, err)
 		assert.NotNil(t, testDoc)
 		sharing, err = createSharing(t, sharingType, testDoc.ID(), isFile, withSelector)
@@ -278,9 +280,10 @@ func acceptedSharing(t *testing.T, sharingType string, isFile, withSelector bool
 		if !isFile {
 			if withSelector {
 				var testDoc2 *couchdb.JSONDoc
-				testDoc2, err = createTestDoc(t)
+				testDoc2, err = createTestDoc(t, withSelector)
 				assert.NoError(t, err)
 				assert.NotNil(t, testDoc2)
+
 				// Wait for the document to arrive and check it
 				time.Sleep(2000 * time.Millisecond)
 				recDoc := &couchdb.JSONDoc{}
@@ -309,7 +312,6 @@ func acceptedSharing(t *testing.T, sharingType string, isFile, withSelector bool
 			// TODO check the file on the recipient side when we'll be able
 			// to create files with fixed id
 		}
-
 	}
 }
 


### PR DESCRIPTION
At the dynamic sharing creation, one needs to create and request a mango index based on the selector to retrieve all the docs concerned by this sharing, before being sent to the recipients.
