### PR TITLE
fix: english text

### DIFF
--- a/assets/locales/en.po
+++ b/assets/locales/en.po
@@ -12,8 +12,8 @@ msgstr "Photos"
 msgid "Tree Uploaded from Cozy Photos"
 msgstr "Uploaded from Cozy Photos"
 
-msgid "Tree Backuped from my mobile"
-msgstr "Backuped from my mobile"
+msgid "Tree Backed up from my mobile"
+msgstr "Backed up from my mobile"
 
 msgid "Login Credentials error"
 msgstr "The credentials you entered are incorrect, please try again."

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -414,7 +414,7 @@ func (i *Instance) createDefaultFilesTree() error {
 	if err == nil {
 		name = i.Translate("Tree Uploaded from Cozy Photos")
 		createDir(vfs.NewDirDoc(i.VFS(), name, photos.ID(), nil)) // #nosec
-		name = i.Translate("Tree Backuped from my mobile")
+		name = i.Translate("Tree Backed up from my mobile")
 		createDir(vfs.NewDirDoc(i.VFS(), name, photos.ID(), nil)) // #nosec
 	}
 


### PR DESCRIPTION
Hi! There was a small english mistake in one of the default folder names.
I'm unsure about the complete process here; I think since the translation id changes, I'll need to update the other languages on transifex after the PR is merged. Is that correct?