### PR TITLE
Use same `createdAt` and `updatedAt` dates

### DIFF
--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 )
@@ -617,8 +616,7 @@ func normalizeDocPatch(data, patch *DocPatch, cdate time.Time) (*DocPatch, error
 	}
 
 	if patch.UpdatedAt.Before(cdate) {
-		log.Error("UPDATE is before CREATION")
-		// return nil, ErrIllegalTime
+		return nil, ErrIllegalTime
 	}
 
 	if patch.Executable == nil {

--- a/pkg/workers/sharings/share_data.go
+++ b/pkg/workers/sharings/share_data.go
@@ -93,6 +93,8 @@ func (opts *SendOptions) fillDetailsAndOpenFile(fs vfs.VFS, fileDoc *vfs.FileDoc
 		"Type":          {consts.FileType},
 		"Name":          {fileDoc.DocName},
 		"Executable":    {strconv.FormatBool(fileDoc.Executable)},
+		"Created_at":    {fileDoc.CreatedAt.Format(time.RFC1123)},
+		"Updated_at":    {fileDoc.UpdatedAt.Format(time.RFC1123)},
 		"Referenced_by": []string{refs},
 	}
 
@@ -293,11 +295,12 @@ func SendDir(ins *instance.Instance, opts *SendOptions, dirDoc *vfs.DirDoc) erro
 				echo.HeaderAuthorization: "Bearer " + recipient.Token,
 			},
 			Queries: url.Values{
-				"Tags":      {dirTags},
-				"Path":      {dirPath},
-				"Recursive": {"true"},
-				"Name":      {dirDoc.DocName},
-				"Type":      {consts.DirType},
+				"Tags":       {dirTags},
+				"Path":       {dirPath},
+				"Name":       {dirDoc.DocName},
+				"Type":       {consts.DirType},
+				"Created_at": {dirDoc.CreatedAt.Format(time.RFC1123)},
+				"Updated_at": {dirDoc.CreatedAt.Format(time.RFC1123)},
 			},
 			NoResponse: true,
 		})

--- a/pkg/workers/sharings/share_data_test.go
+++ b/pkg/workers/sharings/share_data_test.go
@@ -260,9 +260,10 @@ func TestSendDir(t *testing.T) {
 				assert.Equal(t, dirDoc.DocName, c.QueryParam("Name"))
 				dirTags := strings.Join(dirDoc.Tags, files.TagSeparator)
 				assert.Equal(t, dirTags, c.QueryParam("Tags"))
-				dirDocPath, err := dirDoc.Path(fs)
-				assert.NoError(t, err)
-				assert.Equal(t, dirDocPath, c.QueryParam("Path"))
+				assert.Equal(t, dirDoc.CreatedAt.Format(time.RFC1123),
+					c.QueryParam("Created_at"))
+				assert.Equal(t, dirDoc.UpdatedAt.Format(time.RFC1123),
+					c.QueryParam("Updated_at"))
 				return c.JSON(http.StatusOK, nil)
 			})
 		},
@@ -329,6 +330,8 @@ func TestUpdateOrPatchFile(t *testing.T) {
 				assert.Equal(t, consts.FileType, c.QueryParam("Type"))
 				assert.Equal(t, updatedFileDoc.DocName, c.QueryParam("Name"))
 				assert.Equal(t, "false", c.QueryParam("Executable"))
+				assert.Equal(t, updatedFileDoc.UpdatedAt.Format(time.RFC1123),
+					c.QueryParam("Updated_at"))
 				sentFileDoc, err := files.FileDocFromReq(c,
 					updatedFileDoc.DocName, consts.SharedWithMeDirID, nil)
 				assert.NoError(t, err)


### PR DESCRIPTION
Before this PR the recipients and the sharer would have different dates
for the shared files: the recipients would set the `createdAt` date to
when they received a file, and `updatedAt` to when they received an
update.

Now both the sharer and the recipients have the same `createdAt` and
`updatedAt` dates.