### PR TITLE
Fix process termination by killing process and its children 

### DIFF
--- a/pkg/workers/exec/cmd_unix.go
+++ b/pkg/workers/exec/cmd_unix.go
@@ -1,0 +1,18 @@
+// +build !windows
+
+package exec
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func createCmd(cmdStr, workDir string) *exec.Cmd {
+	c := exec.Command(cmdStr, workDir)
+	c.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	return c
+}
+
+func killCmd(c *exec.Cmd) error {
+	return syscall.Kill(-c.Process.Pid, syscall.SIGKILL)
+}

--- a/pkg/workers/exec/cmd_windows.go
+++ b/pkg/workers/exec/cmd_windows.go
@@ -1,0 +1,13 @@
+// +build windows
+
+package exec
+
+import "os/exec"
+
+func createCmd(cmdStr, workDir string) *exec.Cmd {
+	return exec.Command(cmdStr, workDir)
+}
+
+func killCmd(c *exec.Cmd) error {
+	return c.Process.Kill()
+}

--- a/pkg/workers/exec/common.go
+++ b/pkg/workers/exec/common.go
@@ -160,7 +160,8 @@ func ctxToTimeLimit(ctx *jobs.WorkerContext) (timeLimit string) {
 	if deadline, ok := ctx.Deadline(); ok {
 		diff := time.Until(deadline)
 		if diff > 0 {
-			timeLimit = strconv.Itoa(int(diff.Seconds()) + 1)
+			// add a little gap of 5 seconds to prevent racing the two deadlines
+			timeLimit = strconv.Itoa(int(diff.Seconds()) + 5)
 		}
 	}
 	return

--- a/pkg/workers/exec/common.go
+++ b/pkg/workers/exec/common.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -156,6 +157,16 @@ func addExecWorker(workerType string, cfg *jobs.WorkerConfig, createWorker func(
 	cfg.WorkerFunc = workerFunc
 	cfg.WorkerCommit = workerCommit
 	jobs.AddWorker(cfg)
+}
+
+func ctxToTimeLimit(ctx *jobs.WorkerContext) (timeLimit string) {
+	if deadline, ok := ctx.Deadline(); ok {
+		diff := time.Until(deadline)
+		if diff > 0 {
+			timeLimit = strconv.Itoa(int(diff.Seconds()) + 1)
+		}
+	}
+	return
 }
 
 func wrapErr(ctx context.Context, err error) error {

--- a/pkg/workers/exec/konnector.go
+++ b/pkg/workers/exec/konnector.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"strconv"
 	"time"
 
 	"github.com/cozy/cozy-stack/pkg/apps"
@@ -209,6 +210,14 @@ func (w *konnectorWorker) PrepareCmdEnv(ctx *jobs.WorkerContext, i *instance.Ins
 		return
 	}
 
+	var timeLimit string
+	if deadline, ok := ctx.Deadline(); ok {
+		diff := time.Until(deadline)
+		if diff > 0 {
+			timeLimit = strconv.Itoa(int(diff.Seconds()) + 1)
+		}
+	}
+
 	// Directly pass the job message as fields parameters
 	fieldsJSON := w.msg.ToJSON()
 	token := i.BuildKonnectorToken(w.man)
@@ -221,6 +230,7 @@ func (w *konnectorWorker) PrepareCmdEnv(ctx *jobs.WorkerContext, i *instance.Ins
 		"COZY_PARAMETERS=" + string(paramsJSON),
 		"COZY_TYPE=" + w.man.Type,
 		"COZY_LOCALE=" + i.Locale,
+		"COZY_TIME_LIMIT=" + timeLimit,
 		"COZY_JOB_ID=" + ctx.ID(),
 	}
 	return

--- a/pkg/workers/exec/konnector.go
+++ b/pkg/workers/exec/konnector.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"os"
 	"path"
-	"strconv"
 	"time"
 
 	"github.com/cozy/cozy-stack/pkg/apps"
@@ -210,14 +209,6 @@ func (w *konnectorWorker) PrepareCmdEnv(ctx *jobs.WorkerContext, i *instance.Ins
 		return
 	}
 
-	var timeLimit string
-	if deadline, ok := ctx.Deadline(); ok {
-		diff := time.Until(deadline)
-		if diff > 0 {
-			timeLimit = strconv.Itoa(int(diff.Seconds()) + 1)
-		}
-	}
-
 	// Directly pass the job message as fields parameters
 	fieldsJSON := w.msg.ToJSON()
 	token := i.BuildKonnectorToken(w.man)
@@ -230,7 +221,7 @@ func (w *konnectorWorker) PrepareCmdEnv(ctx *jobs.WorkerContext, i *instance.Ins
 		"COZY_PARAMETERS=" + string(paramsJSON),
 		"COZY_TYPE=" + w.man.Type,
 		"COZY_LOCALE=" + i.Locale,
-		"COZY_TIME_LIMIT=" + timeLimit,
+		"COZY_TIME_LIMIT=" + ctxToTimeLimit(ctx),
 		"COZY_JOB_ID=" + ctx.ID(),
 	}
 	return

--- a/pkg/workers/exec/service.go
+++ b/pkg/workers/exec/service.go
@@ -7,8 +7,6 @@ import (
 	"io"
 	"os"
 	"path"
-	"strconv"
-	"time"
 
 	"github.com/cozy/cozy-stack/pkg/apps"
 	"github.com/cozy/cozy-stack/pkg/config"
@@ -92,19 +90,12 @@ func (w *serviceWorker) Slug() string {
 func (w *serviceWorker) PrepareCmdEnv(ctx *jobs.WorkerContext, i *instance.Instance) (cmd string, env []string, err error) {
 	token := i.BuildAppToken(w.man, "")
 	cmd = config.GetConfig().Konnectors.Cmd
-	var timeLimit string
-	if deadline, ok := ctx.Deadline(); ok {
-		diff := time.Until(deadline)
-		if diff > 0 {
-			timeLimit = strconv.Itoa(int(diff.Seconds()) + 1)
-		}
-	}
 	env = []string{
 		"COZY_URL=" + i.PageURL("/", nil),
 		"COZY_CREDENTIALS=" + token,
 		"COZY_TYPE=" + w.opts.Type,
 		"COZY_LOCALE=" + i.Locale,
-		"COZY_TIME_LIMIT=" + timeLimit,
+		"COZY_TIME_LIMIT=" + ctxToTimeLimit(ctx),
 		"COZY_JOB_ID=" + ctx.ID(),
 	}
 	return

--- a/pkg/workers/exec/service.go
+++ b/pkg/workers/exec/service.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"os"
 	"path"
+	"strconv"
+	"time"
 
 	"github.com/cozy/cozy-stack/pkg/apps"
 	"github.com/cozy/cozy-stack/pkg/config"
@@ -90,11 +92,19 @@ func (w *serviceWorker) Slug() string {
 func (w *serviceWorker) PrepareCmdEnv(ctx *jobs.WorkerContext, i *instance.Instance) (cmd string, env []string, err error) {
 	token := i.BuildAppToken(w.man, "")
 	cmd = config.GetConfig().Konnectors.Cmd
+	var timeLimit string
+	if deadline, ok := ctx.Deadline(); ok {
+		diff := time.Until(deadline)
+		if diff > 0 {
+			timeLimit = strconv.Itoa(int(diff.Seconds()) + 1)
+		}
+	}
 	env = []string{
 		"COZY_URL=" + i.PageURL("/", nil),
 		"COZY_CREDENTIALS=" + token,
 		"COZY_TYPE=" + w.opts.Type,
 		"COZY_LOCALE=" + i.Locale,
+		"COZY_TIME_LIMIT=" + timeLimit,
 		"COZY_JOB_ID=" + ctx.ID(),
 	}
 	return

--- a/scripts/konnector-nsjail-run.sh
+++ b/scripts/konnector-nsjail-run.sh
@@ -125,6 +125,7 @@ nsjail \
   --rlimit_fsize 1024 \
   --rlimit_nofile 128 \
   --rlimit_nproc 512 \
+  --time_limit "${COZY_TIME_LIMIT}" \
   --disable_proc \
   --disable_clone_newnet \
   --iface_no_lo \
@@ -154,7 +155,7 @@ nsjail \
 #   --rlimit_fsize 1024 \
 #   --rlimit_nofile 128 \
 #   --rlimit_nproc 512 \
-#   --time_limit=120 \
+#   --time_limit "${COZY_TIME_LIMIT}" \
 #   --disable_proc \
 #   --disable_clone_newnet \
 #   --iface_no_lo \


### PR DESCRIPTION
This PR fixes the process termination on timeout for `konnector` and `service` workers. The killing of these process requires to kill all children of the processes, which is not done by the `cmd.Process.Kill()` command.

A `COZY_TIME_LIMIT` is also added which specify to the script how many time is has to execute. This is useful for instance with nsjail which provide a `--time_limit` option to be extra-careful and avoid leaking processes.