### PR TITLE
Add dev routes to directly test rendering of any mail or template

### DIFF
--- a/pkg/workers/mails/mail_templates.go
+++ b/pkg/workers/mails/mail_templates.go
@@ -261,6 +261,12 @@ func (m *MailTemplater) Execute(name, locale string, recipientName string, data 
 	return
 }
 
+// RenderMail returns a rendered mail for the given template name with the
+// specified locale, recipient name and template data values.
+func RenderMail(name, locale, recipientName string, templateValues interface{}) (string, []*Part, error) {
+	return mailTemplater.Execute(name, locale, recipientName, templateValues)
+}
+
 func init() {
 	mailTemplater = &MailTemplater{[]*MailTemplate{
 		{

--- a/web/dev.go
+++ b/web/dev.go
@@ -1,0 +1,73 @@
+package web
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/cozy/cozy-stack/pkg/workers/mails"
+	"github.com/cozy/cozy-stack/web/statik"
+	"github.com/labstack/echo"
+)
+
+// devMailHandler allow to easily render a mail from a route of the stack. The
+// query parameters are used as data input for the mail template. The
+// ContentType query parameter allow to render the mail in "text/html" or
+// "text/plain".
+func devMailsHandler(c echo.Context) error {
+	name := c.Param("name")
+	locale := statik.GetLanguageFromHeader(c.Request().Header)
+
+	recipientName := c.QueryParam("RecipientName")
+	if recipientName == "" {
+		recipientName = "Jean Dupont"
+	}
+
+	_, parts, err := mails.RenderMail(name, locale, recipientName, devData(c))
+	if err != nil {
+		return err
+	}
+
+	contentType := c.QueryParam("ContentType")
+	if contentType == "" {
+		contentType = "text/html"
+	}
+
+	var part *mails.Part
+	for _, p := range parts {
+		if p.Type == contentType {
+			part = p
+		}
+	}
+	if part == nil {
+		return echo.NewHTTPError(http.StatusNotFound,
+			fmt.Errorf("Could not find template %q with content-type %q", name, contentType))
+	}
+
+	// Remove all CSP policies to display HTML email. this is a dev-only
+	// handler, no need to worry.
+	c.Response().Header().Set(echo.HeaderContentSecurityPolicy, "")
+	if part.Type == "text/html" {
+		return c.HTML(http.StatusOK, part.Body)
+	}
+	return c.String(http.StatusOK, part.Body)
+}
+
+// devTemplatesHandler allow to easily render a given template from a route of
+// the stack. The query parameters are used as data input for the template.
+func devTemplatesHandler(c echo.Context) error {
+	name := c.Param("name")
+	return c.Render(http.StatusOK, name, devData(c))
+}
+
+func devData(c echo.Context) echo.Map {
+	data := make(echo.Map)
+	for k, v := range c.QueryParams() {
+		if len(v) > 0 {
+			data[k] = v[0]
+		}
+	}
+	if _, ok := data["Domain"]; !ok {
+		data["Domain"] = c.Request().Host
+	}
+	return data
+}

--- a/web/routing.go
+++ b/web/routing.go
@@ -141,6 +141,12 @@ func SetupRoutes(router *echo.Echo) error {
 		version.Routes(router.Group("/version"))
 	}
 
+	// dev routes
+	if config.IsDevRelease() {
+		router.GET("/dev/mails/:name", devMailsHandler)
+		router.GET("/dev/templates/:name", devTemplatesHandler)
+	}
+
 	setupRecover(router)
 	router.HTTPErrorHandler = errors.ErrorHandler
 	return nil

--- a/web/statik/handler.go
+++ b/web/statik/handler.go
@@ -137,7 +137,7 @@ func (r *renderer) Render(w io.Writer, name string, data interface{}, c echo.Con
 	if ok {
 		funcMap = template.FuncMap{"t": i.Translate}
 	} else {
-		lang := getLanguageFromHeader(c.Request().Header)
+		lang := GetLanguageFromHeader(c.Request().Header)
 		funcMap = template.FuncMap{"t": i18n.Translator(lang)}
 	}
 	t, err := r.t.Clone()
@@ -147,7 +147,9 @@ func (r *renderer) Render(w io.Writer, name string, data interface{}, c echo.Con
 	return t.Funcs(funcMap).ExecuteTemplate(w, name, data)
 }
 
-func getLanguageFromHeader(header http.Header) (lang string) {
+// GetLanguageFromHeader return the language tag given the Accept-Language
+// header.
+func GetLanguageFromHeader(header http.Header) (lang string) {
 	// TODO: improve language detection with a package like
 	// "golang.org/x/text/language"
 	lang = i18n.DefaultLocale


### PR DESCRIPTION
This PR adds the following routes in a dev release:

  - `GET /dev/mails/:name`
  - `GET /dev/templates/:name`

These routes can be used to help the development and directly render a specific mail or template. The query parameters given are used a input data for the template rendered. For the mail route, it possible to specify a `ContentType` query parameter to render `text/plain` or `text/html` mail.