### PR TITLE
Refresh token after auth error during sharing

### DIFF
--- a/client/auth/auth.go
+++ b/client/auth/auth.go
@@ -228,7 +228,7 @@ func (r *Request) GetAccessToken(c *Client, code string) (*AccessToken, error) {
 func (r *Request) RefreshToken(c *Client, t *AccessToken) (*AccessToken, error) {
 	q := url.Values{
 		"grant_type":    {"refresh_token"},
-		"code":          {t.RefreshToken},
+		"refresh_token": {t.RefreshToken},
 		"client_id":     {c.ClientID},
 		"client_secret": {c.ClientSecret},
 	}

--- a/pkg/sharings/recipients.go
+++ b/pkg/sharings/recipients.go
@@ -28,8 +28,8 @@ type RecipientStatus struct {
 
 	// The sharer is the "client", in the OAuth2 protocol, we keep here the
 	// information she needs to send to authenticate.
-	Client      *auth.Client
-	AccessToken *auth.AccessToken
+	Client      auth.Client
+	AccessToken auth.AccessToken
 
 	// The OAuth ClientID refering to the host's client stored in its db
 	HostClientID string
@@ -140,7 +140,7 @@ func (rs *RecipientStatus) getAccessToken(db couchdb.Database, code string) (*au
 		HTTPClient: new(http.Client),
 	}
 
-	return req.GetAccessToken(rs.Client, code)
+	return req.GetAccessToken(&rs.Client, code)
 }
 
 // Register asks the recipient to register the sharer as a new OAuth client.
@@ -207,7 +207,7 @@ func (rs *RecipientStatus) Register(instance *instance.Instance) error {
 		return err
 	}
 
-	rs.Client = resClient
+	rs.Client = *resClient
 	return nil
 }
 

--- a/pkg/sharings/send_mails_test.go
+++ b/pkg/sharings/send_mails_test.go
@@ -20,7 +20,7 @@ var recStatus = &RecipientStatus{
 	RefRecipient: couchdb.DocReference{
 		Type: consts.Recipients,
 	},
-	Client: &auth.Client{
+	Client: auth.Client{
 		ClientID:     "",
 		RedirectURIs: []string{},
 	},

--- a/pkg/sharings/sharings.go
+++ b/pkg/sharings/sharings.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/cozy/cozy-stack/client/auth"
 	"github.com/cozy/cozy-stack/client/request"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
@@ -70,9 +71,10 @@ type SharingMessage struct {
 // RecipientInfo describes the recipient information that will be transmitted to
 // the sharing workers.
 type RecipientInfo struct {
-	URL    string
-	Scheme string
-	Token  string
+	URL         string
+	Scheme      string
+	Client      *auth.Client
+	AccessToken *auth.AccessToken
 }
 
 // WorkerData describes the basic data the workers need to process the events
@@ -331,9 +333,10 @@ func ShareDoc(instance *instance.Instance, sharing *Sharing, recStatus *Recipien
 				return err
 			}
 			rec := &RecipientInfo{
-				URL:    domain,
-				Scheme: scheme,
-				Token:  recStatus.AccessToken.AccessToken,
+				URL:         domain,
+				Scheme:      scheme,
+				AccessToken: recStatus.AccessToken,
+				Client:      recStatus.Client,
 			}
 
 			workerMsg, err := jobs.NewMessage(jobs.JSONEncoding, WorkerData{

--- a/pkg/sharings/sharings.go
+++ b/pkg/sharings/sharings.go
@@ -73,14 +73,15 @@ type SharingMessage struct {
 type RecipientInfo struct {
 	URL         string
 	Scheme      string
-	Client      *auth.Client
-	AccessToken *auth.AccessToken
+	Client      auth.Client
+	AccessToken auth.AccessToken
 }
 
 // WorkerData describes the basic data the workers need to process the events
 // they will receive.
 type WorkerData struct {
 	DocID      string
+	SharingID  string
 	Selector   string
 	Values     []string
 	DocType    string
@@ -341,6 +342,7 @@ func ShareDoc(instance *instance.Instance, sharing *Sharing, recStatus *Recipien
 
 			workerMsg, err := jobs.NewMessage(jobs.JSONEncoding, WorkerData{
 				DocID:      val,
+				SharingID:  sharing.SharingID,
 				Selector:   rule.Selector,
 				Values:     rule.Values,
 				DocType:    docType,
@@ -582,7 +584,7 @@ func ExchangeCodeForToken(instance *instance.Instance, sharing *Sharing, recStat
 	if err != nil {
 		return err
 	}
-	recStatus.AccessToken = access
+	recStatus.AccessToken = *access
 	return couchdb.UpdateDoc(instance, sharing)
 }
 

--- a/pkg/sharings/sharings_test.go
+++ b/pkg/sharings/sharings_test.go
@@ -352,7 +352,7 @@ func TestGetAccessTokenNoAuth(t *testing.T) {
 	code := "sesame"
 	rs := &RecipientStatus{
 		recipient: &Recipient{URL: recipientURL},
-		Client:    &auth.Client{},
+		Client:    auth.Client{},
 	}
 	_, err := rs.getAccessToken(in, code)
 	assert.Error(t, err)
@@ -362,7 +362,7 @@ func TestGetAccessTokenNoURL(t *testing.T) {
 	code := "dummy"
 	rs := &RecipientStatus{
 		recipient: &Recipient{},
-		Client:    &auth.Client{},
+		Client:    auth.Client{},
 	}
 
 	_, err := rs.getAccessToken(in, code)
@@ -454,7 +454,7 @@ func TestGetSharingRecipientFromClientIDNoClient(t *testing.T) {
 
 	rStatus := &RecipientStatus{
 		RefRecipient: couchdb.DocReference{ID: "id", Type: "type"},
-		Client: &auth.Client{
+		Client: auth.Client{
 			ClientID: "fakeid",
 		},
 	}
@@ -471,7 +471,7 @@ func TestGetSharingRecipientFromClientIDNoClient(t *testing.T) {
 func TestGetSharingRecipientFromClientIDSuccess(t *testing.T) {
 	clientID := "fake client"
 	rs := &RecipientStatus{
-		Client: &auth.Client{
+		Client: auth.Client{
 			ClientID: clientID,
 		},
 	}
@@ -590,7 +590,7 @@ func TestSharingRefusedSuccess(t *testing.T) {
 
 	rStatus := &RecipientStatus{
 		RefRecipient: couchdb.DocReference{ID: recipient.RID},
-		Client: &auth.Client{
+		Client: auth.Client{
 			ClientID: clientID,
 		},
 	}

--- a/pkg/sharings/sharings_test.go
+++ b/pkg/sharings/sharings_test.go
@@ -539,22 +539,6 @@ func TestSharingAcceptedBadCode(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestOneShotSharingAcceptedSuccess(t *testing.T) {
-	acceptedSharing(t, consts.OneShotSharing, false, false)
-}
-
-func TestMasterSlaveSharingAcceptedSuccess(t *testing.T) {
-	acceptedSharing(t, consts.MasterSlaveSharing, false, false)
-}
-
-func TestOneShotFileSharingAcceptedSuccess(t *testing.T) {
-	acceptedSharing(t, consts.OneShotSharing, true, false)
-}
-
-func TestMasterSlaveSharingSelectorAcceptedSuccess(t *testing.T) {
-	acceptedSharing(t, consts.MasterSlaveSharing, false, true)
-}
-
 func TestSharingRefusedNoSharing(t *testing.T) {
 	state := "fake state"
 	clientID := "fake client"

--- a/pkg/workers/sharings/share_data.go
+++ b/pkg/workers/sharings/share_data.go
@@ -16,6 +16,7 @@ import (
 
 	"strings"
 
+	"github.com/cozy/cozy-stack/client/auth"
 	"github.com/cozy/cozy-stack/client/request"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
@@ -41,6 +42,7 @@ func init() {
 type SendOptions struct {
 	DocID      string
 	DocType    string
+	SharingID  string
 	Type       string
 	Recipients []*sharings.RecipientInfo
 	Path       string
@@ -216,11 +218,11 @@ func SendData(ctx context.Context, m *jobs.Message) error {
 
 // DeleteDoc asks the recipients to delete the shared document which id was
 // provided.
-func DeleteDoc(opts *SendOptions) error {
+func DeleteDoc(ins *instance.Instance, opts *SendOptions) error {
 	var errFinal error
 
 	for _, recipient := range opts.Recipients {
-		doc, err := getDocAtRecipient(nil, opts.DocType, opts.DocID, recipient)
+		doc, err := getDocAtRecipient(ins, nil, opts, recipient)
 		if err != nil {
 			errFinal = multierror.Append(errFinal,
 				fmt.Errorf("Error while trying to get remote doc : %s",
@@ -229,7 +231,7 @@ func DeleteDoc(opts *SendOptions) error {
 		}
 		rev := doc.M["_rev"].(string)
 
-		_, errSend := request.Req(&request.Options{
+		reqOpts := &request.Options{
 			Domain: recipient.URL,
 			Scheme: recipient.Scheme,
 			Method: http.MethodDelete,
@@ -237,13 +239,20 @@ func DeleteDoc(opts *SendOptions) error {
 			Headers: request.Headers{
 				"Content-Type":  "application/json",
 				"Accept":        "application/json",
-				"Authorization": "Bearer " + recipient.Token,
+				"Authorization": "Bearer " + recipient.AccessToken.AccessToken,
 			},
 			Queries:    url.Values{"rev": {rev}},
 			NoResponse: true,
-		})
+		}
+		_, errSend := request.Req(reqOpts)
+
 		if errSend != nil {
-			errFinal = multierror.Append(errFinal, fmt.Errorf("Error while trying to share data : %s", errSend.Error()))
+			if authError(err) {
+				_, errSend = refreshTokenAndRetry(ins, opts.SharingID, recipient, reqOpts)
+			}
+			if errSend != nil {
+				errFinal = multierror.Append(errFinal, fmt.Errorf("Error while trying to share data : %s", errSend.Error()))
+			}
 		}
 	}
 
@@ -262,10 +271,10 @@ func SendDoc(ins *instance.Instance, opts *SendOptions) error {
 	delete(doc.M, "_rev")
 
 	for _, rec := range opts.Recipients {
-		errs := sendDocToRecipient(opts, rec, doc, http.MethodPost)
+		errs := sendDocToRecipient(ins, opts, rec, doc, http.MethodPost)
 		if errs != nil {
-			ins.Logger().Error("[sharings] An error occurred while trying to"+
-				"send a document to a recipient: ", errs)
+			ins.Logger().Error("[sharing] An error occurred while trying to"+
+				" send a document to a recipient: ", errs)
 		}
 	}
 
@@ -281,7 +290,7 @@ func UpdateDoc(ins *instance.Instance, opts *SendOptions) error {
 
 	for _, rec := range opts.Recipients {
 		// A doc update requires to set the doc revision from each recipient
-		remoteDoc, err := getDocAtRecipient(doc, opts.DocType, opts.DocID, rec)
+		remoteDoc, err := getDocAtRecipient(ins, doc, opts, rec)
 		if err != nil {
 			ins.Logger().Error("[sharings] An error occurred while trying to "+
 				"get remote doc : ", err)
@@ -294,7 +303,7 @@ func UpdateDoc(ins *instance.Instance, opts *SendOptions) error {
 		rev := remoteDoc.M["_rev"].(string)
 		doc.SetRev(rev)
 
-		errs := sendDocToRecipient(opts, rec, doc, http.MethodPut)
+		errs := sendDocToRecipient(ins, opts, rec, doc, http.MethodPut)
 		if errs != nil {
 			ins.Logger().Error("[sharings] An error occurred while trying to "+
 				"send an update: ", err)
@@ -304,15 +313,14 @@ func UpdateDoc(ins *instance.Instance, opts *SendOptions) error {
 	return nil
 }
 
-func sendDocToRecipient(opts *SendOptions, rec *sharings.RecipientInfo, doc *couchdb.JSONDoc, method string) error {
+func sendDocToRecipient(ins *instance.Instance, opts *SendOptions, rec *sharings.RecipientInfo, doc *couchdb.JSONDoc, method string) error {
 	body, err := request.WriteJSON(doc.M)
 	if err != nil {
 		return err
 	}
-
 	// Send the document to the recipient
 	// TODO : handle send failures
-	_, err = request.Req(&request.Options{
+	reqOpts := &request.Options{
 		Domain: rec.URL,
 		Scheme: rec.Scheme,
 		Method: method,
@@ -320,11 +328,22 @@ func sendDocToRecipient(opts *SendOptions, rec *sharings.RecipientInfo, doc *cou
 		Headers: request.Headers{
 			"Content-Type":  "application/json",
 			"Accept":        "application/json",
-			"Authorization": "Bearer " + rec.Token,
+			"Authorization": "Bearer " + rec.AccessToken.AccessToken,
 		},
 		Body:       body,
 		NoResponse: true,
-	})
+	}
+	_, err = request.Req(reqOpts)
+	if err != nil {
+		if authError(err) {
+			body, berr := request.WriteJSON(doc.M)
+			if berr != nil {
+				return berr
+			}
+			reqOpts.Body = body
+			_, err = refreshTokenAndRetry(ins, opts.SharingID, rec, reqOpts)
+		}
+	}
 
 	return err
 }
@@ -347,7 +366,7 @@ func SendFile(ins *instance.Instance, opts *SendOptions, fileDoc *vfs.FileDoc) e
 		err = headDirOrFileMetadataAtRecipient(opts.DocID, recipient)
 
 		if err == ErrRemoteDocDoesNotExist || err == ErrForbidden {
-			err = sendFileToRecipient(opts, recipient, http.MethodPost)
+			err = sendFileToRecipient(ins, fileDoc, opts, recipient, http.MethodPost)
 			if err != nil {
 				ins.Logger().Errorf("[sharings] An error occurred while "+
 					"trying to share file %v: %v", fileDoc.ID(), err)
@@ -389,14 +408,14 @@ func SendDir(ins *instance.Instance, opts *SendOptions, dirDoc *vfs.DirDoc) erro
 	}
 
 	for _, recipient := range opts.Recipients {
-		_, errReq := request.Req(&request.Options{
+		reqOpts := &request.Options{
 			Domain: recipient.URL,
 			Scheme: recipient.Scheme,
 			Method: http.MethodPost,
 			Path:   opts.Path,
 			Headers: request.Headers{
 				echo.HeaderContentType:   echo.MIMEApplicationJSON,
-				echo.HeaderAuthorization: "Bearer " + recipient.Token,
+				echo.HeaderAuthorization: "Bearer " + recipient.AccessToken.AccessToken,
 			},
 			Queries: url.Values{
 				consts.QueryParamTags: {dirTags},
@@ -410,10 +429,16 @@ func SendDir(ins *instance.Instance, opts *SendOptions, dirDoc *vfs.DirDoc) erro
 				consts.QueryParamReferencedBy: {refs},
 			},
 			NoResponse: true,
-		})
+		}
+		_, errReq := request.Req(reqOpts)
 		if errReq != nil {
-			ins.Logger().Errorf("[sharings] An error occurred while trying to "+
-				"share the directory %v: %v", dirDoc.DocName, err)
+			if authError(errReq) {
+				_, errReq = refreshTokenAndRetry(ins, opts.SharingID, recipient, reqOpts)
+			}
+			if errReq != nil {
+				ins.Logger().Errorf("[sharing] An error occurred while trying to "+
+					"share the directory %v: %v", dirDoc.DocName, errReq)
+			}
 		}
 	}
 
@@ -442,7 +467,7 @@ func UpdateOrPatchFile(ins *instance.Instance, opts *SendOptions, fileDoc *vfs.F
 	defer opts.closeFile()
 
 	for _, recipient := range opts.Recipients {
-		_, remoteFileDoc, err := getDirOrFileMetadataAtRecipient(opts.DocID,
+		_, remoteFileDoc, err := getDirOrFileMetadataAtRecipient(ins, opts,
 			recipient)
 
 		if err != nil {
@@ -451,7 +476,7 @@ func UpdateOrPatchFile(ins *instance.Instance, opts *SendOptions, fileDoc *vfs.F
 				if errf != nil {
 					return err
 				}
-				errf = sendFileToRecipient(opts, recipient, http.MethodPost)
+				errf = sendFileToRecipient(ins, fileDoc, opts, recipient, http.MethodPost)
 				if errf != nil {
 					ins.Logger().Error("[sharings] An error occurred while "+
 						"trying to send file: ", errf)
@@ -476,7 +501,7 @@ func UpdateOrPatchFile(ins *instance.Instance, opts *SendOptions, fileDoc *vfs.F
 				if opts.Selector == consts.SelectorReferencedBy {
 					refs := findNewRefs(opts, fileDoc, remoteFileDoc)
 					if refs != nil {
-						erru := updateReferencesAtRecipient(http.MethodPost,
+						erru := updateReferencesAtRecipient(ins, http.MethodPost,
 							refs, opts, recipient, sendToSharer)
 						if erru != nil {
 							ins.Logger().Error("[sharings] An error occurred "+
@@ -493,7 +518,7 @@ func UpdateOrPatchFile(ins *instance.Instance, opts *SendOptions, fileDoc *vfs.F
 					"file %v: %v", fileDoc.DocName, errp)
 				continue
 			}
-			errsp := sendPatchToRecipient(patch, opts, recipient, fileDoc.DirID)
+			errsp := sendPatchToRecipient(ins, patch, opts, recipient, fileDoc.DirID)
 			if errsp != nil {
 				ins.Logger().Error("[sharings] An error occurred while trying "+
 					"to send patch: ", errsp)
@@ -507,7 +532,7 @@ func UpdateOrPatchFile(ins *instance.Instance, opts *SendOptions, fileDoc *vfs.F
 				"to open %v: %v", fileDoc.DocName, err)
 			continue
 		}
-		err = sendFileToRecipient(opts, recipient, http.MethodPut)
+		err = sendFileToRecipient(ins, fileDoc, opts, recipient, http.MethodPut)
 		if err != nil {
 			ins.Logger().Errorf("[sharings] An error occurred while trying to "+
 				"share an update of file %v to a recipient: %v",
@@ -520,7 +545,7 @@ func UpdateOrPatchFile(ins *instance.Instance, opts *SendOptions, fileDoc *vfs.F
 
 // PatchDir updates the metadata of the corresponding directory at each
 // recipient's.
-func PatchDir(opts *SendOptions, dirDoc *vfs.DirDoc) error {
+func PatchDir(ins *instance.Instance, opts *SendOptions, dirDoc *vfs.DirDoc) error {
 	var errFinal error
 
 	patch, err := generateDirOrFilePatch(dirDoc, nil)
@@ -529,12 +554,12 @@ func PatchDir(opts *SendOptions, dirDoc *vfs.DirDoc) error {
 	}
 
 	for _, rec := range opts.Recipients {
-		rev, err := getDirOrFileRevAtRecipient(opts.DocID, rec)
+		rev, err := getDirOrFileRevAtRecipient(ins, opts, rec)
 		if err != nil {
 			return err
 		}
 		opts.DocRev = rev
-		err = sendPatchToRecipient(patch, opts, rec, dirDoc.DirID)
+		err = sendPatchToRecipient(ins, patch, opts, rec, dirDoc.DirID)
 		if err != nil {
 			errFinal = multierror.Append(errFinal,
 				fmt.Errorf("Error while trying to send a patch: %s",
@@ -568,7 +593,7 @@ func RemoveDirOrFileFromSharing(ins *instance.Instance, opts *SendOptions, sendT
 	}
 
 	for _, recipient := range opts.Recipients {
-		errs := updateReferencesAtRecipient(http.MethodDelete, sharedRefs,
+		errs := updateReferencesAtRecipient(ins, http.MethodDelete, sharedRefs,
 			opts, recipient, sendToSharer)
 		if errs != nil {
 			ins.Logger().Debugf("[sharings] Could not update reference at "+
@@ -581,10 +606,10 @@ func RemoveDirOrFileFromSharing(ins *instance.Instance, opts *SendOptions, sendT
 
 // DeleteDirOrFile asks the recipients to put the file or directory in the
 // trash.
-func DeleteDirOrFile(opts *SendOptions) error {
+func DeleteDirOrFile(ins *instance.Instance, opts *SendOptions) error {
 	var errFinal error
 	for _, recipient := range opts.Recipients {
-		rev, err := getDirOrFileRevAtRecipient(opts.DocID, recipient)
+		rev, err := getDirOrFileRevAtRecipient(ins, opts, recipient)
 		if err != nil {
 			errFinal = multierror.Append(errFinal,
 				fmt.Errorf("Error while trying to get a revision at %v: %v",
@@ -593,26 +618,30 @@ func DeleteDirOrFile(opts *SendOptions) error {
 		}
 		opts.DocRev = rev
 
-		_, err = request.Req(&request.Options{
+		reqOpts := &request.Options{
 			Domain: recipient.URL,
 			Scheme: recipient.Scheme,
 			Method: http.MethodDelete,
 			Path:   opts.Path,
 			Headers: request.Headers{
 				echo.HeaderContentType:   echo.MIMEApplicationJSON,
-				echo.HeaderAuthorization: "Bearer " + recipient.Token,
+				echo.HeaderAuthorization: "Bearer " + recipient.AccessToken.AccessToken,
 			},
 			Queries: url.Values{
 				consts.QueryParamRev:  {opts.DocRev},
 				consts.QueryParamType: {opts.Type},
 			},
 			NoResponse: true,
-		})
-
+		}
+		_, err = request.Req(reqOpts)
 		if err != nil {
-			errFinal = multierror.Append(errFinal,
-				fmt.Errorf("Error while sending request to %v: %v",
-					recipient.URL, err))
+			if authError(err) {
+				_, err = refreshTokenAndRetry(ins, opts.SharingID, recipient, reqOpts)
+			}
+			if err != nil {
+				errFinal = multierror.Append(errFinal,
+					fmt.Errorf("Error while sending request to %v: %v", recipient.URL, err))
+			}
 		}
 	}
 
@@ -631,7 +660,7 @@ func DeleteDirOrFile(opts *SendOptions) error {
 //    Cozy.
 // 2. `opts.DocRev` is NOT empty: the recipient already has the file and the
 //    sharer is updating it.
-func sendFileToRecipient(opts *SendOptions, recipient *sharings.RecipientInfo, method string) error {
+func sendFileToRecipient(ins *instance.Instance, fileDoc *vfs.FileDoc, opts *SendOptions, recipient *sharings.RecipientInfo, method string) error {
 	if !opts.fileOpts.set {
 		return errors.New("[sharings] fileOpts were not set")
 	}
@@ -644,8 +673,7 @@ func sendFileToRecipient(opts *SendOptions, recipient *sharings.RecipientInfo, m
 	if opts.DocRev != "" {
 		opts.fileOpts.queries.Add("rev", opts.DocRev)
 	}
-
-	_, err := request.Req(&request.Options{
+	reqOpts := &request.Options{
 		Domain: recipient.URL,
 		Scheme: recipient.Scheme,
 		Method: method,
@@ -655,17 +683,27 @@ func sendFileToRecipient(opts *SendOptions, recipient *sharings.RecipientInfo, m
 			"Accept":         "application/vnd.api+json",
 			"Content-Length": opts.fileOpts.contentlength,
 			"Content-MD5":    opts.fileOpts.md5,
-			"Authorization":  "Bearer " + recipient.Token,
+			"Authorization":  "Bearer " + recipient.AccessToken.AccessToken,
 		},
 		Queries:    opts.fileOpts.queries,
 		Body:       opts.fileOpts.content,
 		NoResponse: true,
-	})
-
+	}
+	_, err := request.Req(reqOpts)
+	if err != nil {
+		if authError(err) {
+			content, erro := ins.VFS().OpenFile(fileDoc)
+			if erro != nil {
+				return erro
+			}
+			reqOpts.Body = content
+			_, err = refreshTokenAndRetry(ins, opts.SharingID, recipient, reqOpts)
+		}
+	}
 	return err
 }
 
-func sendPatchToRecipient(patch *jsonapi.Document, opts *SendOptions, recipient *sharings.RecipientInfo, dirID string) error {
+func sendPatchToRecipient(ins *instance.Instance, patch *jsonapi.Document, opts *SendOptions, recipient *sharings.RecipientInfo, dirID string) error {
 	body, err := request.WriteJSON(patch)
 	if err != nil {
 		return err
@@ -675,15 +713,14 @@ func sendPatchToRecipient(patch *jsonapi.Document, opts *SendOptions, recipient 
 	if err != nil {
 		return err
 	}
-
-	_, err = request.Req(&request.Options{
+	reqOpts := &request.Options{
 		Domain: recipient.URL,
 		Scheme: recipient.Scheme,
 		Method: http.MethodPatch,
 		Path:   opts.Path,
 		Headers: request.Headers{
 			echo.HeaderContentType:   jsonapi.ContentType,
-			echo.HeaderAuthorization: "Bearer " + recipient.Token,
+			echo.HeaderAuthorization: "Bearer " + recipient.AccessToken.AccessToken,
 		},
 		Queries: url.Values{
 			consts.QueryParamRev:   {opts.DocRev},
@@ -692,8 +729,18 @@ func sendPatchToRecipient(patch *jsonapi.Document, opts *SendOptions, recipient 
 		},
 		Body:       body,
 		NoResponse: true,
-	})
-
+	}
+	_, err = request.Req(reqOpts)
+	if err != nil {
+		if authError(err) {
+			body, errw := request.WriteJSON(patch)
+			if errw != nil {
+				return errw
+			}
+			reqOpts.Body = body
+			_, err = refreshTokenAndRetry(ins, opts.SharingID, recipient, reqOpts)
+		}
+	}
 	return err
 }
 
@@ -702,7 +749,7 @@ func sendPatchToRecipient(patch *jsonapi.Document, opts *SendOptions, recipient 
 // 2. If it's "DELETE" it calls the sharing handler because, in addition to
 //    removing the references, we need to see if the file is still shared and if
 //    not we need to trash it.
-func updateReferencesAtRecipient(method string, refs []couchdb.DocReference, opts *SendOptions, recipient *sharings.RecipientInfo, sendToSharer bool) error {
+func updateReferencesAtRecipient(ins *instance.Instance, method string, refs []couchdb.DocReference, opts *SendOptions, recipient *sharings.RecipientInfo, sendToSharer bool) error {
 	data, err := json.Marshal(refs)
 	if err != nil {
 		return err
@@ -726,7 +773,7 @@ func updateReferencesAtRecipient(method string, refs []couchdb.DocReference, opt
 		consts.QueryParamSharer: {strconv.FormatBool(sendToSharer)},
 	}
 
-	_, err = request.Req(&request.Options{
+	reqOpts := &request.Options{
 		Domain:  recipient.URL,
 		Scheme:  recipient.Scheme,
 		Method:  method,
@@ -734,12 +781,22 @@ func updateReferencesAtRecipient(method string, refs []couchdb.DocReference, opt
 		Queries: values,
 		Headers: request.Headers{
 			echo.HeaderContentType:   jsonapi.ContentType,
-			echo.HeaderAuthorization: "Bearer " + recipient.Token,
+			echo.HeaderAuthorization: "Bearer " + recipient.AccessToken.AccessToken,
 		},
 		Body:       body,
 		NoResponse: true,
-	})
-
+	}
+	_, err = request.Req(reqOpts)
+	if err != nil {
+		if authError(err) {
+			body, errw := request.WriteJSON(doc)
+			if errw != nil {
+				return errw
+			}
+			reqOpts.Body = body
+			_, err = refreshTokenAndRetry(ins, opts.SharingID, recipient, reqOpts)
+		}
+	}
 	return err
 }
 
@@ -830,10 +887,10 @@ func generateDirOrFilePatch(dirDoc *vfs.DirDoc, fileDoc *vfs.FileDoc) (*jsonapi.
 }
 
 // getDocAtRecipient returns the document at the given recipient.
-func getDocAtRecipient(newDoc *couchdb.JSONDoc, doctype, docID string, recInfo *sharings.RecipientInfo) (*couchdb.JSONDoc, error) {
-	path := fmt.Sprintf("/data/%s/%s", doctype, docID)
+func getDocAtRecipient(ins *instance.Instance, newDoc *couchdb.JSONDoc, opts *SendOptions, recInfo *sharings.RecipientInfo) (*couchdb.JSONDoc, error) {
+	path := fmt.Sprintf("/data/%s/%s", opts.DocType, opts.DocID)
 
-	res, err := request.Req(&request.Options{
+	reqOpts := &request.Options{
 		Domain: recInfo.URL,
 		Scheme: recInfo.Scheme,
 		Method: http.MethodGet,
@@ -841,13 +898,20 @@ func getDocAtRecipient(newDoc *couchdb.JSONDoc, doctype, docID string, recInfo *
 		Headers: request.Headers{
 			"Content-Type":  "application/json",
 			"Accept":        "application/json",
-			"Authorization": "Bearer " + recInfo.Token,
+			"Authorization": "Bearer " + recInfo.AccessToken.AccessToken,
 		},
-	})
-	if err != nil {
-		return nil, err
 	}
-
+	var res *http.Response
+	var err error
+	res, err = request.Req(reqOpts)
+	if err != nil {
+		if authError(err) {
+			res, err = refreshTokenAndRetry(ins, opts.SharingID, recInfo, reqOpts)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
 	doc := &couchdb.JSONDoc{}
 	if err := request.ReadJSON(res.Body, doc); err != nil {
 		return nil, err
@@ -855,9 +919,9 @@ func getDocAtRecipient(newDoc *couchdb.JSONDoc, doctype, docID string, recInfo *
 	return doc, nil
 }
 
-func getDirOrFileRevAtRecipient(docID string, recipient *sharings.RecipientInfo) (string, error) {
+func getDirOrFileRevAtRecipient(ins *instance.Instance, opts *SendOptions, recipient *sharings.RecipientInfo) (string, error) {
 	var rev string
-	dirDoc, fileDoc, err := getDirOrFileMetadataAtRecipient(docID, recipient)
+	dirDoc, fileDoc, err := getDirOrFileMetadataAtRecipient(ins, opts, recipient)
 	if err != nil {
 		return "", err
 	}
@@ -870,10 +934,10 @@ func getDirOrFileRevAtRecipient(docID string, recipient *sharings.RecipientInfo)
 	return rev, nil
 }
 
-func getDirOrFileMetadataAtRecipient(id string, recInfo *sharings.RecipientInfo) (*vfs.DirDoc, *vfs.FileDoc, error) {
-	path := fmt.Sprintf("/files/%s", id)
+func getDirOrFileMetadataAtRecipient(ins *instance.Instance, opts *SendOptions, recInfo *sharings.RecipientInfo) (*vfs.DirDoc, *vfs.FileDoc, error) {
+	path := fmt.Sprintf("/files/%s", opts.DocID)
 
-	res, err := request.Req(&request.Options{
+	reqOpts := &request.Options{
 		Domain: recInfo.URL,
 		Scheme: recInfo.Scheme,
 		Method: http.MethodGet,
@@ -881,11 +945,23 @@ func getDirOrFileMetadataAtRecipient(id string, recInfo *sharings.RecipientInfo)
 		Headers: request.Headers{
 			echo.HeaderContentType:    echo.MIMEApplicationJSON,
 			echo.HeaderAcceptEncoding: echo.MIMEApplicationJSON,
-			echo.HeaderAuthorization:  "Bearer " + recInfo.Token,
+			echo.HeaderAuthorization:  "Bearer " + recInfo.AccessToken.AccessToken,
 		},
-	})
+	}
+
+	var res *http.Response
+	var rerr error
+
+	res, err := request.Req(reqOpts)
 	if err != nil {
-		return nil, nil, parseError(err)
+		if authError(err) {
+			res, rerr = refreshTokenAndRetry(ins, opts.SharingID, recInfo, reqOpts)
+			if rerr != nil {
+				return nil, nil, rerr
+			}
+		} else {
+			return nil, nil, parseError(err)
+		}
 	}
 
 	dirOrFileDoc, err := bindDirOrFile(res.Body)
@@ -909,7 +985,7 @@ func headDirOrFileMetadataAtRecipient(id string, recInfo *sharings.RecipientInfo
 		Path:   path,
 		Headers: request.Headers{
 			echo.HeaderContentType:   echo.MIMEApplicationJSON,
-			echo.HeaderAuthorization: "Bearer " + recInfo.Token,
+			echo.HeaderAuthorization: "Bearer " + recInfo.AccessToken.AccessToken,
 		},
 	})
 
@@ -1046,4 +1122,47 @@ func bindDirOrFile(body io.Reader) (*vfs.DirOrFileDoc, error) {
 	dirOrFileDoc.SetRev(obj.Meta.Rev)
 
 	return dirOrFileDoc, nil
+}
+
+func authError(err error) bool {
+	switch v := err.(type) {
+	case *request.Error:
+		if v.Title == "Bad Request" || v.Title == "Unauthorized" {
+			return true
+		}
+	}
+	return false
+}
+
+// refreshTokenAndRetry is called after an authentication failure.
+// It tries to renew the access_token and request again
+func refreshTokenAndRetry(ins *instance.Instance, sharingID string, rec *sharings.RecipientInfo, opts *request.Options) (*http.Response, error) {
+	ins.Logger().Errorf("[sharing] The request is not authorized. "+
+		"Trying to renew the token for %v", rec.URL)
+
+	req := &auth.Request{
+		Domain:     opts.Domain,
+		Scheme:     opts.Scheme,
+		HTTPClient: new(http.Client),
+	}
+	access, rerr := req.RefreshToken(rec.Client, rec.AccessToken)
+	if rerr != nil {
+		ins.Logger().Errorf("[sharing] Refresh token request failed: %v", rerr)
+		return nil, rerr
+	}
+	sharing := &sharings.Sharing{}
+	rerr = couchdb.GetDoc(ins, consts.Sharings, sharingID, sharing)
+	if rerr != nil {
+		recStatus, err := sharing.GetSharingRecipientFromClientID(ins, rec.Client.ClientID)
+		if err != nil {
+			return nil, err
+		}
+		recStatus.AccessToken = access
+		if err := couchdb.UpdateDoc(ins, sharing); err != nil {
+			return nil, err
+		}
+	}
+	opts.Headers["Authorization"] = "Bearer " + access.AccessToken
+	res, rerr := request.Req(opts)
+	return res, rerr
 }

--- a/pkg/workers/sharings/share_data_test.go
+++ b/pkg/workers/sharings/share_data_test.go
@@ -15,6 +15,8 @@ import (
 
 	"net/url"
 
+	"reflect"
+
 	"github.com/cozy/cozy-stack/pkg/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
@@ -30,7 +32,6 @@ import (
 	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/labstack/echo"
 	"github.com/stretchr/testify/assert"
-	"reflect"
 )
 
 var testDocType = "io.cozy.tests"
@@ -203,7 +204,7 @@ func TestDeleteDoc(t *testing.T) {
 		},
 	}
 
-	err = DeleteDoc(opts)
+	err = DeleteDoc(in, opts)
 	assert.NoError(t, err)
 }
 
@@ -612,7 +613,7 @@ func TestPatchDir(t *testing.T) {
 		Recipients: recipients,
 	}
 
-	err = PatchDir(patchSendOptions, dirDoc)
+	err = PatchDir(in, patchSendOptions, dirDoc)
 	assert.NoError(t, err)
 }
 
@@ -758,7 +759,7 @@ func TestDeleteDirOrFile(t *testing.T) {
 		Recipients: recipients,
 	}
 
-	err = DeleteDirOrFile(deleteSendOptions)
+	err = DeleteDirOrFile(in, deleteSendOptions)
 	assert.NoError(t, err)
 }
 

--- a/pkg/workers/sharings/share_data_test.go
+++ b/pkg/workers/sharings/share_data_test.go
@@ -17,6 +17,7 @@ import (
 
 	"reflect"
 
+	"github.com/cozy/cozy-stack/client/auth"
 	"github.com/cozy/cozy-stack/pkg/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
@@ -144,8 +145,8 @@ func TestSendDataBadRecipient(t *testing.T) {
 	}()
 
 	rec := &sharings.RecipientInfo{
-		URL:   "nowhere",
-		Token: "inthesky",
+		URL:         "nowhere",
+		AccessToken: auth.AccessToken{AccessToken: "inthesky"},
 	}
 
 	msg, err := jobs.NewMessage(jobs.JSONEncoding, SendOptions{
@@ -198,8 +199,8 @@ func TestDeleteDoc(t *testing.T) {
 		Path:    fmt.Sprintf("/sharings/doc/%s/%s", testDocType, testDocID),
 		Recipients: []*sharings.RecipientInfo{
 			&sharings.RecipientInfo{
-				URL:   tsURL.Host,
-				Token: "whoneedsone?",
+				URL:         tsURL.Host,
+				AccessToken: auth.AccessToken{AccessToken: "inthesky"},
 			},
 		},
 	}
@@ -242,8 +243,8 @@ func TestSendFile(t *testing.T) {
 	assert.NoError(t, err)
 
 	recipient := &sharings.RecipientInfo{
-		URL:   tsURL.Host,
-		Token: "idontneedoneImtesting",
+		URL:         tsURL.Host,
+		AccessToken: auth.AccessToken{AccessToken: "inthesky"},
 	}
 	recipients := []*sharings.RecipientInfo{recipient}
 
@@ -290,8 +291,8 @@ func TestSendFileAbort(t *testing.T) {
 	assert.NoError(t, err)
 
 	recipient := &sharings.RecipientInfo{
-		URL:   tsURL.Host,
-		Token: "idontneedoneImtesting",
+		URL:         tsURL.Host,
+		AccessToken: auth.AccessToken{AccessToken: "inthesky"},
 	}
 	recipients := []*sharings.RecipientInfo{recipient}
 
@@ -349,8 +350,8 @@ func TestSendFileThroughUpdateOrPatchFile(t *testing.T) {
 	assert.NoError(t, err)
 
 	recipient := &sharings.RecipientInfo{
-		URL:   tsURL.Host,
-		Token: "idontneedoneImtesting",
+		URL:         tsURL.Host,
+		AccessToken: auth.AccessToken{AccessToken: "inthesky"},
 	}
 	recipients := []*sharings.RecipientInfo{recipient}
 
@@ -398,8 +399,8 @@ func TestSendDir(t *testing.T) {
 	assert.NoError(t, err)
 
 	recipient := &sharings.RecipientInfo{
-		URL:   tsURL.Host,
-		Token: "idontneedoneImtesting",
+		URL:         tsURL.Host,
+		AccessToken: auth.AccessToken{AccessToken: "inthesky"},
 	}
 	recipients := []*sharings.RecipientInfo{recipient}
 
@@ -507,8 +508,8 @@ func TestUpdateOrPatchFile(t *testing.T) {
 	tsURL, err := url.Parse(ts.URL)
 	assert.NoError(t, err)
 	testRecipient := &sharings.RecipientInfo{
-		URL:   tsURL.Host,
-		Token: "dontneedoneImtesting",
+		URL:         tsURL.Host,
+		AccessToken: auth.AccessToken{AccessToken: "inthesky"},
 	}
 	recipients := []*sharings.RecipientInfo{testRecipient}
 
@@ -599,8 +600,8 @@ func TestPatchDir(t *testing.T) {
 	tsURL, err := url.Parse(ts.URL)
 	assert.NoError(t, err)
 	testRecipient := &sharings.RecipientInfo{
-		URL:   tsURL.Host,
-		Token: "dontneedoneImtesting",
+		URL:         tsURL.Host,
+		AccessToken: auth.AccessToken{AccessToken: "inthesky"},
 	}
 	recipients := []*sharings.RecipientInfo{testRecipient}
 
@@ -666,8 +667,8 @@ func TestRemoveDirOrFileFromSharing(t *testing.T) {
 	tsURL, err := url.Parse(ts.URL)
 	assert.NoError(t, err)
 	testRecipient := &sharings.RecipientInfo{
-		URL:   tsURL.Host,
-		Token: "dontneedoneImtesting",
+		URL:         tsURL.Host,
+		AccessToken: auth.AccessToken{AccessToken: "inthesky"},
 	}
 	recipients := []*sharings.RecipientInfo{testRecipient}
 
@@ -745,8 +746,8 @@ func TestDeleteDirOrFile(t *testing.T) {
 	tsURL, err := url.Parse(ts.URL)
 	assert.NoError(t, err)
 	testRecipient := &sharings.RecipientInfo{
-		URL:   tsURL.Host,
-		Token: "dontneedoneImtesting",
+		URL:         tsURL.Host,
+		AccessToken: auth.AccessToken{AccessToken: "inthesky"},
 	}
 	recipients := []*sharings.RecipientInfo{testRecipient}
 

--- a/pkg/workers/sharings/sharing_updates.go
+++ b/pkg/workers/sharings/sharing_updates.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"runtime"
 
-	"github.com/cozy/cozy-stack/client/auth"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
@@ -59,28 +58,6 @@ type EventDoc struct {
 type SharingMessage struct {
 	SharingID string           `json:"sharing_id"`
 	Rule      permissions.Rule `json:"rule"`
-}
-
-// Sharing describes the sharing document structure
-type Sharing struct {
-	SharingType      string             `json:"sharing_type"`
-	Permissions      permissions.Set    `json:"permissions,omitempty"`
-	RecipientsStatus []*RecipientStatus `json:"recipients,omitempty"`
-	Sharer           Sharer             `json:"sharer,omitempty"`
-}
-
-// Sharer gives the share info, only on the recipient side
-type Sharer struct {
-	URL          string           `json:"url"`
-	SharerStatus *RecipientStatus `json:"sharer_status"`
-}
-
-// RecipientStatus contains the information about a recipient for a sharing
-type RecipientStatus struct {
-	Status       string               `json:"status,omitempty"`
-	RefRecipient couchdb.DocReference `json:"recipient,omitempty"`
-	AccessToken  *auth.AccessToken
-	Client       *auth.Client
 }
 
 // SharingUpdates handles shared document updates
@@ -157,6 +134,7 @@ func sendToRecipients(ins *instance.Instance, domain string, sharing *sharings.S
 	opts := &SendOptions{
 		DocID:      docID,
 		DocType:    rule.Type,
+		SharingID:  sharing.SharingID,
 		Recipients: recInfos,
 		Selector:   rule.Selector,
 		Values:     rule.Values,

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -15,6 +15,8 @@ import (
 
 	"encoding/base64"
 
+	"reflect"
+
 	authClient "github.com/cozy/cozy-stack/client/auth"
 	"github.com/cozy/cozy-stack/client/request"
 	"github.com/cozy/cozy-stack/pkg/config"
@@ -32,7 +34,6 @@ import (
 	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/labstack/echo"
 	"github.com/stretchr/testify/assert"
-	"reflect"
 )
 
 var ts *httptest.Server
@@ -981,7 +982,7 @@ func TestCreateSharingSuccess(t *testing.T) {
 
 func TestReceiveClientIDBadSharing(t *testing.T) {
 	sharing := createSharing(t, true, consts.OneShotSharing)
-	authCli := &authClient.Client{
+	authCli := authClient.Client{
 		ClientID: "myclientid",
 	}
 	sharing.RecipientsStatus[0].Client = authCli
@@ -998,7 +999,7 @@ func TestReceiveClientIDBadSharing(t *testing.T) {
 
 func TestReceiveClientIDSuccess(t *testing.T) {
 	sharing := createSharing(t, true, consts.OneShotSharing)
-	authCli := &authClient.Client{
+	authCli := authClient.Client{
 		ClientID: "myclientid",
 	}
 	sharing.RecipientsStatus[0].Client = authCli


### PR DESCRIPTION
When a sharing request fails with an authentication error (400 or 401), a token renewal is performed, before retrying the request.

Note this is based on #673 