### PR TITLE
Add domain on whitelist for app LaMusiqueDeMesFilms

### DIFF
--- a/web/middlewares/secure.go
+++ b/web/middlewares/secure.go
@@ -67,7 +67,7 @@ const (
 	// CSPWhitelist is a whitelist of domains that are allowed in CSP. It's not
 	// permanent, this whitelist will be removed when we will have a more
 	// generic way to enable client-side apps to access some domains (proxy).
-	CSPWhitelist = "piwik.cozycloud.cc *.tile.openstreetmap.org *.tile.osm.org *.tiles.mapbox.com api.mapbox.com"
+	CSPWhitelist = "piwik.cozycloud.cc *.tile.openstreetmap.org *.tile.osm.org *.tiles.mapbox.com api.mapbox.com www.wikidata.org query.wikidata.org *.wikipedia.org *.wikimedia.org musicbrainz.org api.deezer.com"
 )
 
 // Secure returns a Middlefunc that can be used to define all the necessary

--- a/web/routing.go
+++ b/web/routing.go
@@ -115,7 +115,7 @@ func newRenderer(assetsPath string) (*renderer, error) {
 func SetupAppsHandler(appsHandler echo.HandlerFunc) echo.HandlerFunc {
 	secure := middlewares.Secure(&middlewares.SecureConfig{
 		HSTSMaxAge:    hstsMaxAge,
-		CSPDefaultSrc: []middlewares.CSPSource{middlewares.CSPSrcSelf, middlewares.CSPSrcParent},
+		CSPDefaultSrc: []middlewares.CSPSource{middlewares.CSPSrcSelf, middlewares.CSPSrcParent, middlewares.CSPSrcWhitelist},
 		CSPStyleSrc:   []middlewares.CSPSource{middlewares.CSPSrcSelf, middlewares.CSPSrcParent, middlewares.CSPUnsafeInline},
 		CSPFontSrc:    []middlewares.CSPSource{middlewares.CSPSrcSelf, middlewares.CSPSrcData, middlewares.CSPSrcParent},
 		CSPImgSrc:     []middlewares.CSPSource{middlewares.CSPSrcSelf, middlewares.CSPSrcData, middlewares.CSPSrcBlob, middlewares.CSPSrcParent, middlewares.CSPSrcWhitelist},


### PR DESCRIPTION
This PR add a list of domains, required to fetch metadata around VoD and replay data from Orange, in the Orange app La Musique de Mes Films.

To make it work, I also add to add this sites to the img-src and default-src CSP headers.