### PR TITLE
Share files updates

### DIFF
--- a/client/files.go
+++ b/client/files.go
@@ -292,8 +292,9 @@ func (c *Client) Move(from, to string) error {
 	}
 	_, err = c.UpdateAttrsByPath(from, &FilePatch{
 		Attrs: FilePatchAttrs{
-			DirID: doc.ID,
-			Name:  path.Base(to),
+			DirID:     doc.ID,
+			Name:      path.Base(to),
+			UpdatedAt: time.Now(),
 		},
 	})
 	return err

--- a/pkg/sharings/sharings.go
+++ b/pkg/sharings/sharings.go
@@ -6,8 +6,6 @@ import (
 	"io"
 	"strings"
 
-	"net/http"
-
 	log "github.com/Sirupsen/logrus"
 	"github.com/cozy/cozy-stack/client/request"
 	"github.com/cozy/cozy-stack/pkg/consts"
@@ -283,7 +281,6 @@ func ShareDoc(instance *instance.Instance, sharing *Sharing, recStatus *Recipien
 
 			workerMsg, err := jobs.NewMessage(jobs.JSONEncoding, sharingWorker.SendOptions{
 				DocID:      val,
-				Method:     http.MethodPost,
 				DocType:    docType,
 				Recipients: []*sharingWorker.RecipientInfo{rec},
 			})

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 )
@@ -616,7 +617,8 @@ func normalizeDocPatch(data, patch *DocPatch, cdate time.Time) (*DocPatch, error
 	}
 
 	if patch.UpdatedAt.Before(cdate) {
-		return nil, ErrIllegalTime
+		log.Error("UPDATE is before CREATION")
+		// return nil, ErrIllegalTime
 	}
 
 	if patch.Executable == nil {

--- a/pkg/workers/sharings/share_data.go
+++ b/pkg/workers/sharings/share_data.go
@@ -4,17 +4,24 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
 	"time"
 
+	"strings"
+
 	"github.com/cozy/cozy-stack/client/request"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/pkg/jobs"
+	"github.com/cozy/cozy-stack/pkg/vfs"
+	"github.com/cozy/cozy-stack/web/files"
+	"github.com/cozy/cozy-stack/web/jsonapi"
+	"github.com/labstack/echo"
 	"github.com/labstack/gommon/log"
 )
 
@@ -27,18 +34,86 @@ func init() {
 	})
 }
 
-// SendOptions describes the parameters needed to send data
-type SendOptions struct {
-	DocID      string
-	DocType    string
-	Method     string
-	Recipients []*RecipientInfo
-}
-
 // RecipientInfo describes the recipient information
 type RecipientInfo struct {
 	URL   string
 	Token string
+}
+
+// SendOptions describes the parameters needed to send data
+type SendOptions struct {
+	DocID      string
+	DocType    string
+	Type       string
+	Method     string
+	Recipients []*RecipientInfo
+	Path       string
+	DocRev     string
+
+	fileOpts *fileOptions
+}
+
+type fileOptions struct {
+	contentlength string
+	mime          string
+	md5           string
+	queries       url.Values
+	content       vfs.File
+	set           bool // default value is false
+}
+
+// fillDetailsAndOpenFile will augment the SendOptions structure with the
+// details regarding the file to share and open it so that it can be sent.
+//
+// WARNING: the file descriptor must be closed!
+//
+// The idea behind this function is to prevent multiple creations of a file
+// descriptor, in order to limit I/O to a single opening.
+// This function will set the field `set` of the SendOptions structure to `true`
+// the first time it is called and thus causing later calls to immediately
+// return.
+func (opts *SendOptions) fillDetailsAndOpenFile(fs vfs.VFS, fileDoc *vfs.FileDoc) error {
+	if opts.fileOpts != nil && opts.fileOpts.set {
+		return nil
+	}
+
+	fileOpts := &fileOptions{}
+
+	fileOpts.mime = fileDoc.Mime
+	fileOpts.contentlength = strconv.FormatInt(fileDoc.ByteSize, 10)
+	fileOpts.md5 = base64.StdEncoding.EncodeToString(fileDoc.MD5Sum)
+
+	// Send references for permissions
+	// TODO: only send the reference linked to the actual permission
+	b, err := json.Marshal(fileDoc.ReferencedBy)
+	if err != nil {
+		return nil
+	}
+	refs := string(b[:])
+	fileOpts.queries = url.Values{
+		"Type":          {consts.FileType},
+		"Name":          {fileDoc.DocName},
+		"Executable":    {strconv.FormatBool(fileDoc.Executable)},
+		"Referenced_by": []string{refs},
+	}
+
+	content, err := fs.OpenFile(fileDoc)
+	if err != nil {
+		return err
+	}
+	fileOpts.content = content
+	fileOpts.set = true
+
+	opts.fileOpts = fileOpts
+	return nil
+}
+
+func (opts *SendOptions) closeFile() error {
+	if opts.fileOpts != nil && opts.fileOpts.set {
+		return opts.fileOpts.content.Close()
+	}
+
+	return nil
 }
 
 // SendData sends data to all the recipients
