### PR TITLE
Always ask for a new code to activate two-factor authentication

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -162,30 +162,6 @@ HTTP/1.1 204 No Content
 Set-Cookie: cozysessid=AAAAShoo3uo1Maic4VibuGohlik2eKUyMmZiN2Q0YTYzNDAxN2Y5NjCmp2Ja56hPgHwufpJCBBGJC2mLeJ5LCRrFFkHwaVVa; Path=/; Domain=alice.example.com; Max-Age=604800; HttpOnly; Secure
 ```
 
-### PUT /settings/confirm_mail
-
-The user can confirm its mail for activation of two-factor authentication. The
-code used as confirmation should have been sent via email.
-
-Status codes:
-  * `204 No Content`: when the mail has been confirmed and two-factor authentication is activated
-  * `422 Unprocessable Entity`: when the confirmation code given is not good.
-
-#### Request
-
-```http
-PUT /settings/confirm_mail HTTP/1.1
-Host: alice.example.com
-Content-Type: application/json
-Cookie: cozysessid=AAAAAFhSXT81MWU0ZTBiMzllMmI1OGUyMmZiN2Q0YTYzNDAxN2Y5NjCmp2Ja56hPgHwufpJCBBGJC2mLeJ5LCRrFFkHwaVVa
-```
-
-```json
-{
-  "mail_confirmation_code": "12345678",
-}
-```
-
 #### Response
 
 ```http
@@ -299,7 +275,31 @@ Content-type: application/json
 To use this endpoint, an application needs a permission on the type
 `io.cozy.settings` for the verb `PUT`.
 
-### PUT /settings/instance/confirm_mail_tfa
+### PUT /settings/instance/activate_tfa
+
+The user can activate of two-factor authentication. The code used as
+confirmation should have been sent via email.
+
+Status codes:
+  * `204 No Content`: when the mail has been confirmed and two-factor authentication is activated
+  * `422 Unprocessable Entity`: when the confirmation code given is not good.
+
+#### Request
+
+```http
+PUT /settings/instance/activate_tfa HTTP/1.1
+Host: alice.example.com
+Content-Type: application/json
+Cookie: cozysessid=AAAAAFhSXT81MWU0ZTBiMzllMmI1OGUyMmZiN2Q0YTYzNDAxN2Y5NjCmp2Ja56hPgHwufpJCBBGJC2mLeJ5LCRrFFkHwaVVa
+```
+
+```json
+{
+  "two_factor_activation_code": "12345678",
+}
+```
+
+### PUT /settings/instance/send_code_tfa
 
 Re-send the two factor authorization code to confirm the user's email address.
 If the mail is already confirmed, no mail is resent.
@@ -312,7 +312,7 @@ send the mail on user demand.
 #### Request
 
 ```http
-PUT /settings/instance/confirm_mail_tfa HTTP/1.1
+PUT /settings/instance/send_code_tfa HTTP/1.1
 Host: alice.example.com
 Content-type: application/vnd.api+json
 Cookie: sessionid=xxxxx

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -275,7 +275,7 @@ Content-type: application/json
 To use this endpoint, an application needs a permission on the type
 `io.cozy.settings` for the verb `PUT`.
 
-### PUT /settings/instance/activate_tfa
+### PUT /settings/instance/tfa
 
 The user can activate of two-factor authentication. The code used as
 confirmation should have been sent via email.
@@ -287,7 +287,7 @@ Status codes:
 #### Request
 
 ```http
-PUT /settings/instance/activate_tfa HTTP/1.1
+PUT /settings/instance/tfa HTTP/1.1
 Host: alice.example.com
 Content-Type: application/json
 Cookie: cozysessid=AAAAAFhSXT81MWU0ZTBiMzllMmI1OGUyMmZiN2Q0YTYzNDAxN2Y5NjCmp2Ja56hPgHwufpJCBBGJC2mLeJ5LCRrFFkHwaVVa
