### PR TITLE
Add route to add a sharing recipient

### DIFF
--- a/pkg/sharings/recipients.go
+++ b/pkg/sharings/recipients.go
@@ -136,6 +136,14 @@ func (rs *RecipientStatus) getAccessToken(db couchdb.Database, code string) (*au
 // - software id: the link to the github repository of the stack.
 // - client URI: the domain of the sharer's Cozy.
 func (rs *RecipientStatus) Register(instance *instance.Instance) error {
+	if rs.recipient == nil {
+		r, err := GetRecipient(instance, rs.RefRecipient.ID)
+		if err != nil {
+			return err
+		}
+		rs.recipient = r
+	}
+
 	// We require the recipient to be persisted in the database.
 	if rs.recipient.RID == "" {
 		return ErrRecipientDoesNotExist

--- a/pkg/sharings/sharings_test.go
+++ b/pkg/sharings/sharings_test.go
@@ -201,7 +201,7 @@ func createSharing(t *testing.T, sharingType string, docID string, withFile, wit
 		RecipientsStatus: []*RecipientStatus{recStatus},
 	}
 
-	err = CreateSharingAndRegisterSharer(in, sharing)
+	err = CreateSharing(in, sharing)
 	assert.NoError(t, err)
 
 	return sharing, err
@@ -715,13 +715,13 @@ func TestCreateSharingAndRegisterSharer(t *testing.T) {
 	}
 
 	// `SharingType` is wrong.
-	err := CreateSharingAndRegisterSharer(in, sharing)
+	err := CreateSharing(in, sharing)
 	assert.Equal(t, ErrBadSharingType, err)
 
 	// `SharingType` is correct.
 	sharing.SharingType = consts.OneShotSharing
 	// However the recipient is not persisted in the database.
-	err = CreateSharingAndRegisterSharer(in, sharing)
+	err = CreateSharing(in, sharing)
 	assert.Equal(t, ErrRecipientDoesNotExist, err)
 
 	// The CreateSharingAndRegisterSharer scenario that succeeds is already

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -194,8 +194,9 @@ func AddSharingRecipient(c echo.Context) error {
 	if err = c.Bind(&ref); err != nil {
 		return err
 	}
-	rs := &sharings.RecipientStatus{}
-	rs.RefRecipient = ref
+	rs := &sharings.RecipientStatus{
+		RefRecipient: ref,
+	}
 	sharing.RecipientsStatus = append(sharing.RecipientsStatus, rs)
 
 	if err = sharings.RegisterRecipient(instance, rs); err != nil {

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -205,7 +205,8 @@ func AddSharingRecipient(c echo.Context) error {
 		return wrapErrors(err)
 	}
 
-	return wrapErrors(err)
+	return jsonapi.Data(c, http.StatusOK, &apiSharing{sharing}, nil)
+
 }
 
 // RecipientRefusedSharing is called when the recipient refused the sharing.

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -91,8 +91,8 @@ func SharingAnswer(c echo.Context) error {
 	return c.Redirect(http.StatusFound, u)
 }
 
-// AddRecipient adds a sharing Recipient.
-func AddRecipient(c echo.Context) error {
+// CreateRecipient adds a sharing Recipient.
+func CreateRecipient(c echo.Context) error {
 
 	recipient := new(sharings.Recipient)
 	if err := c.Bind(recipient); err != nil {
@@ -140,7 +140,7 @@ func CreateSharing(c echo.Context) error {
 		return err
 	}
 
-	err := sharings.CreateSharingAndRegisterSharer(instance, sharing)
+	err := sharings.CreateSharing(instance, sharing)
 	if err != nil {
 		return wrapErrors(err)
 	}
@@ -174,6 +174,38 @@ func SendSharingMails(c echo.Context) error {
 	}
 
 	return nil
+}
+
+// AddSharingRecipient adds an existing recipient to an existing sharing
+func AddSharingRecipient(c echo.Context) error {
+	instance := middlewares.GetInstance(c)
+
+	// Get sharing doc
+	id := c.Param("id")
+	sharing := &sharings.Sharing{}
+	err := couchdb.GetDoc(instance, consts.Sharings, id, sharing)
+	if err != nil {
+		err = sharings.ErrSharingDoesNotExist
+		return wrapErrors(err)
+	}
+
+	// Create recipient, register, and send mail
+	ref := couchdb.DocReference{}
+	if err = c.Bind(&ref); err != nil {
+		return err
+	}
+	rs := &sharings.RecipientStatus{}
+	rs.RefRecipient = ref
+	sharing.RecipientsStatus = append(sharing.RecipientsStatus, rs)
+
+	if err = sharings.RegisterRecipient(instance, rs); err != nil {
+		return wrapErrors(err)
+	}
+	if err = sharings.SendSharingMails(instance, sharing); err != nil {
+		return wrapErrors(err)
+	}
+
+	return wrapErrors(err)
 }
 
 // RecipientRefusedSharing is called when the recipient refused the sharing.
@@ -278,11 +310,12 @@ func deleteDocument(c echo.Context) error {
 // Routes sets the routing for the sharing service
 func Routes(router *echo.Group) {
 	router.POST("/", CreateSharing)
+	router.PUT("/:id/recipient", AddSharingRecipient)
 	router.PUT("/:id/sendMails", SendSharingMails)
 	router.GET("/request", SharingRequest)
 	router.GET("/answer", SharingAnswer)
 	router.POST("/formRefuse", RecipientRefusedSharing)
-	router.POST("/recipient", AddRecipient)
+	router.POST("/recipient", CreateRecipient)
 
 	group := router.Group("/doc/:doctype", data.ValidDoctype)
 	group.POST("/:docid", receiveDocument)


### PR DESCRIPTION
This declares a route in order to add a recipient to an existing sharing.
The sharing process is then triggered, with the recipient registration and a mail sent to the its given address.