### PR TITLE
Deep copy of JSONDoc map

### DIFF
--- a/pkg/couchdb/couchdb.go
+++ b/pkg/couchdb/couchdb.go
@@ -147,11 +147,36 @@ func (j JSONDoc) SetRev(rev string) {
 // Clone is used to create a copy of the document
 func (j JSONDoc) Clone() Doc {
 	cloned := JSONDoc{Type: j.Type}
-	cloned.M = make(map[string]interface{})
-	for k, v := range j.M {
-		cloned.M[k] = v
-	}
+	cloned.M = deepClone(j.M)
 	return cloned
+}
+
+func deepClone(m map[string]interface{}) map[string]interface{} {
+	clone := make(map[string]interface{}, len(m))
+	for k, v := range m {
+		if vv, ok := v.(map[string]interface{}); ok {
+			clone[k] = deepClone(vv)
+		} else if vv, ok := v.([]interface{}); ok {
+			clone[k] = deepCloneSlice(vv)
+		} else {
+			clone[k] = v
+		}
+	}
+	return clone
+}
+
+func deepCloneSlice(s []interface{}) []interface{} {
+	clone := make([]interface{}, len(s))
+	for i, v := range s {
+		if vv, ok := v.(map[string]interface{}); ok {
+			clone[i] = deepClone(vv)
+		} else if vv, ok := v.([]interface{}); ok {
+			clone[i] = deepCloneSlice(vv)
+		} else {
+			clone[i] = v
+		}
+	}
+	return clone
 }
 
 // MarshalJSON implements json.Marshaller by proxying to internal map

--- a/pkg/couchdb/couchdb_test.go
+++ b/pkg/couchdb/couchdb_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/cozy/checkup"
 	"github.com/cozy/cozy-stack/pkg/config"
@@ -321,7 +322,7 @@ func TestMain(m *testing.M) {
 func TestJSONDocClone(t *testing.T) {
 	var m map[string]interface{}
 	data := []byte(`{
-	"foo1":"bar",
+	"foo1": "bar",
 	"foo2": [0,1,2,3],
 	"foo3": ["abc", 1, 1.1],
 	"foo4": {
@@ -331,7 +332,8 @@ func TestJSONDocClone(t *testing.T) {
 		"bar4": {}
 	},
 	"foo5": 1,
-	"foo6": 0.001
+	"foo6": 0.001,
+	"foo7": "toto"
 }`)
 
 	err := json.Unmarshal(data, &m)
@@ -348,6 +350,25 @@ func TestJSONDocClone(t *testing.T) {
 	assert.False(t, reflect.ValueOf(j1.M["foo2"]).Pointer() == reflect.ValueOf(j2.M["foo2"]).Pointer())
 	assert.False(t, reflect.ValueOf(j1.M["foo3"]).Pointer() == reflect.ValueOf(j2.M["foo3"]).Pointer())
 	assert.False(t, reflect.ValueOf(j1.M["foo4"]).Pointer() == reflect.ValueOf(j2.M["foo4"]).Pointer())
+
+	s1 := j1.M["foo1"].(string)
+	s2 := j2.M["foo1"].(string)
+	s3 := j1.M["foo7"].(string)
+	s4 := j2.M["foo7"].(string)
+
+	hdr1 := (*reflect.StringHeader)(unsafe.Pointer(&s1))
+	hdr2 := (*reflect.StringHeader)(unsafe.Pointer(&s2))
+	hdr3 := (*reflect.StringHeader)(unsafe.Pointer(&s3))
+	hdr4 := (*reflect.StringHeader)(unsafe.Pointer(&s4))
+
+	assert.Equal(t, hdr1.Data, hdr2.Data)
+	assert.Equal(t, hdr1.Len, hdr2.Len)
+
+	assert.Equal(t, hdr3.Data, hdr4.Data)
+	assert.Equal(t, hdr3.Len, hdr4.Len)
+
+	assert.NotEqual(t, hdr1.Data, hdr4.Data)
+	assert.NotEqual(t, hdr1.Len, hdr4.Len)
 }
 
 func assertGotEvent(t *testing.T, eventType, id string) bool {


### PR DESCRIPTION
`JSONDoc` may contain nested maps and slices. We need a more robust `Clone()` method of these objects to prevent a category of error with concurrent usages of `JSONDocs`.