### PR TITLE
Fix "Etags" and improve our "go generate"

### DIFF
--- a/pkg/vfs/file.go
+++ b/pkg/vfs/file.go
@@ -4,6 +4,7 @@ import (
 
 	// #nosec
 	"encoding/base64"
+	"fmt"
 	"net/http"
 	"os"
 	"path"
@@ -197,7 +198,7 @@ func ServeFileContent(fs VFS, doc *FileDoc, disposition string, req *http.Reques
 
 	if header.Get("Range") == "" {
 		eTag := base64.StdEncoding.EncodeToString(doc.MD5Sum)
-		header.Set("Etag", eTag)
+		header.Set("Etag", fmt.Sprintf(`"%s"`, eTag))
 	}
 
 	content, err := fs.OpenFile(doc)

--- a/pkg/vfs/vfsswift/impl.go
+++ b/pkg/vfs/vfsswift/impl.go
@@ -776,7 +776,17 @@ func (f *swiftFileCreation) Close() (err error) {
 		var md5sum []byte
 		headers, err = f.f.Headers()
 		if err == nil {
-			md5sum, err = hex.DecodeString(headers["Etag"])
+			// Etags may be double-quoted
+			etag := headers["Etag"]
+			if l := len(etag); l >= 2 {
+				if etag[0] == '"' {
+					etag = etag[1:]
+				}
+				if etag[l-1] == '"' {
+					etag = etag[:l-1]
+				}
+			}
+			md5sum, err = hex.DecodeString(etag)
 			if err == nil {
 				newdoc.MD5Sum = md5sum
 			}

--- a/pkg/vfs/vfsswift/thumbs.go
+++ b/pkg/vfs/vfsswift/thumbs.go
@@ -41,8 +41,10 @@ func (t *thumbs) ServeThumbContent(w http.ResponseWriter, req *http.Request, img
 		return wrapSwiftErr(err)
 	}
 	defer f.Close()
+
 	lastModified, _ := time.Parse(http.TimeFormat, o["Last-Modified"]) // #nosec
-	w.Header().Set("Etag", o["Etag"])
+	w.Header().Set("Etag", fmt.Sprintf(`"%s"`, o["Etag"]))
+
 	http.ServeContent(w, req, name, lastModified, f)
 	return nil
 }

--- a/web/apps/apps.go
+++ b/web/apps/apps.go
@@ -336,13 +336,10 @@ func iconHandler(c echo.Context) error {
 	filepath := path.Join("/", app.Icon)
 	fs := instance.AppsFileServer()
 	err = fs.ServeFileContent(c.Response(), c.Request(), app.Slug(), app.Version(), filepath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return echo.NewHTTPError(http.StatusNotFound, err)
-		}
-		return err
+	if os.IsNotExist(err) {
+		return echo.NewHTTPError(http.StatusNotFound, err)
 	}
-	return nil
+	return err
 }
 
 // WebappsRoutes sets the routing for the web apps service

--- a/web/apps/serve.go
+++ b/web/apps/serve.go
@@ -138,6 +138,7 @@ func ServeAppFile(c echo.Context, i *instance.Instance, fs apps.FileServer, app 
 		}
 		return c.Redirect(http.StatusFound, i.PageURL("/auth/login", redirect))
 	}
+
 	filepath := path.Join("/", route.Folder, file)
 	version := app.Version()
 	if file != route.Index {
@@ -150,9 +151,11 @@ func ServeAppFile(c echo.Context, i *instance.Instance, fs apps.FileServer, app 
 		}
 		return nil
 	}
+
 	if intentID := c.QueryParam("intent"); intentID != "" {
 		handleIntent(c, i, slug, intentID)
 	}
+
 	// For index file, we inject the locale, the stack domain, and a token if the
 	// user is connected
 	content, err := fs.Open(slug, version, filepath)

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -902,6 +902,7 @@ func TestDownloadFileByIDSuccess(t *testing.T) {
 	assert.True(t, strings.Contains(res2.Header.Get("Content-Disposition"), "filename=downloadme1"))
 	assert.True(t, strings.HasPrefix(res2.Header.Get("Content-Type"), "text/plain"))
 	assert.NotEmpty(t, res2.Header.Get("Etag"))
+	assert.Equal(t, res2.Header.Get("Etag")[:1], `"`)
 	assert.Equal(t, res2.Header.Get("Content-Length"), "3")
 	assert.Equal(t, res2.Header.Get("Accept-Ranges"), "bytes")
 	assert.Equal(t, body, string(resbody))

--- a/web/routing.go
+++ b/web/routing.go
@@ -113,7 +113,7 @@ func newRenderer(assetsPath string) (*renderer, error) {
 			return nil, fmt.Errorf("Can't load the assets from %s", assetsPath)
 		}
 		h := http.FileServer(http.Dir(assetsPath))
-		r := &renderer{t: t, Handler: h}
+		r := &renderer{t: t, Handler: http.StripPrefix("/assets", h)}
 		return r, nil
 	}
 
@@ -144,7 +144,7 @@ func newRenderer(assetsPath string) (*renderer, error) {
 		}
 	}
 
-	r := &renderer{t: t, Handler: statikFS.Handler(privateAssets...)}
+	r := &renderer{t: t, Handler: statikFS.Handler("/assets", privateAssets...)}
 	return r, nil
 }
 
