### PR TITLE
Refine debug message to avoid confusion

### DIFF
--- a/pkg/jobs/worker.go
+++ b/pkg/jobs/worker.go
@@ -337,7 +337,7 @@ func (t *task) run() (err error) {
 			time.Sleep(delay)
 		}
 
-		t.ctx.Logger().Debugf("[job] executing job (%d) (timeout %s)",
+		t.ctx.Logger().Debugf("[job] executing job (%d) (timeout set to %s)",
 			t.execCount, timeout)
 
 		var execResultLabel string


### PR DESCRIPTION
Cette précision supplémentaire du message de debug pour éviter la confusion entre positionnement du timeout au lancement et échéance atteinte.