### PR TITLE
chore: add piwik.js as an external lib

### DIFF
--- a/assets/externals
+++ b/assets/externals
@@ -37,3 +37,7 @@ sha256  461ce5ccc61564581b897a7c38290ee19a72c3044232da54d32edbd45ccf11dc
 name    ./fonts/fontawesome-webfont.woff2
 url     https://raw.githubusercontent.com/FortAwesome/Font-Awesome/master/fonts/fontawesome-webfont.woff2
 sha256  2adefcbc041e7d18fcf2d417879dc5a09997aa64d675b7a3c4b6ce33da13f3fe
+
+name    ./js/piwik.js
+url     https://piwik.cozycloud.cc/piwik.js
+sha256  4f51df044b76eabafab2fbf420871d472c8f3a629da79ec5fac75c530d79f266


### PR DESCRIPTION
We will need `piwik.js` to get analytics from usage as explained in https://trello.com/c/zUe4D0KA/269-2-glob-7-traces-d-usage

We tought we could use `piwik.js` by implementing different solution:
- [ ] allow CSP to load `piwik.cozycloud.cc/piwik.js`
- [X] add `piwik.js` in external assets served by the stack
- [ ] bundle the library within the app bundle

Do you think we choose the best solution?