### PR TITLE
Add a current_state field to triggers

### DIFF
--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -507,8 +507,8 @@ Accept: application/vnd.api+json
         "timeout": 60,
         "max_exec_count": 3
       },
-      "present_state": {
-        "current_status": "done",
+      "current_state": {
+        "status": "done",
         "last_success": "2017-11-20T13:31:09.01641731",
         "last_successful_job_id": "abcde",
         "last_execution": "2017-11-20T13:31:09.01641731",

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -506,6 +506,18 @@ Accept: application/vnd.api+json
         "priority": 3,
         "timeout": 60,
         "max_exec_count": 3
+      },
+      "present_state": {
+        "current_status": "done",
+        "last_success": "2017-11-20T13:31:09.01641731",
+        "last_successful_job_id": "abcde",
+        "last_execution": "2017-11-20T13:31:09.01641731",
+        "last_executed_job_id": "abcde",
+        "last_failure": "2017-11-20T13:31:09.01641731",
+        "last_failed_job_id": "abcde",
+        "last_error": "error value",
+        "last_manual_execution": "2017-11-20T13:31:09.01641731",
+        "last_manual_job_id": "abcde"
       }
     },
     "links": {
@@ -644,49 +656,6 @@ Accept: application/vnd.api+json
 To use this endpoint, an application needs a permission on the type
 `io.cozy.triggers` for the verb `GET`. When used on a specific worker, the
 permission can be specified on the `worker` field.
-
-### GET /jobs/triggers/jobs
-
-Get the list of the last job launched by all triggers.
-
-Query parameters:
-
-* `Worker`: to filter only jobs from triggers associated with a specific worker.
-
-#### Request
-
-```http
-GET /jobs/triggers/jobs?Worker=konnector HTTP/1.1
-Accept: application/vnd.api+json
-```
-
-#### Response
-
-```json
-{
-  "data": [
-    {
-      "type": "io.cozy.jobs",
-      "id": "123123",
-      "attributes": {},
-      "links": {
-        "self": "/jobs/123123"
-      }
-    }
-  ]
-}
-```
-
-#### Permissions
-
-To use this endpoint, an application needs a permission on the type
-`io.cozy.triggers` for the verb `GET`. When used on a specific worker, the
-permission can be specified on the `worker` field.
-
-#### Status codes
-
-* 204 No Content, when the trigger has been successfully removed
-* 404 Not Found, when the trigger does not exist
 
 ## Worker pool
 

--- a/pkg/consts/views.go
+++ b/pkg/consts/views.go
@@ -168,22 +168,6 @@ function(doc) {
 `,
 }
 
-// TriggerLastJob indexes the last job launched by a specific trigger.
-var TriggerLastJob = &couchdb.View{
-	Name:    "triggerLastJob",
-	Doctype: Jobs,
-	Map: `
-function(doc) {
-  if (doc.trigger_id) {
-    var state = doc.state;
-    if (state == "done" || state == "errored") {
-      emit([doc.worker, doc.trigger_id], state);
-    }
-  }
-}
-`,
-}
-
 // Views is the list of all views that are created by the stack.
 var Views = []*couchdb.View{
 	DiskUsageView,
@@ -194,7 +178,6 @@ var Views = []*couchdb.View{
 	PermissionsShareByDocView,
 	SharedWithPermissionsView,
 	SharingRecipientView,
-	TriggerLastJob,
 }
 
 // ViewsByDoctype returns the list of views for a specified doc type.

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -66,6 +66,7 @@ type (
 		TriggerID  string      `json:"trigger_id"`
 		Message    Message     `json:"message"`
 		Event      Event       `json:"event"`
+		Manual     bool        `json:"manual_execution"`
 		Debounced  bool        `json:"debounced"`
 		Options    *JobOptions `json:"options"`
 		State      State       `json:"state"`
@@ -82,6 +83,7 @@ type (
 		TriggerID  string
 		Message    Message
 		Event      Event
+		Manual     bool
 		Debounced  bool
 		Options    *JobOptions
 	}
@@ -238,6 +240,7 @@ func NewJob(req *JobRequest) *Job {
 		Domain:     req.Domain,
 		WorkerType: req.WorkerType,
 		TriggerID:  req.TriggerID,
+		Manual:     req.Manual,
 		Message:    req.Message,
 		Debounced:  req.Debounced,
 		Event:      req.Event,

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -2,7 +2,7 @@ package scheduler
 
 import (
 	"context"
-	"encoding/json"
+	"time"
 
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
@@ -40,15 +40,31 @@ type (
 
 	// TriggerInfos is a struct containing all the options of a trigger.
 	TriggerInfos struct {
-		TID        string           `json:"_id,omitempty"`
-		TRev       string           `json:"_rev,omitempty"`
-		Domain     string           `json:"domain"`
-		Type       string           `json:"type"`
-		WorkerType string           `json:"worker"`
-		Arguments  string           `json:"arguments"`
-		Debounce   string           `json:"debounce"`
-		Options    *jobs.JobOptions `json:"options"`
-		Message    jobs.Message     `json:"message"`
+		TID          string           `json:"_id,omitempty"`
+		TRev         string           `json:"_rev,omitempty"`
+		Domain       string           `json:"domain"`
+		Type         string           `json:"type"`
+		WorkerType   string           `json:"worker"`
+		Arguments    string           `json:"arguments"`
+		Debounce     string           `json:"debounce"`
+		Options      *jobs.JobOptions `json:"options"`
+		Message      jobs.Message     `json:"message"`
+		PresentState *TriggerState    `json:"present_state,omitempty"`
+	}
+
+	// TriggerState represent the current state of the trigger
+	TriggerState struct {
+		TID                 string     `json:"trigger_id"`
+		Status              jobs.State `json:"current_status"`
+		LastSuccess         *time.Time `json:"last_success,omitempty"`
+		LastSuccessfulJobID string     `json:"last_successful_job_id,omitempty"`
+		LastExecution       *time.Time `json:"last_execution,omitempty"`
+		LastExecutedJobID   string     `json:"last_executed_job_id,omitempty"`
+		LastFailure         *time.Time `json:"last_failure,omitempty"`
+		LastFailedJobID     string     `json:"last_failed_job_id,omitempty"`
+		LastError           string     `json:"last_error,omitempty"`
+		LastManualExecution *time.Time `json:"last_manual_execution,omitempty"`
+		LastManualJobID     string     `json:"last_manual_job_id,omitempty"`
 	}
 )
 
@@ -153,60 +169,40 @@ func GetJobs(t Trigger, limit int) ([]*jobs.Job, error) {
 	return jobs, nil
 }
 
-// GetLastJob returns the last completed job lauched by the given trigger.
-func GetLastJob(t Trigger) (*jobs.Job, error) {
-	triggerInfos := t.Infos()
-	db := couchdb.SimpleDatabasePrefix(triggerInfos.Domain)
-	req := &couchdb.ViewRequest{
-		Key:         []string{triggerInfos.Type, triggerInfos.ID()},
-		IncludeDocs: true,
-		Reduce:      false,
-		Limit:       1,
-	}
-	res := &couchdb.ViewResponse{}
-	err := couchdb.ExecView(db, consts.TriggerLastJob, req, res)
+// GetTriggerState returns the state of the trigger, calculated from the last
+// launched jobs.
+func GetTriggerState(t Trigger) (*TriggerState, error) {
+	js, err := GetJobs(t, 0)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(res.Rows) != 1 {
-		return nil, ErrNotFoundTrigger
-	}
+	var state TriggerState
 
-	var j *jobs.Job
-	if err := json.Unmarshal(res.Rows[0].Doc, &j); err != nil {
-		return nil, err
-	}
+	state.Status = jobs.Done
+	state.TID = t.ID()
 
-	return j, nil
-}
-
-// GetLastJobs get the last completed job for all workers with the given worker
-// type.
-func GetLastJobs(domain, workerType string) ([]*jobs.Job, error) {
-	db := couchdb.SimpleDatabasePrefix(domain)
-	req := &couchdb.ViewRequest{
-		StartKey:    []string{workerType},
-		EndKey:      []string{workerType, couchdb.MaxString},
-		IncludeDocs: true,
-		Reduce:      false,
-	}
-	res := &couchdb.ViewResponse{}
-	err := couchdb.ExecView(db, consts.TriggerLastJob, req, res)
-	if err != nil {
-		return nil, err
-	}
-
-	js := make([]*jobs.Job, len(res.Rows))
-	for i, v := range res.Rows {
-		var j *jobs.Job
-		if err := json.Unmarshal(v.Doc, &j); err != nil {
-			return nil, err
+	for _, j := range js {
+		startedAt := &j.StartedAt
+		switch j.State {
+		case jobs.Errored:
+			state.LastFailure = startedAt
+			state.LastFailedJobID = j.ID()
+			state.LastError = j.Error
+		case jobs.Done:
+			state.LastSuccess = startedAt
+			state.LastSuccessfulJobID = j.ID()
 		}
-		js[i] = j
+		if j.Manual && (j.State == jobs.Done || j.State == jobs.Errored) {
+			state.LastManualExecution = startedAt
+			state.LastManualJobID = j.ID()
+		}
+		state.LastExecution = startedAt
+		state.LastExecutedJobID = j.ID()
+		state.Status = j.State
 	}
 
-	return js, nil
+	return &state, nil
 }
 
 var _ couchdb.Doc = &TriggerInfos{}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -49,13 +49,13 @@ type (
 		Debounce     string           `json:"debounce"`
 		Options      *jobs.JobOptions `json:"options"`
 		Message      jobs.Message     `json:"message"`
-		PresentState *TriggerState    `json:"present_state,omitempty"`
+		CurrentState *TriggerState    `json:"current_state,omitempty"`
 	}
 
 	// TriggerState represent the current state of the trigger
 	TriggerState struct {
 		TID                 string     `json:"trigger_id"`
-		Status              jobs.State `json:"current_status"`
+		Status              jobs.State `json:"status"`
 		LastSuccess         *time.Time `json:"last_success,omitempty"`
 		LastSuccessfulJobID string     `json:"last_successful_job_id,omitempty"`
 		LastExecution       *time.Time `json:"last_execution,omitempty"`

--- a/web/jobs/jobs.go
+++ b/web/jobs/jobs.go
@@ -293,7 +293,7 @@ func getAllTriggers(c echo.Context) error {
 	for _, t := range ts {
 		tInfos := t.Infos()
 		if workerType == "" || tInfos.WorkerType == workerType {
-			tInfos.PresentState, err = scheduler.GetTriggerState(t)
+			tInfos.CurrentState, err = scheduler.GetTriggerState(t)
 			if err != nil {
 				return wrapJobsError(err)
 			}


### PR DESCRIPTION
The `current_state` field added on triggers can be used to know what is the current state of the jobs triggers. It calculated from the last executed jobs from the trigger.