### PR TITLE
Recipient revocation

### DIFF
--- a/pkg/permissions/set.go
+++ b/pkg/permissions/set.go
@@ -150,9 +150,9 @@ func (ps Set) HasSameRules(other Set) bool {
 		for _, otherRule := range other {
 			if reflect.DeepEqual(rule.Values, otherRule.Values) &&
 				rule.Selector == otherRule.Selector &&
-				len(otherRule.Verbs) == len(rule.Verbs) &&
+				rule.Verbs.ContainsAll(otherRule.Verbs) &&
 				otherRule.Verbs.ContainsAll(rule.Verbs) &&
-				reflect.DeepEqual(rule.Type, rule.Type) {
+				reflect.DeepEqual(otherRule.Type, rule.Type) {
 				match = true
 				break
 			}

--- a/pkg/sharings/sharings.go
+++ b/pkg/sharings/sharings.go
@@ -231,7 +231,9 @@ func FindSharingRecipient(db couchdb.Database, sharingID, clientID string) (*Sha
 }
 
 // AddTrigger creates a new trigger on the updates of the shared documents
-func AddTrigger(instance *instance.Instance, rule permissions.Rule, sharingID string) error {
+// The delTrigger flag is when the trigger must only listen deletions, i.e. a
+// Master-Slave on the recipient side, for the revocation
+func AddTrigger(instance *instance.Instance, rule permissions.Rule, sharingID string, delTrigger bool) error {
 	sched := stack.GetScheduler()
 
 	var eventArgs string
@@ -239,8 +241,14 @@ func AddTrigger(instance *instance.Instance, rule permissions.Rule, sharingID st
 		eventArgs = rule.Type + ":CREATED,UPDATED,DELETED:" +
 			strings.Join(rule.Values, ",") + ":" + rule.Selector
 	} else {
-		eventArgs = rule.Type + ":CREATED,UPDATED,DELETED:" +
-			strings.Join(rule.Values, ",")
+		if delTrigger {
+			eventArgs = rule.Type + ":DELETED:" +
+				strings.Join(rule.Values, ",")
+		} else {
+			eventArgs = rule.Type + ":CREATED,UPDATED,DELETED:" +
+				strings.Join(rule.Values, ",")
+		}
+
 	}
 
 	msg := SharingMessage{
@@ -280,7 +288,7 @@ func ShareDoc(instance *instance.Instance, sharing *Sharing, recStatus *Recipien
 		}
 		// Trigger the updates if the sharing is not one-shot
 		if sharing.SharingType != consts.OneShotSharing {
-			err := AddTrigger(instance, rule, sharing.SharingID)
+			err := AddTrigger(instance, rule, sharing.SharingID, false)
 			if err != nil {
 				return err
 			}
@@ -819,7 +827,7 @@ func RevokeSharing(ins *instance.Instance, sharing *Sharing, recursive bool) err
 	if sharing.Owner {
 		for _, rs := range sharing.RecipientsStatus {
 			if recursive {
-				err = askToRevokeSharing(ins, rs, sharing.SharingID)
+				err = askToRevokeSharing(ins, sharing, rs)
 				if err != nil {
 					continue
 				}
@@ -840,8 +848,7 @@ func RevokeSharing(ins *instance.Instance, sharing *Sharing, recursive bool) err
 
 	} else {
 		if recursive {
-			err = askToRevokeRecipient(ins, sharing.Sharer.SharerStatus,
-				sharing.SharingID)
+			err = askToRevokeRecipient(ins, sharing, sharing.Sharer.SharerStatus)
 			if err != nil {
 				return err
 			}
@@ -859,7 +866,6 @@ func RevokeSharing(ins *instance.Instance, sharing *Sharing, recursive bool) err
 			}
 		}
 	}
-
 	sharing.Revoked = true
 	ins.Logger().Debugf("[sharings] Setting status of sharing %s to revoked",
 		sharing.SharingID)
@@ -884,7 +890,7 @@ func RevokeRecipient(ins *instance.Instance, sharing *Sharing, recipientClientID
 		if recipient.Client.ClientID == recipientClientID {
 
 			if recursive {
-				err := askToRevokeSharing(ins, recipient, sharing.SharingID)
+				err := askToRevokeSharing(ins, sharing, recipient)
 				if err != nil {
 					return err
 				}
@@ -1005,18 +1011,25 @@ func deleteOAuthClient(ins *instance.Instance, rs *RecipientStatus) error {
 	return nil
 }
 
-func askToRevokeSharing(ins *instance.Instance, rs *RecipientStatus, sharingID string) error {
-	return askToRevoke(ins, rs, sharingID, false)
+func askToRevokeSharing(ins *instance.Instance, sharing *Sharing, rs *RecipientStatus) error {
+	return askToRevoke(ins, sharing, rs, "")
 }
 
-func askToRevokeRecipient(ins *instance.Instance, rs *RecipientStatus, sharingID string) error {
-	return askToRevoke(ins, rs, sharingID, true)
+func askToRevokeRecipient(ins *instance.Instance, sharing *Sharing, rs *RecipientStatus) error {
+	// TODO: If the recipient revoke a master-slave sharing, he  cannot request
+	// the sharer yet, as he have no credentials
+	if rs.RefRecipient.ID != "" {
+		return askToRevoke(ins, sharing, rs, rs.Client.ClientID)
+	}
+	return nil
+
 }
 
 // TODO Once we will handle error properly (recipient is disconnected and
 // what not) analyze the error returned and take proper actions every time this
 // function is called.
-func askToRevoke(ins *instance.Instance, rs *RecipientStatus, sharingID string, revokeRecipient bool) error {
+func askToRevoke(ins *instance.Instance, sharing *Sharing, rs *RecipientStatus, recipientClientID string) error {
+	sharingID := sharing.SharingID
 	err := rs.GetRecipient(ins)
 	if err != nil {
 		ins.Logger().Errorf("[sharings] askToRevoke: Could not fetch "+
@@ -1025,13 +1038,19 @@ func askToRevoke(ins *instance.Instance, rs *RecipientStatus, sharingID string, 
 	}
 
 	var path string
-	if revokeRecipient {
-		path = fmt.Sprintf("/sharings/%s/recipient/%s", sharingID,
-			rs.RefRecipient.ID)
-	} else {
+	if recipientClientID == "" {
 		path = fmt.Sprintf("/sharings/%s", sharingID)
+	} else {
+		// From the recipient point of view, only a Master-Master sharing
+		// grants him the rights to request the sharer, as he doesn't have
+		// any credentials otherwise.
+		if sharing.SharingType == consts.MasterMasterSharing {
+			path = fmt.Sprintf("/sharings/%s/recipient/%s", sharingID,
+				rs.HostClientID)
+		} else {
+			return nil
+		}
 	}
-
 	domain, scheme, err := rs.recipient.ExtractDomainAndScheme()
 	if err != nil {
 		return err

--- a/pkg/sharings/sharings_test.go
+++ b/pkg/sharings/sharings_test.go
@@ -759,7 +759,7 @@ func TestRevokeSharing(t *testing.T) {
 	sched := stack.GetScheduler()
 	triggers, _ := sched.GetAll(testInstance.Domain)
 	nbTriggers := len(triggers)
-	err := AddTrigger(testInstance, rule, sharingSharerMM.SharingID)
+	err := AddTrigger(testInstance, rule, sharingSharerMM.SharingID, false)
 	assert.NoError(t, err)
 	triggers, _ = sched.GetAll(testInstance.Domain)
 	assert.Len(t, triggers, nbTriggers+1)
@@ -791,7 +791,7 @@ func TestRevokeSharing(t *testing.T) {
 	sharingRecipientMM := insertSharingIntoDB(t, sharingIDRecipientMM,
 		consts.MasterMasterSharing, false, "", []*Recipient{recipient1}, rule)
 	// We add a trigger to this sharing.
-	err = AddTrigger(testInstance, rule, sharingRecipientMM.SharingID)
+	err = AddTrigger(testInstance, rule, sharingRecipientMM.SharingID, false)
 	assert.NoError(t, err)
 	triggers, _ = sched.GetAll(testInstance.Domain)
 	assert.Len(t, triggers, nbTriggers+1)
@@ -859,7 +859,7 @@ func TestRevokeRecipient(t *testing.T) {
 	sched := stack.GetScheduler()
 	triggers, _ := sched.GetAll(testInstance.Domain)
 	nbTriggers := len(triggers)
-	err = AddTrigger(testInstance, rule, sharing.SharingID)
+	err = AddTrigger(testInstance, rule, sharing.SharingID, false)
 	assert.NoError(t, err)
 	triggers, _ = sched.GetAll(testInstance.Domain)
 	assert.Len(t, triggers, nbTriggers+1)

--- a/pkg/workers/sharings/sharing_updates.go
+++ b/pkg/workers/sharings/sharing_updates.go
@@ -299,10 +299,7 @@ func ExtractHostAndScheme(fullURL string) (string, string, error) {
 // A sharing is on the recipient side iff:
 // - the SharerStatus structure is not nil
 func isRecipientSide(sharing *sharings.Sharing) bool {
-	if sharing.Sharer.SharerStatus != nil {
-		return true
-	}
-	return false
+	return sharing.Sharer.SharerStatus != nil
 }
 
 // This function checks if the document with the given ID still belong in the

--- a/pkg/workers/sharings/sharing_updates.go
+++ b/pkg/workers/sharings/sharing_updates.go
@@ -107,10 +107,26 @@ func SharingUpdates(ctx context.Context, m *jobs.Message) error {
 // TODO explanation
 func sendToRecipients(ins *instance.Instance, domain string, sharing *sharings.Sharing, rule *permissions.Rule, docID, eventType string) error {
 	var recInfos []*sharings.RecipientInfo
+
+	// sharing revoked: drop it
+	// NOTE: this should never happen as a revoked sharing removes the triggers
+	if sharing.Revoked {
+		return nil
+	}
 	sendToSharer := isRecipientSide(sharing)
 
 	if sendToSharer {
 		// We are on the recipient side
+
+		// Particular case: the recipient removes the target of the sharing,
+		// e.g. the shared directory, the photo album, etc
+		if isSharedContainer(rule, docID) {
+			err := sharings.RevokeSharing(ins, sharing, true)
+			if err != nil {
+				return err
+			}
+		}
+
 		recInfos = make([]*sharings.RecipientInfo, 1)
 		sharerStatus := sharing.Sharer.SharerStatus
 		info, err := extractRecipient(ins, sharerStatus)
@@ -118,6 +134,7 @@ func sendToRecipients(ins *instance.Instance, domain string, sharing *sharings.S
 			return err
 		}
 		recInfos[0] = info
+
 	} else {
 		// We are on the sharer side
 		for _, rec := range sharing.RecipientsStatus {
@@ -280,13 +297,10 @@ func ExtractHostAndScheme(fullURL string) (string, string, error) {
 
 // isRecipientSide is used to determine whether or not we are on the recipient side.
 // A sharing is on the recipient side iff:
-// - the sharing type is master-master
 // - the SharerStatus structure is not nil
 func isRecipientSide(sharing *sharings.Sharing) bool {
-	if sharing.SharingType == consts.MasterMasterSharing {
-		if sharing.Sharer.SharerStatus != nil {
-			return true
-		}
+	if sharing.Sharer.SharerStatus != nil {
+		return true
 	}
 	return false
 }
@@ -309,4 +323,17 @@ func isDocumentStillShared(fs vfs.VFS, opts *SendOptions, docRefs []couchdb.DocR
 	default:
 		return isShared(fs, opts.DocID, opts.Values)
 	}
+}
+
+// isSharedContainer returns true if the given doc is the target of the sharing
+func isSharedContainer(rule *permissions.Rule, docID string) bool {
+	if rule.Selector == "" {
+		// Single file or directory sharing
+		if len(rule.Values) == 1 {
+			if rule.Values[0] == docID {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -146,6 +146,14 @@ func SharingRequest(c echo.Context) error {
 		if err = sharings.SendClientID(sharing); err != nil {
 			return wrapErrors(err)
 		}
+	} else if sharing.SharingType == consts.MasterSlaveSharing {
+		// The recipient listens deletes for a master-slave sharing
+		for _, rule := range sharing.Permissions {
+			err = sharings.AddTrigger(instance, rule, sharing.SharingID, true)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	redirectAuthorize := instance.PageURL("/auth/authorize", c.QueryParams())
@@ -338,7 +346,7 @@ func getAccessToken(c echo.Context) error {
 	// Add triggers on the recipient side for each rule
 	if sharing.SharingType == consts.MasterMasterSharing {
 		for _, rule := range sharing.Permissions {
-			err = sharings.AddTrigger(instance, rule, sharing.SharingID)
+			err = sharings.AddTrigger(instance, rule, sharing.SharingID, false)
 			if err != nil {
 				return wrapErrors(err)
 			}
@@ -488,17 +496,7 @@ func revokeRecipient(c echo.Context) error {
 		return jsonapi.NotFound(err)
 	}
 
-	recipientID := c.Param("recipient-id")
-	recipientClientID := ""
-	for _, recipient := range sharing.RecipientsStatus {
-		if recipient.RefRecipient.ID == recipientID {
-			recipientClientID = recipient.Client.ClientID
-			break
-		}
-	}
-	if recipientClientID == "" {
-		return jsonapi.BadRequest(sharings.ErrRecipientDoesNotExist)
-	}
+	recipientClientID := c.Param("recipient-client-id")
 
 	recursiveRaw := c.QueryParam(consts.QueryParamRecursive)
 	recursive := true
@@ -689,7 +687,7 @@ func Routes(router *echo.Group) {
 	router.POST("/discovery", discovery)
 
 	router.DELETE("/:sharing-id", revokeSharing)
-	router.DELETE("/:sharing-id/recipient/:recipient-id", revokeRecipient)
+	router.DELETE("/:sharing-id/recipient/:recipient-client-id", revokeRecipient)
 
 	router.DELETE("/files/:file-id/referenced_by", removeReferences)
 
@@ -722,6 +720,7 @@ func checkRevokeSharingPermissions(c echo.Context, ins *instance.Instance, shari
 // 2. The permissions identify the user that is to be revoked or the sharer.
 func checkRevokePermissions(c echo.Context, ins *instance.Instance, sharing *sharings.Sharing, recipientClientID string, ownerHasToBeSharer bool) error {
 	token := perm.GetRequestToken(c)
+
 	requestPerm, err := perm.GetPermission(c)
 	if err != nil {
 		return err
@@ -753,8 +752,12 @@ func checkRevokePermissions(c echo.Context, ins *instance.Instance, sharing *sha
 			return permissions.ErrInvalidToken
 		}
 		if sharing.Owner {
-			if claims.Subject == recipientClientID {
-				return nil
+			for _, rec := range sharing.RecipientsStatus {
+				if rec.Client.ClientID == recipientClientID {
+					if claims.Subject == rec.HostClientID {
+						return nil
+					}
+				}
 			}
 		} else {
 			sharerClientID := sharing.Sharer.SharerStatus.HostClientID

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -124,8 +124,7 @@ func createSharing(t *testing.T, sharingID, sharingType string, owner bool, slug
 		}
 
 		if sharingType == consts.MasterMasterSharing {
-			hostClient := createOAuthClient(t)
-			rs.HostClientID = hostClient.ClientID
+			rs.HostClientID = client.ClientID
 		}
 
 		if owner {
@@ -1431,7 +1430,7 @@ func TestRevokeRecipient(t *testing.T) {
 		[]*sharings.Recipient{recipient0}, rule)
 
 	delURL = fmt.Sprintf("%s/sharings/%s/recipient/%s", ts.URL,
-		sharing.SharingID, sharing.RecipientsStatus[0].RefRecipient.ID)
+		sharing.SharingID, sharing.RecipientsStatus[0].Client.ClientID)
 	queries := url.Values{consts.QueryParamRecursive: {"false"}}.Encode()
 	req, err = http.NewRequest(http.MethodDelete, delURL+"?"+queries, nil)
 	assert.NoError(t, err)
@@ -1448,7 +1447,7 @@ func TestRevokeRecipient(t *testing.T) {
 		[]*sharings.Recipient{recipient0, recipient1}, rule)
 
 	delURL = fmt.Sprintf("%s/sharings/%s/recipient/%s", ts.URL,
-		sharing.SharingID, sharing.RecipientsStatus[0].RefRecipient.ID)
+		sharing.SharingID, sharing.RecipientsStatus[0].HostClientID)
 	req, err = http.NewRequest(http.MethodDelete, delURL+"?"+queries, nil)
 	assert.NoError(t, err)
 	req.Header.Del(echo.HeaderAuthorization)


### PR DESCRIPTION
When a sharing recipient removes the target of a sharing (e.g. a photo album, a directory), the sharing should be revoked between him and the sharer.
This PR supports this, for master-* scenarios.