### PR TITLE
Compress application assets

### DIFF
--- a/pkg/apps/copier.go
+++ b/pkg/apps/copier.go
@@ -103,8 +103,8 @@ func (f *swiftCopier) Copy(stat os.FileInfo, src io.Reader) (err error) {
 		return err
 	}
 	defer func() {
-		if err == nil {
-			err = gw.Close()
+		if errc := gw.Close(); errc != nil && err == nil {
+			err = errc
 		}
 	}()
 
@@ -167,8 +167,8 @@ func (f *aferoCopier) Copy(stat os.FileInfo, src io.Reader) (err error) {
 		return err
 	}
 	defer func() {
-		if err == nil {
-			err = gw.Close()
+		if errc := gw.Close(); errc != nil && err == nil {
+			err = errc
 		}
 	}()
 

--- a/pkg/apps/installer_konnector_test.go
+++ b/pkg/apps/installer_konnector_test.go
@@ -1,6 +1,9 @@
 package apps_test
 
 import (
+	"bytes"
+	"compress/gzip"
+	"io/ioutil"
 	"path"
 	"testing"
 
@@ -8,6 +11,25 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 )
+
+func compressedFileContainsBytes(fs afero.Fs, filename string, content []byte) (ok bool, err error) {
+	f, err := fs.Open(filename)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	gr, err := gzip.NewReader(f)
+	if err != nil {
+		return
+	}
+	defer gr.Close()
+	b, err := ioutil.ReadAll(gr)
+	if err != nil {
+		return
+	}
+	ok = bytes.Contains(b, content)
+	return
+}
 
 func TestKonnectorInstallSuccessful(t *testing.T) {
 	manGen = manifestKonnector
@@ -55,10 +77,10 @@ func TestKonnectorInstallSuccessful(t *testing.T) {
 		state = man.State()
 	}
 
-	ok, err := afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), "app.tar"))
+	ok, err := afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), "app.tar.gz"))
 	assert.NoError(t, err)
 	assert.True(t, ok, "The manifest is present")
-	ok, err = afero.FileContainsBytes(baseFS, path.Join("/", man.Slug(), man.Version(), "app.tar"), []byte("1.0.0"))
+	ok, err = compressedFileContainsBytes(baseFS, path.Join("/", man.Slug(), man.Version(), "app.tar.gz"), []byte("1.0.0"))
 	assert.NoError(t, err)
 	assert.True(t, ok, "The manifest has the right version")
 
@@ -122,10 +144,10 @@ func TestKonnectorInstallWithUpgrade(t *testing.T) {
 		}
 	}
 
-	ok, err := afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), "app.tar"))
+	ok, err := afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), "app.tar.gz"))
 	assert.NoError(t, err)
 	assert.True(t, ok, "The manifest is present")
-	ok, err = afero.FileContainsBytes(baseFS, path.Join("/", man.Slug(), man.Version(), "app.tar"), []byte("1.0.0"))
+	ok, err = compressedFileContainsBytes(baseFS, path.Join("/", man.Slug(), man.Version(), "app.tar.gz"), []byte("1.0.0"))
 	assert.NoError(t, err)
 	assert.True(t, ok, "The manifest has the right version")
 
@@ -168,10 +190,10 @@ func TestKonnectorInstallWithUpgrade(t *testing.T) {
 		state = man.State()
 	}
 
-	ok, err = afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), "app.tar"))
+	ok, err = afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), "app.tar.gz"))
 	assert.NoError(t, err)
 	assert.True(t, ok, "The manifest is present")
-	ok, err = afero.FileContainsBytes(baseFS, path.Join("/", man.Slug(), man.Version(), "app.tar"), []byte("2.0.0"))
+	ok, err = compressedFileContainsBytes(baseFS, path.Join("/", man.Slug(), man.Version(), "app.tar.gz"), []byte("2.0.0"))
 	assert.NoError(t, err)
 	assert.True(t, ok, "The manifest has the right version")
 }
@@ -221,10 +243,10 @@ func TestKonnectorInstallAndUpgradeWithBranch(t *testing.T) {
 		state = man.State()
 	}
 
