### PR TITLE
Sharings should check the claims issuer and expiration

### DIFF
--- a/pkg/crypto/jwt.go
+++ b/pkg/crypto/jwt.go
@@ -26,7 +26,6 @@ func ParseJWT(tokenString string, keyFunc jwt.Keyfunc, claims jwt.Claims) error 
 		}
 		return keyFunc(token)
 	})
-
 	if err != nil {
 		return err
 	}

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -728,6 +728,8 @@ func checkRevokePermissions(c echo.Context, ins *instance.Instance, sharing *sha
 		return err
 	}
 
+	// TODO: avoid having to parse the JWT token twice — already done by the
+	// perm.GetPermission method.
 	var claims permissions.Claims
 	err = crypto.ParseJWT(token, func(token *jwt.Token) (interface{}, error) {
 		return ins.PickKey(token.Claims.(*permissions.Claims).Audience)


### PR DESCRIPTION
The permissions handler for sharings was missing the check to ensure the issuer of the JWT corresponds to the instance's domain.