### PR TITLE
Add two factor authentication

### DIFF
--- a/assets/locales/en.po
+++ b/assets/locales/en.po
@@ -57,6 +57,18 @@ msgstr "Hello! Once you've confirmed your password, you'll access the permission
 msgid "Login Connect from oauth title"
 msgstr "Confirm your password"
 
+msgid "Login Two factor error"
+msgstr "The passcode you entered is incorrect, please try again."
+
+msgid "Login Two factor field"
+msgstr "Passcode"
+
+msgid "Login Two factor help"
+msgstr "Enter the passcode sent to you to access your Cozy"
+
+msgid "Mail Two factor subject"
+msgstr "Verify your connection to Cozy"
+
 msgid "Login Connect from oauth help"
 msgstr "Hello! Once you've confirmed your password, you'll access the permission board where you can allow the application to access your data or not. It's up to you !"
 

--- a/assets/scripts/submit.js
+++ b/assets/scripts/submit.js
@@ -10,23 +10,36 @@
   const passphraseInput = document.getElementById('password')
   const redirectInput = document.getElementById('redirect')
   const submitButton = document.getElementById('login-submit')
+  const twoFactorPasscodeInput = document.getElementById('two-factor-passcode')
+  const twoFactorTokenInput = document.getElementById('two-factor-token')
+  const twoFactorForm = document.getElementById("two-factor-form")
+  const passwordForm = document.getElementById("password-form")
 
   let errorPanel = loginForm && loginForm.querySelector('.errors')
 
   const showError = function (error) {
-    error = error || 'The Cozy server is unavailable. Do you have network?'
+    if (error) {
+      error = '' + error
+    } else {
+      error = 'The Cozy server is unavailable. Do you have network?'
+    }
 
     if (!errorPanel) {
       errorPanel = document.createElement('div')
       errorPanel.classList.add('errors')
+      errorPanel.appendChild(document.createElement('p'))
       loginForm.appendChild(errorPanel)
     }
 
-    errorPanel.innerHTML = '<p>' + error + '</p>'
+    if (!errorPanel.firstChild) {
+      errorPanel.appendChild(document.createElement('p'))
+    }
+
+    errorPanel.firstChild.textContent = error;
     submitButton.removeAttribute('disabled')
   }
 
