### PR TITLE
Fix missing close of the event subscription

### DIFF
--- a/pkg/scheduler/redis_scheduler.go
+++ b/pkg/scheduler/redis_scheduler.go
@@ -104,11 +104,13 @@ func (s *RedisScheduler) startEventDispatcher() {
 	eventsCh := make(chan *realtime.Event, 100)
 	go func() {
 		c := realtime.GetHub().SubscribeAll()
+		defer func() {
+			c.Close()
+			close(eventsCh)
+		}()
 		for {
 			select {
 			case <-s.stopped:
-				c.Close()
-				close(eventsCh)
 				return
 			case event := <-c.Read():
 				eventsCh <- event

--- a/pkg/scheduler/trigger_event.go
+++ b/pkg/scheduler/trigger_event.go
@@ -58,6 +58,10 @@ func (t *EventTrigger) Schedule() <-chan *jobs.JobRequest {
 	ch := make(chan *jobs.JobRequest)
 	go func() {
 		c := realtime.GetHub().Subscribe(t.infos.Domain, t.mask.Type)
+		defer func() {
+			c.Close()
+			close(ch)
+		}()
 		for {
 			select {
 			case e := <-c.Read():
@@ -65,7 +69,6 @@ func (t *EventTrigger) Schedule() <-chan *jobs.JobRequest {
 					ch <- t.Trigger(e)
 				}
 			case <-t.unscheduled:
-				close(ch)
 				return
 			}
 		}


### PR DESCRIPTION
This PR fixes a missing closing of an event subscription that would cause deadlocks when creating/deleting multiple times the same instance.

/cc @aeris 