### PR TITLE
Use COZY_URL instead of COZY_DOMAIN

### DIFF
--- a/docs/konnectors_workflow_example.md
+++ b/docs/konnectors_workflow_example.md
@@ -368,7 +368,7 @@ Start the konnector through Rkt, passing as ENV variables :
 
     - `COZY_CREDENTIALS`:  security token to communicate with Cozy
     - `COZY_FIELDS`:       JSON-encoded worker_arguments
-    - `COZY_DOMAIN`:       the starting instance domain
+    - `COZY_URL`:          the starting instance URL
 
 The konnector proces can send events trough it's stdout (newline separated JSON object), 
 the konnector worker pass these events to the realtime hub as `io.cozy.jobs.events`.

--- a/pkg/workers/konnectors/konnector.go
+++ b/pkg/workers/konnectors/konnector.go
@@ -119,9 +119,9 @@ func Worker(ctx context.Context, m *jobs.Message) error {
 	konnCmd := config.GetConfig().Konnectors.Cmd
 	cmd := exec.CommandContext(ctx, konnCmd, workDir) // #nosec
 	cmd.Env = []string{
+		"COZY_URL=" + inst.PageURL("/", nil),
 		"COZY_CREDENTIALS=" + token,
 		"COZY_FIELDS=" + string(fieldsJSON),
-		"COZY_DOMAIN=" + domain,
 		"COZY_JOB_ID=" + jobID,
 	}
 

--- a/pkg/workers/konnectors/konnector_test.go
+++ b/pkg/workers/konnectors/konnector_test.go
@@ -88,7 +88,7 @@ func TestSuccess(t *testing.T) {
 
 	script := `#!/bin/bash
 
-echo "{\"COZY_DOMAIN\":\"${COZY_DOMAIN}\", \"COZY_CREDENTIALS\":\"${COZY_CREDENTIALS}\"}"
+echo "{\"COZY_URL\":\"${COZY_URL}\", \"COZY_CREDENTIALS\":\"${COZY_CREDENTIALS}\"}"
 echo "${COZY_FIELDS}"
 echo "bad json"
 echo "{\"Manifest\": \"$(ls ${1}/manifest.konnector)\"}"
@@ -145,7 +145,7 @@ echo "{\"Manifest\": \"$(ls ${1}/manifest.konnector)\"}"
 		doc3 := ev3.Doc.(couchdb.JSONDoc)
 		assert.Equal(t, inst.Domain, ev1.Instance)
 		assert.Equal(t, inst.Domain, ev2.Instance)
-		assert.Equal(t, inst.Domain, doc1.M["COZY_DOMAIN"])
+		assert.Equal(t, inst.PageURL("/", nil), doc1.M["COZY_URL"])
 		assert.Equal(t, account, doc2.M["account"])
 
 		man := doc3.M["Manifest"].(string)

--- a/scripts/konnector-rkt-run.sh
+++ b/scripts/konnector-rkt-run.sh
@@ -10,7 +10,7 @@ echo "COZY_URL=${COZY_URL}" > "${env_file}"
 echo "COZY_FIELDS=${COZY_FIELDS}" >> "${env_file}"
 echo "COZY_CREDENTIALS=${COZY_CREDENTIALS}" >> "${env_file}"
 
-rkt_name=$(echo $COZY_JOB_ID | tr A-Z a-z | sed -e 's/[^a-zA-Z0-9\-]/-/g')
+rkt_name=$(echo $COZY_JOB_ID | tr A-Z a-z | sed -e 's/[^a-z0-9\-]/-/g')
 
 trap 'sudo rkt stop --force --uuid-file="${uuid_file}" 1>&2 && sudo rkt rm --uuid-file="${uuid_file}" 1>&2' SIGINT SIGTERM EXIT
 

--- a/scripts/konnector-rkt-run.sh
+++ b/scripts/konnector-rkt-run.sh
@@ -6,7 +6,7 @@ uuid_file="${1}/.rkt/uuid"
 
 node_image="$(dirname ${0})/nodeslim.aci"
 
-echo "COZY_DOMAIN=${COZY_DOMAIN}" > "${env_file}"
+echo "COZY_URL=${COZY_URL}" > "${env_file}"
 echo "COZY_FIELDS=${COZY_FIELDS}" >> "${env_file}"
 echo "COZY_CREDENTIALS=${COZY_CREDENTIALS}" >> "${env_file}"
 


### PR DESCRIPTION
Seen with @doubleface, it is preferable that the instance gives the url of the cozy instead of the domain only in the case the instance is a `dev` instance and is served over http.