### PR TITLE
[WIP] Simplify API for thumbnails

### DIFF
--- a/docs/files.md
+++ b/docs/files.md
@@ -345,11 +345,11 @@ Location: http://cozy.example.com/files/9152d568-7e7c-11e6-a377-37cbfb190b4b
     "links": {
       "self": "/files/9152d568-7e7c-11e6-a377-37cbfb190b4b",
       "small":
-        "/files/9152d568-7e7c-11e6-a377-37cbfb190b4b/thumbnails/0f9cda56674282ac/small",
+        "/files/9152d568-7e7c-11e6-a377-37cbfb190b4b/thumbnails/small/0f9cda56674282ac",
       "medium":
-        "/files/9152d568-7e7c-11e6-a377-37cbfb190b4b/thumbnails/0f9cda56674282ac/medium",
+        "/files/9152d568-7e7c-11e6-a377-37cbfb190b4b/thumbnails/medium/0f9cda56674282ac",
       "large":
-        "/files/9152d568-7e7c-11e6-a377-37cbfb190b4b/thumbnails/0f9cda56674282ac/large"
+        "/files/9152d568-7e7c-11e6-a377-37cbfb190b4b/thumbnails/large/0f9cda56674282ac"
     }
   }
 }
@@ -357,6 +357,62 @@ Location: http://cozy.example.com/files/9152d568-7e7c-11e6-a377-37cbfb190b4b
 
 **Note**: see [references of documents in VFS](references-docs-in-vfs.md) for
 more informations about the references field.
