### PR TITLE
Auto updates

### DIFF
--- a/client/instances.go
+++ b/client/instances.go
@@ -64,6 +64,12 @@ type OAuthClientOptions struct {
 	SoftwareID  string
 }
 
+// UpdatesOptions is a struct holding all the options to launch an update.
+type UpdatesOptions struct {
+	Domain string
+	Slugs  []string
+}
+
 // GetInstance returns the instance associated with the specified domain.
 func (c *Client) GetInstance(domain string) (*Instance, error) {
 	res, err := c.Req(&request.Options{
@@ -231,6 +237,22 @@ func (c *Client) RegisterOAuthClient(opts *OAuthClientOptions) (string, error) {
 		return "", err
 	}
 	return string(b), nil
+}
+
+// Updates launch the updating process of the applications. When no Domain is
+// specified, the updates are launched for all the existing instances.
+func (c *Client) Updates(opts *UpdatesOptions) error {
+	q := url.Values{
+		"Domain": {opts.Domain},
+		"Slugs":  {strings.Join(opts.Slugs, ",")},
+	}
+	_, err := c.Req(&request.Options{
+		Method:     "POST",
+		Path:       "/instances/updates",
+		Queries:    q,
+		NoResponse: true,
+	})
+	return err
 }
 
 func readInstance(res *http.Response) (*Instance, error) {

--- a/cmd/instances.go
+++ b/cmd/instances.go
@@ -440,8 +440,8 @@ var oauthClientInstanceCmd = &cobra.Command{
 
 var updateCmd = &cobra.Command{
 	Use:   "update [domain] [slugs...]",
-	Short: "Starts the updates for the specified domain instance.",
-	Long: `Starts the updates for the specified domain instance. Use whether the --domain
+	Short: "Start the updates for the specified domain instance.",
+	Long: `Start the updates for the specified domain instance. Use whether the --domain
 flag to specify the instance or the --all-domains flags to updates all domains.
 The slugs arguments can be used to select which applications should be
 updated.`,

--- a/cmd/instances.go
+++ b/cmd/instances.go
@@ -437,6 +437,36 @@ var oauthClientInstanceCmd = &cobra.Command{
 	},
 }
 
+var updateAllCmd = &cobra.Command{
+	Use:   "update-all [slugs...]",
+	Short: "Starts the updates for all instances.",
+	Long: `Starts the updates for all instances. The slugs arguments can be used
+to select which applications should be updated.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c := newAdminClient()
+		return c.Updates(&client.UpdatesOptions{
+			Slugs: args,
+		})
+	},
+}
+
+var updateCmd = &cobra.Command{
+	Use:   "update [domain] [slugs...]",
+	Short: "Starts the updates for the specified domain instance.",
+	Long: `Starts the updates for the specified domain instance. The slugs
+arguments can be used to select which applications should be updated.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 1 {
+			return cmd.Help()
+		}
+		c := newAdminClient()
+		return c.Updates(&client.UpdatesOptions{
+			Domain: args[0],
+			Slugs:  args[1:],
+		})
+	},
+}
+
 func init() {
 	instanceCmdGroup.AddCommand(showInstanceCmd)
 	instanceCmdGroup.AddCommand(addInstanceCmd)
@@ -450,6 +480,8 @@ func init() {
 	instanceCmdGroup.AddCommand(cliTokenInstanceCmd)
 	instanceCmdGroup.AddCommand(oauthTokenInstanceCmd)
 	instanceCmdGroup.AddCommand(oauthClientInstanceCmd)
+	instanceCmdGroup.AddCommand(updateAllCmd)
+	instanceCmdGroup.AddCommand(updateCmd)
 	addInstanceCmd.Flags().StringVar(&flagLocale, "locale", instance.DefaultLocale, "Locale of the new cozy instance")
 	addInstanceCmd.Flags().StringVar(&flagTimezone, "tz", "", "The timezone for the user")
 	addInstanceCmd.Flags().StringVar(&flagEmail, "email", "", "The email of the owner")

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/cozy/cozy-stack/pkg/config"
+	"github.com/cozy/cozy-stack/pkg/globals"
 	"github.com/cozy/cozy-stack/pkg/stack"
 	"github.com/cozy/cozy-stack/pkg/utils"
 	"github.com/cozy/cozy-stack/web"
@@ -76,10 +77,11 @@ example), you can use the --appdir flag like this:
 			}
 		}
 
-		processes, err := stack.Start()
+		broker, schder, processes, err := stack.Start()
 		if err != nil {
 			return err
 		}
+		globals.Set(broker, schder)
 
 		var servers *web.Servers
 		if apps != nil {

--- a/cozy.example.yaml
+++ b/cozy.example.yaml
@@ -76,6 +76,10 @@ mail:
 # directory with the hooks scripts - flags: --hooks
 hooks: ./scripts/hooks
 
+# Auto updates scheduler
+auto_updates:
+  schedule: "@cron 0 0 0 * * *"
+
 log:
   # logger level (debug, info, warning, panic, fatal) - flags: --log-level
   level: info

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -123,6 +123,7 @@ Cookie: sessionid=xxxx
     },
     "attributes": {
       "locale":"fr",
+      "auto_update": true,
       "email": "alice@example.com",
       "public_name":"Alice Martin"
     }

--- a/pkg/accounts/accounts.go
+++ b/pkg/accounts/accounts.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/globals"
 	"github.com/cozy/cozy-stack/pkg/logger"
-	"github.com/cozy/cozy-stack/pkg/stack"
 )
 
 // Account holds configuration information for an account
@@ -73,7 +73,7 @@ func (ac *Account) Valid(field, expected string) bool {
 func init() {
 	couchdb.AddHook(consts.Accounts, couchdb.EventDelete,
 		func(domain string, doc couchdb.Doc, old couchdb.Doc) error {
-			trigs, err := stack.GetScheduler().GetAll(domain)
+			trigs, err := globals.GetScheduler().GetAll(domain)
 			if err != nil {
 				logger.WithDomain(domain).Error(
 					"Failed to fetch triggers after account deletion: ", err)
@@ -98,7 +98,7 @@ func init() {
 					}
 				}
 				if toDelete {
-					if err := stack.GetScheduler().Delete(domain, t.ID()); err != nil {
+					if err := globals.GetScheduler().Delete(domain, t.ID()); err != nil {
 						logger.WithDomain(domain).Errorln("failed to delete orphan trigger", err)
 					}
 				}

--- a/pkg/apps/apps.go
+++ b/pkg/apps/apps.go
@@ -45,7 +45,7 @@ type AppType int
 
 const (
 	// Webapp is the clientside application type
-	Webapp AppType = iota
+	Webapp AppType = iota + 1
 	// Konnector is the serverside application type
 	Konnector
 )
@@ -76,6 +76,7 @@ type Manifest interface {
 	Update(db couchdb.Database) error
 	Delete(db couchdb.Database) error
 
+	AppType() AppType
 	Permissions() permissions.Set
 	Source() string
 	Version() string

--- a/pkg/apps/fetcher_git.go
+++ b/pkg/apps/fetcher_git.go
@@ -53,7 +53,9 @@ func newGitFetcher(manFilename string, log *logrus.Entry) *gitFetcher {
 	}
 }
 
-var manifestClient = &http.Client{
+// ManifestClient is the client used to HTTP resources from the git fetcher. It
+// is exported for tests purposes only.
+var ManifestClient = &http.Client{
 	Timeout: 60 * time.Second,
 }
 
@@ -90,7 +92,7 @@ func (g *gitFetcher) FetchManifest(src *url.URL) (r io.ReadCloser, err error) {
 	}
 
 	g.log.Infof("[git] Fetching manifest on %s", u)
-	res, err := manifestClient.Get(u)
+	res, err := ManifestClient.Get(u)
 	if err != nil || res.StatusCode != 200 {
 		g.log.Errorf("[git] Error while fetching manifest on %s", u)
 		return nil, ErrManifestNotReachable

--- a/pkg/apps/installer.go
+++ b/pkg/apps/installer.go
@@ -212,7 +212,7 @@ func (i *Installer) Run() {
 	if err != nil {
 		i.errc <- err
 	} else {
-		i.manc <- i.man
+		i.manc <- i.man.Clone().(Manifest)
 	}
 }
 
@@ -243,7 +243,7 @@ func (i *Installer) install() error {
 		if err := i.ReadManifest(Installing); err != nil {
 			return err
 		}
-		i.manc <- i.man
+		i.manc <- i.man.Clone().(Manifest)
 		if err := i.fetcher.Fetch(i.src, i.fs, i.man); err != nil {
 			return err
 		}
@@ -270,7 +270,7 @@ func (i *Installer) update() error {
 		return err
 	}
 
-	i.manc <- i.man
+	i.manc <- i.man.Clone().(Manifest)
 
 	// Fast path for registry:// and http:// sources: we do not need to go
 	// further in the case where the fetched manifest has the same version has

--- a/pkg/apps/installer_test.go
+++ b/pkg/apps/installer_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/globals"
 	"github.com/cozy/cozy-stack/pkg/stack"
 	"github.com/spf13/afero"
 )
@@ -136,10 +137,12 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	if _, _, _, err = stack.Start(); err != nil {
+	b, s, _, err := stack.Start()
+	if err != nil {
 		fmt.Println("Error while starting job system", err)
 		os.Exit(1)
 	}
+	globals.Set(b, s)
 
 	manifestClient = &http.Client{
 		Transport: &transport{},

--- a/pkg/apps/installer_test.go
+++ b/pkg/apps/installer_test.go
@@ -1,4 +1,4 @@
-package apps
+package apps_test
 
 import (
 	"fmt"
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/cozy/checkup"
+	"github.com/cozy/cozy-stack/pkg/apps"
 	"github.com/cozy/cozy-stack/pkg/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
@@ -81,8 +82,8 @@ func serveGitRep() {
 	}
 	localGitDir = dir
 	args := `
-echo '` + manifestWebapp() + `' > ` + WebappManifestName + ` && \
-echo '` + manifestKonnector() + `' > ` + KonnectorManifestName + ` && \
+echo '` + manifestWebapp() + `' > ` + apps.WebappManifestName + ` && \
+echo '` + manifestKonnector() + `' > ` + apps.KonnectorManifestName + ` && \
 git init . && \
 git add . && \
 git commit -m 'Initial commit' && \
@@ -109,8 +110,8 @@ git checkout -`
 func doUpgrade(major int) {
 	localVersion = fmt.Sprintf("%d.0.0", major)
 	args := `
-echo '` + manifestWebapp() + `' > ` + WebappManifestName + ` && \
-echo '` + manifestKonnector() + `' > ` + KonnectorManifestName + ` && \
+echo '` + manifestWebapp() + `' > ` + apps.WebappManifestName + ` && \
+echo '` + manifestKonnector() + `' > ` + apps.KonnectorManifestName + ` && \
 git commit -am "Upgrade commit" && \
 git checkout branch && \
 git rebase master && \
@@ -125,7 +126,7 @@ git checkout master`
 }
 
 var db couchdb.Database
-var fs Copier
+var fs apps.Copier
 var baseFS afero.Fs
 
 func TestMain(m *testing.M) {
@@ -144,7 +145,7 @@ func TestMain(m *testing.M) {
 	}
 	globals.Set(b, s)
 
-	manifestClient = &http.Client{
+	apps.ManifestClient = &http.Client{
 		Transport: &transport{},
 	}
 
@@ -173,7 +174,7 @@ func TestMain(m *testing.M) {
 	}
 
 	baseFS = afero.NewMemMapFs()
-	fs = NewAferoCopier(baseFS)
+	fs = apps.NewAferoCopier(baseFS)
 
 	go serveGitRep()
 

--- a/pkg/apps/installer_test.go
+++ b/pkg/apps/installer_test.go
@@ -136,7 +136,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	if _, err = stack.Start(); err != nil {
+	if _, _, _, err = stack.Start(); err != nil {
 		fmt.Println("Error while starting job system", err)
 		os.Exit(1)
 	}

--- a/pkg/apps/konnector.go
+++ b/pkg/apps/konnector.go
@@ -90,6 +90,9 @@ func (m *KonnManifest) SetState(state State) { m.DocState = state }
 // SetVersion is part of the Manifest interface
 func (m *KonnManifest) SetVersion(version string) { m.DocVersion = version }
 
+// ManifestType is part of the Manifest interface
+func (m *KonnManifest) AppType() AppType { return Konnector }
+
 // Permissions is part of the Manifest interface
 func (m *KonnManifest) Permissions() permissions.Set {
 	return m.DocPermissions

--- a/pkg/apps/konnector.go
+++ b/pkg/apps/konnector.go
@@ -90,7 +90,7 @@ func (m *KonnManifest) SetState(state State) { m.DocState = state }
 // SetVersion is part of the Manifest interface
 func (m *KonnManifest) SetVersion(version string) { m.DocVersion = version }
 
-// ManifestType is part of the Manifest interface
+// AppType is part of the Manifest interface
 func (m *KonnManifest) AppType() AppType { return Konnector }
 
 // Permissions is part of the Manifest interface

--- a/pkg/apps/webapp.go
+++ b/pkg/apps/webapp.go
@@ -157,6 +157,9 @@ func (m *WebappManifest) SetState(state State) { m.DocState = state }
 // SetVersion is part of the Manifest interface
 func (m *WebappManifest) SetVersion(version string) { m.DocVersion = version }
 
+// ManifestType is part of the Manifest interface
+func (m *WebappManifest) AppType() AppType { return Webapp }
+
 // Permissions is part of the Manifest interface
 func (m *WebappManifest) Permissions() permissions.Set {
 	return m.DocPermissions
@@ -397,7 +400,7 @@ func GetWebappBySlug(db couchdb.Database, slug string) (*WebappManifest, error) 
 // TODO: pagination
 func ListWebapps(db couchdb.Database) ([]*WebappManifest, error) {
 	var docs []*WebappManifest
-	req := &couchdb.AllDocsRequest{Limit: 100}
+	req := &couchdb.AllDocsRequest{Limit: 200}
 	err := couchdb.GetAllDocs(db, consts.Apps, req, &docs)
 	if err != nil {
 		return nil, err

--- a/pkg/apps/webapp.go
+++ b/pkg/apps/webapp.go
@@ -157,7 +157,7 @@ func (m *WebappManifest) SetState(state State) { m.DocState = state }
 // SetVersion is part of the Manifest interface
 func (m *WebappManifest) SetVersion(version string) { m.DocVersion = version }
 
-// ManifestType is part of the Manifest interface
+// AppType is part of the Manifest interface
 func (m *WebappManifest) AppType() AppType { return Webapp }
 
 // Permissions is part of the Manifest interface

--- a/pkg/apps/webapp.go
+++ b/pkg/apps/webapp.go
@@ -400,7 +400,7 @@ func GetWebappBySlug(db couchdb.Database, slug string) (*WebappManifest, error) 
 // TODO: pagination
 func ListWebapps(db couchdb.Database) ([]*WebappManifest, error) {
 	var docs []*WebappManifest
-	req := &couchdb.AllDocsRequest{Limit: 200}
+	req := &couchdb.AllDocsRequest{Limit: 100}
 	err := couchdb.GetAllDocs(db, consts.Apps, req, &docs)
 	if err != nil {
 		return nil, err

--- a/pkg/apps/webapp.go
+++ b/pkg/apps/webapp.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/globals"
 	"github.com/cozy/cozy-stack/pkg/jobs"
 	"github.com/cozy/cozy-stack/pkg/permissions"
 	"github.com/cozy/cozy-stack/pkg/scheduler"
-	"github.com/cozy/cozy-stack/pkg/stack"
 )
 
 // Route is a struct to serve a folder inside an app
@@ -283,7 +283,7 @@ func diffServices(db couchdb.Database, slug string, oldServices, newServices Ser
 		created = append(created, newService)
 	}
 
-	sched := stack.GetScheduler()
+	sched := globals.GetScheduler()
 	for _, service := range deleted {
 		if err := sched.Delete(domain, service.TriggerID); err != nil {
 			return err

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -71,15 +71,16 @@ var log = logger.WithNamespace("config")
 
 // Config contains the configuration values of the application
 type Config struct {
-	Host       string
-	Port       int
-	Assets     string
-	Doctypes   string
-	Subdomains string
-	AdminHost  string
-	AdminPort  int
-	NoReply    string
-	Hooks      string
+	Host        string
+	Port        int
+	Assets      string
+	Doctypes    string
+	Subdomains  string
+	AdminHost   string
+	AdminPort   int
+	NoReply     string
+	Hooks       string
+	AutoUpdates string
 
 	Fs         Fs
 	CouchDB    CouchDB
@@ -272,15 +273,16 @@ func UseViper(v *viper.Viper) error {
 	}
 
 	config = &Config{
-		Host:       v.GetString("host"),
-		Port:       v.GetInt("port"),
-		Subdomains: v.GetString("subdomains"),
-		AdminHost:  v.GetString("admin.host"),
-		AdminPort:  v.GetInt("admin.port"),
-		Assets:     v.GetString("assets"),
-		Doctypes:   v.GetString("doctypes"),
-		NoReply:    v.GetString("mail.noreply_address"),
-		Hooks:      v.GetString("hooks"),
+		Host:        v.GetString("host"),
+		Port:        v.GetInt("port"),
+		Subdomains:  v.GetString("subdomains"),
+		AdminHost:   v.GetString("admin.host"),
+		AdminPort:   v.GetInt("admin.port"),
+		Assets:      v.GetString("assets"),
+		Doctypes:    v.GetString("doctypes"),
+		NoReply:     v.GetString("mail.noreply_address"),
+		Hooks:       v.GetString("hooks"),
+		AutoUpdates: v.GetString("auto_updates"),
 		Fs: Fs{
 			URL: fsURL,
 		},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -71,22 +71,22 @@ var log = logger.WithNamespace("config")
 
 // Config contains the configuration values of the application
 type Config struct {
-	Host        string
-	Port        int
-	Assets      string
-	Doctypes    string
-	Subdomains  string
-	AdminHost   string
-	AdminPort   int
-	NoReply     string
-	Hooks       string
-	AutoUpdates string
+	Host       string
+	Port       int
+	Assets     string
+	Doctypes   string
+	Subdomains string
+	AdminHost  string
+	AdminPort  int
+	NoReply    string
+	Hooks      string
 
-	Fs         Fs
-	CouchDB    CouchDB
-	Jobs       Jobs
-	Konnectors Konnectors
-	Mail       *gomail.DialerOptions
+	AutoUpdates AutoUpdates
+	Fs          Fs
+	CouchDB     CouchDB
+	Jobs        Jobs
+	Konnectors  Konnectors
+	Mail        *gomail.DialerOptions
 
 	Cache                       RedisConfig
 	Lock                        RedisConfig
@@ -122,6 +122,12 @@ type Jobs struct {
 // Konnectors contains the configuration values for the konnectors
 type Konnectors struct {
 	Cmd string
+}
+
+// AutoUpdates contains the configuration values for auto updates
+type AutoUpdates struct {
+	Activated bool
+	Schedule  string
 }
 
 // RedisConfig contains the configuration values for a redis system
@@ -273,16 +279,15 @@ func UseViper(v *viper.Viper) error {
 	}
 
 	config = &Config{
-		Host:        v.GetString("host"),
-		Port:        v.GetInt("port"),
-		Subdomains:  v.GetString("subdomains"),
-		AdminHost:   v.GetString("admin.host"),
-		AdminPort:   v.GetInt("admin.port"),
-		Assets:      v.GetString("assets"),
-		Doctypes:    v.GetString("doctypes"),
-		NoReply:     v.GetString("mail.noreply_address"),
-		Hooks:       v.GetString("hooks"),
-		AutoUpdates: v.GetString("auto_updates"),
+		Host:       v.GetString("host"),
+		Port:       v.GetInt("port"),
+		Subdomains: v.GetString("subdomains"),
+		AdminHost:  v.GetString("admin.host"),
+		AdminPort:  v.GetInt("admin.port"),
+		Assets:     v.GetString("assets"),
+		Doctypes:   v.GetString("doctypes"),
+		NoReply:    v.GetString("mail.noreply_address"),
+		Hooks:      v.GetString("hooks"),
 		Fs: Fs{
 			URL: fsURL,
 		},
@@ -296,6 +301,10 @@ func UseViper(v *viper.Viper) error {
 		},
 		Konnectors: Konnectors{
 			Cmd: v.GetString("konnectors.cmd"),
+		},
+		AutoUpdates: AutoUpdates{
+			Activated: v.GetString("auto_updates.schedule") != "",
+			Schedule:  v.GetString("auto_updates.schedule"),
 		},
 		Cache:                       NewRedisConfig(v.GetString("cache.url")),
 		Lock:                        NewRedisConfig(v.GetString("lock.url")),

--- a/pkg/globals/globals.go
+++ b/pkg/globals/globals.go
@@ -26,6 +26,7 @@ func GetScheduler() scheduler.Scheduler {
 	return schder
 }
 
+// Set will set the globales values.
 func Set(b jobs.Broker, s scheduler.Scheduler) {
 	broker = b
 	schder = s

--- a/pkg/globals/globals.go
+++ b/pkg/globals/globals.go
@@ -1,0 +1,32 @@
+package globals
+
+import (
+	"github.com/cozy/cozy-stack/pkg/jobs"
+	"github.com/cozy/cozy-stack/pkg/scheduler"
+)
+
+var (
+	broker jobs.Broker
+	schder scheduler.Scheduler
+)
+
+// GetBroker returns the global job broker.
+func GetBroker() jobs.Broker {
+	if broker == nil {
+		panic("Job system not initialized")
+	}
+	return broker
+}
+
+// GetScheduler returns the global job scheduler.
+func GetScheduler() scheduler.Scheduler {
+	if schder == nil {
+		panic("Job system not initialized")
+	}
+	return schder
+}
+
+func Set(b jobs.Broker, s scheduler.Scheduler) {
+	broker = b
+	schder = s
+}

--- a/pkg/instance/auto_update.go
+++ b/pkg/instance/auto_update.go
@@ -1,0 +1,169 @@
+package instance
+
+import (
+	"net/url"
+	"sync"
+	"sync/atomic"
+
+	"github.com/cozy/cozy-stack/pkg/apps"
+	multierror "github.com/hashicorp/go-multierror"
+)
+
+const numUpdaters = 50
+
+var updating uint32
+
+func UpdateAll() error {
+	if !atomic.CompareAndSwapUint32(&updating, 0, 1) {
+		return nil
+	}
+
+	insc := make(chan *apps.Installer)
+	errc := make(chan error)
+
+	var g sync.WaitGroup
+	g.Add(numUpdaters)
+
+	for i := 0; i < numUpdaters; i++ {
+		go func() {
+			for installer := range insc {
+				_, err := installer.RunSync()
+				errc <- err
+			}
+			g.Done()
+		}()
+	}
+
+	go func() {
+		errc <- ForeachInstances(func(inst *Instance) error {
+			return update(inst, insc)
+		})
+		close(insc)
+	}()
+
+	var errm error
+	go func() {
+		for err := range errc {
+			if err != nil {
+				errm = multierror.Append(errm, err)
+			}
+		}
+	}()
+
+	g.Wait()
+	close(errc)
+
+	atomic.SwapUint32(&updating, 0)
+	return errm
+}
+
+func UpdateInstance(inst *Instance) error {
+	insc := make(chan *apps.Installer)
+	errc := make(chan error)
+
+	var g sync.WaitGroup
+	g.Add(4)
+
+	for i := 0; i < 4; i++ {
+		go func() {
+			for installer := range insc {
+				_, err := installer.RunSync()
+				errc <- err
+			}
+			g.Done()
+		}()
+	}
+
+	go func() {
+		errc <- update(inst, insc)
+		close(insc)
+	}()
+
+	var errm error
+	go func() {
+		for err := range errc {
+			if err != nil {
+				errm = multierror.Append(errm, err)
+			}
+		}
+	}()
+
+	g.Wait()
+	close(errc)
+
+	return errm
+}
+
+func update(inst *Instance, insc chan *apps.Installer) error {
+	if !inst.AutoUpdate {
+		return nil
+	}
+
+	registries, err := inst.Registries()
+	if err != nil {
+		return err
+	}
+
+	var g sync.WaitGroup
+	g.Add(2)
+
+	var errm error
+	errc := make(chan error)
+
+	go func() {
+		defer g.Done()
+		webapps, err := apps.ListWebapps(inst)
+		if err != nil {
+			errc <- err
+			return
+		}
+		for _, app := range webapps {
+			installer, err := createInstaller(inst, registries, app)
+			if err != nil {
+				errc <- err
+			} else {
+				insc <- installer
+			}
+		}
+	}()
+
+	go func() {
+		defer g.Done()
+		konnectors, err := apps.ListKonnectors(inst)
+		if err != nil {
+			errc <- err
+			return
+		}
+		for _, app := range konnectors {
+			installer, err := createInstaller(inst, registries, app)
+			if err != nil {
+				errc <- err
+			} else {
+				insc <- installer
+			}
+		}
+	}()
+
+	go func() {
+		for err := range errc {
+			if err != nil {
+				errm = multierror.Append(errm, err)
+			}
+		}
+	}()
+
+	g.Wait()
+	close(errc)
+
+	return errm
+}
+
+func createInstaller(inst *Instance, registries []*url.URL, man apps.Manifest) (*apps.Installer, error) {
+	return apps.NewInstaller(inst, inst.AppsCopier(man.AppType()),
+		&apps.InstallerOptions{
+			Operation:  apps.Update,
+			Manifest:   man,
+			Registries: registries,
+		},
+	)
+}

--- a/pkg/instance/auto_update.go
+++ b/pkg/instance/auto_update.go
@@ -158,9 +158,9 @@ func UpdateInstance(inst *Instance, slugs ...string) error {
 }
 
 func installerPush(inst *Instance, insc chan *apps.Installer, errc chan error, slugs ...string) {
-	// if !inst.AutoUpdate {
-	// 	return
-	// }
+	if !inst.AutoUpdate {
+		return
+	}
 
 	registries, err := inst.Registries()
 	if err != nil {

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -18,13 +18,13 @@ import (
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
 	"github.com/cozy/cozy-stack/pkg/crypto"
+	"github.com/cozy/cozy-stack/pkg/globals"
 	"github.com/cozy/cozy-stack/pkg/hooks"
 	"github.com/cozy/cozy-stack/pkg/jobs"
 	"github.com/cozy/cozy-stack/pkg/lock"
 	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/cozy/cozy-stack/pkg/permissions"
 	"github.com/cozy/cozy-stack/pkg/scheduler"
-	"github.com/cozy/cozy-stack/pkg/stack"
 	"github.com/cozy/cozy-stack/pkg/vfs"
 	"github.com/cozy/cozy-stack/pkg/vfs/vfsafero"
 	"github.com/cozy/cozy-stack/pkg/vfs/vfsswift"
@@ -593,7 +593,7 @@ func CreateWithoutHooks(opts *Options) (*Instance, error) {
 	if err := i.createDefaultFilesTree(); err != nil {
 		return nil, err
 	}
-	sched := stack.GetScheduler()
+	sched := globals.GetScheduler()
 	for _, trigger := range Triggers(i.Domain) {
 		t, err := scheduler.NewTrigger(&trigger)
 		if err != nil {
@@ -754,7 +754,7 @@ func DestroyWithoutHooks(domain string) error {
 	if err != nil {
 		return err
 	}
-	sched := stack.GetScheduler()
+	sched := globals.GetScheduler()
 	triggers, err := sched.GetAll(domain)
 	if err == nil {
 		for _, t := range triggers {
@@ -838,7 +838,7 @@ func (i *Instance) RequestPassphraseReset() error {
 	if err != nil {
 		return err
 	}
-	_, err = stack.GetBroker().PushJob(&jobs.JobRequest{
+	_, err = globals.GetBroker().PushJob(&jobs.JobRequest{
 		Domain:     i.Domain,
 		WorkerType: "sendmail",
 		Message:    msg,

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -76,12 +76,12 @@ var (
 // like the domain, the locale or the access to the databases and files storage
 // It is a couchdb.Doc to be persisted in couchdb.
 type Instance struct {
-	DocID      string `json:"_id,omitempty"`  // couchdb _id
-	DocRev     string `json:"_rev,omitempty"` // couchdb _rev
-	Domain     string `json:"domain"`         // The main DNS domain, like example.cozycloud.cc
-	Locale     string `json:"locale"`         // The locale used on the server
-	AutoUpdate bool   `json:"auto_update"`    // Whether or not the instance has auto updates for its applications
-	Dev        bool   `json:"dev"`            // Whether or not the instance is for development
+	DocID        string `json:"_id,omitempty"`  // couchdb _id
+	DocRev       string `json:"_rev,omitempty"` // couchdb _rev
+	Domain       string `json:"domain"`         // The main DNS domain, like example.cozycloud.cc
+	Locale       string `json:"locale"`         // The locale used on the server
+	NoAutoUpdate bool   `json:"no_auto_update"` // Whether or not the instance has auto updates for its applications
+	Dev          bool   `json:"dev"`            // Whether or not the instance is for development
 
 	OnboardingFinished bool `json:"onboarding_finished"` // Whether or not the onboarding is complete
 

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -76,12 +76,12 @@ var (
 // like the domain, the locale or the access to the databases and files storage
 // It is a couchdb.Doc to be persisted in couchdb.
 type Instance struct {
-	DocID        string `json:"_id,omitempty"`  // couchdb _id
-	DocRev       string `json:"_rev,omitempty"` // couchdb _rev
-	Domain       string `json:"domain"`         // The main DNS domain, like example.cozycloud.cc
-	Locale       string `json:"locale"`         // The locale used on the server
-	NoAutoUpdate bool   `json:"no_auto_update"` // Whether or not the instance has auto updates for its applications
-	Dev          bool   `json:"dev"`            // Whether or not the instance is for development
+	DocID        string `json:"_id,omitempty"`            // couchdb _id
+	DocRev       string `json:"_rev,omitempty"`           // couchdb _rev
+	Domain       string `json:"domain"`                   // The main DNS domain, like example.cozycloud.cc
+	Locale       string `json:"locale"`                   // The locale used on the server
+	NoAutoUpdate bool   `json:"no_auto_update,omitempty"` // Whether or not the instance has auto updates for its applications
+	Dev          bool   `json:"dev,omitempty"`            // Whether or not the instance is for development
 
 	OnboardingFinished bool `json:"onboarding_finished"` // Whether or not the onboarding is complete
 

--- a/pkg/instance/instance_test.go
+++ b/pkg/instance/instance_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
 	"github.com/cozy/cozy-stack/pkg/crypto"
+	"github.com/cozy/cozy-stack/pkg/globals"
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/pkg/stack"
 	"github.com/cozy/cozy-stack/pkg/vfs"
@@ -398,10 +399,12 @@ func TestMain(m *testing.M) {
 		fmt.Println("This test need couchdb to run.")
 		os.Exit(1)
 	}
-	if _, _, _, err = stack.Start(); err != nil {
+	b, s, _, err := stack.Start()
+	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
+	globals.Set(b, s)
 
 	instance.Destroy("test.cozycloud.cc")
 	instance.Destroy("test2.cozycloud.cc")

--- a/pkg/instance/instance_test.go
+++ b/pkg/instance/instance_test.go
@@ -398,7 +398,7 @@ func TestMain(m *testing.M) {
 		fmt.Println("This test need couchdb to run.")
 		os.Exit(1)
 	}
-	if _, err = stack.Start(); err != nil {
+	if _, _, _, err = stack.Start(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/pkg/instance/updates.go
+++ b/pkg/instance/updates.go
@@ -42,11 +42,7 @@ func StartUpdateCron() (utils.Shutdowner, error) {
 		finished: make(chan struct{}),
 	}
 
-	scheduleValue := autoUpdates.Schedule
-	if scheduleValue == "" {
-		scheduleValue = "@midnight"
-	}
-	schedule, err := cron.Parse(scheduleValue)
+	schedule, err := cron.Parse(autoUpdates.Schedule)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/instance/updates.go
+++ b/pkg/instance/updates.go
@@ -110,7 +110,7 @@ func UpdateAll(force bool, slugs ...string) error {
 	go func() {
 		// TODO: filter instances that are AutoUpdate only
 		ForeachInstances(func(inst *Instance) error {
-			if force || inst.AutoUpdate {
+			if force || !inst.NoAutoUpdate {
 				installerPush(inst, insc, errc, slugs...)
 			}
 			return nil

--- a/pkg/instance/updates.go
+++ b/pkg/instance/updates.go
@@ -16,6 +16,7 @@ import (
 )
 
 const numUpdaters = 50
+const numUpdatersSingleInstance = 4
 
 var log = logger.WithNamespace("updates")
 var globalUpdating = make(chan struct{}, 1)
@@ -136,9 +137,9 @@ func UpdateInstance(inst *Instance, slugs ...string) error {
 	errc := make(chan error)
 
 	var g sync.WaitGroup
-	g.Add(4)
+	g.Add(numUpdatersSingleInstance)
 
-	for i := 0; i < 4; i++ {
+	for i := 0; i < numUpdatersSingleInstance; i++ {
 		go func() {
 			for installer := range insc {
 				_, err := installer.RunSync()

--- a/pkg/jobs/mem_jobs.go
+++ b/pkg/jobs/mem_jobs.go
@@ -129,9 +129,9 @@ func (b *memBroker) Shutdown(ctx context.Context) error {
 		}
 	}
 	if errm != nil {
-		fmt.Println("failed: ", errm)
+		fmt.Println("failed:", errm)
 	} else {
-		fmt.Println("ok")
+		fmt.Println("ok.")
 	}
 	return errm
 }

--- a/pkg/notifications/notifications.go
+++ b/pkg/notifications/notifications.go
@@ -3,8 +3,8 @@ package notifications
 import (
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/globals"
 	"github.com/cozy/cozy-stack/pkg/jobs"
-	"github.com/cozy/cozy-stack/pkg/stack"
 	"github.com/cozy/cozy-stack/pkg/workers/mails"
 )
 
@@ -85,7 +85,7 @@ func sendMail(db couchdb.Database, n *Notification) error {
 	if err != nil {
 		return err
 	}
-	_, err = stack.GetBroker().PushJob(&jobs.JobRequest{
+	_, err = globals.GetBroker().PushJob(&jobs.JobRequest{
 		Domain:     db.Prefix(),
 		WorkerType: "sendmail",
 		Message:    msg,

--- a/pkg/scheduler/convert_test.go
+++ b/pkg/scheduler/convert_test.go
@@ -3,9 +3,9 @@ package scheduler_test
 import (
 	"testing"
 
+	"github.com/cozy/cozy-stack/pkg/globals"
 	"github.com/cozy/cozy-stack/pkg/jobs"
 	"github.com/cozy/cozy-stack/pkg/scheduler"
-	"github.com/cozy/cozy-stack/pkg/stack"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -26,7 +26,7 @@ func TestTriggersFromMonoStackAreImportedInRedit(t *testing.T) {
 		return
 	}
 
-	newsched := stack.GetScheduler().(*scheduler.RedisScheduler)
+	newsched := globals.GetScheduler().(*scheduler.RedisScheduler)
 	err = newsched.ImportFromMemStorage()
 	if !assert.NoError(t, err) {
 		return

--- a/pkg/scheduler/redis_scheduler_test.go
+++ b/pkg/scheduler/redis_scheduler_test.go
@@ -11,11 +11,11 @@ import (
 	"github.com/cozy/cozy-stack/pkg/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/globals"
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/pkg/jobs"
 	"github.com/cozy/cozy-stack/pkg/realtime"
 	"github.com/cozy/cozy-stack/pkg/scheduler"
-	"github.com/cozy/cozy-stack/pkg/stack"
 	"github.com/cozy/cozy-stack/pkg/utils"
 	"github.com/cozy/cozy-stack/pkg/vfs"
 	"github.com/cozy/cozy-stack/tests/testutils"
@@ -115,7 +115,7 @@ func TestRedisSchedulerWithTimeTriggers(t *testing.T) {
 		Message:    msg2,
 	}
 
-	sch := stack.GetScheduler().(*scheduler.RedisScheduler)
+	sch := globals.GetScheduler().(*scheduler.RedisScheduler)
 	sch.Shutdown(context.Background())
 	sch.Start(bro)
 
@@ -187,7 +187,7 @@ func TestRedisSchedulerWithCronTriggers(t *testing.T) {
 	assert.NoError(t, err)
 
 	bro := &mockBroker{}
-	sch := stack.GetScheduler().(*scheduler.RedisScheduler)
+	sch := globals.GetScheduler().(*scheduler.RedisScheduler)
 	sch.Shutdown(context.Background())
 	sch.Start(bro)
 	sch.Shutdown(context.Background())
@@ -223,7 +223,7 @@ func TestRedisPollFromSchedKey(t *testing.T) {
 	assert.NoError(t, err)
 
 	bro := &mockBroker{}
-	sch := stack.GetScheduler().(*scheduler.RedisScheduler)
+	sch := globals.GetScheduler().(*scheduler.RedisScheduler)
 	sch.Shutdown(context.Background())
 	sch.Start(bro)
 	sch.Shutdown(context.Background())
@@ -271,7 +271,7 @@ func TestRedisTriggerEvent(t *testing.T) {
 	assert.NoError(t, err)
 
 	bro := &mockBroker{}
-	sch := stack.GetScheduler().(*scheduler.RedisScheduler)
+	sch := globals.GetScheduler().(*scheduler.RedisScheduler)
 	sch.Shutdown(context.Background())
 	time.Sleep(1 * time.Second)
 	sch.Start(bro)
@@ -352,7 +352,7 @@ func TestRedisTriggerEventForDirectories(t *testing.T) {
 	assert.NoError(t, err)
 
 	bro := &mockBroker{}
-	sch := stack.GetScheduler().(*scheduler.RedisScheduler)
+	sch := globals.GetScheduler().(*scheduler.RedisScheduler)
 	sch.Shutdown(context.Background())
 	time.Sleep(1 * time.Second)
 	sch.Start(bro)
@@ -471,7 +471,7 @@ func TestRedisSchedulerWithDebounce(t *testing.T) {
 	assert.NoError(t, err)
 
 	bro := &mockBroker{}
-	sch := stack.GetScheduler().(*scheduler.RedisScheduler)
+	sch := globals.GetScheduler().(*scheduler.RedisScheduler)
 	sch.Shutdown(context.Background())
 	time.Sleep(1 * time.Second)
 	sch.Start(bro)

--- a/pkg/sharings/send_mails.go
+++ b/pkg/sharings/send_mails.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/globals"
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/pkg/jobs"
-	"github.com/cozy/cozy-stack/pkg/stack"
 	"github.com/cozy/cozy-stack/pkg/workers/mails"
 )
 
@@ -50,7 +50,7 @@ func SendDiscoveryMail(instance *instance.Instance, s *Sharing, rs *RecipientSta
 	if err != nil {
 		return err
 	}
-	_, err = stack.GetBroker().PushJob(&jobs.JobRequest{
+	_, err = globals.GetBroker().PushJob(&jobs.JobRequest{
 		Domain:     instance.Domain,
 		WorkerType: "sendmail",
 		Options:    nil,
@@ -122,7 +122,7 @@ func SendSharingMails(instance *instance.Instance, s *Sharing) error {
 			// are of no use in this situation.
 			// FI: they correspond to the job information and to a channel with
 			// which we can check the advancement of said job.
-			_, errJobs := stack.GetBroker().PushJob(&jobs.JobRequest{
+			_, errJobs := globals.GetBroker().PushJob(&jobs.JobRequest{
 				Domain:     instance.Domain,
 				WorkerType: "sendmail",
 				Options:    nil,

--- a/pkg/sharings/sharings.go
+++ b/pkg/sharings/sharings.go
@@ -15,12 +15,12 @@ import (
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
+	"github.com/cozy/cozy-stack/pkg/globals"
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/pkg/jobs"
 	"github.com/cozy/cozy-stack/pkg/oauth"
 	"github.com/cozy/cozy-stack/pkg/permissions"
 	"github.com/cozy/cozy-stack/pkg/scheduler"
-	"github.com/cozy/cozy-stack/pkg/stack"
 	"github.com/cozy/cozy-stack/pkg/utils"
 	"github.com/cozy/cozy-stack/pkg/vfs"
 	"github.com/labstack/echo"
@@ -234,7 +234,7 @@ func FindSharingRecipient(db couchdb.Database, sharingID, clientID string) (*Sha
 // The delTrigger flag is when the trigger must only listen deletions, i.e. a
 // Master-Slave on the recipient side, for the revocation
 func AddTrigger(instance *instance.Instance, rule permissions.Rule, sharingID string, delTrigger bool) error {
-	sched := stack.GetScheduler()
+	sched := globals.GetScheduler()
 
 	var eventArgs string
 	if rule.Selector != "" {
@@ -452,7 +452,7 @@ func sendData(instance *instance.Instance, sharing *Sharing, recStatus *Recipien
 		if err != nil {
 			return err
 		}
-		_, err = stack.GetBroker().PushJob(&jobs.JobRequest{
+		_, err = globals.GetBroker().PushJob(&jobs.JobRequest{
 			Domain:     instance.Domain,
 			WorkerType: "sharedata",
 			Options:    nil,
@@ -967,7 +967,7 @@ func RevokeRecipient(ins *instance.Instance, sharing *Sharing, recipientClientID
 }
 
 func removeSharingTriggers(ins *instance.Instance, sharingID string) error {
-	sched := stack.GetScheduler()
+	sched := globals.GetScheduler()
 	ts, err := sched.GetAll(ins.Domain)
 	if err != nil {
 		ins.Logger().Errorf("[sharings] removeSharingTriggers: Could not get "+

--- a/pkg/sharings/sharings_test.go
+++ b/pkg/sharings/sharings_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
+	"github.com/cozy/cozy-stack/pkg/globals"
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/pkg/oauth"
 	"github.com/cozy/cozy-stack/pkg/permissions"
@@ -886,7 +887,7 @@ func TestRevokeSharing(t *testing.T) {
 		consts.MasterMasterSharing, true, "",
 		[]*Recipient{recipient1, recipient2}, rule)
 	// We add a trigger to this sharing.
-	sched := stack.GetScheduler()
+	sched := globals.GetScheduler()
 	triggers, _ := sched.GetAll(testInstance.Domain)
 	nbTriggers := len(triggers)
 	err := AddTrigger(testInstance, rule, sharingSharerMM.SharingID, false)
@@ -1000,7 +1001,7 @@ func TestRevokeRecipient(t *testing.T) {
 		true, "", []*Recipient{recipient1, recipient2}, rule)
 
 	// We add a trigger to this sharing.
-	sched := stack.GetScheduler()
+	sched := globals.GetScheduler()
 	triggers, _ := sched.GetAll(testInstance.Domain)
 	nbTriggers := len(triggers)
 	err = AddTrigger(testInstance, rule, sharing.SharingID, false)

--- a/pkg/sharings/sharings_test.go
+++ b/pkg/sharings/sharings_test.go
@@ -1158,11 +1158,12 @@ func TestMain(m *testing.M) {
 	}
 
 	createSettings(in)
-	_, _, _, err = stack.Start()
+	b, s, _, err := stack.Start()
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
+	globals.Set(b, s)
 
 	ts = createServer()
 	recipientURL = strings.Split(ts.URL, "http://")[1]

--- a/pkg/sharings/sharings_test.go
+++ b/pkg/sharings/sharings_test.go
@@ -1091,12 +1091,6 @@ func TestMain(m *testing.M) {
 		Path:   tempdir,
 	}
 
-	_, err = stack.Start()
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-
 	// The instance must be created in db in order to retrieve it from
 	// the share_data worker
 	instance.Destroy(domainSharer)
@@ -1164,7 +1158,7 @@ func TestMain(m *testing.M) {
 	}
 
 	createSettings(in)
-	_, err = stack.Start()
+	_, _, _, err = stack.Start()
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/pkg/utils/shutdowner.go
+++ b/pkg/utils/shutdowner.go
@@ -6,6 +6,10 @@ import (
 	multierror "github.com/hashicorp/go-multierror"
 )
 
+// NopShutdown implements the Shutdowner interface but does not execute any
+// process on shutdown.
+var NopShutdown = NewGroupShutdown()
+
 // Shutdowner is an interface with a Shutdown method to gracefully shutdown
 // a running process.
 type Shutdowner interface {

--- a/pkg/workers/exec/konnector.go
+++ b/pkg/workers/exec/konnector.go
@@ -296,7 +296,7 @@ func (w *konnectorWorker) Commit(ctx context.Context, msg *jobs.Message, errjob 
 	// }
 	// log := logger.WithDomain(domain)
 	// log.Info("Konnector has failed definitively, should send mail.", mail)
-	// _, err = stack.GetBroker().PushJob(&jobs.JobRequest{
+	// _, err = globals.GetBroker().PushJob(&jobs.JobRequest{
 	// 	Domain:     domain,
 	// 	WorkerType: "sendmail",
 	// 	Message:    msg,

--- a/pkg/workers/sharings/share_data_test.go
+++ b/pkg/workers/sharings/share_data_test.go
@@ -947,7 +947,7 @@ func TestMain(m *testing.M) {
 	setup = testutils.NewSetup(m, "share_data_test")
 	testInstance = setup.GetTestInstance()
 
-	_, err = stack.Start()
+	_, _, _, err = stack.Start()
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/pkg/workers/sharings/share_data_test.go
+++ b/pkg/workers/sharings/share_data_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
+	"github.com/cozy/cozy-stack/pkg/globals"
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/pkg/jobs"
 	"github.com/cozy/cozy-stack/pkg/permissions"
@@ -947,11 +948,12 @@ func TestMain(m *testing.M) {
 	setup = testutils.NewSetup(m, "share_data_test")
 	testInstance = setup.GetTestInstance()
 
-	_, _, _, err = stack.Start()
+	b, s, _, err := stack.Start()
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
+	globals.Set(b, s)
 
 	instance.Destroy(domainSharer)
 	in, err = createInstance(domainSharer, "Alice")

--- a/tests/testutils/test_utils.go
+++ b/tests/testutils/test_utils.go
@@ -101,7 +101,7 @@ func (c *TestSetup) GetTestInstance(opts ...*instance.Options) *instance.Instanc
 	if c.inst != nil {
 		return c.inst
 	}
-	_, err := stack.Start()
+	_, _, _, err := stack.Start()
 	if err != nil {
 		c.CleanupAndDie("Error while starting job system", err)
 	}

--- a/tests/testutils/test_utils.go
+++ b/tests/testutils/test_utils.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cozy/checkup"
 	"github.com/cozy/cozy-stack/pkg/config"
+	"github.com/cozy/cozy-stack/pkg/globals"
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/pkg/oauth"
 	"github.com/cozy/cozy-stack/pkg/permissions"
@@ -101,10 +102,11 @@ func (c *TestSetup) GetTestInstance(opts ...*instance.Options) *instance.Instanc
 	if c.inst != nil {
 		return c.inst
 	}
-	_, _, _, err := stack.Start()
+	b, s, _, err := stack.Start()
 	if err != nil {
 		c.CleanupAndDie("Error while starting job system", err)
 	}
+	globals.Set(b, s)
 	if len(opts) == 0 {
 		opts = []*instance.Options{{}}
 	}

--- a/web/apps/apps.go
+++ b/web/apps/apps.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cozy/cozy-stack/pkg/apps"
 	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/cozy/cozy-stack/web/permissions"
@@ -317,6 +318,10 @@ func iconHandler(c echo.Context) error {
 		return err
 	}
 	return nil
+}
+
+func autoUpdate(c echo.Context) error {
+	return instance.UpdateAll()
 }
 
 // WebappsRoutes sets the routing for the web apps service

--- a/web/apps/apps.go
+++ b/web/apps/apps.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/cozy/cozy-stack/pkg/apps"
 	"github.com/cozy/cozy-stack/pkg/consts"
-	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/cozy/cozy-stack/web/permissions"
@@ -318,10 +317,6 @@ func iconHandler(c echo.Context) error {
 		return err
 	}
 	return nil
-}
-
-func autoUpdate(c echo.Context) error {
-	return instance.UpdateAll()
 }
 
 // WebappsRoutes sets the routing for the web apps service

--- a/web/instances/instances.go
+++ b/web/instances/instances.go
@@ -270,6 +270,8 @@ func Routes(router *echo.Group) {
 	router.PATCH("/:domain", modifyHandler)
 	router.DELETE("/:domain", deleteHandler)
 	router.GET("/:domain/fsck", fsckHandler)
+	router.POST("/updates", updatesHandler)
+	router.POST("/updates/:slug", updatesHandler)
 	router.POST("/token", createToken)
 	router.POST("/oauth_client", registerClient)
 }

--- a/web/instances/instances.go
+++ b/web/instances/instances.go
@@ -271,7 +271,6 @@ func Routes(router *echo.Group) {
 	router.DELETE("/:domain", deleteHandler)
 	router.GET("/:domain/fsck", fsckHandler)
 	router.POST("/updates", updatesHandler)
-	router.POST("/updates/:slug", updatesHandler)
 	router.POST("/token", createToken)
 	router.POST("/oauth_client", registerClient)
 }

--- a/web/instances/updates.go
+++ b/web/instances/updates.go
@@ -1,0 +1,14 @@
+package instances
+
+import (
+	"github.com/cozy/cozy-stack/pkg/instance"
+	"github.com/labstack/echo"
+)
+
+func updatesHandler(c echo.Context) error {
+	slug := c.Param("slug")
+	if slug != "" {
+		return instance.UpdateAll(slug)
+	}
+	return instance.UpdateAll()
+}

--- a/web/instances/updates.go
+++ b/web/instances/updates.go
@@ -2,13 +2,19 @@ package instances
 
 import (
 	"github.com/cozy/cozy-stack/pkg/instance"
+	"github.com/cozy/cozy-stack/pkg/utils"
 	"github.com/labstack/echo"
 )
 
 func updatesHandler(c echo.Context) error {
-	slug := c.Param("slug")
-	if slug != "" {
-		return instance.UpdateAll(slug)
+	slugs := utils.SplitTrimString(c.QueryParam("Slugs"), ",")
+	domain := c.QueryParam("Domain")
+	if domain != "" {
+		inst, err := instance.Get(domain)
+		if err != nil {
+			return wrapError(err)
+		}
+		return wrapError(instance.UpdateInstance(inst, slugs...))
 	}
-	return instance.UpdateAll()
+	return wrapError(instance.UpdateAll(true, slugs...))
 }

--- a/web/jobs/jobs.go
+++ b/web/jobs/jobs.go
@@ -8,10 +8,10 @@ import (
 	"github.com/cozy/cozy-stack/pkg/accounts"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/globals"
 	"github.com/cozy/cozy-stack/pkg/jobs"
 	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/cozy/cozy-stack/pkg/scheduler"
-	"github.com/cozy/cozy-stack/pkg/stack"
 	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/cozy/cozy-stack/web/permissions"
@@ -106,7 +106,7 @@ func (t *apiTrigger) MarshalJSON() ([]byte, error) {
 
 func getQueue(c echo.Context) error {
 	workerType := c.Param("worker-type")
-	count, err := stack.GetBroker().QueueLen(workerType)
+	count, err := globals.GetBroker().QueueLen(workerType)
 	if err != nil {
 		return wrapJobsError(err)
 	}
@@ -143,7 +143,7 @@ func pushJob(c echo.Context) error {
 		return err
 	}
 
-	job, err := stack.GetBroker().PushJob(jr)
+	job, err := globals.GetBroker().PushJob(jr)
 	if err != nil {
 		return wrapJobsError(err)
 	}
@@ -153,7 +153,7 @@ func pushJob(c echo.Context) error {
 
 func newTrigger(c echo.Context) error {
 	instance := middlewares.GetInstance(c)
-	sched := stack.GetScheduler()
+	sched := globals.GetScheduler()
 	req := &apiTriggerRequest{}
 	if _, err := jsonapi.Bind(c.Request(), &req); err != nil {
 		return wrapJobsError(err)
@@ -193,7 +193,7 @@ func newTrigger(c echo.Context) error {
 
 func getTrigger(c echo.Context) error {
 	instance := middlewares.GetInstance(c)
-	sched := stack.GetScheduler()
+	sched := globals.GetScheduler()
 	t, err := sched.Get(instance.Domain, c.Param("trigger-id"))
 	if err != nil {
 		return wrapJobsError(err)
@@ -206,7 +206,7 @@ func getTrigger(c echo.Context) error {
 
 func deleteTrigger(c echo.Context) error {
 	instance := middlewares.GetInstance(c)
-	sched := stack.GetScheduler()
+	sched := globals.GetScheduler()
 	t, err := sched.Get(instance.Domain, c.Param("trigger-id"))
 	if err != nil {
 		return wrapJobsError(err)
@@ -222,7 +222,7 @@ func deleteTrigger(c echo.Context) error {
 
 func cleanTriggers(c echo.Context) error {
 	instance := middlewares.GetInstance(c)
-	sched := stack.GetScheduler()
+	sched := globals.GetScheduler()
 	if err := permissions.AllowWholeType(c, permissions.GET, consts.Triggers); err != nil {
 		return err
 	}
@@ -265,7 +265,7 @@ func cleanTriggers(c echo.Context) error {
 func getAllTriggers(c echo.Context) error {
 	instance := middlewares.GetInstance(c)
 	workerFilter := c.QueryParam("Worker")
-	sched := stack.GetScheduler()
+	sched := globals.GetScheduler()
 	if err := permissions.AllowWholeType(c, permissions.GET, consts.Triggers); err != nil {
 		return err
 	}
@@ -284,7 +284,7 @@ func getAllTriggers(c echo.Context) error {
 
 func getJob(c echo.Context) error {
 	instance := middlewares.GetInstance(c)
-	job, err := stack.GetBroker().GetJobInfos(instance.Domain, c.Param("job-id"))
+	job, err := globals.GetBroker().GetJobInfos(instance.Domain, c.Param("job-id"))
 	if err != nil {
 		return err
 	}

--- a/web/jobs/jobs_test.go
+++ b/web/jobs/jobs_test.go
@@ -393,7 +393,7 @@ func TestMain(m *testing.M) {
 	})
 
 	testInstance = setup.GetTestInstance()
-	if _, err := stack.Start(); err != nil {
+	if _, _, _, err := stack.Start(); err != nil {
 		testutils.Fatal(err)
 	}
 

--- a/web/jobs/jobs_test.go
+++ b/web/jobs/jobs_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cozy/cozy-stack/pkg/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/globals"
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/pkg/jobs"
 	"github.com/cozy/cozy-stack/pkg/scheduler"
@@ -393,9 +394,11 @@ func TestMain(m *testing.M) {
 	})
 
 	testInstance = setup.GetTestInstance()
-	if _, _, _, err := stack.Start(); err != nil {
+	b, s, _, err := stack.Start()
+	if err != nil {
 		testutils.Fatal(err)
 	}
+	globals.Set(b, s)
 
 	scope := consts.Queues + " " + consts.Jobs + " " + consts.Triggers
 	_, token = setup.GetTestClient(scope)

--- a/web/jsonapi/data.go
+++ b/web/jsonapi/data.go
@@ -94,13 +94,6 @@ func MarshalObject(o Object) (json.RawMessage, error) {
 	links := o.Links()
 	rels := o.Relationships()
 
-	o.SetID("")
-	o.SetRev("")
-	defer func() {
-		o.SetID(id)
-		o.SetRev(rev)
-	}()
-
 	b, err := json.Marshal(o)
 	if err != nil {
 		return nil, err

--- a/web/jsonapi/data.go
+++ b/web/jsonapi/data.go
@@ -99,6 +99,13 @@ func MarshalObject(o Object) (json.RawMessage, error) {
 		return nil, err
 	}
 
+	o.SetID("")
+	o.SetRev("")
+	defer func() {
+		o.SetID(id)
+		o.SetRev(rev)
+	}()
+
 	data := ObjectMarshalling{
 		Type:          o.DocType(),
 		ID:            id,

--- a/web/settings/instance.go
+++ b/web/settings/instance.go
@@ -93,5 +93,7 @@ func updateInstance(c echo.Context) error {
 	}
 
 	doc.M["locale"] = inst.Locale
+	doc.M["onboarding_finished"] = inst.OnboardingFinished
+	doc.M["auto_update"] = !inst.NoAutoUpdate
 	return jsonapi.Data(c, http.StatusOK, &apiInstance{doc}, nil)
 }

--- a/web/settings/instance.go
+++ b/web/settings/instance.go
@@ -43,6 +43,7 @@ func getInstance(c echo.Context) error {
 	}
 	doc.M["locale"] = instance.Locale
 	doc.M["onboarding_finished"] = instance.OnboardingFinished
+	doc.M["auto_update"] = !instance.NoAutoUpdate
 
 	if err = permissions.Allow(c, permissions.GET, doc); err != nil {
 		return err
@@ -77,7 +78,7 @@ func updateInstance(c echo.Context) error {
 
 	if autoUpdate, ok := doc.M["auto_update"].(bool); ok {
 		delete(doc.M, "auto_upate")
-		inst.AutoUpdate = autoUpdate
+		inst.NoAutoUpdate = !autoUpdate
 		needUpdate = true
 	}
 

--- a/web/settings/instance.go
+++ b/web/settings/instance.go
@@ -68,9 +68,20 @@ func updateInstance(c echo.Context) error {
 		return err
 	}
 
+	var needUpdate bool
 	if locale, ok := doc.M["locale"].(string); ok {
 		delete(doc.M, "locale")
 		inst.Locale = locale
+		needUpdate = true
+	}
+
+	if autoUpdate, ok := doc.M["auto_update"].(bool); ok {
+		delete(doc.M, "auto_upate")
+		inst.AutoUpdate = autoUpdate
+		needUpdate = true
+	}
+
+	if needUpdate {
 		if err := instance.Update(inst); err != nil {
 			return err
 		}

--- a/web/settings/instance.go
+++ b/web/settings/instance.go
@@ -69,7 +69,8 @@ func updateInstance(c echo.Context) error {
 		return err
 	}
 
-	var needUpdate bool
+	needUpdate := false
+
 	if locale, ok := doc.M["locale"].(string); ok {
 		delete(doc.M, "locale")
 		inst.Locale = locale


### PR DESCRIPTION
This PR adds the auto updates process. The instance struct has a new `AutoUpdate` field to activate the auto update.

The admin API has new entries to execute manually the auto-updates. The configuration also has a new block to configure the auto-updates scheduler.

~~Still missing: /settings route to set an instance `AutoUpdate`. We also coud decide to make it the default value.~~