### PR TITLE
fix: Do not remove file from sharer's Cozy

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -146,6 +146,9 @@ const (
 	// QueryParamReferencedBy is the key for the `referenced_by` values in a
 	// query string.
 	QueryParamReferencedBy = "Referenced_by"
+	// QueryParamSharer is used to tell if the user that received the query is
+	// the sharer or not.
+	QueryParamSharer = "Sharer"
 )
 
 // AppsRegistry is an hard-coded list of known apps, with their source URLs

--- a/pkg/workers/sharings/sharing_updates.go
+++ b/pkg/workers/sharings/sharing_updates.go
@@ -128,8 +128,9 @@ func SharingUpdates(ctx context.Context, m *jobs.Message) error {
 // TODO explanation
 func sendToRecipients(ins *instance.Instance, domain string, sharing *Sharing, rule *permissions.Rule, docID, eventType string) error {
 	var recInfos []*RecipientInfo
+	sendToSharer := isRecipientSide(sharing)
 
-	if isRecipientSide(sharing) {
+	if sendToSharer {
 		// We are on the recipient side
 		recInfos = make([]*RecipientInfo, 1)
 		sharerStatus := sharing.Sharer.SharerStatus
@@ -203,10 +204,10 @@ func sendToRecipients(ins *instance.Instance, domain string, sharing *Sharing, r
 			if !stillShared {
 				ins.Logger().Debugf("[sharings] Sending remove references "+
 					"from %#v", fileDoc)
-				return RemoveDirOrFileFromSharing(ins, opts)
+				return RemoveDirOrFileFromSharing(ins, opts, sendToSharer)
 			}
 
-			return UpdateOrPatchFile(ins, opts, fileDoc)
+			return UpdateOrPatchFile(ins, opts, fileDoc, sendToSharer)
 		}
 
 		if opts.Type == consts.DirType {
@@ -219,7 +220,7 @@ func sendToRecipients(ins *instance.Instance, domain string, sharing *Sharing, r
 			if !stillShared {
 				ins.Logger().Debugf("[sharings] Sending remove references "+
 					"from %#v", dirDoc)
-				return RemoveDirOrFileFromSharing(ins, opts)
+				return RemoveDirOrFileFromSharing(ins, opts, sendToSharer)
 			}
 
 			ins.Logger().Debugf("[sharings] Sending patch dir %#v", dirDoc)


### PR DESCRIPTION
If a document is removed from a sharing that document would be deleted
from the Cozy of the sharer if it's a recipient that removed it in the
first place. This is a behavior we do not want so this PR fixes it.