### PR TITLE
Increase the timeout for konnectors

### DIFF
--- a/pkg/workers/konnectors/konnector.go
+++ b/pkg/workers/konnectors/konnector.go
@@ -30,7 +30,7 @@ func init() {
 	jobs.AddWorker("konnector", &jobs.WorkerConfig{
 		Concurrency:  4,
 		MaxExecCount: 2,
-		Timeout:      30 * time.Second,
+		Timeout:      60 * time.Second,
 		WorkerFunc:   Worker,
 		WorkerCommit: commit,
 	})


### PR DESCRIPTION
It looks like 30s it not enough for konnectors (the rkt image is slow to load)