### PR TITLE
Fix panic (OAuth redirect with no-token_endpoint)

### DIFF
--- a/web/konnectorsauth/oauth.go
+++ b/web/konnectorsauth/oauth.go
@@ -119,10 +119,13 @@ func redirect(c echo.Context) error {
 		if accountType.TokenEndpoint == "" {
 			params := c.QueryParams()
 			params.Del("state")
-			account.Oauth = &accounts.OauthInfo{
-				ClientID:     accountType.ClientID,
-				ClientSecret: accountType.ClientSecret,
-				Query:        &params,
+			account = &accounts.Account{
+				AccountType: accountTypeID,
+				Oauth: &accounts.OauthInfo{
+					ClientID:     accountType.ClientID,
+					ClientSecret: accountType.ClientSecret,
+					Query:        &params,
+				},
 			}
 		} else {
 			account, err = accountType.RequestAccessToken(i, accessCode, stateCode, state.Nonce)


### PR DESCRIPTION
This patch fix a go panic, while getting redirected to the cozy, after an OAuth authentication, in the specific case where no token_endpoint is provided in account_type.

Below, the go stack trace
```
echo: http: panic serving 127.0.0.1:44724: runtime error: invalid memory address or nil pointer dereference
goroutine 2824 [running]:
net/http.(*conn).serve.func1(0xc420a465a0)
	/usr/lib/go-1.8/src/net/http/server.go:1721 +0xd0
panic(0xe296a0, 0x16023d0)
	/usr/lib/go-1.8/src/runtime/panic.go:489 +0x2cf
github.com/cozy/cozy-stack/web/konnectorsauth.redirect(0x15d5820, 0xc420156230, 0xf625e3, 0x20)
	/home/jacquarg/workspace/cozy_dev/local_tests/src/github.com/cozy/cozy-stack/web/konnectorsauth/oauth.go:126 +0x77e
github.com/labstack/echo.(*Echo).Add.func1(0x15d5820, 0xc420156230, 0x20, 0xf41004)
	/home/jacquarg/workspace/cozy_dev/local_tests/src/github.com/labstack/echo/echo.go:477 +0x90
```

This patch fix the panic, but now I get an error in cozy-collect on the page I get redirected : / ( http://collect.oauthcallback.cozy.local:8080/?account=5090f50b4b715bf5e23b546332003666&state=xxx ). I will have à look at this now : )