### PR TITLE
fix: remove doc from recipient only if not shared

### DIFF
--- a/pkg/sharings/sharings_test.go
+++ b/pkg/sharings/sharings_test.go
@@ -539,22 +539,6 @@ func TestSharingAcceptedBadCode(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestOneShotSharingAcceptedSuccess(t *testing.T) {
-	acceptedSharing(t, consts.OneShotSharing, false, false)
-}
-
-func TestMasterSlaveSharingAcceptedSuccess(t *testing.T) {
-	acceptedSharing(t, consts.MasterSlaveSharing, false, false)
-}
-
-func TestOneShotFileSharingAcceptedSuccess(t *testing.T) {
-	acceptedSharing(t, consts.OneShotSharing, true, false)
-}
-
-func TestMasterSlaveSharingSelectorAcceptedSuccess(t *testing.T) {
-	acceptedSharing(t, consts.MasterSlaveSharing, false, true)
-}
-
 func TestSharingRefusedNoSharing(t *testing.T) {
 	state := "fake state"
 	clientID := "fake client"


### PR DESCRIPTION
We had an unwanted behavior: if a recipient removes a document from a
sharing it would be automatically trashed even if it is still shared
somewhere else.
Now we first check that it is not shared anymore before removing it.

To do so the structures declared in pkg/workers/sharings were moved into
pkg/sharings so that the latter could be imported in the former.