### PR TITLE
Default to localhost for CLI

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -33,6 +33,7 @@ type jsonAPIDocument struct {
 // It holds the elements to authenticate a user, as well as the transport layer
 // used for all the calls to the stack.
 type Client struct {
+	Addr   string
 	Domain string
 	Scheme string
 	Client *http.Client
@@ -80,6 +81,7 @@ func (c *Client) init() error {
 		}
 	}
 	_, err := request.Req(&request.Options{
+		Addr:       c.Addr,
 		Method:     "GET",
 		Path:       "/version",
 		Domain:     c.Domain,
@@ -131,6 +133,7 @@ func (c *Client) Req(opts *request.Options) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
+	opts.Addr = c.Addr
 	opts.Domain = c.Domain
 	opts.Scheme = c.Scheme
 	opts.Client = c.Client

--- a/client/instances.go
+++ b/client/instances.go
@@ -63,9 +63,7 @@ type OAuthClientOptions struct {
 func (c *Client) GetInstance(domain string) (*Instance, error) {
 	res, err := c.Req(&request.Options{
 		Method: "GET",
-		// TODO replace QueryEscape with PathEscape when we will no longer support
-		// go 1.7
-		Path: "/instances/" + url.QueryEscape(domain),
+		Path:   "/instances/" + domain,
 	})
 	if err != nil {
 		return nil, err
@@ -130,9 +128,7 @@ func (c *Client) ModifyInstance(domain string, opts *InstanceOptions) (*Instance
 	}
 	res, err := c.Req(&request.Options{
 		Method: "PATCH",
-		// TODO replace QueryEscape with PathEscape when we will no longer support
-		// go 1.7
-		Path: "/instances/" + url.QueryEscape(domain),
+		Path:   "/instances/" + domain,
 		Queries: url.Values{
 			"Locale":    {opts.Locale},
 			"DiskQuota": {strconv.FormatInt(opts.DiskQuota, 10)},

--- a/client/request/request.go
+++ b/client/request/request.go
@@ -35,6 +35,7 @@ type (
 	// The NoResponse field can be used in case the call's response if not used. In
 	// such cases, the response body is automatically closed.
 	Options struct {
+		Addr       string
 		Domain     string
 		Scheme     string
 		Method     string
@@ -103,9 +104,16 @@ func Req(opts *Options) (*http.Response, error) {
 			scheme = "https"
 		}
 	}
+
+	var host string
+	if opts.Addr != "" {
+		host = opts.Addr
+	} else {
+		host = opts.Domain
+	}
 	u := url.URL{
 		Scheme: scheme,
-		Host:   opts.Domain,
+		Host:   host,
 		Path:   opts.Path,
 	}
 	if opts.Queries != nil {
@@ -116,6 +124,8 @@ func Req(opts *Options) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	req.Host = opts.Domain
 
 	if opts.Headers != nil {
 		for k, v := range opts.Headers {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,6 +58,7 @@ func newClient(domain, scope string) *client.Client {
 		os.Exit(1)
 	}
 	return &client.Client{
+		Addr:       config.ServerAddr(),
 		Domain:     domain,
 		Authorizer: &request.BearerAuthorizer{Token: token},
 	}

--- a/scripts/cozy-app-dev.sh
+++ b/scripts/cozy-app-dev.sh
@@ -117,8 +117,9 @@ do_start() {
 
 	echo ""
 	do_create_instances
-	echo ""
-	echo "Everything is setup. Go to http://${slug}.${cozy_dev_addr}/"
+	if [ -n "${slug}" ]; then
+		echo "Everything is setup. Go to http://${slug}.${cozy_dev_addr}/"
+	fi
 	echo "To exit, press ^C"
 	cat
 }


### PR DESCRIPTION
This PR makes the `cozy-stack` CLI use the `config.ServerAddr()` address to perform its HTTP connection, instead of the domain of the instance.

This address can be overridden with the `--host` and `--port` flags, which default to `localhost:8080`.