### PR TITLE
Simplify jobs.Message struct as simple json.RawMessage

### DIFF
--- a/pkg/apps/webapp.go
+++ b/pkg/apps/webapp.go
@@ -301,7 +301,7 @@ func diffServices(db couchdb.Database, slug string, oldServices, newServices Ser
 		if len(triggerOpts) > 1 {
 			triggerArgs = strings.TrimSpace(triggerOpts[1])
 		}
-		msg, err := jobs.NewMessage(jobs.JSONEncoding, map[string]string{
+		msg, err := jobs.NewMessage(map[string]string{
 			"slug":         slug,
 			"type":         service.Type,
 			"service_file": service.File,

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -830,7 +830,7 @@ func (i *Instance) RequestPassphraseReset() error {
 	resetURL := i.PageURL("/auth/passphrase_renew", url.Values{
 		"token": {hex.EncodeToString(i.PassphraseResetToken)},
 	})
-	msg, err := jobs.NewMessage(jobs.JSONEncoding, map[string]interface{}{
+	msg, err := jobs.NewMessage(map[string]interface{}{
 		"mode":          "noreply",
 		"subject":       i.Translate("Mail Password reset"),
 		"template_name": "passphrase_reset_" + i.Locale,

--- a/pkg/jobs/errors.go
+++ b/pkg/jobs/errors.go
@@ -11,6 +11,6 @@ var (
 	ErrQueueClosed = errors.New("jobs: queue is closed")
 	// ErrUnknownWorker the asked worker does not exist
 	ErrUnknownWorker = errors.New("jobs: could not find worker")
-	// ErrUnknownMessageType is used for an unknown message encoding type
-	ErrUnknownMessageType = errors.New("jobs: unknown message encoding type")
+	// ErrMessageNil is used for an nil message
+	ErrMessageNil = errors.New("jobs: message is nil")
 )

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -182,6 +182,8 @@ func (j *Job) db() couchdb.Database {
 	return couchdb.SimpleDatabasePrefix(j.Domain)
 }
 
+// UnmarshalJSON implements json.Unmarshaler on Message. It should be retro-
+// compatible with the old Message representation { Data, Type }.
 func (m *Message) UnmarshalJSON(data []byte) error {
 	// For retro-compatibility purposes
 	var mm struct {
@@ -204,6 +206,7 @@ func (m *Message) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalJSON implements json.Marshaler on Message.
 func (m Message) MarshalJSON() ([]byte, error) {
 	v := json.RawMessage(m)
 	return json.Marshal(v)

--- a/pkg/jobs/worker.go
+++ b/pkg/jobs/worker.go
@@ -34,16 +34,16 @@ type (
 	WorkerInitFunc func() (interface{}, error)
 
 	// WorkerFunc represent the work function that a worker should implement.
-	WorkerFunc func(context context.Context, msg *Message) error
+	WorkerFunc func(context context.Context, msg Message) error
 
 	// WorkerThreadedFunc represent the work function that a worker should
 	// implement. In addition to a simple WorkerFunc, a threaded one can thread
 	// its context on each call and to the commit method.
-	WorkerThreadedFunc func(context context.Context, cookie interface{}, msg *Message) error
+	WorkerThreadedFunc func(context context.Context, cookie interface{}, msg Message) error
 
 	// WorkerCommit is an optional method that is always called once after the
 	// execution of the WorkerFunc.
-	WorkerCommit func(context context.Context, cookie interface{}, msg *Message, errjob error) error
+	WorkerCommit func(context context.Context, cookie interface{}, msg Message, errjob error) error
 
 	// WorkerConfig is the configuration parameter of a worker defined by the job
 	// system. It contains parameters of the worker along with the worker main

--- a/pkg/notifications/notifications.go
+++ b/pkg/notifications/notifications.go
@@ -82,7 +82,7 @@ func sendMail(db couchdb.Database, n *Notification) error {
 			{Body: n.Content, Type: "text/plain"},
 		},
 	}
-	msg, err := jobs.NewMessage(jobs.JSONEncoding, &mail)
+	msg, err := jobs.NewMessage(&mail)
 	if err != nil {
 		return err
 	}

--- a/pkg/scheduler/mem_scheduler_test.go
+++ b/pkg/scheduler/mem_scheduler_test.go
@@ -46,7 +46,7 @@ func TestMemSchedulerWithTimeTriggers(t *testing.T) {
 			Concurrency:  1,
 			MaxExecCount: 1,
 			Timeout:      1 * time.Millisecond,
-			WorkerFunc: func(ctx context.Context, m *jobs.Message) error {
+			WorkerFunc: func(ctx context.Context, m jobs.Message) error {
 				var msg string
 				if err := m.Unmarshal(&msg); err != nil {
 					return err
@@ -62,8 +62,8 @@ func TestMemSchedulerWithTimeTriggers(t *testing.T) {
 		},
 	})
 
-	msg1, _ := jobs.NewMessage("json", "@at")
-	msg2, _ := jobs.NewMessage("json", "@in")
+	msg1, _ := jobs.NewMessage("@at")
+	msg2, _ := jobs.NewMessage("@in")
 
 	wAt.Add(1) // 1 time in @at
 	wIn.Add(1) // 1 time in @in
@@ -145,14 +145,14 @@ func TestMemSchedulerWithDebounce(t *testing.T) {
 			Concurrency:  1,
 			MaxExecCount: 1,
 			Timeout:      1 * time.Millisecond,
-			WorkerFunc: func(ctx context.Context, m *jobs.Message) error {
+			WorkerFunc: func(ctx context.Context, m jobs.Message) error {
 				called++
 				return nil
 			},
 		},
 	})
 
-	msg, _ := jobs.NewMessage("json", "@event")
+	msg, _ := jobs.NewMessage("@event")
 	ti := &TriggerInfos{
 		Type:       "@event",
 		Domain:     "cozy.local.withdebounce",

--- a/pkg/scheduler/redis_scheduler_test.go
+++ b/pkg/scheduler/redis_scheduler_test.go
@@ -73,7 +73,7 @@ func TestRedisSchedulerWithTimeTriggers(t *testing.T) {
 			Concurrency:  1,
 			MaxExecCount: 1,
 			Timeout:      1 * time.Millisecond,
-			WorkerFunc: func(ctx context.Context, m *jobs.Message) error {
+			WorkerFunc: func(ctx context.Context, m jobs.Message) error {
 				var msg string
 				if err := m.Unmarshal(&msg); err != nil {
 					return err
@@ -89,8 +89,8 @@ func TestRedisSchedulerWithTimeTriggers(t *testing.T) {
 		},
 	})
 
-	msg1, _ := jobs.NewMessage("json", "@at")
-	msg2, _ := jobs.NewMessage("json", "@in")
+	msg1, _ := jobs.NewMessage("@at")
+	msg2, _ := jobs.NewMessage("@in")
 
 	wAt.Add(1) // 1 time in @at
 	wIn.Add(1) // 1 time in @in
@@ -188,7 +188,7 @@ func TestRedisSchedulerWithCronTriggers(t *testing.T) {
 	sch.Shutdown(context.Background())
 	defer sch.Start(bro)
 
-	msg, _ := jobs.NewMessage("json", "@cron")
+	msg, _ := jobs.NewMessage("@cron")
 
 	infos := &scheduler.TriggerInfos{
 		Type:       "@cron",
@@ -225,7 +225,7 @@ func TestRedisPollFromSchedKey(t *testing.T) {
 	defer sch.Start(bro)
 
 	now := time.Now()
-	msg, _ := jobs.NewMessage("json", "@at")
+	msg, _ := jobs.NewMessage("@at")
 
 	at := &scheduler.TriggerInfos{
 		Type:       "@at",

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -19,7 +19,7 @@ type TriggerInfos struct {
 	Arguments  string           `json:"arguments"`
 	Debounce   string           `json:"debounce,omitempty"`
 	Options    *jobs.JobOptions `json:"options"`
-	Message    *jobs.Message    `json:"message"`
+	Message    jobs.Message     `json:"message"`
 }
 
 // ID implements the couchdb.Doc interface
@@ -39,8 +39,9 @@ func (t *TriggerInfos) Clone() couchdb.Doc {
 		cloned.Options = &tmp
 	}
 	if t.Message != nil {
-		tmp := *t.Message
-		cloned.Message = &tmp
+		tmp := t.Message
+		t.Message = make([]byte, len(tmp))
+		copy(t.Message[:], tmp)
 	}
 	return &cloned
 }

--- a/pkg/scheduler/trigger_event.go
+++ b/pkg/scheduler/trigger_event.go
@@ -84,20 +84,15 @@ func (t *EventTrigger) Schedule() <-chan *jobs.JobRequest {
 
 // Trigger returns the triggered job request
 func (t *EventTrigger) Trigger(e *realtime.Event) *jobs.JobRequest {
-	var basemsg interface{}
-	base := t.infos.Message
-	if base != nil {
-		base.Unmarshal(&basemsg)
-	}
 	m := map[string]interface{}{
-		"message": basemsg,
+		"message": t.infos.Message,
 	}
 	if e == nil {
 		m["debounced"] = true
 	} else {
 		m["event"] = e
 	}
-	msg, err := jobs.NewMessage(jobs.JSONEncoding, m)
+	msg, err := jobs.NewMessage(m)
 	if err != nil {
 		logger.WithNamespace("event-trigger").Error(err)
 	}

--- a/pkg/scheduler/trigger_event_test.go
+++ b/pkg/scheduler/trigger_event_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func makeMessage(t *testing.T, msg string) *jobs.Message {
-	out, err := jobs.NewMessage("json", msg)
+func makeMessage(t *testing.T, msg string) jobs.Message {
+	out, err := jobs.NewMessage(msg)
 	assert.NoError(t, err)
 	return out
 }
@@ -28,7 +28,7 @@ func TestTriggerEvent(t *testing.T) {
 			Concurrency:  1,
 			MaxExecCount: 1,
 			Timeout:      1 * time.Millisecond,
-			WorkerFunc: func(ctx context.Context, m *jobs.Message) error {
+			WorkerFunc: func(ctx context.Context, m jobs.Message) error {
 				defer wg.Done()
 				var msg struct {
 					Message string

--- a/pkg/sharings/send_mails.go
+++ b/pkg/sharings/send_mails.go
@@ -165,7 +165,7 @@ func logError(i *instance.Instance, err error) bool {
 // generateMailMessage will extract and compute the relevant information
 // from the sharing to generate the mail we will send to the specified
 // recipient.
-func generateMailMessage(s *Sharing, r *Recipient, mailValues *mailTemplateValues) (*jobs.Message, error) {
+func generateMailMessage(s *Sharing, r *Recipient, mailValues *mailTemplateValues) (jobs.Message, error) {
 	if len(r.Email) == 0 {
 		return nil, ErrRecipientHasNoEmail
 	}
@@ -173,7 +173,7 @@ func generateMailMessage(s *Sharing, r *Recipient, mailValues *mailTemplateValue
 		Name:  r.Email[0].Address,
 		Email: r.Email[0].Address,
 	}}
-	return jobs.NewMessage(jobs.JSONEncoding, mails.Options{
+	return jobs.NewMessage(mails.Options{
 		Mode:           "from",
 		To:             mailAddresses,
 		Subject:        "New sharing request / Nouvelle demande de partage",

--- a/pkg/sharings/sharings.go
+++ b/pkg/sharings/sharings.go
@@ -1,7 +1,6 @@
 package sharings
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -256,7 +255,7 @@ func AddTrigger(instance *instance.Instance, rule permissions.Rule, sharingID st
 		Rule:      rule,
 	}
 
-	workerArgs, err := json.Marshal(msg)
+	workerArgs, err := jobs.NewMessage(msg)
 	if err != nil {
 		return err
 	}
@@ -265,10 +264,7 @@ func AddTrigger(instance *instance.Instance, rule permissions.Rule, sharingID st
 		WorkerType: consts.WorkerTypeSharingUpdates,
 		Domain:     instance.Domain,
 		Arguments:  eventArgs,
-		Message: &jobs.Message{
-			Type: jobs.JSONEncoding,
-			Data: workerArgs,
-		},
+		Message:    workerArgs,
 	})
 	if err != nil {
 		return err
@@ -441,7 +437,7 @@ func sendData(instance *instance.Instance, sharing *Sharing, recStatus *Recipien
 			Client:      recStatus.Client,
 		}
 
-		workerMsg, err := jobs.NewMessage(jobs.JSONEncoding, WorkerData{
+		workerMsg, err := jobs.NewMessage(WorkerData{
 			DocID:      val,
 			SharingID:  sharing.SharingID,
 			Selector:   rule.Selector,

--- a/pkg/workers/exec/common.go
+++ b/pkg/workers/exec/common.go
@@ -34,15 +34,15 @@ func init() {
 }
 
 type execWorker interface {
-	PrepareWorkDir(i *instance.Instance, m *jobs.Message) (string, error)
-	PrepareCmdEnv(i *instance.Instance, m *jobs.Message) (cmd string, env []string, jobID string, err error)
+	PrepareWorkDir(i *instance.Instance, m jobs.Message) (string, error)
+	PrepareCmdEnv(i *instance.Instance, m jobs.Message) (cmd string, env []string, jobID string, err error)
 	ScanOuput(i *instance.Instance, line []byte) error
 	Error(i *instance.Instance, err error) error
-	Commit(ctx context.Context, msg *jobs.Message, errjob error) error
+	Commit(ctx context.Context, msg jobs.Message, errjob error) error
 }
 
 func makeExecWorkerFunc() jobs.WorkerThreadedFunc {
-	return func(ctx context.Context, cookie interface{}, m *jobs.Message) error {
+	return func(ctx context.Context, cookie interface{}, m jobs.Message) error {
 		worker := cookie.(execWorker)
 
 		domain := ctx.Value(jobs.ContextDomainKey).(string)
@@ -114,7 +114,7 @@ func addExecWorker(name string, cfg *jobs.WorkerConfig, createWorker func() exec
 		return createWorker(), nil
 	}
 
-	workerCommit := func(ctx context.Context, cookie interface{}, msg *jobs.Message, errjob error) error {
+	workerCommit := func(ctx context.Context, cookie interface{}, msg jobs.Message, errjob error) error {
 		if w, ok := cookie.(execWorker); ok {
 			return w.Commit(ctx, msg, errjob)
 		}

--- a/pkg/workers/exec/konnector.go
+++ b/pkg/workers/exec/konnector.go
@@ -83,7 +83,7 @@ func (kl *konnectorLogs) Clone() couchdb.Doc {
 func (kl *konnectorLogs) SetID(id string)   {}
 func (kl *konnectorLogs) SetRev(rev string) { kl.DocRev = rev }
 
-func (w *konnectorWorker) PrepareWorkDir(i *instance.Instance, m *jobs.Message) (workDir string, err error) {
+func (w *konnectorWorker) PrepareWorkDir(i *instance.Instance, m jobs.Message) (workDir string, err error) {
 	opts := &KonnectorOptions{}
 	if err = m.Unmarshal(&opts); err != nil {
 		return
@@ -151,7 +151,7 @@ func (w *konnectorWorker) PrepareWorkDir(i *instance.Instance, m *jobs.Message) 
 	return workDir, nil
 }
 
-func (w *konnectorWorker) PrepareCmdEnv(i *instance.Instance, m *jobs.Message) (cmd string, env []string, jobID string, err error) {
+func (w *konnectorWorker) PrepareCmdEnv(i *instance.Instance, m jobs.Message) (cmd string, env []string, jobID string, err error) {
 	jobID = fmt.Sprintf("konnector/%s/%s", w.opts.Konnector, i.Domain)
 
 	fields := struct {
@@ -225,7 +225,7 @@ func (w *konnectorWorker) Error(i *instance.Instance, err error) error {
 	return err
 }
 
-func (w *konnectorWorker) Commit(ctx context.Context, msg *jobs.Message, errjob error) error {
+func (w *konnectorWorker) Commit(ctx context.Context, msg jobs.Message, errjob error) error {
 	if w.opts == nil {
 		return nil
 	}
@@ -298,7 +298,7 @@ func (w *konnectorWorker) Commit(ctx context.Context, msg *jobs.Message, errjob 
 	// 		"KonnectorPage": konnectorURL.String(),
 	// 	},
 	// }
-	// msg, err := jobs.NewMessage(jobs.JSONEncoding, &mail)
+	// msg, err := jobs.NewMessage(&mail)
 	// if err != nil {
 	// 	return err
 	// }

--- a/pkg/workers/exec/konnector_test.go
+++ b/pkg/workers/exec/konnector_test.go
@@ -27,7 +27,7 @@ var konnectorWorkerFunc = makeExecWorkerFunc()
 
 func TestUnknownDomain(t *testing.T) {
 	ctx := jobs.NewWorkerContext("unknown", "id")
-	msg, err := jobs.NewMessage(jobs.JSONEncoding, map[string]interface{}{
+	msg, err := jobs.NewMessage(map[string]interface{}{
 		"konnector": "unknownapp",
 	})
 	assert.NoError(t, err)
@@ -39,7 +39,7 @@ func TestUnknownDomain(t *testing.T) {
 
 func TestUnknownApp(t *testing.T) {
 	ctx := jobs.NewWorkerContext(inst.Domain, "id")
-	msg, err := jobs.NewMessage(jobs.JSONEncoding, map[string]interface{}{
+	msg, err := jobs.NewMessage(map[string]interface{}{
 		"konnector": "unknownapp",
 	})
 	assert.NoError(t, err)
@@ -70,7 +70,7 @@ func TestBadFileExec(t *testing.T) {
 	}
 
 	ctx := jobs.NewWorkerContext(inst.Domain, "id")
-	msg, err := jobs.NewMessage(jobs.JSONEncoding, map[string]interface{}{
+	msg, err := jobs.NewMessage(map[string]interface{}{
 		"konnector":      "my-konnector-1",
 		"account":        account,
 		"folder_to_save": folderToSave,
@@ -172,7 +172,7 @@ echo "{\"type\": \"manifest\", \"message\": \"$(ls ${1}/manifest.konnector)\" }"
 	}()
 
 	ctx := jobs.NewWorkerContext(inst.Domain, "id")
-	msg, err := jobs.NewMessage(jobs.JSONEncoding, map[string]interface{}{
+	msg, err := jobs.NewMessage(map[string]interface{}{
 		"konnector": "my-konnector-2",
 		"account":   account,
 	})

--- a/pkg/workers/exec/service.go
+++ b/pkg/workers/exec/service.go
@@ -28,7 +28,7 @@ type serviceWorker struct {
 	man  *apps.WebappManifest
 }
 
-func (w *serviceWorker) PrepareWorkDir(i *instance.Instance, m *jobs.Message) (workDir string, err error) {
+func (w *serviceWorker) PrepareWorkDir(i *instance.Instance, m jobs.Message) (workDir string, err error) {
 	opts := &ServiceOptions{}
 	if err = m.Unmarshal(&opts); err != nil {
 		return
@@ -79,7 +79,7 @@ func (w *serviceWorker) PrepareWorkDir(i *instance.Instance, m *jobs.Message) (w
 	return workDir, nil
 }
 
-func (w *serviceWorker) PrepareCmdEnv(i *instance.Instance, m *jobs.Message) (cmd string, env []string, jobID string, err error) {
+func (w *serviceWorker) PrepareCmdEnv(i *instance.Instance, m jobs.Message) (cmd string, env []string, jobID string, err error) {
 	jobID = fmt.Sprintf("service/%s/%s", w.opts.Slug, i.Domain)
 
 	token := i.BuildAppToken(w.man)
@@ -103,6 +103,6 @@ func (w *serviceWorker) Error(i *instance.Instance, err error) error {
 	return err
 }
 
-func (w *serviceWorker) Commit(ctx context.Context, msg *jobs.Message, errjob error) error {
+func (w *serviceWorker) Commit(ctx context.Context, msg jobs.Message, errjob error) error {
 	return nil
 }

--- a/pkg/workers/log/log.go
+++ b/pkg/workers/log/log.go
@@ -19,8 +19,8 @@ func init() {
 }
 
 // Worker is the worker that just logs its message (useful for debugging)
-func Worker(ctx context.Context, m *jobs.Message) error {
+func Worker(ctx context.Context, m jobs.Message) error {
 	domain := ctx.Value(jobs.ContextDomainKey).(string)
-	logger.WithDomain(domain).Infof(string(m.Data))
+	logger.WithDomain(domain).Infof(string(m))
 	return nil
 }

--- a/pkg/workers/mails/mail.go
+++ b/pkg/workers/mails/mail.go
@@ -73,7 +73,7 @@ type Part struct {
 }
 
 // SendMail is the sendmail worker function.
-func SendMail(ctx context.Context, m *jobs.Message) error {
+func SendMail(ctx context.Context, m jobs.Message) error {
 	opts := Options{}
 	err := m.Unmarshal(&opts)
 	if err != nil {

--- a/pkg/workers/mails/mail_test.go
+++ b/pkg/workers/mails/mail_test.go
@@ -381,7 +381,7 @@ func TestSendMailNoReply(t *testing.T) {
 		couchdb.DeleteDoc(db, doc)
 		sendMail = doSendMail
 	}()
-	msg, _ := jobs.NewMessage("json", Options{
+	msg, _ := jobs.NewMessage(Options{
 		Mode:    "noreply",
 		Subject: "Up?",
 		Parts: []*Part{
@@ -421,7 +421,7 @@ func TestSendMailFrom(t *testing.T) {
 		couchdb.DeleteDoc(db, doc)
 		sendMail = doSendMail
 	}()
-	msg, _ := jobs.NewMessage("json", Options{
+	msg, _ := jobs.NewMessage(Options{
 		Mode:    "from",
 		Subject: "Up?",
 		To:      []*Address{{Email: "you@you"}},

--- a/pkg/workers/sharings/share_data.go
+++ b/pkg/workers/sharings/share_data.go
@@ -176,7 +176,7 @@ func (opts *SendOptions) extractRelevantReferences(refs []couchdb.DocReference) 
 }
 
 // SendData sends data to all the recipients
-func SendData(ctx context.Context, m *jobs.Message) error {
+func SendData(ctx context.Context, m jobs.Message) error {
 	domain := ctx.Value(jobs.ContextDomainKey).(string)
 
 	opts := &SendOptions{}

--- a/pkg/workers/sharings/share_data_test.go
+++ b/pkg/workers/sharings/share_data_test.go
@@ -95,7 +95,7 @@ func TestSendDataMissingDocType(t *testing.T) {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	msg, err := jobs.NewMessage(jobs.JSONEncoding, SendOptions{
+	msg, err := jobs.NewMessage(SendOptions{
 		DocID:      "fakeid",
 		DocType:    docType,
 		Recipients: []*sharings.RecipientInfo{},
@@ -120,7 +120,7 @@ func TestSendDataBadID(t *testing.T) {
 		couchdb.DeleteDoc(in, doc)
 	}()
 
-	msg, err := jobs.NewMessage(jobs.JSONEncoding, SendOptions{
+	msg, err := jobs.NewMessage(SendOptions{
 		DocID:      "fakeid",
 		DocType:    testDocType,
 		Recipients: []*sharings.RecipientInfo{},
@@ -150,7 +150,7 @@ func TestSendDataBadRecipient(t *testing.T) {
 		AccessToken: auth.AccessToken{AccessToken: "inthesky"},
 	}
 
-	msg, err := jobs.NewMessage(jobs.JSONEncoding, SendOptions{
+	msg, err := jobs.NewMessage(SendOptions{
 		DocID:      testDocID,
 		DocType:    testDocType,
 		Recipients: []*sharings.RecipientInfo{rec},

--- a/pkg/workers/sharings/sharing_updates.go
+++ b/pkg/workers/sharings/sharing_updates.go
@@ -61,7 +61,7 @@ type SharingMessage struct {
 }
 
 // SharingUpdates handles shared document updates
-func SharingUpdates(ctx context.Context, m *jobs.Message) error {
+func SharingUpdates(ctx context.Context, m jobs.Message) error {
 	domain := ctx.Value(jobs.ContextDomainKey).(string)
 
 	event := &TriggerEvent{}

--- a/pkg/workers/sharings/sharing_updates_test.go
+++ b/pkg/workers/sharings/sharing_updates_test.go
@@ -101,7 +101,7 @@ func TestSharingUpdatesNoSharing(t *testing.T) {
 	}()
 	event := createEvent(t, doc, "", "CREATED")
 
-	msg, err := jobs.NewMessage(jobs.JSONEncoding, event)
+	msg, err := jobs.NewMessage(event)
 	assert.NoError(t, err)
 
 	err = SharingUpdates(jobs.NewWorkerContext(domainSharer, "123"), msg)
@@ -123,7 +123,7 @@ func TestSharingUpdatesBadSharing(t *testing.T) {
 
 	event := createEvent(t, doc, "badsharingid", "")
 
-	msg, err := jobs.NewMessage(jobs.JSONEncoding, event)
+	msg, err := jobs.NewMessage(event)
 	assert.NoError(t, err)
 
 	err = SharingUpdates(jobs.NewWorkerContext(domainSharer, "123"), msg)
@@ -149,7 +149,7 @@ func TestSharingUpdatesTooManySharing(t *testing.T) {
 
 	event := createEvent(t, doc, sharingID, "UPDATED")
 
-	msg, err := jobs.NewMessage(jobs.JSONEncoding, event)
+	msg, err := jobs.NewMessage(event)
 	assert.NoError(t, err)
 
 	err = SharingUpdates(jobs.NewWorkerContext(domainSharer, "123"), msg)
@@ -171,7 +171,7 @@ func TestSharingUpdatesBadSharingType(t *testing.T) {
 	sharingID := sharingDoc.M["sharing_id"].(string)
 	event := createEvent(t, doc, sharingID, "UPDATED")
 
-	msg, err := jobs.NewMessage(jobs.JSONEncoding, event)
+	msg, err := jobs.NewMessage(event)
 	assert.NoError(t, err)
 
 	err = SharingUpdates(jobs.NewWorkerContext(domainSharer, "123"), msg)
@@ -202,7 +202,7 @@ func TestSharingUpdatesNoRecipient(t *testing.T) {
 	sharingID := sharingDoc.M["sharing_id"].(string)
 	event := createEvent(t, doc, sharingID, "CREATED")
 
-	msg, err := jobs.NewMessage(jobs.JSONEncoding, event)
+	msg, err := jobs.NewMessage(event)
 	assert.NoError(t, err)
 
 	err = SharingUpdates(jobs.NewWorkerContext(domainSharer, "123"), msg)
@@ -232,7 +232,7 @@ func TestSharingUpdatesBadRecipient(t *testing.T) {
 	sharingID := sharingDoc.M["sharing_id"].(string)
 	event := createEvent(t, doc, sharingID, "CREATED")
 
-	msg, err := jobs.NewMessage(jobs.JSONEncoding, event)
+	msg, err := jobs.NewMessage(event)
 	assert.NoError(t, err)
 
 	err = SharingUpdates(jobs.NewWorkerContext(domainSharer, "123"), msg)
@@ -284,7 +284,7 @@ func TestRevokedRecipient(t *testing.T) {
 	doc := createDoc(t, testDocType, params)
 	event := createEvent(t, doc, sharingID, "UPDATED")
 
-	msg, err := jobs.NewMessage(jobs.JSONEncoding, event)
+	msg, err := jobs.NewMessage(event)
 	assert.NoError(t, err)
 
 	err = SharingUpdates(jobs.NewWorkerContext(domainSharer, "123"), msg)

--- a/pkg/workers/thumbnail/thumbnail.go
+++ b/pkg/workers/thumbnail/thumbnail.go
@@ -38,7 +38,7 @@ func init() {
 }
 
 // Worker is a worker that creates thumbnails for photos and images.
-func Worker(ctx context.Context, m *jobs.Message) error {
+func Worker(ctx context.Context, m jobs.Message) error {
 	msg := &imageMessage{}
 	if err := m.Unmarshal(msg); err != nil {
 		return err

--- a/pkg/workers/unzip/unzip.go
+++ b/pkg/workers/unzip/unzip.go
@@ -31,7 +31,7 @@ func init() {
 }
 
 // Worker is a worker that unzip a file.
-func Worker(ctx context.Context, m *jobs.Message) error {
+func Worker(ctx context.Context, m jobs.Message) error {
 	msg := &zipMessage{}
 	if err := m.Unmarshal(msg); err != nil {
 		return err

--- a/web/instances/move.go
+++ b/web/instances/move.go
@@ -28,7 +28,7 @@ func exporter(c echo.Context) error {
 	if instance.Locale == "fr" {
 		subject = "L'archive contenant toutes les données de Cozy est prête"
 	}
-	msg, err := jobs.NewMessage("json", workers.Options{
+	msg, err := jobs.NewMessage(workers.Options{
 		Mode:         workers.ModeNoReply,
 		Subject:      subject,
 		TemplateName: "archiver_" + instance.Locale,

--- a/web/jobs/jobs.go
+++ b/web/jobs/jobs.go
@@ -127,10 +127,7 @@ func pushJob(c echo.Context) error {
 		Domain:     instance.Domain,
 		WorkerType: c.Param("worker-type"),
 		Options:    req.Options,
-		Message: &jobs.Message{
-			Type: jobs.JSONEncoding,
-			Data: req.Arguments,
-		},
+		Message:    jobs.Message(req.Arguments),
 	}
 	// TODO: uncomment to restric jobs permissions.
 	// if err := permissions.AllowOnFields(c, permissions.POST, jr, "worker"); err != nil {
@@ -169,10 +166,7 @@ func newTrigger(c echo.Context) error {
 		Arguments:  req.Arguments,
 		Debounce:   req.Debounce,
 		Options:    req.Options,
-		Message: &jobs.Message{
-			Type: jobs.JSONEncoding,
-			Data: req.WorkerArguments,
-		},
+		Message:    jobs.Message(req.WorkerArguments),
 	})
 	if err != nil {
 		return wrapJobsError(err)

--- a/web/jobs/jobs_test.go
+++ b/web/jobs/jobs_test.go
@@ -383,7 +383,7 @@ func TestMain(m *testing.M) {
 
 	jobs.AddWorker("print", &jobs.WorkerConfig{
 		Concurrency: 4,
-		WorkerFunc: func(ctx context.Context, m *jobs.Message) error {
+		WorkerFunc: func(ctx context.Context, m jobs.Message) error {
 			var msg string
 			if err := m.Unmarshal(&msg); err != nil {
 				return err


### PR DESCRIPTION
In this PR, I got rid of the jobs message representation `Message { Data, Type }` which aimed at supporting different message encodings for jobs which really was not necessary and confusing.

This PR should be retro-compatible and still be able to unmarshal messages from the database that would be encoded in the old format.