### PR TITLE
Rely on a hermes fork to pass custom template functions

### DIFF
--- a/pkg/workers/mails/mail_templates.go
+++ b/pkg/workers/mails/mail_templates.go
@@ -3,17 +3,27 @@ package mails
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"sync"
 	"text/template"
 
 	"github.com/cozy/cozy-stack/pkg/i18n"
-	"github.com/matcornic/hermes"
+	"github.com/cozy/hermes"
 )
 
 // TODO: avoid having a lock by init-ing hermes instances after loading
 // locales.
 var hermeses map[string]hermes.Hermes
 var hermesesMu sync.Mutex
+
+var templateFuncsMap = map[string]interface{}{
+	"splitList": func(sep, orig string) []string {
+		return strings.Split(orig, sep)
+	},
+	"replace": func(old, new, src string) string {
+		return strings.Replace(src, old, new, -1)
+	},
+}
 
 func getHermes(locale string) hermes.Hermes {
 	hermesesMu.Lock()
@@ -31,6 +41,7 @@ func getHermes(locale string) hermes.Hermes {
 					Copyright:   "",
 					TroubleText: i18n.Translate("Mail Trouble Text", locale),
 				},
+				TemplateFuncsMap: templateFuncsMap,
 			}
 		}
 	}


### PR DESCRIPTION
This is mainly done in order to fix the `go.uuid` API breaking changes, since hermes rely on sprig which rely on this library.

We should introduce quickly the new `go dep` tool in order to lock our dependencies and avoid these kind of issues in the near future.