### PR TITLE
link to source schemes documentation

### DIFF
--- a/docs/cli/cozy-stack_apps_install.md
+++ b/docs/cli/cozy-stack_apps_install.md
@@ -13,6 +13,8 @@ from the given source URL.
 cozy-stack apps install [slug] [sourceurl] [flags]
 ```
 
+[Some schemes](../../docs/apps.md#sources) are allowed as `[sourceurl]`.
+
 ### Examples
 
 ```


### PR DESCRIPTION
As source schemes are documented here https://github.com/cozy/cozy-stack/blob/master/docs/apps.md#sources I found it was a good idea to link both documentation.