### PR TITLE
Add options to migrate applications from git:// to registry://

### DIFF
--- a/client/instances.go
+++ b/client/instances.go
@@ -66,8 +66,9 @@ type OAuthClientOptions struct {
 
 // UpdatesOptions is a struct holding all the options to launch an update.
 type UpdatesOptions struct {
-	Domain string
-	Slugs  []string
+	Domain        string
+	Slugs         []string
+	ForceRegistry bool
 }
 
 // ImportOptions is a struct with the options for importing a tarball.
@@ -249,8 +250,9 @@ func (c *Client) RegisterOAuthClient(opts *OAuthClientOptions) (map[string]inter
 // specified, the updates are launched for all the existing instances.
 func (c *Client) Updates(opts *UpdatesOptions) error {
 	q := url.Values{
-		"Domain": {opts.Domain},
-		"Slugs":  {strings.Join(opts.Slugs, ",")},
+		"Domain":        {opts.Domain},
+		"Slugs":         {strings.Join(opts.Slugs, ",")},
+		"ForceRegistry": {strconv.FormatBool(opts.ForceRegistry)},
 	}
 	_, err := c.Req(&request.Options{
 		Method:     "POST",

--- a/cmd/instances.go
+++ b/cmd/instances.go
@@ -35,6 +35,7 @@ var flagExpire time.Duration
 var flagDry bool
 var flagJSON bool
 var flagDirectory string
+var flagForceRegistry bool
 
 // instanceCmdGroup represents the instances command
 var instanceCmdGroup = &cobra.Command{
@@ -480,15 +481,17 @@ updated.`,
 		c := newAdminClient()
 		if flagAllDomains {
 			return c.Updates(&client.UpdatesOptions{
-				Slugs: args,
+				Slugs:         args,
+				ForceRegistry: flagForceRegistry,
 			})
 		}
 		if flagDomain == "" {
 			return errAppsMissingDomain
 		}
 		return c.Updates(&client.UpdatesOptions{
-			Domain: flagDomain,
-			Slugs:  args,
+			Domain:        flagDomain,
+			Slugs:         args,
+			ForceRegistry: flagForceRegistry,
 		})
 	},
 }
@@ -558,6 +561,7 @@ func init() {
 	oauthClientInstanceCmd.Flags().BoolVar(&flagJSON, "json", false, "Output more informations in JSON format")
 	updateCmd.Flags().BoolVar(&flagAllDomains, "all-domains", false, "Work on all domains iterativelly")
 	updateCmd.Flags().StringVar(&flagDomain, "domain", "", "Specify the domain name of the instance")
+	updateCmd.Flags().BoolVar(&flagForceRegistry, "force-registry", false, "Force to update all applications sources from git to the registry")
 	exportCmd.Flags().StringVar(&flagDomain, "domain", "", "Specify the domain name of the instance")
 	importCmd.Flags().StringVar(&flagDomain, "domain", "", "Specify the domain name of the instance")
 	importCmd.Flags().StringVar(&flagDirectory, "directory", "", "Put the imported files inside this directory")

--- a/docs/cli/cozy-stack_instances_update.md
+++ b/docs/cli/cozy-stack_instances_update.md
@@ -17,9 +17,10 @@ cozy-stack instances update [domain] [slugs...] [flags]
 ### Options
 
 ```
-      --all-domains     Work on all domains iterativelly
-      --domain string   Specify the domain name of the instance
-  -h, --help            help for update
+      --all-domains      Work on all domains iterativelly
+      --domain string    Specify the domain name of the instance
+      --force-registry   Force to update all applications sources from git to the registry
+  -h, --help             help for update
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/cozy-stack_konnectors_run.md
+++ b/docs/cli/cozy-stack_konnectors_run.md
@@ -15,7 +15,6 @@ cozy-stack konnectors run [slug] [flags]
 
 ```
       --account-id string   specify the account ID to use for running the konnector
-      --folder string       specify the folder path associated with the konnector
   -h, --help                help for run
 ```
 

--- a/docs/cli/cozy-stack_serve.md
+++ b/docs/cli/cozy-stack_serve.md
@@ -46,7 +46,7 @@ example), you can use the --appdir flag like this:
       --disable-csp                    Disable the Content Security Policy (only available for development)
       --doctypes string                path to the directory with the doctypes (for developing/testing a remote doctype)
       --downloads-url string           URL for the download secret storage, redis or in-memory
-      --fs-url string                  filesystem url (default "file:///Users/pierre/go/src/github.com/cozy/cozy-stack/storage")
+      --fs-url string                  filesystem url (default "file://./storage")
       --geodb string                   define the location of the database for IP -> City lookups (default ".")
   -h, --help                           help for serve
       --hooks string                   define the directory used for hook scripts (default ".")

--- a/docs/cli/cozy-stack_serve.md
+++ b/docs/cli/cozy-stack_serve.md
@@ -46,12 +46,12 @@ example), you can use the --appdir flag like this:
       --disable-csp                    Disable the Content Security Policy (only available for development)
       --doctypes string                path to the directory with the doctypes (for developing/testing a remote doctype)
       --downloads-url string           URL for the download secret storage, redis or in-memory
-      --fs-url string                  filesystem url (default "file:///storage")
+      --fs-url string                  filesystem url (default "file:///Users/pierre/go/src/github.com/cozy/cozy-stack/storage")
       --geodb string                   define the location of the database for IP -> City lookups (default ".")
   -h, --help                           help for serve
       --hooks string                   define the directory used for hook scripts (default ".")
       --jobs-url string                URL for the jobs system synchronization, redis or in-memory
-      --jobs-workers int               Number of parallel workers (0 to disable the processing of jobs) (default 8)
+      --jobs-workers int               Number of parallel workers (0 to disable the processing of jobs) (default 4)
       --konnectors-cmd string          konnectors command to be executed
       --konnectors-oauthstate string   URL for the storage of OAuth state for konnectors, redis or in-memory
       --lock-url string                URL for the locks, redis or in-memory

--- a/pkg/instance/updates.go
+++ b/pkg/instance/updates.go
@@ -254,7 +254,9 @@ func createInstaller(inst *Instance, registries []*url.URL, man apps.Manifest, o
 	var sourceURL string
 	if opts.ForceRegistry {
 		originalSourceURL, err := url.Parse(man.Source())
-		if err == nil && originalSourceURL.Scheme == "git" {
+		if err == nil && (originalSourceURL.Scheme == "git" ||
+			originalSourceURL.Scheme == "git+ssh" ||
+			originalSourceURL.Scheme == "ssh+git") {
 			var channel string
 			if strings.HasPrefix(originalSourceURL.Fragment, "build") {
 				channel = "dev"

--- a/web/instances/updates.go
+++ b/web/instances/updates.go
@@ -1,6 +1,8 @@
 package instances
 
 import (
+	"strconv"
+
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/pkg/utils"
 	"github.com/labstack/echo"
@@ -9,12 +11,18 @@ import (
 func updatesHandler(c echo.Context) error {
 	slugs := utils.SplitTrimString(c.QueryParam("Slugs"), ",")
 	domain := c.QueryParam("Domain")
+	forceRegistry, _ := strconv.ParseBool(c.QueryParam("ForceRegistry"))
+	opts := &instance.UpdatesOptions{
+		Slugs:         slugs,
+		Force:         true,
+		ForceRegistry: forceRegistry,
+	}
 	if domain != "" {
 		inst, err := instance.Get(domain)
 		if err != nil {
 			return wrapError(err)
 		}
-		return wrapError(instance.UpdateInstance(inst, slugs...))
+		return wrapError(instance.UpdateInstance(inst, opts))
 	}
-	return wrapError(instance.UpdateAll(true, slugs...))
+	return wrapError(instance.UpdateAll(opts))
 }


### PR DESCRIPTION
Add translation step to migrate and update applications from a `git://` to a `registry://`.

Examples of command:

```sh
# update and migrate all applications from all domains
$ cozy-stack instances update --all-domains --force-registry
# update and migrate all application from the foo.bar domain
$ cozy-stack instances update --domain foo.bar --force-registry
# update and migrate collect and drive application from all domains
$ cozy-stack instances update --all-domains --force-registry drive collect
# update and migrate collect and drive application from foo.bar domain
$ cozy-stack instances update --domain foo.bar --force-registry drive collect
```