### PR TITLE
Avoid autocomplete on clear password login field

### DIFF
--- a/assets/scripts/password-visibility.js
+++ b/assets/scripts/password-visibility.js
@@ -6,6 +6,7 @@
     event.preventDefault()
     passwordVisibility = !passwordVisibility
     passwordInput.type = passwordVisibility ? 'text' : 'password'
+    passwordInput.setAttribute('autocomplete', passwordVisibility ? 'off' : 'current-password')
     passwordVisibilityButton.setAttribute('aria-pressed', passwordVisibility)
   })
 })(window.document)


### PR DESCRIPTION
`current-password` works only on password type input, so use `autocomplete="off"`