-	ok, err := afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), "app.tar"))
+	ok, err := afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), "app.tar.gz"))
 	assert.NoError(t, err)
 	assert.True(t, ok, "The manifest is present")
-	ok, err = afero.FileContainsBytes(baseFS, path.Join("/", man.Slug(), man.Version(), "app.tar"), []byte("3.0.0"))
+	ok, err = compressedFileContainsBytes(baseFS, path.Join("/", man.Slug(), man.Version(), "app.tar.gz"), []byte("3.0.0"))
 	assert.NoError(t, err)
 	assert.True(t, ok, "The manifest has the right version")
 
@@ -268,10 +290,10 @@ func TestKonnectorInstallAndUpgradeWithBranch(t *testing.T) {
 		state = man.State()
 	}
 
-	ok, err = afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), "app.tar"))
+	ok, err = afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), "app.tar.gz"))
 	assert.NoError(t, err)
 	assert.True(t, ok, "The manifest is present")
-	ok, err = afero.FileContainsBytes(baseFS, path.Join("/", man.Slug(), man.Version(), "app.tar"), []byte("4.0.0"))
+	ok, err = compressedFileContainsBytes(baseFS, path.Join("/", man.Slug(), man.Version(), "app.tar.gz"), []byte("4.0.0"))
 	assert.NoError(t, err)
 	assert.True(t, ok, "The manifest has the right version")
 }

--- a/pkg/apps/installer_webapp_test.go
+++ b/pkg/apps/installer_webapp_test.go
@@ -113,10 +113,10 @@ func TestWebappInstallSuccessful(t *testing.T) {
 		state = man.State()
 	}
 
-	ok, err := afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), apps.WebappManifestName))
+	ok, err := afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), apps.WebappManifestName+".gz"))
 	assert.NoError(t, err)
 	assert.True(t, ok, "The manifest is present")
-	ok, err = afero.FileContainsBytes(baseFS, path.Join("/", man.Slug(), man.Version(), apps.WebappManifestName), []byte("1.0.0"))
+	ok, err = compressedFileContainsBytes(baseFS, path.Join("/", man.Slug(), man.Version(), apps.WebappManifestName+".gz"), []byte("1.0.0"))
 	assert.NoError(t, err)
 	assert.True(t, ok, "The manifest has the right version")
 
@@ -182,10 +182,10 @@ func TestWebappInstallWithUpgrade(t *testing.T) {
 	man, err := inst.RunSync()
 	assert.NoError(t, err)
 
-	ok, err := afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), apps.WebappManifestName))
+	ok, err := afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), apps.WebappManifestName+".gz"))
 	assert.NoError(t, err)
 	assert.True(t, ok, "The manifest is present")
-	ok, err = afero.FileContainsBytes(baseFS, path.Join("/", man.Slug(), man.Version(), apps.WebappManifestName), []byte("1.0.0"))
+	ok, err = compressedFileContainsBytes(baseFS, path.Join("/", man.Slug(), man.Version(), apps.WebappManifestName+".gz"), []byte("1.0.0"))
 	assert.NoError(t, err)
 	assert.True(t, ok, "The manifest has the right version")
 	version1 := man.Version()
@@ -242,10 +242,10 @@ func TestWebappInstallWithUpgrade(t *testing.T) {
 
 	fmt.Println("versions:", version1, version2)
 
-	ok, err = afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), apps.WebappManifestName))
+	ok, err = afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), apps.WebappManifestName+".gz"))
 	assert.NoError(t, err)
 	assert.True(t, ok, "The manifest is present")
-	ok, err = afero.FileContainsBytes(baseFS, path.Join("/", man.Slug(), man.Version(), apps.WebappManifestName), []byte("2.0.0"))
+	ok, err = compressedFileContainsBytes(baseFS, path.Join("/", man.Slug(), man.Version(), apps.WebappManifestName+".gz"), []byte("2.0.0"))
 	assert.NoError(t, err)
 	assert.True(t, ok, "The manifest has the right version")
 	manWebapp = man.(*apps.WebappManifest)
@@ -297,13 +297,13 @@ func TestWebappInstallAndUpgradeWithBranch(t *testing.T) {
 		state = man.State()
 	}
 
