### PR TITLE
update cozy-client-js to v0.4.3

### DIFF
--- a/assets/externals
+++ b/assets/externals
@@ -12,11 +12,11 @@
 
 name    ./js/cozy-client.min.js
 url     https://raw.githubusercontent.com/cozy/cozy-client-js/v0.4.3/dist/cozy-client.min.js
-sha256  67ac63dcce81a89c0a6b8b095761343f15d601e3eecf0d2c9b38d95efc50384c
+sha256  2b9e925d272fe458ad8778c7b60862d0074b6e4af313ed848f199c748a4054e3
 
 name    ./js/cozy-client.min.js.map
 url     https://raw.githubusercontent.com/cozy/cozy-client-js/v0.4.3/dist/cozy-client.min.js.map
-sha256  a5e87a8674d0ec98258407980be4577c4138d44d1563783bf16c29891835058f
+sha256  6b32efab186a52d99de6e0e690ebc9cd3aa70035f65be59aeaa50517d8eee303
 
 name    ./js/cozy-bar.min.js
 url     https://unpkg.com/cozy-bar@4.5.2/dist/cozy-bar.min.js


### PR DESCRIPTION
https://github.com/cozy/cozy-client-js/releases/tag/v0.4.3

I forgot to manually build cozy-client when releasing v0.4.3.
Here is a new shasum for the real v0.4.3.

cf. https://github.com/cozy/cozy-client-js/pull/236/files