### PR TITLE
Use node 6 to have a prebuilt version of leveldown

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ go:
 
 before_install:
   - docker run -d -p 5984:5984 --net=host --name couch klaemo/couchdb:2.0.0
-  - nvm install 8
+  - nvm install 6
 
 before_script:
   - curl -X PUT http://127.0.0.1:5984/{_users,_replicator,_global_changes}
@@ -19,7 +19,7 @@ before_script:
   - gometalinter --deadline 120s --dupl-threshold 70 -D interfacer -D errcheck -D gocyclo -D dupl ./...
 
 script:
-  - nvm use 8
+  - nvm use 6
   - ./scripts/coverage.sh
   - ./scripts/integration.sh
 


### PR DESCRIPTION
I hope it will help to have a stable travis build