### PR TITLE
Simplify and separate the authentication mode APIs

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -285,8 +285,8 @@ Available authentication modes:
   - `two_factor_mail`: authentication with passphrase and validation with a
     code sent via email to the user.
 
-When asking for activation of the two-factor authentication, a side-effect is
-can be triggered to send the user its code (via email for instance), and the
+When asking for activation of the two-factor authentication, a side-effect can
+be triggered to send the user its code (via email for instance), and the
 activation not being effective. This side-effect should provide the user with
 a code that can be used to finalize the activation of the two-factor
 authentication.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -275,10 +275,27 @@ Content-type: application/json
 To use this endpoint, an application needs a permission on the type
 `io.cozy.settings` for the verb `PUT`.
 
-### PUT /settings/instance/tfa
+### PUT /settings/instance/auth_mode
 
-The user can activate of two-factor authentication. The code used as
-confirmation should have been sent via email.
+With this route, the user can ask for the activation of different
+authentication modes, like two-factor authentication.
+
+Available authentication modes:
+  - `basic`: basic authentication only with passphrase
+  - `two_factor_mail`: authentication with passphrase and validation with a
+    code sent via email to the user.
+
+When asking for activation of the two-factor authentication, a side-effect is
+can be triggered to send the user its code (via email for instance), and the
+activation not being effective. This side-effect should provide the user with
+a code that can be used to finalize the activation of the two-factor
+authentication.
+
+Hence, this route has two behaviors:
+  - the code is not provided: the route is a side effect to ask for the
+    activation of 2FA, and a code is sent
+  - the code is provided, and valid: the two-factor authentication is actually
+    activated.
 
 Status codes:
   * `204 No Content`: when the mail has been confirmed and two-factor authentication is activated
