### PR TITLE
Add master-master sharing support for JSON documents

### DIFF
--- a/pkg/sharings/sharings.go
+++ b/pkg/sharings/sharings.go
@@ -161,8 +161,8 @@ func FindSharingRecipient(db couchdb.Database, sharingID, clientID string) (*Sha
 	return sharing, sRec, nil
 }
 
-// addTrigger creates a new trigger on the updates of the shared documents
-func addTrigger(instance *instance.Instance, rule permissions.Rule, sharingID string) error {
+// AddTrigger creates a new trigger on the updates of the shared documents
+func AddTrigger(instance *instance.Instance, rule permissions.Rule, sharingID string) error {
 	sched := stack.GetScheduler()
 
 	var eventArgs string
@@ -206,7 +206,7 @@ func ShareDoc(instance *instance.Instance, sharing *Sharing, recStatus *Recipien
 		docType := rule.Type
 		// Trigger the updates if the sharing is not one-shot
 		if sharing.SharingType != consts.OneShotSharing {
-			if err := addTrigger(instance, rule, sharing.SharingID); err != nil {
+			if err := AddTrigger(instance, rule, sharing.SharingID); err != nil {
 				return err
 			}
 		}

--- a/pkg/workers/sharings/share_data.go
+++ b/pkg/workers/sharings/share_data.go
@@ -227,7 +227,7 @@ func UpdateDoc(ins *instance.Instance, opts *SendOptions) error {
 			continue
 		}
 		// No changes: nothing to do
-		if changes := docHasChanges(doc, remoteDoc); !changes {
+		if !docHasChanges(doc, remoteDoc) {
 			continue
 		}
 		rev := remoteDoc.M["_rev"].(string)
@@ -279,8 +279,8 @@ func SendFile(ins *instance.Instance, opts *SendOptions, fileDoc *vfs.FileDoc) e
 	for _, rec := range opts.Recipients {
 		err = sendFileToRecipient(opts, rec, http.MethodPost)
 		if err != nil {
-			log.Error("[sharing] An error occurred while trying to share "+
-				"file "+fileDoc.DocName+": ", err)
+			log.Errorf("[sharing] An error occurred while trying to share "+
+				"file %v: %v", fileDoc.DocName, err)
 		}
 	}
 
@@ -316,8 +316,8 @@ func SendDir(ins *instance.Instance, opts *SendOptions, dirDoc *vfs.DirDoc) erro
 			NoResponse: true,
 		})
 		if err != nil {
-			log.Error("[sharing] An error occurred while trying to share "+
-				"the directory "+dirDoc.DocName+": ", err)
+			log.Errorf("[sharing] An error occurred while trying to share "+
+				"the directory %v: %v", dirDoc.DocName, err)
 		}
 	}
 
@@ -336,7 +336,7 @@ func UpdateOrPatchFile(ins *instance.Instance, opts *SendOptions, fileDoc *vfs.F
 		// Get recipient data
 		data, err := getFileOrDirMetadataAtRecipient(opts.DocID, recipient)
 		if err != nil {
-			log.Error("[sharing] Could not get data at "+recipient.URL+": ", err)
+			log.Errorf("[sharing] Could not get data at %v: %v", recipient.URL, err)
 			continue
 		}
 
@@ -351,8 +351,8 @@ func UpdateOrPatchFile(ins *instance.Instance, opts *SendOptions, fileDoc *vfs.F
 			}
 			patch, errp := generateDirOrFilePatch(nil, fileDoc)
 			if errp != nil {
-				log.Error("[sharing] Could not generate patch for file "+
-					fileDoc.DocName+": ", errp)
+				log.Errorf("[sharing] Could not generate patch for file %v: %v",
+					fileDoc.DocName, errp)
 				continue
 			}
 			errsp := sendPatchToRecipient(patch, opts, recipient)
@@ -366,14 +366,14 @@ func UpdateOrPatchFile(ins *instance.Instance, opts *SendOptions, fileDoc *vfs.F
 		// The MD5 did change: this is a PUT
 		err = opts.fillDetailsAndOpenFile(ins.VFS(), fileDoc)
 		if err != nil {
-			log.Error("[sharing] An error occurred while trying to open "+
-				fileDoc.DocName+": ", err)
+			log.Errorf("[sharing] An error occurred while trying to open %v: %v",
+				fileDoc.DocName, err)
 			continue
 		}
 		err = sendFileToRecipient(opts, recipient, http.MethodPut)
 		if err != nil {
-			log.Error("[sharing] An error occurred while trying to share an "+
-				"update of file "+fileDoc.DocName+" to a recipient: ", err)
+			log.Errorf("[sharing] An error occurred while trying to share an "+
+				"update of file %v to a recipient: %v", fileDoc.DocName, err)
 		}
 	}
 
@@ -410,8 +410,8 @@ func DeleteDirOrFile(opts *SendOptions) error {
 	for _, recipient := range opts.Recipients {
 		rev, err := getDirOrFileRevAtRecipient(opts.DocID, recipient)
 		if err != nil {
-			log.Error("[sharing] (delete) An error occurred while trying "+
-				"to get a revision at "+recipient.URL+":", err)
+			log.Errorf("[sharing] (delete) An error occurred while trying "+
+				"to get a revision at %v: %v", recipient.URL, err)
 			continue
 		}
 		opts.DocRev = rev
@@ -433,8 +433,8 @@ func DeleteDirOrFile(opts *SendOptions) error {
 		})
 
 		if err != nil {
-			log.Error("[sharing] (delete) An error occurred while sending "+
-				"request to "+recipient.URL+": ", err)
+			log.Errorf("[sharing] (delete) An error occurred while sending "+
+				"request to %v: %v", recipient.URL, err)
 		}
 	}
 

--- a/pkg/workers/sharings/share_data.go
+++ b/pkg/workers/sharings/share_data.go
@@ -1,5 +1,6 @@
 package sharings
 
+// #nosec
 import (
 	"context"
 	"crypto/md5"
@@ -643,10 +644,7 @@ func getFileOrDirMetadataAtRecipient(id string, recInfo *RecipientInfo) (map[str
 func fileHasChanges(newFileDoc *vfs.FileDoc, data map[string]interface{}) bool {
 	//TODO: support modifications on other fields
 	attributes := data["attributes"].(map[string]interface{})
-	if newFileDoc.Name() != attributes["name"].(string) {
-		return true
-	}
-	return false
+	return newFileDoc.Name() != attributes["name"].(string)
 }
 
 // docHasChanges checks that the local doc do have changes compared to the remote one
@@ -663,7 +661,7 @@ func docHasChanges(newDoc *couchdb.JSONDoc, doc *couchdb.JSONDoc) (bool, error) 
 	if err != nil {
 		return false, err
 	}
-	newChecksum := md5.Sum(bNew)
+	newChecksum := md5.Sum(bNew) // #nosec
 
 	delete(doc.M, "_id")
 	delete(doc.M, "_rev")
@@ -671,7 +669,7 @@ func docHasChanges(newDoc *couchdb.JSONDoc, doc *couchdb.JSONDoc) (bool, error) 
 	if err != nil {
 		return false, err
 	}
-	checksum := md5.Sum(b)
+	checksum := md5.Sum(b) // #nosec
 	if checksum == newChecksum {
 		return false, nil
 	}

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -303,6 +303,15 @@ func getAccessToken(c echo.Context) error {
 	if err != nil {
 		return wrapErrors(err)
 	}
+	// Add triggers on the recipient side for each rule
+	if sharing.SharingType == consts.MasterMasterSharing {
+		for _, rule := range sharing.Permissions {
+			err = sharings.AddTrigger(instance, rule, sharing.SharingID)
+			if err != nil {
+				return wrapErrors(err)
+			}
+		}
+	}
 	return c.JSON(http.StatusOK, nil)
 }
 


### PR DESCRIPTION
This implements an actual master-master sharing, i.e. the changes are synchronized from both the sharer and recipient.
This supports creation, updates, and deletes on JSON documents. Full files support will come later.
