### PR TITLE
Send file when remote doc is not found

### DIFF
--- a/pkg/workers/sharings/share_data.go
+++ b/pkg/workers/sharings/share_data.go
@@ -71,6 +71,8 @@ type fileOptions struct {
 var (
 	// ErrBadFileFormat is used when the given file is not well structured
 	ErrBadFileFormat = errors.New("Bad file format")
+	//ErrRemoteDocDoesNotExist is used when the remote doc does not exist
+	ErrRemoteDocDoesNotExist = errors.New("Remote doc does not exist")
 	// ErrBadPermission is used when a given permission is not valid
 	ErrBadPermission = errors.New("Invalid permission format")
 )
@@ -351,8 +353,18 @@ func UpdateOrPatchFile(ins *instance.Instance, opts *SendOptions, fileDoc *vfs.F
 		// Get recipient data
 		_, remoteFileDoc, err := getDirOrFileMetadataAtRecipient(opts.DocID, recipient)
 		if err != nil {
-			log.Errorf("[sharing] Could not get data at %v: %v", recipient.URL, err)
-			continue
+			// Special case for document not found: send document
+			if err == ErrRemoteDocDoesNotExist {
+				errf := SendFile(ins, opts, fileDoc)
+				if errf != nil {
+					log.Error("[sharing] An error occurred while trying to "+
+						"send file: ", errf)
+				}
+				continue
+			} else {
+				log.Errorf("[sharing] Could not get data at %v: %v", recipient.URL, err)
+				continue
+			}
 		}
 
 		md5AtRec := base64.StdEncoding.EncodeToString(remoteFileDoc.MD5Sum)
@@ -714,6 +726,10 @@ func getDirOrFileMetadataAtRecipient(id string, recInfo *RecipientInfo) (*vfs.Di
 		},
 	})
 	if err != nil {
+		reqErr := err.(*request.Error)
+		if reqErr.Title == "Not Found" {
+			return nil, nil, ErrRemoteDocDoesNotExist
+		}
 		return nil, nil, err
 	}
 	dirOrFileDoc, err := bindDirOrFile(res.Body)

--- a/pkg/workers/sharings/share_data.go
+++ b/pkg/workers/sharings/share_data.go
@@ -360,11 +360,10 @@ func UpdateOrPatchFile(ins *instance.Instance, opts *SendOptions, fileDoc *vfs.F
 					log.Error("[sharing] An error occurred while trying to "+
 						"send file: ", errf)
 				}
-				continue
 			} else {
 				log.Errorf("[sharing] Could not get data at %v: %v", recipient.URL, err)
-				continue
 			}
+			continue
 		}
 
 		md5AtRec := base64.StdEncoding.EncodeToString(remoteFileDoc.MD5Sum)
@@ -405,7 +404,6 @@ func UpdateOrPatchFile(ins *instance.Instance, opts *SendOptions, fileDoc *vfs.F
 					"send patch: ", errsp)
 			}
 			continue
-
 		}
 		// The MD5 did change: this is a PUT
 		err = opts.fillDetailsAndOpenFile(ins.VFS(), fileDoc)

--- a/pkg/workers/sharings/sharing_updates.go
+++ b/pkg/workers/sharings/sharing_updates.go
@@ -270,8 +270,11 @@ func ExtractHostAndScheme(fullURL string) (string, string, error) {
 	return host, scheme, nil
 }
 
+// isRecipientSide is used to determine whether or not we are on the recipient side.
+// A sharing is on the recipient side iff:
+// - the sharing type is master-master
+// - the SharerStatus structure is not nil
 func isRecipientSide(sharing *Sharing) bool {
-	// The recipient cannot do anything if it is not a master-master sharing
 	if sharing.SharingType == consts.MasterMasterSharing {
 		if sharing.Sharer.SharerStatus != nil {
 			return true

--- a/pkg/workers/sharings/sharing_updates.go
+++ b/pkg/workers/sharings/sharing_updates.go
@@ -136,7 +136,7 @@ func checkDocument(sharing *Sharing, docID string) error {
 func sendToRecipients(instance *instance.Instance, domain string, sharing *Sharing, rule *permissions.Rule, docID, eventType string) error {
 	var recInfos []*RecipientInfo
 
-	if sharing.Sharer.SharerStatus != nil && sharing.SharingType == consts.MasterMasterSharing {
+	if isRecipientSide(sharing) {
 		// We are on the recipient side
 		recInfos = make([]*RecipientInfo, 1)
 		sharerStatus := sharing.Sharer.SharerStatus
@@ -268,4 +268,14 @@ func ExtractHostAndScheme(fullURL string) (string, string, error) {
 		scheme = "https"
 	}
 	return host, scheme, nil
+}
+
+func isRecipientSide(sharing *Sharing) bool {
+	// The recipient cannot do anything if it is not a master-master sharing
+	if sharing.SharingType == consts.MasterMasterSharing {
+		if sharing.Sharer.SharerStatus != nil {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
It has the side effect to support photo album adding. As this is viewed as an update on the file, with a new `referenced_by`, the sharing worker will try to fetch the file from the remote, fail, and thus POST the file.
