### PR TITLE
2FA: add salt to derive a new TOTP function for each new passphrase step

### DIFF
--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -30,8 +30,6 @@ import (
 	"github.com/cozy/cozy-stack/pkg/vfs/vfsswift"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/leonelquinteros/gotext"
-	"github.com/pquerna/otp"
-	"github.com/pquerna/otp/totp"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	jwt "gopkg.in/dgrijalva/jwt-go.v3"
@@ -48,13 +46,6 @@ const (
 // passwordResetValidityDuration is the validity duration of the passphrase
 // reset token.
 var passwordResetValidityDuration = 15 * time.Minute
-
-var twoFactorTOTPOptions = totp.ValidateOpts{
-	Period:    30, // 30s
-	Skew:      10, // 30s +- 10*30s = [-5min; 5,5min]
-	Digits:    otp.DigitsSix,
-	Algorithm: otp.AlgorithmSHA256,
-}
 
 // DefaultLocale is the default locale when creating an instance
 const DefaultLocale = "en"


### PR DESCRIPTION
This PR adds a proposition to derive a new key to generate a new TOTP function (from which we generate TOTP passcodes) on each passphrase step.

It works by generating a salt that we encode and sign in the value part of the `two-factor-token` and that is used to derive a new key (with `HKDF(SessionSecret, salt)`) from which we generate TOTPs. This way, on each new connection we generate a new TOTP function, and our token is linked cryptographically to this TOTP function.

Pros:
  + prevent the reuse of TOTPs on another authentication process
  + bind cryptographically the `two-factor-token` and the TOTPs (`two-factor-passcode`s) generated from its associated function

Cons:
  - make the code and the logic more complex

@nono what do you think ?