### PR TITLE
Prioritize manual jobs

### DIFF
--- a/cmd/apps.go
+++ b/cmd/apps.go
@@ -216,7 +216,12 @@ var runKonnectorsCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Println("job", j)
+		json, err := json.MarshalIndent(j, "", "  ")
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(string(json))
 		return nil
 	},
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -622,9 +622,6 @@ cache:
 
 log:
     level: info
-
-jobs:
-    workers: 2
 `
 
 // UseTestFile can be used in a test file to inject a configuration

--- a/pkg/jobs/redis_jobs_test.go
+++ b/pkg/jobs/redis_jobs_test.go
@@ -17,9 +17,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const redisURL = "redis://localhost:6379/15"
+const redisURL1 = "redis://localhost:6379/0"
+const redisURL2 = "redis://localhost:6379/1"
 
-var client *redis.Client
+var client1 *redis.Client
+var client2 *redis.Client
 
 func randomMicro(min, max int) time.Duration {
 	return time.Duration(rand.Intn(max-min)+min) * time.Microsecond
@@ -60,11 +62,11 @@ func TestRedisJobs(t *testing.T) {
 		},
 	}
 
-	broker1 := NewRedisBroker(client)
+	broker1 := NewRedisBroker(client1)
 	err := broker1.Start(workersTestList)
 	assert.NoError(t, err)
 
-	broker2 := NewRedisBroker(client)
+	broker2 := NewRedisBroker(client2)
 	err = broker2.Start(workersTestList)
 	assert.NoError(t, err)
 
@@ -96,6 +98,7 @@ func TestRedisJobs(t *testing.T) {
 				Domain:     "cozy.local.redisjobs",
 				WorkerType: "test",
 				Message:    msg,
+				Manual:     true,
 			})
 			assert.NoError(t, err)
 			time.Sleep(randomMicro(0, v))
@@ -120,7 +123,9 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	opts, _ := redis.ParseURL(redisURL)
-	client = redis.NewClient(opts)
+	opts1, _ := redis.ParseURL(redisURL1)
+	opts2, _ := redis.ParseURL(redisURL2)
+	client1 = redis.NewClient(opts1)
+	client2 = redis.NewClient(opts2)
 	os.Exit(m.Run())
 }

--- a/pkg/jobs/workers_list.go
+++ b/pkg/jobs/workers_list.go
@@ -10,22 +10,24 @@ import (
 // configuration.
 type WorkersList []*WorkerConfig
 
-// WorkersList is the list of available workers with their associated Do
+// workersList is the list of available workers with their associated to
 // function.
 var workersList WorkersList
 
-// GetWorkersList returns a globally defined worker config list.
+// GetWorkersList returns a list of all activated workers, configured
+// as defined by the configuration file.
 func GetWorkersList() ([]*WorkerConfig, error) {
-	if config.GetConfig().Jobs.NoWorkers {
-		return nil, nil
-	}
-
 	workersConfs := config.GetConfig().Jobs.Workers
 	workers := make(WorkersList, 0, len(workersList))
 	for _, w := range workersList {
-		for _, c := range workersConfs {
-			if c.WorkerType == w.WorkerType {
-				w = applyWorkerConfig(w, c)
+		if config.GetConfig().Jobs.NoWorkers {
+			w = w.Clone()
+			w.Concurrency = 0
+		} else {
+			for _, c := range workersConfs {
+				if c.WorkerType == w.WorkerType {
+					w = applyWorkerConfig(w, c)
+				}
 			}
 		}
 		workers = append(workers, w)

--- a/pkg/workers/log/log.go
+++ b/pkg/workers/log/log.go
@@ -24,6 +24,6 @@ func Worker(ctx *jobs.WorkerContext) error {
 	if err := ctx.UnmarshalMessage(&msg); err != nil {
 		return err
 	}
-	logger.WithDomain(ctx.Domain()).Infof(msg)
+	logger.WithDomain(ctx.Domain()).Info(msg)
 	return nil
 }


### PR DESCRIPTION
This PR adds a specific high priority queue in redis `j/$workerType$/p0` used to prioritize manual jobs. We avoid a starvation of the low priority queue in case too many manual jobs are launched.