### PR TITLE
fix: outdated docs

### DIFF
--- a/docs/client-app-dev.md
+++ b/docs/client-app-dev.md
@@ -158,7 +158,7 @@ And `my-app.js`:
 
 document.addEventListener('DOMContentLoaded', () => {
   const app = document.querySelector('[role=application]')
-  cozy.init({
+  cozy.client.init({
     cozyURL: app.dataset.cozyStack,
     token: app.dataset.token
   })


### PR DESCRIPTION
The cozy client is now namespaced inside `cozy`, as mentioned [here](https://github.com/cozy/cozy-client-js/tree/master/docs#cozyclientinitoptions)