### PR TITLE
Add a route to modify apps/konnectors permissions

### DIFF
--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -550,3 +550,15 @@ Content-Type: application/vnd.api+json
   ]
 }
 ```
+
+### PATCH /permissions/apps/:slug
+
+Add permissions or remove permissions to the web application with specified
+slug. It behaves like the `PATCH /permissions/:id` route. See this route for
+more examples.
+
+### PATCH /permissions/konnectors/:slug
+
+Add permissions or remove permissions to the konnector with specified slug. It
+behaves like the `PATCH /permissions/:id` route. See this route for more
+examples.

--- a/web/apps/apps.go
+++ b/web/apps/apps.go
@@ -37,21 +37,19 @@ func (man *apiApp) MarshalJSON() ([]byte, error) {
 func (man *apiApp) Links() *jsonapi.LinksList {
 	var route string
 	links := jsonapi.LinksList{}
-	switch man.DocType() {
-	case consts.Apps:
-		var app = man.Manifest.(*apps.WebappManifest)
+	switch app := man.Manifest.(type) {
+	case (*apps.WebappManifest):
 		route = "/apps/"
 		if app.Icon != "" {
 			links.Icon = "/apps/" + app.Slug() + "/icon"
 		}
 		if app.State() == apps.Ready && app.Instance != nil {
-			links.Related = app.Instance.SubDomain(man.Manifest.Slug()).String()
+			links.Related = app.Instance.SubDomain(app.Slug()).String()
 		}
-
-	case consts.Konnectors:
+	case (*apps.KonnManifest):
 		route = "konnectors"
+		links.Perms = "/permissions/konnectors/" + app.Slug()
 	}
-
 	if route != "" {
 		links.Self = route + man.Manifest.Slug()
 	}

--- a/web/permissions/permissions.go
+++ b/web/permissions/permissions.go
@@ -221,7 +221,7 @@ func patchPermission(getPerms getPermsFunc, paramName string) echo.HandlerFunc {
 			return ErrPatchCodeOrSet
 		}
 
-		toPatch, err := getPerms(instance, paramName)
+		toPatch, err := getPerms(instance, c.Param(paramName))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR adds a route to modify the webapps and konnectors permissions. It also add the `permissions` field to the konnector JSON-API representation, like described in the konnector workflow document.