### PR TITLE
No exec file in konnector workdir

### DIFF
--- a/pkg/workers/konnectors/konnector.go
+++ b/pkg/workers/konnectors/konnector.go
@@ -141,7 +141,7 @@ func Worker(ctx context.Context, m *jobs.Message) error {
 			}
 		}
 		var f afero.File
-		f, err = workFS.OpenFile(hdr.Name, os.O_CREATE|os.O_WRONLY, os.FileMode(hdr.Mode))
+		f, err = workFS.OpenFile(hdr.Name, os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {
 			return err
 		}

--- a/pkg/workers/konnectors/konnector.go
+++ b/pkg/workers/konnectors/konnector.go
@@ -146,8 +146,12 @@ func Worker(ctx context.Context, m *jobs.Message) error {
 			return err
 		}
 		_, err = io.Copy(f, tr)
+		errc := f.Close()
 		if err != nil {
 			return err
+		}
+		if errc != nil {
+			return errc
 		}
 	}
 


### PR DESCRIPTION
This PR makes sure we do not allow an executable file to be installed in the konnector workdir. It also fixes a leak of non-closed file.