### PR TITLE
Add permission syntax for referenced_by doctype

### DIFF
--- a/pkg/permissions/rule.go
+++ b/pkg/permissions/rule.go
@@ -7,6 +7,9 @@ const ruleSep = " "
 const valueSep = ","
 const partSep = ":"
 
+// RefSep is used to separate doctype and value for a referenced selector
+const RefSep = "/"
+
 // Rule represent a single permissions rule, ie a Verb and a type
 type Rule struct {
 	// Type is the JSON-API type or couchdb Doctype

--- a/pkg/sharings/errors.go
+++ b/pkg/sharings/errors.go
@@ -5,6 +5,8 @@ import "errors"
 var (
 	// ErrBadSharingType is used when the given sharing type is not valid
 	ErrBadSharingType = errors.New("Invalid sharing type")
+	// ErrBadPermission is used when a given permission is not valid
+	ErrBadPermission = errors.New("Invalid permission format")
 	//ErrRecipientDoesNotExist is used when the given recipient does not exist
 	ErrRecipientDoesNotExist = errors.New("Recipient with given ID does not exist")
 	//ErrMissingScope is used when a request is missing the mandatory scope

--- a/pkg/sharings/sharings.go
+++ b/pkg/sharings/sharings.go
@@ -218,12 +218,17 @@ func ShareDoc(instance *instance.Instance, sharing *Sharing, recStatus *Recipien
 
 			// Particular case for referenced_by: use the existing view
 			if rule.Selector == "referenced_by" {
-				// The permission tilte is used to know the referenced doctype
-				refType := rule.Title
-
 				for _, val := range rule.Values {
+					// A referenced_by selector implies Values in the form
+					// ["refDocType/refId"]
+					parts := strings.Split(val, permissions.RefSep)
+					if len(parts) != 2 {
+						return ErrBadPermission
+					}
+					refType := parts[0]
+					refID := parts[1]
 					req := &couchdb.ViewRequest{
-						Key: []string{refType, val},
+						Key: []string{refType, refID},
 					}
 					var res couchdb.ViewResponse
 					err := couchdb.ExecView(instance, consts.FilesReferencedByView, req, &res)

--- a/pkg/vfs/permissions.go
+++ b/pkg/vfs/permissions.go
@@ -149,8 +149,15 @@ func (f *FileDoc) Valid(field, expected string) bool {
 		return contains(f.Tags, expected)
 	case "referenced_by":
 		for _, ref := range f.ReferencedBy {
-			if ref.ID == expected {
-				return true
+			parts := strings.Split(expected, permissions.RefSep)
+			if len(parts) == 2 {
+				if ref.Type == parts[0] && ref.ID == parts[1] {
+					return true
+				}
+			} else {
+				if ref.ID == expected {
+					return true
+				}
 			}
 		}
 		return false


### PR DESCRIPTION
This adds the possiblity to define a permission Value embedding the
referenced doctype with the id, separated by a '/'. It is useful for
permissions with a `referenced_by` as a selector.