### PR TITLE
Fix sharing recipient adding

### DIFF
--- a/pkg/sharings/send_mails.go
+++ b/pkg/sharings/send_mails.go
@@ -44,9 +44,8 @@ func SendSharingMails(instance *instance.Instance, s *Sharing) error {
 
 	errorOccurred := false
 	for _, rs := range s.RecipientsStatus {
-
-		// A non-empty status indicates a recipient already treated
-		if rs.Status != "" {
+		// Send mail based on the recipient status
+		if rs.Status == consts.MailNotSentSharingStatus {
 			err = rs.GetRecipient(instance)
 			if err != nil {
 				return err
@@ -94,7 +93,6 @@ func SendSharingMails(instance *instance.Instance, s *Sharing) error {
 			rs.Status = consts.PendingSharingStatus
 		}
 	}
-
 	// Persist the modifications in the database.
 	err = couchdb.UpdateDoc(instance, s)
 	if err != nil {

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -46,7 +46,9 @@ func (s *apiSharing) Included() []jsonapi.Object {
 	var included []jsonapi.Object
 	for _, rec := range s.RecipientsStatus {
 		r := rec.GetCachedRecipient()
-		included = append(included, &apiRecipient{r})
+		if r != nil {
+			included = append(included, &apiRecipient{r})
+		}
 	}
 	return included
 }


### PR DESCRIPTION
This fixes 2 things:

- Add a new sharing recipient doesn't trigger a new mail to the existing recipients for this sharing
- A nil recipient doesn't cause jsonapi to crash for a nil pointer reference