### PR TITLE
Swift: delete backup versions before object and better error handling

### DIFF
--- a/pkg/vfs/download_store_test.go
+++ b/pkg/vfs/download_store_test.go
@@ -1,11 +1,9 @@
 package vfs
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
-	"github.com/cozy/cozy-stack/pkg/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -56,7 +54,6 @@ func TestDownloadStoreInMemory(t *testing.T) {
 }
 
 func TestDownloadStoreInRedis(t *testing.T) {
-	fmt.Println("config.GetConfig().Cache.URL", config.GetConfig().Cache.URL)
 	downloadStoreTTL = 100 * time.Millisecond
 
 	domainA := "alice.cozycloud.local"

--- a/pkg/vfs/vfs_test.go
+++ b/pkg/vfs/vfs_test.go
@@ -755,6 +755,12 @@ func TestCreateFileTooBig(t *testing.T) {
 
 	_, err = fs.FileByPath("/too-big2")
 	assert.True(t, os.IsNotExist(err))
+
+	root, err := fs.DirByPath("/")
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.NoError(t, fs.DestroyDirContent(root))
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/vfs/vfsafero/impl.go
+++ b/pkg/vfs/vfsafero/impl.go
@@ -259,7 +259,7 @@ func (afs *aferoVFS) destroyDirAndContent(doc *vfs.DirDoc) error {
 		return err
 	}
 	err = afs.fs.RemoveAll(doc.Fullpath)
-	if err != nil {
+	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
 	return afs.Indexer.DeleteDirDoc(doc)
@@ -271,7 +271,7 @@ func (afs *aferoVFS) destroyFile(doc *vfs.FileDoc) error {
 		return err
 	}
 	err = afs.fs.Remove(path)
-	if err != nil {
+	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
 	return afs.Indexer.DeleteFileDoc(doc)

--- a/pkg/vfs/vfsafero/impl.go
+++ b/pkg/vfs/vfsafero/impl.go
@@ -248,7 +248,7 @@ func (afs *aferoVFS) destroyDirContent(doc *vfs.DirDoc) error {
 			errd = afs.destroyFile(f)
 		}
 		if errd != nil {
-			errm = multierror.Append(errd)
+			errm = multierror.Append(errm, errd)
 		}
 	}
 }

--- a/pkg/vfs/vfsafero/impl.go
+++ b/pkg/vfs/vfsafero/impl.go
@@ -232,13 +232,14 @@ func (afs *aferoVFS) DestroyFile(doc *vfs.FileDoc) error {
 
 func (afs *aferoVFS) destroyDirContent(doc *vfs.DirDoc) error {
 	iter := afs.Indexer.DirIterator(doc, nil)
-	var err error
+	var errm error
 	for {
-		var d *vfs.DirDoc
-		var f *vfs.FileDoc
-		d, f, err := iter.Next()
-		if err == vfs.ErrIteratorDone {
-			return nil
+		d, f, erri := iter.Next()
+		if erri == vfs.ErrIteratorDone {
+			return errm
+		}
+		if erri != nil {
+			return erri
 		}
 		var errd error
 		if d != nil {
@@ -247,10 +248,9 @@ func (afs *aferoVFS) destroyDirContent(doc *vfs.DirDoc) error {
 			errd = afs.destroyFile(f)
 		}
 		if errd != nil {
-			err = multierror.Append(errd)
+			errm = multierror.Append(errd)
 		}
 	}
-	return err
 }
 
 func (afs *aferoVFS) destroyDirAndContent(doc *vfs.DirDoc) error {

--- a/pkg/vfs/vfsswift/impl.go
+++ b/pkg/vfs/vfsswift/impl.go
@@ -290,7 +290,7 @@ func (sfs *swiftVFS) destroyDirContent(doc *vfs.DirDoc) error {
 			errd = sfs.destroyFile(f)
 		}
 		if errd != nil {
-			errm = multierror.Append(errd)
+			errm = multierror.Append(errm, errd)
 		}
 	}
 }

--- a/pkg/vfs/vfsswift/impl.go
+++ b/pkg/vfs/vfsswift/impl.go
@@ -274,13 +274,14 @@ func (sfs *swiftVFS) DestroyFile(doc *vfs.FileDoc) error {
 
 func (sfs *swiftVFS) destroyDirContent(doc *vfs.DirDoc) error {
 	iter := sfs.DirIterator(doc, nil)
-	var err error
+	var errm error
 	for {
-		var d *vfs.DirDoc
-		var f *vfs.FileDoc
-		d, f, err = iter.Next()
-		if err == vfs.ErrIteratorDone {
-			return nil
+		d, f, erri := iter.Next()
+		if erri == vfs.ErrIteratorDone {
+			return errm
+		}
+		if erri != nil {
+			return erri
 		}
 		var errd error
 		if d != nil {
@@ -289,10 +290,9 @@ func (sfs *swiftVFS) destroyDirContent(doc *vfs.DirDoc) error {
 			errd = sfs.destroyFile(f)
 		}
 		if errd != nil {
-			err = multierror.Append(errd)
+			errm = multierror.Append(errd)
 		}
 	}
-	return err
 }
 
 func (sfs *swiftVFS) destroyDirAndContent(doc *vfs.DirDoc) error {

--- a/pkg/workers/sharings/share_data.go
+++ b/pkg/workers/sharings/share_data.go
@@ -27,8 +27,8 @@ import (
 	"github.com/cozy/cozy-stack/pkg/vfs"
 	"github.com/cozy/cozy-stack/web/files"
 	"github.com/cozy/cozy-stack/web/jsonapi"
-	multierror "github.com/hashicorp/go-multierror"
 	"github.com/cozy/echo"
+	multierror "github.com/hashicorp/go-multierror"
 )
 
 func init() {


### PR DESCRIPTION
Also prevent from adding a file with a -1 size in the index.