### PR TITLE
Add global read/write timeouts

### DIFF
--- a/pkg/vfs/file.go
+++ b/pkg/vfs/file.go
@@ -3,7 +3,6 @@ package vfs
 import (
 	// #nosec
 	"encoding/base64"
-	"fmt"
 	"net/http"
 	"os"
 	"path"
@@ -12,6 +11,7 @@ import (
 
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
+	webutils "github.com/cozy/cozy-stack/web/utils"
 )
 
 // FileDoc is a struct containing all the informations about a file.
@@ -192,14 +192,15 @@ func NewFileDoc(name, dirID string, size int64, md5Sum []byte, mime, class strin
 // non-ranged requests
 func ServeFileContent(fs VFS, doc *FileDoc, disposition string, req *http.Request, w http.ResponseWriter) error {
 	header := w.Header()
-	header.Set("Content-Type", doc.Mime)
 	if disposition != "" {
 		header.Set("Content-Disposition", ContentDisposition(disposition, doc.DocName))
 	}
 
 	if header.Get("Range") == "" {
 		eTag := base64.StdEncoding.EncodeToString(doc.MD5Sum)
-		header.Set("Etag", fmt.Sprintf(`"%s"`, eTag))
+		if webutils.CheckPreconditions(w, req, eTag) {
+			return nil
+		}
 	}
 
 	content, err := fs.OpenFile(doc)
@@ -208,7 +209,7 @@ func ServeFileContent(fs VFS, doc *FileDoc, disposition string, req *http.Reques
 	}
 	defer content.Close()
 
-	http.ServeContent(w, req, doc.DocName, doc.UpdatedAt, content)
+	webutils.ServeContentRanges(w, req, doc.Mime, doc.Size(), content)
 	return nil
 }
 

--- a/pkg/vfs/file.go
+++ b/pkg/vfs/file.go
@@ -190,8 +190,6 @@ func NewFileDoc(name, dirID string, size int64, md5Sum []byte, mime, class strin
 // offering support to Range, If-Modified-Since and If-None-Match
 // requests. It uses the revision of the file as the Etag value for
 // non-ranged requests
-//
-// The content disposition is inlined.
 func ServeFileContent(fs VFS, doc *FileDoc, disposition string, req *http.Request, w http.ResponseWriter) error {
 	header := w.Header()
 	header.Set("Content-Type", doc.Mime)

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -89,6 +89,7 @@ type File interface {
 	io.Seeker
 	io.Writer
 	io.Closer
+	CloseWithError(error) error
 }
 
 // FilePather is an interface for computing the fullpath of a filedoc

--- a/pkg/vfs/vfsafero/impl.go
+++ b/pkg/vfs/vfsafero/impl.go
@@ -633,6 +633,10 @@ func (f *aferoFileOpen) Close() error {
 	return f.f.Close()
 }
 
+func (f *aferoFileOpen) CloseWithError(err error) error {
+	return f.Close()
+}
+
 // aferoFileCreation represents a file open for writing. It is used to
 // create of file or to modify the content of a file.
 //
@@ -757,6 +761,13 @@ func (f *aferoFileCreation) Close() (err error) {
 		return f.afs.Indexer.CreateNamedFileDoc(newdoc)
 	}
 	return f.afs.Indexer.UpdateFileDoc(olddoc, newdoc)
+}
+
+func (f *aferoFileCreation) CloseWithError(err error) error {
+	if f.err == nil {
+		f.err = err
+	}
+	return f.Close()
 }
 
 func safeCreateFile(name string, mode os.FileMode, fs afero.Fs) (afero.File, error) {

--- a/pkg/vfs/vfsswift/impl_v1.go
+++ b/pkg/vfs/vfsswift/impl_v1.go
@@ -834,6 +834,13 @@ func (f *swiftFileCreation) Close() (err error) {
 	return
 }
 
+func (f *swiftFileCreation) CloseWithError(err error) error {
+	if f.err == nil {
+		f.err = err
+	}
+	return f.Close()
+}
+
 type swiftFileOpen struct {
 	f  *swift.ObjectOpenFile
 	br *bytes.Reader
@@ -865,6 +872,10 @@ func (f *swiftFileOpen) Write(p []byte) (int, error) {
 
 func (f *swiftFileOpen) Close() error {
 	return f.f.Close()
+}
+
+func (f *swiftFileOpen) CloseWithError(err error) error {
+	return f.Close()
 }
 
 var (

--- a/pkg/vfs/vfsswift/impl_v1.go
+++ b/pkg/vfs/vfsswift/impl_v1.go
@@ -778,16 +778,16 @@ func (f *swiftFileCreation) Close() (err error) {
 		headers, err = f.f.Headers()
 		if err == nil {
 			// Etags may be double-quoted
-			etag := headers["Etag"]
-			if l := len(etag); l >= 2 {
-				if etag[0] == '"' {
-					etag = etag[1:]
+			eTag := headers["Etag"]
+			if l := len(eTag); l >= 2 {
+				if eTag[0] == '"' {
+					eTag = eTag[1:]
 				}
-				if etag[l-1] == '"' {
-					etag = etag[:l-1]
+				if eTag[l-1] == '"' {
+					eTag = eTag[:l-1]
 				}
 			}
-			md5sum, err = hex.DecodeString(etag)
+			md5sum, err = hex.DecodeString(eTag)
 			if err == nil {
 				newdoc.MD5Sum = md5sum
 			}

--- a/pkg/vfs/vfsswift/impl_v2.go
+++ b/pkg/vfs/vfsswift/impl_v2.go
@@ -655,16 +655,16 @@ func (f *swiftFileCreationV2) Close() (err error) {
 		headers, err = f.f.Headers()
 		if err == nil {
 			// Etags may be double-quoted
-			etag := headers["Etag"]
-			if l := len(etag); l >= 2 {
-				if etag[0] == '"' {
-					etag = etag[1:]
+			eTag := headers["Etag"]
+			if l := len(eTag); l >= 2 {
+				if eTag[0] == '"' {
+					eTag = eTag[1:]
 				}
-				if etag[l-1] == '"' {
-					etag = etag[:l-1]
+				if eTag[l-1] == '"' {
+					eTag = eTag[:l-1]
 				}
 			}
-			md5sum, err = hex.DecodeString(etag)
+			md5sum, err = hex.DecodeString(eTag)
 			if err == nil {
 				newdoc.MD5Sum = md5sum
 			}

--- a/pkg/vfs/vfsswift/impl_v2.go
+++ b/pkg/vfs/vfsswift/impl_v2.go
@@ -711,6 +711,13 @@ func (f *swiftFileCreationV2) Close() (err error) {
 	return
 }
 
+func (f *swiftFileCreationV2) CloseWithError(err error) error {
+	if f.err == nil {
+		f.err = err
+	}
+	return f.Close()
+}
+
 type swiftFileOpenV2 struct {
 	f  *swift.ObjectOpenFile
 	br *bytes.Reader
@@ -742,6 +749,9 @@ func (f *swiftFileOpenV2) Write(p []byte) (int, error) {
 
 func (f *swiftFileOpenV2) Close() error {
 	return f.f.Close()
+}
+func (f *swiftFileOpenV2) CloseWithError(err error) error {
+	return f.Close()
 }
 
 func objectToFileDocV2(c *swift.Connection, container string, object swift.Object) (filePath string, fileDoc *vfs.FileDoc, err error) {

--- a/pkg/workers/exec/common.go
+++ b/pkg/workers/exec/common.go
@@ -75,8 +75,8 @@ func makeExecWorkerFunc() jobs.WorkerFunc {
 		cmd := createCmd(cmdStr, workDir) // #nosec
 		cmd.Env = env
 
-		// set stderr writable with a bytes.Buffer limited total size of 256Ko
-		cmd.Stderr = utils.LimitWriterDiscard(&stderrBuf, 256*1024)
+		// set stderr writable with a bytes.Buffer limited total size of 32Ko
+		cmd.Stderr = utils.LimitWriterDiscard(&stderrBuf, 32*1024)
 
 		// Log out all things printed in stderr, whatever the result of the
 		// konnector is.

--- a/web/apps/serve.go
+++ b/web/apps/serve.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"os"
 	"path"
 	"strings"
 
@@ -53,11 +52,11 @@ func Serve(c echo.Context) error {
 	if err != nil {
 		switch err {
 		case apps.ErrNotFound:
-			return echo.NewHTTPError(http.StatusNotFound, "Application not found")
+			return echo.NewHTTPError(http.StatusNotFound, err)
 		case apps.ErrInvalidSlugName:
-			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+			return echo.NewHTTPError(http.StatusBadRequest, err)
 		default:
-			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+			return echo.NewHTTPError(http.StatusInternalServerError, err)
 		}
 	}
 
@@ -158,16 +157,7 @@ func ServeAppFile(c echo.Context, i *instance.Instance, fs apps.FileServer, app 
 		if _, id := statik.ExtractAssetID(file); id != "" {
 			c.Response().Header().Set("Cache-Control", "max-age=31536000, immutable")
 		}
-
-		err := fs.ServeFileContent(c.Response(), c.Request(), slug, version, filepath)
-		if os.IsNotExist(err) {
-			return echo.NewHTTPError(http.StatusNotFound, "Asset not found")
-		}
-		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, err)
-		}
-
-		return nil
+		return fs.ServeFileContent(c.Response(), c.Request(), slug, version, filepath)
 	}
 
 	if intentID := c.QueryParam("intent"); intentID != "" {

--- a/web/auth/auth.go
+++ b/web/auth/auth.go
@@ -21,7 +21,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/sessions"
 	"github.com/cozy/cozy-stack/pkg/sharings"
 	"github.com/cozy/cozy-stack/pkg/utils"
-	web_errors "github.com/cozy/cozy-stack/web/errors"
+	weberrors "github.com/cozy/cozy-stack/web/errors"
 	"github.com/cozy/cozy-stack/web/middlewares"
 	webpermissions "github.com/cozy/cozy-stack/web/permissions"
 	"github.com/labstack/echo"
@@ -39,7 +39,7 @@ const (
 
 func defaultContentType(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		c.Set(web_errors.DefaultContentTypeOfferKey, echo.MIMETextHTML)
+		c.Set(weberrors.DefaultContentTypeOfferKey, echo.MIMETextHTML)
 		return next(c)
 	}
 }

--- a/web/auth/auth.go
+++ b/web/auth/auth.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/sessions"
 	"github.com/cozy/cozy-stack/pkg/sharings"
 	"github.com/cozy/cozy-stack/pkg/utils"
+	web_errors "github.com/cozy/cozy-stack/web/errors"
 	"github.com/cozy/cozy-stack/web/middlewares"
 	webpermissions "github.com/cozy/cozy-stack/web/permissions"
 	"github.com/labstack/echo"
@@ -35,6 +36,13 @@ const (
 	// user when he/she enters incorrect two factor secret
 	TwoFactorErrorKey = "Login Two factor error"
 )
+
+func defaultContentType(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		c.Set(web_errors.DefaultContentTypeOfferKey, echo.MIMETextHTML)
+		return next(c)
+	}
+}
 
 // Home is the handler for /
 // It redirects to the login page is the user is not yet authentified
@@ -962,29 +970,29 @@ func Routes(router *echo.Group) {
 		CookieSecure:   !config.IsDevRelease(),
 	})
 
-	router.GET("/login", loginForm, noCSRF)
-	router.POST("/login", login, noCSRF)
+	router.GET("/login", loginForm, defaultContentType, noCSRF)
+	router.POST("/login", login, defaultContentType, noCSRF)
 
 	router.DELETE("/login/others", logoutOthers)
 	router.OPTIONS("/login/others", logoutPreflight)
 	router.DELETE("/login", logout)
 	router.OPTIONS("/login", logoutPreflight)
 
-	router.GET("/passphrase_reset", passphraseResetForm, noCSRF)
-	router.POST("/passphrase_reset", passphraseReset, noCSRF)
-	router.GET("/passphrase_renew", passphraseRenewForm, noCSRF)
-	router.POST("/passphrase_renew", passphraseRenew, noCSRF)
+	router.GET("/passphrase_reset", passphraseResetForm, defaultContentType, noCSRF)
+	router.POST("/passphrase_reset", passphraseReset, defaultContentType, noCSRF)
+	router.GET("/passphrase_renew", passphraseRenewForm, defaultContentType, noCSRF)
+	router.POST("/passphrase_renew", passphraseRenew, defaultContentType, noCSRF)
 
 	router.POST("/register", registerClient, middlewares.AcceptJSON, middlewares.ContentTypeJSON)
 	router.GET("/register/:client-id", readClient, middlewares.AcceptJSON, checkRegistrationToken)
 	router.PUT("/register/:client-id", updateClient, middlewares.AcceptJSON, middlewares.ContentTypeJSON, checkRegistrationToken)
 	router.DELETE("/register/:client-id", deleteClient, checkRegistrationToken)
 
-	authorizeGroup := router.Group("/authorize", noCSRF)
+	authorizeGroup := router.Group("/authorize", defaultContentType, noCSRF)
 	authorizeGroup.GET("", authorizeForm)
 	authorizeGroup.POST("", authorize)
 	authorizeGroup.GET("/app", authorizeAppForm)
 	authorizeGroup.POST("/app", authorizeApp)
 
-	router.POST("/access_token", accessToken)
+	router.POST("/access_token", accessToken, defaultContentType)
 }

--- a/web/auth/auth_test.go
+++ b/web/auth/auth_test.go
@@ -104,7 +104,7 @@ func TestShowLoginPageWithRedirectBadURL(t *testing.T) {
 	assert.NoError(t, err)
 	defer res1.Body.Close()
 	assert.Equal(t, "400 Bad Request", res1.Status)
-	assert.Equal(t, "text/plain; charset=UTF-8", res1.Header.Get("Content-Type"))
+	assert.Equal(t, "text/html", res1.Header.Get("Content-Type"))
 
 	req2, _ := http.NewRequest("GET", ts.URL+"/auth/login?redirect="+url.QueryEscape("foo.bar"), nil)
 	req2.Host = domain
@@ -112,7 +112,7 @@ func TestShowLoginPageWithRedirectBadURL(t *testing.T) {
 	assert.NoError(t, err)
 	defer res2.Body.Close()
 	assert.Equal(t, "400 Bad Request", res2.Status)
-	assert.Equal(t, "text/plain; charset=UTF-8", res2.Header.Get("Content-Type"))
+	assert.Equal(t, "text/html", res2.Header.Get("Content-Type"))
 
 	req3, _ := http.NewRequest("GET", ts.URL+"/auth/login?redirect="+url.QueryEscape("ftp://sub."+domain+"/foo"), nil)
 	req3.Host = domain
@@ -120,7 +120,7 @@ func TestShowLoginPageWithRedirectBadURL(t *testing.T) {
 	assert.NoError(t, err)
 	defer res3.Body.Close()
 	assert.Equal(t, "400 Bad Request", res3.Status)
-	assert.Equal(t, "text/plain; charset=UTF-8", res3.Header.Get("Content-Type"))
+	assert.Equal(t, "text/html", res3.Header.Get("Content-Type"))
 }
 
 func TestShowLoginPageWithRedirectXSS(t *testing.T) {

--- a/web/errors/errors.go
+++ b/web/errors/errors.go
@@ -62,7 +62,7 @@ func (e *ErrorNormalized) Title() string {
 	if e.title != "" {
 		return e.title
 	}
-	return e.inner.Error()
+	return http.StatusText(e.status)
 }
 
 // Detail returns the error detailed string value.
@@ -130,8 +130,7 @@ func NormalizeError(err error) *ErrorNormalized {
 		n.detail = ce.Reason
 	}
 
-	if n.title == "" {
-		n.title = http.StatusText(n.status)
+	if n.titleLocale == "" {
 		if n.status >= http.StatusInternalServerError {
 			n.titleLocale = "Error Internal Server Error Title"
 			n.detailLocale = "Error Internal Server Error Message"

--- a/web/errors/errors.go
+++ b/web/errors/errors.go
@@ -107,7 +107,8 @@ func NormalizeError(err error) *ErrorNormalized {
 			n.detail = he.Inner.Error()
 			err = he.Inner
 		} else {
-			n.detail = fmt.Sprintf("%v", he.Message)
+			n.title = fmt.Sprintf("%v", he.Message)
+			n.detail = n.title
 		}
 	}
 
@@ -216,12 +217,7 @@ func WriteError(err error, res http.ResponseWriter, c echo.Context) {
 	res.Header().Set("Content-Type", contentType)
 	res.Header().Set("Content-Length", strconv.Itoa(b.Len()))
 	res.WriteHeader(errn.Status())
-	_, errw := res.Write(b.Bytes())
-
-	if errw != nil && log != nil {
-		log.Errorf("[http] could not write out request: %s %s: %s",
-			req.Method, req.URL.Path, err)
-	}
+	res.Write(b.Bytes())
 }
 
 var bufferPool = sync.Pool{

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -901,6 +901,7 @@ func TestDownloadFileByIDSuccess(t *testing.T) {
 	assert.True(t, strings.HasPrefix(res2.Header.Get("Content-Disposition"), "inline"))
 	assert.True(t, strings.Contains(res2.Header.Get("Content-Disposition"), "filename=downloadme1"))
 	assert.True(t, strings.HasPrefix(res2.Header.Get("Content-Type"), "text/plain"))
+	assert.Equal(t, res2.ContentLength, int64(len(body)))
 	assert.NotEmpty(t, res2.Header.Get("Etag"))
 	assert.Equal(t, res2.Header.Get("Etag")[:1], `"`)
 	assert.Equal(t, res2.Header.Get("Content-Length"), "3")
@@ -1050,7 +1051,7 @@ func TestArchiveDirectDownload(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 200, res.StatusCode)
 	assert.Equal(t, "application/zip", res.Header.Get("Content-Type"))
-
+	assert.Equal(t, int64(-1), res.ContentLength)
 }
 
 func TestArchiveCreateAndDownload(t *testing.T) {
@@ -1102,6 +1103,7 @@ func TestArchiveCreateAndDownload(t *testing.T) {
 	assert.Equal(t, 200, res2.StatusCode)
 	disposition := res2.Header.Get("Content-Disposition")
 	assert.Equal(t, `attachment; filename=archive.zip`, disposition)
+	assert.Equal(t, int64(-1), res2.ContentLength)
 }
 
 func TestFileCreateAndDownloadByPath(t *testing.T) {

--- a/web/jsonapi/jsonapi.go
+++ b/web/jsonapi/jsonapi.go
@@ -56,6 +56,15 @@ func WriteData(w io.Writer, o Object, links *LinksList) error {
 	return json.NewEncoder(w).Encode(doc)
 }
 
+// WriteError can be called to write a JSON-API error document into an
+// io.Writer.
+func WriteError(w io.Writer, err *Error) error {
+	doc := Document{
+		Errors: ErrorList{err},
+	}
+	return json.NewEncoder(w).Encode(doc)
+}
+
 // Data can be called to send an answer with a JSON-API document containing a
 // single object as data
 func Data(c echo.Context, statusCode int, o Object, links *LinksList) error {
@@ -137,13 +146,10 @@ func DataRelations(c echo.Context, statusCode int, refs []couchdb.DocReference, 
 // DataError can be called to send an error answer with a JSON-API document
 // containing a single value error.
 func DataError(c echo.Context, err *Error) error {
-	doc := Document{
-		Errors: ErrorList{err},
-	}
 	resp := c.Response()
 	resp.Header().Set("Content-Type", ContentType)
 	resp.WriteHeader(err.Status)
-	return json.NewEncoder(resp).Encode(doc)
+	return WriteError(resp, err)
 }
 
 // DataErrorList can be called to send an error answer with a JSON-API document

--- a/web/permissions/permissions_test.go
+++ b/web/permissions/permissions_test.go
@@ -83,12 +83,13 @@ func TestGetPermissionsForRevokedClient(t *testing.T) {
 	assert.NoError(t, err)
 	req, _ := http.NewRequest("GET", ts.URL+"/permissions/self", nil)
 	req.Header.Add("Authorization", "Bearer "+tok)
+	req.Header.Set("Accept", "text/plain")
 	res, err := http.DefaultClient.Do(req)
 	assert.NoError(t, err)
 	assert.Equal(t, 400, res.StatusCode)
 	body, err := ioutil.ReadAll(res.Body)
 	assert.NoError(t, err)
-	assert.Equal(t, `Invalid JWT token`, string(body))
+	assert.Equal(t, `Bad Request: Invalid JWT token`, string(body))
 }
 
 func TestGetPermissionsForExpiredToken(t *testing.T) {
@@ -98,12 +99,13 @@ func TestGetPermissionsForExpiredToken(t *testing.T) {
 	assert.NoError(t, err)
 	req, _ := http.NewRequest("GET", ts.URL+"/permissions/self", nil)
 	req.Header.Add("Authorization", "Bearer "+tok)
+	req.Header.Set("Accept", "text/plain")
 	res, err := http.DefaultClient.Do(req)
 	assert.NoError(t, err)
 	assert.Equal(t, 400, res.StatusCode)
 	body, err := ioutil.ReadAll(res.Body)
 	assert.NoError(t, err)
-	assert.Equal(t, `Expired token`, string(body))
+	assert.Equal(t, `Bad Request: Expired token`, string(body))
 }
 
 func TestBadPermissionsBearer(t *testing.T) {

--- a/web/routing.go
+++ b/web/routing.go
@@ -204,6 +204,7 @@ func CreateSubdomainProxy(router *echo.Echo, appsHandler echo.HandlerFunc) (*ech
 		// TODO(optim): minimize the number of instance requests
 		if parent, slug, _ := middlewares.SplitHost(c.Request().Host); slug != "" {
 			if i, err := instance.Get(parent); err == nil {
+				c.Set(errors.DefaultContentTypeOfferKey, echo.MIMETextHTML)
 				c.Set("instance", i)
 				c.Set("slug", slug)
 				return appsHandler(c)

--- a/web/routing.go
+++ b/web/routing.go
@@ -214,7 +214,7 @@ func CreateSubdomainProxy(router *echo.Echo, appsHandler echo.HandlerFunc) (*ech
 		return nil
 	})
 
-	main.HTTPErrorHandler = errors.HTMLErrorHandler
+	main.HTTPErrorHandler = errors.ErrorHandler
 	return main, nil
 }
 

--- a/web/server.go
+++ b/web/server.go
@@ -27,10 +27,17 @@ import (
 	statikFS "github.com/cozy/statik/fs"
 )
 
-// ReadHeaderTimeout is the amount of time allowed to read request headers for
-// all servers. This is activated for all handlers from all http servers
-// created by the stack.
-var ReadHeaderTimeout = 15 * time.Second
+var (
+	// ReadTimeout is the amount of time allowed to read the request body. It
+	// impacts all handlers except the one that hijack the connection: for
+	// download/upload handlers.
+	ReadTimeout = 20 * time.Second
+
+	// WriteTimeout is the amount of time allowed to write into the response body.
+	// It impacts all handlers except the one that hijack the connection: for
+	// download/upload handlers.
+	WriteTimeout = 20 * time.Second
+)
 
 // LoadSupportedLocales reads the po files packed in go or from the assets directory
 // and loads them for translations
@@ -192,13 +199,15 @@ func (e *Servers) Start() {
 	e.errs = make(chan error)
 
 	go e.start(e.major, "major", &http.Server{
-		Addr:              config.ServerAddr(),
-		ReadHeaderTimeout: ReadHeaderTimeout,
+		Addr:         config.ServerAddr(),
+		ReadTimeout:  ReadTimeout,
+		WriteTimeout: WriteTimeout,
 	})
 
 	go e.start(e.admin, "admin", &http.Server{
-		Addr:              config.AdminServerAddr(),
-		ReadHeaderTimeout: ReadHeaderTimeout,
+		Addr:         config.AdminServerAddr(),
+		ReadTimeout:  ReadTimeout,
+		WriteTimeout: WriteTimeout,
 	})
 }
 

--- a/web/statik/handler.go
+++ b/web/statik/handler.go
@@ -15,7 +15,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/i18n"
 	"github.com/cozy/cozy-stack/pkg/utils"
 	"github.com/cozy/cozy-stack/web/middlewares"
-	web_utils "github.com/cozy/cozy-stack/web/utils"
+	webutils "github.com/cozy/cozy-stack/web/utils"
 	"github.com/cozy/statik/fs"
 	"github.com/labstack/echo"
 )
@@ -288,7 +288,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	checkETag := id == ""
-	if checkETag && web_utils.CheckPreconditions(w, r, f.Etag()) {
+	if checkETag && webutils.CheckPreconditions(w, r, f.Etag()) {
 		return
 	}
 

--- a/web/utils/serve_content.go
+++ b/web/utils/serve_content.go
@@ -1,12 +1,16 @@
 package utils
 
 import (
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/textproto"
 	"strconv"
 	"strings"
 )
+
+var errNoOverlap = errors.New("invalid range: failed to overlap")
 
 // ServeContent replies to the request using the content in the provided
 // reader. The Content-Length and Content-Type headers are added with the
@@ -16,21 +20,97 @@ func ServeContent(w http.ResponseWriter, r *http.Request, contentType string, si
 	if size > 0 {
 		h.Set("Content-Length", strconv.FormatInt(size, 10))
 	}
-	if contentType != "" {
-		h.Set("Content-Type", contentType)
+	if contentType == "" {
+		contentType = "application/octet-stream"
 	}
+	h.Set("Content-Type", contentType)
 	w.WriteHeader(http.StatusOK)
 	if r.Method != "HEAD" {
 		io.Copy(w, content)
 	}
 }
 
+// ServeContentRanges acts like ServeContent but also checks the Range headers
+// to serve a Content-Ranged response, accodingly to the asked ranges.
+func ServeContentRanges(w http.ResponseWriter, r *http.Request, contentType string, size int64, content io.ReadSeeker) {
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+
+	w.Header().Set("Accept-Ranges", "bytes")
+	w.Header().Set("Content-Type", contentType)
+
+	code := http.StatusOK
+	rangeReq := r.Header.Get("Range")
+	sendSize := size
+	if size >= 0 && rangeReq != "" {
+		ranges, err := parseRange(rangeReq, size)
+		if err != nil {
+			if err == errNoOverlap {
+				w.Header().Set("Content-Range", fmt.Sprintf("bytes */%d", size))
+			}
+			http.Error(w, err.Error(), http.StatusRequestedRangeNotSatisfiable)
+			return
+		}
+		if sumRangesSize(ranges) > size {
+			// The total number of bytes in all the ranges
+			// is larger than the size of the file by
+			// itself, so this is probably an attack, or a
+			// dumb client. Ignore the range request.
+			ranges = nil
+		}
+		switch {
+		case len(ranges) == 1:
+			// RFC 2616, Section 14.16:
+			// "When an HTTP message includes the content of a single
+			// range (for example, a response to a request for a
+			// single range, or to a request for a set of ranges
+			// transmitted with a Content-Range header, and a
+			// Content-Length header showing the number of bytes
+			// actually transferred.
+			// ...
+			// A response to a request for a single range MUST NOT
+			// be sent using the multipart/byteranges media type."
+			ra := ranges[0]
+			if _, err := content.Seek(ra.start, io.SeekStart); err != nil {
+				http.Error(w, err.Error(), http.StatusRequestedRangeNotSatisfiable)
+				return
+			}
+			sendSize = ra.length
+			code = http.StatusPartialContent
+			w.Header().Set("Content-Range", ra.contentRange(size))
+		case len(ranges) > 1:
+			http.Error(w, "invalid range: multi-part ranges is not supported",
+				http.StatusRequestedRangeNotSatisfiable)
+			return
+		}
+		if w.Header().Get("Content-Encoding") == "" {
+			w.Header().Set("Content-Length", strconv.FormatInt(sendSize, 10))
+		}
+	} else if size >= 0 {
+		w.Header().Set("Content-Length", strconv.FormatInt(size, 10))
+	}
+	w.WriteHeader(code)
+	if r.Method != "HEAD" {
+		io.CopyN(w, content, sendSize)
+	}
+}
+
 // CheckPreconditions evaluates request preconditions based only on the Etag
 // values.
 func CheckPreconditions(w http.ResponseWriter, r *http.Request, etag string) (done bool) {
-	if etag != "" && checkIfNoneMatch(w, r, etag) {
-		writeNotModified(w)
-		return true
+	if etag != "" {
+		if etag[0] != '"' {
+			etag = `"` + etag
+		}
+		if etag[len(etag)-1] != '"' {
+			etag += `"`
+		}
+		if checkIfNoneMatch(w, r, etag) {
+			writeNotModified(w)
+			return true
+		}
+		w.Header().Set("Etag", etag)
 	}
 	return false
 }
@@ -95,6 +175,100 @@ func scanETag(s string) (etag string, remain string) {
 		}
 	}
 	return "", ""
+}
+
+// httpRange specifies the byte range to be sent to the client.
+type httpRange struct {
+	start, length int64
+}
+
+func (r httpRange) contentRange(size int64) string {
+	return fmt.Sprintf("bytes %d-%d/%d", r.start, r.start+r.length-1, size)
+}
+
+// parseRange parses a Range header string as per R80FC 2616.
+// errNoOverlap is returned if none of the ranges overlap.
+func parseRange(s string, size int64) ([]httpRange, error) {
+	if s == "" {
+		return nil, nil // header not present
+	}
+	const b = "bytes="
+	if !strings.HasPrefix(s, b) {
+		return nil, errors.New("invalid range")
+	}
+	var ranges []httpRange
+	noOverlap := false
+	for _, ra := range strings.Split(s[len(b):], ",") {
+		ra = strings.TrimSpace(ra)
+		if ra == "" {
+			continue
+		}
+		i := strings.Index(ra, "-")
+		if i < 0 {
+			return nil, errors.New("invalid range")
+		}
+		start, end := strings.TrimSpace(ra[:i]), strings.TrimSpace(ra[i+1:])
+		var r httpRange
+		if start == "" {
+			// If no start is specified, end specifies the
+			// range start relative to the end of the file.
+			i, err := strconv.ParseInt(end, 10, 64)
+			if err != nil {
+				return nil, errors.New("invalid range")
+			}
+			if i > size {
+				i = size
+			}
+			r.start = size - i
+			r.length = size - r.start
+		} else {
+			i, err := strconv.ParseInt(start, 10, 64)
+			if err != nil || i < 0 {
+				return nil, errors.New("invalid range")
+			}
+			if i >= size {
+				// If the range begins after the size of the content,
+				// then it does not overlap.
+				noOverlap = true
+				continue
+			}
+			r.start = i
+			if end == "" {
+				// If no end is specified, range extends to end of the file.
+				r.length = size - r.start
+			} else {
+				i, err := strconv.ParseInt(end, 10, 64)
+				if err != nil || r.start > i {
+					return nil, errors.New("invalid range")
+				}
+				if i >= size {
+					i = size - 1
+				}
+				r.length = i - r.start + 1
+			}
+		}
+		ranges = append(ranges, r)
+	}
+	if noOverlap && len(ranges) == 0 {
+		// The specified ranges did not overlap with the content.
+		return nil, errNoOverlap
+	}
+	return ranges, nil
+}
+
+// countingWriter counts how many bytes have been written to it.
+type countingWriter int64
+
+func (w *countingWriter) Write(p []byte) (n int, err error) {
+	*w += countingWriter(len(p))
+	return len(p), nil
+}
+
+func sumRangesSize(ranges []httpRange) (size int64) {
+	for _, ra := range ranges {
+		size += ra.length
+	}
+	return
 }
 
 func writeNotModified(w http.ResponseWriter) {


### PR DESCRIPTION
This PR adds global timeouts on the created `http.Server`. To support longer timeouts for upload and download handler, a special read/writer is used using a moving window as timeout, shifted on each read/write operation.

The `ErrorHandler` is also modified to better support the `Accept` header negotiation.