### PR TITLE
Ignore web/statik test coverage on codecov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
 /assets/locales/*.po
 !/assets/locales/en.po
-/coverage.txt
 /cozy-stack*
 /debian
 /storage
+/tests/coverage.txt
 /.cozy
 /.assets
 *.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
   - bash $COMMAND
 
 after_success:
-  - if [[ "$CODECOV" == "true" ]]; then bash <(curl -s https://codecov.io/bash); fi
+  - if [[ "$CODECOV" == "true" ]]; then cd tests && bash <(curl -s https://codecov.io/bash); fi
 
 after_failure:
   - docker ps -a

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -2,7 +2,7 @@
 
 # See https://golang.org/doc/go1.10#test
 go test \
-	-coverprofile=coverage.txt \
+	-coverprofile=tests/coverage.txt \
 	-covermode=count \
 	-coverpkg=./pkg/...,./web/... \
 	-vet=off \

--- a/tests/codecov.yml
+++ b/tests/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "web/statik"

--- a/tests/codecov.yml
+++ b/tests/codecov.yml
@@ -1,2 +1,5 @@
+coverage:
+  range: 50..80
+  precision: 2
 ignore:
   - "web/statik"


### PR DESCRIPTION
Our coverage with go 1.10 on codecov looks like this:

![coverage](https://codecov.io/gh/cozy/cozy-stack/commit/bf7afa87188ae6ded5907100704d2022a9a11a2e/graphs/tree.svg)

The big green shape is `web/statik/statik.go`