-	ok, err := afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), apps.WebappManifestName))
+	ok, err := afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), apps.WebappManifestName+".gz"))
 	assert.NoError(t, err)
 	assert.True(t, ok, "The manifest is present")
-	ok, err = afero.FileContainsBytes(baseFS, path.Join("/", man.Slug(), man.Version(), apps.WebappManifestName), []byte("3.0.0"))
+	ok, err = compressedFileContainsBytes(baseFS, path.Join("/", man.Slug(), man.Version(), apps.WebappManifestName+".gz"), []byte("3.0.0"))
 	assert.NoError(t, err)
 	assert.True(t, ok, "The manifest has the right version")
-	ok, err = afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), "branch"))
+	ok, err = afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), "branch.gz"))
 	assert.NoError(t, err)
 	assert.True(t, ok, "The good branch was checked out")
 
@@ -347,13 +347,13 @@ func TestWebappInstallAndUpgradeWithBranch(t *testing.T) {
 		state = man.State()
 	}
 
-	ok, err = afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), apps.WebappManifestName))
+	ok, err = afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), apps.WebappManifestName+".gz"))
 	assert.NoError(t, err)
 	assert.True(t, ok, "The manifest is present")
-	ok, err = afero.FileContainsBytes(baseFS, path.Join("/", man.Slug(), man.Version(), apps.WebappManifestName), []byte("4.0.0"))
+	ok, err = compressedFileContainsBytes(baseFS, path.Join("/", man.Slug(), man.Version(), apps.WebappManifestName+".gz"), []byte("4.0.0"))
 	assert.NoError(t, err)
 	assert.True(t, ok, "The manifest has the right version")
-	ok, err = afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), "branch"))
+	ok, err = afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), "branch.gz"))
 	assert.NoError(t, err)
 	assert.True(t, ok, "The good branch was checked out")
 
@@ -375,13 +375,13 @@ func TestWebappInstallAndUpgradeWithBranch(t *testing.T) {
 	}
 	assert.Equal(t, "git://localhost/", man.Source())
 
-	ok, err = afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), apps.WebappManifestName))
+	ok, err = afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), apps.WebappManifestName+".gz"))
 	assert.NoError(t, err)
 	assert.True(t, ok, "The manifest is present")
-	ok, err = afero.FileContainsBytes(baseFS, path.Join("/", man.Slug(), man.Version(), apps.WebappManifestName), []byte("5.0.0"))
+	ok, err = compressedFileContainsBytes(baseFS, path.Join("/", man.Slug(), man.Version(), apps.WebappManifestName+".gz"), []byte("5.0.0"))
 	assert.NoError(t, err)
 	assert.True(t, ok, "The manifest has the right version")
-	ok, err = afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), "branch"))
+	ok, err = afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), "branch.gz"))
 	assert.NoError(t, err)
 	assert.False(t, ok, "The good branch was checked out")
 }

--- a/pkg/apps/server.go
+++ b/pkg/apps/server.go
@@ -129,6 +129,9 @@ func (s *swiftServer) ServeFileContent(w http.ResponseWriter, req *http.Request,
 	if contentType == "" {
 		contentType = magic.MIMETypeByExtension(path.Ext(file))
 	}
+	if contentType == "text/html" {
+		contentType = "text/html; charset=utf-8"
+	}
 
 	size, _ := strconv.ParseInt(contentLength, 10, 64)
 	web_utils.ServeContent(w, req, contentType, size, r)
@@ -235,6 +238,9 @@ func (s *aferoServer) serveFileContent(w http.ResponseWriter, req *http.Request,
 	}
 
 	contentType := magic.MIMETypeByExtension(path.Ext(filepath))
+	if contentType == "text/html" {
+		contentType = "text/html; charset=utf-8"
+	}
 	web_utils.ServeContent(w, req, contentType, size, content)
 	return nil
 }

