### PR TITLE
Refacto: rewrite of the common exec

### DIFF
--- a/pkg/workers/exec/common.go
+++ b/pkg/workers/exec/common.go
@@ -21,20 +21,28 @@ import (
 var defaultTimeout = 300 * time.Second
 
 func init() {
-	addExecWorker("konnector", &jobs.WorkerConfig{
+	jobs.AddWorker(&jobs.WorkerConfig{
+		WorkerType: "konnector",
+		WorkerStart: func(ctx *jobs.WorkerContext) (*jobs.WorkerContext, error) {
+			return ctx.WithCookie(&konnectorWorker{}), nil
+		},
+		WorkerFunc:   worker,
+		WorkerCommit: commit,
 		Concurrency:  runtime.NumCPU() * 2,
 		MaxExecCount: 2,
 		Timeout:      defaultTimeout,
-	}, func() execWorker {
-		return &konnectorWorker{}
 	})
 
-	addExecWorker("service", &jobs.WorkerConfig{
+	jobs.AddWorker(&jobs.WorkerConfig{
+		WorkerType: "service",
+		WorkerStart: func(ctx *jobs.WorkerContext) (*jobs.WorkerContext, error) {
+			return ctx.WithCookie(&serviceWorker{}), nil
+		},
+		WorkerFunc:   worker,
+		WorkerCommit: commit,
 		Concurrency:  runtime.NumCPU() * 2,
 		MaxExecCount: 2,
 		Timeout:      defaultTimeout,
-	}, func() execWorker {
-		return &serviceWorker{}
 	})
 }
 
@@ -48,119 +56,99 @@ type execWorker interface {
 	Commit(ctx *jobs.WorkerContext, errjob error) error
 }
 
-func makeExecWorkerFunc() jobs.WorkerFunc {
-	return func(ctx *jobs.WorkerContext) (err error) {
-		worker := ctx.Cookie().(execWorker)
-		domain := ctx.Domain()
+func worker(ctx *jobs.WorkerContext) (err error) {
+	worker := ctx.Cookie().(execWorker)
+	domain := ctx.Domain()
 
-		inst, err := instance.Get(domain)
-		if err != nil {
-			return err
-		}
-
-		workDir, err := worker.PrepareWorkDir(ctx, inst)
-		if err != nil {
-			worker.Logger(ctx).Errorf("PrepareWorkDir: %s", err)
-			return err
-		}
-		defer os.RemoveAll(workDir)
-
-		cmdStr, env, err := worker.PrepareCmdEnv(ctx, inst)
-		if err != nil {
-			worker.Logger(ctx).Errorf("PrepareCmdEnv: %s", err)
-			return err
-		}
-
-		var stderrBuf bytes.Buffer
-		cmd := createCmd(cmdStr, workDir) // #nosec
-		cmd.Env = env
-
-		// set stderr writable with a bytes.Buffer limited total size of 256Ko
-		cmd.Stderr = utils.LimitWriterDiscard(&stderrBuf, 256*1024)
-
-		// Log out all things printed in stderr, whatever the result of the
-		// konnector is.
-		log := worker.Logger(ctx)
-		defer func() {
-			if stderrBuf.Len() > 0 {
-				log.Error("Stderr: ", stderrBuf.String())
-			}
-		}()
-
-		cmdOut, err := cmd.StdoutPipe()
-		if err != nil {
-			return err
-		}
-		scanBuf := make([]byte, 16*1024)
-		scanOut := bufio.NewScanner(cmdOut)
-		scanOut.Buffer(scanBuf, 64*1024)
-
-		timer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
-			var result string
-			if err != nil {
-				result = metrics.WorkerExecResultErrored
-			} else {
-				result = metrics.WorkerExecResultSuccess
-			}
-			metrics.WorkersKonnectorsExecDurations.
-				WithLabelValues(worker.Slug(), result).
-				Observe(v)
-		}))
-		defer timer.ObserveDuration()
-
-		if err = cmd.Start(); err != nil {
-			return wrapErr(ctx, err)
-		}
-
-		go func() {
-			for scanOut.Scan() {
-				if errOut := worker.ScanOutput(ctx, inst, scanOut.Bytes()); errOut != nil {
-					log.Error(errOut)
-				}
-			}
-			if errs := scanOut.Err(); errs != nil {
-				log.Errorf("could not scan stdout: %s", err)
-			}
-		}()
-
-		waitDone := make(chan error)
-		go func() {
-			waitDone <- cmd.Wait()
-			close(waitDone)
-		}()
-
-		select {
-		case err = <-waitDone:
-		case <-ctx.Done():
-			err = ctx.Err()
-			killCmd(cmd)
-			<-waitDone
-		}
-
-		return worker.Error(inst, err)
+	inst, err := instance.Get(domain)
+	if err != nil {
+		return err
 	}
+
+	workDir, err := worker.PrepareWorkDir(ctx, inst)
+	if err != nil {
+		worker.Logger(ctx).Errorf("PrepareWorkDir: %s", err)
+		return err
+	}
+	defer os.RemoveAll(workDir)
+
+	cmdStr, env, err := worker.PrepareCmdEnv(ctx, inst)
+	if err != nil {
+		worker.Logger(ctx).Errorf("PrepareCmdEnv: %s", err)
+		return err
+	}
+
+	var stderrBuf bytes.Buffer
+	cmd := createCmd(cmdStr, workDir) // #nosec
+	cmd.Env = env
+
+	// set stderr writable with a bytes.Buffer limited total size of 256Ko
+	cmd.Stderr = utils.LimitWriterDiscard(&stderrBuf, 256*1024)
+
+	// Log out all things printed in stderr, whatever the result of the
+	// konnector is.
+	log := worker.Logger(ctx)
+	defer func() {
+		if stderrBuf.Len() > 0 {
+			log.Error("Stderr: ", stderrBuf.String())
+		}
+	}()
+
+	cmdOut, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	scanBuf := make([]byte, 16*1024)
+	scanOut := bufio.NewScanner(cmdOut)
+	scanOut.Buffer(scanBuf, 64*1024)
+
+	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
+		var result string
+		if err != nil {
+			result = metrics.WorkerExecResultErrored
+		} else {
+			result = metrics.WorkerExecResultSuccess
+		}
+		metrics.WorkersKonnectorsExecDurations.
+			WithLabelValues(worker.Slug(), result).
+			Observe(v)
+	}))
+	defer timer.ObserveDuration()
+
+	if err = cmd.Start(); err != nil {
+		return wrapErr(ctx, err)
+	}
+
+	go func() {
+		for scanOut.Scan() {
+			if errOut := worker.ScanOutput(ctx, inst, scanOut.Bytes()); errOut != nil {
+				log.Error(errOut)
+			}
+		}
+		if errs := scanOut.Err(); errs != nil {
+			log.Errorf("could not scan stdout: %s", err)
+		}
+	}()
+
+	waitDone := make(chan error)
+	go func() {
+		waitDone <- cmd.Wait()
+		close(waitDone)
+	}()
+
+	select {
+	case err = <-waitDone:
+	case <-ctx.Done():
+		err = ctx.Err()
+		killCmd(cmd)
+		<-waitDone
+	}
+
+	return worker.Error(inst, err)
 }
 
-func addExecWorker(workerType string, cfg *jobs.WorkerConfig, createWorker func() execWorker) {
-	workerFunc := makeExecWorkerFunc()
-
-	workerStart := func(ctx *jobs.WorkerContext) (*jobs.WorkerContext, error) {
-		return ctx.WithCookie(createWorker()), nil
-	}
-
-	workerCommit := func(ctx *jobs.WorkerContext, errjob error) error {
-		if w, ok := ctx.Cookie().(execWorker); ok {
-			return w.Commit(ctx, errjob)
-		}
-		return nil
-	}
-
-	cfg = cfg.Clone()
-	cfg.WorkerType = workerType
-	cfg.WorkerStart = workerStart
-	cfg.WorkerFunc = workerFunc
-	cfg.WorkerCommit = workerCommit
-	jobs.AddWorker(cfg)
+func commit(ctx *jobs.WorkerContext, errjob error) error {
+	return ctx.Cookie().(execWorker).Commit(ctx, errjob)
 }
 
 func ctxToTimeLimit(ctx *jobs.WorkerContext) string {

--- a/pkg/workers/exec/konnector_test.go
+++ b/pkg/workers/exec/konnector_test.go
@@ -23,8 +23,6 @@ import (
 
 var inst *instance.Instance
 
-var konnectorWorkerFunc = makeExecWorkerFunc()
-
 func TestUnknownDomain(t *testing.T) {
 	msg, err := jobs.NewMessage(map[string]interface{}{
 		"konnector": "unknownapp",
@@ -36,7 +34,7 @@ func TestUnknownDomain(t *testing.T) {
 		WorkerType: "konnector",
 	})
 	ctx := jobs.NewWorkerContext("id", j).WithCookie(&konnectorWorker{})
-	err = konnectorWorkerFunc(ctx)
+	err = worker(ctx)
 	assert.Error(t, err)
 	assert.Equal(t, "Instance not found", err.Error())
 }
@@ -52,7 +50,7 @@ func TestUnknownApp(t *testing.T) {
 		WorkerType: "konnector",
 	})
 	ctx := jobs.NewWorkerContext("id", j).WithCookie(&konnectorWorker{})
-	err = konnectorWorkerFunc(ctx)
+	err = worker(ctx)
 	assert.Error(t, err)
 	assert.Equal(t, "Application is not installed", err.Error())
 }
@@ -92,12 +90,12 @@ func TestBadFileExec(t *testing.T) {
 
 	config.GetConfig().Konnectors.Cmd = ""
 	ctx := jobs.NewWorkerContext("id", j).WithCookie(&konnectorWorker{})
-	err = konnectorWorkerFunc(ctx)
+	err = worker(ctx)
 	assert.Error(t, err)
 	assert.Equal(t, "fork/exec : no such file or directory", err.Error())
 
 	config.GetConfig().Konnectors.Cmd = "echo"
-	err = konnectorWorkerFunc(ctx)
+	err = worker(ctx)
 	assert.NoError(t, err)
 }
 
@@ -197,7 +195,7 @@ echo "{\"type\": \"manifest\", \"message\": \"$(ls ${1}/manifest.konnector)\" }"
 
 	config.GetConfig().Konnectors.Cmd = tmpScript.Name()
 	ctx := jobs.NewWorkerContext("id", j).WithCookie(&konnectorWorker{})
-	err = konnectorWorkerFunc(ctx)
+	err = worker(ctx)
 	assert.NoError(t, err)
 
 	wg.Wait()


### PR DESCRIPTION
This PR is a small refactorization of the code in `pkg/workers/exec` to simplify the structure of the `konnector` and `services` workers.

Better watch the diff [without whitespaces](https://github.com/cozy/cozy-stack/pull/1248/commits/1b0564a888efb5b5a892efad739fb836fb67549c?w=1).