-  loginForm && loginForm.addEventListener('submit', (event) => {
+  const onSubmitPassphrase = function(event) {
     event.preventDefault()
     submitButton.setAttribute('disabled', true)
 
@@ -44,6 +57,10 @@
       const loginSuccess = response.status < 400
       response.json().then((body) => {
         if (loginSuccess) {
+          if (body.two_factor_token) {
+            renderTwoFactorForm(body.two_factor_token)
+            return
+          }
           submitButton.innerHTML = '<svg width="16" height="16"><use xlink:href="#fa-check"/></svg>'
           submitButton.classList.add('btn-success')
           if (body.redirect) {
@@ -57,7 +74,57 @@
         }
       }).catch(showError)
     }).catch(showError)
-  })
+  }
+
+  const onSubmitTwoFactorCode = function(event) {
+    event.preventDefault()
+    submitButton.setAttribute('disabled', true)
+
+    const passcode = twoFactorPasscodeInput.value
+    const token = twoFactorTokenInput.value
+    const redirect = redirectInput.value + window.location.hash
+    let headers = new Headers()
+    headers.append('Content-Type', 'application/x-www-form-urlencoded')
+    headers.append('Accept', 'application/json')
+    const reqBody = encodeURIComponent('two-factor-passcode') + '=' + encodeURIComponent(passcode) +
+      '&' + encodeURIComponent('two-factor-token') + '=' + encodeURIComponent(token) +
+      '&' + encodeURIComponent('redirect') + '=' + encodeURIComponent(redirect);
+    fetch('/auth/login', {
+      method: 'POST',
+      headers: headers,
+      body: reqBody,
+      credentials: 'same-origin'
+    }).then((response) => {
+      const loginSuccess = response.status < 400
+      response.json().then((body) => {
+        if (loginSuccess) {
+          submitButton.innerHTML = '<svg width="16" height="16"><use xlink:href="#fa-check"/></svg>'
+          submitButton.classList.add('btn-success')
+          if (body.redirect) {
+            window.location = body.redirect
+          } else {
+            form.submit()
+          }
+        } else {
+          showError(body.error)
+          twoFactorPasscodeInput.select()
+        }
+      }).catch(showError)
+    }).catch(showError)
+  }
+
+  function renderTwoFactorForm(twoFactorToken) {
+    twoFactorForm.classList.remove('display-none')
+    passwordForm.classList.add('display-none')
+    submitButton.removeAttribute('disabled')
+    twoFactorTokenInput.value = twoFactorToken
+    twoFactorPasscodeInput.value = ''
+    twoFactorPasscodeInput.focus()
+    loginForm.removeEventListener('submit', onSubmitPassphrase)
+    loginForm.addEventListener('submit', onSubmitTwoFactorCode)
+  }
+
+  loginForm && loginForm.addEventListener('submit', onSubmitPassphrase)
 
   resetForm && resetForm.addEventListener('submit', (event) => {
     event.preventDefault()

--- a/assets/scripts/submit.js
+++ b/assets/scripts/submit.js
@@ -12,7 +12,7 @@
   const submitButton = document.getElementById('login-submit')
   const twoFactorPasscodeInput = document.getElementById('two-factor-passcode')
   const twoFactorTokenInput = document.getElementById('two-factor-token')
-  const twoFactorForm = document.getElementById("two-factor-form")
+  const twoFactorForm = document.getElementById('two-factor-form')
   const passwordForm = document.getElementById("password-form")
 
   let errorPanel = loginForm && loginForm.querySelector('.errors')
@@ -27,7 +27,6 @@
     if (!errorPanel) {
       errorPanel = document.createElement('div')
       errorPanel.classList.add('errors')
-      errorPanel.appendChild(document.createElement('p'))
       loginForm.appendChild(errorPanel)
     }
 

--- a/assets/styles/login.css
+++ b/assets/styles/login.css
@@ -210,6 +210,9 @@ label {
     display: none;
     color: #ff3713
 }
+.display-none {
+    display: none !important;
+}
 input[type=number],
 input[type=password],
 input[type=text],

--- a/assets/templates/login.html
+++ b/assets/templates/login.html
@@ -38,14 +38,21 @@
               <div role="region">
                   <input id="redirect" type="hidden" name="redirect" value="{{.Redirect}}" />
                   <p class="help" id="login-password-tip">{{.Help}}</p>
-                  <p class="line">
+                    {{if not .TwoFactorForm}}
+                    <p id="password-form" class="line">
                     <label for="password" aria-describedby="login-password-tip">{{t "Login Password field"}}</label>
                     <button id="password-visibility-button" class="icon password-visibility-icon masked"
                         type="button"
                         title="{{t "Login Password show"}}"
                         name="password-visibility"></button>
                     <input id="password" name="passphrase" placeholder="{{t "Login Password field"}}" type="password" autofocus="true" autocomplete="current-password" />
-                  </p>
+                    </p>
+                    {{end}}
+                    <p id="two-factor-form" class="line{{if not .TwoFactorForm}} display-none{{end}}">
+                    <label for="two-factor-passcode" aria-describedby="login-two-factor-passcode-tip">{{t "Login Two factor field"}}</label>
+                    <input id="two-factor-token" type="hidden" name="two-factor-token" value="{{.TwoFactorToken}}" />
+                    <input id="two-factor-passcode" name="two-factor-passcode" placeholder="{{t "Login Two factor field"}}" type="text" autofocus="true" autocomplete="current-password" />
+                    </p>
                   {{if .CredentialsError}}
                   <div class="errors">
                     <p>{{.CredentialsError}}</p>

--- a/assets/templates/login.html
+++ b/assets/templates/login.html
@@ -37,22 +37,23 @@
               </header>
               <div role="region">
                   <input id="redirect" type="hidden" name="redirect" value="{{.Redirect}}" />
-                  <p class="help" id="login-password-tip">{{.Help}}</p>
-                    {{if not .TwoFactorForm}}
-                    <p id="password-form" class="line">
-                    <label for="password" aria-describedby="login-password-tip">{{t "Login Password field"}}</label>
-                    <button id="password-visibility-button" class="icon password-visibility-icon masked"
-                        type="button"
-                        title="{{t "Login Password show"}}"
-                        name="password-visibility"></button>
-                    <input id="password" name="passphrase" placeholder="{{t "Login Password field"}}" type="password" autofocus="true" autocomplete="current-password" />
-                    </p>
-                    {{end}}
-                    <p id="two-factor-form" class="line{{if not .TwoFactorForm}} display-none{{end}}">
-                    <label for="two-factor-passcode" aria-describedby="login-two-factor-passcode-tip">{{t "Login Two factor field"}}</label>
-                    <input id="two-factor-token" type="hidden" name="two-factor-token" value="{{.TwoFactorToken}}" />
-                    <input id="two-factor-passcode" name="two-factor-passcode" placeholder="{{t "Login Two factor field"}}" type="text" autofocus="true" autocomplete="current-password" />
-                    </p>
+                  {{if not .TwoFactorForm}}
+                  <p class="help" id="login-password-tip">{{.PasswordHelp}}</p>
+                  <p id="password-form" class="line">
+                  <label for="password" aria-describedby="login-password-tip">{{t "Login Password field"}}</label>
+                  <button id="password-visibility-button" class="icon password-visibility-icon masked"
+                      type="button"
+                      title="{{t "Login Password show"}}"
+                      name="password-visibility"></button>
+                  <input id="password" name="passphrase" placeholder="{{t "Login Password field"}}" type="password" autofocus="true" autocomplete="current-password" />
+                  </p>
+                  {{end}}
+                  <p class="help" id="login-password-tip">{{.TwoFactorHelp}}</p>
+                  <p id="two-factor-form" class="line{{if not .TwoFactorForm}} display-none{{end}}">
+                  <label for="two-factor-passcode" aria-describedby="login-two-factor-passcode-tip">{{t "Login Two factor field"}}</label>
+                  <input id="two-factor-token" type="hidden" name="two-factor-token" value="{{.TwoFactorToken}}" />
+                  <input id="two-factor-passcode" name="two-factor-passcode" placeholder="{{t "Login Two factor field"}}" type="text" autofocus="true" autocomplete="current-password" />
+                  </p>
                   {{if .CredentialsError}}
                   <div class="errors">
                     <p>{{.CredentialsError}}</p>

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -125,7 +125,8 @@ Cookie: sessionid=xxxx
       "locale":"fr",
       "auto_update": true,
       "email": "alice@example.com",
-      "public_name":"Alice Martin"
+      "public_name":"Alice Martin",
+      "auth_mode": "basic"
     }
   }
 }
