### PR TITLE
Only cozy-stack serve needs to read the admin passphrase file

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -79,6 +79,13 @@ example), you can use the --appdir flag like this:
 			}
 		}
 
+		if !config.IsDevRelease() {
+			adminSecretFile := config.GetConfig().AdminSecretFileName
+			if _, err := config.FindConfigFile(adminSecretFile); err != nil {
+				return err
+			}
+		}
+
 		broker, schder, processes, err := stack.Start()
 		if err != nil {
 			return err

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -421,12 +421,6 @@ func UseViper(v *viper.Viper) error {
 		adminSecretFile = defaultAdminSecretFileName
 	}
 
-	if !IsDevRelease() {
-		if _, err := FindConfigFile(adminSecretFile); err != nil {
-			return err
-		}
-	}
-
 	config = &Config{
 		Host:                v.GetString("host"),
 		Port:                v.GetInt("port"),


### PR DESCRIPTION
Other CLI commands (like `cozy-stack instances add`) can now be run without needing to be able to read the admin passphrase file