### PR TITLE
Bootstrap the `/metrics` endpoint

### DIFF
--- a/pkg/couchdb/couchdb.go
+++ b/pkg/couchdb/couchdb.go
@@ -725,6 +725,7 @@ func FindDocsRaw(db Database, doctype string, req interface{}, results interface
 	return json.Unmarshal(response.Docs, results)
 }
 
+// CountAllDocs returns the number of documents of the given doctype.
 func CountAllDocs(db Database, doctype string) (int, error) {
 	var response AllDocsResponse
 	url := makeDBName(db, doctype) + "/_all_docs?limit=0"

--- a/pkg/couchdb/couchdb.go
+++ b/pkg/couchdb/couchdb.go
@@ -725,6 +725,16 @@ func FindDocsRaw(db Database, doctype string, req interface{}, results interface
 	return json.Unmarshal(response.Docs, results)
 }
 
+func CountAllDocs(db Database, doctype string) (int, error) {
+	var response AllDocsResponse
+	url := makeDBName(db, doctype) + "/_all_docs?limit=0"
+	err := makeRequest(db, "GET", url, nil, &response)
+	if err != nil {
+		return 0, err
+	}
+	return response.TotalRows, nil
+}
+
 // GetAllDocs returns all documents of a specified doctype. It filters
 // out the possible _design document.
 func GetAllDocs(db Database, doctype string, req *AllDocsRequest, results interface{}) error {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,43 @@
+package metrics
+
+import (
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// innerDataCollector collects data from the database, like the number of cozy
+// instances. These data are global and collected on demand from the database.
+type innerDataCollector struct {
+	instancesCountDesc *prometheus.Desc
+}
+
+func newInnerDataCollector() prometheus.Collector {
+	return &innerDataCollector{
+		instancesCountDesc: prometheus.NewDesc(
+			"inner_data_instances_count",  /* fqName*/
+			"Number of created instances", /* help */
+			[]string{},                    /* variableLabels */
+			prometheus.Labels{},           /* constLabels */
+		),
+	}
+}
+
+func (i *innerDataCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- i.instancesCountDesc
+}
+
+func (i *innerDataCollector) Collect(ch chan<- prometheus.Metric) {
+	if count, err := couchdb.CountAllDocs(couchdb.GlobalDB, consts.Instances); err == nil {
+		ch <- prometheus.MustNewConstMetric(
+			i.instancesCountDesc,
+			prometheus.CounterValue,
+			float64(count),
+		)
+	}
+}
+
+func init() {
+	prometheus.MustRegister(newInnerDataCollector())
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -4,7 +4,10 @@ import (
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 
+	"github.com/labstack/echo"
+
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 // innerDataCollector collects data from the database, like the number of cozy
@@ -36,6 +39,17 @@ func (i *innerDataCollector) Collect(ch chan<- prometheus.Metric) {
 			float64(count),
 		)
 	}
+}
+
+// Routes set the /metrics routes.
+//
+// Default prometheus handler comes with two collectors:
+//  - ProcessCollector: cpu, memory and file descriptor usage as well as the
+//    process start time for the given process id under the given
+//    namespace...
+//  - GoCollector: current go process, goroutines, GC pauses, ...
+func Routes(g *echo.Group) {
+	g.GET("", echo.WrapHandler(promhttp.Handler()))
 }
 
 func init() {

--- a/pkg/stack/main.go
+++ b/pkg/stack/main.go
@@ -14,8 +14,6 @@ import (
 	"github.com/cozy/cozy-stack/pkg/scheduler"
 	"github.com/cozy/cozy-stack/pkg/utils"
 
-	_ "github.com/cozy/cozy-stack/pkg/metrics"
-
 	"github.com/google/gops/agent"
 	"github.com/sirupsen/logrus"
 )

--- a/pkg/stack/main.go
+++ b/pkg/stack/main.go
@@ -13,6 +13,9 @@ import (
 	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/cozy/cozy-stack/pkg/scheduler"
 	"github.com/cozy/cozy-stack/pkg/utils"
+
+	_ "github.com/cozy/cozy-stack/pkg/metrics"
+
 	"github.com/google/gops/agent"
 	"github.com/sirupsen/logrus"
 )

--- a/web/routing.go
+++ b/web/routing.go
@@ -33,7 +33,9 @@ import (
 	_ "github.com/cozy/cozy-stack/web/statik" // Generated file with the packed assets
 	"github.com/cozy/cozy-stack/web/status"
 	"github.com/cozy/cozy-stack/web/version"
+
 	"github.com/labstack/echo"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rakyll/statik/fs"
 )
 
@@ -204,6 +206,12 @@ func SetupAdminRoutes(router *echo.Echo) error {
 		router.Use(middlewares.BasicAuth(config.AdminSecretFileName))
 	}
 
+	// Default prometheus handler comes with two collectors:
+	//  - ProcessCollector: cpu, memory and file descriptor usage as well as the
+	//    process start time for the given process id under the given
+	//    namespace...
+	//  - GoCollector: current go process, goroutines, GC pauses, ...
+	router.GET("/metrics", echo.WrapHandler(promhttp.Handler()))
 	instances.Routes(router.Group("/instances"))
 	version.Routes(router.Group("/version"))
 

--- a/web/routing.go
+++ b/web/routing.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cozy/cozy-stack/pkg/config"
 	"github.com/cozy/cozy-stack/pkg/instance"
+	"github.com/cozy/cozy-stack/pkg/metrics"
 	"github.com/cozy/cozy-stack/web/apps"
 	"github.com/cozy/cozy-stack/web/auth"
 	"github.com/cozy/cozy-stack/web/data"
@@ -35,7 +36,6 @@ import (
 	"github.com/cozy/cozy-stack/web/version"
 
 	"github.com/labstack/echo"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rakyll/statik/fs"
 )
 
@@ -206,12 +206,7 @@ func SetupAdminRoutes(router *echo.Echo) error {
 		router.Use(middlewares.BasicAuth(config.AdminSecretFileName))
 	}
 
-	// Default prometheus handler comes with two collectors:
-	//  - ProcessCollector: cpu, memory and file descriptor usage as well as the
-	//    process start time for the given process id under the given
-	//    namespace...
-	//  - GoCollector: current go process, goroutines, GC pauses, ...
-	router.GET("/metrics", echo.WrapHandler(promhttp.Handler()))
+	metrics.Routes(router.Group("/metrics"))
 	instances.Routes(router.Group("/instances"))
 	version.Routes(router.Group("/version"))
 


### PR DESCRIPTION
Export the `/metrics` endpoint on the administration interface, using Prometheus client library.

The default endpoint, exposed by the said library, exports generic metrics on the current process and go runtime properties.