@@ -163,7 +164,8 @@ Authorization: Bearer settings-token
       "locale":"fr",
       "email": "alice@example.com",
       "public_name":"Alice Martin",
-      "timezone": "Europe/Berlin"
+      "timezone": "Europe/Berlin",
+      "auth_mode": "two_factor_mail"
     }
   }
 }
@@ -188,7 +190,8 @@ Content-type: application/json
       "locale":"fr",
       "email": "alice@example.com",
       "public_name":"Alice Martin",
-      "timezone": "Europe/Berlin"
+      "timezone": "Europe/Berlin",
+      "auth_mode": "two_factor_mail"
     }
   }
 }

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -51,7 +51,7 @@ var passwordResetValidityDuration = 15 * time.Minute
 
 var twoFactorTOTPOptions = totp.ValidateOpts{
 	Period:    30, // 30s
-	Skew:      4,  // 30s +- 4*30s = [-2min; 2,5min]
+	Skew:      10, // 30s +- 10*30s = [-5min; 5,5min]
 	Digits:    otp.DigitsSix,
 	Algorithm: otp.AlgorithmSHA256,
 }

--- a/pkg/instance/two_factor_auth.go
+++ b/pkg/instance/two_factor_auth.go
@@ -15,10 +15,30 @@ type AuthMode int
 const (
 	// Basic authentication mode, only passphrase
 	Basic AuthMode = iota
-	// TwoFactor authentication mode, with passphrase + passcode sent via another
-	// factor.
-	TwoFactor
+	// TwoFactorMail authentication mode, with passcode sent via email
+	TwoFactorMail
 )
