### PR TITLE
Add a per-worker type configuration

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -9,7 +9,6 @@ import (
 	"os/signal"
 	"path"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 
@@ -163,9 +162,6 @@ func init() {
 
 	flags.String("downloads-url", "", "URL for the download secret storage, redis or in-memory")
 	checkNoErr(viper.BindPFlag("downloads.url", flags.Lookup("downloads-url")))
-
-	flags.Int("jobs-workers", runtime.NumCPU(), "Number of parallel workers (0 to disable the processing of jobs)")
-	checkNoErr(viper.BindPFlag("jobs.workers", flags.Lookup("jobs-workers")))
 
 	flags.String("jobs-url", "", "URL for the jobs system synchronization, redis or in-memory")
 	checkNoErr(viper.BindPFlag("jobs.url", flags.Lookup("jobs-url")))

--- a/cozy.example.yaml
+++ b/cozy.example.yaml
@@ -52,9 +52,49 @@ couchdb:
 
 # jobs parameters to configure the job system
 jobs:
-  # workers define the number of concurrent workers running on the system. if
-  # this parameter is set to 0, no worker is running
-  workers: 1
+  # workers individual configrations.
+  #
+  # For each worker type it is possible to configure the following fields:
+  #   - concurrency: the maximum number of jobs executed in parallel. when set
+  #     to zero, the worker is deactivated
+  #   - max_exec_count: the maximum number of retries for one job in case of an
+  #     error
+  #   - timeout: the maximum amount of time allowed for one execution of a job
+  #
+  # List of available workers:
+  #
+  #   - "konnector":      launching konnectors
+  #   - "push":           sending push notifications
+  #   - "sendmail":       sending mails
+  #   - "service":        launching services
+  #   - "sharedata":      data sharing between cozies
+  #   - "sharingupdates": update of sharings data
+  #   - "thumbnail":      creatings and deleting thumbnails for images
+  #   - "unzip":          unzipping tarball
+  #
+  # When no configuration is given for a worker, a default configuration is
+  # used. When a false boolean value is given, the worker is deactivated.
+  #
+  # To deactivate all workers, the workers field can be set to "false" or
+  # "none".
+  workers:
+    # thumbnail:
+    #   concurrency: {{mul .NumCPU 4}}
+    #   max_exec_count: 2
+    #   timeout: 15s
+
+    # konnector:
+    #   concurrency: {{.NumCPU}}
+    #   max_exec_count: 2
+    #   timeout: 200s
+
+    # service:
+    #   concurrency: {{.NumCPU}}
+    #   max_exec_count: 2
+    #   timeout: 200s
+
+    # sharedata:      false
+    # sharingupdates: false
 
 # konnectors execution parameters for executing external processes.
 konnectors:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -459,19 +459,29 @@ func UseViper(v *viper.Viper) error {
 						w.Concurrency = &zero
 					}
 				} else if m, ok := mapInterface.(map[string]interface{}); ok {
-					if concurrency, ok := m["concurrency"].(int); ok {
-						w.Concurrency = &concurrency
-					}
-					if maxExecCount, ok := m["max_exec_count"].(int); ok {
-						w.MaxExecCount = &maxExecCount
-					}
-					if timeout, ok := m["timeout"].(string); ok {
-						d, err := time.ParseDuration(timeout)
-						if err != nil {
-							return fmt.Errorf("config: could not parse timeout duration for worker %q: %s",
-								workerType, err)
+					for k, v := range m {
+						switch k {
+						case "concurrency":
+							if concurrency, ok := v.(int); ok {
+								w.Concurrency = &concurrency
+							}
+						case "max_exec_count":
+							if maxExecCount, ok := v.(int); ok {
+								w.MaxExecCount = &maxExecCount
+							}
+						case "timeout":
+							if timeout, ok := v.(string); ok {
+								d, err := time.ParseDuration(timeout)
+								if err != nil {
+									return fmt.Errorf("config: could not parse timeout duration for worker %q: %s",
+										workerType, err)
+								}
+								w.Timeout = &d
+							}
+						default:
+							return fmt.Errorf("config: unknown key %q",
+								"jobs.workers."+workerType+"."+k)
 						}
-						w.Timeout = &d
 					}
 				} else {
 					return fmt.Errorf("config: expecting a map in the key %q",

--- a/pkg/jobs/mem_jobs_test.go
+++ b/pkg/jobs/mem_jobs_test.go
@@ -67,7 +67,8 @@ func TestInMemoryJobs(t *testing.T) {
 	var w sync.WaitGroup
 
 	var workersTestList = WorkersList{
-		"test": {
+		{
+			WorkerType:  "test",
 			Concurrency: 4,
 			WorkerFunc: func(ctx *WorkerContext) error {
 				var msg string
@@ -90,8 +91,8 @@ func TestInMemoryJobs(t *testing.T) {
 		},
 	}
 
-	broker1 := NewMemBroker(4)
-	broker2 := NewMemBroker(4)
+	broker1 := NewMemBroker()
+	broker2 := NewMemBroker()
 	broker1.Start(workersTestList)
 	broker2.Start(workersTestList)
 	w.Add(2)
@@ -130,7 +131,7 @@ func TestInMemoryJobs(t *testing.T) {
 }
 
 func TestUnknownWorkerError(t *testing.T) {
-	broker := NewMemBroker(1)
+	broker := NewMemBroker()
 	broker.Start(WorkersList{})
 	_, err := broker.PushJob(&JobRequest{
 		Domain:     "cozy.local",
@@ -144,9 +145,10 @@ func TestUnknownWorkerError(t *testing.T) {
 func TestUnknownMessageType(t *testing.T) {
 	var w sync.WaitGroup
 
-	broker := NewMemBroker(4)
+	broker := NewMemBroker()
 	broker.Start(WorkersList{
-		"test": {
+		{
+			WorkerType:  "test",
 			Concurrency: 4,
 			WorkerFunc: func(ctx *WorkerContext) error {
 				var msg string
@@ -173,9 +175,10 @@ func TestUnknownMessageType(t *testing.T) {
 func TestTimeout(t *testing.T) {
 	var w sync.WaitGroup
 
-	broker := NewMemBroker(1)
+	broker := NewMemBroker()
 	broker.Start(WorkersList{
-		"timeout": {
+		{
+			WorkerType:   "timeout",
 			Concurrency:  1,
 			MaxExecCount: 1,
 			Timeout:      1 * time.Millisecond,
@@ -204,9 +207,10 @@ func TestRetry(t *testing.T) {
 	maxExecCount := 4
 
 	var count int
-	broker := NewMemBroker(1)
+	broker := NewMemBroker()
 	broker.Start(WorkersList{
-		"test": {
+		{
+			WorkerType:   "test",
 			Concurrency:  1,
 			MaxExecCount: maxExecCount,
 			Timeout:      1 * time.Millisecond,
@@ -239,9 +243,10 @@ func TestPanicRetried(t *testing.T) {
 
 	maxExecCount := 4
 
-	broker := NewMemBroker(1)
+	broker := NewMemBroker()
 	broker.Start(WorkersList{
-		"panic": {
+		{
+			WorkerType:   "panic",
 			Concurrency:  1,
 			MaxExecCount: maxExecCount,
 			RetryDelay:   1 * time.Millisecond,
@@ -269,9 +274,10 @@ func TestPanic(t *testing.T) {
 	even, _ := NewMessage(0)
 	odd, _ := NewMessage(1)
 
-	broker := NewMemBroker(1)
+	broker := NewMemBroker()
 	broker.Start(WorkersList{
-		"panic2": {
+		{
+			WorkerType:   "panic2",
 			Concurrency:  1,
 			MaxExecCount: 1,
 			RetryDelay:   1 * time.Millisecond,

--- a/pkg/jobs/redis_jobs_test.go
+++ b/pkg/jobs/redis_jobs_test.go
@@ -33,7 +33,8 @@ func TestRedisJobs(t *testing.T) {
 	w.Add(2*n + 1)
 
 	var workersTestList = WorkersList{
-		"test": {
+		{
+			WorkerType:  "test",
 			Concurrency: 4,
 			WorkerFunc: func(ctx *WorkerContext) error {
 				var msg string
@@ -59,11 +60,11 @@ func TestRedisJobs(t *testing.T) {
 		},
 	}
 
-	broker1 := NewRedisBroker(4, client)
+	broker1 := NewRedisBroker(client)
 	err := broker1.Start(workersTestList)
 	assert.NoError(t, err)
 
-	broker2 := NewRedisBroker(4, client)
+	broker2 := NewRedisBroker(client)
 	err = broker2.Start(workersTestList)
 	assert.NoError(t, err)
 

--- a/pkg/jobs/workers_list.go
+++ b/pkg/jobs/workers_list.go
@@ -1,24 +1,79 @@
 package jobs
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/cozy/cozy-stack/pkg/config"
+)
 
 // WorkersList is a map associating a worker type with its acutal
 // configuration.
-type WorkersList map[string]*WorkerConfig
+type WorkersList []*WorkerConfig
 
 // WorkersList is the list of available workers with their associated Do
 // function.
-var workersList = WorkersList{}
+var workersList WorkersList
 
 // GetWorkersList returns a globally defined worker config list.
-func GetWorkersList() WorkersList {
-	return workersList
+func GetWorkersList() ([]*WorkerConfig, error) {
+	if config.GetConfig().Jobs.NoWorkers {
+		return nil, nil
+	}
+
+	workersConfs := config.GetConfig().Jobs.Workers
+	workers := make(WorkersList, 0, len(workersList))
+	for _, w := range workersList {
+		for _, c := range workersConfs {
+			if c.WorkerType == w.WorkerType {
+				w = applyWorkerConfig(w, c)
+			}
+		}
+		workers = append(workers, w)
+	}
+
+	for _, c := range workersConfs {
+		_, found := findWorkerByType(c.WorkerType)
+		if !found {
+			return nil, fmt.Errorf("Defined configuration for the worker %q that does not exist",
+				c.WorkerType)
+		}
+	}
+
+	return workers, nil
+}
+
+func applyWorkerConfig(w *WorkerConfig, c config.Worker) *WorkerConfig {
+	w = w.Clone()
+	if c.Concurrency != nil {
+		w.Concurrency = *c.Concurrency
+	}
+	if c.MaxExecCount != nil {
+		w.MaxExecCount = *c.MaxExecCount
+	}
+	if c.Timeout != nil {
+		w.Timeout = *c.Timeout
+	}
+	return w
+}
+
+func findWorkerByType(workerType string) (*WorkerConfig, bool) {
+	for _, w := range workersList {
+		if w.WorkerType == workerType {
+			return w, true
+		}
+	}
+	return nil, false
 }
 
 // AddWorker adds a new worker to global list of available workers.
-func AddWorker(name string, conf *WorkerConfig) {
-	if _, ok := workersList[name]; ok {
-		panic(fmt.Errorf("A worker with the name %s is already defined", name))
+func AddWorker(conf *WorkerConfig) {
+	if conf.WorkerType == "" {
+		panic("Missing worker type field")
 	}
-	workersList[name] = conf
+	for _, w := range workersList {
+		if w.WorkerType == conf.WorkerType {
+			panic(fmt.Errorf("A worker with of type %q is already defined", conf.WorkerType))
+		}
+	}
+	workersList = append(workersList, conf)
 }

--- a/pkg/scheduler/mem_scheduler_test.go
+++ b/pkg/scheduler/mem_scheduler_test.go
@@ -40,9 +40,10 @@ func TestTriggersBadArguments(t *testing.T) {
 func TestMemSchedulerWithTimeTriggers(t *testing.T) {
 	var wAt sync.WaitGroup
 	var wIn sync.WaitGroup
-	bro := jobs.NewMemBroker(1)
+	bro := jobs.NewMemBroker()
 	bro.Start(jobs.WorkersList{
-		"worker": {
+		{
+			WorkerType:   "worker",
 			Concurrency:  1,
 			MaxExecCount: 1,
 			Timeout:      1 * time.Millisecond,
@@ -139,9 +140,10 @@ func TestMemSchedulerWithTimeTriggers(t *testing.T) {
 
 func TestMemSchedulerWithDebounce(t *testing.T) {
 	called := 0
-	bro := jobs.NewMemBroker(1)
+	bro := jobs.NewMemBroker()
 	bro.Start(jobs.WorkersList{
-		"worker": {
+		{
+			WorkerType:   "worker",
 			Concurrency:  1,
 			MaxExecCount: 1,
 			Timeout:      1 * time.Millisecond,

--- a/pkg/scheduler/redis_scheduler_test.go
+++ b/pkg/scheduler/redis_scheduler_test.go
@@ -71,9 +71,10 @@ func (b *mockBroker) WorkersTypes() []string {
 func TestRedisSchedulerWithTimeTriggers(t *testing.T) {
 	var wAt sync.WaitGroup
 	var wIn sync.WaitGroup
-	bro := jobs.NewMemBroker(1)
+	bro := jobs.NewMemBroker()
 	bro.Start(jobs.WorkersList{
-		"worker": {
+		{
+			WorkerType:   "worker",
 			Concurrency:  1,
 			MaxExecCount: 1,
 			Timeout:      1 * time.Millisecond,

--- a/pkg/scheduler/trigger_event_test.go
+++ b/pkg/scheduler/trigger_event_test.go
@@ -22,9 +22,10 @@ func TestTriggerEvent(t *testing.T) {
 	var wg sync.WaitGroup
 	var called = make(map[string]bool)
 
-	bro := jobs.NewMemBroker(1)
+	bro := jobs.NewMemBroker()
 	bro.Start(jobs.WorkersList{
-		"worker_event": {
+		{
+			WorkerType:   "worker_event",
 			Concurrency:  1,
 			MaxExecCount: 1,
 			Timeout:      1 * time.Millisecond,

--- a/pkg/stack/main.go
+++ b/pkg/stack/main.go
@@ -90,16 +90,21 @@ security features. Please do not use this binary as your production server.
 		return
 	}
 
+	workersList, err := jobs.GetWorkersList()
+	if err != nil {
+		return
+	}
+
 	jobsConfig := config.GetConfig().Jobs
-	nbWorkers := jobsConfig.Workers
 	if cli := jobsConfig.Client(); cli != nil {
-		broker = jobs.NewRedisBroker(nbWorkers, cli)
+		broker = jobs.NewRedisBroker(cli)
 		schder = scheduler.NewRedisScheduler(cli)
 	} else {
-		broker = jobs.NewMemBroker(nbWorkers)
+		broker = jobs.NewMemBroker()
 		schder = scheduler.NewMemScheduler()
 	}
-	if err = broker.Start(jobs.GetWorkersList()); err != nil {
+
+	if err = broker.Start(workersList); err != nil {
 		return
 	}
 	if err = schder.Start(broker); err != nil {

--- a/pkg/workers/exec/common.go
+++ b/pkg/workers/exec/common.go
@@ -19,7 +19,6 @@ func init() {
 	addExecWorker("konnector", &jobs.WorkerConfig{
 		Concurrency:  runtime.NumCPU() * 2,
 		MaxExecCount: 2,
-		MaxExecTime:  200 * time.Second,
 		Timeout:      200 * time.Second,
 	}, func() execWorker {
 		return &konnectorWorker{}
@@ -28,7 +27,6 @@ func init() {
 	addExecWorker("service", &jobs.WorkerConfig{
 		Concurrency:  runtime.NumCPU() * 2,
 		MaxExecCount: 2,
-		MaxExecTime:  200 * time.Second,
 		Timeout:      200 * time.Second,
 	}, func() execWorker {
 		return &serviceWorker{}
@@ -120,7 +118,7 @@ func makeExecWorkerFunc() jobs.WorkerFunc {
 	}
 }
 
-func addExecWorker(name string, cfg *jobs.WorkerConfig, createWorker func() execWorker) {
+func addExecWorker(workerType string, cfg *jobs.WorkerConfig, createWorker func() execWorker) {
 	workerFunc := makeExecWorkerFunc()
 
 	workerStart := func(ctx *jobs.WorkerContext) (*jobs.WorkerContext, error) {
@@ -135,11 +133,11 @@ func addExecWorker(name string, cfg *jobs.WorkerConfig, createWorker func() exec
 	}
 
 	cfg = cfg.Clone()
+	cfg.WorkerType = workerType
 	cfg.WorkerStart = workerStart
 	cfg.WorkerFunc = workerFunc
 	cfg.WorkerCommit = workerCommit
-
-	jobs.AddWorker(name, cfg)
+	jobs.AddWorker(cfg)
 }
 
 func wrapErr(ctx context.Context, err error) error {

--- a/pkg/workers/log/log.go
+++ b/pkg/workers/log/log.go
@@ -9,7 +9,8 @@ import (
 )
 
 func init() {
-	jobs.AddWorker("log", &jobs.WorkerConfig{
+	jobs.AddWorker(&jobs.WorkerConfig{
+		WorkerType:   "log",
 		Concurrency:  runtime.NumCPU(),
 		MaxExecCount: 1,
 		Timeout:      1 * time.Second,

--- a/pkg/workers/mails/mail.go
+++ b/pkg/workers/mails/mail.go
@@ -18,7 +18,8 @@ import (
 )
 
 func init() {
-	jobs.AddWorker("sendmail", &jobs.WorkerConfig{
+	jobs.AddWorker(&jobs.WorkerConfig{
+		WorkerType:  "sendmail",
 		Concurrency: runtime.NumCPU(),
 		WorkerFunc:  SendMail,
 	})

--- a/pkg/workers/push/push.go
+++ b/pkg/workers/push/push.go
@@ -30,7 +30,8 @@ var (
 )
 
 func init() {
-	jobs.AddWorker("push", &jobs.WorkerConfig{
+	jobs.AddWorker(&jobs.WorkerConfig{
+		WorkerType:   "push",
 		Concurrency:  runtime.NumCPU(),
 		MaxExecCount: 2,
 		Timeout:      10 * time.Second,

--- a/pkg/workers/sharings/share_data.go
+++ b/pkg/workers/sharings/share_data.go
@@ -29,7 +29,8 @@ import (
 )
 
 func init() {
-	jobs.AddWorker("sharedata", &jobs.WorkerConfig{
+	jobs.AddWorker(&jobs.WorkerConfig{
+		WorkerType:  "sharedata",
 		Concurrency: 1, // no concurency, to make sure directory hierarchy order is respected
 		WorkerFunc:  SendData,
 	})

--- a/pkg/workers/sharings/sharing_updates.go
+++ b/pkg/workers/sharings/sharing_updates.go
@@ -17,7 +17,8 @@ import (
 )
 
 func init() {
-	jobs.AddWorker("sharingupdates", &jobs.WorkerConfig{
+	jobs.AddWorker(&jobs.WorkerConfig{
+		WorkerType:  "sharingupdates",
 		Concurrency: runtime.NumCPU(),
 		WorkerFunc:  SharingUpdates,
 	})

--- a/pkg/workers/thumbnail/thumbnail.go
+++ b/pkg/workers/thumbnail/thumbnail.go
@@ -27,8 +27,9 @@ var formats = map[string]string{
 }
 
 func init() {
-	jobs.AddWorker("thumbnail", &jobs.WorkerConfig{
-		Concurrency:  (runtime.NumCPU() + 1) / 2,
+	jobs.AddWorker(&jobs.WorkerConfig{
+		WorkerType:   "thumbnail",
+		Concurrency:  runtime.NumCPU(),
 		MaxExecCount: 2,
 		Timeout:      15 * time.Second,
 		WorkerFunc:   Worker,

--- a/pkg/workers/unzip/unzip.go
+++ b/pkg/workers/unzip/unzip.go
@@ -21,8 +21,9 @@ type zipMessage struct {
 }
 
 func init() {
-	jobs.AddWorker("unzip", &jobs.WorkerConfig{
-		Concurrency:  (runtime.NumCPU() + 1) / 2,
+	jobs.AddWorker(&jobs.WorkerConfig{
+		WorkerType:   "unzip",
+		Concurrency:  runtime.NumCPU(),
 		MaxExecCount: 2,
 		Timeout:      30 * time.Second,
 		WorkerFunc:   Worker,

--- a/web/jobs/jobs_test.go
+++ b/web/jobs/jobs_test.go
@@ -380,7 +380,8 @@ func TestMain(m *testing.M) {
 	testutils.NeedCouchdb()
 	setup := testutils.NewSetup(m, "jobs_test")
 
-	jobs.AddWorker("print", &jobs.WorkerConfig{
+	jobs.AddWorker(&jobs.WorkerConfig{
+		WorkerType:  "print",
 		Concurrency: 4,
 		WorkerFunc: func(ctx *jobs.WorkerContext) error {
 			var msg string

--- a/web/routing.go
+++ b/web/routing.go
@@ -194,6 +194,7 @@ func CreateSubdomainProxy(router *echo.Echo, appsHandler echo.HandlerFunc) (*ech
 
 	main := echo.New()
 	main.HideBanner = true
+	main.HidePort = true
 	main.Renderer = router.Renderer
 	main.Any("/*", func(c echo.Context) error {
 		// TODO(optim): minimize the number of instance requests

--- a/web/server.go
+++ b/web/server.go
@@ -143,6 +143,7 @@ func checkExists(filepath string) error {
 func listenAndServe(appsHandler echo.HandlerFunc) (*Servers, error) {
 	e := echo.New()
 	e.HideBanner = true
+	e.HidePort = true
 
 	major, err := CreateSubdomainProxy(e, appsHandler)
 	if err != nil {
@@ -160,6 +161,7 @@ func listenAndServe(appsHandler echo.HandlerFunc) (*Servers, error) {
 
 	admin := echo.New()
 	admin.HideBanner = true
+	admin.HidePort = true
 
 	if err = SetupAdminRoutes(admin); err != nil {
 		return nil, err


### PR DESCRIPTION
This PR adds a per-worker type configuration to configure workers individually.

The global hard-limit on the number of the total number of concurrent workers is now removed by default, but kept for retro-compatibility when the `jobs.workers` configuration field is set to an positive integer. Setting such a hard limit now produces a warning log.

The `jobs` configuration is now described as follow:

```yaml
# jobs parameters
jobs:
  # workers individual configrations.
  #
  # For each worker type it is possible to configure the following fields:
  #   - concurrency: the maximum number of jobs executed in parallel. when set
  #     to zero, the worker is deactivated
  #   - max_exec_count: the maximum number of retries for one job in case of an
  #     error
  #   - timeout: the maximum amount of time allowed for one execution of a job
  #
  # List of available workers:
  #
  #   - "konnector":      launching konnectors
  #   - "push":           sending push notifications
  #   - "sendmail":       sending mails
  #   - "service":        launching services
  #   - "sharedata":      data sharing between cozies
  #   - "sharingupdates": update of sharings data
  #   - "thumbnail":      creatings and deleting thumbnails for images
  #   - "unzip":          unzipping tarball
  #
  # When no configuration is given for a worker, a default configuration is
  # used. When a false boolean value is given, the worker is deactivated.
  #
  # To deactivate all workers, the workers field can be set to "false" or
  # "none".
  workers:
    # thumbnail:
    #   concurrency: {{mul .NumCPU 4}}
    #   max_exec_count: 2
    #   timeout: 15s

    # konnector:
    #   concurrency: {{.NumCPU}}
    #   max_exec_count: 2
    #   timeout: 200s

    # service:
    #   concurrency: {{.NumCPU}}
    #   max_exec_count: 2
    #   timeout: 200s

    # sharedata:      false
    # sharingupdates: false
```

The `max_exec_time` configuration for workers has also been removed since it has not proved being useful, and rather unsuitable (not orthogonal to the `timeout` and `max_exec_count` parameters).