@@ -179,7 +179,7 @@ func SetupAssets(router *echo.Echo, assetsPath string) error {
 	}
 
 	router.Renderer = r
-	router.GET("/assets/*", echo.WrapHandler(http.StripPrefix("/assets", r)))
+	router.GET("/assets/*", echo.WrapHandler(r))
 	router.GET("/favicon.ico", echo.WrapHandler(r))
 	router.GET("/robots.txt", echo.WrapHandler(r))
 	return nil

--- a/web/routing.go
+++ b/web/routing.go
@@ -39,7 +39,7 @@ import (
 	"github.com/cozy/cozy-stack/web/status"
 	"github.com/cozy/cozy-stack/web/version"
 
-	"github.com/cozy/statik/fs"
+	statikFS "github.com/cozy/statik/fs"
 	"github.com/labstack/echo"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -115,11 +115,6 @@ func newRenderer(assetsPath string) (*renderer, error) {
 		h := http.FileServer(http.Dir(assetsPath))
 		r := &renderer{t: t, Handler: http.StripPrefix("/assets", h)}
 		return r, nil
-	}
-
-	statikFS, err := fs.New()
-	if err != nil {
-		return nil, err
 	}
 
 	var t, tmpl *template.Template

--- a/web/routing.go
+++ b/web/routing.go
@@ -58,6 +58,12 @@ var (
 		"passphrase_renew.html",
 		"sharing_discovery.html",
 	}
+
+	privateAssets = []string{
+		"/templates/",
+		"/locales/",
+		"/externals",
+	}
 )
 
 type renderer struct {
@@ -138,7 +144,7 @@ func newRenderer(assetsPath string) (*renderer, error) {
 		}
 	}
 
-	r := &renderer{t: t, Handler: statikFS}
+	r := &renderer{t: t, Handler: statikFS.Handler(privateAssets...)}
 	return r, nil
 }
 

--- a/web/routing.go
+++ b/web/routing.go
@@ -1,4 +1,4 @@
-//go:generate statik -src=../.assets -dest=.
+//go:generate statik -src=../assets -dest=. -externals=../assets/externals
 
 package web
 
@@ -39,9 +39,9 @@ import (
 	"github.com/cozy/cozy-stack/web/status"
 	"github.com/cozy/cozy-stack/web/version"
 
+	"github.com/cozy/statik/fs"
 	"github.com/labstack/echo"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/rakyll/statik/fs"
 )
 
 var (
@@ -138,8 +138,7 @@ func newRenderer(assetsPath string) (*renderer, error) {
 		}
 	}
 
-	h := http.FileServer(statikFS)
-	r := &renderer{t: t, Handler: h}
+	r := &renderer{t: t, Handler: statikFS}
 	return r, nil
 }
 
@@ -174,7 +173,7 @@ func SetupAssets(router *echo.Echo, assetsPath string) error {
 	}
 
 	router.Renderer = r
-	router.GET("/assets/*", echo.WrapHandler(http.StripPrefix("/assets/", r)))
+	router.GET("/assets/*", echo.WrapHandler(http.StripPrefix("/assets", r)))
 	router.GET("/favicon.ico", echo.WrapHandler(r))
 	router.GET("/robots.txt", echo.WrapHandler(r))
 	return nil

--- a/web/server.go
+++ b/web/server.go
@@ -22,7 +22,7 @@ import (
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/middleware"
 
-	"github.com/rakyll/statik/fs"
+	"github.com/cozy/statik/fs"
 	"github.com/spf13/afero"
 )
 

--- a/web/server.go
+++ b/web/server.go
@@ -22,7 +22,7 @@ import (
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/middleware"
 
-	"github.com/cozy/statik/fs"
+	statikFS "github.com/cozy/statik/fs"
 	"github.com/spf13/afero"
 )
 
@@ -44,10 +44,6 @@ func LoadSupportedLocales() error {
 		return nil
 	}
 
-	statikFS, err := fs.New()
-	if err != nil {
-		return err
-	}
 	for _, locale := range i18n.SupportedLocales {
 		f, err := statikFS.Open("/locales/" + locale + ".po")
 		if err != nil {


### PR DESCRIPTION
This PR aims at fixing some issues I found from our asset caching control: mainly the `Etag` headers that weren't set properly.

It also switch to a fork of `statik`: `github.com/cozy/statik`, that handles our `assets/externals` file and download assets only if necessary. The generation of our static file now is entirely done with a `go generate`. No real needs to execute `./scripts/build.sh assets` except for download transifex translations.