### PR TITLE
feat: a document can be reshared

### DIFF
--- a/pkg/couchdb/couchdb.go
+++ b/pkg/couchdb/couchdb.go
@@ -214,6 +214,9 @@ func (j JSONDoc) Valid(field, value string) bool {
 		}
 
 		values := strings.Split(value, "/")
+		if len(values) != 2 {
+			return false
+		}
 		valueType, valueID := values[0], values[1]
 
 		for _, ref := range references {

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -320,14 +320,16 @@ func getAccessToken(c echo.Context) error {
 // If the document to store is a "io.cozy.files" our custom handler will be
 // called, otherwise we will redirect to /data.
 func receiveDocument(c echo.Context) error {
-	var err error
+	ins := middlewares.GetInstance(c)
+	ins.Logger().Debugf("[sharings] Receiving %s: %s", c.Param("doctype"),
+		c.Param("docid"))
 
+	var err error
 	switch c.Param("doctype") {
 	case consts.Files:
-		err = creationWithIDHandler(c)
+		err = creationWithIDHandler(c, ins)
 	default:
 		currDoctype := c.Param("doctype")
-		ins := middlewares.GetInstance(c)
 
 		doctypes, errc := couchdb.AllDoctypes(ins)
 		if errc != nil {
@@ -364,8 +366,11 @@ func receiveDocument(c echo.Context) error {
 //    to see if the document is still shared after the update. If not then it is
 //    deleted.
 func updateDocument(c echo.Context) error {
-	var err error
+	ins := middlewares.GetInstance(c)
+	ins.Logger().Debugf("[sharings] Updating %s: %s", c.Param("doctype"),
+		c.Param("docid"))
 
+	var err error
 	switch c.Param("doctype") {
 	case consts.Files:
 		err = updateFile(c)
@@ -388,8 +393,11 @@ func updateDocument(c echo.Context) error {
 }
 
 func deleteDocument(c echo.Context) error {
-	var err error
+	ins := middlewares.GetInstance(c)
+	ins.Logger().Debugf("[sharings] Deleting %s: %s", c.Param("doctype"),
+		c.Param("docid"))
 
+	var err error
 	switch c.Param("doctype") {
 	case consts.Files:
 		err = trashHandler(c)


### PR DESCRIPTION
With this PR it is possible to share several times the same document. We
detect that a document is reshared when we try to fetch it: we receive a
403 error — the document already exists but we can't access it.
When we receive such error we send the document as is if it was a
creation and the recipient will interpret it as an update.