### PR TITLE
feat: Choose sharing destination directory

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -87,9 +87,8 @@ const (
 	DiskUsageID = "io.cozy.settings.disk-usage"
 	// InstanceSettingsID is the id of settings document for the instance
 	InstanceSettingsID = "io.cozy.settings.instance"
-	// SharedWithMeDirID is the id of the directory where all the files received
-	// by sharing will end up.
-	SharedWithMeDirID = "io.cozy.sharings.shared-with-me-dir"
+	// SharingSettingsID is the id of the settings document for sharings.
+	SharingSettingsID = "io.cozy.settings.sharings"
 )
 
 const (
@@ -131,8 +130,9 @@ const (
 )
 
 const (
-	// QueryParamRev is the key for the revision value in a query string.
-	QueryParamRev = "Rev"
+	// QueryParamRev is the key for the revision value in a query string. In
+	// web/data the revision is expected as "rev", not "Rev".
+	QueryParamRev = "rev"
 	// QueryParamDirID is the key for the `DirID` field of a vfs.FileDoc or
 	// vfs.DirDoc, in a query string.
 	QueryParamDirID = "Dir_id"
@@ -161,6 +161,13 @@ const (
 	// QueryParamSharer is used to tell if the user that received the query is
 	// the sharer or not.
 	QueryParamSharer = "Sharer"
+	// QueryParamAppSlug is used to transmit the application slug in a query
+	// string.
+	QueryParamAppSlug = "App_slug"
+	// QueryParamDocType is used to transmit the doctype in a query string.
+	QueryParamDocType = "Doctype"
+	// QueryParamSharingID is used to transmit the sharingID in a query string.
+	QueryParamSharingID = "Sharing_id"
 )
 
 // AppsRegistry is an hard-coded list of known apps, with their source URLs

--- a/pkg/sharings/settings.go
+++ b/pkg/sharings/settings.go
@@ -1,0 +1,187 @@
+package sharings
+
+import (
+	"time"
+
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/instance"
+	"github.com/cozy/cozy-stack/pkg/vfs"
+)
+
+// SharingSettings is the list of destination directories set by the
+// different applications.
+type SharingSettings struct {
+	AppDestination      map[string]map[string]string `json:"app_destination"`
+	SharingsSettingsID  string                       `json:"_id,omitempty"`
+	SharingsSettingsRev string                       `json:"_rev,omitempty"`
+	SharedWithMeDirID   string                       `json:"shared_w_me_dir_id,omitempty"`
+}
+
+// ID returns the SharingSettings qualified identifier.
+func (s SharingSettings) ID() string { return s.SharingsSettingsID }
+
+// Rev returns the SharingSettings revision.
+func (s SharingSettings) Rev() string { return s.SharingsSettingsRev }
+
+// DocType returns the SharingSettings doctype.
+func (s SharingSettings) DocType() string { return consts.Settings }
+
+// Clone returns a new SharingSettings with the same values.
+func (s *SharingSettings) Clone() couchdb.Doc {
+	cloned := *s
+	cloned.AppDestination = make(map[string]map[string]string)
+	for app, dest := range s.AppDestination {
+		appDestMap := make(map[string]string)
+		for doctype, dirID := range dest {
+			appDestMap[doctype] = dirID
+		}
+
+		cloned.AppDestination[app] = appDestMap
+	}
+	return &cloned
+}
+
+// SetID changes the SharingSettings qualified identifier.
+func (s *SharingSettings) SetID(id string) { s.SharingsSettingsID = id }
+
+// SetRev changes the SharingSettings revision.
+func (s *SharingSettings) SetRev(rev string) { s.SharingsSettingsRev = rev }
+
+// Check if the database `consts.Settings` exists, creates it if not, and
+// finally creates the `SharingSettings` document.
+func createSharingSettingsDocument(ins *instance.Instance) (*SharingSettings, error) {
+	doctypes, err := couchdb.AllDoctypes(ins)
+	if err != nil {
+		return nil, err
+	}
+
+	var exist bool
+	for _, doctype := range doctypes {
+		if consts.Settings == doctype {
+			exist = true
+			break
+		}
+	}
+
+	if !exist {
+		err = couchdb.CreateDB(ins, consts.Settings)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	s := SharingSettings{
+		SharingsSettingsID: consts.SharingSettingsID,
+		AppDestination:     make(map[string]map[string]string),
+	}
+	err = couchdb.CreateNamedDoc(ins, &s)
+	if err != nil {
+		return nil, err
+	}
+
+	return &s, nil
+}
+
+// UpdateApplicationDestinationDirID updates the destination settings for the
+// provided app.
+//
+// slug:    the application slug.
+// doctype: the doctype to consider.
+// dirID:   where to put futur shared documents of the given doctypes.
+func UpdateApplicationDestinationDirID(ins *instance.Instance, slug, doctype, dirID string) error {
+	s := SharingSettings{}
+	err := couchdb.GetDoc(ins, consts.Settings, consts.SharingSettingsID, &s)
+	if err != nil {
+		sd, errc := createSharingSettingsDocument(ins)
+		if errc != nil {
+			return errc
+		}
+
+		s = *sd
+	}
+
+	if _, ok := s.AppDestination[slug]; ok {
+		delete(s.AppDestination[slug], doctype)
+		s.AppDestination[slug][doctype] = dirID
+	} else {
+		s.AppDestination[slug] = map[string]string{doctype: dirID}
+	}
+
+	err = couchdb.UpdateDoc(ins, &s)
+	return err
+}
+
+// RetrieveApplicationDestinationDirID retrieves the destination directory for
+// the given application and doctype. The default value is the id of the
+// "/Shared with Me" directory.
+func RetrieveApplicationDestinationDirID(ins *instance.Instance, slug, doctype string) (string, error) {
+	s := &SharingSettings{}
+	err := couchdb.GetDoc(ins, consts.Settings, consts.SharingSettingsID, s)
+	if err != nil {
+		s, err = createSharingSettingsDocument(ins)
+		if err != nil {
+			return "", err
+		}
+
+		return retrieveSharedWithMeDirID(ins, s)
+	}
+
+	if slug != "" && doctype != "" {
+		if dest, ok := s.AppDestination[slug]; ok {
+			if dirID, ok := dest[doctype]; ok && dirID != "" {
+				if _, err := ins.VFS().DirByID(dirID); err == nil {
+					return dirID, nil
+				}
+			}
+		}
+	}
+
+	return retrieveSharedWithMeDirID(ins, s)
+}
+
+func retrieveSharedWithMeDirID(ins *instance.Instance, s *SharingSettings) (string, error) {
+	if id := s.SharedWithMeDirID; id != "" {
+		dirDoc, err := ins.VFS().DirByID(id)
+		if err != nil {
+			return createSharedWithMeDir(ins, s)
+		}
+
+		if dirDoc.DirID == consts.TrashDirID {
+			return createSharedWithMeDir(ins, s)
+		}
+
+		return id, nil
+	}
+
+	return createSharedWithMeDir(ins, s)
+}
+
+func createSharedWithMeDir(ins *instance.Instance, s *SharingSettings) (string, error) {
+	dirDoc, err := vfs.NewDirDoc(ins.VFS(),
+		ins.Translate("Sharings Shared with Me directory"), "", nil)
+	if err != nil {
+		return "", err
+	}
+
+	t := time.Now()
+	dirDoc.CreatedAt = t
+	dirDoc.UpdatedAt = t
+
+	err = ins.VFS().CreateDir(dirDoc)
+	if err != nil {
+		return "", nil
+	}
+
+	s.SharedWithMeDirID = dirDoc.ID()
+	err = couchdb.UpdateDoc(ins, s)
+	if err != nil {
+		return "", nil
+	}
+
+	return s.SharedWithMeDirID, nil
+}
+
+var (
+	_ couchdb.Doc = &SharingSettings{}
+)

--- a/pkg/sharings/settings.go
+++ b/pkg/sharings/settings.go
@@ -12,6 +12,7 @@ import (
 // SharingSettings is the list of destination directories set by the
 // different applications.
 type SharingSettings struct {
+	// AppDestination is following the format: app slug -> doctype -> dirID
 	AppDestination      map[string]map[string]string `json:"app_destination"`
 	SharingsSettingsID  string                       `json:"_id,omitempty"`
 	SharingsSettingsRev string                       `json:"_rev,omitempty"`

--- a/pkg/sharings/settings.go
+++ b/pkg/sharings/settings.go
@@ -48,36 +48,18 @@ func (s *SharingSettings) SetID(id string) { s.SharingsSettingsID = id }
 // SetRev changes the SharingSettings revision.
 func (s *SharingSettings) SetRev(rev string) { s.SharingsSettingsRev = rev }
 
-// Check if the database `consts.Settings` exists, creates it if not, and
-// finally creates the `SharingSettings` document.
 func createSharingSettingsDocument(ins *instance.Instance) (*SharingSettings, error) {
-	doctypes, err := couchdb.AllDoctypes(ins)
+	s := SharingSettings{}
+	err := couchdb.GetDoc(ins, consts.Settings, consts.SharingSettingsID, &s)
 	if err != nil {
-		return nil, err
-	}
-
-	var exist bool
-	for _, doctype := range doctypes {
-		if consts.Settings == doctype {
-			exist = true
-			break
+		s = SharingSettings{
+			SharingsSettingsID: consts.SharingSettingsID,
+			AppDestination:     make(map[string]map[string]string),
 		}
-	}
-
-	if !exist {
-		err = couchdb.CreateDB(ins, consts.Settings)
+		err = couchdb.CreateNamedDocWithDB(ins, &s)
 		if err != nil {
 			return nil, err
 		}
-	}
-
-	s := SharingSettings{
-		SharingsSettingsID: consts.SharingSettingsID,
-		AppDestination:     make(map[string]map[string]string),
-	}
-	err = couchdb.CreateNamedDoc(ins, &s)
-	if err != nil {
-		return nil, err
 	}
 
 	return &s, nil

--- a/pkg/sharings/settings_test.go
+++ b/pkg/sharings/settings_test.go
@@ -1,0 +1,95 @@
+package sharings
+
+import (
+	"testing"
+
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUpdateApplicationDestinationDirID(t *testing.T) {
+	// Test: update a destination directory.
+	slug := "randomslug"
+	dirID := "randomdirid"
+	doctype := "io.cozy.foos"
+
+	err := UpdateApplicationDestinationDirID(testInstance, slug, doctype, dirID)
+	assert.NoError(t, err)
+
+	s := &SharingSettings{}
+	err = couchdb.GetDoc(testInstance, consts.Settings,
+		consts.SharingSettingsID, s)
+	assert.NoError(t, err)
+	assert.Equal(t, dirID, s.AppDestination[slug][doctype])
+
+	// Test: update the same destination directory and see if the change was
+	// persisted.
+	err = UpdateApplicationDestinationDirID(testInstance, slug, doctype,
+		"otherdirid")
+	assert.NoError(t, err)
+
+	sbis := &SharingSettings{}
+	err = couchdb.GetDoc(testInstance, consts.Settings,
+		consts.SharingSettingsID, sbis)
+	assert.NoError(t, err)
+	assert.Equal(t, "otherdirid", sbis.AppDestination[slug][doctype])
+}
+
+func TestRetrieveApplicationDestinationDirID(t *testing.T) {
+	// Test retrive destination dirID when sharing settings does not exist.
+	s := SharingSettings{}
+	err := couchdb.GetDoc(testInstance, consts.Settings,
+		consts.SharingSettingsID, &s)
+	if err == nil {
+		err = couchdb.DeleteDoc(testInstance, &s)
+		assert.NoError(t, err)
+	}
+
+	dirID, err := RetrieveApplicationDestinationDirID(testInstance,
+		"randomslug", "io.cozy.files")
+	assert.NoError(t, err)
+
+	s = SharingSettings{}
+	err = couchdb.GetDoc(testInstance, consts.Settings,
+		consts.SharingSettingsID, &s)
+	assert.NoError(t, err)
+	assert.Equal(t, dirID, s.SharedWithMeDirID)
+
+	// Test: set a destination directory and fetch it afterwards.
+	dirDoc := createDir(t, testInstance.VFS(), "retrievetest",
+		[]couchdb.DocReference{})
+	slug := "randomretrieveslug"
+	doctype := "io.cozy.foos.bars"
+
+	err = UpdateApplicationDestinationDirID(testInstance, slug, doctype,
+		dirDoc.ID())
+	assert.NoError(t, err)
+
+	retrievedDirID, err := RetrieveApplicationDestinationDirID(testInstance,
+		slug, doctype)
+	assert.NoError(t, err)
+	assert.Equal(t, dirDoc.ID(), retrievedDirID)
+
+	// Test: set a destination directory while the directory doesn't exist and
+	// check that we receive the shared with me dirid.
+	err = UpdateApplicationDestinationDirID(testInstance, slug, consts.Files,
+		"randomdirid")
+	assert.NoError(t, err)
+	s = SharingSettings{}
+	err = couchdb.GetDoc(testInstance, consts.Settings,
+		consts.SharingSettingsID, &s)
+	assert.NoError(t, err)
+
+	retrievedDirID, err = RetrieveApplicationDestinationDirID(testInstance,
+		slug, consts.Files)
+	assert.NoError(t, err)
+	assert.Equal(t, s.SharedWithMeDirID, retrievedDirID)
+
+	// Test: fetch a destination directory for a doctype for which we didn't set
+	// any and check that we receive the shared with me dirid.
+	defaultDirID, err := RetrieveApplicationDestinationDirID(testInstance, slug,
+		"io.cozy.bazs")
+	assert.NoError(t, err)
+	assert.Equal(t, s.SharedWithMeDirID, defaultDirID)
+}

--- a/pkg/sharings/sharings.go
+++ b/pkg/sharings/sharings.go
@@ -29,10 +29,10 @@ import (
 type Sharing struct {
 	SID         string `json:"_id,omitempty"`
 	SRev        string `json:"_rev,omitempty"`
-	Type        string `json:"type,omitempty"`
 	Desc        string `json:"desc,omitempty"`
 	SharingID   string `json:"sharing_id,omitempty"`
 	SharingType string `json:"sharing_type"`
+	AppSlug     string `json:"app_slug"`
 	Owner       bool   `json:"owner"`
 	Revoked     bool   `json:"revoked,omitempty"`
 
@@ -654,7 +654,7 @@ func RevokeSharing(ins *instance.Instance, sharing *Sharing) error {
 
 	var err error
 	if sharing.Owner {
-		if sharing.Type == consts.MasterMasterSharing {
+		if sharing.SharingType == consts.MasterMasterSharing {
 			for _, recipient := range sharing.RecipientsStatus {
 				err = deleteOAuthClient(ins, recipient.HostClientID)
 				if err != nil {
@@ -678,7 +678,7 @@ func RevokeSharing(ins *instance.Instance, sharing *Sharing) error {
 
 		sharing.Sharer.SharerStatus.HostClientID = ""
 
-		if sharing.Type == consts.MasterMasterSharing {
+		if sharing.SharingType == consts.MasterMasterSharing {
 			err = removeSharingTriggers(ins, sharing.SharingID)
 			if err != nil {
 				return err

--- a/pkg/sharings/sharings_test.go
+++ b/pkg/sharings/sharings_test.go
@@ -197,6 +197,17 @@ func createFile(t *testing.T, fs vfs.VFS, name, content string, refs []couchdb.D
 	return doc
 }
 
+func createDir(t *testing.T, fs vfs.VFS, name string, refs []couchdb.DocReference) *vfs.DirDoc {
+	dirDoc, err := vfs.NewDirDoc(fs, name, "", []string{"It's", "me", "again"})
+	assert.NoError(t, err)
+	dirDoc.CreatedAt = time.Now()
+	dirDoc.UpdatedAt = time.Now()
+	err = fs.CreateDir(dirDoc)
+	assert.NoError(t, err)
+
+	return dirDoc
+}
+
 func updateTestDoc(t *testing.T, doc *couchdb.JSONDoc, k, v string) {
 	doc.M[k] = v
 	err := couchdb.UpdateDoc(in, doc)

--- a/pkg/workers/sharings/share_data_test.go
+++ b/pkg/workers/sharings/share_data_test.go
@@ -166,7 +166,7 @@ func TestDeleteDoc(t *testing.T) {
 	mpr := map[string]func(*echo.Group){
 		"/sharings": func(router *echo.Group) {
 			router.DELETE("/doc/:doctype/:docid", func(c echo.Context) error {
-				assert.Equal(t, randomrev, c.QueryParam("rev"))
+				assert.Equal(t, randomrev, c.QueryParam(consts.QueryParamRev))
 				assert.Equal(t, testDocID, c.Param("docid"))
 				assert.Equal(t, testDocType, c.Param("doctype"))
 				return c.JSON(http.StatusOK, nil)
@@ -228,7 +228,7 @@ func TestSendFile(t *testing.T) {
 				assert.Equal(t, consts.FileType, c.QueryParam("Type"))
 				assert.Equal(t, fileDoc.DocName, c.QueryParam("Name"))
 				sentFileDoc, err := files.FileDocFromReq(c, fileDoc.DocName,
-					consts.SharedWithMeDirID, nil)
+					"", nil)
 				assert.NoError(t, err)
 				assert.Equal(t, fileDoc.MD5Sum, sentFileDoc.MD5Sum)
 				return c.JSON(http.StatusOK, nil)
@@ -335,7 +335,7 @@ func TestSendFileThroughUpdateOrPatchFile(t *testing.T) {
 				assert.Equal(t, consts.FileType, c.QueryParam("Type"))
 				assert.Equal(t, fileDoc.DocName, c.QueryParam("Name"))
 				sentFileDoc, err := files.FileDocFromReq(c, fileDoc.DocName,
-					consts.SharedWithMeDirID, nil)
+					"", nil)
 				assert.NoError(t, err)
 				assert.Equal(t, fileDoc.MD5Sum, sentFileDoc.MD5Sum)
 				return c.JSON(http.StatusOK, nil)
@@ -494,7 +494,7 @@ func TestUpdateOrPatchFile(t *testing.T) {
 				assert.Equal(t, updatedFileDoc.UpdatedAt.Format(time.RFC1123),
 					c.QueryParam("Updated_at"))
 				sentFileDoc, err := files.FileDocFromReq(c,
-					updatedFileDoc.DocName, consts.SharedWithMeDirID, nil)
+					updatedFileDoc.DocName, "", nil)
 				assert.NoError(t, err)
 				assert.Equal(t, updatedFileDoc.MD5Sum, sentFileDoc.MD5Sum)
 				return c.JSON(http.StatusOK, nil)
@@ -918,42 +918,6 @@ func TestFindMissingRefs(t *testing.T) {
 	assert.True(t, reflect.DeepEqual(missRefs[0], couchdb.DocReference{
 		Type: "second", ID: "456",
 	}))
-}
-
-func TestGetParentDirID(t *testing.T) {
-	optsRoot := SendOptions{
-		Selector: "",
-		DocID:    consts.RootDirID,
-	}
-	_, err := getParentDirID(&optsRoot, "dir")
-	assert.Error(t, err)
-
-	optsShared := SendOptions{
-		Selector: "",
-		DocID:    "123",
-		Values:   []string{"123"},
-	}
-	dirID, err := getParentDirID(&optsShared, "dirID")
-	assert.NoError(t, err)
-	assert.Equal(t, consts.SharedWithMeDirID, dirID)
-
-	optsNotShared := SendOptions{
-		Selector: "",
-		DocID:    "123",
-		Values:   []string{"456"},
-	}
-	dirID, err = getParentDirID(&optsNotShared, "dirID")
-	assert.NoError(t, err)
-	assert.Equal(t, "dirID", dirID)
-
-	optsNoSelector := SendOptions{
-		Selector: consts.SelectorReferencedBy,
-		DocID:    "123",
-		Values:   []string{"123", "456"},
-	}
-	dirID, err = getParentDirID(&optsNoSelector, "dirID")
-	assert.NoError(t, err)
-	assert.Equal(t, consts.SharedWithMeDirID, dirID)
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/workers/sharings/sharing_updates_test.go
+++ b/pkg/workers/sharings/sharing_updates_test.go
@@ -46,7 +46,6 @@ func createEvent(t *testing.T, doc couchdb.JSONDoc, sharingID, eventType string)
 func createSharing(t *testing.T, sharingType string, owner bool, rule permissions.Rule) sharings.Sharing {
 	sharing := sharings.Sharing{
 		Owner:       owner,
-		Type:        consts.Sharings,
 		SharingType: sharingType,
 		SharingID:   utils.RandomString(32),
 		Permissions: permissions.Set{rule},

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -532,5 +532,5 @@ func wrapErrors(err error) error {
 
 func doctypeExists(ins *instance.Instance, doctype string) bool {
 	_, err := couchdb.DBStatus(ins, doctype)
-	return err != nil
+	return err == nil
 }

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -340,7 +340,7 @@ func receiveDocument(c echo.Context) error {
 		err = creationWithIDHandler(c, ins, sharing.AppSlug)
 	default:
 		doctype := c.Param("doctype")
-		if doctypeExists(ins, doctype) {
+		if !doctypeExists(ins, doctype) {
 			err = couchdb.CreateDB(ins, doctype)
 			if err != nil {
 				return err
@@ -463,7 +463,7 @@ func setDestinationDirectory(c echo.Context) error {
 	}
 
 	ins := middlewares.GetInstance(c)
-	if doctypeExists(ins, doctype) {
+	if !doctypeExists(ins, doctype) {
 		return jsonapi.BadRequest(errors.New("Doctype does not exist"))
 	}
 


### PR DESCRIPTION
This PR adds the possibility to choose the sharing directory for a given
app and doctype.

To enable that we made the following modifications:
* the application slug is now included in the sharing document;
* the sharingID is now transmitted in all requests to be able to fetch
the application slug at the recipient;
* a settings document was created for sharing;
* a route was added to set the destination directory given an
application slug and a doctype.