### PR TITLE
feat: Add app.editor reading from manifest

### DIFF
--- a/client/apps.go
+++ b/client/apps.go
@@ -18,6 +18,7 @@ type AppManifest struct {
 	Rev   string `json:"rev"`
 	Attrs struct {
 		Name        string `json:"name"`
+		Editor      string `json:"editor"`
 		Slug        string `json:"slug"`
 		Source      string `json:"source"`
 		State       string `json:"state"`

--- a/docs/apps.md
+++ b/docs/apps.md
@@ -26,6 +26,7 @@ Field          | Description
 ---------------|---------------------------------------------------------------------
 name           | the name to display on the home
 slug           | the default slug (it can be changed at install time)
+editor         | the editor's name to display on the cozy-bar of the app
 icon           | an icon for the home
 description    | a short description of the application
 source         | where the files of the app can be downloaded

--- a/docs/client-app-dev.md
+++ b/docs/client-app-dev.md
@@ -113,6 +113,7 @@ it as a template and will insert the relevant values.
 - `{{.Domain}}` will be replaced by the stack hostname.
 - `{{.Locale}}` will be replaced by the locale for the instance.
 - `{{.AppName}}`: will be replaced by the application name.
+- `{{.AppEditor}}`: will be replaced by the application's editor.
 - `{{.IconPath}}`: will be replaced by the application's icon path.
 - `{{.CozyBar}}` will be replaced by the JavaScript to inject the cozy-bar.
 - `{{.CozyClientJS}}` will be replaced by the JavaScript to inject the cozy-client-js.

--- a/pkg/apps/webapp.go
+++ b/pkg/apps/webapp.go
@@ -40,6 +40,7 @@ type WebappManifest struct {
 	Type string `json:"type,omitempty"`
 
 	Name        string     `json:"name"`
+	Editor      string     `json:"editor"`
 	DocSource   string     `json:"source"`
 	DocSlug     string     `json:"slug"`
 	DocState    State      `json:"state"`

--- a/web/apps/serve.go
+++ b/web/apps/serve.go
@@ -159,6 +159,7 @@ func ServeAppFile(c echo.Context, i *instance.Instance, fs AppFileServer, app *a
 		"Domain":       i.Domain,
 		"Locale":       i.Locale,
 		"AppName":      app.Name,
+		"AppEditor":    app.Editor,
 		"IconPath":     app.Icon,
 		"CozyBar":      cozybar(i),
 		"CozyClientJS": cozyclientjs(i),


### PR DESCRIPTION
So we can use it to display the name of the app in the Cozy-bar