### PR TITLE
Trigger run

### DIFF
--- a/client/jobs.go
+++ b/client/jobs.go
@@ -30,11 +30,18 @@ type Job struct {
 	Attrs struct {
 		Domain    string          `json:"domain"`
 		Message   json.RawMessage `json:"message"`
-		Options   *jobOptions     `json:"options"`
-		QueuedAt  time.Time       `json:"queued_at"`
-		StartedAt time.Time       `json:"started_at"`
-		State     string          `json:"state"`
-		Worker    string          `json:"worker"`
+		Debounced bool            `json:"debounced"`
+		Event     struct {
+			Domain string          `json:"domain"`
+			Verb   string          `json:"verb"`
+			Doc    json.RawMessage `json:"doc"`
+			OldDoc json.RawMessage `json:"old,omitempty"`
+		} `json:"event"`
+		Options   *jobOptions `json:"options"`
+		QueuedAt  time.Time   `json:"queued_at"`
+		StartedAt time.Time   `json:"started_at"`
+		State     string      `json:"state"`
+		Worker    string      `json:"worker"`
 	} `json:"attributes"`
 }
 

--- a/client/jobs.go
+++ b/client/jobs.go
@@ -46,6 +46,7 @@ type Job struct {
 	} `json:"attributes"`
 }
 
