### PR TITLE
feat: folders hierarchy in sharing

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -120,7 +120,8 @@ const (
 	// QueryParamType is the key for the `type` value (file or directory) in
 	// a query string.
 	QueryParamType = "Type"
-	// QueryParamExecutable is key for the `recursive` value in a query string.
+	// QueryParamExecutable is key for the `executable` field of a vfs.FileDoc
+	// in a query string.
 	QueryParamExecutable = "Executable"
 	// QueryParamCreatedAt is the key for the `created_at` value in a query
 	// string.

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -109,6 +109,35 @@ const (
 	MailNotSentSharingStatus = "mail-not-sent"
 )
 
+const (
+	// QueryParamRev is the key for the revision value in a query string.
+	QueryParamRev = "rev"
+	// QueryParamDirID is the key for the `DirID` field of a vfs.FileDoc or
+	// vfs.DirDoc, in a query string.
+	QueryParamDirID = "dir_id"
+	// QueryParamName is the key for the name value in a query string.
+	QueryParamName = "Name"
+	// QueryParamType is the key for the `type` value (file or directory) in
+	// a query string.
+	QueryParamType = "Type"
+	// QueryParamExecutable is key for the `recursive` value in a query string.
+	QueryParamExecutable = "Executable"
+	// QueryParamCreatedAt is the key for the `created_at` value in a query
+	// string.
+	QueryParamCreatedAt = "Created_at"
+	// QueryParamUpdatedAt is the key for the `Updated_at` value in a query
+	// string.
+	QueryParamUpdatedAt = "Updated_at"
+	// QueryParamReferencedBy is the key for the `referenced_by` values in a
+	// query string.
+	QueryParamReferencedBy = "Referenced_by"
+	// QueryParamRecursive is the key for the `recursive` value in a query
+	// string.
+	QueryParamRecursive = "Recursive"
+	// QueryParamTags is the key for the `tags` values in a query string.
+	QueryParamTags = "Tags"
+)
+
 // AppsRegistry is an hard-coded list of known apps, with their source URLs
 // TODO remove it when we will have a true registry
 var AppsRegistry = map[string]string{

--- a/pkg/sharings/sharings.go
+++ b/pkg/sharings/sharings.go
@@ -287,6 +287,8 @@ func ShareDoc(instance *instance.Instance, sharing *Sharing, recStatus *Recipien
 
 			workerMsg, err := jobs.NewMessage(jobs.JSONEncoding, sharingWorker.SendOptions{
 				DocID:      val,
+				Selector:   rule.Selector,
+				Values:     values,
 				DocType:    docType,
 				Recipients: []*sharingWorker.RecipientInfo{rec},
 			})

--- a/pkg/sharings/sharings.go
+++ b/pkg/sharings/sharings.go
@@ -174,7 +174,7 @@ func AddTrigger(instance *instance.Instance, rule permissions.Rule, sharingID st
 
 	msg := sharingWorker.SharingMessage{
 		SharingID: sharingID,
-		DocType:   rule.Type,
+		Rule:      rule,
 	}
 	workerArgs, err := json.Marshal(msg)
 	if err != nil {

--- a/pkg/workers/sharings/share_data_test.go
+++ b/pkg/workers/sharings/share_data_test.go
@@ -290,7 +290,7 @@ func TestSendDir(t *testing.T) {
 		Recipients: recipients,
 	}
 
-	err = SendDir(testInstance, sendDirOpts, dirDoc)
+	err = SendDir(sendDirOpts, dirDoc)
 	assert.NoError(t, err)
 }
 

--- a/pkg/workers/sharings/sharing_updates.go
+++ b/pkg/workers/sharings/sharing_updates.go
@@ -58,8 +58,8 @@ type EventDoc struct {
 
 // SharingMessage describes a sharing message
 type SharingMessage struct {
-	SharingID string `json:"sharing_id"`
-	DocType   string `json:"doctype"`
+	SharingID string           `json:"sharing_id"`
+	Rule      permissions.Rule `json:"rule"`
 }
 
 // Sharing describes the sharing document structure
@@ -93,7 +93,7 @@ func SharingUpdates(ctx context.Context, m *jobs.Message) error {
 		return err
 	}
 	sharingID := event.Message.SharingID
-	docType := event.Message.DocType
+	rule := event.Message.Rule
 	docID := event.Event.Doc.M["_id"].(string)
 
 	// Get the sharing document
@@ -120,7 +120,7 @@ func SharingUpdates(ctx context.Context, m *jobs.Message) error {
 	if err = checkDocument(sharing, docID); err != nil {
 		return err
 	}
-	return sendToRecipients(i, domain, sharing, docType, docID, event.Event.Type)
+	return sendToRecipients(i, domain, sharing, &rule, docID, event.Event.Type)
 }
 
 // checkDocument checks the legitimity of the updated document to be shared
@@ -133,7 +133,7 @@ func checkDocument(sharing *Sharing, docID string) error {
 }
 
 // sendToRecipients sends the document to the recipient, or sharer
-func sendToRecipients(instance *instance.Instance, domain string, sharing *Sharing, docType, docID, eventType string) error {
+func sendToRecipients(instance *instance.Instance, domain string, sharing *Sharing, rule *permissions.Rule, docID, eventType string) error {
 	var recInfos []*RecipientInfo
 
 	if sharing.Sharer != nil && sharing.SharingType == consts.MasterMasterSharing {
@@ -159,15 +159,18 @@ func sendToRecipients(instance *instance.Instance, domain string, sharing *Shari
 
 	opts := &SendOptions{
 		DocID:      docID,
-		DocType:    docType,
+		DocType:    rule.Type,
 		Recipients: recInfos,
-		Path:       fmt.Sprintf("/sharings/doc/%s/%s", docType, docID),
+		Path:       fmt.Sprintf("/sharings/doc/%s/%s", rule.Type, docID),
 	}
 
 	var fileDoc *vfs.FileDoc
 	var dirDoc *vfs.DirDoc
 	var err error
 	if opts.DocType == consts.Files && eventType != realtime.EventDelete {
+		opts.Selector = rule.Selector
+		opts.Values = rule.Values
+
 		fs := instance.VFS()
 		dirDoc, fileDoc, err = fs.DirOrFileByID(docID)
 		if err != nil {

--- a/pkg/workers/sharings/sharing_updates.go
+++ b/pkg/workers/sharings/sharing_updates.go
@@ -187,7 +187,7 @@ func sendToRecipients(instance *instance.Instance, domain string, sharing *Shari
 			return SendFile(instance, opts, fileDoc)
 		}
 		if opts.Type == consts.DirType {
-			return SendDir(instance, opts, dirDoc)
+			return SendDir(opts, dirDoc)
 		}
 		return SendDoc(instance, opts)
 

--- a/pkg/workers/sharings/sharing_updates_test.go
+++ b/pkg/workers/sharings/sharing_updates_test.go
@@ -27,7 +27,12 @@ func createDoc(t *testing.T, docType string, params map[string]interface{}) couc
 func createEvent(t *testing.T, doc couchdb.JSONDoc, sharingID, eventType string) *TriggerEvent {
 	msg := &SharingMessage{
 		SharingID: sharingID,
-		DocType:   doc.Type,
+		Rule: permissions.Rule{
+			Description: "randomdesc",
+			Selector:    "",
+			Type:        doc.DocType(),
+			Values:      []string{},
+		},
 	}
 	event := &TriggerEvent{
 		Event:   &EventDoc{Type: eventType, Doc: &doc},

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -187,12 +187,12 @@ func TestReceiveDocumentSuccessFile(t *testing.T) {
 	strNow := time.Now().Format(time.RFC1123)
 
 	values := url.Values{
-		"Name":          {"TestFile"},
-		"Executable":    {"false"},
-		"Type":          {consts.FileType},
-		"Referenced_by": []string{refs},
-		"Created_at":    {strNow},
-		"Updated_at":    {strNow},
+		consts.QueryParamName:         {"TestFile"},
+		consts.QueryParamType:         {consts.FileType},
+		consts.QueryParamReferencedBy: []string{refs},
+		consts.QueryParamCreatedAt:    {strNow},
+		consts.QueryParamUpdatedAt:    {strNow},
+		consts.QueryParamDirID:        {consts.SharedWithMeDirID},
 	}
 	urlDest.RawQuery = values.Encode()
 	buf := strings.NewReader(body)
@@ -900,7 +900,7 @@ func TestMain(m *testing.M) {
 	clientID = clientOAuth.ClientID
 
 	// As shared files are put in the shared with me dir, we need it
-	err = createSharedWithMeDir(testInstance.VFS())
+	err = createDirForSharing(testInstance.VFS(), consts.SharedWithMeDirID, "")
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)


### PR DESCRIPTION
This PR introduces the necessary code to propagate what we call the
"folders hierarchy": if Alice shares a folder containing subfolders then
the recipient should retrieve the same structure, and if changes are
made they should also be propagated.

In addition this PR introduces the possibility to create specific
folders other than "Shared With Me". It will be used for photos in
particular.