### PR TITLE
fix: valid function with empty field/selector

### DIFF
--- a/pkg/couchdb/couchdb.go
+++ b/pkg/couchdb/couchdb.go
@@ -225,6 +225,9 @@ func (j JSONDoc) Valid(field, value string) bool {
 		return false
 	}
 
+	if field == "" {
+		field = "_id"
+	}
 	return fmt.Sprintf("%v", j.Get(field)) == value
 }
 

--- a/pkg/couchdb/couchdb.go
+++ b/pkg/couchdb/couchdb.go
@@ -225,9 +225,6 @@ func (j JSONDoc) Valid(field, value string) bool {
 		return false
 	}
 
-	if field == "" {
-		field = "_id"
-	}
 	return fmt.Sprintf("%v", j.Get(field)) == value
 }
 

--- a/pkg/sharings/sharings.go
+++ b/pkg/sharings/sharings.go
@@ -744,10 +744,11 @@ func RemoveDocumentIfNotShared(ins *instance.Instance, doctype, docID string) er
 		}
 
 		for _, perm := range perms {
-			for _, rule := range perm.Permissions {
-				if rule.ValuesValid(doc) {
-					return nil
-				}
+			if perm.Permissions.Allow(permissions.GET, doc) ||
+				perm.Permissions.Allow(permissions.POST, doc) ||
+				perm.Permissions.Allow(permissions.PUT, doc) ||
+				perm.Permissions.Allow(permissions.DELETE, doc) {
+				return nil
 			}
 		}
 

--- a/pkg/sharings/sharings.go
+++ b/pkg/sharings/sharings.go
@@ -756,6 +756,9 @@ func RemoveDocumentIfNotShared(ins *instance.Instance, doctype, docID string) er
 		}
 	}
 
+	ins.Logger().Debugf("[sharings] Document %s is no longer shared, "+
+		"removing it", docID)
+
 	switch doctype {
 	case consts.Files:
 		dirDoc, fileDoc, errd := fs.DirOrFileByID(docID)


### PR DESCRIPTION
Defaults the "field" parameter to "_id" if it is empty. We had a problem
in the sharings because of that.