### PR TITLE
Add master-master sharing token exchange

### DIFF
--- a/pkg/sharings/errors.go
+++ b/pkg/sharings/errors.go
@@ -11,6 +11,8 @@ var (
 	ErrMissingScope = errors.New("The scope parameter is mandatory")
 	//ErrMissingState is used when a request is missing the mandatory state
 	ErrMissingState = errors.New("The state parameter is mandatory")
+	//ErrMissingCode is used when a request is missing the mandatory code
+	ErrMissingCode = errors.New("The code parameter is mandatory")
 	// ErrSharingDoesNotExist is used when the given sharing does not exist.
 	ErrSharingDoesNotExist = errors.New("Sharing does not exist")
 	// ErrRecipientHasNoEmail is used to signal that a recipient has no email.

--- a/pkg/sharings/recipients.go
+++ b/pkg/sharings/recipients.go
@@ -80,9 +80,6 @@ func (rs *RecipientStatus) GetRecipient(db couchdb.Database) error {
 // CreateRecipient inserts a Recipient document in database. Email and URL must
 // not be empty.
 func CreateRecipient(db couchdb.Database, doc *Recipient) error {
-	if doc.Email == "" {
-		return ErrRecipientHasNoEmail
-	}
 	if doc.URL == "" {
 		return ErrRecipientHasNoURL
 	}

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -587,6 +587,33 @@ func TestReceiveClientIDSuccess(t *testing.T) {
 	assert.Equal(t, 200, res.StatusCode)
 }
 
+func TestGetAccessTokenMissingState(t *testing.T) {
+	res, err := postJSON(t, "/sharings/access/code", echo.Map{
+		"state": "",
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 400, res.StatusCode)
+}
+
+func TestGetAccessTokenMissingCode(t *testing.T) {
+	sharing, err := createSharing(t, nil)
+	assert.NoError(t, err)
+	res, err := postJSON(t, "/sharings/access/code", echo.Map{
+		"state": sharing.SharingID,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 500, res.StatusCode)
+}
+
+func TestGetAccessTokenBadState(t *testing.T) {
+	res, err := postJSON(t, "/sharings/access/code", echo.Map{
+		"state": "fakeid",
+		"code":  "fakecode",
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 404, res.StatusCode)
+}
+
 func TestMain(m *testing.M) {
 	config.UseTestFile()
 	testutils.NeedCouchdb()


### PR DESCRIPTION
This completes en ends the master-master OAuth support.
After a sharing being accepted and the answer received on the sharer side, an access code is generated and sent to the recipient. He then asks the sharer for an access token, and save it in database.

Note this relies on #516 