### PR TITLE
WIP: Initial Windows support

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -2,8 +2,9 @@ package cmd
 
 import (
 	"errors"
-	"fmt"
 	"os"
+	"net/url"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -78,7 +79,11 @@ func init() {
 	flags.String("assets", "", "path to the directory with the assets (use the packed assets by default)")
 	checkNoErr(viper.BindPFlag("assets", flags.Lookup("assets")))
 
-	flags.String("fs-url", fmt.Sprintf("file://localhost%s/%s", binDir, DefaultStorageDir), "filesystem url")
+	defaultFsUrl := &url.URL{
+		Scheme: "file",
+		Path: path.Join(filepath.ToSlash(binDir), DefaultStorageDir),
+	}
+	flags.String("fs-url", defaultFsUrl.String(), "filesystem url")
 	checkNoErr(viper.BindPFlag("fs.url", flags.Lookup("fs-url")))
 
 	flags.String("couchdb-url", "http://localhost:5984/", "CouchDB URL")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,8 +3,6 @@ package config
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
-	"log/syslog"
 	"net"
 	"net/url"
 	"os"
@@ -14,8 +12,8 @@ import (
 	"text/template"
 
 	"github.com/Sirupsen/logrus"
-	logrus_syslog "github.com/Sirupsen/logrus/hooks/syslog"
 	"github.com/cozy/cozy-stack/pkg/logger"
+	logger_hooks "github.com/cozy/cozy-stack/pkg/logger/hooks"
 	"github.com/cozy/cozy-stack/pkg/utils"
 	"github.com/cozy/gomail"
 	"github.com/go-redis/redis"
@@ -404,12 +402,10 @@ func configureLogger() error {
 
 	logrus.SetLevel(logLevel)
 	if loggerCfg.Syslog {
-		hook, err := logrus_syslog.NewSyslogHook("", "", syslog.LOG_INFO, "cozy")
+		err := logger_hooks.SetupSyslog()
 		if err != nil {
 			return err
 		}
-		logrus.AddHook(hook)
-		logrus.SetOutput(ioutil.Discard)
 	}
 	return nil
 }

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -139,7 +139,7 @@ func (i *Instance) Prefix() string {
 }
 
 func (i *Instance) PathSegment() string {
-	return i.Domain
+	return strings.Replace(i.Domain, ":", "_", -1)
 }
 
 // Logger returns the logger associated with the instance

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -138,6 +138,10 @@ func (i *Instance) Prefix() string {
 	return i.Domain + "/"
 }
 
+func (i *Instance) PathSegment() string {
+	return i.Domain
+}
+
 // Logger returns the logger associated with the instance
 func (i *Instance) Logger() *logrus.Entry {
 	return logger.WithDomain(i.Domain)
@@ -163,7 +167,7 @@ func (i *Instance) makeVFS() error {
 	var err error
 	switch fsURL.Scheme {
 	case config.SchemeFile, config.SchemeMem:
-		i.vfs, err = vfsafero.New(index, disk, mutex, fsURL, i.Domain)
+		i.vfs, err = vfsafero.New(index, disk, mutex, fsURL, i.PathSegment())
 	case config.SchemeSwift:
 		i.vfs, err = vfsswift.New(index, disk, mutex, i.Domain)
 	default:
@@ -186,7 +190,7 @@ func (i *Instance) AppsCopier(appsType apps.AppType) apps.Copier {
 			baseDirName = vfs.KonnectorsDirName
 		}
 		baseFS := afero.NewBasePathFs(afero.NewOsFs(),
-			path.Join(fsURL.Path, i.Domain, baseDirName))
+			path.Join(fsURL.Path, i.PathSegment(), baseDirName))
 		return apps.NewAferoCopier(baseFS)
 	case config.SchemeSwift:
 		return apps.NewSwiftCopier(config.GetSwiftConnection(), appsType)
@@ -202,7 +206,7 @@ func (i *Instance) AppsFileServer() apps.FileServer {
 	switch fsURL.Scheme {
 	case config.SchemeFile, config.SchemeMem:
 		baseFS := afero.NewBasePathFs(afero.NewOsFs(),
-			path.Join(fsURL.Path, i.Domain, vfs.WebappsDirName))
+			path.Join(fsURL.Path, i.PathSegment(), vfs.WebappsDirName))
 		return apps.NewAferoFileServer(baseFS, nil)
 	case config.SchemeSwift:
 		return apps.NewSwiftFileServer(config.GetSwiftConnection(), apps.Webapp)
@@ -218,7 +222,7 @@ func (i *Instance) KonnectorsFileServer() apps.FileServer {
 	switch fsURL.Scheme {
 	case config.SchemeFile, config.SchemeMem:
 		baseFS := afero.NewBasePathFs(afero.NewOsFs(),
-			path.Join(fsURL.Path, i.Domain, vfs.KonnectorsDirName))
+			path.Join(fsURL.Path, i.PathSegment(), vfs.KonnectorsDirName))
 		return apps.NewAferoFileServer(baseFS, nil)
 	case config.SchemeSwift:
 		return apps.NewSwiftFileServer(config.GetSwiftConnection(), apps.Konnector)
@@ -234,7 +238,7 @@ func (i *Instance) ThumbsFS() vfs.Thumbser {
 	switch fsURL.Scheme {
 	case config.SchemeFile, config.SchemeMem:
 		baseFS := afero.NewBasePathFs(afero.NewOsFs(),
-			path.Join(fsURL.Path, i.Domain, vfs.ThumbsDirName))
+			path.Join(fsURL.Path, i.PathSegment(), vfs.ThumbsDirName))
 		return vfsafero.NewThumbsFs(baseFS)
 	case config.SchemeSwift:
 		return vfsswift.NewThumbsFs(config.GetSwiftConnection(), i.Domain)

--- a/pkg/logger/hooks/syslog.go
+++ b/pkg/logger/hooks/syslog.go
@@ -1,0 +1,19 @@
+// +build !windows
+
+package hooks
+
+import (
+	"io/ioutil"
+	std_syslog "log/syslog"
+
+	logrus_syslog "github.com/Sirupsen/logrus/hooks/syslog"
+)
+
+func SetupSyslog() error {
+	hook, err := logrus_syslog.NewSyslogHook("", "", std_syslog.LOG_INFO, "cozy")
+	if err != nil {
+		return err
+	}
+	logrus.AddHook(hook)
+	logrus.SetOutput(ioutil.Discard)
+}

--- a/pkg/logger/hooks/syslog_unavailable.go
+++ b/pkg/logger/hooks/syslog_unavailable.go
@@ -1,0 +1,11 @@
+// +build windows
+
+package hooks
+
+import (
+	"errors"
+)
+
+func SetupSyslog() error {
+  return errors.New("Syslog is not available on Windows!")
+}

--- a/pkg/vfs/vfsafero/impl.go
+++ b/pkg/vfs/vfsafero/impl.go
@@ -38,15 +38,15 @@ type aferoVFS struct {
 //
 // The supported scheme of the storage url are file://, for an OS-FS store, and
 // mem:// for an in-memory store. The backend used is the afero package.
-func New(index vfs.Indexer, disk vfs.DiskThresholder, mu lock.ErrorRWLocker, fsURL *url.URL, domain string) (vfs.VFS, error) {
+func New(index vfs.Indexer, disk vfs.DiskThresholder, mu lock.ErrorRWLocker, fsURL *url.URL, pathSegment string) (vfs.VFS, error) {
 	if fsURL.Scheme != "mem" && fsURL.Path == "" {
 		return nil, fmt.Errorf("vfsafero: please check the supplied fs url: %s",
 			fsURL.String())
 	}
-	if domain == "" {
-		return nil, fmt.Errorf("vfsafero: specified domain is empty")
+	if pathSegment == "" {
+		return nil, fmt.Errorf("vfsafero: specified path segment is empty")
 	}
-	pth := path.Join(fsURL.Path, domain)
+	pth := path.Join(fsURL.Path, pathSegment)
 	var fs afero.Fs
 	switch fsURL.Scheme {
 	case "file":


### PR DESCRIPTION
**dislaimer: this is WIP**

The following few changes allow me to build the cozy-stack on Windows and make the cozy-desktop tests pass 😍 
It could make it possible to use the cozy-stack on AppVeyor (instead of depending on an instance hosted somewhere else).

Main issues encountered:
- logrus' syslog hook doesn't build on Windows (I moved setup to a dedicated package, conditionnally building a runtime-failing stub on unsupported OS)
- The default fs-url was mixing backslash-separated parts with slash-separated ones. Also `file://localhost/C:/...` [doesn't seem to work well on Windows](https://en.wikipedia.org/wiki/File_URI_scheme#Windows), and may be better replaced with `file:///C:/...`
- Using the instance's `domain:port` as a dir name can't work as colon is a reserved char on Windows. Replacing it with an underscore works, but I wonder whether underscores may be allowed in some cases, so we may better find a safer replacement char...

Except for those, it basically works, although I clearly didn't use the whole API.

Wdyt?
I'm aware it may not be the best timing to discuss this, so feel free to postpone it!