+
+### POST /files/_find
+
+Make a mango request to find files and directories.
+
+This request allows to make a mango request on the filesystem index. See the
+[find documents](docs/mango.md#find-documents) part of the mango documentation
+for more informations on mango requests.
+
+The response is in JSON-API format.
+
+#### Request
+
+```http
+POST /files/_find
+```
+
+```json
+{
+  "selector": {},
+  "limit": 2,
+  "skip": 3,
+}
+```
+
+#### Response
+
+```json
+{
+  "data": [
+    {
+      "type": "io.cozy.files",
+      "id": "df24aac0-7f3d-11e6-81c0-d38812bfa0a8",
+      "meta": {
+        "rev": "1-3b75377c"
+      },
+      "attributes": {
+        "type": "file",
+        "name": "foo.txt",
+        "trashed": true,
+        "md5sum": "YjAxMzQxZTc4MDNjODAwYwo=",
+        "created_at": "2016-09-19T12:38:04Z",
+        "updated_at": "2016-09-19T12:38:04Z",
+        "tags": [],
+        "size": 123,
+        "executable": false,
+        "class": "document",
+        "mime": "text/plain"
+      },
+      "links": {
+        "self": "/files/trash/df24aac0-7f3d-11e6-81c0-d38812bfa0a8"
+      }
+    }
+  ]
+}
+```
 
 ### GET /files/download/:file-id
 
@@ -395,10 +451,19 @@ By default the `content-disposition` will be `inline`, but it will be
 GET /files/download?Path=/Documents/hello.txt&Dl=1 HTTP/1.1
 ```
 
-### GET /files/:file-id/thumbnails/:secret/:format
+### GET /files/:file-id/thumbnails/:format
 
 Get a thumbnail of a file (for an image only). `:format` can be `small`
 (640x480), `medium` (1280x720), or `large` (1920x1080).
+
+### GET /files/:file-id/thumbnails/:format/:secret
+
+Get a thumbnail of a file on the specified format: like the `GET /files/:file-
+id/thumbnails/:format` route.
+
+This route does not need a specific permission with `Bearer` token. The
+permission itself is given by the `secret` value encoded in the path. It
+requires a valid session cookie though.
 
 ### PUT /files/:file-id
 

--- a/pkg/crypto/mac.go
+++ b/pkg/crypto/mac.go
@@ -11,7 +11,6 @@ import (
 )
 
 var (
-	errMACTooLong = errors.New("mac: too long")
 	errMACExpired = errors.New("mac: expired")
 	errMACInvalid = errors.New("mac: the value is not valid")
 )
@@ -98,7 +97,7 @@ func DecodeAuthMessage(c MACConfig, key, enc, additionalData []byte) ([]byte, er
 	// Check length
 	if c.MaxLen > 0 {
 		if len(enc) > c.MaxLen {
-			return nil, errMACTooLong
+			return nil, errMACInvalid
 		}
 	}
 
@@ -108,7 +107,7 @@ func DecodeAuthMessage(c MACConfig, key, enc, additionalData []byte) ([]byte, er
 	}
 	dec, err := Base64Decode(enc)
 	if err != nil {
-		return nil, err
+		return nil, errMACInvalid
 	}
 
 	// Prepend name and additional data

--- a/pkg/crypto/mac_test.go
+++ b/pkg/crypto/mac_test.go
@@ -95,6 +95,7 @@ func TestMACWrongMessage(t *testing.T) {
 	k := []byte("0123456789012345")
 	o := MACConfig{
 		Name:   "name",
+		MaxAge: 1 * time.Minute,
 		MaxLen: 256,
 	}
 
@@ -197,7 +198,7 @@ func TestAuthentication(t *testing.T) {
 	hashKey := []byte("secret-key")
 	for _, value := range testStrings {
 		mac := createMAC(hashKey, []byte(value))
-		if !assert.Len(t, mac, macLen) {
+		if !assert.Len(t, mac, hmacLen) {
 			return
 		}
 		ok1 := verifyMAC(hashKey, []byte(value), mac)

--- a/pkg/crypto/mac_test.go
+++ b/pkg/crypto/mac_test.go
@@ -13,53 +13,47 @@ var testStrings = []string{"foo", "bar", "baz"}
 func TestMACMessageWithName(t *testing.T) {
 	value := []byte("myvalue")
 
-	o1 := &MACConfig{
-		Key:  []byte("0123456789012345"),
-		Name: "message1",
-	}
-	o2 := &MACConfig{
-		Key:  []byte("0123456789012345"),
-		Name: "",
-	}
-	o3 := &MACConfig{
-		Key:  []byte("9876543210987654"),
-		Name: "message1",
-	}
+	k1 := []byte("0123456789012345")
+	k2 := []byte("0123456789012345")
+	k3 := []byte("9876543210987654")
+	o1 := MACConfig{Name: "message1"}
+	o2 := MACConfig{Name: ""}
+	o3 := MACConfig{Name: "message1"}
 
-	encoded, err1 := EncodeAuthMessage(o1, value, nil)
+	encoded, err1 := EncodeAuthMessage(o1, k1, value, nil)
 	if !assert.NoError(t, err1) {
 		return
 	}
-	v, err2 := DecodeAuthMessage(o1, encoded, nil)
+	v, err2 := DecodeAuthMessage(o1, k1, encoded, nil)
 	if !assert.NoError(t, err2) {
 		return
 	}
 	if !assert.EqualValues(t, v, value) {
 		t.Fatalf("Expected %v, got %v.", v, value)
 	}
-	_, err3 := DecodeAuthMessage(o2, encoded, nil)
+	_, err3 := DecodeAuthMessage(o2, k2, encoded, nil)
 	if !assert.Error(t, err3) {
 		return
 	}
-	_, err4 := DecodeAuthMessage(o3, encoded, nil)
+	_, err4 := DecodeAuthMessage(o3, k3, encoded, nil)
 	if !assert.Error(t, err4) {
 		return
 	}
-	_, err5 := DecodeAuthMessage(o1, encoded, []byte("plop"))
+	_, err5 := DecodeAuthMessage(o1, k1, encoded, []byte("plop"))
 	if !assert.Error(t, err5) {
 		return
 	}
 
-	encoded2, err6 := EncodeAuthMessage(o1, value, []byte("foo"))
+	encoded2, err6 := EncodeAuthMessage(o1, k1, value, []byte("foo"))
 	if !assert.NoError(t, err6) {
 		return
 	}
 
-	_, err7 := DecodeAuthMessage(o1, encoded2, []byte("foo"))
+	_, err7 := DecodeAuthMessage(o1, k1, encoded2, []byte("foo"))
 	if !assert.NoError(t, err7) {
 		return
 	}
-	_, err8 := DecodeAuthMessage(o1, encoded2, []byte("plop"))
+	_, err8 := DecodeAuthMessage(o1, k1, encoded2, []byte("plop"))
 	if !assert.Error(t, err8) {
 		return
 	}
@@ -68,60 +62,52 @@ func TestMACMessageWithName(t *testing.T) {
 func TestMACMessageWithoutName(t *testing.T) {
 	value := []byte("myvalue")
 
-	o1 := &MACConfig{
-		Key:  []byte("0123456789012345"),
-		Name: "",
-	}
-	o2 := &MACConfig{
-		Key:  []byte("0123456789012345"),
-		Name: "message1",
-	}
-	o3 := &MACConfig{
-		Key:  []byte("9876543210987654"),
-		Name: "",
-	}
+	k1 := []byte("0123456789012345")
+	k2 := []byte("0123456789012345")
+	k3 := []byte("9876543210987654")
+	o1 := MACConfig{Name: ""}
+	o2 := MACConfig{Name: "message1"}
+	o3 := MACConfig{Name: ""}
 
-	encoded, err1 := EncodeAuthMessage(o1, value, nil)
+	encoded, err1 := EncodeAuthMessage(o1, k1, value, nil)
 	if !assert.NoError(t, err1) {
 		return
 	}
-	v, err2 := DecodeAuthMessage(o1, encoded, nil)
+	v, err2 := DecodeAuthMessage(o1, k1, encoded, nil)
 	if !assert.NoError(t, err2) {
 		return
 	}
 	if !reflect.DeepEqual(v, value) {
 		t.Fatalf("Expected %v, got %v.", value, v)
 	}
-	_, err3 := DecodeAuthMessage(o2, encoded, nil)
+	_, err3 := DecodeAuthMessage(o2, k2, encoded, nil)
 	if !assert.Error(t, err3) {
 		return
 	}
-	_, err4 := DecodeAuthMessage(o3, encoded, nil)
+	_, err4 := DecodeAuthMessage(o3, k3, encoded, nil)
 	if !assert.Error(t, err4) {
 		return
 	}
 }
 
 func TestMACWrongMessage(t *testing.T) {
-	key := []byte("0123456789012345")
-	o := &MACConfig{
-		Key: key,
-	}
+	k := []byte("0123456789012345")
+	o := MACConfig{}
 
 	buf1 := new(bytes.Buffer)
-	_, err1 := DecodeAuthMessage(o, buf1.Bytes(), nil)
+	_, err1 := DecodeAuthMessage(o, k, buf1.Bytes(), nil)
 	if !assert.Equal(t, errMACInvalid, err1) {
 		return
 	}
 
 	buf2 := Base64Encode(GenerateRandomBytes(32))
-	_, err2 := DecodeAuthMessage(o, buf2, nil)
+	_, err2 := DecodeAuthMessage(o, k, buf2, nil)
 	if !assert.Equal(t, errMACInvalid, err2) {
 		return
 	}
 
-	buf3 := Base64Encode(createMAC(key, []byte("")))
-	_, err3 := DecodeAuthMessage(o, buf3, nil)
+	buf3 := Base64Encode(createMAC(k, []byte("")))
+	_, err3 := DecodeAuthMessage(o, k, buf3, nil)
 	if !assert.Equal(t, errMACInvalid, err3) {
 		return
 	}

--- a/pkg/crypto/utils.go
+++ b/pkg/crypto/utils.go
@@ -20,7 +20,7 @@ func GenerateRandomBytes(n int) []byte {
 
 // Timestamp returns the current timestamp, in seconds.
 func Timestamp() int64 {
-	return time.Now().UTC().Unix()
+	return time.Now().Unix()
 }
 
 // Base64Encode encodes a value using base64.

--- a/pkg/sessions/session.go
+++ b/pkg/sessions/session.go
@@ -20,11 +20,11 @@ const SessionCookieName = "cozysessid"
 
 const (
 	// SessionMaxAge is the maximum duration of the session in seconds
-	SessionMaxAge = 7 * 24 * 60 * 60
+	SessionMaxAge = 7 * 24 * time.Hour
 
 	// AppCookieMaxAge is the maximum duration of the application cookie is
 	// seconds
-	AppCookieMaxAge = 24 * 60 * 60
+	AppCookieMaxAge = 24 * time.Hour
 )
 
 var (
@@ -110,7 +110,7 @@ func Get(i *instance.Instance, sessionID string) (*Session, error) {
 
 	// if the session is older than the session max age, it has expired and
 	// should be deleted.
-	if s.OlderThan(SessionMaxAge * time.Second) {
+	if s.OlderThan(SessionMaxAge) {
 		err := couchdb.DeleteDoc(i, s)
 		if err != nil {
 			i.Logger().Warn("[session] Failed to delte expired session:", err)
@@ -122,7 +122,7 @@ func Get(i *instance.Instance, sessionID string) (*Session, error) {
 	}
 
 	// if the session is older than half its half-life, update the LastSeen date.
-	if s.OlderThan((SessionMaxAge * time.Second) / 2) {
+	if s.OlderThan(SessionMaxAge / 2) {
 		lastSeen := s.LastSeen
 		s.LastSeen = time.Now()
 		err := couchdb.UpdateDoc(i, s)
@@ -148,7 +148,7 @@ func FromCookie(c echo.Context, i *instance.Instance) (*Session, error) {
 		return nil, ErrNoCookie
 	}
 
-	sessionID, err := crypto.DecodeAuthMessage(cookieMACConfig(i, SessionMaxAge),
+	sessionID, err := crypto.DecodeAuthMessage(cookieSessionMACConfig, i.SessionSecret,
 		[]byte(cookie.Value), nil)
 	if err != nil {
 		return nil, err
@@ -165,7 +165,7 @@ func FromAppCookie(c echo.Context, i *instance.Instance, slug string) (*Session,
 			return nil, ErrNoCookie
 		}
 
-		sessionID, err := crypto.DecodeAuthMessage(cookieMACConfig(i, AppCookieMaxAge),
+		sessionID, err := crypto.DecodeAuthMessage(cookieAppMACConfig, i.SessionSecret,
 			[]byte(cookie.Value), []byte(slug))
 		if err != nil {
 			return nil, err
@@ -204,7 +204,7 @@ func (s *Session) Delete(i *instance.Instance) *http.Cookie {
 
 // ToCookie returns an http.Cookie for this Session
 func (s *Session) ToCookie() (*http.Cookie, error) {
-	encoded, err := crypto.EncodeAuthMessage(cookieMACConfig(s.Instance, SessionMaxAge), []byte(s.ID()), nil)
+	encoded, err := crypto.EncodeAuthMessage(cookieSessionMACConfig, s.Instance.SessionSecret, []byte(s.ID()), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -212,7 +212,7 @@ func (s *Session) ToCookie() (*http.Cookie, error) {
 	return &http.Cookie{
 		Name:     SessionCookieName,
 		Value:    string(encoded),
-		MaxAge:   SessionMaxAge,
+		MaxAge:   int(SessionMaxAge.Seconds()),
 		Path:     "/",
 		Domain:   utils.StripPort("." + s.Instance.Domain),
 		Secure:   !s.Instance.Dev,
@@ -222,7 +222,7 @@ func (s *Session) ToCookie() (*http.Cookie, error) {
 
 // ToAppCookie returns an http.Cookie for this Session on an app subdomain
 func (s *Session) ToAppCookie(domain, slug string) (*http.Cookie, error) {
-	encoded, err := crypto.EncodeAuthMessage(cookieMACConfig(s.Instance, AppCookieMaxAge), []byte(s.ID()), []byte(slug))
+	encoded, err := crypto.EncodeAuthMessage(cookieAppMACConfig, s.Instance.SessionSecret, []byte(s.ID()), []byte(slug))
 	if err != nil {
 		return nil, err
 	}
@@ -230,7 +230,7 @@ func (s *Session) ToAppCookie(domain, slug string) (*http.Cookie, error) {
 	return &http.Cookie{
 		Name:     SessionCookieName,
 		Value:    string(encoded),
-		MaxAge:   AppCookieMaxAge,
+		MaxAge:   int(AppCookieMaxAge.Seconds()),
 		Path:     "/",
 		Domain:   utils.StripPort(domain),
 		Secure:   !s.Instance.Dev,
@@ -276,11 +276,14 @@ func DeleteOthers(i *instance.Instance, selfSessionID string) error {
 //
 // 256 bytes should be sufficient enough to support any type of session.
 //
-func cookieMACConfig(i *instance.Instance, maxAge int64) *crypto.MACConfig {
-	return &crypto.MACConfig{
-		Name:   SessionCookieName,
-		Key:    i.SessionSecret,
-		MaxAge: maxAge,
-		MaxLen: 256,
-	}
+var cookieAppMACConfig = crypto.MACConfig{
+	Name:   SessionCookieName,
+	MaxAge: SessionMaxAge,
+	MaxLen: 256,
+}
+
+var cookieSessionMACConfig = crypto.MACConfig{
+	Name:   SessionCookieName,
+	MaxAge: AppCookieMaxAge,
+	MaxLen: 256,
 }

--- a/pkg/vfs/download_store.go
+++ b/pkg/vfs/download_store.go
@@ -13,7 +13,7 @@ import (
 
 var downloadLinkMac = crypto.MACConfig{
 	Name:   "download-link",
-	MaxAge: 24 * time.Hour,
+	MaxAge: 0,
 	MaxLen: 64,
 }
 
@@ -23,7 +23,8 @@ var downloadLinkMac = crypto.MACConfig{
 // An optional sessionID can be specified in order to sign the associated
 // session in the returned token.
 func GenerateSecureLinkSecret(key []byte, doc *FileDoc, sessionID string) string {
-	mac, err := crypto.EncodeAuthMessage(downloadLinkMac, key, nil, []byte(doc.ID()+sessionID))
+	additionalData := []byte(doc.ID() + sessionID)
+	mac, err := crypto.EncodeAuthMessage(downloadLinkMac, key, nil, additionalData)
 	if err != nil {
 		return ""
 	}
@@ -34,6 +35,9 @@ func GenerateSecureLinkSecret(key []byte, doc *FileDoc, sessionID string) string
 // checks that it corresponds to the given fileID. A sessionID may be given,
 // and will be checked as long with the fileID.
 func VerifySecureLinkSecret(key []byte, secret, fileID, sessionID string) bool {
+	if sessionID == "" || fileID == "" {
+		return false
+	}
 	_, err := crypto.DecodeAuthMessage(downloadLinkMac, key, []byte(secret), []byte(fileID+sessionID))
 	return err == nil
 }

--- a/pkg/vfs/download_store.go
+++ b/pkg/vfs/download_store.go
@@ -14,6 +14,7 @@ import (
 var downloadLinkMac = crypto.MACConfig{
 	Name:   "download-link",
 	MaxAge: 24 * time.Hour,
+	MaxLen: 64,
 }
 
 // GenerateSecureLinkSecret generates a signature that can be used in exchange

--- a/pkg/vfs/download_store_test.go
+++ b/pkg/vfs/download_store_test.go
@@ -1,9 +1,14 @@
 package vfs
 
 import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
+	"github.com/cozy/cozy-stack/pkg/crypto"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -11,26 +16,7 @@ func TestDownloadStoreInMemory(t *testing.T) {
 	downloadStoreTTL = 100 * time.Millisecond
 
 	domainA := "alice.cozycloud.local"
-	domainB := "bob.cozycloud.local"
 	store := newMemStore()
-
-	path := "/test/random/path.txt"
-	key1, err := store.AddFile(domainA, path)
-	assert.NoError(t, err)
-
-	path2, err := store.GetFile(domainB, key1)
-	assert.NoError(t, err)
-	assert.Zero(t, path2, "Inter-instances store leaking")
-
-	path3, err := store.GetFile(domainA, key1)
-	assert.NoError(t, err)
-	assert.Equal(t, path, path3)
-
-	time.Sleep(2 * downloadStoreTTL)
-
-	path4, err := store.GetFile(domainA, key1)
-	assert.NoError(t, err)
-	assert.Zero(t, path4, "no expiration")
 
 	a := &Archive{
 		Name: "test",
@@ -57,26 +43,7 @@ func TestDownloadStoreInRedis(t *testing.T) {
 	downloadStoreTTL = 100 * time.Millisecond
 
 	domainA := "alice.cozycloud.local"
-	domainB := "bob.cozycloud.local"
 	store := GetStore()
-
-	path := "/test/random/path.txt"
-	key1, err := store.AddFile(domainA, path)
-	assert.NoError(t, err)
-
-	path2, err := store.GetFile(domainB, key1)
-	assert.NoError(t, err)
-	assert.Zero(t, path2, "Inter-instances store leaking")
-
-	path3, err := store.GetFile(domainA, key1)
-	assert.NoError(t, err)
-	assert.Equal(t, path, path3)
-
-	time.Sleep(2 * downloadStoreTTL)
-
-	path4, err := store.GetFile(domainA, key1)
-	assert.NoError(t, err)
-	assert.Zero(t, path4, "no expiration")
 
 	a := &Archive{
 		Name: "test",
@@ -97,4 +64,58 @@ func TestDownloadStoreInRedis(t *testing.T) {
 	a3, err := store.GetArchive(domainA, key2)
 	assert.NoError(t, err)
 	assert.Nil(t, a3, "no expiration")
+}
+
+var result interface{}
+
+func BenchmarkGenerateLinkSecret(b *testing.B) {
+	fmt.Println(">>>>>", time.Now(), time.Now().UTC())
+	fmt.Println(">>>>>", time.Now().Unix(), time.Now().UTC().Unix())
+	key := crypto.GenerateRandomBytes(64)
+	ids := make([]string, 256)
+	for i := range ids {
+		ids[i] = hex.EncodeToString(crypto.GenerateRandomBytes(32))
+	}
+
+	secrets := make([]string, 50)
+	for i := 0; i < b.N; i++ {
+		for n := 0; n < 50; n++ {
+			s := GenerateSecureLinkSecret(key, &FileDoc{DocID: ids[i%256], DocRev: ids[(i+1)%256]}, ids[(i+2)%256])
+			secrets[n] = s
+		}
+	}
+
+	result = secrets
+}
+
+func BenchmarkSerializeFiles(b *testing.B) {
+	files := make([]*FileDoc, 50)
+	for i := range files {
+		files[i] = &FileDoc{
+			Type:        "file",
+			DocID:       hex.EncodeToString(crypto.GenerateRandomBytes(16)),
+			DocRev:      hex.EncodeToString(crypto.GenerateRandomBytes(16)),
+			DocName:     "MyNameIs" + strconv.Itoa(i),
+			DirID:       hex.EncodeToString(crypto.GenerateRandomBytes(16)),
+			RestorePath: "",
+			ByteSize:    6341,
+			MD5Sum:      crypto.GenerateRandomBytes(16),
+			Mime:        "application/octet-stream",
+			Class:       "image",
+			Executable:  false,
+			Trashed:     false,
+			Tags:        []string{"foo", "bar"},
+		}
+	}
+
+	var r []byte
+	for i := 0; i < b.N; i++ {
+		var err error
+		r, err = json.Marshal(files)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	result = r
 }

--- a/pkg/vfs/vfsswift/thumbs.go
+++ b/pkg/vfs/vfsswift/thumbs.go
@@ -11,6 +11,8 @@ import (
 	"github.com/cozy/swift"
 )
 
+var unixZeroEpoch = time.Time{}
+
 // NewThumbsFs creates a new thumb filesystem base on swift.
 func NewThumbsFs(c *swift.Connection, domain string) vfs.Thumbser {
 	return &thumbs{c: c, container: "data-" + domain}
@@ -42,10 +44,8 @@ func (t *thumbs) ServeThumbContent(w http.ResponseWriter, req *http.Request, img
 	}
 	defer f.Close()
 
-	lastModified, _ := time.Parse(http.TimeFormat, o["Last-Modified"]) // #nosec
 	w.Header().Set("Etag", fmt.Sprintf(`"%s"`, o["Etag"]))
-
-	http.ServeContent(w, req, name, lastModified, f)
+	http.ServeContent(w, req, name, unixZeroEpoch, f)
 	return nil
 }
 

--- a/web/files/references.go
+++ b/web/files/references.go
@@ -19,7 +19,7 @@ import (
 
 const maxRefLimit = 100
 
-func rawMessageToObject(i *instance.Instance, bb json.RawMessage) (jsonapi.Object, error) {
+func rawMessageToObject(i *instance.Instance, sessionID string, bb json.RawMessage) (jsonapi.Object, error) {
 	var dof vfs.DirOrFileDoc
 	err := json.Unmarshal(bb, &dof)
 	if err != nil {
@@ -29,8 +29,7 @@ func rawMessageToObject(i *instance.Instance, bb json.RawMessage) (jsonapi.Objec
 	if d != nil {
 		return newDir(d), nil
 	}
-
-	return newFile(f, i), nil
+	return newFile(f, i, sessionID), nil
 }
 
 // ListReferencesHandler list all files referenced by a doc
@@ -38,6 +37,7 @@ func rawMessageToObject(i *instance.Instance, bb json.RawMessage) (jsonapi.Objec
 // Beware, this is actually used in the web/data Routes
 func ListReferencesHandler(c echo.Context) error {
 	instance := middlewares.GetInstance(c)
+	sessionID := middlewares.GetSessionID(c)
 	doctype := c.Get("doctype").(string)
 	id := c.Param("docid")
 	include := c.QueryParam("include")
@@ -123,7 +123,7 @@ func ListReferencesHandler(c echo.Context) error {
 		}
 
 		if includeDocs {
-			docs[i], err = rawMessageToObject(instance, row.Doc)
+			docs[i], err = rawMessageToObject(instance, sessionID, row.Doc)
 			if err != nil {
 				return err
 			}

--- a/web/middlewares/session.go
+++ b/web/middlewares/session.go
@@ -49,6 +49,19 @@ func GetSession(c echo.Context) (session *sessions.Session, ok bool) {
 	v := c.Get(sessionKey)
 	if v != nil {
 		session, ok = v.(*sessions.Session)
+		if ok {
+			return session, true
+		}
 	}
-	return session, ok
+	return nil, false
+}
+
+// GetSessionID returns the current session identifier if any. Returns an empty
+// string if there is none.
+func GetSessionID(c echo.Context) string {
+	s, ok := GetSession(c)
+	if ok {
+		return s.ID()
+	}
+	return ""
 }


### PR DESCRIPTION
This PR adds simpler possibilities to access thumbnails:

  - a handler to access thumbnails with a standard `Bearer` token has been added and should be useful for mobile access (which can overload their request to images with the correct headers)

  - a secret generated with a HMAC (instead of a stored random state) for browsers in exchange of a valid `Bearer` token: this secret is signed with the sessionID responsible for the secret generation request and only gives permission to *one* specific file ID. This way, the secret can only be used with the same valid session on the main domain and only for the one file.

For mango request, the `/files/_find` should be used when possible as they contain a generated file with secret, when required.