### PR TITLE
Remove expiration of sessions cookies

### DIFF
--- a/pkg/sessions/session.go
+++ b/pkg/sessions/session.go
@@ -126,8 +126,9 @@ func Get(i *instance.Instance, sessionID string) (*Session, error) {
 		err := couchdb.UpdateDoc(i, s)
 		if err != nil {
 			i.Logger().Warn("[session] Failed to update session last seen:", err)
-		} else {
 			s.LastSeen = lastSeen
+			updateCache = false
+		} else {
 			updateCache = true
 		}
 	}


### PR DESCRIPTION
This PR removes the expiration of session cookies with a maxage parameter. This does not mean the session does not have an expiration anymore, but the expiration value is only stored in the session itself instead of specified client-side and server-side.

The renewal period of the session is now a bit more granular: one day instead of a half session time (3.5 days).

Finally, an invalid cache bug is fixed to prevent a bad `last_seen` value in the redis cache after a renewal of the session.