### PR TITLE
feat: Get permissions for Cozy-to-Cozy sharings

### DIFF
--- a/pkg/consts/views.go
+++ b/pkg/consts/views.go
@@ -97,7 +97,7 @@ function(doc){
       var p = doc.permissions[k];
       var selector = p.selector || "_id";
       for (var i=0; i<p.values.length; i++) {
-				emit([p.type, selector, p.values[i]], p.verbs);
+        emit([p.type, selector, p.values[i]], p.verbs);
       }
     });
   }


### PR DESCRIPTION
Following /permissions/doctype/:doctype two routes were added to fetch
the list of permissions associated to Cozy-to-Cozy sharings.  The first
one fetches the list of permissions for sharings for which the user is a
recipient ("sharedWithMe").
The second one fetches the list of permissions for sharings for which
the user is the sharer ("sharedWithOthers").

For clarity the route /permissions/doctype/:doctype was renamed to
/permissions/doctype/:doctype/sharedByLink.