### PR TITLE
Add a debug line for konnector

### DIFF
--- a/pkg/workers/konnectors/konnector.go
+++ b/pkg/workers/konnectors/konnector.go
@@ -238,6 +238,7 @@ func doScanOut(jobID string, scanner *bufio.Scanner, domain string,
 			}
 		}
 		log.Warnf("[konnector] %s: Could not parse as JSON", jobID)
+		log.Debugf("[konnector] %s: %s", jobID, string(linebb))
 	}
 	if err := scanner.Err(); err != nil {
 		log.Errorf("[konnector] %s: Error while reading stdout: %s", jobID, err)


### PR DESCRIPTION
We have some messages "Could not parse as JSON" in our logs. I think it comes from a debug or error messages that contains a `\n`, but it's hard to tell what/where without the message.