### PR TITLE
Konnector rkt run

### DIFF
--- a/cozy.example.yaml
+++ b/cozy.example.yaml
@@ -32,7 +32,7 @@ couchdb:
   url: http://localhost:5984/
 
 konnectors:
-  cmd: ./scripts/konnector-run.sh
+  cmd: ./scripts/konnector-rkt-run.sh
 
 mail:
   # mail smtp host - flags: --mail-host

--- a/pkg/apps/copier.go
+++ b/pkg/apps/copier.go
@@ -156,7 +156,7 @@ func newTarCopier(src Copier, name string) Copier {
 
 func (t *tarCopier) Start(slug, version string) (bool, error) {
 	fs := afero.NewOsFs()
-	tmp, err := afero.TempFile(fs, "", "")
+	tmp, err := afero.TempFile(fs, "", "konnector-")
 	if err != nil {
 		return false, err
 	}

--- a/pkg/apps/copier.go
+++ b/pkg/apps/copier.go
@@ -155,6 +155,9 @@ func newTarCopier(src Copier, name string) Copier {
 }
 
 func (t *tarCopier) Start(slug, version string) (bool, error) {
+	if exists, err := t.src.Start(slug, version); err != nil || exists {
+		return exists, err
+	}
 	fs := afero.NewOsFs()
 	tmp, err := afero.TempFile(fs, "", "konnector-")
 	if err != nil {
@@ -164,7 +167,7 @@ func (t *tarCopier) Start(slug, version string) (bool, error) {
 	t.tmp = tmp
 	t.fs = fs
 	t.tw = tw
-	return t.src.Start(slug, version)
+	return false, nil
 }
 
 func (t *tarCopier) Copy(stat os.FileInfo, src io.Reader) error {
@@ -189,6 +192,9 @@ func (t *tarCopier) Close() (err error) {
 			err = errc
 		}
 	}()
+	if t.tw == nil || t.tmp == nil {
+		return nil
+	}
 	if err = t.tw.Flush(); err != nil {
 		return err
 	}

--- a/pkg/apps/git.go
+++ b/pkg/apps/git.go
@@ -82,7 +82,7 @@ func (g *gitFetcher) FetchManifest(src *url.URL) (io.ReadCloser, error) {
 	return res.Body, nil
 }
 
-func (g *gitFetcher) Fetch(src *url.URL, fs Copier, man Manifest) error {
+func (g *gitFetcher) Fetch(src *url.URL, fs Copier, man Manifest) (err error) {
 	log.Debugf("[git] Fetch %s", src.String())
 
 	osFs := afero.NewOsFs()

--- a/pkg/apps/installer.go
+++ b/pkg/apps/installer.go
@@ -55,7 +55,7 @@ type Fetcher interface {
 	FetchManifest(src *url.URL) (io.ReadCloser, error)
 	// Fetch should download the application and install it in the given
 	// directory.
-	Fetch(src *url.URL, fs Copier, man Manifest) (Manifest, error)
+	Fetch(src *url.URL, fs Copier, man Manifest) error
 }
 
 // NewInstaller creates a new Installer
@@ -198,7 +198,7 @@ func (i *Installer) install() (Manifest, error) {
 		return man, err
 	}
 	i.manc <- man
-	return i.fetcher.Fetch(i.src, i.fs, man)
+	return man, i.fetcher.Fetch(i.src, i.fs, man)
 }
 
 // update will perform the update of an already installed application. It
@@ -219,7 +219,7 @@ func (i *Installer) update() (Manifest, error) {
 		return man, err
 	}
 	i.manc <- man
-	return i.fetcher.Fetch(i.src, i.fs, man)
+	return man, i.fetcher.Fetch(i.src, i.fs, man)
 }
 
 func (i *Installer) delete() (Manifest, error) {

--- a/pkg/workers/konnectors/konnector.go
+++ b/pkg/workers/konnectors/konnector.go
@@ -122,6 +122,7 @@ func Worker(ctx context.Context, m *jobs.Message) error {
 		"COZY_CREDENTIALS=" + token,
 		"COZY_FIELDS=" + string(fieldsJSON),
 		"COZY_DOMAIN=" + domain,
+		"COZY_JOB_ID=" + jobID,
 	}
 
 	cmdErr, err := cmd.StderrPipe()

--- a/scripts/konnector-rkt-run.sh
+++ b/scripts/konnector-rkt-run.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+mkdir "${1}/.rkt"
+env_file="${1}/.rkt/env"
+uuid_file="${1}/.rkt/uuid"
+
+node_image="$(dirname ${0})/nodeslim.aci"
+
+echo "COZY_DOMAIN=${COZY_DOMAIN}" > "${env_file}"
+echo "COZY_FIELDS=${COZY_FIELDS}" >> "${env_file}"
+echo "COZY_CREDENTIALS=${COZY_CREDENTIALS}" >> "${env_file}"
+
+trap 'sudo rkt stop --force --uuid-file="${uuid_file}" && sudo rkt rm --uuid-file="${uuid_file}"' SIGINT SIGTERM EXIT
+
+sudo rkt run \
+  --net=host \
+  --set-env-file="${env_file}" \
+  --uuid-file-save="${uuid_file}" \
+  --volume data,kind=host,source="${1}" \
+  --mount volume=data,target=/usr/src/app \
+  --insecure-options=image "${node_image}" \
+  --cpu=100m \
+  --memory=128M \
+  --name "${COZY_JOB_ID}" \
+  --exec node \
+  -- /usr/src/app/index.js

--- a/scripts/konnector-run.sh
+++ b/scripts/konnector-run.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-echo "COZY_URL=${COZY_URL}"
-echo "COZY_DOMAIN=${COZY_DOMAIN}"
-echo "COZY_FIELDS=${COZY_FIELDS}"
-echo "COZY_CREDENTIALS=${COZY_CREDENTIALS}"
-echo "SLUG=${1}"


### PR DESCRIPTION
This PR add a new konnector executing script designed for RKT.

It also contains two fixes for konnector and webapps installation:
  - fix a leak of empty temporary files (copier were not properly closed)
  - fix a bad state manifest, preventing a delete/upgrade a konnector that would have failed to install