### PR TITLE
fix: prevent consecutive sendings

### DIFF
--- a/pkg/workers/sharings/share_data_test.go
+++ b/pkg/workers/sharings/share_data_test.go
@@ -209,9 +209,9 @@ func TestSendFile(t *testing.T) {
 
 	mpr := map[string]func(*echo.Group){
 		"/files": func(router *echo.Group) {
-			router.GET("/:file-id", func(c echo.Context) error {
+			router.HEAD("/download/:file-id", func(c echo.Context) error {
 				assert.Equal(t, fileDoc.ID(), c.Param("file-id"))
-				return c.JSON(http.StatusNotFound, nil)
+				return c.JSON(http.StatusForbidden, nil)
 			})
 		},
 		"/sharings": func(router *echo.Group) {
@@ -260,9 +260,9 @@ func TestSendFileAbort(t *testing.T) {
 
 	mpr := map[string]func(*echo.Group){
 		"/files": func(router *echo.Group) {
-			router.GET("/:file-id", func(c echo.Context) error {
+			router.HEAD("/download/:file-id", func(c echo.Context) error {
 				assert.Equal(t, fileDoc.ID(), c.Param("file-id"))
-				return c.JSON(http.StatusConflict, nil)
+				return c.JSON(http.StatusOK, nil)
 			})
 		},
 		"/sharings": func(router *echo.Group) {

--- a/pkg/workers/sharings/sharing_updates.go
+++ b/pkg/workers/sharings/sharing_updates.go
@@ -181,29 +181,32 @@ func sendToRecipients(ins *instance.Instance, domain string, sharing *Sharing, r
 	switch eventType {
 	case realtime.EventCreate:
 		if opts.Type == consts.FileType {
-			ins.Logger().Debugf("[sharings] Sending file: %#v", fileDoc)
+			ins.Logger().Debugf("[sharings] sharing_update: Sending file: %#v",
+				fileDoc)
 			return SendFile(ins, opts, fileDoc)
 		}
 		if opts.Type == consts.DirType {
-			ins.Logger().Debugf("[sharings] Sending directory: %#v", dirDoc)
+			ins.Logger().Debugf("[sharings] sharing_update: Sending "+
+				"directory: %#v", dirDoc)
 			return SendDir(ins, opts, dirDoc)
 		}
 
-		ins.Logger().Debugf("[sharings] Sending JSON (%v): %v", opts.DocType,
-			opts.DocID)
+		ins.Logger().Debugf("[sharings] sharing_update: Sending %v: %v",
+			opts.DocType, opts.DocID)
 		return SendDoc(ins, opts)
 
 	case realtime.EventUpdate:
 		if opts.Type == consts.FileType {
 			if fileDoc.Trashed {
-				ins.Logger().Debugf("[sharings] Sending trash: %#v", fileDoc)
+				ins.Logger().Debugf("[sharings] sharing_update: Sending "+
+					"trash: %#v", fileDoc)
 				return DeleteDirOrFile(opts)
 			}
 
 			stillShared := isDocumentStillShared(opts, fileDoc.ReferencedBy)
 			if !stillShared {
-				ins.Logger().Debugf("[sharings] Sending remove references "+
-					"from %#v", fileDoc)
+				ins.Logger().Debugf("[sharings] sharing_update: Sending "+
+					"remove references from %#v", fileDoc)
 				return RemoveDirOrFileFromSharing(ins, opts, sendToSharer)
 			}
 
@@ -212,23 +215,25 @@ func sendToRecipients(ins *instance.Instance, domain string, sharing *Sharing, r
 
 		if opts.Type == consts.DirType {
 			if dirDoc.DirID == consts.TrashDirID {
-				ins.Logger().Debugf("[sharings] Sending trash: %#v", dirDoc)
+				ins.Logger().Debugf("[sharings] sharing_update: Sending "+
+					"trash: %v", dirDoc)
 				return DeleteDirOrFile(opts)
 			}
 
 			stillShared := isDocumentStillShared(opts, dirDoc.ReferencedBy)
 			if !stillShared {
-				ins.Logger().Debugf("[sharings] Sending remove references "+
-					"from %#v", dirDoc)
+				ins.Logger().Debugf("[sharings] sharing_update: Sending "+
+					"remove references from %v", dirDoc)
 				return RemoveDirOrFileFromSharing(ins, opts, sendToSharer)
 			}
 
-			ins.Logger().Debugf("[sharings] Sending patch dir %#v", dirDoc)
+			ins.Logger().Debugf("[sharings] sharing_update: Sending patch "+
+				"dir: %v", dirDoc)
 			return PatchDir(opts, dirDoc)
 		}
 
-		ins.Logger().Debugf("[sharings] Sending update JSON (%v): %v",
-			opts.DocType, opts.DocID)
+		ins.Logger().Debugf("[sharings] sharing_update: Sending update "+
+			"%s: %s", opts.DocType, opts.DocID)
 		return UpdateDoc(ins, opts)
 
 	case realtime.EventDelete:


### PR DESCRIPTION
When Alice shares a photo with Bob through a Master-Master sharing,
Bob's Cozy starts the sharing_update worker. It sees this event as a
creation and tries to send that very same photo to Alice. This led to
errors in the stack log.

This PR fixes this behavior: when we send a file we first try to get it
and unless we receive a 404 or 403 error we abort.