@@ -299,7 +299,7 @@ Cookie: cozysessid=AAAAAFhSXT81MWU0ZTBiMzllMmI1OGUyMmZiN2Q0YTYzNDAxN2Y5NjCmp2Ja5
 }
 ```
 
-### PUT /settings/instance/send_code_tfa
+### POST /settings/instance/tfa/code
 
 Re-send the two factor authorization code to confirm the user's email address.
 If the mail is already confirmed, no mail is resent.
@@ -312,7 +312,7 @@ send the mail on user demand.
 #### Request
 
 ```http
-PUT /settings/instance/send_code_tfa HTTP/1.1
+POST /settings/instance/tfa/code HTTP/1.1
 Host: alice.example.com
 Content-type: application/vnd.api+json
 Cookie: sessionid=xxxxx

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -282,7 +282,7 @@ confirmation should have been sent via email.
 
 Status codes:
   * `204 No Content`: when the mail has been confirmed and two-factor authentication is activated
-  * `422 Unprocessable Entity`: when the confirmation code given is not good.
+  * `422 Unprocessable Entity`: when the given confirmation code is not good.
 
 #### Request
 

--- a/web/settings/instance.go
+++ b/web/settings/instance.go
@@ -140,6 +140,30 @@ func updateInstance(c echo.Context) error {
 	return jsonapi.Data(c, http.StatusOK, &apiInstance{doc}, nil)
 }
 
