### PR TITLE
Support master-master sharing for files

### DIFF
--- a/pkg/workers/sharings/share_data.go
+++ b/pkg/workers/sharings/share_data.go
@@ -355,7 +355,7 @@ func UpdateOrPatchFile(ins *instance.Instance, opts *SendOptions, fileDoc *vfs.F
 		// The MD5 didn't change: this is a PATCH
 		if md5 == md5AtRec {
 			// Check the metadata did change to do the patch
-			if hasChanges := fileHasChanges(fileDoc, remoteFileDoc); !hasChanges {
+			if !fileHasChanges(fileDoc, remoteFileDoc) {
 				continue
 			}
 			patch, errp := generateDirOrFilePatch(nil, fileDoc)

--- a/pkg/workers/sharings/share_data.go
+++ b/pkg/workers/sharings/share_data.go
@@ -67,6 +67,11 @@ type fileOptions struct {
 	set           bool // default value is false
 }
 
+var (
+	// ErrBadFileFormat is used when the given file is not well structured
+	ErrBadFileFormat = errors.New("Bad file format")
+)
+
 // fillDetailsAndOpenFile will augment the SendOptions structure with the
 // details regarding the file to share and open it so that it can be sent.
 //
@@ -659,6 +664,9 @@ func getDirOrFileMetadataAtRecipient(id string, recInfo *RecipientInfo) (*vfs.Di
 	dirOrFileDoc, err := bindDirOrFile(res.Body)
 	if err != nil {
 		return nil, nil, err
+	}
+	if dirOrFileDoc == nil {
+		return nil, nil, ErrBadFileFormat
 	}
 	dirDoc, fileDoc := dirOrFileDoc.Refine()
 	return dirDoc, fileDoc, nil

--- a/web/sharings/files.go
+++ b/web/sharings/files.go
@@ -140,7 +140,7 @@ func updateFile(c echo.Context) error {
 	newdoc, err := files.FileDocFromReq(
 		c,
 		c.QueryParam(consts.QueryParamName),
-		c.QueryParam(consts.QueryParamDirID),
+		olddoc.DirID,
 		olddoc.Tags,
 	)
 	newdoc.ReferencedBy = olddoc.ReferencedBy
@@ -195,7 +195,6 @@ func patchDirOrFile(c echo.Context) error {
 		return jsonapi.BadJSON()
 	}
 
-	*patch.DirID = c.QueryParam(consts.QueryParamDirID)
 	patch.RestorePath = nil
 
 	dirDoc, fileDoc, err := instance.VFS().DirOrFileByID(c.Param("docid"))
@@ -205,8 +204,10 @@ func patchDirOrFile(c echo.Context) error {
 
 	var rev string
 	if dirDoc != nil {
+		*patch.DirID = dirDoc.DirID
 		rev = dirDoc.Rev()
 	} else {
+		*patch.DirID = fileDoc.DirID
 		rev = fileDoc.Rev()
 	}
 


### PR DESCRIPTION
This deals with PUT/PATCH/DELETE on files, both on the sharer and recipient side.
It is able to detect if a remote file is different after a local change, and mitigate the modification.

Note this is based on #575.