### PR TITLE
Avoid a wildcard in the img-src CSP configuration and use nonce instead

### DIFF
--- a/assets/templates/authorize_sharing.html
+++ b/assets/templates/authorize_sharing.html
@@ -26,7 +26,7 @@
             <div role="region">
               <h1>{{t "Authorize Sharing Title" .Client.ClientName}}</h1>
               {{if .Client.LogoURI}}
-              <img class="client-logo" src="{{.Client.LogoURI}}" />
+              <img nonce="{{.ClientLogoNonce}}" class="client-logo" src="{{.Client.LogoURI}}" />
               {{end}}
               <p class="help">
                 {{t "Authorize Sharing Request" .Client.ClientName}}

--- a/web/auth/auth.go
+++ b/web/auth/auth.go
@@ -3,6 +3,7 @@ package auth
 
 import (
 	"crypto/subtle"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -15,6 +16,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/crypto"
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/pkg/oauth"
 	"github.com/cozy/cozy-stack/pkg/permissions"
@@ -566,17 +568,34 @@ func authorizeForm(c echo.Context) error {
 	if params.resType == consts.SharingResponseType {
 		tmpl = "authorize_sharing.html"
 	}
+
+	// This Content-Security-Policy (CSP) nonce is here to allow the display of
+	// logos for OAuth clients on the authorize page.
+	var logoNonce string
+	if logoURI := params.client.LogoURI; logoURI != "" {
+		logoNonce = base64.URLEncoding.EncodeToString(crypto.GenerateRandomBytes(16))
+		csp := c.Response().Header().Get(echo.HeaderContentSecurityPolicy)
+		if !strings.Contains(csp, "img-src") {
+			if csp != "" && csp[len(csp)-1] != ';' {
+				csp += ";"
+			}
+			c.Response().Header().Set(echo.HeaderContentSecurityPolicy,
+				fmt.Sprintf("%s img-src 'nonce-%s';", csp, logoNonce))
+		}
+	}
+
 	return c.Render(http.StatusOK, tmpl, echo.Map{
-		"Domain":       instance.Domain,
-		"ClientDomain": clientDomain,
-		"Locale":       instance.Locale,
-		"Client":       params.client,
-		"State":        params.state,
-		"RedirectURI":  params.redirectURI,
-		"Scope":        params.scope,
-		"Permissions":  permissions,
-		"ReadOnly":     readOnly,
-		"CSRF":         c.Get("csrf"),
+		"Domain":          instance.Domain,
+		"ClientDomain":    clientDomain,
+		"Locale":          instance.Locale,
+		"Client":          params.client,
+		"ClientLogoNonce": logoNonce,
+		"State":           params.state,
+		"RedirectURI":     params.redirectURI,
+		"Scope":           params.scope,
+		"Permissions":     permissions,
+		"ReadOnly":        readOnly,
+		"CSRF":            c.Get("csrf"),
 	})
 }
 

--- a/web/routing.go
+++ b/web/routing.go
@@ -91,8 +91,6 @@ func SetupRoutes(router *echo.Echo) error {
 		secure := middlewares.Secure(&middlewares.SecureConfig{
 			HSTSMaxAge:    hstsMaxAge,
 			CSPDefaultSrc: []middlewares.CSPSource{middlewares.CSPSrcSelf},
-			// Display logos of OAuth clients on the authorize page
-			CSPImgSrc:     []middlewares.CSPSource{middlewares.CSPSrcAny},
 			XFrameOptions: middlewares.XFrameDeny,
 		})
 		router.Use(secure)


### PR DESCRIPTION
This PR is a proposal to avoid loosening our CSP policy on `img-src` on all our main domain pages and using a specific `img-src nonce-random-value` to mitigate the issue of displaying an external logo for the OAuth clients.