### PR TITLE
Refacto: add a WorkerContext

### DIFF
--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -312,15 +312,14 @@ func (e Event) Unmarshal(evt interface{}) error {
 // Clone clones the worker config
 func (w *WorkerConfig) Clone() *WorkerConfig {
 	return &WorkerConfig{
-		WorkerInit:         w.WorkerInit,
-		WorkerFunc:         w.WorkerFunc,
-		WorkerThreadedFunc: w.WorkerThreadedFunc,
-		WorkerCommit:       w.WorkerCommit,
-		Concurrency:        w.Concurrency,
-		MaxExecCount:       w.MaxExecCount,
-		MaxExecTime:        w.MaxExecTime,
-		Timeout:            w.Timeout,
-		RetryDelay:         w.RetryDelay,
+		WorkerInit:   w.WorkerInit,
+		WorkerFunc:   w.WorkerFunc,
+		WorkerCommit: w.WorkerCommit,
+		Concurrency:  w.Concurrency,
+		MaxExecCount: w.MaxExecCount,
+		MaxExecTime:  w.MaxExecTime,
+		Timeout:      w.Timeout,
+		RetryDelay:   w.RetryDelay,
 	}
 }
 

--- a/pkg/jobs/mem_jobs_test.go
+++ b/pkg/jobs/mem_jobs_test.go
@@ -1,7 +1,6 @@
 package jobs
 
 import (
-	"context"
 	"encoding/json"
 	"strconv"
 	"strings"
@@ -70,9 +69,9 @@ func TestInMemoryJobs(t *testing.T) {
 	var workersTestList = WorkersList{
 		"test": {
 			Concurrency: 4,
-			WorkerFunc: func(ctx context.Context, m Message) error {
+			WorkerFunc: func(ctx *WorkerContext) error {
 				var msg string
-				err := m.Unmarshal(&msg)
+				err := ctx.UnmarshalMessage(&msg)
 				if !assert.NoError(t, err) {
 					return err
 				}
@@ -149,9 +148,9 @@ func TestUnknownMessageType(t *testing.T) {
 	broker.Start(WorkersList{
 		"test": {
 			Concurrency: 4,
-			WorkerFunc: func(ctx context.Context, m Message) error {
+			WorkerFunc: func(ctx *WorkerContext) error {
 				var msg string
-				err := m.Unmarshal(&msg)
+				err := ctx.UnmarshalMessage(&msg)
 				assert.Error(t, err)
 				assert.Equal(t, ErrMessageNil, err)
 				w.Done()
@@ -180,7 +179,7 @@ func TestTimeout(t *testing.T) {
 			Concurrency:  1,
 			MaxExecCount: 1,
 			Timeout:      1 * time.Millisecond,
-			WorkerFunc: func(ctx context.Context, _ Message) error {
+			WorkerFunc: func(ctx *WorkerContext) error {
 				<-ctx.Done()
 				w.Done()
 				return ctx.Err()
@@ -212,7 +211,7 @@ func TestRetry(t *testing.T) {
 			MaxExecCount: maxExecCount,
 			Timeout:      1 * time.Millisecond,
 			RetryDelay:   1 * time.Millisecond,
-			WorkerFunc: func(ctx context.Context, _ Message) error {
+			WorkerFunc: func(ctx *WorkerContext) error {
 				<-ctx.Done()
 				w.Done()
 				count++
@@ -246,7 +245,7 @@ func TestPanicRetried(t *testing.T) {
 			Concurrency:  1,
 			MaxExecCount: maxExecCount,
 			RetryDelay:   1 * time.Millisecond,
-			WorkerFunc: func(ctx context.Context, _ Message) error {
+			WorkerFunc: func(ctx *WorkerContext) error {
 				w.Done()
 				panic("oops")
 			},
@@ -276,9 +275,9 @@ func TestPanic(t *testing.T) {
 			Concurrency:  1,
 			MaxExecCount: 1,
 			RetryDelay:   1 * time.Millisecond,
-			WorkerFunc: func(ctx context.Context, m Message) error {
+			WorkerFunc: func(ctx *WorkerContext) error {
 				var i int
-				if err := m.Unmarshal(&i); err != nil {
+				if err := ctx.UnmarshalMessage(&i); err != nil {
 					return err
 				}
 				if i%2 != 0 {

--- a/pkg/jobs/redis_jobs_test.go
+++ b/pkg/jobs/redis_jobs_test.go
@@ -35,9 +35,9 @@ func TestRedisJobs(t *testing.T) {
 	var workersTestList = WorkersList{
 		"test": {
 			Concurrency: 4,
-			WorkerFunc: func(ctx context.Context, m Message) error {
+			WorkerFunc: func(ctx *WorkerContext) error {
 				var msg string
-				err := m.Unmarshal(&msg)
+				err := ctx.UnmarshalMessage(&msg)
 				if !assert.NoError(t, err) {
 					return err
 				}

--- a/pkg/scheduler/mem_scheduler_test.go
+++ b/pkg/scheduler/mem_scheduler_test.go
@@ -46,9 +46,9 @@ func TestMemSchedulerWithTimeTriggers(t *testing.T) {
 			Concurrency:  1,
 			MaxExecCount: 1,
 			Timeout:      1 * time.Millisecond,
-			WorkerFunc: func(ctx context.Context, m jobs.Message) error {
+			WorkerFunc: func(ctx *jobs.WorkerContext) error {
 				var msg string
-				if err := m.Unmarshal(&msg); err != nil {
+				if err := ctx.UnmarshalMessage(&msg); err != nil {
 					return err
 				}
 				switch msg {
@@ -145,7 +145,7 @@ func TestMemSchedulerWithDebounce(t *testing.T) {
 			Concurrency:  1,
 			MaxExecCount: 1,
 			Timeout:      1 * time.Millisecond,
-			WorkerFunc: func(ctx context.Context, m jobs.Message) error {
+			WorkerFunc: func(ctx *jobs.WorkerContext) error {
 				called++
 				return nil
 			},

--- a/pkg/scheduler/redis_scheduler_test.go
+++ b/pkg/scheduler/redis_scheduler_test.go
@@ -73,9 +73,9 @@ func TestRedisSchedulerWithTimeTriggers(t *testing.T) {
 			Concurrency:  1,
 			MaxExecCount: 1,
 			Timeout:      1 * time.Millisecond,
-			WorkerFunc: func(ctx context.Context, m jobs.Message) error {
+			WorkerFunc: func(ctx *jobs.WorkerContext) error {
 				var msg string
-				if err := m.Unmarshal(&msg); err != nil {
+				if err := ctx.UnmarshalMessage(&msg); err != nil {
 					return err
 				}
 				switch msg {

--- a/pkg/scheduler/trigger_event_test.go
+++ b/pkg/scheduler/trigger_event_test.go
@@ -28,21 +28,19 @@ func TestTriggerEvent(t *testing.T) {
 			Concurrency:  1,
 			MaxExecCount: 1,
 			Timeout:      1 * time.Millisecond,
-			WorkerFunc: func(ctx context.Context, m jobs.Message) error {
+			WorkerFunc: func(ctx *jobs.WorkerContext) error {
 				defer wg.Done()
 				var msg string
-				if err := m.Unmarshal(&msg); err != nil {
+				if err := ctx.UnmarshalMessage(&msg); err != nil {
 					assert.NoError(t, err)
 					return err
 				}
-				e, ok := ctx.Value(jobs.ContextEventKey).(jobs.Event)
-				assert.True(t, ok)
 				var evt struct {
 					Domain string `json:"domain"`
 					Verb   string `json:"verb"`
 					Doc    couchdb.JSONDoc
 				}
-				if err := e.Unmarshal(&evt); err != nil {
+				if err := ctx.UnmarshalEvent(&evt); err != nil {
 					assert.NoError(t, err)
 					return nil
 				}

--- a/pkg/workers/exec/service.go
+++ b/pkg/workers/exec/service.go
@@ -1,7 +1,6 @@
 package exec
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -12,7 +11,6 @@ import (
 	"github.com/cozy/cozy-stack/pkg/config"
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/pkg/jobs"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 )
 
@@ -29,9 +27,9 @@ type serviceWorker struct {
 	man  *apps.WebappManifest
 }
 
-func (w *serviceWorker) PrepareWorkDir(i *instance.Instance, m jobs.Message) (workDir string, err error) {
+func (w *serviceWorker) PrepareWorkDir(ctx *jobs.WorkerContext, i *instance.Instance) (workDir string, err error) {
 	opts := &ServiceOptions{}
-	if err = m.Unmarshal(&opts); err != nil {
+	if err = ctx.UnmarshalMessage(&opts); err != nil {
 		return
 	}
 	if opts.Message != nil {
@@ -80,7 +78,7 @@ func (w *serviceWorker) PrepareWorkDir(i *instance.Instance, m jobs.Message) (wo
 	return workDir, nil
 }
 
-func (w *serviceWorker) PrepareCmdEnv(i *instance.Instance, m jobs.Message) (cmd string, env []string, jobID string, err error) {
+func (w *serviceWorker) PrepareCmdEnv(ctx *jobs.WorkerContext, i *instance.Instance) (cmd string, env []string, jobID string, err error) {
 	jobID = fmt.Sprintf("service/%s/%s", w.opts.Slug, i.Domain)
 
 	token := i.BuildAppToken(w.man)
@@ -96,7 +94,7 @@ func (w *serviceWorker) PrepareCmdEnv(i *instance.Instance, m jobs.Message) (cmd
 	return
 }
 
-func (w *serviceWorker) ScanOuput(i *instance.Instance, log *logrus.Entry, line []byte) error {
+func (w *serviceWorker) ScanOuput(ctx *jobs.WorkerContext, i *instance.Instance, line []byte) error {
 	return nil
 }
 
@@ -104,6 +102,6 @@ func (w *serviceWorker) Error(i *instance.Instance, err error) error {
 	return err
 }
 
-func (w *serviceWorker) Commit(ctx context.Context, msg jobs.Message, errjob error) error {
+func (w *serviceWorker) Commit(ctx *jobs.WorkerContext, errjob error) error {
 	return nil
 }

--- a/pkg/workers/log/log.go
+++ b/pkg/workers/log/log.go
@@ -1,7 +1,6 @@
 package log
 
 import (
-	"context"
 	"runtime"
 	"time"
 
@@ -19,8 +18,11 @@ func init() {
 }
 
 // Worker is the worker that just logs its message (useful for debugging)
-func Worker(ctx context.Context, m jobs.Message) error {
-	domain := ctx.Value(jobs.ContextDomainKey).(string)
-	logger.WithDomain(domain).Infof(string(m))
+func Worker(ctx *jobs.WorkerContext) error {
+	var msg string
+	if err := ctx.UnmarshalMessage(&msg); err != nil {
+		return err
+	}
+	logger.WithDomain(ctx.Domain()).Infof(msg)
 	return nil
 }

--- a/pkg/workers/mails/mail.go
+++ b/pkg/workers/mails/mail.go
@@ -73,13 +73,13 @@ type Part struct {
 }
 
 // SendMail is the sendmail worker function.
-func SendMail(ctx context.Context, m jobs.Message) error {
+func SendMail(ctx *jobs.WorkerContext) error {
 	opts := Options{}
-	err := m.Unmarshal(&opts)
+	err := ctx.UnmarshalMessage(&opts)
 	if err != nil {
 		return err
 	}
-	domain := ctx.Value(jobs.ContextDomainKey).(string)
+	domain := ctx.Domain()
 	from := config.GetConfig().NoReply
 	if from == "" {
 		from = "noreply@" + utils.StripPort(domain)

--- a/pkg/workers/mails/mail_test.go
+++ b/pkg/workers/mails/mail_test.go
@@ -391,7 +391,7 @@ func TestSendMailNoReply(t *testing.T) {
 			},
 		},
 	})
-	err = SendMail(jobs.NewWorkerContext("noreply.triggers", "123"), msg)
+	err = SendMail(jobs.NewWorkerContext("noreply.triggers", "123", msg))
 	if assert.Error(t, err) {
 		assert.Equal(t, "yes", err.Error())
 	}
@@ -432,7 +432,7 @@ func TestSendMailFrom(t *testing.T) {
 			},
 		},
 	})
-	err = SendMail(jobs.NewWorkerContext("from.triggers", "123"), msg)
+	err = SendMail(jobs.NewWorkerContext("from.triggers", "123", msg))
 	if assert.Error(t, err) {
 		assert.Equal(t, "yes", err.Error())
 	}

--- a/pkg/workers/sharings/share_data.go
+++ b/pkg/workers/sharings/share_data.go
@@ -1,7 +1,6 @@
 package sharings
 
 import (
-	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -176,11 +175,11 @@ func (opts *SendOptions) extractRelevantReferences(refs []couchdb.DocReference) 
 }
 
 // SendData sends data to all the recipients
-func SendData(ctx context.Context, m jobs.Message) error {
-	domain := ctx.Value(jobs.ContextDomainKey).(string)
+func SendData(ctx *jobs.WorkerContext) error {
+	domain := ctx.Domain()
 
 	opts := &SendOptions{}
-	err := m.Unmarshal(&opts)
+	err := ctx.UnmarshalMessage(&opts)
 	if err != nil {
 		return err
 	}
@@ -199,16 +198,16 @@ func SendData(ctx context.Context, m jobs.Message) error {
 
 		if dirDoc != nil {
 			opts.Type = consts.DirType
-			ins.Logger().Debugf("[sharings] share_data: Sending directory: %v",
+			ctx.Logger().Debugf("[sharings] share_data: Sending directory: %v",
 				dirDoc)
 			return SendDir(ins, opts, dirDoc)
 		}
 		opts.Type = consts.FileType
-		ins.Logger().Debugf("[sharings] share_data: Sending file: %v", fileDoc)
+		ctx.Logger().Debugf("[sharings] share_data: Sending file: %v", fileDoc)
 		return SendFile(ins, opts, fileDoc)
 	}
 
-	ins.Logger().Debugf("[sharings] share_data: Sending %s: %s", opts.DocType,
+	ctx.Logger().Debugf("[sharings] share_data: Sending %s: %s", opts.DocType,
 		opts.DocID)
 	return SendDoc(ins, opts)
 }

--- a/pkg/workers/sharings/share_data_test.go
+++ b/pkg/workers/sharings/share_data_test.go
@@ -102,7 +102,7 @@ func TestSendDataMissingDocType(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	err = SendData(jobs.NewWorkerContext(domainSharer, "123"), msg)
+	err = SendData(jobs.NewWorkerContext(domainSharer, "123", msg))
 	assert.Error(t, err)
 	assert.Equal(t, "CouchDB(not_found): missing", err.Error())
 }
@@ -127,7 +127,7 @@ func TestSendDataBadID(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	err = SendData(jobs.NewWorkerContext(domainSharer, "123"), msg)
+	err = SendData(jobs.NewWorkerContext(domainSharer, "123", msg))
 	assert.Error(t, err)
 	assert.Equal(t, "CouchDB(not_found): missing", err.Error())
 }
@@ -157,7 +157,7 @@ func TestSendDataBadRecipient(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	err = SendData(jobs.NewWorkerContext(domainSharer, "123"), msg)
+	err = SendData(jobs.NewWorkerContext(domainSharer, "123", msg))
 	assert.NoError(t, err)
 }
 

--- a/pkg/workers/sharings/sharing_updates.go
+++ b/pkg/workers/sharings/sharing_updates.go
@@ -1,7 +1,6 @@
 package sharings
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -49,24 +48,18 @@ type SharingMessage struct {
 }
 
 // SharingUpdates handles shared document updates
-func SharingUpdates(ctx context.Context, m jobs.Message) error {
-	domain := ctx.Value(jobs.ContextDomainKey).(string)
-	e, ok := ctx.Value(jobs.ContextEventKey).(jobs.Event)
-	if !ok {
-		return errors.New("Missing realtime event from context")
-	}
-
+func SharingUpdates(ctx *jobs.WorkerContext) error {
+	domain := ctx.Domain()
 	var event struct {
 		Verb string `json:"verb"`
 		Doc  *couchdb.JSONDoc
 	}
-	if err := e.Unmarshal(&event); err != nil {
+	if err := ctx.UnmarshalEvent(&event); err != nil {
 		return err
 	}
 
 	var msg *sharings.SharingMessage
-	err := m.Unmarshal(&msg)
-	if err != nil {
+	if err := ctx.UnmarshalMessage(&msg); err != nil {
 		return err
 	}
 

--- a/pkg/workers/sharings/sharing_updates_test.go
+++ b/pkg/workers/sharings/sharing_updates_test.go
@@ -106,7 +106,7 @@ func TestSharingUpdatesNoSharing(t *testing.T) {
 	}()
 	msg, event := createEvent(t, doc, "", "CREATED")
 
-	err := SharingUpdates(jobs.NewWorkerContextWithEvent(domainSharer, "123", event), msg)
+	err := SharingUpdates(jobs.NewWorkerContextWithEvent(domainSharer, "123", msg, event))
 	assert.Error(t, err)
 	assert.Equal(t, "Sharing does not exist", err.Error())
 
@@ -125,7 +125,7 @@ func TestSharingUpdatesBadSharing(t *testing.T) {
 
 	msg, event := createEvent(t, doc, "badsharingid", "")
 
-	err := SharingUpdates(jobs.NewWorkerContextWithEvent(domainSharer, "123", event), msg)
+	err := SharingUpdates(jobs.NewWorkerContextWithEvent(domainSharer, "123", msg, event))
 	assert.Error(t, err)
 	assert.Equal(t, ErrSharingDoesNotExist, err)
 
@@ -148,7 +148,7 @@ func TestSharingUpdatesTooManySharing(t *testing.T) {
 
 	msg, event := createEvent(t, doc, sharingID, "UPDATED")
 
-	err := SharingUpdates(jobs.NewWorkerContextWithEvent(domainSharer, "123", event), msg)
+	err := SharingUpdates(jobs.NewWorkerContextWithEvent(domainSharer, "123", msg, event))
 	assert.Error(t, err)
 	assert.Equal(t, ErrSharingIDNotUnique, err)
 }
@@ -167,7 +167,7 @@ func TestSharingUpdatesBadSharingType(t *testing.T) {
 	sharingID := sharingDoc.M["sharing_id"].(string)
 	msg, event := createEvent(t, doc, sharingID, "UPDATED")
 
-	err := SharingUpdates(jobs.NewWorkerContextWithEvent(domainSharer, "123", event), msg)
+	err := SharingUpdates(jobs.NewWorkerContextWithEvent(domainSharer, "123", msg, event))
 	assert.Error(t, err)
 	assert.Equal(t, ErrDocumentNotLegitimate, err)
 }
@@ -195,7 +195,7 @@ func TestSharingUpdatesNoRecipient(t *testing.T) {
 	sharingID := sharingDoc.M["sharing_id"].(string)
 	msg, event := createEvent(t, doc, sharingID, "CREATED")
 
-	err := SharingUpdates(jobs.NewWorkerContextWithEvent(domainSharer, "123", event), msg)
+	err := SharingUpdates(jobs.NewWorkerContextWithEvent(domainSharer, "123", msg, event))
 	assert.NoError(t, err)
 }
 
@@ -222,7 +222,7 @@ func TestSharingUpdatesBadRecipient(t *testing.T) {
 	sharingID := sharingDoc.M["sharing_id"].(string)
 	msg, event := createEvent(t, doc, sharingID, "CREATED")
 
-	err := SharingUpdates(jobs.NewWorkerContextWithEvent(domainSharer, "123", event), msg)
+	err := SharingUpdates(jobs.NewWorkerContextWithEvent(domainSharer, "123", msg, event))
 	assert.NoError(t, err)
 }
 
@@ -271,6 +271,6 @@ func TestRevokedRecipient(t *testing.T) {
 	doc := createDoc(t, testDocType, params)
 	msg, event := createEvent(t, doc, sharingID, "UPDATED")
 
-	err = SharingUpdates(jobs.NewWorkerContextWithEvent(domainSharer, "123", event), msg)
+	err = SharingUpdates(jobs.NewWorkerContextWithEvent(domainSharer, "123", msg, event))
 	assert.NoError(t, err)
 }

--- a/pkg/workers/thumbnail/thumbnail.go
+++ b/pkg/workers/thumbnail/thumbnail.go
@@ -3,7 +3,6 @@ package thumbnail
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os/exec"
@@ -37,17 +36,14 @@ func init() {
 }
 
 // Worker is a worker that creates thumbnails for photos and images.
-func Worker(ctx context.Context, m jobs.Message) error {
-	domain := ctx.Value(jobs.ContextDomainKey).(string)
-	e, ok := ctx.Value(jobs.ContextEventKey).(jobs.Event)
-	if !ok {
-		return errors.New("Missing realtime event from context")
-	}
+func Worker(ctx *jobs.WorkerContext) error {
+	domain := ctx.Domain()
 
 	var img imageEvent
-	if err := e.Unmarshal(&img); err != nil {
+	if err := ctx.UnmarshalEvent(&img); err != nil {
 		return err
 	}
+
 	if img.Verb != "DELETED" && img.Doc.Trashed {
 		return nil
 	}

--- a/pkg/workers/unzip/unzip.go
+++ b/pkg/workers/unzip/unzip.go
@@ -2,7 +2,6 @@ package unzip
 
 import (
 	"archive/zip"
-	"context"
 	"fmt"
 	"io"
 	"path"
@@ -12,7 +11,6 @@ import (
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/pkg/jobs"
-	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/cozy/cozy-stack/pkg/utils"
 	"github.com/cozy/cozy-stack/pkg/vfs"
 )
@@ -32,15 +30,13 @@ func init() {
 }
 
 // Worker is a worker that unzip a file.
-func Worker(ctx context.Context, m jobs.Message) error {
+func Worker(ctx *jobs.WorkerContext) error {
 	msg := &zipMessage{}
-	if err := m.Unmarshal(msg); err != nil {
+	if err := ctx.UnmarshalMessage(msg); err != nil {
 		return err
 	}
-	domain := ctx.Value(jobs.ContextDomainKey).(string)
-	log := logger.WithDomain(domain)
-	log.Infof("[jobs] unzip %s in %s", msg.Zip, msg.Destination)
-	i, err := instance.Get(domain)
+	ctx.Logger().Infof("[jobs] unzip %s in %s", msg.Zip, msg.Destination)
+	i, err := instance.Get(ctx.Domain())
 	if err != nil {
 		return err
 	}

--- a/web/instances/move.go
+++ b/web/instances/move.go
@@ -40,8 +40,8 @@ func exporter(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	context := jobs.NewWorkerContext(instance.Domain, "export")
-	if err = workers.SendMail(context, msg); err != nil {
+	ctx := jobs.NewWorkerContext(instance.Domain, "export", msg)
+	if err = workers.SendMail(ctx); err != nil {
 		return err
 	}
 

--- a/web/jobs/jobs_test.go
+++ b/web/jobs/jobs_test.go
@@ -2,7 +2,6 @@ package jobs
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -383,9 +382,9 @@ func TestMain(m *testing.M) {
 
 	jobs.AddWorker("print", &jobs.WorkerConfig{
 		Concurrency: 4,
-		WorkerFunc: func(ctx context.Context, m jobs.Message) error {
+		WorkerFunc: func(ctx *jobs.WorkerContext) error {
 			var msg string
-			if err := m.Unmarshal(&msg); err != nil {
+			if err := ctx.UnmarshalMessage(&msg); err != nil {
 				return err
 			}
 			_, err := fmt.Println(msg)


### PR DESCRIPTION
This PR tries to simplify workers by introducing a new struct `WorkerContext` inheriting a `context.Context`, containing job data and some helpers.