--- a/web/utils/serve_content.go
+++ b/web/utils/serve_content.go
@@ -1,0 +1,140 @@
+package utils
+
+import (
+	"io"
+	"net/http"
+	"net/textproto"
+	"strconv"
+	"strings"
+)
+
+// ServeContent replies to the request using the content in the provided
+// reader. The Content-Length and Content-Type headers are added with the
+// provided values.
+func ServeContent(w http.ResponseWriter, r *http.Request, contentType string, size int64, content io.Reader) {
+	h := w.Header()
+	if size > 0 {
+		h.Set("Content-Length", strconv.FormatInt(size, 10))
+	}
+	if contentType != "" {
+		h.Set("Content-Type", contentType)
+	}
+	w.WriteHeader(http.StatusOK)
+	if r.Method != "HEAD" {
+		io.Copy(w, content)
+	}
+}
+
+// CheckPreconditions evaluates request preconditions based only on the Etag
+// values.
+func CheckPreconditions(w http.ResponseWriter, r *http.Request, etag string) (done bool) {
+	if etag != "" && (checkIfMatch(w, r, etag) || checkIfNoneMatch(w, r, etag)) {
+		writeNotModified(w)
+		return true
+	}
+	return false
+}
+
+func checkIfMatch(w http.ResponseWriter, r *http.Request, definedETag string) (match bool) {
+	im := r.Header.Get("If-Match")
+	if im == "" {
+		return false
+	}
+	for {
+		im = textproto.TrimString(im)
+		if len(im) == 0 {
+			break
+		}
+		if im[0] == ',' {
+			im = im[1:]
+			continue
+		}
+		if im[0] == '*' {
+			return true
+		}
+		etag, remain := scanETag(im)
+		if etag == "" {
+			break
+		}
+		if etagStrongMatch(etag, definedETag) {
+			return true
+		}
+		im = remain
+	}
+	return false
+}
+
+func checkIfNoneMatch(w http.ResponseWriter, r *http.Request, definedETag string) (match bool) {
+	inm := r.Header.Get("If-None-Match")
+	if inm == "" {
+		return false
+	}
+	buf := inm
+	for {
+		buf = textproto.TrimString(buf)
+		if len(buf) == 0 {
+			break
+		}
+		if buf[0] == ',' {
+			buf = buf[1:]
+		}
+		if buf[0] == '*' {
+			return false
+		}
+		etag, remain := scanETag(buf)
+		if etag == "" {
+			break
+		}
+		if etagWeakMatch(etag, definedETag) {
+			return false
+		}
+		buf = remain
+	}
+	return true
+}
+
+// etagWeakMatch reports whether a and b match using weak ETag comparison.
+// Assumes a and b are valid ETags.
+func etagWeakMatch(a, b string) bool {
+	return strings.TrimPrefix(a, "W/") == strings.TrimPrefix(b, "W/")
+}
+
+// etagStrongMatch reports whether a and b match using strong ETag comparison.
+// Assumes a and b are valid ETags.
+func etagStrongMatch(a, b string) bool {
+	return a == b && a != "" && a[0] == '"'
+}
+
+// scanETag determines if a syntactically valid ETag is present at s. If so,
+// the ETag and remaining text after consuming ETag is returned. Otherwise,
+// it returns "", "".
+func scanETag(s string) (etag string, remain string) {
+	start := 0
+	if len(s) >= 2 && s[0] == 'W' && s[1] == '/' {
+		start = 2
+	}
+	if len(s[start:]) < 2 || s[start] != '"' {
+		return "", ""
+	}
+	// ETag is either W/"text" or "text".
+	// See RFC 7232 2.3.
+	for i := start + 1; i < len(s); i++ {
+		c := s[i]
+		switch {
+		// Character values allowed in ETags.
+		case c == 0x21 || c >= 0x23 && c <= 0x7E || c >= 0x80:
+		case c == '"':
+			return s[:i+1], s[i+1:]
+		default:
+			return "", ""
+		}
+	}
+	return "", ""
+}
+
+func writeNotModified(w http.ResponseWriter) {
+	h := w.Header()
+	delete(h, "Content-Type")
+	delete(h, "Content-Length")
+	w.WriteHeader(http.StatusNotModified)
+}


### PR DESCRIPTION
Adds compression before storing application assets and serve them as is when the user accepts gzip encoding with `Accept-Encoding: gzip` header.