### PR TITLE
Redirect to passphrase renew page when using outdated token

### DIFF
--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -765,9 +765,9 @@ func (i *Instance) RequestPassphraseReset() error {
 	return err
 }
 
-// PassphraseRenew changes the passphrase to the specified one if the given
-// token matches the `PassphraseResetToken` field.
-func (i *Instance) PassphraseRenew(pass, tok []byte) error {
+// CheckPassphraseRenewToken checks whether the given token is good to use for
+// resetting the passphrase.
+func (i *Instance) CheckPassphraseRenewToken(tok []byte) error {
 	if i.PassphraseResetToken == nil {
 		return ErrMissingToken
 	}
@@ -776,6 +776,16 @@ func (i *Instance) PassphraseRenew(pass, tok []byte) error {
 	}
 	if subtle.ConstantTimeCompare(i.PassphraseResetToken, tok) != 1 {
 		return ErrInvalidToken
+	}
+	return nil
+}
+
+// PassphraseRenew changes the passphrase to the specified one if the given
+// token matches the `PassphraseResetToken` field.
+func (i *Instance) PassphraseRenew(pass, tok []byte) error {
+	err := i.CheckPassphraseRenewToken(tok)
+	if err != nil {
+		return err
 	}
 	hash, err := crypto.GenerateFromPassphrase(pass)
 	if err != nil {

--- a/web/auth/auth_test.go
+++ b/web/auth/auth_test.go
@@ -1110,9 +1110,7 @@ func TestPassphraseRenewFormWithToken(t *testing.T) {
 		return
 	}
 	defer res.Body.Close()
-	assert.Equal(t, "200 OK", res.Status)
-	body, _ := ioutil.ReadAll(res.Body)
-	assert.Contains(t, string(body), `type="hidden" name="passphrase_reset_token" value="badbee" />`)
+	assert.Equal(t, "400 Bad Request", res.Status)
 }
 
 func TestPassphraseRenew(t *testing.T) {


### PR DESCRIPTION
Since token have only 15 minutes of availability, we should redirect when presenting a good token that expired.