### PR TITLE
Fix meta extraction for large file

### DIFF
--- a/pkg/vfs/vfsafero/impl.go
+++ b/pkg/vfs/vfsafero/impl.go
@@ -6,6 +6,7 @@ import (
 	"crypto/md5"
 	"fmt"
 	"hash"
+	"io"
 	"net/url"
 	"os"
 	"path"
@@ -461,7 +462,7 @@ func (f *aferoFileCreation) Write(p []byte) (int, error) {
 	}
 
 	if f.meta != nil {
-		if _, err = (*f.meta).Write(p); err != nil {
+		if _, err = (*f.meta).Write(p); err != nil && err != io.ErrClosedPipe {
 			(*f.meta).Abort(err)
 			f.meta = nil
 		}

--- a/pkg/vfs/vfsswift/impl.go
+++ b/pkg/vfs/vfsswift/impl.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"strconv"
@@ -422,7 +423,7 @@ func (f *swiftFileCreation) Seek(offset int64, whence int) (int64, error) {
 
 func (f *swiftFileCreation) Write(p []byte) (int, error) {
 	if f.meta != nil {
-		if _, err := (*f.meta).Write(p); err != nil {
+		if _, err := (*f.meta).Write(p); err != nil && err != io.ErrClosedPipe {
 			(*f.meta).Abort(err)
 			f.meta = nil
 		}


### PR DESCRIPTION
In some cases (large files), image.DecodeConfig will return sooner, so we closes the reader part of the Pipe. which causes a io.ErrClosedPipe on next Write, which cause loss of metadata. This fixes that.