### PR TITLE
Register the recipient for master-master sharing

### DIFF
--- a/pkg/sharings/recipients.go
+++ b/pkg/sharings/recipients.go
@@ -136,6 +136,14 @@ func (rs *RecipientStatus) getAccessToken(db couchdb.Database, code string) (*au
 // - software id: the link to the github repository of the stack.
 // - client URI: the domain of the sharer's Cozy.
 func (rs *RecipientStatus) Register(instance *instance.Instance) error {
+	if rs.recipient == nil {
+		r, err := GetRecipient(instance, rs.RefRecipient.ID)
+		if err != nil {
+			return err
+		}
+		rs.recipient = r
+	}
+
 	// We require the recipient to be persisted in the database.
 	if rs.recipient.RID == "" {
 		return ErrRecipientDoesNotExist

--- a/pkg/sharings/recipients.go
+++ b/pkg/sharings/recipients.go
@@ -65,6 +65,18 @@ func (r *Recipient) ExtractDomain() (string, error) {
 	return u.Host, nil
 }
 
+// GetRecipient get the actual recipient of a RecipientStatus
+func (rs *RecipientStatus) GetRecipient(db couchdb.Database) error {
+	if rs.recipient == nil {
+		recipient, err := GetRecipient(db, rs.RefRecipient.ID)
+		if err != nil {
+			return err
+		}
+		rs.recipient = recipient
+	}
+	return nil
+}
+
 // CreateRecipient inserts a Recipient document in database. Email and URL must
 // not be empty.
 func CreateRecipient(db couchdb.Database, doc *Recipient) error {

--- a/pkg/sharings/recipients.go
+++ b/pkg/sharings/recipients.go
@@ -2,7 +2,7 @@ package sharings
 
 import (
 	"net/http"
-	"strings"
+	"net/url"
 
 	"github.com/cozy/cozy-stack/client/auth"
 	"github.com/cozy/cozy-stack/pkg/consts"
@@ -30,6 +30,9 @@ type RecipientStatus struct {
 	// information she needs to send to authenticate.
 	Client      *auth.Client
 	AccessToken *auth.AccessToken
+
+	// The OAuth ClientID refering to the host's client stored in its db
+	HostClientID string
 }
 
 // ID returns the recipient qualified identifier
@@ -55,10 +58,11 @@ func (r *Recipient) ExtractDomain() (string, error) {
 	if r.URL == "" {
 		return "", ErrRecipientHasNoURL
 	}
-	if tokens := strings.Split(r.URL, "://"); len(tokens) > 1 {
-		return tokens[1], nil
+	u, err := url.Parse(r.URL)
+	if err != nil {
+		return "", err
 	}
-	return r.URL, nil
+	return u.Host, nil
 }
 
 // CreateRecipient inserts a Recipient document in database. Email and URL must

--- a/pkg/sharings/recipients.go
+++ b/pkg/sharings/recipients.go
@@ -128,7 +128,7 @@ func (rs *RecipientStatus) getAccessToken(db couchdb.Database, code string) (*au
 
 // Register asks the recipient to register the sharer as a new OAuth client.
 //
-// To register the sharer must provide the following information:
+// The following information must be provided to register:
 // - redirect uri: where the recipient must answer the sharing request. Our
 //		protocol forces this field to be: "sharerdomain/sharings/answer".
 // - client name: the sharer's public name.
@@ -144,11 +144,6 @@ func (rs *RecipientStatus) Register(instance *instance.Instance) error {
 		rs.recipient = r
 	}
 
-	// We require the recipient to be persisted in the database.
-	if rs.recipient.RID == "" {
-		return ErrRecipientDoesNotExist
-	}
-
 	// If the recipient has no URL there is no point in registering.
 	if rs.recipient.URL == "" {
 		return ErrRecipientHasNoURL
@@ -161,9 +156,8 @@ func (rs *RecipientStatus) Register(instance *instance.Instance) error {
 	if err != nil {
 		return err
 	}
-
-	sharerPublicName, _ := doc.M["public_name"].(string)
-	if sharerPublicName == "" {
+	publicName, _ := doc.M["public_name"].(string)
+	if publicName == "" {
 		return ErrPublicNameNotDefined
 	}
 
@@ -173,7 +167,7 @@ func (rs *RecipientStatus) Register(instance *instance.Instance) error {
 	// We have all we need to register an OAuth client.
 	authClient := &auth.Client{
 		RedirectURIs: []string{redirectURI},
-		ClientName:   sharerPublicName,
+		ClientName:   publicName,
 		ClientKind:   "sharing",
 		SoftwareID:   "github.com/cozy/cozy-stack",
 		ClientURI:    clientURI,

--- a/pkg/sharings/send_mails.go
+++ b/pkg/sharings/send_mails.go
@@ -46,12 +46,9 @@ func SendSharingMails(instance *instance.Instance, s *Sharing) error {
 
 		// A non-empty status indicates a recipient already treated
 		if rs.Status != "" {
-			// Sanity check: recipient is private.
-			if rs.recipient == nil {
-				rs.recipient, err = GetRecipient(instance, rs.RefRecipient.ID)
-				if err != nil {
-					return err
-				}
+			err = rs.GetRecipient(instance)
+			if err != nil {
+				return err
 			}
 
 			// Generate recipient specific OAuth query string.

--- a/pkg/sharings/sharings.go
+++ b/pkg/sharings/sharings.go
@@ -451,10 +451,7 @@ func SendClientID(instance *instance.Instance, sharing *Sharing) error {
 		ClientID:     sharing.Sharer.SharerStatus.HostClientID,
 		HostClientID: newClientID,
 	}
-	if err = Request("POST", domain, path, params); err != nil {
-		return err
-	}
-	return nil
+	return Request("POST", domain, path, params)
 }
 
 // Request is a utility method to send request to remote sharing party

--- a/pkg/sharings/sharings.go
+++ b/pkg/sharings/sharings.go
@@ -322,13 +322,9 @@ func SharingRefused(db couchdb.Database, state, clientID string) (string, error)
 
 	// Sanity check: as the `recipient` is private if the document is fetched
 	// from the database it is nil.
-	if recStatus.recipient == nil {
-		recipient, errGet := GetRecipient(db, recStatus.RefRecipient.ID)
-		if errGet != nil {
-			return "", nil
-		}
-
-		recStatus.recipient = recipient
+	err = recStatus.GetRecipient(db)
+	if err != nil {
+		return "", nil
 	}
 
 	redirect := recStatus.recipient.URL
@@ -415,8 +411,8 @@ func RegisterRecipient(instance *instance.Instance, rs *RecipientStatus) error {
 	err := rs.Register(instance)
 	if err != nil {
 		if rs.recipient != nil {
-			log.Error("[sharing] Could not register at "+
-				rs.recipient.URL+" ", err)
+			log.Errorf("sharing] Could not register at %v : %v",
+				rs.recipient.URL, err)
 			rs.Status = consts.UnregisteredSharingStatus
 		} else {
 			log.Error("[sharing] Sharing recipient not found")

--- a/pkg/sharings/sharings_test.go
+++ b/pkg/sharings/sharings_test.go
@@ -201,7 +201,7 @@ func createSharing(t *testing.T, sharingType string, docID string, withFile, wit
 		RecipientsStatus: []*RecipientStatus{recStatus},
 	}
 
-	err = CreateSharingAndRegisterSharer(in, sharing)
+	err = CreateSharing(in, sharing)
 	assert.NoError(t, err)
 
 	return sharing, err
@@ -715,13 +715,13 @@ func TestCreateSharingAndRegisterSharer(t *testing.T) {
 	}
 
 	// `SharingType` is wrong.
-	err := CreateSharingAndRegisterSharer(in, sharing)
+	err := CreateSharing(in, sharing)
 	assert.Equal(t, ErrBadSharingType, err)
 
 	// `SharingType` is correct.
 	sharing.SharingType = consts.OneShotSharing
 	// However the recipient is not persisted in the database.
-	err = CreateSharingAndRegisterSharer(in, sharing)
+	err = CreateSharing(in, sharing)
 	assert.Equal(t, ErrRecipientDoesNotExist, err)
 
 	// The CreateSharingAndRegisterSharer scenario that succeeds is already

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -194,8 +194,9 @@ func AddSharingRecipient(c echo.Context) error {
 	if err = c.Bind(&ref); err != nil {
 		return err
 	}
-	rs := &sharings.RecipientStatus{}
-	rs.RefRecipient = ref
+	rs := &sharings.RecipientStatus{
+		RefRecipient: ref,
+	}
 	sharing.RecipientsStatus = append(sharing.RecipientsStatus, rs)
 
 	if err = sharings.RegisterRecipient(instance, rs); err != nil {

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -205,7 +205,8 @@ func AddSharingRecipient(c echo.Context) error {
 		return wrapErrors(err)
 	}
 
-	return wrapErrors(err)
+	return jsonapi.Data(c, http.StatusOK, &apiSharing{sharing}, nil)
+
 }
 
 // RecipientRefusedSharing is called when the recipient refused the sharing.

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -91,8 +91,8 @@ func SharingAnswer(c echo.Context) error {
 	return c.Redirect(http.StatusFound, u)
 }
 
-// AddRecipient adds a sharing Recipient.
-func AddRecipient(c echo.Context) error {
+// CreateRecipient adds a sharing Recipient.
+func CreateRecipient(c echo.Context) error {
 
 	recipient := new(sharings.Recipient)
 	if err := c.Bind(recipient); err != nil {
@@ -140,7 +140,7 @@ func CreateSharing(c echo.Context) error {
 		return err
 	}
 
-	err := sharings.CreateSharingAndRegisterSharer(instance, sharing)
+	err := sharings.CreateSharing(instance, sharing)
 	if err != nil {
 		return wrapErrors(err)
 	}
@@ -174,6 +174,38 @@ func SendSharingMails(c echo.Context) error {
 	}
 
 	return nil
+}
+
+// AddSharingRecipient adds an existing recipient to an existing sharing
+func AddSharingRecipient(c echo.Context) error {
+	instance := middlewares.GetInstance(c)
+
+	// Get sharing doc
+	id := c.Param("id")
+	sharing := &sharings.Sharing{}
+	err := couchdb.GetDoc(instance, consts.Sharings, id, sharing)
+	if err != nil {
+		err = sharings.ErrSharingDoesNotExist
+		return wrapErrors(err)
+	}
+
+	// Create recipient, register, and send mail
+	ref := couchdb.DocReference{}
+	if err = c.Bind(&ref); err != nil {
+		return err
+	}
+	rs := &sharings.RecipientStatus{}
+	rs.RefRecipient = ref
+	sharing.RecipientsStatus = append(sharing.RecipientsStatus, rs)
+
+	if err = sharings.RegisterRecipient(instance, rs); err != nil {
+		return wrapErrors(err)
+	}
+	if err = sharings.SendSharingMails(instance, sharing); err != nil {
+		return wrapErrors(err)
+	}
+
+	return wrapErrors(err)
 }
 
 // RecipientRefusedSharing is called when the recipient refused the sharing.
@@ -278,11 +310,12 @@ func deleteDocument(c echo.Context) error {
 // Routes sets the routing for the sharing service
 func Routes(router *echo.Group) {
 	router.POST("/", CreateSharing)
+	router.PUT("/:id/recipient", AddSharingRecipient)
 	router.PUT("/:id/sendMails", SendSharingMails)
 	router.GET("/request", SharingRequest)
 	router.GET("/answer", SharingAnswer)
 	router.POST("/formRefuse", RecipientRefusedSharing)
-	router.POST("/recipient", AddRecipient)
+	router.POST("/recipient", CreateRecipient)
 
 	group := router.Group("/doc/:doctype", data.ValidDoctype)
 	group.POST("/:docid", receiveDocument)

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -2,7 +2,6 @@ package sharings
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/url"
 
@@ -127,10 +126,10 @@ func SharingRequest(c echo.Context) error {
 	// Particular case for master-master: register the sharer
 	if sharingType == consts.MasterMasterSharing {
 		if err = sharings.RegisterSharer(instance, sharing); err != nil {
-			return err
+			return wrapErrors(err)
 		}
 		if err = sharings.SendClientID(instance, sharing); err != nil {
-			return err
+			return wrapErrors(err)
 		}
 	}
 
@@ -214,9 +213,6 @@ func AddSharingRecipient(c echo.Context) error {
 	if err = sharings.SendSharingMails(instance, sharing); err != nil {
 		return wrapErrors(err)
 	}
-	fmt.Printf("add recipient ok\n")
-	fmt.Printf("sharing : %+v\n", sharing)
-
 	return jsonapi.Data(c, http.StatusOK, &apiSharing{sharing}, nil)
 
 }
@@ -270,7 +266,7 @@ func ReceiveClientID(c echo.Context) error {
 	}
 	sharing, rec, err := sharings.FindSharingRecipient(instance, p.SharingID, p.ClientID)
 	if err != nil {
-		return err
+		return wrapErrors(err)
 	}
 	rec.HostClientID = p.HostClientID
 	err = couchdb.UpdateDoc(instance, sharing)


### PR DESCRIPTION
In a Master-Master sharing context, the recipient must register an OAuth client to the sharer, as it will be necessary for the recipient to have access on the sharer docs.
This PR implements this registration, just after the sharing request is received on the recipient side. It then sends the generated `client_id` to the sharer, for him to save it in his sharing document.

Note this relies on #502