+func activateTwoFactorMail(c echo.Context) error {
+	inst := middlewares.GetInstance(c)
+
+	if err := webpermissions.AllowWholeType(c, permissions.PUT, consts.Settings); err != nil {
+		return err
+	}
+
+	if inst.MailConfirmed {
+		return c.NoContent(http.StatusNoContent)
+	}
+
+	args := struct {
+		TwoFactorActivationCode string `json:"two_factor_activation_code"`
+	}{}
+	if err := c.Bind(&args); err != nil {
+		return err
+	}
+
+	if ok := inst.ConfirmMail(args.TwoFactorActivationCode); !ok {
+		return c.NoContent(http.StatusUnprocessableEntity)
+	}
+	return c.NoContent(http.StatusNoContent)
+}
+
 func sendTwoFactorConfirmMail(c echo.Context) error {
 	err := webpermissions.AllowWholeType(c, webpermissions.PUT, consts.Settings)
 	if err != nil {

--- a/web/settings/instance.go
+++ b/web/settings/instance.go
@@ -103,8 +103,10 @@ func updateInstance(c echo.Context) error {
 		if inst.AuthMode != authMode {
 			inst.AuthMode = authMode
 			needUpdate = true
-			needMailConfirmation =
-				authMode == instance.TwoFactorMail && !inst.MailConfirmed
+			needMailConfirmation = authMode == instance.TwoFactorMail
+			if inst.AuthMode != instance.TwoFactorMail {
+				inst.MailConfirmed = false
+			}
 		}
 	}
 

--- a/web/settings/passphrase.go
+++ b/web/settings/passphrase.go
@@ -98,7 +98,7 @@ func updatePassphrase(c echo.Context) error {
 	return c.NoContent(http.StatusNoContent)
 }
 
-func confirmMail(c echo.Context) error {
+func activateTwoFactorMail(c echo.Context) error {
 	inst := middlewares.GetInstance(c)
 
 	if err := permissions.AllowWholeType(c, permissions.PUT, consts.Settings); err != nil {
@@ -110,13 +110,13 @@ func confirmMail(c echo.Context) error {
 	}
 
 	args := struct {
-		MailConfirmationCode string `json:"mail_confirmation_code"`
+		TwoFactorActivationCode string `json:"two_factor_activation_code"`
 	}{}
 	if err := c.Bind(&args); err != nil {
 		return err
 	}
 
-	if ok := inst.ConfirmMail(args.MailConfirmationCode); !ok {
+	if ok := inst.ConfirmMail(args.TwoFactorActivationCode); !ok {
 		return c.NoContent(http.StatusUnprocessableEntity)
 	}
 	return c.NoContent(http.StatusNoContent)

--- a/web/settings/passphrase.go
+++ b/web/settings/passphrase.go
@@ -97,27 +97,3 @@ func updatePassphrase(c echo.Context) error {
 
 	return c.NoContent(http.StatusNoContent)
 }
-
-func activateTwoFactorMail(c echo.Context) error {
-	inst := middlewares.GetInstance(c)
-
-	if err := permissions.AllowWholeType(c, permissions.PUT, consts.Settings); err != nil {
-		return err
-	}
-
-	if inst.MailConfirmed {
-		return c.NoContent(http.StatusNoContent)
-	}
-
-	args := struct {
-		TwoFactorActivationCode string `json:"two_factor_activation_code"`
-	}{}
-	if err := c.Bind(&args); err != nil {
-		return err
-	}
-
-	if ok := inst.ConfirmMail(args.TwoFactorActivationCode); !ok {
-		return c.NoContent(http.StatusUnprocessableEntity)
-	}
-	return c.NoContent(http.StatusNoContent)
-}

--- a/web/settings/settings.go
+++ b/web/settings/settings.go
@@ -59,8 +59,8 @@ func Routes(router *echo.Group) {
 
 	router.GET("/instance", getInstance)
 	router.PUT("/instance", updateInstance)
-	router.PUT("/instance/send_code_tfa", sendTwoFactorConfirmMail)
-	router.PUT("/instance/activate_tfa", activateTwoFactorMail)
+	router.PUT("/instance/tfa", activateTwoFactorMail)
+	router.POST("/instance/tfa/code", sendTwoFactorConfirmMail)
 	router.GET("/sessions", getSessions)
 
 	router.GET("/clients", listClients)

--- a/web/settings/settings.go
+++ b/web/settings/settings.go
@@ -56,11 +56,11 @@ func Routes(router *echo.Group) {
 
 	router.POST("/passphrase", registerPassphrase)
 	router.PUT("/passphrase", updatePassphrase)
-	router.PUT("/confirm_mail", confirmMail)
 
 	router.GET("/instance", getInstance)
 	router.PUT("/instance", updateInstance)
-	router.PUT("/instance/confirm_mail_tfa", sendTwoFactorConfirmMail)
+	router.PUT("/instance/send_code_tfa", sendTwoFactorConfirmMail)
+	router.PUT("/instance/activate_tfa", activateTwoFactorMail)
 	router.GET("/sessions", getSessions)
 
 	router.GET("/clients", listClients)

--- a/web/settings/settings_test.go
+++ b/web/settings/settings_test.go
@@ -255,7 +255,7 @@ func TestUpdatePassphraseWithTwoFactorAuth(t *testing.T) {
 		"two_factor_activation_code": "%s"
 	}`
 	body = fmt.Sprintf(body, mailPassCode)
-	req, _ = http.NewRequest("PUT", ts.URL+"/settings/confirm_mail", bytes.NewBufferString(body))
+	req, _ = http.NewRequest("PUT", ts.URL+"/settings/instance/tfa", bytes.NewBufferString(body))
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("Authorization", "Bearer "+token)

--- a/web/settings/settings_test.go
+++ b/web/settings/settings_test.go
@@ -252,7 +252,7 @@ func TestUpdatePassphraseWithTwoFactorAuth(t *testing.T) {
 	mailPassCode, err := testInstance.GenerateMailConfirmationCode()
 	assert.NoError(t, err)
 	body = `{
-		"mail_confirmation_code": "%s"
+		"two_factor_activation_code": "%s"
 	}`
 	body = fmt.Sprintf(body, mailPassCode)
 	req, _ = http.NewRequest("PUT", ts.URL+"/settings/confirm_mail", bytes.NewBufferString(body))


### PR DESCRIPTION
This PR changes the API to activate the two-factor authentication.