### PR TITLE
Clearer errors messages and fix parsing of verbs set

### DIFF
--- a/pkg/permissions/errors.go
+++ b/pkg/permissions/errors.go
@@ -24,4 +24,18 @@ var (
 	// ErrBadScope is used when the given scope is malformed
 	ErrBadScope = echo.NewHTTPError(http.StatusBadRequest,
 		"Permission scope is empty or malformed")
+
+	// ErrNotSubset is returned on requests attempting to create a Set of
+	// permissions which is not a subset of the request's own token.
+	ErrNotSubset = echo.NewHTTPError(http.StatusForbidden,
+		"Attempt to create a larger permission set")
+
+	// ErrOnlyAppCanCreateSubSet is returned if a non-app attempts to create
+	// sharing permissions.
+	ErrOnlyAppCanCreateSubSet = echo.NewHTTPError(http.StatusForbidden,
+		"Only apps can create sharing permissions")
+
+	// ErrNotParent is used when the permissions should have a specific parent.
+	ErrNotParent = echo.NewHTTPError(http.StatusForbidden,
+		"Permissions can be updated only by its parent")
 )

--- a/pkg/permissions/permissions.go
+++ b/pkg/permissions/permissions.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
-	"github.com/labstack/echo"
 )
 
 // Permission is a storable object containing a set of rules and
@@ -42,16 +41,6 @@ const (
 
 	// TypeCLI if the value of Permission.Type for a command-line permission doc
 	TypeCLI = "cli"
-)
-
-var (
-	// ErrNotSubset is returned on requests attempting to create a Set of
-	// permissions which is not a subset of the request's own token.
-	ErrNotSubset = echo.NewHTTPError(403, "attempt to create a larger permission set")
-
-	// ErrOnlyAppCanCreateSubSet is returned if a non-app attempts to create
-	// sharing permissions.
-	ErrOnlyAppCanCreateSubSet = echo.NewHTTPError(403, "only apps can create sharing permissions")
 )
 
 // ID implements jsonapi.Doc

--- a/pkg/permissions/permissions_test.go
+++ b/pkg/permissions/permissions_test.go
@@ -85,12 +85,12 @@ func TestJSON2Set(t *testing.T) {
     "contacts": {
       "type": "io.cozy.contacts",
       "description": "Required for autocompletion on @name",
-      "verbs": ["GET"]
+      "verbs": ["GET","PUT"]
     },
     "images": {
       "type": "io.cozy.files",
       "description": "Required for the background",
-      "verbs": ["GET"],
+      "verbs": ["ALL"],
       "values": ["io.cozy.files.music-dir"]
     },
     "mail": {
@@ -107,6 +107,22 @@ func TestJSON2Set(t *testing.T) {
 	assert.Contains(t, []string{"contacts", "images", "mail"}, s[0].Title)
 	assert.Contains(t, []string{"contacts", "images", "mail"}, s[1].Title)
 	assert.Contains(t, []string{"contacts", "images", "mail"}, s[2].Title)
+	assert.EqualValues(t, VerbSet{"GET": struct{}{}, "PUT": struct{}{}}, s[0].Verbs)
+	assert.EqualValues(t, VerbSet{}, s[1].Verbs)
+}
+
+func TestBadJSONSet(t *testing.T) {
+	jsonSet := []byte(`{
+    "contacts": {
+      "type": "io.cozy.contacts",
+      "description": "Required for autocompletion on @name",
+      "verbs": ["BAD"]
+    }
+  }`)
+	var s Set
+	err := json.Unmarshal(jsonSet, &s)
+	assert.Error(t, err)
+	assert.Equal(t, ErrBadScope, err)
 }
 
 func TestSetToString(t *testing.T) {

--- a/pkg/permissions/verbs.go
+++ b/pkg/permissions/verbs.go
@@ -80,19 +80,23 @@ func (vs VerbSet) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON implements json.Unmarshaller on VerbSet
 // it expects a json array
 func (vs *VerbSet) UnmarshalJSON(b []byte) error {
-	if *vs == nil {
-		*vs = make(VerbSet)
-	}
+	*vs = make(VerbSet)
 	var s []string
 	err := json.Unmarshal(b, &s)
 	if err != nil {
 		return err
 	}
-	for v := range ALL {
-		delete(*vs, v)
+	// empty set and ["ALL"] set = ALL
+	if len(s) == 0 || (len(s) == 1 && s[0] == allVerbs) {
+		return nil
 	}
 	for _, v := range s {
-		(*vs)[Verb(v)] = struct{}{}
+		switch v {
+		case "GET", "POST", "PUT", "PATCH", "DELETE":
+			(*vs)[Verb(v)] = struct{}{}
+		default:
+			return ErrBadScope
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
This PR uses more specific error messages for modifying/revoking permissions.
It also should fix the parsing of the verbs set shortcut `["ALL"]`.