@@ -287,7 +304,7 @@ Status codes:
 #### Request
 
 ```http
-PUT /settings/instance/tfa HTTP/1.1
+PUT /settings/instance/auth_mode HTTP/1.1
 Host: alice.example.com
 Content-Type: application/json
 Cookie: cozysessid=AAAAAFhSXT81MWU0ZTBiMzllMmI1OGUyMmZiN2Q0YTYzNDAxN2Y5NjCmp2Ja56hPgHwufpJCBBGJC2mLeJ5LCRrFFkHwaVVa
@@ -295,38 +312,10 @@ Cookie: cozysessid=AAAAAFhSXT81MWU0ZTBiMzllMmI1OGUyMmZiN2Q0YTYzNDAxN2Y5NjCmp2Ja5
 
 ```json
 {
+  "auth_mode": "two_factor_mail",
   "two_factor_activation_code": "12345678",
 }
 ```
-
-### POST /settings/instance/tfa/code
-
-Re-send the two factor authorization code to confirm the user's email address.
-If the mail is already confirmed, no mail is resent.
-
-The `auth_mode` should be set to `two_factor_mail` before using this route. On
-the first activation of this mode, using the `PUT /instance` route, the
-confirmation mail is already sent if needed. This route is only useful to re-
-send the mail on user demand.
-
-#### Request
-
-```http
-POST /settings/instance/tfa/code HTTP/1.1
-Host: alice.example.com
-Content-type: application/vnd.api+json
-Cookie: sessionid=xxxxx
-Authorization: Bearer settings-token
-```
-
-```
-HTTP/1.1 204 No Content
-```
-
-#### Permissions
-
-To use this endpoint, an application needs a permission on the type
-`io.cozy.settings` for the verb `PUT`.
 
 ### GET /settings/sessions
 

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -71,8 +71,6 @@ var (
 	ErrContextNotFound = errors.New("Context not found")
 	// ErrResetAlreadyRequested is returned when a passphrase reset token is already set and valid
 	ErrResetAlreadyRequested = errors.New("The passphrase reset has already been requested")
-	// ErrMailIsNotConfirmed is returned when the mail has not been confirmed
-	ErrMailIsNotConfirmed = errors.New("Mail has not been confirmed")
 	// ErrUnknownAuthMode is returned when an unknwon authentication mode is
 	// used.
 	ErrUnknownAuthMode = errors.New("Unknown authentication mode")

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -73,6 +73,9 @@ var (
 	ErrResetAlreadyRequested = errors.New("The passphrase reset has already been requested")
 	// ErrMailIsNotConfirmed is returned when the mail has not been confirmed
 	ErrMailIsNotConfirmed = errors.New("Mail has not been confirmed")
+	// ErrUnknownAuthMode is returned when an unknwon authentication mode is
+	// used.
+	ErrUnknownAuthMode = errors.New("Unknown authentication mode")
 )
 
 // An Instance has the informations relatives to the logical cozy instance,
@@ -88,7 +91,6 @@ type Instance struct {
 	Dev          bool     `json:"dev,omitempty"`            // Whether or not the instance is for development
 
 	OnboardingFinished bool  `json:"onboarding_finished"`         // Whether or not the onboarding is complete.
-	MailConfirmed      bool  `json:"mail_confirmed"`              // Whether or not the mail has been confirmed.
 	BytesDiskQuota     int64 `json:"disk_quota,string,omitempty"` // The total size in bytes allowed to the user
 	IndexViewsVersion  int   `json:"indexes_version"`
 

--- a/pkg/instance/two_factor_auth.go
+++ b/pkg/instance/two_factor_auth.go
@@ -123,9 +123,6 @@ func (i *Instance) ValidateTwoFactorPasscode(token []byte, passcode string) bool
 // SendTwoFactorPasscode sends by mail the two factor secret to the owner of
 // the instance. It returns the generated token.
 func (i *Instance) SendTwoFactorPasscode() ([]byte, error) {
-	if i.HasAuthMode(TwoFactorMail) {
-		return nil, ErrMailIsNotConfirmed
-	}
 	token, passcode, err := i.GenerateTwoFactorSecrets()
 	if err != nil {
 		return nil, err

--- a/pkg/instance/two_factor_auth.go
+++ b/pkg/instance/two_factor_auth.go
@@ -56,24 +56,21 @@ func AuthModeToString(authMode AuthMode) string {
 
 // StringToAuthMode converts a string encoded authentication mode into a
 // AuthMode int.
-func StringToAuthMode(authMode string) AuthMode {
+func StringToAuthMode(authMode string) (AuthMode, error) {
 	switch authMode {
 	case "two_factor_mail":
-		return TwoFactorMail
+		return TwoFactorMail, nil
+	case "basic":
+		return Basic, nil
 	default:
-		return Basic
+		return 0, ErrUnknownAuthMode
 	}
 }
 
 // HasAuthMode returns whether or not the instance has the given authentication
 // mode activated.
 func (i *Instance) HasAuthMode(authMode AuthMode) bool {
-	switch authMode {
-	case TwoFactorMail:
-		return i.AuthMode == TwoFactorMail && i.MailConfirmed
-	default:
-		return i.AuthMode == authMode
-	}
+	return i.AuthMode == authMode
 }
 
 // GenerateTwoFactorSecrets generates a (token, passcode) pair that can be
@@ -126,7 +123,7 @@ func (i *Instance) ValidateTwoFactorPasscode(token []byte, passcode string) bool
 // SendTwoFactorPasscode sends by mail the two factor secret to the owner of
 // the instance. It returns the generated token.
 func (i *Instance) SendTwoFactorPasscode() ([]byte, error) {
-	if i.AuthMode == TwoFactorMail && !i.MailConfirmed {
+	if i.HasAuthMode(TwoFactorMail) {
 		return nil, ErrMailIsNotConfirmed
 	}
 	token, passcode, err := i.GenerateTwoFactorSecrets()
@@ -193,12 +190,8 @@ func (i *Instance) SendMailConfirmationCode() error {
 	})
 }
 
-// ConfirmMail set the `MailConfirmed` field to true after verifying the code
-// token.
-func (i *Instance) ConfirmMail(passcode string) bool {
-	if i.MailConfirmed {
-		return true
-	}
+// ValidateMailConfirmationCode returns true if the given passcode is valid.
+func (i *Instance) ValidateMailConfirmationCode(passcode string) bool {
 	email, err := i.SettingsEMail()
 	if err != nil {
 		return false
@@ -214,7 +207,5 @@ func (i *Instance) ConfirmMail(passcode string) bool {
 	if !ok || err != nil {
 		return false
 	}
-	i.MailConfirmed = true
-	Update(i)
 	return true
 }

--- a/web/settings/settings.go
+++ b/web/settings/settings.go
@@ -59,8 +59,8 @@ func Routes(router *echo.Group) {
 
 	router.GET("/instance", getInstance)
 	router.PUT("/instance", updateInstance)
-	router.PUT("/instance/tfa", activateTwoFactorMail)
-	router.POST("/instance/tfa/code", sendTwoFactorConfirmMail)
+	router.PUT("/instance/auth_mode", updateInstanceAuthMode)
+
 	router.GET("/sessions", getSessions)
 
 	router.GET("/clients", listClients)

--- a/web/settings/settings_test.go
+++ b/web/settings/settings_test.go
@@ -227,35 +227,27 @@ func TestUpdateInstance(t *testing.T) {
 
 func TestUpdatePassphraseWithTwoFactorAuth(t *testing.T) {
 	body := `{
-		"data": {
-			"type": "io.cozy.settings",
-			"id": "io.cozy.settings.instance",
-			"meta": {
-				"rev": "%s"
-			},
-			"attributes": {
-				"auth_mode": "two_factor_mail"
-			}
-		}
+		"auth_mode": "two_factor_mail"
 	}`
 	body = fmt.Sprintf(body, instanceRev)
-	req, _ := http.NewRequest("PUT", ts.URL+"/settings/instance", bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/vnd.api+json")
-	req.Header.Add("Accept", "application/vnd.api+json")
+	req, _ := http.NewRequest("PUT", ts.URL+"/settings/instance/auth_mode", bytes.NewBufferString(body))
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Accept", "application/json")
 	req.Header.Add("Authorization", "Bearer "+token)
 	res, err := http.DefaultClient.Do(req)
 	assert.NoError(t, err)
-	if !assert.Equal(t, "200 OK", res.Status) {
+	if !assert.Equal(t, "204 No Content", res.Status) {
 		return
 	}
 
 	mailPassCode, err := testInstance.GenerateMailConfirmationCode()
 	assert.NoError(t, err)
 	body = `{
+		"auth_mode": "two_factor_mail",
 		"two_factor_activation_code": "%s"
 	}`
 	body = fmt.Sprintf(body, mailPassCode)
-	req, _ = http.NewRequest("PUT", ts.URL+"/settings/instance/tfa", bytes.NewBufferString(body))
+	req, _ = http.NewRequest("PUT", ts.URL+"/settings/instance/auth_mode", bytes.NewBufferString(body))
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("Authorization", "Bearer "+token)
@@ -280,6 +272,7 @@ func TestUpdatePassphraseWithTwoFactorAuth(t *testing.T) {
 	err = json.NewDecoder(res.Body).Decode(&result)
 	assert.NoError(t, err)
 
+	fmt.Println(">>>", result)
 	{
 		twoFactorToken, ok := result["two_factor_token"].(string)
 		assert.True(t, ok)


### PR DESCRIPTION
Simplify the authentication mode APIs. Rely on a separate route `PUT /settings/instance/auth_mode` to activate / deactivate the two-factor authentications.