### PR TITLE
Execute konnector on account deletion

### DIFF
--- a/pkg/apps/konnector.go
+++ b/pkg/apps/konnector.go
@@ -37,6 +37,10 @@ type KonnManifest struct {
 	DocVersion     string           `json:"version"`
 	DocPermissions permissions.Set  `json:"permissions"`
 
+	// OnDeleteAccount can be used to specify a file path which will be executed
+	// when an account associated with the konnector is deleted.
+	OnDeleteAccount string `json:"on_delete_account,omitempty"`
+
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 

--- a/pkg/jobs/errors.go
+++ b/pkg/jobs/errors.go
@@ -15,4 +15,7 @@ var (
 	ErrMessageNil = errors.New("jobs: message is nil")
 	// ErrMessageUnmarshal is used when unmarshalling a message causes an error
 	ErrMessageUnmarshal = errors.New("jobs: message unmarshal")
+	// ErrAbort can be used to abort the execution of the job without causing
+	// errors.
+	ErrAbort = errors.New("jobs: abort")
 )

--- a/pkg/utils/limit_writer.go
+++ b/pkg/utils/limit_writer.go
@@ -1,0 +1,51 @@
+package utils
+
+import "io"
+
+type limitedWriter struct {
+	w io.Writer
+	n int64
+
+	discard bool
+}
+
+func (l *limitedWriter) Write(p []byte) (n int, err error) {
+	if l.n <= 0 {
+		if l.discard {
+			return len(p), nil
+		}
+		return 0, io.ErrShortWrite
+	}
+	var discarded bool
+	if int64(len(p)) > l.n {
+		p = p[0:l.n]
+		if l.discard {
+			discarded = true
+		} else {
+			err = io.ErrShortWrite
+		}
+	}
+	n, errw := l.w.Write(p)
+	if errw != nil {
+		err = errw
+	}
+	l.n -= int64(n)
+	if discarded {
+		n = len(p)
+	}
+	return n, err
+}
+
+// LimitWriter works like io.LimitReader. It writes at most n bytes to the
+// underlying Writer. It returns io.ErrShortWrite if more than n bytes are
+// attempted to be written.
+func LimitWriter(w io.Writer, n int64) io.Writer {
+	return &limitedWriter{w, n, false}
+}
+
+// LimitWriterDiscard works like io.LimitReader. It writes at most n bytes to
+// the underlying Writer. It does not return any error if more than n bytes are
+// attempted to be written, the data is discarded.
+func LimitWriterDiscard(w io.Writer, n int64) io.Writer {
+	return &limitedWriter{w, n, true}
+}

--- a/pkg/workers/exec/service.go
+++ b/pkg/workers/exec/service.go
@@ -29,7 +29,7 @@ type serviceWorker struct {
 	man  *apps.WebappManifest
 }
 
-func (w *serviceWorker) PrepareWorkDir(ctx *jobs.WorkerContext, i *instance.Instance) (workDir string, err error) {
+func (w *serviceWorker) PrepareWorkDir(ctx *jobs.WorkerContext, i *instance.Instance) (workDir, fileExecPath string, err error) {
 	opts := &ServiceOptions{}
 	if err = ctx.UnmarshalMessage(&opts); err != nil {
 		return
@@ -77,7 +77,7 @@ func (w *serviceWorker) PrepareWorkDir(ctx *jobs.WorkerContext, i *instance.Inst
 		return
 	}
 
-	return workDir, nil
+	return workDir, "", nil
 }
 
 func (w *serviceWorker) Slug() string {

--- a/scripts/konnector-node-run.sh
+++ b/scripts/konnector-node-run.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
+set -e
 
 rundir="${1}"
+runfile="${2}"
 
-cd $rundir
-node index.js
+if [ -z "${runfile}" ]; then
+  runfile="./index.js"
+else
+  runfile="./${runfile}"
+fi
+
+cd "${rundir}"
+node "${runfile}"

--- a/scripts/konnector-nsjail-run.sh
+++ b/scripts/konnector-nsjail-run.sh
@@ -1,10 +1,17 @@
 #!/bin/bash
 
 rundir="${1}"
+runfile="${2}"
 
 if [ -z "${rundir}" ]; then
-  >&2 echo "Usage: $0 [dir]"
+  >&2 echo "Usage: $0 directory [file]"
   exit 1
+fi
+
+if [ -z "${runfile}" ]; then
+  runfile="/usr/src/konnector"
+else
+  runfile="/usr/src/konnector/${runfile}"
 fi
 
 if [ -z "${COZY_JOB_ID}" ]; then
@@ -129,7 +136,7 @@ nsjail \
   -R /dev/urandom \
   -R /etc/resolv.conf \
   -R /etc/ssl/certs \
-  -- /usr/bin/nodejs /usr/src/konnector
+  -- /usr/bin/nodejs "${runfile}"
 
 # Via a chroot with nodejs installed inside
 # nsjail \
@@ -151,4 +158,4 @@ nsjail \
 #   -E "COZY_CREDENTIALS=${COZY_CREDENTIALS}" \
 #   -E "COZY_LOCALE=${COZY_LOCALE}" \
 #   -R "${rundir}:/usr/src/konnector/" \
-#   -- /usr/bin/nodejs /usr/src/konnector/index.js
+#   -- /usr/bin/nodejs "${runfile}"


### PR DESCRIPTION
This PR adds a specific field `"on_delete_account"` in the manifest of konnectors which can specify a filename to execute at the deletion of an associated account.

This field is not yet documented as it is designed to support a specific behavior of konnectors which may be handled in the future with a more generic system.