+
+// AuthModeToString encode authentication mode in a string
+func AuthModeToString(authMode AuthMode) string {
+	switch authMode {
+	case TwoFactorMail:
+		return "two_factor_mail"
+	default:
+		return "basic"
+	}
+}
+
+// StringToAuthMode converts a string encoded authentication mode into a
+// AuthMode int.
+func StringToAuthMode(authMode string) AuthMode {
+	switch authMode {
+	case "two_factor_mail":
+		return TwoFactorMail
+	default:
+		return Basic
+	}
+}
 
 // GenerateTwoFactorSecrets generates a (token, passcode) pair that can be
 // used as a two factor authentication secret value. The token is used to allow

--- a/pkg/instance/two_factor_auth.go
+++ b/pkg/instance/two_factor_auth.go
@@ -1,0 +1,81 @@
+package instance
+
+import (
+	"encoding/base32"
+	"time"
+
+	"github.com/cozy/cozy-stack/pkg/crypto"
+	"github.com/pquerna/otp/totp"
+)
+
+// AuthMode defines the authentication mode chosen for the connection to this
+// instance.
+type AuthMode int
+
+const (
+	// Basic authentication mode, only passphrase
+	Basic AuthMode = iota
+	// TwoFactor authentication mode, with passphrase + passcode sent via another
+	// factor.
+	TwoFactor
+)
+
+// GenerateTwoFactorSecrets generates a (token, passcode) pair that can be
+// used as a two factor authentication secret value. The token is used to allow
+// the two-factor form — meaning the user has correctly entered its passphrase
+// and successfully done the first part of the two factor authentication.
+//
+// The passcode should be send to the user by another mean (mail, SMS, ...)
+func (i *Instance) GenerateTwoFactorSecrets() (token []byte, passcode string, err error) {
+	passcode, err = totp.GenerateCodeCustom(base32.StdEncoding.EncodeToString(i.SessionSecret),
+		time.Now().UTC(), twoFactorTOTPOptions)
+	if err != nil {
+		return
+	}
+	token, err = crypto.EncodeAuthMessage(i.totpMACConfig(), []byte(i.Domain))
+	return
+}
+
+// ValidateTwoFactorPasscode validates the given (token, passcode) pair for two
+// factor authentication.
+func (i *Instance) ValidateTwoFactorPasscode(token []byte, passcode string) bool {
+	v, err := crypto.DecodeAuthMessage(i.totpMACConfig(), token)
+	if err != nil || string(v) != i.Domain {
+		return false
+	}
+	ok, err := totp.ValidateCustom(passcode, base32.StdEncoding.EncodeToString(i.SessionSecret),
+		time.Now().UTC(), twoFactorTOTPOptions)
+	if err != nil || !ok {
+		return false
+	}
+	return true
+}
+
+// SendTwoFactorPasscode sends by mail the two factor secret to the owner of
+// the instance. It returns the generated token.
+func (i *Instance) SendTwoFactorPasscode() ([]byte, error) {
+	token, passcode, err := i.GenerateTwoFactorSecrets()
+	if err != nil {
+		return nil, err
+	}
+	err = i.SendMail(&Mail{
+		SubjectKey:   "Mail Two factor subject",
+		TemplateName: "two_factor",
+		TemplateValues: map[string]interface{}{
+			"TwoFactorPasscode": passcode,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return token, nil
+}
+
+func (i *Instance) totpMACConfig() *crypto.MACConfig {
+	return &crypto.MACConfig{
+		Name:   "totp",
+		Key:    i.SessionSecret,
+		MaxAge: int64(twoFactorTOTPOptions.Period * twoFactorTOTPOptions.Skew),
+		MaxLen: 256,
+	}
+}

--- a/pkg/workers/mails/mail_templates.go
+++ b/pkg/workers/mails/mail_templates.go
@@ -126,10 +126,27 @@ The Cozy Team`
 		`Bonjour {{.RecipientName}},
 
 L'archive contenant l'ensemble des données de votre Cozy est prête à être téléchargée. Vous pouvez la télécharger en cliquant sur ce lien : {{.Link}}
-
 Nous vous souhaitons une très bonne journée,
 
 L'équipe Cozy.`
+
+	mailTwoFactorHTMLFr = ``
+	mailTwoFactorTextFr = `` +
+		`Bonjour {{.RecipientName}},
+
+Code à utiliser pour l'authentification double-facteurs: {{.TwoFactorPasscode}}
+Nous vous souhaitons une très bonne journée,
+
+L'équipe Cozy.`
+
+	mailTwoFactorHTMLEn = ``
+	mailTwoFactorTextEn = `` +
+		`Hello {{.RecipientName}},
+
+Here is the code to use for two-factor authentication: {{.TwoFactorPasscode}}.
+We wish you a great day,
+
+The Cozy Team`
 )
 
 // MailTemplate is a struct to define a mail template with HTML and text parts.
@@ -225,6 +242,16 @@ func init() {
 			Name:     "archiver_en",
 			BodyHTML: mailArchiveHTMLEn,
 			BodyText: mailArchiveTextEn,
+		},
+		{
+			Name:     "two_factor_fr",
+			BodyHTML: mailTwoFactorHTMLFr,
+			BodyText: mailTwoFactorTextFr,
+		},
+		{
+			Name:     "two_factor_en",
+			BodyHTML: mailTwoFactorHTMLEn,
+			BodyText: mailTwoFactorTextEn,
 		},
 	})
 }

