### PR TITLE
Apps HTTP fetcher

### DIFF
--- a/docs/registry.md
+++ b/docs/registry.md
@@ -381,7 +381,7 @@ In the configuration file of a stack, a `registries` namespace is added. This na
 
 The stack itself implements the querying API of a registry. When querying this API, to ask for an application, the stack uses this hierarchy of registries to proxy or redirect the user.
 
-The hierarchy can also be contextualised to specify different registries to different contexts. The `defaults` context is applied lastly.
+The hierarchy can also be contextualised to specify different registries to different contexts. The `default` context is applied lastly.
 
 ### Examples:
 
@@ -407,7 +407,7 @@ registries:
   context2:
     - https://context2.registry.cozy.io/
 
-  defaults:
+  default:
     - https://myregistry.home/
     - https://main.registry.cozy.io/
 ```

--- a/pkg/apps/errors.go
+++ b/pkg/apps/errors.go
@@ -28,4 +28,7 @@ var (
 	// ErrMissingSource is used when installing an application, but there is no
 	// source URL
 	ErrMissingSource = errors.New("The source URL for the app is missing")
+	// ErrBadChecksum is used when the application checksum does not match the
+	// specified one.
+	ErrBadChecksum = errors.New("Application checksum does not match")
 )

--- a/pkg/apps/fetcher_git.go
+++ b/pkg/apps/fetcher_git.go
@@ -46,14 +46,7 @@ type gitFetcher struct {
 	log         *logrus.Entry
 }
 
-func newGitFetcher(appType AppType, log *logrus.Entry) *gitFetcher {
-	var manFilename string
-	switch appType {
-	case Webapp:
-		manFilename = WebappManifestName
-	case Konnector:
-		manFilename = KonnectorManifestName
-	}
+func newGitFetcher(manFilename string, log *logrus.Entry) *gitFetcher {
 	return &gitFetcher{
 		manFilename: manFilename,
 		log:         log,

--- a/pkg/apps/fetcher_git.go
+++ b/pkg/apps/fetcher_git.go
@@ -218,7 +218,7 @@ func (g *gitFetcher) fetchWithGit(gitFs afero.Fs, gitDir string, src *url.URL, f
 		return err
 	}
 	defer func() {
-		if errc := fs.Close(); errc != nil && err = nil {
+		if errc := fs.Close(); errc != nil && err == nil {
 			err = errc
 		}
 	}()

--- a/pkg/apps/fetcher_git.go
+++ b/pkg/apps/fetcher_git.go
@@ -218,7 +218,7 @@ func (g *gitFetcher) fetchWithGit(gitFs afero.Fs, gitDir string, src *url.URL, f
 		return err
 	}
 	defer func() {
-		if errc := fs.Close(); errc != nil {
+		if errc := fs.Close(); errc != nil && err = nil {
 			err = errc
 		}
 	}()

--- a/pkg/apps/fetcher_http.go
+++ b/pkg/apps/fetcher_http.go
@@ -148,7 +148,7 @@ func (f *httpFetcher) Fetch(src *url.URL, fs Copier, man Manifest) (err error) {
 	for {
 		hdr, err := tarReader.Next()
 		if err == io.EOF {
-			return nil
+			break
 		}
 		if err != nil {
 			return err

--- a/pkg/apps/fetcher_http.go
+++ b/pkg/apps/fetcher_http.go
@@ -121,7 +121,7 @@ func (f *httpFetcher) Fetch(src *url.URL, fs Copier, man Manifest) (err error) {
 		return err
 	}
 	defer func() {
-		if errc := fs.Close(); errc != nil {
+		if errc := fs.Close(); errc != nil && err == nil {
 			err = errc
 		}
 	}()

--- a/pkg/apps/fetcher_http.go
+++ b/pkg/apps/fetcher_http.go
@@ -1,0 +1,157 @@
+package apps
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/cozy/cozy-stack/pkg/utils"
+	"github.com/sirupsen/logrus"
+)
+
+var httpClient = http.Client{Timeout: 20 * time.Second}
+
+type httpFetcher struct {
+	manFilename string
+	prefix      string
+	log         *logrus.Entry
+}
+
+func newHTTPFetcher(manFilename string, log *logrus.Entry) *httpFetcher {
+	return &httpFetcher{
+		manFilename: manFilename,
+		log:         log,
+	}
+}
+
+func (f *httpFetcher) FetchManifest(src *url.URL) (r io.ReadCloser, err error) {
+	req, err := http.NewRequest(http.MethodGet, src.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil {
+			resp.Body.Close()
+		}
+	}()
+	if resp.StatusCode != 200 {
+		return nil, ErrManifestNotReachable
+	}
+	contentType := resp.Header.Get("Content-Type")
+	var reader io.Reader
+	switch contentType {
+	case
+		"application/gzip",
+		"application/x-gzip",
+		"application/x-tgz",
+		"application/tar+gzip":
+		reader, err = gzip.NewReader(resp.Body)
+	default:
+		reader = resp.Body
+	}
+	if err != nil {
+		return nil, ErrManifestNotReachable
+	}
+	tarReader := tar.NewReader(reader)
+	for {
+		hdr, err := tarReader.Next()
+		if err == io.EOF {
+			return nil, ErrManifestNotReachable
+		}
+		if err != nil {
+			return nil, ErrManifestNotReachable
+		}
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+		baseName := path.Base(hdr.Name)
+		if baseName != f.manFilename {
+			continue
+		}
+		if baseName != hdr.Name {
+			f.prefix = path.Dir(hdr.Name) + "/"
+		}
+		return utils.ReadCloser(tarReader, func() error {
+			return resp.Body.Close()
+		}), nil
+	}
+}
+
+func (f *httpFetcher) Fetch(src *url.URL, fs Copier, man Manifest) (err error) {
+	req, err := http.NewRequest(http.MethodGet, src.String(), nil)
+	if err != nil {
+		return err
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return ErrNotFound
+	}
+	contentType := resp.Header.Get("Content-Type")
+	var reader io.Reader
+	switch contentType {
+	case
+		"application/gzip",
+		"application/x-gzip",
+		"application/x-tgz",
+		"application/tar+gzip":
+		reader, err = gzip.NewReader(resp.Body)
+	default:
+		reader = resp.Body
+	}
+	if err != nil {
+		return err
+	}
+
+	exists, err := fs.Start(man.Slug(), man.Version())
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if errc := fs.Close(); errc != nil {
+			err = errc
+		}
+	}()
+	if exists {
+		return nil
+	}
+
+	tarReader := tar.NewReader(reader)
+	for {
+		hdr, err := tarReader.Next()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+		name := hdr.Name
+		if len(f.prefix) > 0 && strings.HasPrefix(name, f.prefix) {
+			name = name[len(f.prefix):]
+		}
+		err = fs.Copy(&fileInfo{
+			name: name,
+			size: hdr.Size,
+			mode: os.FileMode(hdr.Mode),
+		}, tarReader)
+		if err != nil {
+			return err
+		}
+	}
+}

--- a/pkg/apps/installer.go
+++ b/pkg/apps/installer.go
@@ -147,9 +147,9 @@ func NewInstaller(db couchdb.Database, fs Copier, opts *InstallerOptions) (*Inst
 		fetcher = newGitFetcher(manFilename, log)
 	case "http", "https":
 		fetcher = newHTTPFetcher(manFilename, log)
-	case "registry":
-		// TODO:
-		// fetcher = newRegistryFetcher(manFilename, log)
+	// TODO:
+	// case "registry":
+	// fetcher = newRegistryFetcher(manFilename, log)
 	default:
 		return nil, ErrNotSupportedSource
 	}

--- a/pkg/apps/installer.go
+++ b/pkg/apps/installer.go
@@ -133,10 +133,23 @@ func NewInstaller(db couchdb.Database, fs Copier, opts *InstallerOptions) (*Inst
 
 	log := logger.WithDomain(db.Prefix())
 
+	var manFilename string
+	switch opts.Type {
+	case Webapp:
+		manFilename = WebappManifestName
+	case Konnector:
+		manFilename = KonnectorManifestName
+	}
+
 	var fetcher Fetcher
 	switch src.Scheme {
 	case "git", "git+ssh", "ssh+git":
-		fetcher = newGitFetcher(opts.Type, log)
+		fetcher = newGitFetcher(manFilename, log)
+	case "http", "https":
+		fetcher = newHTTPFetcher(manFilename, log)
+	case "registry":
+		// TODO:
+		// fetcher = newRegistryFetcher(manFilename, log)
 	default:
 		return nil, ErrNotSupportedSource
 	}

--- a/pkg/apps/installer_webapp_test.go
+++ b/pkg/apps/installer_webapp_test.go
@@ -483,6 +483,55 @@ func TestWebappInstallFromHTTP(t *testing.T) {
 	}
 }
 
+func TestWebappInstallFromHTTPWithBadChecksum(t *testing.T) {
+	manGen = manifestWebapp
+	manName = WebappManifestName
+	inst, err := NewInstaller(db, fs, &InstallerOptions{
+		Operation: Install,
+		Type:      Webapp,
+		Slug:      "http-cozy-drive-bad-checksum",
+		SourceURL: "https://github.com/cozy/cozy-drive/archive/71e5cde66f754f986afc7111962ed2dd361bd5e4.tar.gz#466aa0815926fdbf33fda523af2b9bf34520906ffbb9bf512ddf20df2992a46f",
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	go inst.Run()
+
+	_, _, err = inst.Poll()
+	assert.NoError(t, err)
+
+	_, _, err = inst.Poll()
+	assert.Error(t, err)
+	assert.Equal(t, ErrBadChecksum, err)
+}
+
+func TestWebappInstallFromHTTPWithGoodChecksum(t *testing.T) {
+	manGen = manifestWebapp
+	manName = WebappManifestName
+	inst, err := NewInstaller(db, fs, &InstallerOptions{
+		Operation: Install,
+		Type:      Webapp,
+		Slug:      "http-cozy-drive-good-checksum",
+		SourceURL: "https://github.com/cozy/cozy-drive/archive/71e5cde66f754f986afc7111962ed2dd361bd5e4.tar.gz#290c3fbeaa61506493fbb4075105b0c7d4eba42020bcc6fd5e1d7a834c20b417",
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	go inst.Run()
+
+	for {
+		_, done, err := inst.Poll()
+		if !assert.NoError(t, err) {
+			return
+		}
+		if done {
+			break
+		}
+	}
+}
+
 func TestWebappUninstall(t *testing.T) {
 	manGen = manifestWebapp
 	manName = WebappManifestName

--- a/pkg/apps/installer_webapp_test.go
+++ b/pkg/apps/installer_webapp_test.go
@@ -442,6 +442,47 @@ func TestWebappInstallFromGitlab(t *testing.T) {
 	}
 }
 
+func TestWebappInstallFromHTTP(t *testing.T) {
+	manGen = manifestWebapp
+	manName = WebappManifestName
+	inst, err := NewInstaller(db, fs, &InstallerOptions{
+		Operation: Install,
+		Type:      Webapp,
+		Slug:      "http-cozy-drive",
+		SourceURL: "https://github.com/cozy/cozy-drive/archive/71e5cde66f754f986afc7111962ed2dd361bd5e4.tar.gz",
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	go inst.Run()
+
+	var state State
+	for {
+		man, done, err := inst.Poll()
+		if !assert.NoError(t, err) {
+			return
+		}
+		if state == "" {
+			if !assert.EqualValues(t, Installing, man.State()) {
+				return
+			}
+		} else if state == Installing {
+			if !assert.EqualValues(t, Ready, man.State()) {
+				return
+			}
+			if !assert.True(t, done) {
+				return
+			}
+			break
+		} else {
+			t.Fatalf("invalid state")
+			return
+		}
+		state = man.State()
+	}
+}
+
 func TestWebappUninstall(t *testing.T) {
 	manGen = manifestWebapp
 	manName = WebappManifestName

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -356,7 +356,7 @@ func makeRegistries(v *viper.Viper) (map[string][]*url.URL, error) {
 			if ctx == "default" {
 				continue
 			}
-			urls = append(urls, defaults...)
+			regs[ctx] = append(urls, defaults...)
 		}
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -93,7 +93,8 @@ type Config struct {
 	KonnectorsOauthStateStorage RedisConfig
 	Realtime                    RedisConfig
 
-	Contexts map[string]interface{}
+	Contexts   map[string]interface{}
+	Registries map[string][]*url.URL
 }
 
 // Fs contains the configuration values of the file-system
@@ -262,6 +263,11 @@ func UseViper(v *viper.Viper) error {
 		couchURL.Path = "/"
 	}
 
+	regs, err := makeRegistries(v)
+	if err != nil {
+		return err
+	}
+
 	config = &Config{
 		Host:       v.GetString("host"),
 		Port:       v.GetInt("port"),
@@ -299,7 +305,8 @@ func UseViper(v *viper.Viper) error {
 			DisableTLS:                v.GetBool("mail.disable_tls"),
 			SkipCertificateValidation: v.GetBool("mail.skip_certificate_validation"),
 		},
-		Contexts: v.GetStringMap("contexts"),
+		Contexts:   v.GetStringMap("contexts"),
+		Registries: regs,
 	}
 
 	loggerRedis := NewRedisConfig(v.GetString("log.redis"))
@@ -308,6 +315,52 @@ func UseViper(v *viper.Viper) error {
 		Syslog: v.GetBool("log.syslog"),
 		Redis:  loggerRedis.Client(),
 	})
+}
+
+func makeRegistries(v *viper.Viper) (map[string][]*url.URL, error) {
+	regs := make(map[string][]*url.URL)
+
+	regsSlice := v.GetStringSlice("registries")
+	if len(regsSlice) > 0 {
+		urlList := make([]*url.URL, len(regsSlice))
+		for i, s := range regsSlice {
+			u, err := url.Parse(s)
+			if err != nil {
+				return nil, err
+			}
+			urlList[i] = u
+		}
+		regs["default"] = urlList
+	} else {
+		for k, v := range v.GetStringMap("registries") {
+			list, ok := v.([]interface{})
+			if !ok {
+				return nil, fmt.Errorf(
+					"Bad format in the registries section of the configuration file: "+
+						"should be a list of strings, got %#v", v)
+			}
+			urlList := make([]*url.URL, len(list))
+			for i, s := range list {
+				u, err := url.Parse(s.(string))
+				if err != nil {
+					return nil, err
+				}
+				urlList[i] = u
+			}
+			regs[k] = urlList
+		}
+	}
+
+	if defaults, ok := regs["default"]; ok {
+		for ctx, urls := range regs {
+			if ctx == "default" {
+				continue
+			}
+			urls = append(urls, defaults...)
+		}
+	}
+
+	return regs, nil
 }
 
 const defaultTestConfig = `

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -61,6 +61,10 @@ mail:
 log:
     # logger level (debug, info, warning, panic, fatal) - flags: --log-level
     level: warning