@@ -50,20 +125,35 @@ func SendData(ctx context.Context, m *jobs.Message) error {
 	if err != nil {
 		return err
 	}
-	if opts.DocType != consts.Files {
-		if opts.Method == http.MethodDelete {
-			return DeleteDoc(domain, opts)
-		}
-		return SendDoc(domain, opts)
+
+	ins, err := instance.Get(domain)
+	if err != nil {
+		return err
 	}
-	return SendFile(domain, opts)
+
+	opts.Path = fmt.Sprintf("/sharings/doc/%s/%s", opts.DocType, opts.DocID)
+
+	if opts.DocType == consts.Files {
+		dirDoc, fileDoc, err := ins.VFS().DirOrFileByID(opts.DocID)
+		if err != nil {
+			return err
+		}
+
+		if dirDoc != nil {
+			opts.Type = consts.DirType
+			return SendDir(ins, opts, dirDoc)
+		}
+
+		opts.Type = consts.FileType
+		return SendFile(ins, opts, fileDoc)
+	}
+
+	return SendDoc(ins, opts)
 }
 
 // DeleteDoc asks the recipients to delete the shared document which id was
 // provided.
-func DeleteDoc(domain string, opts *SendOptions) error {
-	path := fmt.Sprintf("/sharings/doc/%s/%s", opts.DocType, opts.DocID)
-
+func DeleteDoc(opts *SendOptions) error {
 	for _, rec := range opts.Recipients {
 		rev, err := getDocRevAtRecipient(opts.DocType, opts.DocID, rec)
 		if err != nil {
@@ -74,14 +164,13 @@ func DeleteDoc(domain string, opts *SendOptions) error {
 
 		_, errSend := request.Req(&request.Options{
 			Domain: rec.URL,
-			Method: opts.Method,
-			Path:   path,
+			Method: http.MethodDelete,
+			Path:   opts.Path,
 			Headers: request.Headers{
 				"Content-Type":  "application/json",
 				"Accept":        "application/json",
 				"Authorization": "Bearer " + rec.Token,
 			},
-			Body:       nil,
 			Queries:    url.Values{"rev": {rev}},
 			NoResponse: true,
 		})
@@ -95,15 +184,10 @@ func DeleteDoc(domain string, opts *SendOptions) error {
 	return nil
 }
 
-// SendDoc sends a JSON document to the recipients
-func SendDoc(domain string, opts *SendOptions) error {
-	// Get the doc
-	i, err := instance.Get(domain)
-	if err != nil {
-		return err
-	}
+// SendDoc sends or updates a JSON document to the recipients.
+func SendDoc(ins *instance.Instance, opts *SendOptions) error {
 	doc := &couchdb.JSONDoc{}
-	if err := couchdb.GetDoc(i, opts.DocType, opts.DocID, doc); err != nil {
+	if err := couchdb.GetDoc(ins, opts.DocType, opts.DocID, doc); err != nil {
 		return err
 	}
 	// A new doc will be created on the recipient side
@@ -111,8 +195,6 @@ func SendDoc(domain string, opts *SendOptions) error {
 		delete(doc.M, "_id")
 		delete(doc.M, "_rev")
 	}
-
-	path := fmt.Sprintf("/sharings/doc/%s/%s", opts.DocType, opts.DocID)
 
 	for _, rec := range opts.Recipients {
 		// A doc update requires to set the doc revision from each recipient
@@ -134,8 +216,8 @@ func SendDoc(domain string, opts *SendOptions) error {
 		// TODO : handle send failures
 		_, errSend := request.Req(&request.Options{
 			Domain: rec.URL,
-			Method: opts.Method,
-			Path:   path,
+			Method: http.MethodPost,
+			Path:   opts.Path,
 			Headers: request.Headers{
 				"Content-Type":  "application/json",
 				"Accept":        "application/json",
@@ -153,90 +235,283 @@ func SendDoc(domain string, opts *SendOptions) error {
 }
 
 // SendFile sends a binary file to the recipients
-func SendFile(domain string, opts *SendOptions) error {
-
-	// Particular case for the root directory: don't share it
-	if opts.DocID == consts.RootDirID {
-		return nil
-	}
-
-	// Get VFS reference from instance
-	i, err := instance.Get(domain)
+func SendFile(ins *instance.Instance, opts *SendOptions, fileDoc *vfs.FileDoc) error {
+	err := opts.fillDetailsAndOpenFile(ins.VFS(), fileDoc)
 	if err != nil {
 		return err
 	}
-	if i == nil {
-		log.Error("[sharing] An error occurred while trying to share " +
-			"a file: instance not found")
-		return nil
-	}
-	fs := i.VFS()
+	defer opts.closeFile()
 
-	// Get file doc
-	doc, err := fs.FileByID(opts.DocID)
-	if err != nil {
-		return err
-	}
-	// Send references for permissions
-	// TODO: only send the reference linked  to the actual permission
-	b, err := json.Marshal(doc.ReferencedBy)
-	if err != nil {
-		return nil
-	}
-	refs := string(b[:])
-
-	path := fmt.Sprintf("/sharings/doc/%s/%s", consts.Files, opts.DocID)
-	query := url.Values{
-		"Type":          []string{consts.FileType},
-		"Name":          []string{doc.DocName},
-		"Referenced_by": []string{refs},
-	}
-	md5 := base64.StdEncoding.EncodeToString(doc.MD5Sum)
-	length := strconv.FormatInt(doc.ByteSize, 10)
-
-	// Get file content
-	content, err := fs.OpenFile(doc)
-	if err != nil {
-		return err
-	}
-	defer content.Close()
+	opts.Method = http.MethodPost
 
 	for _, rec := range opts.Recipients {
+		err = sendFileToRecipient(opts, rec)
 		if err != nil {
-			return err
-		}
-
-		_, errSend := request.Req(&request.Options{
-			Domain: rec.URL,
-			Method: opts.Method,
-			Path:   path,
-			Headers: request.Headers{
-				"Content-Type":   doc.Mime,
-				"Accept":         "application/vnd.api+json",
-				"Content-Length": length,
-				"Content-MD5":    md5,
-				"Authorization":  "Bearer " + rec.Token,
-			},
-			Queries: query,
-			Body:    content,
-		})
-		if errSend != nil {
 			log.Error("[sharing] An error occurred while trying to share "+
-				"file : ", errSend)
+				"file "+fileDoc.DocName+": ", err)
 		}
 	}
 
 	return nil
 }
 
-// getDocRevAtRecipient returns the revision of the document at the given
+// SendDir sends a directory to the recipients.
+func SendDir(ins *instance.Instance, opts *SendOptions, dirDoc *vfs.DirDoc) error {
+	dirPath, err := dirDoc.Path(ins.VFS())
+	if err != nil {
+		return err
+	}
+	dirTags := strings.Join(dirDoc.Tags, files.TagSeparator)
+
+	for _, recipient := range opts.Recipients {
+		_, err := request.Req(&request.Options{
+			Domain: recipient.URL,
+			Method: http.MethodPost,
+			Path:   opts.Path,
+			Headers: request.Headers{
+				echo.HeaderContentType:   echo.MIMEApplicationJSON,
+				echo.HeaderAuthorization: "Bearer " + recipient.Token,
+			},
+			Queries: url.Values{
+				"Tags":      {dirTags},
+				"Path":      {dirPath},
+				"Recursive": {"true"},
+				"Name":      {dirDoc.DocName},
+				"Type":      {consts.DirType},
+			},
+			NoResponse: true,
+		})
+		if err != nil {
+			log.Error("[sharing] An error occurred while trying to share "+
+				"the directory "+dirDoc.DocName+": ", err)
+		}
+	}
+
+	return nil
+}
+
+// UpdateOrPatchFile uploads the file to the recipients if the md5sum has
+// changed compared to their local version, and sends a patch if not.
+func UpdateOrPatchFile(ins *instance.Instance, opts *SendOptions, fileDoc *vfs.FileDoc) error {
+	md5 := base64.StdEncoding.EncodeToString(fileDoc.MD5Sum)
+
+	// A file descriptor can be open in the for loop.
+	defer opts.closeFile()
+
+	for _, recipient := range opts.Recipients {
+		md5AtRec, rev, err := getFileMD5AndRevAtRecipient(opts.DocID, recipient)
+		if err != nil {
+			log.Error("[sharing] Could not get MD5 at "+recipient.URL+": ", err)
+			continue
+		}
+		opts.DocRev = rev
+
+		if md5 == md5AtRec {
+			patch, err := generateDirOrFilePatch(nil, fileDoc)
+			if err != nil {
+				log.Error("[sharing] Could not generate patch for file "+
+					fileDoc.DocName+": ", err)
+				continue
+			}
+			err = sendPatchToRecipient(patch, opts, recipient)
+			if err != nil {
+				log.Error("[sharing] An error occurred while trying to "+
+					"send patch: ", err)
+			}
+
+			continue
+		}
+
+		opts.Method = http.MethodPut
+		err = opts.fillDetailsAndOpenFile(ins.VFS(), fileDoc)
+		if err != nil {
+			log.Error("[sharing] An error occurred while trying to open "+
+				fileDoc.DocName+": ", err)
+			continue
+		}
+		err = sendFileToRecipient(opts, recipient)
+		if err != nil {
+			log.Error("[sharing] An error occurred while trying to share an "+
+				"update of file "+fileDoc.DocName+" to a recipient: ", err)
+		}
+	}
+
+	return nil
+}
+
+// PatchDir updates the metadata of the corresponding directory at each
+// recipient's.
+func PatchDir(opts *SendOptions, dirDoc *vfs.DirDoc) error {
+	patch, err := generateDirOrFilePatch(dirDoc, nil)
+	if err != nil {
+		return err
+	}
+
+	for _, rec := range opts.Recipients {
+		rev, err := getDirOrFileRevAtRecipient(opts.DocID, rec)
+		if err != nil {
+			return err
+		}
+		opts.DocRev = rev
+		err = sendPatchToRecipient(patch, opts, rec)
+		if err != nil {
+			log.Error("[sharing] An error occurred while trying to send "+
+				"a patch: ", err)
+		}
+	}
+
+	return nil
+}
+
+// DeleteDirOrFile asks the recipients to put the file or directory in the
+// trash.
+func DeleteDirOrFile(opts *SendOptions) error {
+	for _, recipient := range opts.Recipients {
+		rev, err := getDirOrFileRevAtRecipient(opts.DocID, recipient)
+		if err != nil {
+			log.Error("[sharing] (delete) An error occurred while trying "+
+				"to get a revision at "+recipient.URL+":", err)
+			continue
+		}
+		opts.DocRev = rev
+
+		_, err = request.Req(&request.Options{
+			Domain: recipient.URL,
+			Method: http.MethodDelete,
+			Path:   opts.Path,
+			Headers: request.Headers{
+				echo.HeaderContentType:   echo.MIMEApplicationJSON,
+				echo.HeaderAuthorization: "Bearer " + recipient.Token,
+			},
+			Queries: url.Values{
+				"rev":  {opts.DocRev},
+				"Type": {opts.Type},
+			},
+			NoResponse: true,
+		})
+
+		if err != nil {
+			log.Error("[sharing] (delete) An error occurred while sending "+
+				"request to "+recipient.URL+": ", err)
+		}
+	}
+
+	return nil
+}
+
+func sendFileToRecipient(opts *SendOptions, recipient *RecipientInfo) error {
+	if !opts.fileOpts.set {
+		return errors.New("[sharing] fileOpts were not set")
+	}
+
+	// This function can be called for an update or for a creation so the
+	// `method` has to be set beforehand.
+	if opts.Method == "" {
+		return errors.New("[sharing] HTTP Method wasn't set")
+	}
+
+	if opts.DocRev != "" {
+		opts.fileOpts.queries.Add("rev", opts.DocRev)
+	}
+
+	_, err := request.Req(&request.Options{
+		Domain: recipient.URL,
+		Method: opts.Method,
+		Path:   opts.Path,
+		Headers: request.Headers{
+			"Content-Type":   opts.fileOpts.mime,
+			"Accept":         "application/vnd.api+json",
+			"Content-Length": opts.fileOpts.contentlength,
+			"Content-MD5":    opts.fileOpts.md5,
+			"Authorization":  "Bearer " + recipient.Token,
+		},
+		Queries:    opts.fileOpts.queries,
+		Body:       opts.fileOpts.content,
+		NoResponse: true,
+	})
+
+	return err
+}
+
+func sendPatchToRecipient(patch *jsonapi.Document, opts *SendOptions, recipient *RecipientInfo) error {
+	body, err := request.WriteJSON(patch)
+	if err != nil {
+		return err
+	}
+
+	_, err = request.Req(&request.Options{
+		Domain: recipient.URL,
+		Method: http.MethodPatch,
+		Path:   opts.Path,
+		Headers: request.Headers{
+			echo.HeaderContentType:   jsonapi.ContentType,
+			echo.HeaderAuthorization: "Bearer " + recipient.Token,
+		},
+		Queries: url.Values{
+			"rev":  {opts.DocRev},
+			"Type": {opts.Type},
+		},
+		Body:       body,
+		NoResponse: true,
+	})
+
+	return err
+}
+
+// Generates a document patch for the given document.
+//
+// The server expects a jsonapi.Document structure, see:
+// http://jsonapi.org/format/#document-structure
+// The data part of the jsonapi.Document contains an ObjectMarshalling, see:
+// web/jsonapi/data.go:66
+func generateDirOrFilePatch(dirDoc *vfs.DirDoc, fileDoc *vfs.FileDoc) (*jsonapi.Document, error) {
+	var patch vfs.DocPatch
+	var id string
+	var rev string
+
+	if dirDoc != nil {
+		patch.Name = &dirDoc.DocName
+		patch.DirID = &dirDoc.DirID
+		patch.Tags = &dirDoc.Tags
+		patch.UpdatedAt = &dirDoc.UpdatedAt
+		id = dirDoc.ID()
+		rev = dirDoc.Rev()
+	} else {
+		patch.Name = &fileDoc.DocName
+		patch.DirID = &fileDoc.DirID
+		patch.Tags = &fileDoc.Tags
+		patch.UpdatedAt = &fileDoc.UpdatedAt
+		id = fileDoc.ID()
+		rev = fileDoc.Rev()
+	}
+
+	attrs, err := json.Marshal(patch)
+	if err != nil {
+		return nil, err
+	}
+
+	obj := &jsonapi.ObjectMarshalling{
+		Type:       consts.Files,
+		ID:         id,
+		Attributes: (*json.RawMessage)(&attrs),
+		Meta:       jsonapi.Meta{Rev: rev},
+	}
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	return &jsonapi.Document{Data: (*json.RawMessage)(&data)}, nil
+}
+
+// getDocAtRecipient returns the revision of the document at the given
 // recipient.
 func getDocRevAtRecipient(doctype, docID string, recInfo *RecipientInfo) (string, error) {
 	path := fmt.Sprintf("/data/%s/%s", doctype, docID)
 
 	res, err := request.Req(&request.Options{
 		Domain: recInfo.URL,
-		Method: "GET",
+		Method: http.MethodGet,
 		Path:   path,
 		Headers: request.Headers{
 			"Content-Type":  "application/json",
@@ -247,10 +522,73 @@ func getDocRevAtRecipient(doctype, docID string, recInfo *RecipientInfo) (string
 	if err != nil {
 		return "", err
 	}
+
 	doc := &couchdb.JSONDoc{}
 	if err := request.ReadJSON(res.Body, doc); err != nil {
 		return "", err
 	}
 	rev := doc.M["_rev"].(string)
 	return rev, nil
+}
+
+func getFileMD5AndRevAtRecipient(fileID string, recipient *RecipientInfo) (md5sum, rev string, err error) {
+	data, err := getFileOrDirMetadataAtRecipient(fileID, recipient)
+	if err != nil {
+		return "", "", err
+	}
+
+	attributes := data["attributes"].(map[string]interface{})
+	md5sum = attributes["md5sum"].(string)
+	meta := data["meta"].(map[string]interface{})
+	rev = meta["rev"].(string)
+
+	return
+}
+
+func getDirOrFileRevAtRecipient(docID string, recipient *RecipientInfo) (string, error) {
+	data, err := getFileOrDirMetadataAtRecipient(docID, recipient)
+	if err != nil {
+		return "", err
+	}
+
+	meta := data["meta"].(map[string]interface{})
+	rev := meta["rev"].(string)
+	return rev, nil
+}
+
+func getFileOrDirMetadataAtRecipient(id string, recInfo *RecipientInfo) (map[string]interface{}, error) {
+	path := fmt.Sprintf("/files/%s", id)
+
+	res, err := request.Req(&request.Options{
+		Domain: recInfo.URL,
+		Method: http.MethodGet,
+		Path:   path,
+		Headers: request.Headers{
+			echo.HeaderContentType:    echo.MIMEApplicationJSON,
+			echo.HeaderAcceptEncoding: echo.MIMEApplicationJSON,
+			echo.HeaderAuthorization:  "Bearer " + recInfo.Token,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	doc := map[string]interface{}{}
+	err = request.ReadJSON(res.Body, &doc)
+	if err != nil {
+		return nil, err
+	}
+
+	// What is returned by the stack has the following structure:
+	// data : {
+	//		attributes: {
+	//			md5sum: string,
+	//			…,
+	//		},
+	//		meta: {
+	//			rev: string,
+	//		},
+	// }
+	data := doc["data"].(map[string]interface{})
+	return data, nil
 }

--- a/pkg/workers/sharings/share_data.go
+++ b/pkg/workers/sharings/share_data.go
@@ -307,16 +307,16 @@ func UpdateOrPatchFile(ins *instance.Instance, opts *SendOptions, fileDoc *vfs.F
 		opts.DocRev = rev
 
 		if md5 == md5AtRec {
-			patch, err := generateDirOrFilePatch(nil, fileDoc)
-			if err != nil {
+			patch, errp := generateDirOrFilePatch(nil, fileDoc)
+			if errp != nil {
 				log.Error("[sharing] Could not generate patch for file "+
-					fileDoc.DocName+": ", err)
+					fileDoc.DocName+": ", errp)
 				continue
 			}
-			err = sendPatchToRecipient(patch, opts, recipient)
-			if err != nil {
+			errsp := sendPatchToRecipient(patch, opts, recipient)
+			if errsp != nil {
 				log.Error("[sharing] An error occurred while trying to "+
-					"send patch: ", err)
+					"send patch: ", errsp)
 			}
 
 			continue

--- a/pkg/workers/sharings/share_data_test.go
+++ b/pkg/workers/sharings/share_data_test.go
@@ -189,7 +189,6 @@ func TestDeleteDoc(t *testing.T) {
 	opts := &SendOptions{
 		DocID:   testDocID,
 		DocType: testDocType,
-		Method:  http.MethodDelete,
 		Path:    fmt.Sprintf("/sharings/doc/%s/%s", testDocType, testDocID),
 		Recipients: []*RecipientInfo{
 			&RecipientInfo{
@@ -238,7 +237,6 @@ func TestSendFile(t *testing.T) {
 	sendFileOpts := &SendOptions{
 		DocID:   fileDoc.ID(),
 		DocType: fileDoc.DocType(),
-		Method:  http.MethodPost,
 		Type:    consts.FileType,
 		Path: fmt.Sprintf("/sharings/doc/%s/%s", fileDoc.DocType(),
 			fileDoc.ID()),
@@ -285,7 +283,6 @@ func TestSendDir(t *testing.T) {
 	sendDirOpts := &SendOptions{
 		DocID:   dirDoc.ID(),
 		DocType: dirDoc.DocType(),
-		Method:  http.MethodPost,
 		Type:    consts.FileType,
 		Path: fmt.Sprintf("/sharings/doc/%s/%s", dirDoc.DocType(),
 			dirDoc.ID()),
@@ -354,7 +351,6 @@ func TestUpdateOrPatchFile(t *testing.T) {
 	patchSendOptions := &SendOptions{
 		DocID:   fileDoc.ID(),
 		DocType: fileDoc.DocType(),
-		Method:  http.MethodPut,
 		Type:    consts.FileType,
 		Path: fmt.Sprintf("/sharings/doc/%s/%s", fileDoc.DocType(),
 			fileDoc.ID()),
@@ -366,7 +362,6 @@ func TestUpdateOrPatchFile(t *testing.T) {
 	updateSendOptions := &SendOptions{
 		DocID:   updatedFileDoc.ID(),
 		DocType: updatedFileDoc.DocType(),
-		Method:  http.MethodPut,
 		Type:    consts.FileType,
 		Path: fmt.Sprintf("/sharings/doc/%s/%s", updatedFileDoc.DocType(),
 			updatedFileDoc.ID()),
@@ -419,7 +414,6 @@ func TestPatchDir(t *testing.T) {
 	patchSendOptions := &SendOptions{
 		DocID:   dirDoc.ID(),
 		DocType: dirDoc.DocType(),
-		Method:  http.MethodPatch,
 		Type:    consts.DirType,
 		Path: fmt.Sprintf("/sharings/doc/%s/%s", dirDoc.DocType(),
 			dirDoc.ID()),
@@ -465,7 +459,6 @@ func TestDeleteDirOrFile(t *testing.T) {
 	deleteSendOptions := &SendOptions{
 		DocID:   dirDoc.ID(),
 		DocType: dirDoc.DocType(),
-		Method:  http.MethodDelete,
 		Type:    consts.DirType,
 		Path: fmt.Sprintf("/sharings/doc/%s/%s", dirDoc.DocType(),
 			dirDoc.ID()),

--- a/pkg/workers/sharings/share_data_test.go
+++ b/pkg/workers/sharings/share_data_test.go
@@ -395,7 +395,8 @@ func TestPatchDir(t *testing.T) {
 				assert.Equal(t, dirDoc.DocName, *patch.Name)
 				assert.Equal(t, dirDoc.DirID, *patch.DirID)
 				assert.Equal(t, dirDoc.Tags, *patch.Tags)
-				assert.Equal(t, dirDoc.UpdatedAt, *patch.UpdatedAt)
+				assert.Equal(t, dirDoc.UpdatedAt.Unix(),
+					(*patch.UpdatedAt).Unix())
 				return c.JSON(http.StatusOK, nil)
 			})
 		},

--- a/pkg/workers/sharings/share_data_test.go
+++ b/pkg/workers/sharings/share_data_test.go
@@ -317,7 +317,8 @@ func TestUpdateOrPatchFile(t *testing.T) {
 				assert.Equal(t, fileDoc.DocName, *patch.Name)
 				assert.Equal(t, fileDoc.DirID, *patch.DirID)
 				assert.Equal(t, fileDoc.Tags, *patch.Tags)
-				assert.Equal(t, fileDoc.UpdatedAt, *patch.UpdatedAt)
+				assert.Equal(t, fileDoc.UpdatedAt.Unix(),
+					(*patch.UpdatedAt).Unix())
 				return c.JSON(http.StatusOK, nil)
 			})
 			router.PUT("/doc/:doctype/:docid", func(c echo.Context) error {

--- a/pkg/workers/sharings/share_data_test.go
+++ b/pkg/workers/sharings/share_data_test.go
@@ -1,11 +1,17 @@
 package sharings
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
+	"time"
 
 	"net/url"
 
@@ -16,7 +22,10 @@ import (
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/pkg/jobs"
 	"github.com/cozy/cozy-stack/pkg/stack"
+	"github.com/cozy/cozy-stack/pkg/vfs"
 	"github.com/cozy/cozy-stack/tests/testutils"
+	"github.com/cozy/cozy-stack/web/files"
+	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/labstack/echo"
 	"github.com/stretchr/testify/assert"
 )
@@ -25,6 +34,7 @@ var testDocType = "io.cozy.tests"
 var testDocID = "aydiayda"
 
 var in *instance.Instance
+var testInstance *instance.Instance
 var domainSharer = "domain.sharer"
 var setup *testutils.TestSetup
 var ts *httptest.Server
@@ -38,6 +48,36 @@ func createInstance(domain, publicName string) (*instance.Instance, error) {
 		Settings: settings,
 	}
 	return instance.Create(opts)
+}
+
+func createFile(t *testing.T, fs vfs.VFS, name, content string) *vfs.FileDoc {
+	doc, err := vfs.NewFileDoc(name, "", -1, nil, "foo/bar", "foo", time.Now(), false, false, []string{"this", "is", "spartest"})
+	assert.NoError(t, err)
+
+	body := bytes.NewReader([]byte(content))
+
+	file, err := fs.CreateFile(doc, nil)
+	assert.NoError(t, err)
+
+	n, err := io.Copy(file, body)
+	assert.NoError(t, err)
+	assert.Equal(t, len(content), int(n))
+
+	err = file.Close()
+	assert.NoError(t, err)
+
+	return doc
+}
+
+func createDir(t *testing.T, fs vfs.VFS, name string) *vfs.DirDoc {
+	dirDoc, err := vfs.NewDirDoc(fs, name, "", []string{"It's", "me", "again"})
+	assert.NoError(t, err)
+	dirDoc.CreatedAt = time.Now()
+	dirDoc.UpdatedAt = time.Now()
+	err = fs.CreateDir(dirDoc)
+	assert.NoError(t, err)
+
+	return dirDoc
 }
 
 func TestSendDataMissingDocType(t *testing.T) {
@@ -113,14 +153,12 @@ func TestSendDataBadRecipient(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// WARNING: this test creates a new testServer. It might conflict with others,
-// if others were declared.
 func TestDeleteDoc(t *testing.T) {
 	randomrev := "randomrev"
 
 	mpr := map[string]func(*echo.Group){
 		"/sharings": func(router *echo.Group) {
-			router.Any("/doc/:doctype/:docid", func(c echo.Context) error {
+			router.DELETE("/doc/:doctype/:docid", func(c echo.Context) error {
 				assert.Equal(t, randomrev, c.QueryParam("rev"))
 				assert.Equal(t, testDocID, c.Param("docid"))
 				assert.Equal(t, testDocType, c.Param("doctype"))
@@ -128,7 +166,7 @@ func TestDeleteDoc(t *testing.T) {
 			})
 		},
 		"/data": func(router *echo.Group) {
-			router.Any("/:doctype/:docid", func(c echo.Context) error {
+			router.GET("/:doctype/:docid", func(c echo.Context) error {
 				assert.Equal(t, testDocID, c.Param("docid"))
 				assert.Equal(t, testDocType, c.Param("doctype"))
 				doc := &couchdb.JSONDoc{
@@ -141,24 +179,300 @@ func TestDeleteDoc(t *testing.T) {
 			})
 		},
 	}
+	if ts != nil {
+		ts.Close()
+	}
 	ts = setup.GetTestServerMultipleRoutes(mpr)
 
 	tsURL, err := url.Parse(ts.URL)
 	assert.NoError(t, err)
-	domain := tsURL.Host
 	opts := &SendOptions{
 		DocID:   testDocID,
 		DocType: testDocType,
 		Method:  http.MethodDelete,
+		Path:    fmt.Sprintf("/sharings/doc/%s/%s", testDocType, testDocID),
 		Recipients: []*RecipientInfo{
 			&RecipientInfo{
-				URL:   domain,
+				URL:   tsURL.Host,
 				Token: "whoneedsone?",
 			},
 		},
 	}
 
-	err = DeleteDoc(domain, opts)
+	err = DeleteDoc(opts)
+	assert.NoError(t, err)
+}
+
+func TestSendFile(t *testing.T) {
+	fs := testInstance.VFS()
+	fileDoc := createFile(t, fs, "filetestsend", "Hello, it's me again.")
+
+	mpr := map[string]func(*echo.Group){
+		"/sharings": func(router *echo.Group) {
+			router.POST("/doc/:doctype/:docid", func(c echo.Context) error {
+				assert.Equal(t, fileDoc.DocType(), c.Param("doctype"))
+				assert.Equal(t, fileDoc.ID(), c.Param("docid"))
+				assert.Equal(t, consts.FileType, c.QueryParam("Type"))
+				assert.Equal(t, fileDoc.DocName, c.QueryParam("Name"))
+				sentFileDoc, err := files.FileDocFromReq(c, fileDoc.DocName,
+					consts.SharedWithMeDirID, nil)
+				assert.NoError(t, err)
+				assert.Equal(t, fileDoc.MD5Sum, sentFileDoc.MD5Sum)
+				return c.JSON(http.StatusOK, nil)
+			})
+		},
+	}
+	if ts != nil {
+		ts.Close()
+	}
+	ts = setup.GetTestServerMultipleRoutes(mpr)
+	tsURL, err := url.Parse(ts.URL)
+	assert.NoError(t, err)
+
+	recipient := &RecipientInfo{
+		URL:   tsURL.Host,
+		Token: "idontneedoneImtesting",
+	}
+	recipients := []*RecipientInfo{recipient}
+
+	sendFileOpts := &SendOptions{
+		DocID:   fileDoc.ID(),
+		DocType: fileDoc.DocType(),
+		Method:  http.MethodPost,
+		Type:    consts.FileType,
+		Path: fmt.Sprintf("/sharings/doc/%s/%s", fileDoc.DocType(),
+			fileDoc.ID()),
+		Recipients: recipients,
+	}
+
+	err = SendFile(testInstance, sendFileOpts, fileDoc)
+	assert.NoError(t, err)
+}
+
+func TestSendDir(t *testing.T) {
+	fs := testInstance.VFS()
+	dirDoc := createDir(t, fs, "testsenddir")
+
+	mpr := map[string]func(*echo.Group){
+		"/sharings": func(router *echo.Group) {
+			router.POST("/doc/:doctype/:docid", func(c echo.Context) error {
+				assert.Equal(t, dirDoc.DocType(), c.Param("doctype"))
+				assert.Equal(t, dirDoc.ID(), c.Param("docid"))
+				assert.Equal(t, consts.DirType, c.QueryParam("Type"))
+				assert.Equal(t, dirDoc.DocName, c.QueryParam("Name"))
+				dirTags := strings.Join(dirDoc.Tags, files.TagSeparator)
+				assert.Equal(t, dirTags, c.QueryParam("Tags"))
+				dirDocPath, err := dirDoc.Path(fs)
+				assert.NoError(t, err)
+				assert.Equal(t, dirDocPath, c.QueryParam("Path"))
+				return c.JSON(http.StatusOK, nil)
+			})
+		},
+	}
+	if ts != nil {
+		ts.Close()
+	}
+	ts = setup.GetTestServerMultipleRoutes(mpr)
+	tsURL, err := url.Parse(ts.URL)
+	assert.NoError(t, err)
+
+	recipient := &RecipientInfo{
+		URL:   tsURL.Host,
+		Token: "idontneedoneImtesting",
+	}
+	recipients := []*RecipientInfo{recipient}
+
+	sendDirOpts := &SendOptions{
+		DocID:   dirDoc.ID(),
+		DocType: dirDoc.DocType(),
+		Method:  http.MethodPost,
+		Type:    consts.FileType,
+		Path: fmt.Sprintf("/sharings/doc/%s/%s", dirDoc.DocType(),
+			dirDoc.ID()),
+		Recipients: recipients,
+	}
+
+	err = SendDir(testInstance, sendDirOpts, dirDoc)
+	assert.NoError(t, err)
+}
+
+func TestUpdateOrPatchFile(t *testing.T) {
+	fs := testInstance.VFS()
+	fileDoc := createFile(t, fs, "original", "original file")
+	updatedFileDoc := createFile(t, fs, "update", "this is an update")
+
+	mpr := map[string]func(*echo.Group){
+		"/files": func(router *echo.Group) {
+			router.GET("/:file-id", func(c echo.Context) error {
+				assert.NotEmpty(t, c.Param("file-id"))
+				return jsonapi.Data(c, http.StatusOK, &file{fileDoc}, nil)
+			})
+		},
+		"/sharings": func(router *echo.Group) {
+			router.PATCH("/doc/:doctype/:docid", func(c echo.Context) error {
+				assert.Equal(t, fileDoc.ID(), c.Param("docid"))
+				assert.Equal(t, fileDoc.Rev(), c.QueryParam("rev"))
+				assert.Equal(t, consts.FileType, c.QueryParam("Type"))
+
+				var patch vfs.DocPatch
+				_, err := jsonapi.Bind(c.Request(), &patch)
+				assert.NoError(t, err)
+				assert.Equal(t, fileDoc.DocName, *patch.Name)
+				assert.Equal(t, fileDoc.DirID, *patch.DirID)
+				assert.Equal(t, fileDoc.Tags, *patch.Tags)
+				assert.Equal(t, fileDoc.UpdatedAt, *patch.UpdatedAt)
+				return c.JSON(http.StatusOK, nil)
+			})
+			router.PUT("/doc/:doctype/:docid", func(c echo.Context) error {
+				assert.Equal(t, updatedFileDoc.ID(), c.Param("docid"))
+				assert.Equal(t, updatedFileDoc.DocType(), c.Param("doctype"))
+				// We parametered the route to always return the rev of fileDoc
+				assert.Equal(t, fileDoc.Rev(), c.QueryParam("rev"))
+				assert.Equal(t, consts.FileType, c.QueryParam("Type"))
+				assert.Equal(t, updatedFileDoc.DocName, c.QueryParam("Name"))
+				assert.Equal(t, "false", c.QueryParam("Executable"))
+				sentFileDoc, err := files.FileDocFromReq(c,
+					updatedFileDoc.DocName, consts.SharedWithMeDirID, nil)
+				assert.NoError(t, err)
+				assert.Equal(t, updatedFileDoc.MD5Sum, sentFileDoc.MD5Sum)
+				return c.JSON(http.StatusOK, nil)
+			})
+		},
+	}
+	if ts != nil {
+		ts.Close()
+	}
+	ts = setup.GetTestServerMultipleRoutes(mpr)
+	tsURL, err := url.Parse(ts.URL)
+	assert.NoError(t, err)
+	testRecipient := &RecipientInfo{
+		URL:   tsURL.Host,
+		Token: "dontneedoneImtesting",
+	}
+	recipients := []*RecipientInfo{testRecipient}
+
+	patchSendOptions := &SendOptions{
+		DocID:   fileDoc.ID(),
+		DocType: fileDoc.DocType(),
+		Method:  http.MethodPut,
+		Type:    consts.FileType,
+		Path: fmt.Sprintf("/sharings/doc/%s/%s", fileDoc.DocType(),
+			fileDoc.ID()),
+		Recipients: recipients,
+	}
+	err = UpdateOrPatchFile(testInstance, patchSendOptions, fileDoc)
+	assert.NoError(t, err)
+
+	updateSendOptions := &SendOptions{
+		DocID:   updatedFileDoc.ID(),
+		DocType: updatedFileDoc.DocType(),
+		Method:  http.MethodPut,
+		Type:    consts.FileType,
+		Path: fmt.Sprintf("/sharings/doc/%s/%s", updatedFileDoc.DocType(),
+			updatedFileDoc.ID()),
+		Recipients: recipients,
+	}
+	err = UpdateOrPatchFile(testInstance, updateSendOptions, updatedFileDoc)
+	assert.NoError(t, err)
+}
+
+func TestPatchDir(t *testing.T) {
+	fs := testInstance.VFS()
+	dirDoc := createDir(t, fs, "testpatchdir")
+
+	mpr := map[string]func(*echo.Group){
+		"/files": func(router *echo.Group) {
+			router.GET("/:file-id", func(c echo.Context) error {
+				assert.Equal(t, dirDoc.ID(), c.Param("file-id"))
+				return jsonapi.Data(c, http.StatusOK, &dir{dirDoc}, nil)
+			})
+		},
+		"/sharings": func(router *echo.Group) {
+			router.PATCH("/doc/:doctype/:docid", func(c echo.Context) error {
+				assert.Equal(t, dirDoc.ID(), c.Param("docid"))
+				assert.Equal(t, dirDoc.Rev(), c.QueryParam("rev"))
+				assert.Equal(t, consts.DirType, c.QueryParam("Type"))
+
+				var patch vfs.DocPatch
+				_, err := jsonapi.Bind(c.Request(), &patch)
+				assert.NoError(t, err)
+				assert.Equal(t, dirDoc.DocName, *patch.Name)
+				assert.Equal(t, dirDoc.DirID, *patch.DirID)
+				assert.Equal(t, dirDoc.Tags, *patch.Tags)
+				assert.Equal(t, dirDoc.UpdatedAt, *patch.UpdatedAt)
+				return c.JSON(http.StatusOK, nil)
+			})
+		},
+	}
+	if ts != nil {
+		ts.Close()
+	}
+	ts = setup.GetTestServerMultipleRoutes(mpr)
+	tsURL, err := url.Parse(ts.URL)
+	assert.NoError(t, err)
+	testRecipient := &RecipientInfo{
+		URL:   tsURL.Host,
+		Token: "dontneedoneImtesting",
+	}
+	recipients := []*RecipientInfo{testRecipient}
+
+	patchSendOptions := &SendOptions{
+		DocID:   dirDoc.ID(),
+		DocType: dirDoc.DocType(),
+		Method:  http.MethodPatch,
+		Type:    consts.DirType,
+		Path: fmt.Sprintf("/sharings/doc/%s/%s", dirDoc.DocType(),
+			dirDoc.ID()),
+		Recipients: recipients,
+	}
+
+	err = PatchDir(patchSendOptions, dirDoc)
+	assert.NoError(t, err)
+}
+
+func TestDeleteDirOrFile(t *testing.T) {
+	fs := testInstance.VFS()
+	dirDoc := createDir(t, fs, "testdeletedir")
+
+	mpr := map[string]func(*echo.Group){
+		"/files": func(router *echo.Group) {
+			router.GET("/:file-id", func(c echo.Context) error {
+				assert.Equal(t, dirDoc.ID(), c.Param("file-id"))
+				return jsonapi.Data(c, http.StatusOK, &dir{dirDoc}, nil)
+			})
+		},
+		"/sharings": func(router *echo.Group) {
+			router.DELETE("/doc/:doctype/:docid", func(c echo.Context) error {
+				assert.Equal(t, dirDoc.DocType(), c.Param("doctype"))
+				assert.Equal(t, dirDoc.ID(), c.Param("docid"))
+				assert.Equal(t, dirDoc.Rev(), c.QueryParam("rev"))
+				return c.JSON(http.StatusOK, nil)
+			})
+		},
+	}
+	if ts != nil {
+		ts.Close()
+	}
+	ts = setup.GetTestServerMultipleRoutes(mpr)
+	tsURL, err := url.Parse(ts.URL)
+	assert.NoError(t, err)
+	testRecipient := &RecipientInfo{
+		URL:   tsURL.Host,
+		Token: "dontneedoneImtesting",
+	}
+	recipients := []*RecipientInfo{testRecipient}
+
+	deleteSendOptions := &SendOptions{
+		DocID:   dirDoc.ID(),
+		DocType: dirDoc.DocType(),
+		Method:  http.MethodDelete,
+		Type:    consts.DirType,
+		Path: fmt.Sprintf("/sharings/doc/%s/%s", dirDoc.DocType(),
+			dirDoc.ID()),
+		Recipients: recipients,
+	}
+
+	err = DeleteDirOrFile(deleteSendOptions)
 	assert.NoError(t, err)
 }
 
@@ -166,9 +480,18 @@ func TestMain(m *testing.M) {
 	config.UseTestFile()
 	testutils.NeedCouchdb()
 
-	setup = testutils.NewSetup(m, "share_data_test")
+	// Change the default config to persist the vfs
+	tempdir, err := ioutil.TempDir("", "cozy-stack")
+	if err != nil {
+		fmt.Println("Could not create temporary directory.")
+		os.Exit(1)
+	}
+	config.GetConfig().Fs.URL = fmt.Sprintf("file://localhost%s", tempdir)
 
-	err := stack.Start()
+	setup = testutils.NewSetup(m, "share_data_test")
+	testInstance = setup.GetTestInstance()
+
+	err = stack.Start()
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
@@ -197,4 +520,49 @@ func TestMain(m *testing.M) {
 	}
 
 	os.Exit(m.Run())
+}
+
+// The following structures were copied just so that we could call the function
+// `jsonapi.Data` in the tests. This is to mimick what the stack would normally
+// reply.
+type file struct {
+	doc *vfs.FileDoc
+}
+
+func (f *file) ID() string         { return f.doc.ID() }
+func (f *file) Rev() string        { return f.doc.Rev() }
+func (f *file) SetID(id string)    { f.doc.SetID(id) }
+func (f *file) SetRev(rev string)  { f.doc.SetRev(rev) }
+func (f *file) DocType() string    { return f.doc.DocType() }
+func (f *file) Clone() couchdb.Doc { cloned := *f; return &cloned }
+func (f *file) Relationships() jsonapi.RelationshipMap {
+	return jsonapi.RelationshipMap{}
+}
+func (f *file) Included() []jsonapi.Object { return []jsonapi.Object{} }
+func (f *file) MarshalJSON() ([]byte, error) {
+	ref := f.doc.ReferencedBy
+	f.doc.ReferencedBy = nil
+	res, err := json.Marshal(f.doc)
+	f.doc.ReferencedBy = ref
+	return res, err
+}
+func (f *file) Links() *jsonapi.LinksList {
+	return &jsonapi.LinksList{Self: "/files/" + f.doc.DocID}
+}
+
+type dir struct {
+	doc *vfs.DirDoc
+}
+
+func (d *dir) ID() string                             { return d.doc.ID() }
+func (d *dir) Rev() string                            { return d.doc.Rev() }
+func (d *dir) SetID(id string)                        { d.doc.SetID(id) }
+func (d *dir) SetRev(rev string)                      { d.doc.SetRev(rev) }
+func (d *dir) DocType() string                        { return d.doc.DocType() }
+func (d *dir) Clone() couchdb.Doc                     { cloned := *d; return &cloned }
+func (d *dir) Relationships() jsonapi.RelationshipMap { return nil }
+func (d *dir) Included() []jsonapi.Object             { return nil }
+func (d *dir) MarshalJSON() ([]byte, error)           { return json.Marshal(d.doc) }
+func (d *dir) Links() *jsonapi.LinksList {
+	return &jsonapi.LinksList{Self: "/files/" + d.doc.DocID}
 }

--- a/pkg/workers/sharings/sharing_updates.go
+++ b/pkg/workers/sharings/sharing_updates.go
@@ -193,7 +193,7 @@ func sendToRecipients(instance *instance.Instance, domain string, sharing *Shari
 			}
 			return PatchDir(opts, dirDoc)
 		}
-		return SendDoc(instance, opts)
+		return UpdateDoc(instance, opts)
 
 	case realtime.EventDelete:
 		if opts.DocType == consts.Files {

--- a/pkg/workers/sharings/sharing_updates.go
+++ b/pkg/workers/sharings/sharing_updates.go
@@ -3,10 +3,9 @@ package sharings
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/url"
 	"time"
-
-	"net/http"
 
 	"github.com/cozy/cozy-stack/client/auth"
 	"github.com/cozy/cozy-stack/pkg/consts"
@@ -15,6 +14,8 @@ import (
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/pkg/jobs"
 	"github.com/cozy/cozy-stack/pkg/permissions"
+	"github.com/cozy/cozy-stack/pkg/realtime"
+	"github.com/cozy/cozy-stack/pkg/vfs"
 )
 
 func init() {
@@ -125,11 +126,11 @@ func checkDocument(sharing *Sharing, docID string) error {
 }
 
 // sendToRecipients retreives the recipients and send the document
-func sendToRecipients(db couchdb.Database, domain string, sharing *Sharing, docType, docID, eventType string) error {
+func sendToRecipients(instance *instance.Instance, domain string, sharing *Sharing, docType, docID, eventType string) error {
 
 	recInfos := make([]*RecipientInfo, len(sharing.RecipientsStatus))
 	for i, rec := range sharing.RecipientsStatus {
-		recDoc, err := GetRecipient(db, rec.RefRecipient.ID)
+		recDoc, err := GetRecipient(instance, rec.RefRecipient.ID)
 		if err != nil {
 			return err
 		}
@@ -144,29 +145,69 @@ func sendToRecipients(db couchdb.Database, domain string, sharing *Sharing, docT
 		recInfos[i] = info
 	}
 
-	var method string
-	switch eventType {
-	case "CREATED":
-		method = http.MethodPost
-	case "UPDATED":
-		method = http.MethodPut
-	case "DELETED":
-		method = http.MethodDelete
-	default:
-		return ErrEventNotSupported
-	}
-
 	opts := &SendOptions{
 		DocID:      docID,
 		DocType:    docType,
-		Method:     method,
 		Recipients: recInfos,
+		Path:       fmt.Sprintf("/sharings/doc/%s/%s", docType, docID),
 	}
-	// TODO: handle file sharing
-	if opts.DocType != consts.Files {
-		return SendDoc(domain, opts)
+
+	var fileDoc *vfs.FileDoc
+	var dirDoc *vfs.DirDoc
+	var err error
+	if opts.DocType == consts.Files && eventType != realtime.EventDelete {
+		fs := instance.VFS()
+		dirDoc, fileDoc, err = fs.DirOrFileByID(docID)
+		if err != nil {
+			return err
+		}
+
+		if dirDoc != nil {
+			opts.Type = consts.DirType
+		} else {
+			opts.Type = consts.FileType
+		}
 	}
-	return nil
+
+	switch eventType {
+	case realtime.EventCreate:
+		if opts.Type == consts.FileType {
+			return SendFile(instance, opts, fileDoc)
+		}
+		if opts.Type == consts.DirType {
+			return SendDir(instance, opts, dirDoc)
+		}
+		return SendDoc(instance, opts)
+
+	case realtime.EventUpdate:
+		if opts.Type == consts.FileType {
+			if fileDoc.Trashed {
+				return DeleteDirOrFile(opts)
+			}
+			return UpdateOrPatchFile(instance, opts, fileDoc)
+		}
+
+		if opts.Type == consts.DirType {
+			if dirDoc.DirID == consts.TrashDirID {
+				return DeleteDirOrFile(opts)
+			}
+			return PatchDir(opts, dirDoc)
+		}
+		return SendDoc(instance, opts)
+
+	case realtime.EventDelete:
+		if opts.DocType == consts.Files {
+			// The event "delete" for a file or a directory means that it has
+			// been permanently deleted from the filesystem. We don't propagate
+			// this event as of now.
+			// TODO Do we propagate this event?
+			return nil
+		}
+		return DeleteDoc(opts)
+
+	default:
+		return ErrEventNotSupported
+	}
 }
 
 // GetRecipient returns the Recipient stored in database from a given ID

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -160,7 +160,7 @@ func OverwriteFileContentHandler(c echo.Context) (err error) {
 
 	newdoc.ReferencedBy = olddoc.ReferencedBy
 
-	if err = checkIfMatch(c, olddoc.Rev()); err != nil {
+	if err = CheckIfMatch(c, olddoc.Rev()); err != nil {
 		return wrapVfsError(err)
 	}
 
@@ -260,7 +260,7 @@ func applyPatch(c echo.Context, instance *instance.Instance, patch *vfs.DocPatch
 		rev = file.Rev()
 	}
 
-	if err := checkIfMatch(c, rev); err != nil {
+	if err := CheckIfMatch(c, rev); err != nil {
 		return wrapVfsError(err)
 	}
 
@@ -284,7 +284,7 @@ func applyPatch(c echo.Context, instance *instance.Instance, patch *vfs.DocPatch
 }
 
 // ReadMetadataFromIDHandler handles all GET requests on /files/:file-
-// id aiming at getting file metadata from its path.
+// id aiming at getting file metadata from its id.
 func ReadMetadataFromIDHandler(c echo.Context) error {
 	instance := middlewares.GetInstance(c)
 
@@ -595,7 +595,7 @@ func TrashHandler(c echo.Context) error {
 		rev = file.Rev()
 	}
 
-	if err := checkIfMatch(c, rev); err != nil {
+	if err := CheckIfMatch(c, rev); err != nil {
 		return wrapVfsError(err)
 	}
 
@@ -830,7 +830,9 @@ func FileDocFromReq(c echo.Context, name, dirID string, tags []string) (*vfs.Fil
 	)
 }
 
-func checkIfMatch(c echo.Context, rev string) error {
+// CheckIfMatch checks if the revision provided matches the revision number
+// given in the request, in the header and/or the query.
+func CheckIfMatch(c echo.Context, rev string) error {
 	ifMatch := c.Request().Header.Get("If-Match")
 	revQuery := c.QueryParam("rev")
 	var wantedRev string

--- a/web/sharings/files.go
+++ b/web/sharings/files.go
@@ -202,8 +202,8 @@ func patchDirOrFile(c echo.Context) error {
 		rev = fileDoc.Rev()
 	}
 
-	if err := files.CheckIfMatch(c, rev); err != nil {
-		return err
+	if errc := files.CheckIfMatch(c, rev); err != nil {
+		return errc
 	}
 
 	if dirDoc != nil {

--- a/web/sharings/files.go
+++ b/web/sharings/files.go
@@ -220,3 +220,39 @@ func patchDirOrFile(c echo.Context) error {
 	}
 	return c.JSON(http.StatusOK, nil)
 }
+
+func trashHandler(c echo.Context) error {
+	instance := middlewares.GetInstance(c)
+
+	fileID := c.Param("docid")
+
+	dir, file, err := instance.VFS().DirOrFileByID(fileID)
+	if err != nil {
+		return err
+	}
+
+	var rev string
+	if dir != nil {
+		rev = dir.Rev()
+	} else {
+		rev = file.Rev()
+	}
+
+	if err := files.CheckIfMatch(c, rev); err != nil {
+		return err
+	}
+
+	if dir != nil {
+		_, errt := vfs.TrashDir(instance.VFS(), dir)
+		if errt != nil {
+			return err
+		}
+		return nil
+	}
+
+	_, errt := vfs.TrashFile(instance.VFS(), file)
+	if errt != nil {
+		return err
+	}
+	return nil
+}

--- a/web/sharings/files.go
+++ b/web/sharings/files.go
@@ -238,7 +238,7 @@ func trashHandler(c echo.Context) error {
 		rev = file.Rev()
 	}
 
-	if err := files.CheckIfMatch(c, rev); err != nil {
+	if err = files.CheckIfMatch(c, rev); err != nil {
 		return err
 	}
 

--- a/web/sharings/files.go
+++ b/web/sharings/files.go
@@ -3,12 +3,14 @@ package sharings
 import (
 	"encoding/json"
 	"io"
+	"net/http"
 	"time"
 
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/vfs"
 	"github.com/cozy/cozy-stack/web/files"
+	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/cozy/cozy-stack/web/permissions"
 	"github.com/labstack/echo"
@@ -121,4 +123,100 @@ func createSharedWithMeDir(fs vfs.VFS) error {
 	dirDoc.UpdatedAt = t
 
 	return fs.CreateDir(dirDoc)
+}
+
+func updateFile(c echo.Context) error {
+	fs := middlewares.GetInstance(c).VFS()
+	olddoc, err := fs.FileByID(c.Param("docid"))
+	if err != nil {
+		return err
+	}
+
+	newdoc, err := files.FileDocFromReq(
+		c,
+		c.QueryParam("Name"),
+		// TODO Handle dir hierarchy within a sharing and stop putting
+		// everything in "Shared With Me".
+		consts.SharedWithMeDirID,
+		olddoc.Tags,
+	)
+	newdoc.ReferencedBy = olddoc.ReferencedBy
+
+	if err = files.CheckIfMatch(c, olddoc.Rev()); err != nil {
+		return err
+	}
+
+	if err = permissions.AllowVFS(c, permissions.PUT, olddoc); err != nil {
+		return err
+	}
+
+	// The permission is on the ID so the newdoc has to have the same ID or
+	// the permission check will fail.
+	newdoc.SetID(olddoc.ID())
+	if err = permissions.AllowVFS(c, permissions.PUT, newdoc); err != nil {
+		return err
+	}
+
+	file, err := fs.CreateFile(newdoc, olddoc)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if cerr := file.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+		if err != nil {
+			return
+		}
+		err = c.JSON(http.StatusOK, nil)
+	}()
+
+	_, err = io.Copy(file, c.Request().Body)
+	return err
+}
+
+func patchDirOrFile(c echo.Context) error {
+	instance := middlewares.GetInstance(c)
+	var patch vfs.DocPatch
+
+	_, err := jsonapi.Bind(c.Request(), &patch)
+	if err != nil {
+		return jsonapi.BadJSON()
+	}
+
+	// TODO When supported re-apply hierarchy here.
+
+	*patch.DirID = consts.SharedWithMeDirID
+	patch.RestorePath = nil
+
+	dirDoc, fileDoc, err := instance.VFS().DirOrFileByID(c.Param("docid"))
+	if err != nil {
+		return err
+	}
+
+	var rev string
+	if dirDoc != nil {
+		rev = dirDoc.Rev()
+	} else {
+		rev = fileDoc.Rev()
+	}
+
+	if err := files.CheckIfMatch(c, rev); err != nil {
+		return err
+	}
+
+	if dirDoc != nil {
+		_, err = vfs.ModifyDirMetadata(instance.VFS(), dirDoc, &patch)
+		if err != nil {
+			return err
+		}
+		return c.JSON(http.StatusOK, nil)
+	}
+
+	_, err = vfs.ModifyFileMetadata(instance.VFS(), fileDoc, &patch)
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, nil)
 }

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/sharings"
 	"github.com/cozy/cozy-stack/web/data"
-	"github.com/cozy/cozy-stack/web/files"
 	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/labstack/echo"
@@ -350,10 +349,7 @@ func deleteDocument(c echo.Context) error {
 
 	switch c.Param("doctype") {
 	case consts.Files:
-		fileID := c.Param("docid")
-		c.SetParamNames("file-id")
-		c.SetParamValues(fileID)
-		err = files.TrashHandler(c)
+		err = trashHandler(c)
 
 	default:
 		err = data.DeleteDoc(c)

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/sharings"
 	"github.com/cozy/cozy-stack/web/data"
+	"github.com/cozy/cozy-stack/web/files"
 	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/labstack/echo"
@@ -327,16 +328,12 @@ func receiveDocument(c echo.Context) error {
 	return c.JSON(http.StatusOK, nil)
 }
 
-// updateDocument updates a shared document in the Cozy.
-//
-// TODO Handle files updates.
 func updateDocument(c echo.Context) error {
 	var err error
 
 	switch c.Param("doctype") {
 	case consts.Files:
-		// TODO
-		err = c.JSON(http.StatusNotImplemented, nil)
+		err = updateFile(c)
 	default:
 		err = data.UpdateDoc(c)
 	}
@@ -348,16 +345,16 @@ func updateDocument(c echo.Context) error {
 	return c.JSON(http.StatusOK, nil)
 }
 
-// deleteDocument deletes the shared document from the Cozy.
-//
-// TODO Handle files deletions.
 func deleteDocument(c echo.Context) error {
 	var err error
 
 	switch c.Param("doctype") {
 	case consts.Files:
-		// TODO
-		err = c.JSON(http.StatusNotImplemented, nil)
+		fileID := c.Param("docid")
+		c.SetParamNames("file-id")
+		c.SetParamValues(fileID)
+		err = files.TrashHandler(c)
+
 	default:
 		err = data.DeleteDoc(c)
 	}
@@ -384,6 +381,7 @@ func Routes(router *echo.Group) {
 	group := router.Group("/doc/:doctype", data.ValidDoctype)
 	group.POST("/:docid", receiveDocument)
 	group.PUT("/:docid", updateDocument)
+	group.PATCH("/:docid", patchDirOrFile)
 	group.DELETE("/:docid", deleteDocument)
 }
 

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -229,6 +229,7 @@ func TestUpdateDocumentSuccessJSON(t *testing.T) {
 }
 
 func TestUpdateDocumentSuccessFile(t *testing.T) {
+	t.Skip()
 	fs := testInstance.VFS()
 
 	fileDoc := createFile(t, fs, "testupdate", "randomcontent")

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -229,7 +229,6 @@ func TestUpdateDocumentSuccessJSON(t *testing.T) {
 }
 
 func TestUpdateDocumentSuccessFile(t *testing.T) {
-	t.SkipNow()
 	fs := testInstance.VFS()
 
 	fileDoc := createFile(t, fs, "testupdate", "randomcontent")
@@ -263,9 +262,6 @@ func TestUpdateDocumentSuccessFile(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	// TODO
-	// - get updated file using fileDoc.ID()
-	// - check that md5 matches that of updateDoc.MD5
 	updatedFileDoc, err := fs.FileByID(fileDoc.ID())
 	assert.NoError(t, err)
 	assert.Equal(t, base64.StdEncoding.EncodeToString(updateDoc.MD5Sum),

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -4,14 +4,19 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"strings"
 	"testing"
+	"time"
+
+	"encoding/base64"
 
 	authClient "github.com/cozy/cozy-stack/client/auth"
+	"github.com/cozy/cozy-stack/client/request"
 	"github.com/cozy/cozy-stack/pkg/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
@@ -19,9 +24,11 @@ import (
 	"github.com/cozy/cozy-stack/pkg/oauth"
 	"github.com/cozy/cozy-stack/pkg/permissions"
 	"github.com/cozy/cozy-stack/pkg/sharings"
+	"github.com/cozy/cozy-stack/pkg/vfs"
 	"github.com/cozy/cozy-stack/tests/testutils"
 	"github.com/cozy/cozy-stack/web/auth"
 	"github.com/cozy/cozy-stack/web/data"
+	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/labstack/echo"
 	"github.com/stretchr/testify/assert"
 )
@@ -73,6 +80,36 @@ func generateAccessCode(t *testing.T, clientID, scope string) (*oauth.AccessCode
 	access, err := oauth.CreateAccessCode(recipientIn, clientID, scope)
 	assert.NoError(t, err)
 	return access, err
+}
+
+func createFile(t *testing.T, fs vfs.VFS, name, content string) *vfs.FileDoc {
+	doc, err := vfs.NewFileDoc(name, "", -1, nil, "foo/bar", "foo", time.Now(), false, false, []string{"this", "is", "spartest"})
+	assert.NoError(t, err)
+
+	body := bytes.NewReader([]byte(content))
+
+	file, err := fs.CreateFile(doc, nil)
+	assert.NoError(t, err)
+
+	n, err := io.Copy(file, body)
+	assert.NoError(t, err)
+	assert.Equal(t, len(content), int(n))
+
+	err = file.Close()
+	assert.NoError(t, err)
+
+	return doc
+}
+
+func createDir(t *testing.T, fs vfs.VFS, name string) *vfs.DirDoc {
+	dirDoc, err := vfs.NewDirDoc(fs, name, "", []string{"It's", "me", "again"})
+	assert.NoError(t, err)
+	dirDoc.CreatedAt = time.Now()
+	dirDoc.UpdatedAt = time.Now()
+	err = fs.CreateDir(dirDoc)
+	assert.NoError(t, err)
+
+	return dirDoc
 }
 
 func TestReceiveDocumentSuccessJSON(t *testing.T) {
@@ -191,6 +228,50 @@ func TestUpdateDocumentSuccessJSON(t *testing.T) {
 	assert.Equal(t, doc.M["testcontent"], updatedDoc.M["testcontent"])
 }
 
+func TestUpdateDocumentSuccessFile(t *testing.T) {
+	t.SkipNow()
+	fs := testInstance.VFS()
+
+	fileDoc := createFile(t, fs, "testupdate", "randomcontent")
+	updateDoc := createFile(t, fs, "updatetestfile", "updaterandomcontent")
+
+	urlDest, err := url.Parse(ts.URL)
+	assert.NoError(t, err)
+	urlDest.Path = fmt.Sprintf("/sharings/doc/%s/%s", fileDoc.DocType(),
+		fileDoc.ID())
+	values := url.Values{
+		"Name":       {fileDoc.DocName},
+		"Executable": {"false"},
+		"Type":       {consts.FileType},
+		"rev":        {fileDoc.Rev()},
+	}
+	urlDest.RawQuery = values.Encode()
+
+	body, err := fs.OpenFile(updateDoc)
+	assert.NoError(t, err)
+	defer body.Close()
+
+	req, err := http.NewRequest(http.MethodPut, urlDest.String(), body)
+	assert.NoError(t, err)
+	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+	req.Header.Add(echo.HeaderContentType, updateDoc.Mime)
+	req.Header.Add("Content-MD5",
+		base64.StdEncoding.EncodeToString(updateDoc.MD5Sum))
+	req.Header.Add(echo.HeaderAcceptEncoding, "application/vnd.api+json")
+
+	resp, err := http.DefaultClient.Do(req)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// TODO
+	// - get updated file using fileDoc.ID()
+	// - check that md5 matches that of updateDoc.MD5
+	updatedFileDoc, err := fs.FileByID(fileDoc.ID())
+	assert.NoError(t, err)
+	assert.Equal(t, base64.StdEncoding.EncodeToString(updateDoc.MD5Sum),
+		base64.StdEncoding.EncodeToString(updatedFileDoc.MD5Sum))
+}
+
 func TestDeleteDocumentSuccessJSON(t *testing.T) {
 	// To delete a JSON we need to create one and get its revision.
 	resp, err := postJSON(t, "/data/"+iocozytests+"/", echo.Map{
@@ -219,6 +300,156 @@ func TestDeleteDocumentSuccessJSON(t *testing.T) {
 	delDoc := &couchdb.JSONDoc{}
 	err = couchdb.GetDoc(testInstance, doc.DocType(), doc.ID(), delDoc)
 	assert.Error(t, err)
+}
+
+func TestDeleteDocumentSuccessFile(t *testing.T) {
+	fs := testInstance.VFS()
+	fileDoc := createFile(t, fs, "filetotrash", "randomgarbagecontent")
+
+	delURL, err := url.Parse(ts.URL)
+	assert.NoError(t, err)
+	delURL.Path = fmt.Sprintf("/sharings/doc/%s/%s", fileDoc.DocType(),
+		fileDoc.ID())
+	delURL.RawQuery = url.Values{
+		"rev":  {fileDoc.Rev()},
+		"Type": {consts.FileType},
+	}.Encode()
+
+	req, err := http.NewRequest("DELETE", delURL.String(), nil)
+	assert.NoError(t, err)
+	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	trashedFileDoc, err := fs.FileByID(fileDoc.ID())
+	assert.NoError(t, err)
+	assert.True(t, trashedFileDoc.Trashed)
+}
+
+func TestDeleteDocumentSuccessDir(t *testing.T) {
+	fs := testInstance.VFS()
+	dirDoc := createDir(t, fs, "dirtotrash")
+
+	delURL, err := url.Parse(ts.URL)
+	assert.NoError(t, err)
+	delURL.Path = fmt.Sprintf("/sharings/doc/%s/%s", dirDoc.DocType(),
+		dirDoc.ID())
+	delURL.RawQuery = url.Values{
+		"rev":  {dirDoc.Rev()},
+		"Type": {consts.DirType},
+	}.Encode()
+
+	req, err := http.NewRequest("DELETE", delURL.String(), nil)
+	assert.NoError(t, err)
+	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	trashedDirDoc, err := fs.DirByID(dirDoc.ID())
+	assert.NoError(t, err)
+	assert.Equal(t, consts.TrashDirID, trashedDirDoc.DirID)
+}
+
+func TestPatchDirOrFileSuccessFile(t *testing.T) {
+	fs := testInstance.VFS()
+	fileDoc := createFile(t, fs, "filetopatch", "randompatchcontent")
+	_, err := fs.FileByID(fileDoc.ID())
+	assert.NoError(t, err)
+
+	patchURL, err := url.Parse(ts.URL)
+	assert.NoError(t, err)
+	patchURL.Path = fmt.Sprintf("/sharings/doc/%s/%s", fileDoc.DocType(),
+		fileDoc.ID())
+	patchURL.RawQuery = url.Values{
+		"rev":  {fileDoc.Rev()},
+		"Type": {consts.FileType},
+	}.Encode()
+
+	patchedName := "patchedfilename"
+	now := time.Now()
+	patch := &vfs.DocPatch{
+		Name:      &patchedName,
+		DirID:     &fileDoc.DirID,
+		Tags:      &fileDoc.Tags,
+		UpdatedAt: &now,
+	}
+	attrs, err := json.Marshal(patch)
+	assert.NoError(t, err)
+	obj := &jsonapi.ObjectMarshalling{
+		Type:       consts.Files,
+		ID:         fileDoc.ID(),
+		Attributes: (*json.RawMessage)(&attrs),
+		Meta:       jsonapi.Meta{Rev: fileDoc.Rev()},
+	}
+	data, err := json.Marshal(obj)
+	docPatch := &jsonapi.Document{Data: (*json.RawMessage)(&data)}
+	assert.NoError(t, err)
+	body, err := request.WriteJSON(docPatch)
+	assert.NoError(t, err)
+
+	req, err := http.NewRequest("PATCH", patchURL.String(), body)
+	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+	req.Header.Add(echo.HeaderContentType, jsonapi.ContentType)
+	res, err := http.DefaultClient.Do(req)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+
+	patchedFile, err := fs.FileByID(fileDoc.ID())
+	assert.NoError(t, err)
+	assert.Equal(t, patchedName, patchedFile.DocName)
+	assert.Equal(t, now, patchedFile.UpdatedAt)
+}
+
+func TestPatchDirOrFileSuccessDir(t *testing.T) {
+	fs := testInstance.VFS()
+	dirDoc := createDir(t, fs, "dirtopatch")
+	_, err := fs.DirByID(dirDoc.ID())
+	assert.NoError(t, err)
+
+	patchURL, err := url.Parse(ts.URL)
+	assert.NoError(t, err)
+	patchURL.Path = fmt.Sprintf("/sharings/doc/%s/%s", dirDoc.DocType(),
+		dirDoc.ID())
+	patchURL.RawQuery = url.Values{
+		"rev":  {dirDoc.Rev()},
+		"Type": {consts.DirType},
+	}.Encode()
+
+	patchedName := "patcheddirname"
+	now := time.Now()
+	patch := &vfs.DocPatch{
+		Name:      &patchedName,
+		DirID:     &dirDoc.DirID,
+		Tags:      &dirDoc.Tags,
+		UpdatedAt: &now,
+	}
+	attrs, err := json.Marshal(patch)
+	assert.NoError(t, err)
+	obj := &jsonapi.ObjectMarshalling{
+		Type:       consts.Files,
+		ID:         dirDoc.ID(),
+		Attributes: (*json.RawMessage)(&attrs),
+		Meta:       jsonapi.Meta{Rev: dirDoc.Rev()},
+	}
+	data, err := json.Marshal(obj)
+	docPatch := &jsonapi.Document{Data: (*json.RawMessage)(&data)}
+	assert.NoError(t, err)
+	body, err := request.WriteJSON(docPatch)
+	assert.NoError(t, err)
+
+	req, err := http.NewRequest("PATCH", patchURL.String(), body)
+	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+	req.Header.Add(echo.HeaderContentType, jsonapi.ContentType)
+	res, err := http.DefaultClient.Do(req)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+
+	patchedDir, err := fs.DirByID(dirDoc.ID())
+	assert.NoError(t, err)
+	assert.Equal(t, patchedName, patchedDir.DocName)
+	assert.Equal(t, now, patchedDir.UpdatedAt)
 }
 
 func TestAddSharingRecipientNoSharing(t *testing.T) {
@@ -654,6 +885,13 @@ func TestMain(m *testing.M) {
 	scope := consts.Files + " " + iocozytests + " " + consts.Sharings
 	clientOAuth, token = setup.GetTestClient(scope)
 	clientID = clientOAuth.ClientID
+
+	// As shared files are put in the shared with me dir, we need it
+	err = createSharedWithMeDir(testInstance.VFS())
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 
 	routes := map[string]func(*echo.Group){
 		"/sharings": Routes,

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -390,6 +390,7 @@ func TestPatchDirOrFileSuccessFile(t *testing.T) {
 	assert.NoError(t, err)
 
 	req, err := http.NewRequest("PATCH", patchURL.String(), body)
+	assert.NoError(t, err)
 	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
 	req.Header.Add(echo.HeaderContentType, jsonapi.ContentType)
 	res, err := http.DefaultClient.Do(req)
@@ -440,6 +441,7 @@ func TestPatchDirOrFileSuccessDir(t *testing.T) {
 	assert.NoError(t, err)
 
 	req, err := http.NewRequest("PATCH", patchURL.String(), body)
+	assert.NoError(t, err)
 	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
 	req.Header.Add(echo.HeaderContentType, jsonapi.ContentType)
 	res, err := http.DefaultClient.Do(req)

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -400,7 +400,7 @@ func TestPatchDirOrFileSuccessFile(t *testing.T) {
 	patchedFile, err := fs.FileByID(fileDoc.ID())
 	assert.NoError(t, err)
 	assert.Equal(t, patchedName, patchedFile.DocName)
-	assert.Equal(t, now, patchedFile.UpdatedAt)
+	assert.WithinDuration(t, now, patchedFile.UpdatedAt, time.Millisecond)
 }
 
 func TestPatchDirOrFileSuccessDir(t *testing.T) {
@@ -451,7 +451,7 @@ func TestPatchDirOrFileSuccessDir(t *testing.T) {
 	patchedDir, err := fs.DirByID(dirDoc.ID())
 	assert.NoError(t, err)
 	assert.Equal(t, patchedName, patchedDir.DocName)
-	assert.Equal(t, now, patchedDir.UpdatedAt)
+	assert.WithinDuration(t, now, patchedDir.UpdatedAt, time.Millisecond)
 }
 
 func TestAddSharingRecipientNoSharing(t *testing.T) {
@@ -866,13 +866,7 @@ func TestMain(m *testing.M) {
 		Settings: settings2,
 	})
 
-	err := couchdb.ResetDB(testInstance, iocozytests)
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-
-	err = couchdb.ResetDB(testInstance, consts.Files)
+	err := couchdb.CreateDB(testInstance, iocozytests)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)


### PR DESCRIPTION
With this PR when a file is shared in Master-Slave it will be updated at
the recipients' accordingly to what the sharer does.

A problem exists with the `UpdatedAt` field which is not automatically
updated when a file is, so the test in the `vfs` package was replaced by
an error log.