### PR TITLE
Make jobs permissions more strict: specific to a worker

### DIFF
--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -245,6 +245,8 @@ Accept: application/vnd.api+json
 
 Enqueue programmatically a new job.
 
+This route requires a specific permission on the worker-type. A global permission on the global `io.cozy.jobs` doctype is not allowed.
+
 #### Request
 
 ```http
@@ -297,8 +299,9 @@ Accept: application/vnd.api+json
 #### Permissions
 
 To use this endpoint, an application needs a permission on the type
-`io.cozy.jobs` for the verb `POST`. In most cases, the application will
-restrict its permission to only one worker, like this:
+`io.cozy.jobs` for the verb `POST`. The is required to restrict its permission
+to specific worker(s), like this (a global permission on the doctype is not
+allowed):
 
 ```json
 {
@@ -365,6 +368,8 @@ restrict its permission to only one worker, like this:
 ### POST /jobs/triggers
 
 Add a trigger of the worker. See [triggers' descriptions](#triggers) to see the types of trigger and their arguments syntax.
+
+This route requires a specific permission on the worker type. A global permission on the global `io.cozy.triggers` doctype is not allowed.
 
 The `debounce` parameter can be used to limit the number of jobs created in a burst. It delays the creation of the job on the first input by the given time argument, and if the trigger has its condition matched again during this period, it won't create another job.
 It can be useful to combine it with the changes feed of couchdb with a last sequence number persisted by the worker, as it allows to have a nice diff between two executions of the worker.

--- a/pkg/permissions/rule.go
+++ b/pkg/permissions/rule.go
@@ -125,7 +125,7 @@ func (r Rule) TranslationKey() string {
 		if r.Verbs.ReadOnly() && len(r.Values) == 1 && r.Values[0] == consts.DiskUsageID {
 			return "Permissions disk usage"
 		}
-	case consts.Jobs:
+	case consts.Jobs, consts.Triggers:
 		if len(r.Values) == 1 && r.Selector == "worker" {
 			return "Permissions worker " + r.Values[0]
 		}

--- a/web/jobs/jobs.go
+++ b/web/jobs/jobs.go
@@ -134,7 +134,7 @@ func pushJob(c echo.Context) error {
 			Data: req.Arguments,
 		},
 	}
-	if err := permissions.Allow(c, permissions.POST, jr); err != nil {
+	if err := permissions.AllowOnFields(c, permissions.POST, jr, "worker"); err != nil {
 		return err
 	}
 
@@ -175,8 +175,7 @@ func newTrigger(c echo.Context) error {
 	if err != nil {
 		return wrapJobsError(err)
 	}
-
-	if err = permissions.Allow(c, permissions.POST, t); err != nil {
+	if err = permissions.AllowOnFields(c, permissions.POST, t, "worker"); err != nil {
 		return err
 	}
 

--- a/web/jobs/jobs_test.go
+++ b/web/jobs/jobs_test.go
@@ -83,10 +83,10 @@ func TestCreateJobNotExist(t *testing.T) {
 		},
 	})
 	req, err := http.NewRequest(http.MethodPost, ts.URL+"/jobs/queue/none", bytes.NewReader(body))
-	token, _ := testInstance.MakeJWT(permissions.CLIAudience, "CLI",
+	tokenNone, _ := testInstance.MakeJWT(permissions.CLIAudience, "CLI",
 		consts.Jobs+":ALL:none:worker",
 		time.Now())
-	req.Header.Add("Authorization", "Bearer "+token)
+	req.Header.Add("Authorization", "Bearer "+tokenNone)
 	assert.NoError(t, err)
 	res, err := http.DefaultClient.Do(req)
 	if !assert.NoError(t, err) {

--- a/web/permissions/allow.go
+++ b/web/permissions/allow.go
@@ -39,6 +39,19 @@ func Allow(c echo.Context, v permissions.Verb, o permissions.Validable) error {
 	return nil
 }
 
+// AllowOnFields validates the validable object againt the context permission
+// set and ensure the selector validates the given fields.
+func AllowOnFields(c echo.Context, v permissions.Verb, o permissions.Validable, fields ...string) error {
+	pdoc, err := GetPermission(c)
+	if err != nil {
+		return err
+	}
+	if !pdoc.Permissions.AllowOnFields(v, o, fields...) {
+		return errForbidden
+	}
+	return nil
+}
+
 // AllowTypeAndID validates a type & ID against the context permission set
 func AllowTypeAndID(c echo.Context, v permissions.Verb, doctype, id string) error {
 	pdoc, err := GetPermission(c)


### PR DESCRIPTION
Please, do not merge this PR as it is a breaking change for some applications.

The permissions on `io.cozy.jobs` are made more specific by this change. We do not allow the global permission on `io.cozy.jobs` doctype anymore and require a specific permission on the `worker` field. Applications should be updated accordingly.

For instance:

```json
{
  "type": "io.cozy.jobs",
  "verbs": ["POST"],
  "selector": "worker",
  "values": ["mail", "unzip"]
}
```