### PR TITLE
Add album sharing support

### DIFF
--- a/pkg/sharings/sharings.go
+++ b/pkg/sharings/sharings.go
@@ -210,30 +210,53 @@ func ShareDoc(instance *instance.Instance, sharing *Sharing, recStatus *Recipien
 
 		// Dynamic sharing
 		if rule.Selector != "" {
-			// Create index based on selector to retrieve documents to share
-			indexName := "by-" + rule.Selector
-			index := mango.IndexOnFields(docType, indexName, []string{rule.Selector})
-			err := couchdb.DefineIndex(instance, index)
-			if err != nil {
-				return err
-			}
 
-			var docs []couchdb.JSONDoc
+			// Particular case for referenced_by: use the existing view
+			if rule.Selector == "referenced_by" {
+				// The permission tilte is used to know the referenced doctype
+				refType := rule.Title
 
-			// Request the index for all values
-			// NOTE: this is not efficient in case of many Values
-			// We might consider a map-reduce approach in case of bottleneck
-			for _, val := range rule.Values {
-				err = couchdb.FindDocs(instance, docType, &couchdb.FindRequest{
-					UseIndex: indexName,
-					Selector: mango.Equal(rule.Selector, val),
-				}, &docs)
+				for _, val := range rule.Values {
+					req := &couchdb.ViewRequest{
+						Key: []string{refType, val},
+					}
+					var res couchdb.ViewResponse
+					err := couchdb.ExecView(instance, consts.FilesReferencedByView, req, &res)
+					if err != nil {
+						return err
+					}
+					for _, row := range res.Rows {
+						values = append(values, row.ID)
+					}
+
+				}
+			} else {
+
+				// Create index based on selector to retrieve documents to share
+				indexName := "by-" + rule.Selector
+				index := mango.IndexOnFields(docType, indexName, []string{rule.Selector})
+				err := couchdb.DefineIndex(instance, index)
 				if err != nil {
 					return err
 				}
-				// Save returned doc ids
-				for _, d := range docs {
-					values = append(values, d.ID())
+
+				var docs []couchdb.JSONDoc
+
+				// Request the index for all values
+				// NOTE: this is not efficient in case of many Values
+				// We might consider a map-reduce approach in case of bottleneck
+				for _, val := range rule.Values {
+					err = couchdb.FindDocs(instance, docType, &couchdb.FindRequest{
+						UseIndex: indexName,
+						Selector: mango.Equal(rule.Selector, val),
+					}, &docs)
+					if err != nil {
+						return err
+					}
+					// Save returned doc ids
+					for _, d := range docs {
+						values = append(values, d.ID())
+					}
 				}
 			}
 		} else {

--- a/pkg/workers/sharings/share_data.go
+++ b/pkg/workers/sharings/share_data.go
@@ -3,6 +3,7 @@ package sharings
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -176,11 +177,19 @@ func SendFile(domain string, opts *SendOptions) error {
 	if err != nil {
 		return err
 	}
+	// Send references for permissions
+	// TODO: only send the reference linked  to the actual permission
+	b, err := json.Marshal(doc.ReferencedBy)
+	if err != nil {
+		return nil
+	}
+	refs := string(b[:])
 
 	path := fmt.Sprintf("/sharings/doc/%s/%s", consts.Files, opts.DocID)
 	query := url.Values{
-		"Type": []string{consts.FileType},
-		"Name": []string{doc.DocName},
+		"Type":          []string{consts.FileType},
+		"Name":          []string{doc.DocName},
+		"Referenced_by": []string{refs},
 	}
 	md5 := base64.StdEncoding.EncodeToString(doc.MD5Sum)
 	length := strconv.FormatInt(doc.ByteSize, 10)

--- a/web/sharings/files.go
+++ b/web/sharings/files.go
@@ -1,10 +1,12 @@
 package sharings
 
 import (
+	"encoding/json"
 	"io"
 	"time"
 
 	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/vfs"
 	"github.com/cozy/cozy-stack/web/files"
 	"github.com/cozy/cozy-stack/web/middlewares"
@@ -76,6 +78,14 @@ func createFileWithIDHandler(c echo.Context, fs vfs.VFS) error {
 
 	doc.SetID(c.Param("docid"))
 	doc.DirID = consts.SharedWithMeDirID
+
+	refBy := c.QueryParam("Referenced_by")
+	var refs = &[]couchdb.DocReference{}
+	b := []byte(refBy)
+	if err = json.Unmarshal(b, refs); err != nil {
+		return err
+	}
+	doc.ReferencedBy = *refs
 
 	if err = permissions.AllowVFS(c, "POST", doc); err != nil {
 		return err

--- a/web/sharings/files.go
+++ b/web/sharings/files.go
@@ -80,12 +80,14 @@ func createFileWithIDHandler(c echo.Context, fs vfs.VFS) error {
 	doc.DirID = consts.SharedWithMeDirID
 
 	refBy := c.QueryParam("Referenced_by")
-	var refs = &[]couchdb.DocReference{}
-	b := []byte(refBy)
-	if err = json.Unmarshal(b, refs); err != nil {
-		return err
+	if refBy != "" {
+		var refs = &[]couchdb.DocReference{}
+		b := []byte(refBy)
+		if err = json.Unmarshal(b, refs); err != nil {
+			return err
+		}
+		doc.ReferencedBy = *refs
 	}
-	doc.ReferencedBy = *refs
 
 	if err = permissions.AllowVFS(c, "POST", doc); err != nil {
 		return err

--- a/web/sharings/files.go
+++ b/web/sharings/files.go
@@ -81,12 +81,12 @@ func createFileWithIDHandler(c echo.Context, fs vfs.VFS) error {
 
 	refBy := c.QueryParam("Referenced_by")
 	if refBy != "" {
-		var refs = &[]couchdb.DocReference{}
+		var refs = []couchdb.DocReference{}
 		b := []byte(refBy)
-		if err = json.Unmarshal(b, refs); err != nil {
+		if err = json.Unmarshal(b, &refs); err != nil {
 			return err
 		}
-		doc.ReferencedBy = *refs
+		doc.ReferencedBy = refs
 	}
 
 	if err = permissions.AllowVFS(c, "POST", doc); err != nil {


### PR DESCRIPTION
This adds the possibility to define a `referenced_by` selector, which is useful for album sharing.
It sends the `references_by` attributes to the recipient, for him to check the associated permissions. 

Note that at the sharing creation, the `Title` permission field is used to know which doctype is referenced, needed to query the referenced view. I'm open to suggestions for a better way to get this doctype.
