### PR TITLE
Support for deletes in shared directory

### DIFF
--- a/pkg/scheduler/trigger_event.go
+++ b/pkg/scheduler/trigger_event.go
@@ -132,6 +132,7 @@ func eventMatchPermission(e *realtime.Event, rule *permissions.Rule) bool {
 			return true
 		}
 		if e.Doc.DocType() == consts.Files {
+
 			for _, value := range rule.Values {
 				var dir vfs.DirDoc
 				db := couchdb.SimpleDatabasePrefix(e.Domain)
@@ -184,6 +185,9 @@ func testPath(dir *vfs.DirDoc, doc realtime.Doc) bool {
 		return strings.HasPrefix(d.Fullpath, dir.Fullpath+"/")
 	}
 	if f, ok := doc.(*vfs.FileDoc); ok {
+		if f.Trashed {
+			return strings.HasPrefix(f.RestorePath, dir.Fullpath)
+		}
 		p, err := f.Path(dumpFilePather)
 		if err != nil {
 			return false

--- a/pkg/workers/sharings/share_data.go
+++ b/pkg/workers/sharings/share_data.go
@@ -601,8 +601,8 @@ func RemoveDirOrFileFromSharing(ins *instance.Instance, opts *SendOptions, sendT
 }
 
 // DeleteDirOrFile asks the recipients to put the file or directory in the
-// trash.
-func DeleteDirOrFile(ins *instance.Instance, opts *SendOptions) error {
+// trash, if hardDelete is false
+func DeleteDirOrFile(ins *instance.Instance, opts *SendOptions, hardDelete bool) error {
 	var errFinal error
 	for _, recipient := range opts.Recipients {
 		rev, err := getDirOrFileRevAtRecipient(ins, opts, recipient)
@@ -627,6 +627,7 @@ func DeleteDirOrFile(ins *instance.Instance, opts *SendOptions) error {
 				consts.QueryParamSharingID: {opts.SharingID},
 				consts.QueryParamRev:       {opts.DocRev},
 				consts.QueryParamType:      {opts.Type},
+				"hard_delete":              {strconv.FormatBool(hardDelete)},
 			},
 			NoResponse: true,
 		}

--- a/pkg/workers/sharings/share_data_test.go
+++ b/pkg/workers/sharings/share_data_test.go
@@ -759,7 +759,7 @@ func TestDeleteDirOrFile(t *testing.T) {
 		Recipients: recipients,
 	}
 
-	err = DeleteDirOrFile(in, deleteSendOptions)
+	err = DeleteDirOrFile(in, deleteSendOptions, false)
 	assert.NoError(t, err)
 }
 


### PR DESCRIPTION
This allows the propagation of deletions events in a shared directory to the recipients.
When a delete event ends up with a 404, we propagate a "hard delete", so that the recipient removes the dir or file without the trash. This is done to deal with the client desktop behaviour which fully delete a directory if it's empty.