### PR TITLE
Improvements for instance deletions

### DIFF
--- a/client/instances.go
+++ b/client/instances.go
@@ -135,18 +135,16 @@ func (c *Client) ModifyInstance(domain string, opts *InstanceOptions) (*Instance
 }
 
 // DestroyInstance is used to delete an instance and all its data.
-func (c *Client) DestroyInstance(domain string) (*Instance, error) {
+func (c *Client) DestroyInstance(domain string) error {
 	if !validDomain(domain) {
-		return nil, fmt.Errorf("Invalid domain: %s", domain)
+		return fmt.Errorf("Invalid domain: %s", domain)
 	}
-	res, err := c.Req(&request.Options{
-		Method: "DELETE",
-		Path:   "/instances/" + domain,
+	_, err := c.Req(&request.Options{
+		Method:     "DELETE",
+		Path:       "/instances/" + domain,
+		NoResponse: true,
 	})
-	if err != nil {
-		return nil, err
-	}
-	return readInstance(res)
+	return err
 }
 
 // GetToken is used to generate a toke with the specified options.

--- a/cmd/instances.go
+++ b/cmd/instances.go
@@ -236,18 +236,18 @@ All data associated with this domain will be permanently lost.
 			if str != "yes" && str != "y" {
 				return nil
 			}
+
+			fmt.Println()
 		}
 
 		c := newAdminClient()
-		in, err := c.DestroyInstance(domain)
+		err := c.DestroyInstance(domain)
 		if err != nil {
-			log.Errorf("Failed to remove instance for domain %s", domain)
+			log.Errorf("An error occured while destroying instance for domain %s", domain)
 			return err
 		}
 
-		fmt.Println()
-
-		log.Infof("Instance for domain %s has been destroyed with success", in.Attrs.Domain)
+		log.Infof("Instance for domain %s has been destroyed with success", domain)
 		return nil
 	},
 }

--- a/cmd/instances.go
+++ b/cmd/instances.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"text/tabwriter"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
@@ -178,19 +179,31 @@ by this server.
 		if err != nil {
 			return err
 		}
-
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 		for _, i := range list {
-			var dev string
-			if i.Attrs.Dev {
-				dev = "dev"
-			} else {
-				dev = "prod"
-			}
-			fmt.Printf("%s\t%s\n", i.Attrs.Domain, dev)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+				i.Attrs.Domain,
+				i.Attrs.Locale,
+				printSize(i.Attrs.BytesDiskQuota),
+				printDev(i.Attrs.Dev),
+			)
 		}
-
-		return nil
+		return w.Flush()
 	},
