### PR TITLE
 Remove konnectors result and add new routes to fetch triggers' jobs 

### DIFF
--- a/client/jobs.go
+++ b/client/jobs.go
@@ -30,6 +30,7 @@ type Job struct {
 	Rev   string `json:"rev"`
 	Attrs struct {
 		Domain    string          `json:"domain"`
+		TriggerID string          `json:"trigger_id"`
 		Message   json.RawMessage `json:"message"`
 		Debounced bool            `json:"debounced"`
 		Event     struct {

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -503,10 +503,14 @@ To use this endpoint, an application needs a permission on the type
 
 Get the jobs launched by the trigger with the specified ID.
 
+Query parameters:
+
+  - `Limit`: to specify the number of jobs to get out
+
 #### Request
 
 ```http
-GET /jobs/triggers/123123/jobs HTTP/1.1
+GET /jobs/triggers/123123/jobs?Limit=1 HTTP/1.1
 Accept: application/vnd.api+json
 ```
 

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -635,7 +635,7 @@ Query parameters:
 #### Request
 
 ```http
-GET /jobs/triggers?Worker=konnector HTTP/1.1
+GET /jobs/triggers/jobs?Worker=konnector HTTP/1.1
 Accept: application/vnd.api+json
 ```
 

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -499,6 +499,34 @@ Accept: application/vnd.api+json
 To use this endpoint, an application needs a permission on the type
 `io.cozy.triggers` for the verb `GET`.
 
+### GET /jobs/triggers/:trigger-id/jobs
+
+Get the jobs launched by the trigger with the specified ID.
+
+#### Request
+
+```http
+GET /jobs/triggers/123123/jobs HTTP/1.1
+Accept: application/vnd.api+json
+```
+
+#### Response
+
+```json
+{
+  "data": [
+    {
+      "type": "io.cozy.jobs",
+      "id": "123123",
+      "attributes": {},
+      "links": {
+        "self": "/jobs/123123"
+      }
+    }
+  ]
+}
+```
+
 ### POST /jobs/triggers/:trigger-id/launch
 
 Launch a trigger manually given its ID and return the created job.
@@ -538,14 +566,34 @@ Accept: application/vnd.api+json
 To use this endpoint, an application needs a permission on the type
 `io.cozy.triggers` for the verb `POST`.
 
-### GET /jobs/triggers
+### DELETE /jobs/triggers/:trigger-id
 
-Get the list of triggers.
+Delete a trigger given its ID.
 
 #### Request
 
 ```http
-GET /jobs/triggers HTTP/1.1
+DELETE /jobs/triggers/123123 HTTP/1.1
+Accept: application/vnd.api+json
+```
+
+#### Permissions
+
+To use this endpoint, an application needs a permission on the type
+`io.cozy.triggers` for the verb `DELETE`.
+
+### GET /jobs/triggers
+
+Get the list of triggers.
+
+Query parameters:
+
+  - `Worker`: to filter only triggers associated with a specific worker.
+
+#### Request
+
+```http
+GET /jobs/triggers?Worker=konnector HTTP/1.1
 Accept: application/vnd.api+json
 ```
 
@@ -569,24 +617,46 @@ Accept: application/vnd.api+json
 #### Permissions
 
 To use this endpoint, an application needs a permission on the type
-`io.cozy.triggers` for the verb `GET`.
+`io.cozy.triggers` for the verb `GET`. When used on a specific worker, the
+permission can be specified on the `worker` field.
 
+### GET /jobs/triggers/jobs
 
-### DELETE /jobs/triggers/:trigger-id
+Get the list of the last job launched by all triggers.
 
-Delete a trigger given its ID.
+Query parameters:
+
+  - `Worker`: to filter only jobs from triggers associated with a specific worker.
 
 #### Request
 
 ```http
-DELETE /jobs/triggers/123123 HTTP/1.1
+GET /jobs/triggers?Worker=konnector HTTP/1.1
 Accept: application/vnd.api+json
+```
+
+#### Response
+
+```json
+{
+  "data": [
+    {
+      "type": "io.cozy.jobs",
+      "id": "123123",
+      "attributes": {},
+      "links": {
+        "self": "/jobs/123123"
+      }
+    }
+  ]
+}
 ```
 
 #### Permissions
 
 To use this endpoint, an application needs a permission on the type
-`io.cozy.triggers` for the verb `DELETE`.
+`io.cozy.triggers` for the verb `GET`. When used on a specific worker, the
+permission can be specified on the `worker` field.
 
 #### Status codes
 

--- a/pkg/consts/views.go
+++ b/pkg/consts/views.go
@@ -176,11 +176,12 @@ var TriggerLastJob = &couchdb.View{
 function(doc) {
   if (doc.trigger_id) {
     var state = doc.state;
-    if (state == "done" || state == "errored")) {
-      emit([doc.worker, doc.trigger_id], state)
+    if (state == "done" || state == "errored") {
+      emit([doc.worker, doc.trigger_id], state);
     }
   }
-}`,
+}
+`,
 }
 
 // Views is the list of all views that are created by the stack.

--- a/pkg/couchdb/couchdb.go
+++ b/pkg/couchdb/couchdb.go
@@ -897,10 +897,10 @@ type ViewRequest struct {
 
 // ViewResponseRow is a row in a ViewResponse
 type ViewResponseRow struct {
-	ID    string           `json:"id"`
-	Key   interface{}      `json:"key"`
-	Value interface{}      `json:"value"`
-	Doc   *json.RawMessage `json:"doc"`
+	ID    string          `json:"id"`
+	Key   interface{}     `json:"key"`
+	Value interface{}     `json:"value"`
+	Doc   json.RawMessage `json:"doc"`
 }
 
 // ViewResponse is the response we receive when executing a view

--- a/pkg/couchdb/mango/query.go
+++ b/pkg/couchdb/mango/query.go
@@ -184,7 +184,7 @@ type SortBy struct {
 // MarshalJSON implements json.Marshaller on SortBy
 // it will returns a json array [field, direction]
 func (s SortBy) MarshalJSON() ([]byte, error) {
-	asSlice := []string{s.Field, string(s.Direction)}
+	asSlice := []Map{makeMap(s.Field, string(s.Direction))}
 	return json.Marshal(asSlice)
 }
 

--- a/pkg/couchdb/mango/query_test.go
+++ b/pkg/couchdb/mango/query_test.go
@@ -39,6 +39,6 @@ func TestSortMarshaling(t *testing.T) {
 	s1 := &SortBy{"dir_id", Asc}
 	j1, err := json.Marshal(s1)
 	if assert.NoError(t, err) {
-		assert.Equal(t, j1, []byte(`["dir_id","asc"]`))
+		assert.Equal(t, j1, []byte(`[{"dir_id":"asc"}]`))
 	}
 }

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -63,6 +63,7 @@ type (
 		JobRev     string      `json:"_rev,omitempty"`
 		Domain     string      `json:"domain"`
 		WorkerType string      `json:"worker"`
+		TriggerID  string      `json:"trigger_id"`
 		Message    Message     `json:"message"`
 		Event      Event       `json:"event"`
 		Debounced  bool        `json:"debounced"`
@@ -77,6 +78,7 @@ type (
 	JobRequest struct {
 		Domain     string
 		WorkerType string
+		TriggerID  string
 		Message    Message
 		Event      Event
 		Debounced  bool
@@ -232,6 +234,7 @@ func NewJob(req *JobRequest) *Job {
 	return &Job{
 		Domain:     req.Domain,
 		WorkerType: req.WorkerType,
+		TriggerID:  req.TriggerID,
 		Message:    req.Message,
 		Debounced:  req.Debounced,
 		Event:      req.Event,
@@ -270,7 +273,10 @@ func GetQueuedJobs(domain, workerType string) ([]*Job, error) {
 		Limit: 200,
 	}
 	err := couchdb.FindDocs(db, consts.Jobs, req, &results)
-	return results, err
+	if err != nil {
+		return nil, err
+	}
+	return results, nil
 }
 
 // NewMessage returns a json encoded data

--- a/pkg/permissions/permissions.go
+++ b/pkg/permissions/permissions.go
@@ -216,7 +216,7 @@ func GetForShareCode(db couchdb.Database, tokenCode string) (*Permission, error)
 	}
 
 	var pdoc Permission
-	err = json.Unmarshal(*res.Rows[0].Doc, &pdoc)
+	err = json.Unmarshal(res.Rows[0].Doc, &pdoc)
 	if err != nil {
 		return nil, err
 	}
@@ -423,7 +423,7 @@ func GetPermissionsByType(db couchdb.Database, doctype string, cursor couchdb.Cu
 	result := make([]*Permission, len(res.Rows))
 	for i, row := range res.Rows {
 		var pdoc Permission
-		err := json.Unmarshal(*row.Doc, &pdoc)
+		err := json.Unmarshal(row.Doc, &pdoc)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/scheduler/mem_scheduler.go
+++ b/pkg/scheduler/mem_scheduler.go
@@ -153,7 +153,7 @@ func (s *MemScheduler) GetAll(domain string) ([]Trigger, error) {
 }
 
 func (s *MemScheduler) schedule(t Trigger) {
-	s.log.Infof("[scheduler] trigger %s(%s): Starting trigger",
+	s.log.Debugf("[scheduler] trigger %s(%s): Starting trigger",
 		t.Type(), t.Infos().TID)
 	ch := t.Schedule()
 	var debounced <-chan time.Time

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -134,14 +134,17 @@ func (t *TriggerInfos) Valid(key, value string) bool {
 }
 
 // GetJobs returns the jobs launched by the given trigger.
-func GetJobs(t Trigger) ([]*jobs.Job, error) {
+func GetJobs(t Trigger, limit int) ([]*jobs.Job, error) {
 	triggerInfos := t.Infos()
 	db := couchdb.SimpleDatabasePrefix(triggerInfos.Domain)
 	var jobs []*jobs.Job
+	if limit <= 0 || limit > 50 {
+		limit = 50
+	}
 	req := &couchdb.FindRequest{
 		UseIndex: "by-trigger-id",
 		Selector: mango.Equal("trigger_id", triggerInfos.ID()),
-		Limit:    50,
+		Limit:    limit,
 	}
 	err := couchdb.FindDocs(db, consts.Jobs, req, &jobs)
 	if err != nil {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -150,7 +150,7 @@ func GetJobs(t Trigger) ([]*jobs.Job, error) {
 	return jobs, nil
 }
 
-// GetLastJob returns the last
+// GetLastJob returns the last completed job lauched by the given trigger.
 func GetLastJob(t Trigger) (*jobs.Job, error) {
 	triggerInfos := t.Infos()
 	db := couchdb.SimpleDatabasePrefix(triggerInfos.Domain)
@@ -178,7 +178,8 @@ func GetLastJob(t Trigger) (*jobs.Job, error) {
 	return j, nil
 }
 
-// GetLastJobs get the last job for all workers with the given worker type.
+// GetLastJobs get the last completed job for all workers with the given worker
+// type.
 func GetLastJobs(domain, workerType string) ([]*jobs.Job, error) {
 	db := couchdb.SimpleDatabasePrefix(domain)
 	req := &couchdb.ViewRequest{

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -2,9 +2,11 @@ package scheduler
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
 	"github.com/cozy/cozy-stack/pkg/jobs"
 	"github.com/cozy/cozy-stack/pkg/permissions"
 	"github.com/cozy/cozy-stack/pkg/realtime"
@@ -98,6 +100,7 @@ func (t *TriggerInfos) JobRequest() *jobs.JobRequest {
 	return &jobs.JobRequest{
 		Domain:     t.Domain,
 		WorkerType: t.WorkerType,
+		TriggerID:  t.ID(),
 		Message:    t.Message,
 		Options:    t.Options,
 	}
@@ -106,11 +109,11 @@ func (t *TriggerInfos) JobRequest() *jobs.JobRequest {
 // JobRequestWithEvent returns a job request associated with the scheduler
 // informations associated to the specified realtime event.
 func (t *TriggerInfos) JobRequestWithEvent(event *realtime.Event) (*jobs.JobRequest, error) {
-	req := t.JobRequest()
 	evt, err := jobs.NewEvent(event)
 	if err != nil {
 		return nil, err
 	}
+	req := t.JobRequest()
 	req.Event = evt
 	return req, nil
 }
@@ -120,5 +123,86 @@ func (t *TriggerInfos) SetID(id string) { t.TID = id }
 
 // SetRev implements the couchdb.Doc interface
 func (t *TriggerInfos) SetRev(rev string) { t.TRev = rev }
+
+// Valid implements the permissions.Validable interface
+func (t *TriggerInfos) Valid(key, value string) bool {
+	switch key {
+	case "worker":
+		return t.WorkerType == value
+	}
+	return false
+}
+
+// GetJobs returns the jobs launched by the given trigger.
+func GetJobs(t Trigger) ([]*jobs.Job, error) {
+	triggerInfos := t.Infos()
+	db := couchdb.SimpleDatabasePrefix(triggerInfos.Domain)
+	var jobs []*jobs.Job
+	req := &couchdb.FindRequest{
+		UseIndex: "by-trigger-id",
+		Selector: mango.Equal("trigger_id", triggerInfos.ID()),
+		Limit:    50,
+	}
+	err := couchdb.FindDocs(db, consts.Jobs, req, &jobs)
+	if err != nil {
+		return nil, err
+	}
+	return jobs, nil
+}
+
+// GetLastJob returns the last
+func GetLastJob(t Trigger) (*jobs.Job, error) {
+	triggerInfos := t.Infos()
+	db := couchdb.SimpleDatabasePrefix(triggerInfos.Domain)
+	req := &couchdb.ViewRequest{
+		Key:         []string{triggerInfos.Type, triggerInfos.ID()},
+		IncludeDocs: true,
+		Reduce:      false,
+		Limit:       1,
+	}
+	res := &couchdb.ViewResponse{}
+	err := couchdb.ExecView(db, consts.TriggerLastJob, req, res)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(res.Rows) != 1 {
+		return nil, ErrNotFoundTrigger
+	}
+
+	var j *jobs.Job
+	if err := json.Unmarshal(res.Rows[0].Doc, &j); err != nil {
+		return nil, err
+	}
+
+	return j, nil
+}
+
+// GetLastJobs get the last job for all workers with the given worker type.
+func GetLastJobs(domain, workerType string) ([]*jobs.Job, error) {
+	db := couchdb.SimpleDatabasePrefix(domain)
+	req := &couchdb.ViewRequest{
+		StartKey:    []string{workerType},
+		EndKey:      []string{workerType, couchdb.MaxString},
+		IncludeDocs: true,
+		Reduce:      false,
+	}
+	res := &couchdb.ViewResponse{}
+	err := couchdb.ExecView(db, consts.TriggerLastJob, req, res)
+	if err != nil {
+		return nil, err
+	}
+
+	js := make([]*jobs.Job, len(res.Rows))
+	for i, v := range res.Rows {
+		var j *jobs.Job
+		if err := json.Unmarshal(v.Doc, &j); err != nil {
+			return nil, err
+		}
+		js[i] = j
+	}
+
+	return js, nil
+}
 
 var _ couchdb.Doc = &TriggerInfos{}

--- a/pkg/sharings/recipients.go
+++ b/pkg/sharings/recipients.go
@@ -117,11 +117,11 @@ func CreateOrUpdateRecipient(db couchdb.Database, doc *Recipient) error {
 		}, &res)
 		if err == nil && len(res.Rows) > 0 {
 			if len(doc.Cozy) == 0 {
-				return json.Unmarshal(*res.Rows[0].Doc, &doc)
+				return json.Unmarshal(res.Rows[0].Doc, &doc)
 			}
 			cozy := doc.Cozy[0]
 			doc.Cozy = nil
-			if err = json.Unmarshal(*res.Rows[0].Doc, &doc); err != nil {
+			if err = json.Unmarshal(res.Rows[0].Doc, &doc); err != nil {
 				return err
 			}
 			for _, c := range doc.Cozy {
@@ -142,11 +142,11 @@ func CreateOrUpdateRecipient(db couchdb.Database, doc *Recipient) error {
 		}, &res)
 		if err == nil && len(res.Rows) > 0 {
 			if len(doc.Email) == 0 {
-				return json.Unmarshal(*res.Rows[0].Doc, &doc)
+				return json.Unmarshal(res.Rows[0].Doc, &doc)
 			}
 			email := doc.Email[0]
 			doc.Email = nil
-			if err = json.Unmarshal(*res.Rows[0].Doc, &doc); err != nil {
+			if err = json.Unmarshal(res.Rows[0].Doc, &doc); err != nil {
 				return err
 			}
 			for _, e := range doc.Email {

--- a/pkg/vfs/couchdb_indexer.go
+++ b/pkg/vfs/couchdb_indexer.go
@@ -251,7 +251,7 @@ func (c *couchdbIndexer) FileByPath(name string) (*FileDoc, error) {
 	}
 
 	var fdoc FileDoc
-	err = json.Unmarshal(*res.Rows[0].Doc, &fdoc)
+	err = json.Unmarshal(res.Rows[0].Doc, &fdoc)
 	return &fdoc, err
 }
 
@@ -321,7 +321,7 @@ func (c *couchdbIndexer) DirBatch(doc *DirDoc, cursor couchdb.Cursor) ([]DirOrFi
 	docs := make([]DirOrFileDoc, len(res.Rows))
 	for i, row := range res.Rows {
 		var doc DirOrFileDoc
-		err := json.Unmarshal(*row.Doc, &doc)
+		err := json.Unmarshal(row.Doc, &doc)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/workers/exec/konnector_test.go
+++ b/pkg/workers/exec/konnector_test.go
@@ -31,7 +31,7 @@ func TestUnknownDomain(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	j := jobs.NewJob(&jobs.JobRequest{
-		Domain:     "",
+		Domain:     "instance.does.not.exist",
 		Message:    msg,
 		WorkerType: "konnector",
 	})

--- a/pkg/workers/exec/konnector_test.go
+++ b/pkg/workers/exec/konnector_test.go
@@ -30,7 +30,12 @@ func TestUnknownDomain(t *testing.T) {
 		"konnector": "unknownapp",
 	})
 	assert.NoError(t, err)
-	ctx := jobs.NewWorkerContext("unknown", "id", msg).WithCookie(&konnectorWorker{})
+	j := jobs.NewJob(&jobs.JobRequest{
+		Domain:     "",
+		Message:    msg,
+		WorkerType: "konnector",
+	})
+	ctx := jobs.NewWorkerContext("id", j).WithCookie(&konnectorWorker{})
 	err = konnectorWorkerFunc(ctx)
 	assert.Error(t, err)
 	assert.Equal(t, "Instance not found", err.Error())
@@ -41,7 +46,12 @@ func TestUnknownApp(t *testing.T) {
 		"konnector": "unknownapp",
 	})
 	assert.NoError(t, err)
-	ctx := jobs.NewWorkerContext(inst.Domain, "id", msg).WithCookie(&konnectorWorker{})
+	j := jobs.NewJob(&jobs.JobRequest{
+		Domain:     inst.Domain,
+		Message:    msg,
+		WorkerType: "konnector",
+	})
+	ctx := jobs.NewWorkerContext("id", j).WithCookie(&konnectorWorker{})
 	err = konnectorWorkerFunc(ctx)
 	assert.Error(t, err)
 	assert.Equal(t, "Application is not installed", err.Error())
@@ -74,8 +84,14 @@ func TestBadFileExec(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
+	j := jobs.NewJob(&jobs.JobRequest{
+		Domain:     inst.Domain,
+		Message:    msg,
+		WorkerType: "konnector",
+	})
+
 	config.GetConfig().Konnectors.Cmd = ""
-	ctx := jobs.NewWorkerContext(inst.Domain, "id", msg).WithCookie(&konnectorWorker{})
+	ctx := jobs.NewWorkerContext("id", j).WithCookie(&konnectorWorker{})
 	err = konnectorWorkerFunc(ctx)
 	assert.Error(t, err)
 	assert.Equal(t, "fork/exec : no such file or directory", err.Error())
@@ -173,8 +189,14 @@ echo "{\"type\": \"manifest\", \"message\": \"$(ls ${1}/manifest.konnector)\" }"
 	})
 	assert.NoError(t, err)
 
+	j := jobs.NewJob(&jobs.JobRequest{
+		Domain:     inst.Domain,
+		Message:    msg,
+		WorkerType: "konnector",
+	})
+
 	config.GetConfig().Konnectors.Cmd = tmpScript.Name()
-	ctx := jobs.NewWorkerContext(inst.Domain, "id", msg).WithCookie(&konnectorWorker{})
+	ctx := jobs.NewWorkerContext("id", j).WithCookie(&konnectorWorker{})
 	err = konnectorWorkerFunc(ctx)
 	assert.NoError(t, err)
 

--- a/pkg/workers/mails/mail_test.go
+++ b/pkg/workers/mails/mail_test.go
@@ -391,7 +391,12 @@ func TestSendMailNoReply(t *testing.T) {
 			},
 		},
 	})
-	err = SendMail(jobs.NewWorkerContext("noreply.triggers", "123", msg))
+	j := jobs.NewJob(&jobs.JobRequest{
+		Domain:     "noreply.triggers",
+		Message:    msg,
+		WorkerType: "sendmail",
+	})
+	err = SendMail(jobs.NewWorkerContext("123", j))
 	if assert.Error(t, err) {
 		assert.Equal(t, "yes", err.Error())
 	}
@@ -432,7 +437,12 @@ func TestSendMailFrom(t *testing.T) {
 			},
 		},
 	})
-	err = SendMail(jobs.NewWorkerContext("from.triggers", "123", msg))
+	j := jobs.NewJob(&jobs.JobRequest{
+		Domain:     "from.triggers",
+		Message:    msg,
+		WorkerType: "sendmail",
+	})
+	err = SendMail(jobs.NewWorkerContext("123", j))
 	if assert.Error(t, err) {
 		assert.Equal(t, "yes", err.Error())
 	}

--- a/pkg/workers/sharings/share_data_test.go
+++ b/pkg/workers/sharings/share_data_test.go
@@ -102,7 +102,13 @@ func TestSendDataMissingDocType(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	err = SendData(jobs.NewWorkerContext(domainSharer, "123", msg))
+	j := jobs.NewJob(&jobs.JobRequest{
+		Domain:     domainSharer,
+		Message:    msg,
+		WorkerType: "sharedata",
+	})
+
+	err = SendData(jobs.NewWorkerContext("123", j))
 	assert.Error(t, err)
 	assert.Equal(t, "CouchDB(not_found): missing", err.Error())
 }
@@ -127,7 +133,13 @@ func TestSendDataBadID(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	err = SendData(jobs.NewWorkerContext(domainSharer, "123", msg))
+	j := jobs.NewJob(&jobs.JobRequest{
+		Domain:     domainSharer,
+		Message:    msg,
+		WorkerType: "sharedata",
+	})
+
+	err = SendData(jobs.NewWorkerContext("123", j))
 	assert.Error(t, err)
 	assert.Equal(t, "CouchDB(not_found): missing", err.Error())
 }
@@ -157,7 +169,13 @@ func TestSendDataBadRecipient(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	err = SendData(jobs.NewWorkerContext(domainSharer, "123", msg))
+	j := jobs.NewJob(&jobs.JobRequest{
+		Domain:     domainSharer,
+		Message:    msg,
+		WorkerType: "sharedata",
+	})
+
+	err = SendData(jobs.NewWorkerContext("123", j))
 	assert.NoError(t, err)
 }
 

--- a/pkg/workers/sharings/sharing_updates_test.go
+++ b/pkg/workers/sharings/sharing_updates_test.go
@@ -106,7 +106,13 @@ func TestSharingUpdatesNoSharing(t *testing.T) {
 	}()
 	msg, event := createEvent(t, doc, "", "CREATED")
 
-	err := SharingUpdates(jobs.NewWorkerContextWithEvent(domainSharer, "123", msg, event))
+	j := jobs.NewJob(&jobs.JobRequest{
+		Domain:     domainSharer,
+		Message:    msg,
+		WorkerType: "sharingupdates",
+	})
+
+	err := SharingUpdates(jobs.NewWorkerContextWithEvent("123", j, event))
 	assert.Error(t, err)
 	assert.Equal(t, "Sharing does not exist", err.Error())
 
@@ -125,7 +131,13 @@ func TestSharingUpdatesBadSharing(t *testing.T) {
 
 	msg, event := createEvent(t, doc, "badsharingid", "")
 
-	err := SharingUpdates(jobs.NewWorkerContextWithEvent(domainSharer, "123", msg, event))
+	j := jobs.NewJob(&jobs.JobRequest{
+		Domain:     domainSharer,
+		Message:    msg,
+		WorkerType: "sharingupdates",
+	})
+
+	err := SharingUpdates(jobs.NewWorkerContextWithEvent("123", j, event))
 	assert.Error(t, err)
 	assert.Equal(t, ErrSharingDoesNotExist, err)
 
@@ -148,7 +160,13 @@ func TestSharingUpdatesTooManySharing(t *testing.T) {
 
 	msg, event := createEvent(t, doc, sharingID, "UPDATED")
 
-	err := SharingUpdates(jobs.NewWorkerContextWithEvent(domainSharer, "123", msg, event))
+	j := jobs.NewJob(&jobs.JobRequest{
+		Domain:     domainSharer,
+		Message:    msg,
+		WorkerType: "sharingupdates",
+	})
+
+	err := SharingUpdates(jobs.NewWorkerContextWithEvent("123", j, event))
 	assert.Error(t, err)
 	assert.Equal(t, ErrSharingIDNotUnique, err)
 }
@@ -167,7 +185,13 @@ func TestSharingUpdatesBadSharingType(t *testing.T) {
 	sharingID := sharingDoc.M["sharing_id"].(string)
 	msg, event := createEvent(t, doc, sharingID, "UPDATED")
 
-	err := SharingUpdates(jobs.NewWorkerContextWithEvent(domainSharer, "123", msg, event))
+	j := jobs.NewJob(&jobs.JobRequest{
+		Domain:     domainSharer,
+		Message:    msg,
+		WorkerType: "sharingupdates",
+	})
+
+	err := SharingUpdates(jobs.NewWorkerContextWithEvent("123", j, event))
 	assert.Error(t, err)
 	assert.Equal(t, ErrDocumentNotLegitimate, err)
 }
@@ -195,7 +219,13 @@ func TestSharingUpdatesNoRecipient(t *testing.T) {
 	sharingID := sharingDoc.M["sharing_id"].(string)
 	msg, event := createEvent(t, doc, sharingID, "CREATED")
 
-	err := SharingUpdates(jobs.NewWorkerContextWithEvent(domainSharer, "123", msg, event))
+	j := jobs.NewJob(&jobs.JobRequest{
+		Domain:     domainSharer,
+		Message:    msg,
+		WorkerType: "sharingupdates",
+	})
+
+	err := SharingUpdates(jobs.NewWorkerContextWithEvent("123", j, event))
 	assert.NoError(t, err)
 }
 
@@ -222,7 +252,13 @@ func TestSharingUpdatesBadRecipient(t *testing.T) {
 	sharingID := sharingDoc.M["sharing_id"].(string)
 	msg, event := createEvent(t, doc, sharingID, "CREATED")
 
-	err := SharingUpdates(jobs.NewWorkerContextWithEvent(domainSharer, "123", msg, event))
+	j := jobs.NewJob(&jobs.JobRequest{
+		Domain:     domainSharer,
+		Message:    msg,
+		WorkerType: "sharingupdates",
+	})
+
+	err := SharingUpdates(jobs.NewWorkerContextWithEvent("123", j, event))
 	assert.NoError(t, err)
 }
 
@@ -271,6 +307,12 @@ func TestRevokedRecipient(t *testing.T) {
 	doc := createDoc(t, testDocType, params)
 	msg, event := createEvent(t, doc, sharingID, "UPDATED")
 
-	err = SharingUpdates(jobs.NewWorkerContextWithEvent(domainSharer, "123", msg, event))
+	j := jobs.NewJob(&jobs.JobRequest{
+		Domain:     domainSharer,
+		Message:    msg,
+		WorkerType: "sharingupdates",
+	})
+
+	err = SharingUpdates(jobs.NewWorkerContextWithEvent("123", j, event))
 	assert.NoError(t, err)
 }

--- a/web/data/permissions.go
+++ b/web/data/permissions.go
@@ -26,13 +26,12 @@ var blackList = map[string]bool{
 	consts.Jobs:     readable,
 	consts.Triggers: readable,
 
-	consts.Apps:             readable,
-	consts.Konnectors:       readable,
-	consts.KonnectorResults: readable,
-	consts.Files:            readable,
-	consts.Notifications:    readable,
-	consts.RemoteRequests:   readable,
-	consts.SessionsLogins:   readable,
+	consts.Apps:           readable,
+	consts.Konnectors:     readable,
+	consts.Files:          readable,
+	consts.Notifications:  readable,
+	consts.RemoteRequests: readable,
+	consts.SessionsLogins: readable,
 }
 
 // CheckReadable will abort the context and returns false if the doctype

--- a/web/files/references.go
+++ b/web/files/references.go
@@ -123,7 +123,7 @@ func ListReferencesHandler(c echo.Context) error {
 		}
 
 		if includeDocs {
-			docs[i], err = rawMessageToObject(instance, *row.Doc)
+			docs[i], err = rawMessageToObject(instance, row.Doc)
 			if err != nil {
 				return err
 			}

--- a/web/instances/move.go
+++ b/web/instances/move.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/cozy/cozy-stack/pkg/globals"
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/pkg/jobs"
 	"github.com/cozy/cozy-stack/pkg/move"
@@ -40,8 +41,14 @@ func exporter(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	ctx := jobs.NewWorkerContext(instance.Domain, "export", msg)
-	if err = workers.SendMail(ctx); err != nil {
+
+	broker := globals.GetBroker()
+	_, err = broker.PushJob(&jobs.JobRequest{
+		Domain:     instance.Domain,
+		WorkerType: "sendmail",
+		Message:    msg,
+	})
+	if err != nil {
 		return err
 	}
 

--- a/web/jobs/jobs.go
+++ b/web/jobs/jobs.go
@@ -279,11 +279,10 @@ func getAllTriggers(c echo.Context) error {
 	instance := middlewares.GetInstance(c)
 	workerType := c.QueryParam("Worker")
 
-	if workerType == "" {
-		if err := permissions.AllowWholeType(c, permissions.GET, consts.Triggers); err != nil {
+	if err := permissions.AllowWholeType(c, permissions.GET, consts.Triggers); err != nil {
+		if workerType == "" {
 			return err
 		}
-	} else {
 		o := &scheduler.TriggerInfos{WorkerType: workerType}
 		if err := permissions.AllowOnFields(c, permissions.GET, o, "worker"); err != nil {
 			return err
@@ -310,11 +309,10 @@ func getTriggersLastJob(c echo.Context) error {
 	instance := middlewares.GetInstance(c)
 	workerType := c.QueryParam("Worker")
 
-	if workerType == "" {
-		if err := permissions.AllowWholeType(c, permissions.GET, consts.Triggers); err != nil {
+	if err := permissions.AllowWholeType(c, permissions.GET, consts.Triggers); err != nil {
+		if workerType == "" {
 			return err
 		}
-	} else {
 		o := &scheduler.TriggerInfos{WorkerType: workerType}
 		if err := permissions.AllowOnFields(c, permissions.GET, o, "worker"); err != nil {
 			return err

--- a/web/jobs/jobs.go
+++ b/web/jobs/jobs.go
@@ -348,7 +348,7 @@ func getJob(c echo.Context) error {
 
 func cleanJobs(c echo.Context) error {
 	instance := middlewares.GetInstance(c)
-	if err := permissions.AllowWholeType(c, permissions.GET, consts.Jobs); err != nil {
+	if err := permissions.AllowWholeType(c, permissions.POST, consts.Jobs); err != nil {
 		return err
 	}
 	var ups []*jobs.Job

--- a/web/jobs/jobs.go
+++ b/web/jobs/jobs.go
@@ -358,11 +358,10 @@ func cleanJobs(c echo.Context) error {
 		if err := json.Unmarshal(data, &job); err != nil {
 			return err
 		}
-		if job.State != jobs.Running {
-			return nil
-		}
-		if job.StartedAt.Add(1 * time.Hour).Before(now) {
-			ups = append(ups, job)
+		if job.State == jobs.Running || job.State == jobs.Queued {
+			if job.StartedAt.Add(1 * time.Hour).Before(now) {
+				ups = append(ups, job)
+			}
 		}
 		return nil
 	})


### PR DESCRIPTION
This PR get rids of `io.cozy.konnectors.results` and only rely on `io.cozy.jobs`. The `io.cozy.jobs` now contain the `trigger_id` field when launched from a trigger, which allows to fetch the jobs associated with a specific trigger.

New routes:

  - `/triggers/jobs?Worker=???`: fetch all the last jobs (from a specific worker)
  - `/triggers/:trigger-id/jobs`: fetch all completed the jobs launched by a trigger
  - ~~`/triggers/:trigger-id/jobs/last`: fetch the last completed job launched by a trigger~~

/cc @CPatchane 

~~⚠️ This is not a retro-compatible change~~