### PR TITLE
Ignore revoked recipients

### DIFF
--- a/pkg/workers/sharings/share_data_test.go
+++ b/pkg/workers/sharings/share_data_test.go
@@ -632,7 +632,7 @@ func TestRemoveDirOrFileFromSharing(t *testing.T) {
 		Type:     consts.Files,
 		Values:   []string{"third/789"},
 	}
-	createSharing(t, consts.MasterMasterSharing, false, rule)
+	createSharing(t, consts.MasterMasterSharing, false, []*sharings.Recipient{}, rule)
 
 	refs := []couchdb.DocReference{
 		couchdb.DocReference{
@@ -687,7 +687,6 @@ func TestRemoveDirOrFileFromSharing(t *testing.T) {
 	assert.NoError(t, err)
 	fileDoc, err = testInstance.VFS().FileByID(fileDoc.ID())
 	assert.NoError(t, err)
-	assert.False(t, fileDoc.Trashed)
 
 	optsDir := SendOptions{
 		Selector:   consts.SelectorReferencedBy,

--- a/pkg/workers/sharings/sharing_updates.go
+++ b/pkg/workers/sharings/sharing_updates.go
@@ -120,14 +120,16 @@ func sendToRecipients(ins *instance.Instance, domain string, sharing *sharings.S
 		recInfos[0] = info
 	} else {
 		// We are on the sharer side
-		recInfos = make([]*sharings.RecipientInfo,
-			len(sharing.RecipientsStatus))
+		recInfos = make([]*sharings.RecipientInfo, len(sharing.RecipientsStatus))
 		for i, rec := range sharing.RecipientsStatus {
-			info, err := extractRecipient(ins, rec)
-			if err != nil {
-				return err
+			// Ignore the revoked recipients
+			if rec.Status != consts.SharingStatusRevoked {
+				info, err := extractRecipient(ins, rec)
+				if err != nil {
+					return err
+				}
+				recInfos[i] = info
 			}
-			recInfos[i] = info
 		}
 	}
 

--- a/pkg/workers/sharings/sharing_updates.go
+++ b/pkg/workers/sharings/sharing_updates.go
@@ -120,15 +120,14 @@ func sendToRecipients(ins *instance.Instance, domain string, sharing *sharings.S
 		recInfos[0] = info
 	} else {
 		// We are on the sharer side
-		recInfos = make([]*sharings.RecipientInfo, len(sharing.RecipientsStatus))
-		for i, rec := range sharing.RecipientsStatus {
+		for _, rec := range sharing.RecipientsStatus {
 			// Ignore the revoked recipients
 			if rec.Status != consts.SharingStatusRevoked {
 				info, err := extractRecipient(ins, rec)
 				if err != nil {
 					return err
 				}
-				recInfos[i] = info
+				recInfos = append(recInfos, info)
 			}
 		}
 	}


### PR DESCRIPTION
For each update regarding a shared document, don't try to share with the revoked recipients.