### PR TITLE
feat: Revoke a recipient

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -98,19 +98,27 @@ const (
 )
 
 const (
-	// PendingSharingStatus is the sharing pending status
-	PendingSharingStatus = "pending"
-	// RefusedSharingStatus is the sharing refused status
-	RefusedSharingStatus = "refused"
-	// AcceptedSharingStatus is the sharing accepted status
-	AcceptedSharingStatus = "accepted"
-	// ErrorSharingStatus is when the request could not be sent
-	ErrorSharingStatus = "error"
-	// UnregisteredSharingStatus is when the sharer could not register herself
+	// SharingStatusPending is the sharing pending status
+	SharingStatusPending = "pending"
+	// SharingStatusRefused is the sharing refused status
+	SharingStatusRefused = "refused"
+	// SharingStatusAccepted is the sharing accepted status
+	SharingStatusAccepted = "accepted"
+	// SharingStatusError is when the request could not be sent
+	SharingStatusError = "error"
+	// SharingStatusUnregistered is when the sharer could not register herself
 	// as an OAuth client at the recipient's
-	UnregisteredSharingStatus = "unregistered"
-	// MailNotSentSharingStatus is when the mail invitation was not sent
-	MailNotSentSharingStatus = "mail-not-sent"
+	SharingStatusUnregistered = "unregistered"
+	// SharingStatusMailNotSent is when the mail invitation was not sent
+	SharingStatusMailNotSent = "mail-not-sent"
+	// SharingStatusRevoked is to tell if a recipient is revoked.
+	SharingStatusRevoked = "revoked"
+)
+
+const (
+	// WorkerTypeSharingUpdates is the string representation of the type of
+	// workers that deals with updating sharings.
+	WorkerTypeSharingUpdates = "sharingupdates"
 )
 
 const (

--- a/pkg/sharings/send_mails.go
+++ b/pkg/sharings/send_mails.go
@@ -44,7 +44,7 @@ func SendSharingMails(instance *instance.Instance, s *Sharing) error {
 	errorOccurred := false
 	for _, rs := range s.RecipientsStatus {
 		// Send mail based on the recipient status
-		if rs.Status == consts.MailNotSentSharingStatus {
+		if rs.Status == consts.SharingStatusMailNotSent {
 			err = rs.GetRecipient(instance)
 			if err != nil {
 				return err
@@ -89,7 +89,7 @@ func SendSharingMails(instance *instance.Instance, s *Sharing) error {
 			}
 
 			// Job was created, we set the status to "pending".
-			rs.Status = consts.PendingSharingStatus
+			rs.Status = consts.SharingStatusPending
 		}
 	}
 	// Persist the modifications in the database.

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -423,12 +423,32 @@ func revokeSharing(c echo.Context) error {
 		return jsonapi.NotFound(err)
 	}
 
+	// TODO Add permission check
+
 	err = sharings.RevokeSharing(instance, sharing)
 	if err != nil {
 		return wrapErrors(err)
 	}
 
 	return c.JSON(http.StatusOK, nil)
+}
+
+func revokeRecipient(c echo.Context) error {
+	ins := middlewares.GetInstance(c)
+
+	sharingID := c.Param("id")
+	sharing, err := sharings.FindSharing(ins, sharingID)
+	if err != nil {
+		return jsonapi.NotFound(err)
+	}
+
+	// TODO Add permission check
+	err = sharings.RevokeRecipient(ins, sharing, c.Param("recipient-client-id"))
+	if err != nil {
+		return wrapErrors(err)
+	}
+
+	return c.NoContent(http.StatusOK)
 }
 
 // Routes sets the routing for the sharing service
@@ -442,7 +462,9 @@ func Routes(router *echo.Group) {
 	router.POST("/recipient", CreateRecipient)
 	router.POST("/access/client", ReceiveClientID)
 	router.POST("/access/code", getAccessToken)
+
 	router.DELETE("/:id", revokeSharing)
+	router.DELETE("/:id/recipient/:recipient-client-id", revokeRecipient)
 
 	router.DELETE("/files/:file-id/referenced_by", removeReferences)
 

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -1080,6 +1080,29 @@ func TestRevokeSharing(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func TestRevokeRecipient(t *testing.T) {
+	// Test: we provide a wrong sharing id.
+	delURL := fmt.Sprintf("%s/sharings/nothing/recipient/noone", ts.URL)
+	req, err := http.NewRequest(http.MethodDelete, delURL, nil)
+	assert.NoError(t, err)
+	res, err := http.DefaultClient.Do(req)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, res.StatusCode)
+
+	// Create a legitimate sharing.
+	sharing := createSharing(t, false, consts.MasterMasterSharing)
+	// Test: we provide a wrong recipient.
+	delURL = fmt.Sprintf("%s/sharings/%s/recipient/noone", ts.URL,
+		sharing.SharingID)
+	req, err = http.NewRequest(http.MethodDelete, delURL, nil)
+	assert.NoError(t, err)
+	res, err = http.DefaultClient.Do(req)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, res.StatusCode)
+
+	// The success scenario is tested in pkg/sharings/sharings_test.go.
+}
+
 func TestMergeMetadata(t *testing.T) {
 	newMeta := vfs.Metadata{"un": "1", "deux": "2"}
 	oldMeta := vfs.Metadata{"trois": "3"}


### PR DESCRIPTION
This PR introduces the following feature: the sharer can now revoke a
recipient. To do so one needs to call the newly created route:
`DELETE /sharings/:id/recipient/:recipient-client-id`

The "recipient-client-id" is the id of the OAuth client of the recipient
for this sharing.