### PR TITLE
Add a "critical" message log to use as returned error

### DIFF
--- a/pkg/workers/exec/konnector.go
+++ b/pkg/workers/exec/konnector.go
@@ -55,12 +55,12 @@ func (r *result) SetID(id string)    { r.DocID = id }
 func (r *result) SetRev(rev string)  { r.DocRev = rev }
 
 const (
+	konnectorMsgTypeDebug    = "debug"
 	konnectorMsgTypeWarning  = "warning"
 	konnectorMsgTypeError    = "error"
 	konnectorMsgTypeCritical = "critical"
 )
 
-// const konnectorMsgTypeDebug string = "debug"
 // const konnectorMsgTypeProgress string = "progress"
 
 type konnectorMsg struct {
@@ -201,10 +201,12 @@ func (w *konnectorWorker) ScanOuput(i *instance.Instance, log *logrus.Entry, lin
 	}
 
 	switch msg.Type {
-	case konnectorMsgTypeError, konnectorMsgTypeCritical:
-		log.Error(msg.Message)
+	case konnectorMsgTypeDebug:
+		log.Debug(msg.Message)
 	case konnectorMsgTypeWarning:
 		log.Warn(msg.Message)
+	case konnectorMsgTypeError, konnectorMsgTypeCritical:
+		log.Error(msg.Message)
 	}
 
 	w.messages = append(w.messages, msg)

--- a/pkg/workers/exec/service.go
+++ b/pkg/workers/exec/service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/config"
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/pkg/jobs"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 )
 
@@ -95,7 +96,7 @@ func (w *serviceWorker) PrepareCmdEnv(i *instance.Instance, m jobs.Message) (cmd
 	return
 }
 
-func (w *serviceWorker) ScanOuput(i *instance.Instance, line []byte) error {
+func (w *serviceWorker) ScanOuput(i *instance.Instance, log *logrus.Entry, line []byte) error {
 	return nil
 }
 


### PR DESCRIPTION
This PR also logs errors and warning messages from konnectors into syslog directly. And also remove the storage of logs inside couchdb.