### PR TITLE
Robustness: make app installation and update more robust to failure and concurrency

### DIFF
--- a/pkg/apps/copier.go
+++ b/pkg/apps/copier.go
@@ -10,10 +10,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cozy/afero"
 	"github.com/cozy/cozy-stack/pkg/magic"
 	"github.com/cozy/cozy-stack/pkg/utils"
 	"github.com/cozy/swift"
-	"github.com/spf13/afero"
 )
 
 // Copier is an interface defining a common set of functions for the installer
@@ -131,7 +131,7 @@ func (f *swiftCopier) Commit() error {
 	}
 	for _, srcObjectName := range objectNames {
 		dstObjectName := path.Join(f.appObj, strings.TrimPrefix(srcObjectName, f.tmpObj))
-		err := f.c.ObjectMove(f.container, srcObjectName, f.container, dstObjectName)
+		err = f.c.ObjectMove(f.container, srcObjectName, f.container, dstObjectName)
 		if err != nil {
 			return f.Abort()
 		}
@@ -156,7 +156,7 @@ func (f *aferoCopier) Start(slug, version string) (bool, error) {
 		return exists, err
 	}
 	dir := path.Dir(f.appDir)
-	if err := f.fs.MkdirAll(dir, 0755); err != nil {
+	if err = f.fs.MkdirAll(dir, 0755); err != nil {
 		return false, err
 	}
 	f.tmpDir, err = afero.TempDir(f.fs, dir, "tmp")

--- a/pkg/apps/copier.go
+++ b/pkg/apps/copier.go
@@ -7,9 +7,11 @@ import (
 	"os"
 	"path"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/cozy/cozy-stack/pkg/magic"
+	"github.com/cozy/cozy-stack/pkg/utils"
 	"github.com/cozy/swift"
 	"github.com/spf13/afero"
 )
@@ -19,12 +21,14 @@ import (
 type Copier interface {
 	Start(slug, version string) (exists bool, err error)
 	Copy(stat os.FileInfo, src io.Reader) error
-	Close() error
+	Abort() error
+	Commit() error
 }
 
 type swiftCopier struct {
 	c         *swift.Connection
-	rootObj   string
+	appObj    string
+	tmpObj    string
 	container string
 	started   bool
 }
@@ -32,6 +36,7 @@ type swiftCopier struct {
 type aferoCopier struct {
 	fs      afero.Fs
 	appDir  string
+	tmpDir  string
 	started bool
 }
 
@@ -44,8 +49,8 @@ func NewSwiftCopier(conn *swift.Connection, appsType AppType) Copier {
 }
 
 func (f *swiftCopier) Start(slug, version string) (bool, error) {
-	f.rootObj = path.Join(slug, version)
-	_, _, err := f.c.Object(f.container, f.rootObj)
+	f.appObj = path.Join(slug, version)
+	_, _, err := f.c.Object(f.container, f.appObj)
 	if err == nil {
 		return true, nil
 	}
@@ -57,12 +62,8 @@ func (f *swiftCopier) Start(slug, version string) (bool, error) {
 			return false, err
 		}
 	}
-	o, err := f.c.ObjectCreate(f.container, f.rootObj, false, "", "", nil)
-	if err != nil {
-		return false, err
-	}
-	err = o.Close()
-	f.started = err == nil
+	f.tmpObj = "tmp-" + utils.RandomString(20) + "/"
+	f.started = true
 	return false, err
 }
 
@@ -70,12 +71,8 @@ func (f *swiftCopier) Copy(stat os.FileInfo, src io.Reader) (err error) {
 	if !f.started {
 		panic("copier should call Start() before Copy()")
 	}
-	defer func() {
-		if err != nil {
-			f.c.ObjectDelete(f.container, f.rootObj) // #nosec
-		}
-	}()
-	objName := path.Join(f.rootObj, stat.Name())
+
+	objName := path.Join(f.tmpObj, stat.Name())
 	objMeta := swift.Metadata{
 		"content-encoding":        "gzip",
 		"original-content-length": strconv.FormatInt(stat.Size(), 10),
@@ -114,8 +111,36 @@ func (f *swiftCopier) Copy(stat os.FileInfo, src io.Reader) (err error) {
 	return err
 }
 
-func (f *swiftCopier) Close() error {
-	return nil
+func (f *swiftCopier) Abort() error {
+	objectNames, err := f.c.ObjectNamesAll(f.container, &swift.ObjectsOpts{
+		Prefix: f.tmpObj,
+	})
+	if err != nil {
+		return err
+	}
+	_, err = f.c.BulkDelete(f.container, objectNames)
+	return err
+}
+
+func (f *swiftCopier) Commit() error {
+	objectNames, err := f.c.ObjectNamesAll(f.container, &swift.ObjectsOpts{
+		Prefix: f.tmpObj,
+	})
+	if err != nil {
+		return err
+	}
+	for _, srcObjectName := range objectNames {
+		dstObjectName := path.Join(f.appObj, strings.TrimPrefix(srcObjectName, f.tmpObj))
+		err := f.c.ObjectMove(f.container, srcObjectName, f.container, dstObjectName)
+		if err != nil {
+			return f.Abort()
+		}
+	}
+	o, err := f.c.ObjectCreate(f.container, f.appObj, false, "", "", nil)
+	if err != nil {
+		return err
+	}
+	return o.Close()
 }
 
 // NewAferoCopier defines a copier using an afero.Fs filesystem to store the
@@ -127,15 +152,19 @@ func NewAferoCopier(fs afero.Fs) Copier {
 func (f *aferoCopier) Start(slug, version string) (bool, error) {
 	f.appDir = path.Join("/", slug, version)
 	exists, err := afero.DirExists(f.fs, f.appDir)
+	if err != nil || exists {
+		return exists, err
+	}
+	dir := path.Dir(f.appDir)
+	if err := f.fs.MkdirAll(dir, 0755); err != nil {
+		return false, err
+	}
+	f.tmpDir, err = afero.TempDir(f.fs, dir, "tmp")
 	if err != nil {
 		return false, err
 	}
-	if exists {
-		return true, nil
-	}
-	err = f.fs.MkdirAll(f.appDir, 0755)
-	f.started = err == nil
-	return false, err
+	f.started = true
+	return false, nil
 }
 
 func (f *aferoCopier) Copy(stat os.FileInfo, src io.Reader) (err error) {
@@ -143,16 +172,11 @@ func (f *aferoCopier) Copy(stat os.FileInfo, src io.Reader) (err error) {
 		panic("copier should call Start() before Copy()")
 	}
 
-	fullpath := path.Join(f.appDir, stat.Name()) + ".gz"
+	fullpath := path.Join(f.tmpDir, stat.Name()) + ".gz"
 	dir := path.Dir(fullpath)
 	if err = f.fs.MkdirAll(dir, 0755); err != nil {
 		return err
 	}
-	defer func() {
-		if err != nil {
-			f.fs.RemoveAll(f.appDir) // #nosec
-		}
-	}()
 
 	dst, err := f.fs.Create(fullpath)
 	if err != nil {
@@ -178,8 +202,12 @@ func (f *aferoCopier) Copy(stat os.FileInfo, src io.Reader) (err error) {
 	return err
 }
 
-func (f *aferoCopier) Close() error {
-	return nil
+func (f *aferoCopier) Commit() error {
+	return f.fs.Rename(f.tmpDir, f.appDir)
+}
+
+func (f *aferoCopier) Abort() error {
+	return f.fs.RemoveAll(f.tmpDir)
 }
 
 type tarCopier struct {
@@ -229,13 +257,15 @@ func (t *tarCopier) Copy(stat os.FileInfo, src io.Reader) error {
 	return err
 }
 
-func (t *tarCopier) Close() (err error) {
+func (t *tarCopier) Commit() (err error) {
 	defer func() {
 		if t.tmp != nil {
 			t.fs.Remove(t.tmp.Name()) // #nosec
 		}
-		if errc := t.src.Close(); errc != nil && err == nil {
-			err = errc
+		if err != nil {
+			t.src.Abort()
+		} else {
+			err = t.src.Commit()
 		}
 	}()
 	if t.tw == nil || t.tmp == nil {
@@ -248,6 +278,13 @@ func (t *tarCopier) Close() (err error) {
 		return err
 	}
 	return t.src.Copy(&fileInfo{name: KonnectorArchiveName}, t.tmp)
+}
+
+func (t *tarCopier) Abort() error {
+	if t.tmp != nil {
+		t.fs.Remove(t.tmp.Name())
+	}
+	return t.src.Abort()
 }
 
 type fileInfo struct {

--- a/pkg/apps/fetcher_file.go
+++ b/pkg/apps/fetcher_file.go
@@ -42,17 +42,16 @@ func (f *fileFetcher) Fetch(src *url.URL, fs Copier, man Manifest) (err error) {
 	version := man.Version() + "-" + utils.RandomString(10)
 	man.SetVersion(version)
 	exists, err := fs.Start(man.Slug(), man.Version())
-	if err != nil {
+	if err != nil || exists {
 		return err
 	}
 	defer func() {
-		if errc := fs.Close(); errc != nil && err == nil {
-			err = errc
+		if err != nil {
+			fs.Abort()
+		} else {
+			err = fs.Commit()
 		}
 	}()
-	if exists {
-		return nil
-	}
 	return copyRec(src.Path, "/", fs)
 }
 

--- a/pkg/apps/fetcher_git.go
+++ b/pkg/apps/fetcher_git.go
@@ -17,12 +17,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cozy/afero"
 	git "github.com/cozy/go-git"
 	gitPlumbing "github.com/cozy/go-git/plumbing"
 	gitObject "github.com/cozy/go-git/plumbing/object"
 	gitStorage "github.com/cozy/go-git/storage/filesystem"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
 	gitOsFS "gopkg.in/src-d/go-billy.v2/osfs"
 )
 

--- a/pkg/apps/fetcher_git.go
+++ b/pkg/apps/fetcher_git.go
@@ -216,17 +216,16 @@ func (g *gitFetcher) fetchWithGit(gitFs afero.Fs, gitDir string, src *url.URL, f
 
 	// If the application folder already exists, we can bail early.
 	exists, err := fs.Start(slug, version)
-	if err != nil {
+	if err != nil || exists {
 		return err
 	}
 	defer func() {
-		if errc := fs.Close(); errc != nil && err == nil {
-			err = errc
+		if err != nil {
+			fs.Abort()
+		} else {
+			err = fs.Commit()
 		}
 	}()
-	if exists {
-		return nil
-	}
 
 	cmd = exec.CommandContext(ctx, "git",
 		"clone",
@@ -321,17 +320,16 @@ func (g *gitFetcher) fetchWithGoGit(gitDir string, src *url.URL, fs Copier, man 
 
 	// If the application folder already exists, we can bail early.
 	exists, err := fs.Start(slug, version)
-	if err != nil {
+	if err != nil || exists {
 		return err
 	}
 	defer func() {
-		if errc := fs.Close(); errc != nil {
-			err = errc
+		if err != nil {
+			fs.Abort()
+		} else {
+			err = fs.Commit()
 		}
 	}()
-	if exists {
-		return nil
-	}
 
 	commit, err := rep.CommitObject(ref.Hash())
 	if err != nil {

--- a/pkg/apps/installer_konnector_test.go
+++ b/pkg/apps/installer_konnector_test.go
@@ -7,8 +7,8 @@ import (
 	"path"
 	"testing"
 
+	"github.com/cozy/afero"
 	"github.com/cozy/cozy-stack/pkg/apps"
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/apps/installer_test.go
+++ b/pkg/apps/installer_test.go
@@ -173,7 +173,16 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	baseFS = afero.NewMemMapFs()
+	var tmpDir string
+	osFS := afero.NewOsFs()
+	tmpDir, err = afero.TempDir(osFS, "", "cozy-installer-test")
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer osFS.RemoveAll(tmpDir)
+
+	baseFS = afero.NewBasePathFs(osFS, tmpDir)
 	fs = apps.NewAferoCopier(baseFS)
 
 	go serveGitRep()

--- a/pkg/apps/installer_test.go
+++ b/pkg/apps/installer_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cozy/afero"
 	"github.com/cozy/checkup"
 	"github.com/cozy/cozy-stack/pkg/apps"
 	"github.com/cozy/cozy-stack/pkg/config"
@@ -19,7 +20,6 @@ import (
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/globals"
 	"github.com/cozy/cozy-stack/pkg/stack"
-	"github.com/spf13/afero"
 )
 
 var localGitCmd *exec.Cmd

--- a/pkg/apps/installer_webapp_test.go
+++ b/pkg/apps/installer_webapp_test.go
@@ -5,8 +5,8 @@ import (
 	"path"
 	"testing"
 
+	"github.com/cozy/afero"
 	"github.com/cozy/cozy-stack/pkg/apps"
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/apps/server.go
+++ b/pkg/apps/server.go
@@ -14,10 +14,10 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/cozy/afero"
 	"github.com/cozy/cozy-stack/pkg/magic"
 	web_utils "github.com/cozy/cozy-stack/web/utils"
 	"github.com/cozy/swift"
-	"github.com/spf13/afero"
 )
 
 // FileServer interface defines a way to access and serve the application's

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cozy/afero"
 	"github.com/cozy/cozy-stack/pkg/apps"
 	"github.com/cozy/cozy-stack/pkg/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
@@ -31,7 +32,6 @@ import (
 	"github.com/cozy/cozy-stack/pkg/vfs/vfsswift"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
 	jwt "gopkg.in/dgrijalva/jwt-go.v3"
 )
 

--- a/pkg/vfs/vfsafero/impl.go
+++ b/pkg/vfs/vfsafero/impl.go
@@ -17,8 +17,8 @@ import (
 	"github.com/cozy/cozy-stack/pkg/magic"
 	"github.com/cozy/cozy-stack/pkg/vfs"
 
+	"github.com/cozy/afero"
 	multierror "github.com/hashicorp/go-multierror"
-	"github.com/spf13/afero"
 )
 
 // aferoVFS is a struct implementing the vfs.VFS interface associated with

--- a/pkg/vfs/vfsafero/thumbs.go
+++ b/pkg/vfs/vfsafero/thumbs.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"path"
 
+	"github.com/cozy/afero"
 	"github.com/cozy/cozy-stack/pkg/vfs"
 	multierror "github.com/hashicorp/go-multierror"
-	"github.com/spf13/afero"
 )
 
 // NewThumbsFs creates a new thumb filesystem base on a afero.Fs.
@@ -47,7 +47,7 @@ func (t *thumbs) CreateThumb(img *vfs.FileDoc, format string) (vfs.ThumbFiler, e
 	if err != nil {
 		return nil, err
 	}
-	tmpname := path.Join(dir, path.Base(f.Name()))
+	tmpname := f.Name()
 	th := &thumb{
 		File:    f,
 		fs:      t.fs,

--- a/pkg/workers/exec/konnector.go
+++ b/pkg/workers/exec/konnector.go
@@ -19,7 +19,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/realtime"
 	"github.com/sirupsen/logrus"
 
-	"github.com/spf13/afero"
+	"github.com/cozy/afero"
 )
 
 type konnectorWorker struct {

--- a/pkg/workers/exec/konnector_test.go
+++ b/pkg/workers/exec/konnector_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/cozy/afero"
 	"github.com/cozy/cozy-stack/pkg/apps"
 	"github.com/cozy/cozy-stack/pkg/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
@@ -16,7 +17,6 @@ import (
 	"github.com/cozy/cozy-stack/pkg/permissions"
 	"github.com/cozy/cozy-stack/pkg/realtime"
 	"github.com/cozy/cozy-stack/tests/testutils"
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	jwt "gopkg.in/dgrijalva/jwt-go.v3"
 )

--- a/pkg/workers/exec/service.go
+++ b/pkg/workers/exec/service.go
@@ -8,12 +8,12 @@ import (
 	"os"
 	"path"
 
+	"github.com/cozy/afero"
 	"github.com/cozy/cozy-stack/pkg/apps"
 	"github.com/cozy/cozy-stack/pkg/config"
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/pkg/jobs"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
 )
 
 // ServiceOptions contains the options to execute a service.

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -6,6 +6,16 @@ echo "" > coverage.txt
 failed=false
 gosrc="$(go env GOPATH)/src"
 
+if git grep -l \
+  -e 'github.com/labstack/gommon/log' \
+  -e 'github.com/dgrijalva/jwt-go' \
+  -e 'github.com/cozy/echo' \
+  -e 'github.com/spf13/afero' \
+  -- '*.go'; then
+  echo "Forbidden packages"
+  exit 1
+fi
+
 for d in $(go list ./pkg/... ./web/...); do
 	if test -n "$(find $gosrc/$d -maxdepth 1 -name '*_test.go' -print -quit)"; then
 		go test \

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -19,15 +19,6 @@ assetsresult=$?
 pidstack=$(jobs -pr)
 [ -n "$pidstack" ] && kill -9 "$pidstack"
 
-if git grep -l \
-  -e 'github.com/labstack/gommon/log' \
-  -e 'github.com/dgrijalva/jwt-go' \
-  -e 'github.com/cozy/echo' \
-  -- '*.go'; then
-  echo "Forbidden packages"
-  exit 1
-fi
-
 if [ $testresult -gt 0 ]; then
   echo "Bad tests"
   exit $testresult

--- a/web/server.go
+++ b/web/server.go
@@ -23,8 +23,8 @@ import (
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/middleware"
 
+	"github.com/cozy/afero"
 	statikFS "github.com/cozy/statik/fs"
-	"github.com/spf13/afero"
 )
 
 // ReadHeaderTimeout is the amount of time allowed to read request headers for


### PR DESCRIPTION
This PR should make the installation and update more robust to failure by adding the possibility to abort an installation in case of an error during the process: i/o error or checksum mismatch: a temporary folder is used to store file during installation and committed (renamed) only on success.