### PR TITLE
Fix destroying a file in swift

### DIFF
--- a/pkg/vfs/vfsswift/impl.go
+++ b/pkg/vfs/vfsswift/impl.go
@@ -290,7 +290,8 @@ func (sfs *swiftVFS) destroyFile(doc *vfs.FileDoc) error {
 	if len(versionObjNames) > 0 {
 		_, err = sfs.c.BulkDelete(sfs.version, versionObjNames)
 		if err != nil {
-			return err
+			log.Errorf("[vfsswift] Could not delete version of %s: %s",
+				objName, err.Error())
 		}
 	}
 	return sfs.Indexer.DeleteFileDoc(doc)

--- a/pkg/vfs/vfsswift/impl.go
+++ b/pkg/vfs/vfsswift/impl.go
@@ -287,9 +287,11 @@ func (sfs *swiftVFS) destroyFile(doc *vfs.FileDoc) error {
 	if err != nil {
 		return err
 	}
-	_, err = sfs.c.BulkDelete(sfs.version, versionObjNames)
-	if err != nil {
-		return err
+	if len(versionObjNames) > 0 {
+		_, err = sfs.c.BulkDelete(sfs.version, versionObjNames)
+		if err != nil {
+			return err
+		}
 	}
 	return sfs.Indexer.DeleteFileDoc(doc)
 }


### PR DESCRIPTION
When `BulkDelete` is used with an empty list, `Swift` answers with a weird `Length missing` error. This PR should fix it.