### PR TITLE
Add md5 field when uploading a file to swift

### DIFF
--- a/pkg/apps/copier.go
+++ b/pkg/apps/copier.go
@@ -7,7 +7,7 @@ import (
 	"path"
 	"time"
 
-	"github.com/ncw/swift"
+	"github.com/cozy/swift"
 	"github.com/spf13/afero"
 )
 

--- a/pkg/apps/server.go
+++ b/pkg/apps/server.go
@@ -7,7 +7,7 @@ import (
 	"path"
 	"time"
 
-	"github.com/ncw/swift"
+	"github.com/cozy/swift"
 	"github.com/spf13/afero"
 )
 

--- a/pkg/config/swift.go
+++ b/pkg/config/swift.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/ncw/swift"
+	"github.com/cozy/swift"
 )
 
 var swiftConn *swift.Connection

--- a/pkg/vfs/vfsswift/impl.go
+++ b/pkg/vfs/vfsswift/impl.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/lock"
 	"github.com/cozy/cozy-stack/pkg/vfs"
-	"github.com/ncw/swift"
+	"github.com/cozy/swift"
 )
 
 const versionSuffix = "-version"

--- a/pkg/vfs/vfsswift/impl.go
+++ b/pkg/vfs/vfsswift/impl.go
@@ -69,16 +69,16 @@ func (sfs *swiftVFS) InitFs() error {
 }
 
 func (sfs *swiftVFS) Delete() error {
-	err := sfs.deleteContainer(sfs.container)
-	if err != nil {
-		log.Errorf("[vfsswift] Could not delete container %s: %s",
-			sfs.container, err.Error())
-		return err
-	}
-	err = sfs.deleteContainer(sfs.version)
+	err := sfs.deleteContainer(sfs.version)
 	if err != nil {
 		log.Errorf("[vfsswift] Could not delete version container %s: %s",
 			sfs.version, err.Error())
+		return err
+	}
+	err = sfs.deleteContainer(sfs.container)
+	if err != nil {
+		log.Errorf("[vfsswift] Could not delete container %s: %s",
+			sfs.container, err.Error())
 		return err
 	}
 	log.Infof("[vfsswift] Deleted container %s", sfs.container)
@@ -485,6 +485,18 @@ func (f *swiftFileCreation) Close() (err error) {
 	if f.meta != nil {
 		if errc := (*f.meta).Close(); errc == nil {
 			newdoc.Metadata = (*f.meta).Result()
+		}
+	}
+
+	// The actual check of the optionally given md5 hash is handled by the swift
+	// library.
+	if newdoc.MD5Sum == nil {
+		headers, err := f.f.Headers()
+		if err == nil {
+			md5sum, err := hex.DecodeString(headers["Etag"])
+			if err == nil {
+				newdoc.MD5Sum = md5sum
+			}
 		}
 	}
 

--- a/pkg/vfs/vfsswift/impl.go
+++ b/pkg/vfs/vfsswift/impl.go
@@ -491,9 +491,11 @@ func (f *swiftFileCreation) Close() (err error) {
 	// The actual check of the optionally given md5 hash is handled by the swift
 	// library.
 	if newdoc.MD5Sum == nil {
-		headers, err := f.f.Headers()
+		var headers swift.Headers
+		var md5sum []byte
+		headers, err = f.f.Headers()
 		if err == nil {
-			md5sum, err := hex.DecodeString(headers["Etag"])
+			md5sum, err = hex.DecodeString(headers["Etag"])
 			if err == nil {
 				newdoc.MD5Sum = md5sum
 			}

--- a/pkg/vfs/vfsswift/thumbs.go
+++ b/pkg/vfs/vfsswift/thumbs.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/cozy/cozy-stack/pkg/vfs"
-	"github.com/ncw/swift"
+	"github.com/cozy/swift"
 )
 
 // NewThumbsFs creates a new thumb filesystem base on swift.


### PR DESCRIPTION
This PR also switches to a [fork](https://github.com/cozy/swift) of the swift library fixing a bug in the `BulkDelete` method, preventing from deleting objects which names contained a white space.

cf: https://github.com/cozy/swift/commit/3e216a7ab367dd8fc804fb43f484962004f36f49