--- a/web/auth/auth.go
+++ b/web/auth/auth.go
@@ -121,10 +121,13 @@ func renderLoginForm(c echo.Context, i *instance.Instance, code int, credsErrors
 		help = i.Translate("Login Password help")
 	}
 
+	twoFactorHelp := i.Translate("Login Two factor help")
+
 	return c.Render(code, "login.html", echo.Map{
 		"Locale":           i.Locale,
 		"Title":            title,
-		"Help":             help,
+		"PasswordHelp":     help,
+		"TwoFactorHelp":    twoFactorHelp,
 		"CredentialsError": credsErrors,
 		"Redirect":         redirect,
 		"TwoFactorForm":    false,

--- a/web/auth/auth.go
+++ b/web/auth/auth.go
@@ -24,9 +24,14 @@ import (
 	"github.com/labstack/echo/middleware"
 )
 
-// CredentialsErrorKey is the key for translating the message showed to the
-// user when he/she enters incorrect credentials
-const CredentialsErrorKey = "Login Credentials error"
+const (
+	// CredentialsErrorKey is the key for translating the message showed to the
+	// user when he/she enters incorrect credentials
+	CredentialsErrorKey = "Login Credentials error"
+	// TwoFactorErrorKey is the key for translating the message showed to the
+	// user when he/she enters incorrect two factor secret
+	TwoFactorErrorKey = "Login Two factor error"
+)
 
 // Home is the handler for /
 // It redirects to the login page is the user is not yet authentified
@@ -90,11 +95,8 @@ func SetCookieForNewSession(c echo.Context) (string, error) {
 	return session.ID(), nil
 }
 
-func renderLoginForm(c echo.Context, i *instance.Instance, code int, redirect string) error {
-	var title, help, credsErrors string
-	if code == http.StatusUnauthorized {
-		credsErrors = i.Translate(CredentialsErrorKey)
-	}
+func renderLoginForm(c echo.Context, i *instance.Instance, code int, credsErrors, redirect string) error {
+	var title, help string
 
 	publicName, err := i.PublicName()
 	if err != nil {
@@ -125,6 +127,19 @@ func renderLoginForm(c echo.Context, i *instance.Instance, code int, redirect st
 		"Help":             help,
 		"CredentialsError": credsErrors,
 		"Redirect":         redirect,
+		"TwoFactorForm":    false,
+	})
+}
+
+func renderTwoFactorForm(c echo.Context, i *instance.Instance, code int, redirect string, twoFactorToken []byte) error {
+	return c.Render(code, "login.html", echo.Map{
+		"Locale":           i.Locale,
+		"Title":            i.Translate("Login Two factor title"),
+		"Help":             i.Translate("Login Two factor help"),
+		"CredentialsError": nil,
+		"Redirect":         redirect,
+		"TwoFactorForm":    true,
+		"TwoFactorToken":   string(twoFactorToken),
 	})
 }
 
@@ -142,49 +157,82 @@ func loginForm(c echo.Context) error {
 		return c.Redirect(http.StatusSeeOther, redirect)
 	}
 
-	return renderLoginForm(c, instance, http.StatusOK, redirect)
+	return renderLoginForm(c, instance, http.StatusOK, "", redirect)
 }
 
 func login(c echo.Context) error {
-	instance := middlewares.GetInstance(c)
+	inst := middlewares.GetInstance(c)
 	wantsJSON := c.Request().Header.Get("Accept") == "application/json"
 
-	redirect, err := checkRedirectParam(c, instance.DefaultRedirection())
+	redirect, err := checkRedirectParam(c, inst.DefaultRedirection())
 	if err != nil {
 		return err
 	}
 
 	var sessionID string
-	session, err := sessions.GetSession(c, instance)
+	successfulAuthentication := false
+
+	twoFactorToken := []byte(c.FormValue("two-factor-token"))
+	twoFactorPasscode := c.FormValue("two-factor-passcode")
+	passphrase := []byte(c.FormValue("passphrase"))
+
+	twoFactorRequest := len(twoFactorToken) > 0 && twoFactorPasscode != ""
+
+	session, err := sessions.GetSession(c, inst)
 	if err == nil {
 		sessionID = session.ID()
-	} else {
-		passphrase := []byte(c.FormValue("passphrase"))
-		if err := instance.CheckPassphrase(passphrase); err == nil {
-			if sessionID, err = SetCookieForNewSession(c); err != nil {
+	} else if twoFactorRequest {
+		successfulAuthentication = inst.ValidateTwoFactorPasscode(twoFactorToken, twoFactorPasscode)
+	} else if len(passphrase) > 0 && inst.CheckPassphrase(passphrase) == nil {
+		switch inst.AuthMode {
+		case instance.TwoFactor:
+			twoFactorToken, err = inst.SendTwoFactorPasscode()
+			if err != nil {
 				return err
 			}
-			if err := sessions.StoreNewLoginEntry(instance, c.Request()); err != nil {
-				return err
+			if wantsJSON {
+				return c.JSON(http.StatusOK, echo.Map{
+					"redirect":         redirect,
+					"two_factor_token": string(twoFactorToken),
+				})
 			}
+			return renderTwoFactorForm(c, inst, http.StatusOK, redirect, twoFactorToken)
+		default:
+			successfulAuthentication = true
 		}
 	}
 
-	if sessionID != "" {
-		redirect = addCodeToRedirect(redirect, instance.Domain, sessionID)
+	if successfulAuthentication {
+		if sessionID, err = SetCookieForNewSession(c); err != nil {
+			return err
+		}
+		if err = sessions.StoreNewLoginEntry(inst, c.Request()); err != nil {
+			return err
+		}
+	}
+
+	// not logged-in
+	if sessionID == "" {
+		var errorMessage string
+		if twoFactorRequest {
+			errorMessage = inst.Translate(TwoFactorErrorKey)
+		} else {
+			errorMessage = inst.Translate(CredentialsErrorKey)
+		}
 		if wantsJSON {
-			return c.JSON(http.StatusOK, echo.Map{"redirect": redirect})
+			return c.JSON(http.StatusUnauthorized, echo.Map{
+				"error": errorMessage,
+			})
 		}
-		return c.Redirect(http.StatusSeeOther, redirect)
+		return renderLoginForm(c, inst, http.StatusUnauthorized, errorMessage, redirect)
 	}
 
+	// logged-in
+	redirect = addCodeToRedirect(redirect, inst.Domain, sessionID)
 	if wantsJSON {
-		return c.JSON(http.StatusUnauthorized, echo.Map{
-			"error": instance.Translate(CredentialsErrorKey),
-		})
+		return c.JSON(http.StatusOK, echo.Map{"redirect": redirect})
 	}
-
-	return renderLoginForm(c, instance, http.StatusUnauthorized, redirect)
+	return c.Redirect(http.StatusSeeOther, redirect)
 }
 
 func logout(c echo.Context) error {

--- a/web/auth/auth.go
+++ b/web/auth/auth.go
@@ -132,9 +132,19 @@ func renderLoginForm(c echo.Context, i *instance.Instance, code int, credsErrors
 }
 
 func renderTwoFactorForm(c echo.Context, i *instance.Instance, code int, redirect string, twoFactorToken []byte) error {
+	var title string
+	publicName, err := i.PublicName()
+	if err != nil {
+		publicName = ""
+	}
+	if publicName == "" {
+		title = i.Translate("Login Welcome")
+	} else {
+		title = i.Translate("Login Welcome name", publicName)
+	}
 	return c.Render(code, "login.html", echo.Map{
 		"Locale":           i.Locale,
-		"Title":            i.Translate("Login Two factor title"),
+		"Title":            title,
 		"Help":             i.Translate("Login Two factor help"),
 		"CredentialsError": nil,
 		"Redirect":         redirect,
@@ -185,7 +195,7 @@ func login(c echo.Context) error {
 		successfulAuthentication = inst.ValidateTwoFactorPasscode(twoFactorToken, twoFactorPasscode)
 	} else if len(passphrase) > 0 && inst.CheckPassphrase(passphrase) == nil {
 		switch inst.AuthMode {
-		case instance.TwoFactor:
+		case instance.TwoFactorMail:
 			twoFactorToken, err = inst.SendTwoFactorPasscode()
 			if err != nil {
 				return err


### PR DESCRIPTION
This PR adds two factor authentication using the following scheme:

  - when user asks for two factor authentication, this parameter is saved on the instance document directly
  - on each connection, when the TFA is activated:
    * the user is asked for its passphrase first
    * when entering correct passphrase, the user is then asked for:
      - a TOTP (Timebased One-Time password, RFC 6238) derived from the `SessionSecret` with a period of 30secondes and a skew validity of 4 periods (for ~2 minutes validity) composed of six digits, named `two-factor-passcode`
      - a short term timestamped MAC with the same validity time-range and also derived from the `SessionSecret` named `two-factor-token`
    * when sending a correct and still-valid pair `(two-factor-passcode, two-factor-token)`, the user is granted with authentication cookie

The `two-factor-passcode` is sent to the instance's owner email (more transport shall be added later) and the `two-factor-token` is sent with the response to a successful passphrased login directly in the response (in a `two_factor_token` field for `application/json` or in a hidden field for html response).

The library used for TOTP generation is: https://github.com/pquerna/otp/totp
