### PR TITLE
Add primary principles for services system

### DIFF
--- a/pkg/apps/apps.go
+++ b/pkg/apps/apps.go
@@ -32,8 +32,6 @@ const (
 	Upgrading = "upgrading"
 	// Uninstalling state
 	Uninstalling = "uninstalling"
-	// Errored state
-	Errored = "errored"
 	// Installed state, can be used to state that an application has been
 	// installed but needs a user interaction to be activated and "ready".
 	Installed = "installed"
@@ -84,11 +82,9 @@ type Manifest interface {
 	Slug() string
 	State() State
 	LastUpdate() time.Time
-	Error() error
 
 	SetState(state State)
 	SetVersion(version string)
-	SetError(err error)
 }
 
 // GetBySlug returns an app manifest identified by its slug

--- a/pkg/apps/fetcher_git.go
+++ b/pkg/apps/fetcher_git.go
@@ -234,8 +234,7 @@ func (g *gitFetcher) fetchWithGit(gitFs afero.Fs, gitDir string, src *url.URL, f
 		"--branch", branch,
 		"--", srcStr, gitDir) // #nosec
 
-	g.log.Infof("[git] Clone with git %s %s in %s: %s", srcStr, branch, gitDir,
-		strings.Join(cmd.Args, " "))
+	g.log.Infof("[git] Clone with git: %s", strings.Join(cmd.Args, " "))
 	stdoutStderr, err := cmd.CombinedOutput()
 	if err != nil {
 		if err != exec.ErrNotFound {

--- a/pkg/apps/installer_test.go
+++ b/pkg/apps/installer_test.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"strings"
 	"testing"
 	"time"
 
@@ -24,6 +23,7 @@ import (
 var localGitCmd *exec.Cmd
 var localGitDir string
 var localVersion string
+var localServices string
 var ts *httptest.Server
 
 var manGen func() string
@@ -39,7 +39,10 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func manifestWebapp() string {
-	return strings.Replace(`{
+	if localServices == "" {
+		localServices = "{}"
+	}
+	return `{
   "description": "A mini app to test cozy-stack-v2",
   "developer": {
     "name": "Bruno",
@@ -49,12 +52,13 @@ func manifestWebapp() string {
   "name": "mini-app",
   "permissions": {},
   "slug": "mini",
-  "version": "`+localVersion+`"
-}`, "\n", "", -1)
+  "version": "` + localVersion + `",
+  "services": ` + localServices + `
+}`
 }
 
 func manifestKonnector() string {
-	return strings.Replace(`{
+	return `{
   "description": "A mini konnector to test cozy-stack-v2",
   "type": "node",
   "developer": {
@@ -65,8 +69,8 @@ func manifestKonnector() string {
   "name": "mini-app",
   "permissions": {},
   "slug": "mini",
-  "version": "`+localVersion+`"
-}`, "\n", "", -1)
+  "version": "` + localVersion + `"
+}`
 }
 
 func serveGitRep() {

--- a/pkg/apps/installer_test.go
+++ b/pkg/apps/installer_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/stack"
 	"github.com/spf13/afero"
 )
 
@@ -96,6 +97,7 @@ git checkout -`
 	localGitCmd.Dir = localGitDir
 	if out, err := localGitCmd.CombinedOutput(); err != nil {
 		fmt.Println(string(out))
+		os.Exit(1)
 	}
 }
 
@@ -112,6 +114,8 @@ git checkout master`
 	cmd.Dir = localGitDir
 	if out, err := cmd.Output(); err != nil {
 		fmt.Println(string(out), err)
+	} else {
+		fmt.Println("did upgrade", localVersion)
 	}
 }
 
@@ -125,6 +129,11 @@ func TestMain(m *testing.M) {
 	check, err := checkup.HTTPChecker{URL: config.CouchURL().String()}.Check()
 	if err != nil || check.Status() != checkup.Healthy {
 		fmt.Println("This test need couchdb to run.")
+		os.Exit(1)
+	}
+
+	if _, err = stack.Start(); err != nil {
+		fmt.Println("Error while starting job system", err)
 		os.Exit(1)
 	}
 

--- a/pkg/apps/server.go
+++ b/pkg/apps/server.go
@@ -39,6 +39,9 @@ func NewSwiftFileServer(conn *swift.Connection, appsType AppType) FileServer {
 }
 
 func (s *swiftServer) Open(slug, version, file string) (io.ReadCloser, error) {
+	if !path.IsAbs(file) {
+		return nil, os.ErrNotExist
+	}
 	objName := s.makeObjectName(slug, version, file)
 	f, _, err := s.c.ObjectOpen(s.container, objName, false, nil)
 	if err != nil {
@@ -48,6 +51,9 @@ func (s *swiftServer) Open(slug, version, file string) (io.ReadCloser, error) {
 }
 
 func (s *swiftServer) ServeFileContent(w http.ResponseWriter, req *http.Request, slug, version, file string) error {
+	if !path.IsAbs(file) {
+		return os.ErrNotExist
+	}
 	objName := s.makeObjectName(slug, version, file)
 	f, o, err := s.c.ObjectOpen(s.container, objName, false, nil)
 	if err != nil {
@@ -81,6 +87,9 @@ func NewAferoFileServer(fs afero.Fs, makePath func(slug, version, file string) s
 }
 
 func (s *aferoServer) Open(slug, version, file string) (io.ReadCloser, error) {
+	if !path.IsAbs(file) {
+		return nil, os.ErrNotExist
+	}
 	filepath := s.mkPath(slug, version, file)
 	f, err := s.open(filepath)
 	if os.IsNotExist(err) {
@@ -93,6 +102,9 @@ func (s *aferoServer) open(filepath string) (io.ReadCloser, error) {
 }
 
 func (s *aferoServer) ServeFileContent(w http.ResponseWriter, req *http.Request, slug, version, file string) error {
+	if !path.IsAbs(file) {
+		return os.ErrNotExist
+	}
 	filepath := s.mkPath(slug, version, file)
 	err := s.serveFileContent(w, req, filepath)
 	if os.IsNotExist(err) {

--- a/pkg/apps/webapp.go
+++ b/pkg/apps/webapp.go
@@ -203,8 +203,7 @@ func (m *WebappManifest) ReadManifest(r io.Reader, slug, sourceURL string) error
 
 // Create is part of the Manifest interface
 func (m *WebappManifest) Create(db couchdb.Database) error {
-	err := diffServices(db, m.Slug(), nil, m.Services)
-	if err != nil {
+	if err := diffServices(db, m.Slug(), nil, m.Services); err != nil {
 		return err
 	}
 	m.CreatedAt = time.Now()
@@ -212,22 +211,20 @@ func (m *WebappManifest) Create(db couchdb.Database) error {
 	if err := couchdb.CreateNamedDocWithDB(db, m); err != nil {
 		return err
 	}
-	_, err = permissions.CreateWebappSet(db, m.Slug(), m.Permissions())
+	_, err := permissions.CreateWebappSet(db, m.Slug(), m.Permissions())
 	return err
 }
 
 // Update is part of the Manifest interface
 func (m *WebappManifest) Update(db couchdb.Database) error {
-	err := diffServices(db, m.Slug(), m.oldServices, m.Services)
-	if err != nil {
+	if err := diffServices(db, m.Slug(), m.oldServices, m.Services); err != nil {
 		return err
 	}
 	m.UpdatedAt = time.Now()
-	err = couchdb.UpdateDoc(db, m)
-	if err != nil {
+	if err := couchdb.UpdateDoc(db, m); err != nil {
 		return err
 	}
-	_, err = permissions.UpdateWebappSet(db, m.Slug(), m.Permissions())
+	_, err := permissions.UpdateWebappSet(db, m.Slug(), m.Permissions())
 	return err
 }
 

--- a/pkg/apps/webapp.go
+++ b/pkg/apps/webapp.go
@@ -274,7 +274,9 @@ func diffServices(db couchdb.Database, slug string, oldServices, newServices Ser
 			triggerArgs = strings.TrimSpace(triggerOpts[1])
 		}
 		msg, err := jobs.NewMessage(jobs.JSONEncoding, map[string]string{
-			"slug": slug,
+			"slug":         slug,
+			"type":         service.Type,
+			"service_file": service.File,
 		})
 		if err != nil {
 			return nil, err

--- a/pkg/apps/webapp.go
+++ b/pkg/apps/webapp.go
@@ -2,7 +2,6 @@ package apps
 
 import (
 	"encoding/json"
-	"errors"
 	"io"
 	"path"
 	"strings"
@@ -10,7 +9,10 @@ import (
 
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/jobs"
 	"github.com/cozy/cozy-stack/pkg/permissions"
+	"github.com/cozy/cozy-stack/pkg/scheduler"
+	"github.com/cozy/cozy-stack/pkg/stack"
 )
 
 // Route is a struct to serve a folder inside an app
@@ -23,8 +25,19 @@ type Route struct {
 // NotFound returns true for a blank route (ie not found by FindRoute)
 func (c *Route) NotFound() bool { return c.Folder == "" }
 
-// Routes are a map for routing inside an application.
+// Routes is a map for routing inside an application.
 type Routes map[string]Route
+
+// Service is a struct to define a service executed by the stack.
+type Service struct {
+	Type           string `json:"type"`
+	File           string `json:"file"`
+	TriggerOptions string `json:"trigger"`
+	TriggerID      string `json:"trigger_id"`
+}
+
+// Services is a map to define services assciated with an application.
+type Services map[string]*Service
 
 // Intent is a declaration of a service for other client-side apps
 type Intent struct {
@@ -61,9 +74,13 @@ type WebappManifest struct {
 	DocPermissions permissions.Set `json:"permissions"`
 	Intents        []Intent        `json:"intents"`
 	Routes         Routes          `json:"routes"`
+	Services       Services        `json:"services"`
+	CreatedAt      time.Time       `json:"created_at"`
 	UpdatedAt      time.Time       `json:"updated_at"`
 
 	Instance SubDomainer `json:"-"` // Used for JSON-API links
+
+	oldServices Services // Used to diff against when updating the app
 }
 
 // ID is part of the Manifest interface
@@ -108,19 +125,8 @@ func (m *WebappManifest) State() State { return m.DocState }
 // LastUpdate is part of the Manifest interface
 func (m *WebappManifest) LastUpdate() time.Time { return m.UpdatedAt }
 
-// Error is part of the Manifest interface
-func (m *WebappManifest) Error() error {
-	if m.DocError == "" {
-		return nil
-	}
-	return errors.New(m.DocError)
-}
-
 // SetState is part of the Manifest interface
 func (m *WebappManifest) SetState(state State) { m.DocState = state }
-
-// SetError is part of the Manifest interface
-func (m *WebappManifest) SetError(err error) { m.DocError = err.Error() }
 
 // SetVersion is part of the Manifest interface
 func (m *WebappManifest) SetVersion(version string) { m.DocVersion = version }
@@ -143,38 +149,57 @@ func (m *WebappManifest) Valid(field, value string) bool {
 
 // ReadManifest is part of the Manifest interface
 func (m *WebappManifest) ReadManifest(r io.Reader, slug, sourceURL string) error {
-	if err := json.NewDecoder(r).Decode(&m); err != nil {
+	var newManifest WebappManifest
+	if err := json.NewDecoder(r).Decode(&newManifest); err != nil {
 		return ErrBadManifest
 	}
 
-	m.DocSlug = slug
-	m.DocSource = sourceURL
-
-	if m.Routes == nil {
-		m.Routes = make(Routes)
-		m.Routes["/"] = Route{
+	newManifest.SetID(m.ID())
+	newManifest.SetRev(m.Rev())
+	newManifest.SetState(m.State())
+	newManifest.CreatedAt = m.CreatedAt
+	newManifest.Instance = m.Instance
+	newManifest.DocSlug = slug
+	newManifest.DocSource = sourceURL
+	newManifest.oldServices = m.Services
+	if newManifest.Routes == nil {
+		newManifest.Routes = make(Routes)
+		newManifest.Routes["/"] = Route{
 			Folder: "/",
 			Index:  "index.html",
 			Public: false,
 		}
 	}
+
+	*m = newManifest
 	return nil
 }
 
 // Create is part of the Manifest interface
 func (m *WebappManifest) Create(db couchdb.Database) error {
+	var err error
+	m.Services, err = diffServices(db, m.Slug(), nil, m.Services)
+	if err != nil {
+		return err
+	}
+	m.CreatedAt = time.Now()
 	m.UpdatedAt = time.Now()
 	if err := couchdb.CreateNamedDocWithDB(db, m); err != nil {
 		return err
 	}
-	_, err := permissions.CreateWebappSet(db, m.Slug(), m.Permissions())
+	_, err = permissions.CreateWebappSet(db, m.Slug(), m.Permissions())
 	return err
 }
 
 // Update is part of the Manifest interface
 func (m *WebappManifest) Update(db couchdb.Database) error {
+	var err error
+	m.Services, err = diffServices(db, m.Slug(), m.oldServices, m.Services)
+	if err != nil {
+		return err
+	}
 	m.UpdatedAt = time.Now()
-	err := couchdb.UpdateDoc(db, m)
+	err = couchdb.UpdateDoc(db, m)
 	if err != nil {
 		return err
 	}
@@ -184,11 +209,93 @@ func (m *WebappManifest) Update(db couchdb.Database) error {
 
 // Delete is part of the Manifest interface
 func (m *WebappManifest) Delete(db couchdb.Database) error {
-	err := permissions.DestroyWebapp(db, m.Slug())
+	_, err := diffServices(db, m.Slug(), m.Services, nil)
+	if err != nil {
+		return err
+	}
+	err = permissions.DestroyWebapp(db, m.Slug())
 	if err != nil && !couchdb.IsNotFoundError(err) {
 		return err
 	}
 	return couchdb.DeleteDoc(db, m)
+}
+
+func diffServices(db couchdb.Database, slug string, oldServices, newServices Services) (Services, error) {
+	domain := db.Prefix()
+
+	if oldServices == nil {
+		oldServices = make(Services)
+	}
+	if newServices == nil {
+		newServices = make(Services)
+	}
+
+	var deleted []*Service
+	var created []*Service
+
+	var clone = make(Services)
+	for newName, newService := range newServices {
+		clone[newName] = newService
+	}
+
+	for name, oldService := range oldServices {
+		newService, ok := newServices[name]
+		if !ok {
+			deleted = append(deleted, oldService)
+			continue
+		}
+		delete(clone, name)
+		if newService.File != oldService.File ||
+			newService.Type != oldService.Type ||
+			newService.TriggerOptions != oldService.TriggerOptions {
+			deleted = append(deleted, oldService)
+			created = append(created, newService)
+		}
+	}
+	for _, newService := range clone {
+		created = append(created, newService)
+	}
+
+	sched := stack.GetScheduler()
+	for _, service := range deleted {
+		if err := sched.Delete(domain, service.TriggerID); err != nil {
+			return nil, err
+		}
+	}
+
+	for _, service := range created {
+		var triggerType string
+		var triggerArgs string
+		triggerOpts := strings.SplitN(service.TriggerOptions, " ", 2)
+		if len(triggerOpts) > 0 {
+			triggerType = strings.TrimSpace(triggerOpts[0])
+		}
+		if len(triggerOpts) > 1 {
+			triggerArgs = strings.TrimSpace(triggerOpts[1])
+		}
+		msg, err := jobs.NewMessage(jobs.JSONEncoding, map[string]string{
+			"slug": slug,
+		})
+		if err != nil {
+			return nil, err
+		}
+		trigger, err := scheduler.NewTrigger(&scheduler.TriggerInfos{
+			Type:       triggerType,
+			WorkerType: "service",
+			Domain:     domain,
+			Arguments:  triggerArgs,
+			Message:    msg,
+		})
+		if err != nil {
+			return nil, err
+		}
+		if err = sched.Add(trigger); err != nil {
+			return nil, err
+		}
+		service.TriggerID = trigger.ID()
+	}
+
+	return newServices, nil
 }
 
 // FindRoute takes a path, returns the route which matches the best,

--- a/pkg/workers/exec/common.go
+++ b/pkg/workers/exec/common.go
@@ -22,6 +22,15 @@ func init() {
 	}, func() execWorker {
 		return &konnectorWorker{}
 	})
+
+	addExecWorker("service", &jobs.WorkerConfig{
+		Concurrency:  runtime.NumCPU() * 2,
+		MaxExecCount: 2,
+		MaxExecTime:  200 * time.Second,
+		Timeout:      200 * time.Second,
+	}, func() execWorker {
+		return &serviceWorker{}
+	})
 }
 
 type execWorker interface {

--- a/pkg/workers/exec/konnector.go
+++ b/pkg/workers/exec/konnector.go
@@ -106,7 +106,8 @@ func (w *konnectorWorker) PrepareWorkDir(i *instance.Instance, m *jobs.Message) 
 	workFS := afero.NewBasePathFs(osFS, workDir)
 
 	fileServer := i.KonnectorsFileServer()
-	tarFile, err := fileServer.Open(slug, man.Version(), apps.KonnectorArchiveName)
+	tarFileName := path.Join("/", apps.KonnectorArchiveName)
+	tarFile, err := fileServer.Open(slug, man.Version(), tarFileName)
 	if err != nil {
 		return
 	}

--- a/pkg/workers/exec/konnector.go
+++ b/pkg/workers/exec/konnector.go
@@ -106,8 +106,7 @@ func (w *konnectorWorker) PrepareWorkDir(i *instance.Instance, m *jobs.Message) 
 	workFS := afero.NewBasePathFs(osFS, workDir)
 
 	fileServer := i.KonnectorsFileServer()
-	tarFileName := path.Join("/", apps.KonnectorArchiveName)
-	tarFile, err := fileServer.Open(slug, man.Version(), tarFileName)
+	tarFile, err := fileServer.Open(slug, man.Version(), apps.KonnectorArchiveName)
 	if err != nil {
 		return
 	}

--- a/pkg/workers/exec/konnector.go
+++ b/pkg/workers/exec/konnector.go
@@ -128,7 +128,7 @@ func (w *konnectorWorker) PrepareWorkDir(i *instance.Instance, m *jobs.Message) 
 			}
 		}
 		var f afero.File
-		f, err = workFS.OpenFile(hdr.Name, os.O_CREATE|os.O_WRONLY, 0644)
+		f, err = workFS.OpenFile(hdr.Name, os.O_CREATE|os.O_WRONLY, 0640)
 		if err != nil {
 			return
 		}

--- a/pkg/workers/exec/service.go
+++ b/pkg/workers/exec/service.go
@@ -1,0 +1,103 @@
+package exec
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+
+	"github.com/cozy/cozy-stack/pkg/apps"
+	"github.com/cozy/cozy-stack/pkg/config"
+	"github.com/cozy/cozy-stack/pkg/instance"
+	"github.com/cozy/cozy-stack/pkg/jobs"
+	"github.com/spf13/afero"
+)
+
+// ServiceOptions contains the options to execute a service.
+type ServiceOptions struct {
+	Slug        string `json:"slug"`
+	Type        string `json:"type"`
+	ServiceFile string `json:"service_file"`
+}
+
+type serviceWorker struct {
+	opts *ServiceOptions
+	man  *apps.WebappManifest
+}
+
+func (w *serviceWorker) PrepareWorkDir(i *instance.Instance, m *jobs.Message) (workDir string, err error) {
+	opts := &ServiceOptions{}
+	if err = m.Unmarshal(&opts); err != nil {
+		return
+	}
+
+	slug := opts.Slug
+
+	man, err := apps.GetWebappBySlug(i, slug)
+	if err != nil {
+		return
+	}
+	if man.State() != apps.Ready {
+		err = errors.New("Application is not ready")
+		return
+	}
+
+	w.opts = opts
+	w.man = man
+
+	osFS := afero.NewOsFs()
+	workDir, err = afero.TempDir(osFS, "", "service-"+slug)
+	if err != nil {
+		return
+	}
+	workFS := afero.NewBasePathFs(osFS, workDir)
+
+	fs := i.AppsFileServer()
+	src, err := fs.Open(man.Slug(), man.Version(), path.Join("/", opts.ServiceFile))
+	if err != nil {
+		return
+	}
+	defer src.Close()
+
+	dst, err := workFS.OpenFile("index.js", os.O_CREATE|os.O_WRONLY, 0640)
+	if err != nil {
+		return
+	}
+	defer dst.Close()
+
+	_, err = io.Copy(dst, src)
+	if err != nil {
+		return
+	}
+
+	return workDir, nil
+}
+
+func (w *serviceWorker) PrepareCmdEnv(i *instance.Instance, m *jobs.Message) (cmd string, env []string, jobID string, err error) {
+	jobID = fmt.Sprintf("service/%s/%s", w.opts.Slug, i.Domain)
+
+	token := i.BuildAppToken(w.man)
+
+	cmd = config.GetConfig().Konnectors.Cmd
+	env = []string{
+		"COZY_URL=" + i.PageURL("/", nil),
+		"COZY_CREDENTIALS=" + token,
+		"COZY_TYPE=" + w.opts.Type,
+		"COZY_JOB_ID=" + jobID,
+	}
+	return
+}
+
+func (w *serviceWorker) ScanOuput(i *instance.Instance, line []byte) error {
+	return nil
+}
+
+func (w *serviceWorker) Error(i *instance.Instance, err error) error {
+	return err
+}
+
+func (w *serviceWorker) Commit(ctx context.Context, msg *jobs.Message, errjob error) error {
+	return errjob
+}

--- a/web/apps/serve.go
+++ b/web/apps/serve.go
@@ -137,7 +137,7 @@ func ServeAppFile(c echo.Context, i *instance.Instance, fs apps.FileServer, app 
 		}
 		return c.Redirect(http.StatusFound, i.PageURL("/auth/login", redirect))
 	}
-	filepath := path.Join(route.Folder, file)
+	filepath := path.Join("/", route.Folder, file)
 	version := app.Version()
 	if file != route.Index {
 		err := fs.ServeFileContent(c.Response(), c.Request(), slug, version, filepath)


### PR DESCRIPTION
This PR adds the possibility to associate services to an applications.

It also fixes some issues with the installation process and simplifies it:
  - no more `Errored` state
  - application document is created/updated in CouchDB *after* the code is reached and copied
  - fixes the `Clone()` on the `WebappManifest` struct