### PR TITLE
Use domain as public name if missing

### DIFF
--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -331,6 +331,21 @@ func (i *Instance) PageURL(path string, queries url.Values) string {
 	return u.String()
 }
 
+// PublicName returns the settings' public name or a default one if missing
+func (i *Instance) PublicName() (string, error) {
+	doc, err := i.SettingsDocument()
+	if err != nil {
+		return "", err
+	}
+	publicName, _ := doc.M["public_name"].(string)
+	// if the public name is not defined, use the instance's domain
+	if publicName == "" {
+		split := strings.Split(i.Domain, ".")
+		publicName = split[0]
+	}
+	return publicName, nil
+}
+
 func (i *Instance) redirection(key, defaultSlug string) *url.URL {
 	context, err := i.Context()
 	if err != nil {

--- a/pkg/sharings/recipients.go
+++ b/pkg/sharings/recipients.go
@@ -3,7 +3,6 @@ package sharings
 import (
 	"net/http"
 	"net/url"
-	"strings"
 
 	"github.com/cozy/cozy-stack/client/auth"
 	"github.com/cozy/cozy-stack/pkg/consts"
@@ -167,8 +166,7 @@ func (rs *RecipientStatus) Register(instance *instance.Instance) error {
 		return ErrRecipientHasNoURL
 	}
 
-	// We get the instance document to extract the public name.
-	publicName, err := getPublicName(instance)
+	publicName, err := instance.PublicName()
 	if err != nil {
 		return err
 	}
@@ -204,20 +202,6 @@ func (rs *RecipientStatus) Register(instance *instance.Instance) error {
 
 	rs.Client = *resClient
 	return nil
-}
-
-func getPublicName(instance *instance.Instance) (string, error) {
-	doc, err := instance.SettingsDocument()
-	if err != nil {
-		return "", err
-	}
-	sharerPublicName, _ := doc.M["public_name"].(string)
-	// if the public name is not defined, use the instance domain
-	if sharerPublicName == "" {
-		split := strings.Split(instance.Domain, ".")
-		sharerPublicName = split[0]
-	}
-	return sharerPublicName, nil
 }
 
 var (

--- a/pkg/sharings/recipients.go
+++ b/pkg/sharings/recipients.go
@@ -3,6 +3,7 @@ package sharings
 import (
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/cozy/cozy-stack/client/auth"
 	"github.com/cozy/cozy-stack/pkg/consts"
@@ -167,13 +168,9 @@ func (rs *RecipientStatus) Register(instance *instance.Instance) error {
 	}
 
 	// We get the instance document to extract the public name.
-	doc, err := instance.SettingsDocument()
+	publicName, err := getPublicName(instance)
 	if err != nil {
 		return err
-	}
-	publicName, _ := doc.M["public_name"].(string)
-	if publicName == "" {
-		return ErrPublicNameNotDefined
 	}
 
 	redirectURI := instance.PageURL("/sharings/answer", nil)
@@ -207,6 +204,20 @@ func (rs *RecipientStatus) Register(instance *instance.Instance) error {
 
 	rs.Client = *resClient
 	return nil
+}
+
+func getPublicName(instance *instance.Instance) (string, error) {
+	doc, err := instance.SettingsDocument()
+	if err != nil {
+		return "", err
+	}
+	sharerPublicName, _ := doc.M["public_name"].(string)
+	// if the public name is not defined, use the instance domain
+	if sharerPublicName == "" {
+		split := strings.Split(instance.Domain, ".")
+		sharerPublicName = split[0]
+	}
+	return sharerPublicName, nil
 }
 
 var (

--- a/pkg/sharings/send_mails.go
+++ b/pkg/sharings/send_mails.go
@@ -24,7 +24,7 @@ type mailTemplateValues struct {
 // SendDiscoveryMail send a mail to the recipient, in order for him to give his
 // URL to the sender
 func SendDiscoveryMail(instance *instance.Instance, s *Sharing, rs *RecipientStatus) error {
-	sharerPublicName, err := getPublicName(instance)
+	sharerPublicName, err := instance.PublicName()
 	if err != nil {
 		return err
 	}
@@ -62,7 +62,7 @@ func SendDiscoveryMail(instance *instance.Instance, s *Sharing, rs *RecipientSta
 // SendSharingMails will generate the mail containing the details
 // regarding this sharing, and will then send it to all the recipients.
 func SendSharingMails(instance *instance.Instance, s *Sharing) error {
-	sharerPublicName, err := getPublicName(instance)
+	sharerPublicName, err := instance.PublicName()
 	if err != nil {
 		return err
 	}

--- a/pkg/sharings/send_mails.go
+++ b/pkg/sharings/send_mails.go
@@ -250,12 +250,3 @@ func generateDiscoveryLink(instance *instance.Instance, s *Sharing, rs *Recipien
 
 	return discURL.String(), nil
 }
-
-func getPublicName(instance *instance.Instance) (string, error) {
-	doc, err := instance.SettingsDocument()
-	if err != nil {
-		return "", err
-	}
-	sharerPublicName, _ := doc.M["public_name"].(string)
-	return sharerPublicName, nil
-}

--- a/pkg/sharings/sharings_test.go
+++ b/pkg/sharings/sharings_test.go
@@ -426,17 +426,6 @@ func TestRegisterNoURL(t *testing.T) {
 	assert.Equal(t, ErrRecipientHasNoURL, err)
 }
 
-func TestRegisterNoPublicName(t *testing.T) {
-	rs := &RecipientStatus{
-		recipient: &Recipient{
-			URL: "http://toto.fr",
-			RID: "dummyid",
-		},
-	}
-	err := rs.Register(in)
-	assert.Equal(t, ErrPublicNameNotDefined, err)
-}
-
 func TestRegisterSuccess(t *testing.T) {
 	// In Go 1.8 url.Parse returns the following error if we try to parse an
 	// url that looks like "127.0.0.1:46473": "first path segment in URL cannot


### PR DESCRIPTION
This avoids to block the sharing if the public name is missing. Instead, we use the first part of the domain as a default public name. For instance, zoebellot.mycozy.cloud -> zoebellot