### PR TITLE
chore: update bar version

### DIFF
--- a/assets/externals
+++ b/assets/externals
@@ -19,11 +19,11 @@ url     https://raw.githubusercontent.com/cozy/cozy-client-js/v0.3.17/dist/cozy-
 sha256  f1ca05e5870a649750006304068cd55fd8bac24d8a2f5b8e44b05a93534b5469
 
 name    ./js/cozy-bar.min.js
-url     https://raw.githubusercontent.com/cozy/cozy-bar/v4.2.6/dist/cozy-bar.min.js
-sha256  5afae64dc4c29f62021efe0005d0f5265465ed03826be77c3f109769ec6a2ce9
+url     https://unpkg.com/cozy-bar@4.3.3/dist/cozy-bar.min.js
+sha256  85a2f0b42004771d4bee28097257fc291c84f97bd0a82294a3006f91941ba93a
 
 name    ./css/cozy-bar.min.css
-url     https://raw.githubusercontent.com/cozy/cozy-bar/v4.2.6/dist/cozy-bar.min.css
+url     https://unpkg.com/cozy-bar@4.3.3/dist/cozy-bar.min.css
 sha256  fc34f51f33aa0b9b841081476a52b0fe12c127073b5d1c4e23b1c556ecd38e5c
 
 name    ./js/piwik.js


### PR DESCRIPTION
Since the `dist/` folder is no longer versioned, I used unpkg.com to get the files.