### PR TITLE
Add request scheme

### DIFF
--- a/client/auth/auth.go
+++ b/client/auth/auth.go
@@ -55,6 +55,7 @@ type (
 		ClientParams *Client
 		Scopes       []string
 		Domain       string
+		Scheme       string
 		HTTPClient   *http.Client
 		UserAgent    string
 		UserAccept   UserAcceptFunc
@@ -183,6 +184,7 @@ func (r *Request) AuthCodeURL(c *Client, state string) (string, error) {
 // req performs an authentication HTTP request
 func (r *Request) req(opts *request.Options) (*http.Response, error) {
 	opts.Domain = r.Domain
+	opts.Scheme = r.Scheme
 	opts.Client = r.HTTPClient
 	opts.ParseError = parseError
 	return request.Req(opts)

--- a/pkg/workers/sharings/share_data.go
+++ b/pkg/workers/sharings/share_data.go
@@ -36,8 +36,9 @@ func init() {
 
 // RecipientInfo describes the recipient information
 type RecipientInfo struct {
-	URL   string
-	Token string
+	URL    string
+	Scheme string
+	Token  string
 }
 
 // SendOptions describes the parameters needed to send data
@@ -165,6 +166,7 @@ func DeleteDoc(opts *SendOptions) error {
 
 		_, errSend := request.Req(&request.Options{
 			Domain: rec.URL,
+			Scheme: rec.Scheme,
 			Method: http.MethodDelete,
 			Path:   opts.Path,
 			Headers: request.Headers{
@@ -244,6 +246,7 @@ func sendDocToRecipient(opts *SendOptions, rec *RecipientInfo, doc *couchdb.JSON
 	// TODO : handle send failures
 	_, err = request.Req(&request.Options{
 		Domain: rec.URL,
+		Scheme: rec.Scheme,
 		Method: method,
 		Path:   opts.Path,
 		Headers: request.Headers{
@@ -288,6 +291,7 @@ func SendDir(ins *instance.Instance, opts *SendOptions, dirDoc *vfs.DirDoc) erro
 	for _, recipient := range opts.Recipients {
 		_, err := request.Req(&request.Options{
 			Domain: recipient.URL,
+			Scheme: recipient.Scheme,
 			Method: http.MethodPost,
 			Path:   opts.Path,
 			Headers: request.Headers{
@@ -399,6 +403,7 @@ func DeleteDirOrFile(opts *SendOptions) error {
 
 		_, err = request.Req(&request.Options{
 			Domain: recipient.URL,
+			Scheme: recipient.Scheme,
 			Method: http.MethodDelete,
 			Path:   opts.Path,
 			Headers: request.Headers{
@@ -432,6 +437,7 @@ func sendFileToRecipient(opts *SendOptions, recipient *RecipientInfo, method str
 
 	_, err := request.Req(&request.Options{
 		Domain: recipient.URL,
+		Scheme: recipient.Scheme,
 		Method: method,
 		Path:   opts.Path,
 		Headers: request.Headers{
@@ -457,6 +463,7 @@ func sendPatchToRecipient(patch *jsonapi.Document, opts *SendOptions, recipient 
 
 	_, err = request.Req(&request.Options{
 		Domain: recipient.URL,
+		Scheme: recipient.Scheme,
 		Method: http.MethodPatch,
 		Path:   opts.Path,
 		Headers: request.Headers{
@@ -527,6 +534,7 @@ func getDocRevAtRecipient(doctype, docID string, recInfo *RecipientInfo) (string
 
 	res, err := request.Req(&request.Options{
 		Domain: recInfo.URL,
+		Scheme: recInfo.Scheme,
 		Method: http.MethodGet,
 		Path:   path,
 		Headers: request.Headers{
@@ -577,6 +585,7 @@ func getFileOrDirMetadataAtRecipient(id string, recInfo *RecipientInfo) (map[str
 
 	res, err := request.Req(&request.Options{
 		Domain: recInfo.URL,
+		Scheme: recInfo.Scheme,
 		Method: http.MethodGet,
 		Path:   path,
 		Headers: request.Headers{

--- a/pkg/workers/sharings/sharing_updates.go
+++ b/pkg/workers/sharings/sharing_updates.go
@@ -134,13 +134,14 @@ func sendToRecipients(instance *instance.Instance, domain string, sharing *Shari
 		if err != nil {
 			return err
 		}
-		u, err := ExtractHost(recDoc.M["url"].(string))
+		u, scheme, err := ExtractHostAndScheme(recDoc.M["url"].(string))
 		if err != nil {
 			return err
 		}
 		info := &RecipientInfo{
-			URL:   u,
-			Token: rec.AccessToken.AccessToken,
+			URL:    u,
+			Scheme: scheme,
+			Token:  rec.AccessToken.AccessToken,
 		}
 		recInfos[i] = info
 	}
@@ -220,14 +221,19 @@ func GetRecipient(db couchdb.Database, recID string) (*couchdb.JSONDoc, error) {
 	return doc, err
 }
 
-// ExtractHost returns the recipient's host, without the scheme
-func ExtractHost(fullURL string) (string, error) {
+// ExtractHostAndScheme returns the recipient's host and the scheme
+func ExtractHostAndScheme(fullURL string) (string, string, error) {
 	if fullURL == "" {
-		return "", ErrRecipientHasNoURL
+		return "", "", ErrRecipientHasNoURL
 	}
 	u, err := url.Parse(fullURL)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
-	return u.Host, nil
+	host := u.Host
+	scheme := u.Scheme
+	if scheme == "" {
+		scheme = "https"
+	}
+	return host, scheme, nil
 }


### PR DESCRIPTION
The sharing was broken in https because the scheme is no longer deduced since #548.
This fixes the issue by adding the scheme for each http(s) request.