+}
+
+func printDev(dev bool) string {
+	if dev {
+		return "dev"
+	}
+	return "prod"
+}
+
+func printSize(size int64) string {
+	if size == 0 {
+		return "unlimited"
+	}
+	return humanize.Bytes(uint64(size))
 }
 
 var destroyInstanceCmd = &cobra.Command{

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -46,6 +46,8 @@ var passwordResetValidityDuration = 15 * time.Minute
 // DefaultLocale is the default locale when creating an instance
 const DefaultLocale = "en"
 
+const illegalChars = " /?#@\t\r\n\x00"
+
 var (
 	// ErrNotFound is used when the seeked instance was not found
 	ErrNotFound = errors.New("Instance not found")
@@ -319,12 +321,9 @@ func (i *Instance) defineViewsAndIndex() error {
 
 // Create builds an instance and initializes it
 func Create(opts *Options) (*Instance, error) {
-	domain := strings.TrimSpace(opts.Domain)
-	if domain == "" || domain == ".." || domain == "." {
-		return nil, ErrIllegalDomain
-	}
-	if strings.ContainsAny(domain, " /?#@\t\r\n\x00") {
-		return nil, ErrIllegalDomain
+	domain, err := validateDomain(opts.Domain)
+	if err != nil {
+		return nil, err
 	}
 	if config.GetConfig().Subdomains == config.FlatSubdomains {
 		parts := strings.SplitN(domain, ".", 2)
@@ -431,8 +430,12 @@ func Create(opts *Options) (*Instance, error) {
 
 // Get retrieves the instance for a request by its host.
 func Get(domain string) (*Instance, error) {
-	cache := getCache()
 	var err error
+	domain, err = validateDomain(domain)
+	if err != nil {
+		return nil, err
+	}
+	cache := getCache()
 	i := cache.Get(domain)
 	if i == nil {
 		i, err = getFromCouch(domain)
@@ -528,8 +531,11 @@ func Update(i *Instance) error {
 // Destroy is used to remove the instance. All the data linked to this
 // instance will be permanently deleted.
 func Destroy(domain string) error {
-	getCache().Revoke(domain)
-
+	var err error
+	domain, err = validateDomain(domain)
+	if err != nil {
+		return err
+	}
 	sched := stack.GetScheduler()
 	triggers, err := sched.GetAll(domain)
 	if err == nil {
@@ -539,14 +545,13 @@ func Destroy(domain string) error {
 			}
 		}
 	}
-
-	db := couchdb.SimpleDatabasePrefix(domain)
-	if err = couchdb.DeleteAllDBs(db); err != nil {
-		return err
-	}
-
 	i, err := Get(domain)
 	if err != nil {
+		return err
+	}
+	defer getCache().Revoke(domain)
+	db := couchdb.SimpleDatabasePrefix(domain)
+	if err = couchdb.DeleteAllDBs(db); err != nil {
 		return err
 	}
 	if err = i.VFS().Delete(); err != nil {
@@ -747,6 +752,17 @@ func (i *Instance) BuildKonnectorToken(m apps.Manifest) string {
 		return ""
 	}
 	return token
+}
+
+func validateDomain(domain string) (string, error) {
+	domain = strings.TrimSpace(domain)
+	if domain == "" || domain == ".." || domain == "." {
+		return "", ErrIllegalDomain
+	}
+	if strings.ContainsAny(domain, illegalChars) {
+		return "", ErrIllegalDomain
+	}
+	return domain, nil
 }
 
 // ensure Instance implements couchdb.Doc

--- a/pkg/instance/instance_test.go
+++ b/pkg/instance/instance_test.go
@@ -360,15 +360,12 @@ func TestInstanceDestroy(t *testing.T) {
 		return
 	}
 
-	inst, err := instance.Destroy("test.cozycloud.cc")
-	if assert.NoError(t, err) {
-		assert.NotNil(t, inst)
-	}
+	err = instance.Destroy("test.cozycloud.cc")
+	assert.NoError(t, err)
 
-	inst, err = instance.Destroy("test.cozycloud.cc")
+	err = instance.Destroy("test.cozycloud.cc")
 	if assert.Error(t, err) {
 		assert.Equal(t, instance.ErrNotFound, err)
-		assert.Nil(t, inst)
 	}
 }
 

--- a/pkg/instance/instance_test.go
+++ b/pkg/instance/instance_test.go
@@ -399,14 +399,14 @@ func TestMain(m *testing.M) {
 		fmt.Println("This test need couchdb to run.")
 		os.Exit(1)
 	}
-	instance.Destroy("test.cozycloud.cc")
-	instance.Destroy("test2.cozycloud.cc")
-	instance.Destroy("test.cozycloud.cc.duplicate")
-
 	if err = stack.Start(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
+
+	instance.Destroy("test.cozycloud.cc")
+	instance.Destroy("test2.cozycloud.cc")
+	instance.Destroy("test.cozycloud.cc.duplicate")
 
 	os.RemoveAll("/usr/local/var/cozy2/")
 

--- a/pkg/sharings/sharings_test.go
+++ b/pkg/sharings/sharings_test.go
@@ -753,13 +753,13 @@ func TestMain(m *testing.M) {
 
 	// The instance must be created in db in order to retrieve it from
 	// the share_data worker
-	_, _ = instance.Destroy(domainSharer)
+	instance.Destroy(domainSharer)
 	in, err = createInstance(domainSharer, "Alice")
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	_, _ = instance.Destroy(domainRecipient)
+	instance.Destroy(domainRecipient)
 	recipientIn, err = createInstance(domainRecipient, "Bob")
 	if err != nil {
 		fmt.Println(err)

--- a/pkg/vfs/vfsswift/impl.go
+++ b/pkg/vfs/vfsswift/impl.go
@@ -96,8 +96,13 @@ func (sfs *swiftVFS) deleteContainer(container string) error {
 	if err != nil {
 		return err
 	}
-	_, err = sfs.c.BulkDelete(container, objectNames)
-	return err
+	if len(objectNames) > 0 {
+		_, err = sfs.c.BulkDelete(container, objectNames)
+		if err != nil {
+			return err
+		}
+	}
+	return sfs.c.ContainerDelete(container)
 }
 
 func (sfs *swiftVFS) CreateDir(doc *vfs.DirDoc) error {

--- a/pkg/vfs/vfsswift/impl.go
+++ b/pkg/vfs/vfsswift/impl.go
@@ -68,24 +68,36 @@ func (sfs *swiftVFS) InitFs() error {
 }
 
 func (sfs *swiftVFS) Delete() error {
-	// Mark the container as deleted but do not actually delete all the file of
-	// the container. For deleting actual files we should rely on another system
-	// for safety and because swift does not provide a convinient way to delete
-	// a container and its content.
-	err := sfs.c.ContainerUpdate(sfs.container, swift.Headers{"Deleted": "true"})
+	err := sfs.deleteContainer(sfs.container)
 	if err != nil {
-		log.Errorf("[vfsswift] Could not mark container as deleted %s: %s",
+		log.Errorf("[vfsswift] Could not delete container %s: %s",
 			sfs.container, err.Error())
 		return err
 	}
-	err = sfs.c.ContainerUpdate(sfs.version, swift.Headers{"Deleted": "true"})
-	if err != nil && err != swift.ContainerNotFound {
-		log.Errorf("[vfsswift] Could not mark version container as deleted %s: %s",
-			sfs.container, err.Error())
+	err = sfs.deleteContainer(sfs.version)
+	if err != nil {
+		log.Errorf("[vfsswift] Could not delete version container %s: %s",
+			sfs.version, err.Error())
 		return err
 	}
-	log.Infof("[vfsswift] Marked container as deleted %s", sfs.container)
+	log.Infof("[vfsswift] Deleted container %s", sfs.container)
 	return nil
+}
+
+func (sfs *swiftVFS) deleteContainer(container string) error {
+	_, _, err := sfs.c.Container(container)
+	if err == swift.ContainerNotFound {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	objectNames, err := sfs.c.ObjectNamesAll(container, nil)
+	if err != nil {
+		return err
+	}
+	_, err = sfs.c.BulkDelete(container, objectNames)
+	return err
 }
 
 func (sfs *swiftVFS) CreateDir(doc *vfs.DirDoc) error {

--- a/pkg/workers/sharings/share_data_test.go
+++ b/pkg/workers/sharings/share_data_test.go
@@ -634,7 +634,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	_, _ = instance.Destroy(domainSharer)
+	instance.Destroy(domainSharer)
 	in, err = createInstance(domainSharer, "Alice")
 	if err != nil {
 		fmt.Println(err)

--- a/tests/testutils/test_utils.go
+++ b/tests/testutils/test_utils.go
@@ -113,7 +113,7 @@ func (c *TestSetup) GetTestInstance(opts ...*instance.Options) *instance.Instanc
 	} else {
 		c.host = opts[0].Domain
 	}
-	_, err = instance.Destroy(c.host)
+	err = instance.Destroy(c.host)
 	if err != nil && err != instance.ErrNotFound {
 		c.CleanupAndDie("Error while destroying instance", err)
 	}
@@ -122,7 +122,7 @@ func (c *TestSetup) GetTestInstance(opts ...*instance.Options) *instance.Instanc
 	if err != nil {
 		c.CleanupAndDie("Cannot create test instance", err)
 	}
-	c.AddCleanup(func() error { _, err := instance.Destroy(i.Domain); return err })
+	c.AddCleanup(func() error { err := instance.Destroy(i.Domain); return err })
 	c.inst = i
 	return i
 }

--- a/web/instances/instances.go
+++ b/web/instances/instances.go
@@ -139,11 +139,11 @@ func listHandler(c echo.Context) error {
 
 func deleteHandler(c echo.Context) error {
 	domain := c.Param("domain")
-	i, err := instance.Destroy(domain)
+	err := instance.Destroy(domain)
 	if err != nil {
 		return wrapError(err)
 	}
-	return jsonapi.Data(c, http.StatusOK, &apiInstance{i}, nil)
+	return c.NoContent(http.StatusNoContent)
 }
 
 func createToken(c echo.Context) error {


### PR DESCRIPTION
- better printings of the `instances ls` command using `tabwriter`
- better resilience of the `instance.Destroy` command should not fail and leave the couchdb state in an intermediate state
- deleting an instance based on swift now also deletes the containers associated with it