### PR TITLE
Share and update JSON documents

### DIFF
--- a/pkg/sharings/sharings.go
+++ b/pkg/sharings/sharings.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"net/http"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
@@ -250,7 +252,7 @@ func ShareDoc(instance *instance.Instance, sharing *Sharing, recStatus *Recipien
 
 			workerMsg, err := jobs.NewMessage(jobs.JSONEncoding, sharingWorker.SendOptions{
 				DocID:      val,
-				Update:     false,
+				Method:     http.MethodPost,
 				DocType:    docType,
 				Recipients: []*sharingWorker.RecipientInfo{rec},
 			})

--- a/pkg/workers/sharings/sharing_updates_test.go
+++ b/pkg/workers/sharings/sharing_updates_test.go
@@ -24,13 +24,13 @@ func createDoc(t *testing.T, docType string, params map[string]interface{}) couc
 	return doc
 }
 
-func createEvent(t *testing.T, doc couchdb.JSONDoc, sharingID string) *TriggerEvent {
+func createEvent(t *testing.T, doc couchdb.JSONDoc, sharingID, eventType string) *TriggerEvent {
 	msg := &SharingMessage{
 		SharingID: sharingID,
 		DocType:   doc.Type,
 	}
 	event := &TriggerEvent{
-		Event:   &EventDoc{Doc: &doc},
+		Event:   &EventDoc{Type: eventType, Doc: &doc},
 		Message: msg,
 	}
 	return event
@@ -41,7 +41,7 @@ func TestSharingUpdatesNoSharing(t *testing.T) {
 	defer func() {
 		couchdb.DeleteDoc(in, doc)
 	}()
-	event := createEvent(t, doc, "")
+	event := createEvent(t, doc, "", "CREATED")
 
 	msg, err := jobs.NewMessage(jobs.JSONEncoding, event)
 	assert.NoError(t, err)
@@ -63,7 +63,7 @@ func TestSharingUpdatesBadSharing(t *testing.T) {
 		couchdb.DeleteDoc(in, sharingDoc)
 	}()
 
-	event := createEvent(t, doc, "badsharingid")
+	event := createEvent(t, doc, "badsharingid", "")
 
 	msg, err := jobs.NewMessage(jobs.JSONEncoding, event)
 	assert.NoError(t, err)
@@ -89,7 +89,7 @@ func TestSharingUpdatesTooManySharing(t *testing.T) {
 	}()
 	sharingID := doc.M["sharing_id"].(string)
 
-	event := createEvent(t, doc, sharingID)
+	event := createEvent(t, doc, sharingID, "UPDATED")
 
 	msg, err := jobs.NewMessage(jobs.JSONEncoding, event)
 	assert.NoError(t, err)
@@ -111,7 +111,7 @@ func TestSharingUpdatesBadSharingType(t *testing.T) {
 		couchdb.DeleteDoc(in, sharingDoc)
 	}()
 	sharingID := sharingDoc.M["sharing_id"].(string)
-	event := createEvent(t, doc, sharingID)
+	event := createEvent(t, doc, sharingID, "UPDATED")
 
 	msg, err := jobs.NewMessage(jobs.JSONEncoding, event)
 	assert.NoError(t, err)
@@ -142,7 +142,7 @@ func TestSharingUpdatesNoRecipient(t *testing.T) {
 		couchdb.DeleteDoc(in, sharingDoc)
 	}()
 	sharingID := sharingDoc.M["sharing_id"].(string)
-	event := createEvent(t, doc, sharingID)
+	event := createEvent(t, doc, sharingID, "CREATED")
 
 	msg, err := jobs.NewMessage(jobs.JSONEncoding, event)
 	assert.NoError(t, err)
@@ -172,7 +172,7 @@ func TestSharingUpdatesBadRecipient(t *testing.T) {
 		couchdb.DeleteDoc(in, sharingDoc)
 	}()
 	sharingID := sharingDoc.M["sharing_id"].(string)
-	event := createEvent(t, doc, sharingID)
+	event := createEvent(t, doc, sharingID, "CREATED")
 
 	msg, err := jobs.NewMessage(jobs.JSONEncoding, event)
 	assert.NoError(t, err)

--- a/web/data/data.go
+++ b/web/data/data.go
@@ -13,8 +13,9 @@ import (
 	"github.com/labstack/echo"
 )
 
-func validDoctype(next echo.HandlerFunc) echo.HandlerFunc {
-	// TODO extends me to verificate characters allowed in db name.
+// ValidDoctype validates the doctype and sets it in the context of the request.
+func ValidDoctype(next echo.HandlerFunc) echo.HandlerFunc {
+	// TODO extends me to verify characters allowed in db name.
 	return func(c echo.Context) error {
 		doctype := c.Param("doctype")
 		if doctype == "" {
@@ -206,7 +207,8 @@ func UpdateDoc(c echo.Context) error {
 	})
 }
 
-func deleteDoc(c echo.Context) error {
+// DeleteDoc deletes the provided document from its database.
+func DeleteDoc(c echo.Context) error {
 	instance := middlewares.GetInstance(c)
 	doctype := c.Get("doctype").(string)
 	docid := c.Param("docid")
@@ -445,14 +447,14 @@ func Routes(router *echo.Group) {
 	router.GET("/", dataAPIWelcome)
 	router.GET("/_all_doctypes", allDoctypes)
 
-	group := router.Group("/:doctype", validDoctype)
+	group := router.Group("/:doctype", ValidDoctype)
 
 	replicationRoutes(group)
 
 	// API Routes under /:doctype
 	group.GET("/:docid", getDoc)
 	group.PUT("/:docid", UpdateDoc)
-	group.DELETE("/:docid", deleteDoc)
+	group.DELETE("/:docid", DeleteDoc)
 	group.GET("/:docid/relationships/references", listReferencesHandler)
 	group.POST("/:docid/relationships/references", addReferencesHandler)
 	group.DELETE("/:docid/relationships/references", removeReferencesHandler)

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -215,18 +215,57 @@ func RecipientRefusedSharing(c echo.Context) error {
 // receiveDocument stores a shared document in the Cozy.
 //
 // If the document to store is a "io.cozy.files" our custom handler will be
-// called, otherwise we will redirect the request to PUT /data/:doctype/:id.
+// called, otherwise we will redirect to /data.
 func receiveDocument(c echo.Context) error {
 	var err error
 
 	switch c.Param("doctype") {
-	case "":
-		err = echo.NewHTTPError(http.StatusBadRequest,
-			"Missing parameter: doctype")
 	case consts.Files:
 		err = creationWithIDHandler(c)
 	default:
 		err = data.UpdateDoc(c)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(http.StatusOK, nil)
+}
+
+// updateDocument updates a shared document in the Cozy.
+//
+// TODO Handle files updates.
+func updateDocument(c echo.Context) error {
+	var err error
+
+	switch c.Param("doctype") {
+	case consts.Files:
+		// TODO
+		err = c.JSON(http.StatusNotImplemented, nil)
+	default:
+		err = data.UpdateDoc(c)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(http.StatusOK, nil)
+}
+
+// deleteDocument deletes the shared document from the Cozy.
+//
+// TODO Handle files deletions.
+func deleteDocument(c echo.Context) error {
+	var err error
+
+	switch c.Param("doctype") {
+	case consts.Files:
+		// TODO
+		err = c.JSON(http.StatusNotImplemented, nil)
+	default:
+		err = data.DeleteDoc(c)
 	}
 
 	if err != nil {
@@ -244,7 +283,11 @@ func Routes(router *echo.Group) {
 	router.GET("/answer", SharingAnswer)
 	router.POST("/formRefuse", RecipientRefusedSharing)
 	router.POST("/recipient", AddRecipient)
-	router.POST("/doc/:doctype/:docid", receiveDocument)
+
+	group := router.Group("/doc/:doctype", data.ValidDoctype)
+	group.POST("/:docid", receiveDocument)
+	group.PUT("/:docid", updateDocument)
+	group.DELETE("/:docid", deleteDocument)
 }
 
 // wrapErrors returns a formatted error


### PR DESCRIPTION
With a previous PR two regressions were introduced: it was no longer
possible to share a JSON, and its updates were not propagated. This PR
fixes those issues and enhance the propagation of updates as it is now
possible for a sharer to propagate the deletion of a shared document.