+
+registries:
+  - http://abc
+  - http://def
 `))
 	if !assert.NoError(t, err) {
 		return

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -24,6 +24,7 @@ func TestSetup(t *testing.T) {
 	if !assert.NoError(t, err) {
 		return
 	}
+	defer tmpfile.Close()
 	defer os.Remove(tmpfile.Name())
 
 	os.Setenv("OS_USERNAME", "os_username_val")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -63,8 +64,14 @@ log:
     level: warning
 
 registries:
-  - http://abc
-  - http://def
+  foo:
+    - http://abc
+    - http://def
+  bar:
+    - http://def
+    - http://abc
+  default:
+    - https://default
 `))
 	if !assert.NoError(t, err) {
 		return
@@ -83,4 +90,16 @@ registries:
 	assert.Equal(t, "mail_username_val", GetConfig().Mail.Username)
 	assert.Equal(t, "mail_password_val", GetConfig().Mail.Password)
 	assert.Equal(t, logrus.GetLevel(), logrus.WarnLevel)
+
+	assert.EqualValues(t, []string{"http://abc", "http://def", "https://default"}, regsToStrings(GetConfig().Registries["foo"]))
+	assert.EqualValues(t, []string{"http://def", "http://abc", "https://default"}, regsToStrings(GetConfig().Registries["bar"]))
+	assert.EqualValues(t, []string{"https://default"}, regsToStrings(GetConfig().Registries["default"]))
+}
+
+func regsToStrings(regs []*url.URL) []string {
+	ss := make([]string, len(regs))
+	for i, r := range regs {
+		ss[i] = r.String()
+	}
+	return ss
 }

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -274,6 +274,23 @@ func (i *Instance) Context() (map[string]interface{}, error) {
 	return context, nil
 }
 
