### PR TITLE
Improve docker image

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -67,8 +67,8 @@ ENV COZY_STACK_HOST cozy.tools
 ENV COZY_STACK_PORT 8080
 ENV COZY_STACK_PATH cozy-stack
 
-COPY ./cozy-app-dev.sh ./cozy-stack /usr/bin/
 COPY ./docker-entrypoint.sh /
+COPY ./cozy-app-dev.sh ./cozy-stack /usr/bin/
 
 RUN chmod +x /docker-entrypoint.sh \
               /usr/bin/cozy-app-dev.sh \


### PR DESCRIPTION
I think that the docker entrypoint will change less often than the cozy-stack binary, so it should be before to avoid re-uploading / re-downloading its docker layer when the image is updated