### PR TITLE
feat: allow oauth applications to post notifications

### DIFF
--- a/web/notifications/notifications.go
+++ b/web/notifications/notifications.go
@@ -39,7 +39,11 @@ func createHandler(c echo.Context) error {
 	if _, err := jsonapi.Bind(c.Request(), &n); err != nil {
 		return err
 	}
-	sourceID, err := permissions.AllowForApp(c, permissions.POST, n)
+	err := permissions.Allow(c, permissions.POST, n)
+	if err != nil {
+		return err
+	}
+	sourceID, err := permissions.GetSourceID(c)
 	if err != nil {
 		return err
 	}

--- a/web/permissions/allow.go
+++ b/web/permissions/allow.go
@@ -130,7 +130,8 @@ func AllowForApp(c echo.Context, v permissions.Verb, o permissions.Validable) (s
 	return pdoc.SourceID, nil
 }
 
-// Get the sourceID of a permission
+// GetSourceID returns the sourceID of the permissions associated with the
+// given context.
 func GetSourceID(c echo.Context) (slug string, err error) {
 	pdoc, err := GetPermission(c)
 	if err != nil {

--- a/web/permissions/allow.go
+++ b/web/permissions/allow.go
@@ -130,6 +130,15 @@ func AllowForApp(c echo.Context, v permissions.Verb, o permissions.Validable) (s
 	return pdoc.SourceID, nil
 }
 
+// Get the sourceID of a permission
+func GetSourceID(c echo.Context) (slug string, err error) {
+	pdoc, err := GetPermission(c)
+	if err != nil {
+		return "", err
+	}
+	return pdoc.SourceID, nil
+}
+
 // AllowLogout checks if the current permission allows loging out.
 // all apps can trigger a logout.
 func AllowLogout(c echo.Context) bool {


### PR DESCRIPTION
As discussed via Zoom, we use OAuth tokens while developing and an app should be able to send notifications. The sourceId for OAuth app is the id of the app.

```
      "source": "ff13a635265094f840756fe604037517",
```