### PR TITLE
Add a no-retry flag on jobs to avoid a retry when needed

### DIFF
--- a/pkg/jobs/worker.go
+++ b/pkg/jobs/worker.go
@@ -121,13 +121,13 @@ func (c *WorkerContext) WithCookie(cookie interface{}) *WorkerContext {
 }
 
 // SetNoRetry set the no-retry flag to prevent a retry on the next execution.
-func (w *WorkerContext) SetNoRetry() {
-	w.noRetry = true
+func (c *WorkerContext) SetNoRetry() {
+	c.noRetry = true
 }
 
 // NoRetry returns the no-retry flag.
-func (w *WorkerContext) NoRetry() bool {
-	return w.noRetry
+func (c *WorkerContext) NoRetry() bool {
+	return c.noRetry
 }
 
 func (c *WorkerContext) clone() *WorkerContext {

--- a/pkg/workers/exec/konnector.go
+++ b/pkg/workers/exec/konnector.go
@@ -235,6 +235,7 @@ func (w *konnectorWorker) ScanOutput(ctx *jobs.WorkerContext, i *instance.Instan
 	var msg struct {
 		Type    string `json:"type"`
 		Message string `json:"message"`
+		NoRetry bool   `json:"no_retry"`
 	}
 	if err := json.Unmarshal(line, &msg); err != nil {
 		return fmt.Errorf("Could not parse stdout as JSON: %q", string(line))
@@ -254,6 +255,9 @@ func (w *konnectorWorker) ScanOutput(ctx *jobs.WorkerContext, i *instance.Instan
 		log.Error(msg.Message)
 	case konnectorMsgTypeCritical:
 		w.err = errors.New(msg.Message)
+		if msg.NoRetry {
+			ctx.SetNoRetry()
+		}
 		log.Error(msg.Message)
 	}
 


### PR DESCRIPTION
This PR adds a flag to avoid a retry for jobs. A konnector can send in its `critical` JSON message log a `no_retry` field as `true`, the job won't be retried, regardless the worker configuration.