+// Registries returns the list of registries associated with the instance.
+func (i *Instance) Registries() ([]*url.URL, error) {
+	doc, err := i.SettingsDocument()
+	if err != nil {
+		return nil, err
+	}
+	ctx, ok := doc.M["context"].(string)
+	if !ok {
+		ctx = "default"
+	}
+	regs, ok := config.GetConfig().Registries[ctx]
+	if !ok {
+		return nil, ErrContextNotFound
+	}
+	return regs, nil
+}
+
 // DiskQuota returns the number of bytes allowed on the disk to the user.
 func (i *Instance) DiskQuota() int64 {
 	return i.BytesDiskQuota

--- a/pkg/utils/iocloser.go
+++ b/pkg/utils/iocloser.go
@@ -1,0 +1,20 @@
+package utils
+
+import "io"
+
+type readCloser struct {
+	io.Reader
+	c func() error
+}
+
+func ReadCloser(r io.Reader, c func() error) io.ReadCloser {
+	return &readCloser{r, c}
+}
+
+func (r *readCloser) Read(p []byte) (int, error) {
+	return r.Reader.Read(p)
+}
+
+func (r *readCloser) Close() error {
+	return r.c()
+}

--- a/pkg/utils/iocloser.go
+++ b/pkg/utils/iocloser.go
@@ -7,6 +7,7 @@ type readCloser struct {
 	c func() error
 }
 
+// ReadCloser returns an io.ReadCloser from a io.Reader and a close method.
 func ReadCloser(r io.Reader, c func() error) io.ReadCloser {
 	return &readCloser{r, c}
 }


### PR DESCRIPTION
This PR adds the possibility to install application via a simple http URL. It is a first step toward the support for the `registry://` scheme.

It also adds the support for the `registries` section of the configuration.