+// Trigger is a struct representing a trigger
 type Trigger struct {
 	ID    string `json:"id"`
 	Rev   string `json:"rev"`
@@ -114,6 +115,7 @@ func (c *Client) JobPush(r *JobOptions) (*Job, error) {
 	return j, nil
 }
 
+// GetTrigger return the trigger with the specified ID.
 func (c *Client) GetTrigger(triggerID string) (*Trigger, error) {
 	res, err := c.Req(&request.Options{
 		Method: "GET",
@@ -129,6 +131,7 @@ func (c *Client) GetTrigger(triggerID string) (*Trigger, error) {
 	return t, nil
 }
 
+// GetTriggers returns the list of all triggers with the specified worker type.
 func (c *Client) GetTriggers(worker string) ([]*Trigger, error) {
 	res, err := c.Req(&request.Options{
 		Method:  "GET",
@@ -145,7 +148,8 @@ func (c *Client) GetTriggers(worker string) ([]*Trigger, error) {
 	return t, nil
 }
 
-func (c *Client) TriggerRun(triggerID string) (*Job, error) {
+// TriggerLaunch launches manually the trigger with the specified ID.
+func (c *Client) TriggerLaunch(triggerID string) (*Job, error) {
 	res, err := c.Req(&request.Options{
 		Method: "POST",
 		Path:   fmt.Sprintf("/jobs/triggers/%s/launch", url.PathEscape(triggerID)),

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -499,6 +499,44 @@ Accept: application/vnd.api+json
 To use this endpoint, an application needs a permission on the type
 `io.cozy.triggers` for the verb `GET`.
 
+### POST /jobs/triggers/:trigger-id/launch
+
+Launch a trigger manually given its ID and return the created job.
+
+#### Request
+
+```http
+POST /jobs/triggers/123123/launch HTTP/1.1
+Accept: application/vnd.api+json
+```
+
+#### Response
+
+```json
+{
+  "data": {
+    "type": "io.cozy.jobs",
+    "id": "123123",
+    "attributes": {
+      "domain": "me.cozy.tools",
+      "worker": "sendmail",
+      "options": {},
+      "state": "running",
+      "queued_at": "2016-09-19T12:35:08Z",
+      "started_at": "2016-09-19T12:35:08Z",
+      "error": ""
+    },
+    "links": {
+      "self": "/jobs/123123"
+    }
+  }
+}
+```
+
+#### Permissions
+
+To use this endpoint, an application needs a permission on the type
+`io.cozy.triggers` for the verb `POST`.
 
 ### GET /jobs/triggers
 

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -53,21 +53,24 @@ type (
 	// Message is a json encoded job message.
 	Message json.RawMessage
 
+	// Event is a json encoded value of a realtime.Event
+	Event json.RawMessage
+
 	// Job contains all the metadata informations of a Job. It can be
 	// marshalled in JSON.
 	Job struct {
-		JobID      string          `json:"_id,omitempty"`
-		JobRev     string          `json:"_rev,omitempty"`
-		Domain     string          `json:"domain"`
-		WorkerType string          `json:"worker"`
-		Message    Message         `json:"message"`
-		Debounced  bool            `json:"debounced"`
-		Event      *realtime.Event `json:"event"`
-		Options    *JobOptions     `json:"options"`
-		State      State           `json:"state"`
-		QueuedAt   time.Time       `json:"queued_at"`
-		StartedAt  time.Time       `json:"started_at,omitempty"`
-		Error      string          `json:"error,omitempty"`
+		JobID      string      `json:"_id,omitempty"`
+		JobRev     string      `json:"_rev,omitempty"`
+		Domain     string      `json:"domain"`
+		WorkerType string      `json:"worker"`
+		Message    Message     `json:"message"`
+		Event      Event       `json:"event"`
+		Debounced  bool        `json:"debounced"`
+		Options    *JobOptions `json:"options"`
+		State      State       `json:"state"`
+		QueuedAt   time.Time   `json:"queued_at"`
+		StartedAt  time.Time   `json:"started_at,omitempty"`
+		Error      string      `json:"error,omitempty"`
 	}
 
 	// JobRequest struct is used to represent a new job request.
@@ -75,8 +78,8 @@ type (
 		Domain     string
 		WorkerType string
 		Message    Message
+		Event      Event
 		Debounced  bool
-		Event      *realtime.Event
 		Options    *JobOptions
 	}
 
@@ -265,13 +268,22 @@ func GetQueuedJobs(domain, workerType string) ([]*Job, error) {
 	return results, err
 }
 
-// NewMessage returns a new Message encoded in the specified format.
+// NewMessage returns a json encoded data
 func NewMessage(data interface{}) (Message, error) {
 	b, err := json.Marshal(data)
 	if err != nil {
 		return nil, err
 	}
 	return Message(b), nil
+}
+
+// NewEvent return a json encoded realtime.Event
+func NewEvent(data *realtime.Event) (Event, error) {
+	b, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+	return Event(b), nil
 }
 
 // Unmarshal can be used to unmarshal the encoded message value in the
@@ -281,6 +293,15 @@ func (m Message) Unmarshal(msg interface{}) error {
 		return ErrMessageNil
 	}
 	return json.Unmarshal(m, &msg)
+}
+
+// Unmarshal can be used to unmarshal the encoded message value in the
+// specified interface's type.
+func (e Event) Unmarshal(evt interface{}) error {
+	if e == nil {
+		return ErrMessageNil
+	}
+	return json.Unmarshal(e, &evt)
 }
 
 // Clone clones the worker config

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
 	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/cozy/cozy-stack/pkg/permissions"
+	"github.com/cozy/cozy-stack/pkg/realtime"
 	"github.com/sirupsen/logrus"
 )
 
@@ -55,16 +56,18 @@ type (
 	// Job contains all the metadata informations of a Job. It can be
 	// marshalled in JSON.
 	Job struct {
-		JobID      string      `json:"_id,omitempty"`
-		JobRev     string      `json:"_rev,omitempty"`
-		Domain     string      `json:"domain"`
-		WorkerType string      `json:"worker"`
-		Message    Message     `json:"message"`
-		Options    *JobOptions `json:"options"`
-		State      State       `json:"state"`
-		QueuedAt   time.Time   `json:"queued_at"`
-		StartedAt  time.Time   `json:"started_at,omitempty"`
-		Error      string      `json:"error,omitempty"`
+		JobID      string          `json:"_id,omitempty"`
+		JobRev     string          `json:"_rev,omitempty"`
+		Domain     string          `json:"domain"`
+		WorkerType string          `json:"worker"`
+		Message    Message         `json:"message"`
+		Debounced  bool            `json:"debounced"`
+		Event      *realtime.Event `json:"event"`
+		Options    *JobOptions     `json:"options"`
+		State      State           `json:"state"`
+		QueuedAt   time.Time       `json:"queued_at"`
+		StartedAt  time.Time       `json:"started_at,omitempty"`
+		Error      string          `json:"error,omitempty"`
 	}
 
 	// JobRequest struct is used to represent a new job request.
@@ -72,6 +75,8 @@ type (
 		Domain     string
 		WorkerType string
 		Message    Message
+		Debounced  bool
+		Event      *realtime.Event
 		Options    *JobOptions
 	}
 
@@ -220,6 +225,8 @@ func NewJob(req *JobRequest) *Job {
 		Domain:     req.Domain,
 		WorkerType: req.WorkerType,
 		Message:    req.Message,
+		Debounced:  req.Debounced,
+		Event:      req.Event,
 		Options:    req.Options,
 		State:      Queued,
 		QueuedAt:   time.Now(),

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -111,6 +111,11 @@ func (j *Job) Clone() couchdb.Doc {
 		j.Message = make([]byte, len(tmp))
 		copy(j.Message[:], tmp)
 	}
+	if j.Event != nil {
+		tmp := j.Event
+		j.Event = make([]byte, len(tmp))
+		copy(j.Event[:], tmp)
+	}
 	return &cloned
 }
 

--- a/pkg/jobs/worker.go
+++ b/pkg/jobs/worker.go
@@ -8,8 +8,6 @@ import (
 	"runtime/debug"
 	"sync/atomic"
 	"time"
-
-	"github.com/cozy/cozy-stack/pkg/realtime"
 )
 
 // contextKey are the keys used in the worker context
@@ -20,8 +18,8 @@ const (
 	ContextDomainKey contextKey = iota
 	// ContextWorkerKey is used to store the workerID string
 	ContextWorkerKey
-	// ContextEventKey is used to store an optional *realtime.Event pointer when
-	// the worker is executed with an event (via the @event trigger for instance).
+	// ContextEventKey is used to store an optional Event when the worker is
+	// executed with an event (via the @event trigger for instance).
 	ContextEventKey
 )
 
@@ -96,9 +94,8 @@ func NewWorkerContext(domain, workerID string) context.Context {
 
 // NewWorkerContextWithEvent returns a context.Context usable by a worker. It
 // returns the same context as NewWorkerContext except that it also includes
-// the event (realtime.Event pointer) responsible for the job, from a @event
-// trigger for instance.
-func NewWorkerContextWithEvent(domain, workerID string, event *realtime.Event) context.Context {
+// the event responsible for the job, from a @event trigger for instance.
+func NewWorkerContextWithEvent(domain, workerID string, event Event) context.Context {
 	ctx := NewWorkerContext(domain, workerID)
 	ctx = context.WithValue(ctx, ContextEventKey, event)
 	return ctx

--- a/pkg/scheduler/redis_scheduler.go
+++ b/pkg/scheduler/redis_scheduler.go
@@ -166,7 +166,7 @@ func (s *RedisScheduler) eventLoop(eventsCh <-chan *realtime.Event) {
 				s.log.Warnf("[scheduler] Trigger %s %s has an invalid debounce: %s",
 					et.infos.Domain, et.infos.TID, et.infos.Debounce)
 			}
-			_, err = s.broker.PushJob(et.Trigger(event))
+			_, err = s.broker.PushJob(et.Infos().JobRequestWithEvent(event))
 			if err != nil {
 				s.log.Warnf("[scheduler] Could not push job trigger by event %s %s: %s",
 					event.Domain, triggerID, err.Error())
@@ -220,12 +220,13 @@ func (s *RedisScheduler) Poll(now int64) error {
 		}
 		switch t := t.(type) {
 		case *EventTrigger: // Debounced
-			job := t.Trigger(nil)
+			job := t.Infos().JobRequest()
+			job.Debounced = true
 			if _, err = s.broker.PushJob(job); err != nil {
 				return err
 			}
 		case *AtTrigger:
-			job := t.Trigger()
+			job := t.Infos().JobRequest()
 			if _, err = s.broker.PushJob(job); err != nil {
 				return err
 			}
@@ -233,7 +234,7 @@ func (s *RedisScheduler) Poll(now int64) error {
 				return err
 			}
 		case *CronTrigger:
-			job := t.Trigger()
+			job := t.Infos().JobRequest()
 			if _, err = s.broker.PushJob(job); err != nil {
 				return err
 			}

--- a/pkg/scheduler/redis_scheduler.go
+++ b/pkg/scheduler/redis_scheduler.go
@@ -166,7 +166,13 @@ func (s *RedisScheduler) eventLoop(eventsCh <-chan *realtime.Event) {
 				s.log.Warnf("[scheduler] Trigger %s %s has an invalid debounce: %s",
 					et.infos.Domain, et.infos.TID, et.infos.Debounce)
 			}
-			_, err = s.broker.PushJob(et.Infos().JobRequestWithEvent(event))
+			jobRequest, err := et.Infos().JobRequestWithEvent(event)
+			if err != nil {
+				s.log.Warnf("[scheduler] Could not encode realtime event %s %s: %s",
+					event.Domain, triggerID, err.Error())
+				continue
+			}
+			_, err = s.broker.PushJob(jobRequest)
 			if err != nil {
 				s.log.Warnf("[scheduler] Could not push job trigger by event %s %s: %s",
 					event.Domain, triggerID, err.Error())

--- a/pkg/scheduler/redis_scheduler_test.go
+++ b/pkg/scheduler/redis_scheduler_test.go
@@ -297,15 +297,18 @@ func TestRedisTriggerEvent(t *testing.T) {
 		return
 	}
 
-	type eventMessage struct {
-		Message string
-		Event   map[string]interface{}
+	var evt struct {
+		Domain string `json:"domain"`
+		Verb   string `json:"verb"`
 	}
-	var data eventMessage
+	var data string
+	err = bro.jobs[0].Event.Unmarshal(&evt)
+	assert.NoError(t, err)
 	err = bro.jobs[0].Message.Unmarshal(&data)
 	assert.NoError(t, err)
-	assert.Equal(t, data.Event["domain"].(string), instanceName)
-	assert.Equal(t, data.Event["verb"].(string), "CREATED")
+
+	assert.Equal(t, evt.Domain, instanceName)
+	assert.Equal(t, evt.Verb, "CREATED")
 
 	realtime.GetHub().Publish(&realtime.Event{
 		Domain: instanceName,

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -7,52 +7,8 @@ import (
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/jobs"
 	"github.com/cozy/cozy-stack/pkg/permissions"
+	"github.com/cozy/cozy-stack/pkg/realtime"
 )
-
-// TriggerInfos is a struct containing all the options of a trigger.
-type TriggerInfos struct {
-	TID        string           `json:"_id,omitempty"`
-	TRev       string           `json:"_rev,omitempty"`
-	Domain     string           `json:"domain"`
-	Type       string           `json:"type"`
-	WorkerType string           `json:"worker"`
-	Arguments  string           `json:"arguments"`
-	Debounce   string           `json:"debounce,omitempty"`
-	Options    *jobs.JobOptions `json:"options"`
-	Message    jobs.Message     `json:"message"`
-}
-
-// ID implements the couchdb.Doc interface
-func (t *TriggerInfos) ID() string { return t.TID }
-
-// Rev implements the couchdb.Doc interface
-func (t *TriggerInfos) Rev() string { return t.TRev }
-
-// DocType implements the couchdb.Doc interface
-func (t *TriggerInfos) DocType() string { return consts.Triggers }
-
-// Clone implements the couchdb.Doc interface
-func (t *TriggerInfos) Clone() couchdb.Doc {
-	cloned := *t
-	if t.Options != nil {
-		tmp := *t.Options
-		cloned.Options = &tmp
-	}
-	if t.Message != nil {
-		tmp := t.Message
-		t.Message = make([]byte, len(tmp))
-		copy(t.Message[:], tmp)
-	}
-	return &cloned
-}
-
-// SetID implements the couchdb.Doc interface
-func (t *TriggerInfos) SetID(id string) { t.TID = id }
-
-// SetRev implements the couchdb.Doc interface
-func (t *TriggerInfos) SetRev(rev string) { t.TRev = rev }
-
-var _ couchdb.Doc = &TriggerInfos{}
 
 type (
 	// Trigger interface is used to represent a trigger.
@@ -79,6 +35,19 @@ type (
 		GetAll(domain string) ([]Trigger, error)
 		RebuildRedis(domain string) error
 	}
+
+	// TriggerInfos is a struct containing all the options of a trigger.
+	TriggerInfos struct {
+		TID        string           `json:"_id,omitempty"`
+		TRev       string           `json:"_rev,omitempty"`
+		Domain     string           `json:"domain"`
+		Type       string           `json:"type"`
+		WorkerType string           `json:"worker"`
+		Arguments  string           `json:"arguments"`
+		Debounce   string           `json:"debounce"`
+		Options    *jobs.JobOptions `json:"options"`
+		Message    jobs.Message     `json:"message"`
+	}
 )
 
 // NewTrigger creates the trigger associates with the specified trigger
@@ -99,3 +68,53 @@ func NewTrigger(infos *TriggerInfos) (Trigger, error) {
 		return nil, ErrUnknownTrigger
 	}
 }
+
+// ID implements the couchdb.Doc interface
+func (t *TriggerInfos) ID() string { return t.TID }
+
+// Rev implements the couchdb.Doc interface
+func (t *TriggerInfos) Rev() string { return t.TRev }
+
+// DocType implements the couchdb.Doc interface
+func (t *TriggerInfos) DocType() string { return consts.Triggers }
+
+// Clone implements the couchdb.Doc interface
+func (t *TriggerInfos) Clone() couchdb.Doc {
+	cloned := *t
+	if t.Options != nil {
+		tmp := *t.Options
+		cloned.Options = &tmp
+	}
+	if t.Message != nil {
+		tmp := t.Message
+		t.Message = make([]byte, len(tmp))
+		copy(t.Message[:], tmp)
+	}
+	return &cloned
+}
+
+// JobRequest returns a job request associated with the scheduler informations.
+func (t *TriggerInfos) JobRequest() *jobs.JobRequest {
+	return &jobs.JobRequest{
+		Domain:     t.Domain,
+		WorkerType: t.WorkerType,
+		Message:    t.Message,
+		Options:    t.Options,
+	}
+}
+
+// JobRequestWithEvent returns a job request associated with the scheduler
+// informations associated to the specified realtime event.
+func (t *TriggerInfos) JobRequestWithEvent(event *realtime.Event) *jobs.JobRequest {
+	req := t.JobRequest()
+	req.Event = event
+	return req
+}
+
+// SetID implements the couchdb.Doc interface
+func (t *TriggerInfos) SetID(id string) { t.TID = id }
+
+// SetRev implements the couchdb.Doc interface
+func (t *TriggerInfos) SetRev(rev string) { t.TRev = rev }
+
+var _ couchdb.Doc = &TriggerInfos{}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -105,10 +105,14 @@ func (t *TriggerInfos) JobRequest() *jobs.JobRequest {
 
 // JobRequestWithEvent returns a job request associated with the scheduler
 // informations associated to the specified realtime event.
-func (t *TriggerInfos) JobRequestWithEvent(event *realtime.Event) *jobs.JobRequest {
+func (t *TriggerInfos) JobRequestWithEvent(event *realtime.Event) (*jobs.JobRequest, error) {
 	req := t.JobRequest()
-	req.Event = event
-	return req
+	evt, err := jobs.NewEvent(event)
+	if err != nil {
+		return nil, err
+	}
+	req.Event = evt
+	return req, nil
 }
 
 // SetID implements the couchdb.Doc interface

--- a/pkg/scheduler/trigger_at.go
+++ b/pkg/scheduler/trigger_at.go
@@ -79,29 +79,19 @@ func (a *AtTrigger) Schedule() <-chan *jobs.JobRequest {
 		duration := -time.Since(a.at)
 		if duration < 0 {
 			if duration > -maxPastTriggerTime {
-				ch <- a.Trigger()
+				ch <- a.in.JobRequest()
 			}
 			close(ch)
 			return
 		}
 		select {
 		case <-time.After(duration):
-			ch <- a.Trigger()
+			ch <- a.in.JobRequest()
 		case <-a.done:
 		}
 		close(ch)
 	}()
 	return ch
-}
-
-// Trigger returns the triggered job request
-func (a *AtTrigger) Trigger() *jobs.JobRequest {
-	return &jobs.JobRequest{
-		Domain:     a.in.Domain,
-		WorkerType: a.in.WorkerType,
-		Message:    a.in.Message,
-		Options:    a.in.Options,
-	}
 }
 
 // Unschedule implements the Unschedule method of the Trigger interface.

--- a/pkg/scheduler/trigger_cron.go
+++ b/pkg/scheduler/trigger_cron.go
@@ -81,7 +81,7 @@ func (c *CronTrigger) Schedule() <-chan *jobs.JobRequest {
 			next = c.NextExecution(next)
 			select {
 			case <-time.After(-time.Since(next)):
-				ch <- c.Trigger()
+				ch <- c.infos.JobRequest()
 			case <-c.done:
 				close(ch)
 				return
@@ -89,16 +89,6 @@ func (c *CronTrigger) Schedule() <-chan *jobs.JobRequest {
 		}
 	}()
 	return ch
-}
-
-// Trigger returns the triggered job request
-func (c *CronTrigger) Trigger() *jobs.JobRequest {
-	return &jobs.JobRequest{
-		Domain:     c.infos.Domain,
-		WorkerType: c.infos.WorkerType,
-		Message:    c.infos.Message,
-		Options:    c.infos.Options,
-	}
 }
 
 // Unschedule implements the Unschedule method of the Trigger interface.

--- a/pkg/scheduler/trigger_event.go
+++ b/pkg/scheduler/trigger_event.go
@@ -72,7 +72,9 @@ func (t *EventTrigger) Schedule() <-chan *jobs.JobRequest {
 			select {
 			case e := <-sub.Channel:
 				if eventMatchPermission(e, &t.mask) {
-					ch <- t.Infos().JobRequestWithEvent(e)
+					if evt, err := t.Infos().JobRequestWithEvent(e); err == nil {
+						ch <- evt
+					}
 				}
 			case <-t.unscheduled:
 				return

--- a/pkg/scheduler/trigger_event.go
+++ b/pkg/scheduler/trigger_event.go
@@ -72,7 +72,7 @@ func (t *EventTrigger) Schedule() <-chan *jobs.JobRequest {
 			select {
 			case e := <-sub.Channel:
 				if eventMatchPermission(e, &t.mask) {
-					ch <- t.Trigger(e)
+					ch <- t.Infos().JobRequestWithEvent(e)
 				}
 			case <-t.unscheduled:
 				return
@@ -80,28 +80,6 @@ func (t *EventTrigger) Schedule() <-chan *jobs.JobRequest {
 		}
 	}()
 	return ch
-}
-
-// Trigger returns the triggered job request
-func (t *EventTrigger) Trigger(e *realtime.Event) *jobs.JobRequest {
-	m := map[string]interface{}{
-		"message": t.infos.Message,
-	}
-	if e == nil {
-		m["debounced"] = true
-	} else {
-		m["event"] = e
-	}
-	msg, err := jobs.NewMessage(m)
-	if err != nil {
-		logger.WithNamespace("event-trigger").Error(err)
-	}
-	return &jobs.JobRequest{
-		Domain:     t.infos.Domain,
-		WorkerType: t.infos.WorkerType,
-		Message:    msg,
-		Options:    t.infos.Options,
-	}
 }
 
 // Unschedule implements the Unschedule method of the Trigger interface.

--- a/pkg/workers/sharings/sharing_updates.go
+++ b/pkg/workers/sharings/sharing_updates.go
@@ -51,9 +51,17 @@ type SharingMessage struct {
 // SharingUpdates handles shared document updates
 func SharingUpdates(ctx context.Context, m jobs.Message) error {
 	domain := ctx.Value(jobs.ContextDomainKey).(string)
-	event, ok := ctx.Value(jobs.ContextEventKey).(*realtime.Event)
+	e, ok := ctx.Value(jobs.ContextEventKey).(jobs.Event)
 	if !ok {
-		return fmt.Errorf("Missing realtime event from context")
+		return errors.New("Missing realtime event from context")
+	}
+
+	var event struct {
+		Verb string `json:"verb"`
+		Doc  *couchdb.JSONDoc
+	}
+	if err := e.Unmarshal(&event); err != nil {
+		return err
 	}
 
 	var msg *sharings.SharingMessage

--- a/pkg/workers/sharings/sharing_updates_test.go
+++ b/pkg/workers/sharings/sharing_updates_test.go
@@ -28,7 +28,7 @@ func createDoc(t *testing.T, docType string, params map[string]interface{}) couc
 	return doc
 }
 
-func createEvent(t *testing.T, doc couchdb.JSONDoc, sharingID, eventType string) (jobs.Message, *realtime.Event) {
+func createEvent(t *testing.T, doc couchdb.JSONDoc, sharingID, eventType string) (jobs.Message, jobs.Event) {
 	data := &sharings.SharingMessage{
 		SharingID: sharingID,
 		Rule: permissions.Rule{
@@ -40,11 +40,13 @@ func createEvent(t *testing.T, doc couchdb.JSONDoc, sharingID, eventType string)
 	}
 	msg, err := jobs.NewMessage(data)
 	assert.NoError(t, err)
-	event := &realtime.Event{
+
+	evt, err := jobs.NewEvent(&realtime.Event{
 		Verb: eventType,
 		Doc:  doc,
-	}
-	return msg, event
+	})
+	assert.NoError(t, err)
+	return msg, evt
 }
 
 func createRecipient(t *testing.T, email, url string) *sharings.Recipient {


### PR DESCRIPTION
This PR adds a `POST /jobs/triggers/:trigger-id/launch` route to allow launching manually the trigger.

It also removes the specific message transformation made by the the `@event` trigger to include the event (`*realtime.Event`) data inside the message field of the job. (`"message": { "message": ..., "event": {} }`). The event is now forwarded to the worker in the worker execution context in a specific key. This was used in the `sharing_updates` worker.

This way, jobs always have an `"message"` field matching the original message of the trigger, independently of the trigger type.