### PR TITLE
Dynamic sharing for files

### DIFF
--- a/pkg/vfs/permissions.go
+++ b/pkg/vfs/permissions.go
@@ -147,6 +147,8 @@ func (f *FileDoc) Valid(field, expected string) bool {
 		return f.Class == expected
 	case "tags":
 		return contains(f.Tags, expected)
+	case "dir_id":
+		return f.DirID == expected
 	default:
 		return false
 	}

--- a/pkg/workers/sharings/sharing_updates.go
+++ b/pkg/workers/sharings/sharing_updates.go
@@ -162,11 +162,10 @@ func sendToRecipients(db couchdb.Database, domain string, sharing *Sharing, docT
 		Method:     method,
 		Recipients: recInfos,
 	}
-	// TODO: handle file sharing
 	if opts.DocType != consts.Files {
 		return SendDoc(domain, opts)
 	}
-	return nil
+	return SendFile(domain, opts)
 }
 
 // GetRecipient returns the Recipient stored in database from a given ID


### PR DESCRIPTION
This adds the possibility to define a permission on a `dir_id`, which is useful to share a directory through a selector.
Note this only handles one level of a hierarchy: full recursive permissions will probably require more work.