### PR TITLE
Move the "trash" logic in the indexer

### DIFF
--- a/pkg/couchdb/couchdb.go
+++ b/pkg/couchdb/couchdb.go
@@ -547,9 +547,14 @@ func UpdateDoc(db Database, doc Doc) error {
 
 // BulkUpdateDocs is used to update several docs in one call, as a bulk.
 func BulkUpdateDocs(db Database, doctype string, docs []interface{}) error {
+	if len(docs) == 0 {
+		return nil
+	}
 	body := struct {
 		Docs []interface{} `json:"docs"`
-	}{docs}
+	}{
+		Docs: docs,
+	}
 	var res []updateResponse
 	if err := makeRequest(db, doctype, http.MethodPost, "_bulk_docs", body, &res); err != nil {
 		return err

--- a/pkg/vfs/couchdb_indexer.go
+++ b/pkg/vfs/couchdb_indexer.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/cozy/cozy-stack/pkg/consts"
@@ -136,12 +137,36 @@ func (c *couchdbIndexer) CreateNamedDirDoc(doc *DirDoc) error {
 func (c *couchdbIndexer) UpdateDirDoc(olddoc, newdoc *DirDoc) error {
 	newdoc.SetID(olddoc.ID())
 	newdoc.SetRev(olddoc.Rev())
+
+	oldTrashed := strings.HasPrefix(olddoc.Fullpath, TrashDirName)
+	newTrashed := strings.HasPrefix(newdoc.Fullpath, TrashDirName)
+
+	isRestored := oldTrashed && !newTrashed
+	isTrashed := !oldTrashed && newTrashed
+
+	if isTrashed {
+		if err := c.setTrashedForFilesInsideDir(olddoc, true); err != nil {
+			return err
+		}
+	}
+
 	if newdoc.Fullpath != olddoc.Fullpath {
 		if err := c.moveDir(olddoc.Fullpath, newdoc.Fullpath); err != nil {
 			return err
 		}
 	}
-	return couchdb.UpdateDoc(c.db, newdoc)
+
+	if err := couchdb.UpdateDoc(c.db, newdoc); err != nil {
+		return err
+	}
+
+	if isRestored {
+		if err := c.setTrashedForFilesInsideDir(newdoc, false); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (c *couchdbIndexer) DeleteDirDoc(doc *DirDoc) error {
@@ -149,23 +174,43 @@ func (c *couchdbIndexer) DeleteDirDoc(doc *DirDoc) error {
 }
 
 func (c *couchdbIndexer) moveDir(oldpath, newpath string) error {
+	var docs []interface{}
 	var children []*DirDoc
-	sel := mango.StartWith("path", oldpath+"/")
-	req := &couchdb.FindRequest{
-		UseIndex: "dir-by-path",
-		Selector: sel,
-	}
-	err := couchdb.FindDocs(c.db, consts.Files, req, &children)
-	if err != nil || len(children) == 0 {
-		return err
+
+	limit := 256
+	for {
+		sel := mango.StartWith("path", oldpath+"/")
+		req := &couchdb.FindRequest{
+			UseIndex: "dir-by-path",
+			Selector: sel,
+			Skip:     0,
+			Limit:    limit,
+		}
+		err := couchdb.FindDocs(c.db, consts.Files, req, &children)
+		if err != nil {
+			return err
+		}
+		if len(children) == 0 {
+			break
+		}
+		if cap(docs) < len(children) {
+			docs = make([]interface{}, 0, len(children))
+		}
+		for _, child := range children {
+			child.Fullpath = path.Join(newpath, child.Fullpath[len(oldpath)+1:])
+			docs = append(docs, child)
+		}
+		if err = couchdb.BulkUpdateDocs(c.db, consts.Files, docs); err != nil {
+			return err
+		}
+		if len(children) < limit {
+			break
+		}
+		children = children[:0]
+		docs = docs[:0]
 	}
 
-	couchdocs := make([]interface{}, len(children))
-	for i, child := range children {
-		child.Fullpath = path.Join(newpath, child.Fullpath[len(oldpath)+1:])
-		couchdocs[i] = child
-	}
-	return couchdb.BulkUpdateDocs(c.db, consts.Files, couchdocs)
+	return nil
 }
 
 func (c *couchdbIndexer) DirByID(fileID string) (*DirDoc, error) {
@@ -383,4 +428,19 @@ func (c *couchdbIndexer) DirChildExists(dirID, name string) (bool, error) {
 		return false, ErrWrongCouchdbState
 	}
 	return int(f64) > 0, nil
+}
+
+func (c *couchdbIndexer) setTrashedForFilesInsideDir(doc *DirDoc, trashed bool) error {
+	var files []interface{}
+	err := walk(c, doc.Name(), doc, nil, func(name string, dir *DirDoc, file *FileDoc, err error) error {
+		if file != nil {
+			file.Trashed = trashed
+			files = append(files, file)
+		}
+		return err
+	}, 0)
+	if err != nil {
+		return err
+	}
+	return couchdb.BulkUpdateDocs(c.db, consts.Files, files)
 }

--- a/pkg/vfs/couchdb_indexer.go
+++ b/pkg/vfs/couchdb_indexer.go
@@ -433,7 +433,7 @@ func (c *couchdbIndexer) DirChildExists(dirID, name string) (bool, error) {
 func (c *couchdbIndexer) setTrashedForFilesInsideDir(doc *DirDoc, trashed bool) error {
 	var files []interface{}
 	err := walk(c, doc.Name(), doc, nil, func(name string, dir *DirDoc, file *FileDoc, err error) error {
-		if file != nil {
+		if file != nil && file.Trashed != trashed {
 			file.Trashed = trashed
 			files = append(files, file)
 		}

--- a/pkg/vfs/directory.go
+++ b/pkg/vfs/directory.go
@@ -228,27 +228,13 @@ func ModifyDirMetadata(fs VFS, olddoc *DirDoc, patch *DocPatch) (*DirDoc, error)
 	return newdoc, nil
 }
 
-func setTrashedForFilesInsideDir(fs VFS, doc *DirDoc, trashed bool) error {
-	files := []*FileDoc{}
-	err := walk(fs, doc.Name(), doc, nil, func(name string, dir *DirDoc, file *FileDoc, err error) error {
-		if file != nil {
-			file.Trashed = trashed
-			files = append(files, file)
-		}
-		return err
-	}, 0)
-	if err != nil {
-		return err
-	}
-	return fs.UpdateFileDocs(files)
-}
-
 // TrashDir is used to delete a directory given its document
 func TrashDir(fs VFS, olddoc *DirDoc) (*DirDoc, error) {
 	oldpath, err := olddoc.Path(fs)
 	if err != nil {
 		return nil, err
 	}
+
 	if strings.HasPrefix(oldpath, TrashDirName) {
 		return nil, ErrFileInTrash
 	}
@@ -256,23 +242,18 @@ func TrashDir(fs VFS, olddoc *DirDoc) (*DirDoc, error) {
 	trashDirID := consts.TrashDirID
 	restorePath := path.Dir(oldpath)
 
-	if err = setTrashedForFilesInsideDir(fs, olddoc, true); err != nil {
-		return nil, err
-	}
-
 	var newdoc *DirDoc
-	tryOrUseSuffix(olddoc.DocName, conflictFormat, func(name string) error {
-		newdoc, err = ModifyDirMetadata(fs, olddoc, &DocPatch{
-			DirID:       &trashDirID,
-			RestorePath: &restorePath,
-			Name:        &name,
-		})
-		return err
+	err = tryOrUseSuffix(olddoc.DocName, conflictFormat, func(name string) error {
+		newdoc = olddoc.Clone().(*DirDoc)
+		newdoc.DirID = trashDirID
+		newdoc.RestorePath = restorePath
+		newdoc.DocName = name
+		newdoc.Fullpath = path.Join(TrashDirName, name)
+		return fs.UpdateDirDoc(olddoc, newdoc)
 	})
 	if err != nil {
 		return nil, err
 	}
-
 	return newdoc, nil
 }
 
@@ -282,27 +263,24 @@ func RestoreDir(fs VFS, olddoc *DirDoc) (*DirDoc, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	restoreDir, err := getRestoreDir(fs, oldpath, olddoc.RestorePath)
 	if err != nil {
 		return nil, err
 	}
 
-	var newdoc *DirDoc
-	var emptyStr string
 	name := stripSuffix(olddoc.DocName, conflictSuffix)
-	tryOrUseSuffix(name, "%s (%s)", func(name string) error {
-		newdoc, err = ModifyDirMetadata(fs, olddoc, &DocPatch{
-			DirID:       &restoreDir.DocID,
-			RestorePath: &emptyStr,
-			Name:        &name,
-		})
-		return err
+
+	var newdoc *DirDoc
+	err = tryOrUseSuffix(name, "%s (%s)", func(name string) error {
+		newdoc = olddoc.Clone().(*DirDoc)
+		newdoc.DirID = restoreDir.DocID
+		newdoc.RestorePath = ""
+		newdoc.DocName = name
+		newdoc.Fullpath = path.Join(TrashDirName, name)
+		return fs.UpdateDirDoc(olddoc, newdoc)
 	})
 	if err != nil {
-		return nil, err
-	}
-
-	if err := setTrashedForFilesInsideDir(fs, olddoc, false); err != nil {
 		return nil, err
 	}
 

--- a/pkg/vfs/directory.go
+++ b/pkg/vfs/directory.go
@@ -277,7 +277,7 @@ func RestoreDir(fs VFS, olddoc *DirDoc) (*DirDoc, error) {
 		newdoc.DirID = restoreDir.DocID
 		newdoc.RestorePath = ""
 		newdoc.DocName = name
-		newdoc.Fullpath = path.Join(TrashDirName, name)
+		newdoc.Fullpath = path.Join(restoreDir.Fullpath, name)
 		return fs.UpdateDirDoc(olddoc, newdoc)
 	})
 	if err != nil {

--- a/pkg/vfs/file.go
+++ b/pkg/vfs/file.go
@@ -286,6 +286,7 @@ func TrashFile(fs VFS, olddoc *FileDoc) (*FileDoc, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	if strings.HasPrefix(oldpath, TrashDirName) {
 		return nil, ErrFileInTrash
 	}
@@ -294,14 +295,14 @@ func TrashFile(fs VFS, olddoc *FileDoc) (*FileDoc, error) {
 	restorePath := path.Dir(oldpath)
 
 	var newdoc *FileDoc
-	tryOrUseSuffix(olddoc.DocName, conflictFormat, func(name string) error {
-		newdoc, err = ModifyFileMetadata(fs, olddoc, &DocPatch{
-			DirID:       &trashDirID,
-			RestorePath: &restorePath,
-			Name:        &name,
-		})
-		return err
+	err = tryOrUseSuffix(olddoc.DocName, conflictFormat, func(name string) error {
+		newdoc = olddoc.Clone().(*FileDoc)
+		newdoc.DirID = trashDirID
+		newdoc.RestorePath = restorePath
+		newdoc.DocName = name
+		return fs.UpdateFileDoc(olddoc, newdoc)
 	})
+
 	return newdoc, err
 }
 
@@ -311,21 +312,23 @@ func RestoreFile(fs VFS, olddoc *FileDoc) (*FileDoc, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	restoreDir, err := getRestoreDir(fs, oldpath, olddoc.RestorePath)
 	if err != nil {
 		return nil, err
 	}
-	var newdoc *FileDoc
-	var emptyStr string
+
 	name := stripSuffix(olddoc.DocName, conflictSuffix)
-	tryOrUseSuffix(name, "%s (%s)", func(name string) error {
-		newdoc, err = ModifyFileMetadata(fs, olddoc, &DocPatch{
-			DirID:       &restoreDir.DocID,
-			RestorePath: &emptyStr,
-			Name:        &name,
-		})
-		return err
+
+	var newdoc *FileDoc
+	err = tryOrUseSuffix(name, "%s (%s)", func(name string) error {
+		newdoc = olddoc.Clone().(*FileDoc)
+		newdoc.DirID = restoreDir.DocID
+		newdoc.RestorePath = ""
+		newdoc.DocName = name
+		return fs.UpdateFileDoc(olddoc, newdoc)
 	})
+
 	return newdoc, err
 }
 

--- a/pkg/vfs/file.go
+++ b/pkg/vfs/file.go
@@ -300,6 +300,8 @@ func TrashFile(fs VFS, olddoc *FileDoc) (*FileDoc, error) {
 		newdoc.DirID = trashDirID
 		newdoc.RestorePath = restorePath
 		newdoc.DocName = name
+		newdoc.Trashed = true
+		newdoc.fullpath = path.Join(TrashDirName, name)
 		return fs.UpdateFileDoc(olddoc, newdoc)
 	})
 
@@ -326,6 +328,8 @@ func RestoreFile(fs VFS, olddoc *FileDoc) (*FileDoc, error) {
 		newdoc.DirID = restoreDir.DocID
 		newdoc.RestorePath = ""
 		newdoc.DocName = name
+		newdoc.Trashed = false
+		newdoc.fullpath = path.Join(restoreDir.Fullpath, name)
 		return fs.UpdateFileDoc(olddoc, newdoc)
 	})
 

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -142,6 +142,10 @@ type Indexer interface {
 	UpdateDirDoc(olddoc, newdoc *DirDoc) error
 	// DeleteDirDoc removes from the index the specified directory document.
 	DeleteDirDoc(doc *DirDoc) error
+	// DeleteDirDocAndContent removes from the index the specified directory as
+	// well all its children. It returns the list of the children files ids that
+	// were removed.
+	DeleteDirDocAndContent(doc *DirDoc, onlyContent bool) ([]string, error)
 
 	// DirByID returns the directory document information associated with the
 	// specified identifier.

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -520,7 +520,7 @@ type WalkFn func(name string, dir *DirDoc, file *FileDoc, err error) error
 
 // Walk walks the file tree document rooted at root. It should work
 // like filepath.Walk.
-func Walk(fs VFS, root string, walkFn WalkFn) error {
+func Walk(fs Indexer, root string, walkFn WalkFn) error {
 	dir, file, err := fs.DirOrFileByPath(root)
 	if err != nil {
 		return walkFn(root, dir, file, err)
@@ -528,7 +528,7 @@ func Walk(fs VFS, root string, walkFn WalkFn) error {
 	return walk(fs, root, dir, file, walkFn, 0)
 }
 
-func walk(fs VFS, name string, dir *DirDoc, file *FileDoc, walkFn WalkFn, count int) error {
+func walk(fs Indexer, name string, dir *DirDoc, file *FileDoc, walkFn WalkFn, count int) error {
 	if count >= maxWalkRecursive {
 		return ErrWalkOverflow
 	}
@@ -633,10 +633,10 @@ func getRestoreDir(fs VFS, name, restorePath string) (*DirDoc, error) {
 		return nil, ErrFileNotInTrash
 	}
 
-	// If the restore path is set, it means that the file is part of a directory
-	// hierarchy which has been trashed. The parent directory at the root of the
-	// trash directory is the document which contains the information of
-	// the restore path.
+	// If the restore path is not set, it means that the file is part of a
+	// directory hierarchy which has been trashed. The parent directory at the
+	// root of the trash directory is the document which contains the information
+	// of the restore path.
 	//
 	// For instance, when trying the restore the baz file inside
 	// TrashDirName/foo/bar/baz/quz, it should extract the "foo" (root) and
@@ -667,9 +667,8 @@ func getRestoreDir(fs VFS, name, restorePath string) (*DirDoc, error) {
 	// directory hierarchy to restore the file in.
 	restoreDir, err := fs.DirByPath(restorePath)
 	if os.IsNotExist(err) {
-		restoreDir, err = MkdirAll(fs, restorePath, nil)
+		return MkdirAll(fs, restorePath, nil)
 	}
-
 	return restoreDir, err
 }
 

--- a/pkg/vfs/vfsswift/impl_v2.go
+++ b/pkg/vfs/vfsswift/impl_v2.go
@@ -270,6 +270,14 @@ func (sfs *swiftVFSV2) DestroyDirContent(doc *vfs.DirDoc) error {
 		objNames[i] = MakeObjectName(id)
 	}
 	_, err = sfs.c.BulkDelete(sfs.container, objNames)
+	if err == swift.Forbidden {
+		err = nil
+		for _, objName := range objNames {
+			if errd := sfs.c.ObjectDelete(sfs.container, objName); err == nil {
+				err = errd
+			}
+		}
+	}
 	return err
 }
 
@@ -287,6 +295,14 @@ func (sfs *swiftVFSV2) DestroyDirAndContent(doc *vfs.DirDoc) error {
 		objNames[i] = MakeObjectName(id)
 	}
 	_, err = sfs.c.BulkDelete(sfs.container, objNames)
+	if err == swift.Forbidden {
+		err = nil
+		for _, objName := range objNames {
+			if errd := sfs.c.ObjectDelete(sfs.container, objName); err == nil {
+				err = errd
+			}
+		}
+	}
 	return err
 }
 

--- a/pkg/vfs/vfsswift/impl_v2.go
+++ b/pkg/vfs/vfsswift/impl_v2.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cozy/cozy-stack/pkg/utils"
 	"github.com/cozy/cozy-stack/pkg/vfs"
 	"github.com/cozy/swift"
-	multierror "github.com/hashicorp/go-multierror"
 	"github.com/sirupsen/logrus"
 )
 
@@ -262,7 +261,16 @@ func (sfs *swiftVFSV2) DestroyDirContent(doc *vfs.DirDoc) error {
 		return lockerr
 	}
 	defer sfs.mu.Unlock()
-	return sfs.destroyDirContent(doc)
+	ids, err := sfs.Indexer.DeleteDirDocAndContent(doc, true)
+	if err != nil {
+		return err
+	}
+	objNames := make([]string, len(ids))
+	for i, id := range ids {
+		objNames[i] = MakeObjectName(id)
+	}
+	_, err = sfs.c.BulkDelete(sfs.container, objNames)
+	return err
 }
 
 func (sfs *swiftVFSV2) DestroyDirAndContent(doc *vfs.DirDoc) error {
@@ -270,7 +278,16 @@ func (sfs *swiftVFSV2) DestroyDirAndContent(doc *vfs.DirDoc) error {
 		return lockerr
 	}
 	defer sfs.mu.Unlock()
-	return sfs.destroyDirAndContent(doc)
+	ids, err := sfs.Indexer.DeleteDirDocAndContent(doc, false)
+	if err != nil {
+		return err
+	}
+	objNames := make([]string, len(ids))
+	for i, id := range ids {
+		objNames[i] = MakeObjectName(id)
+	}
+	_, err = sfs.c.BulkDelete(sfs.container, objNames)
+	return err
 }
 
 func (sfs *swiftVFSV2) DestroyFile(doc *vfs.FileDoc) error {
@@ -278,39 +295,6 @@ func (sfs *swiftVFSV2) DestroyFile(doc *vfs.FileDoc) error {
 		return lockerr
 	}
 	defer sfs.mu.Unlock()
-	return sfs.destroyFile(doc)
-}
-
-func (sfs *swiftVFSV2) destroyDirContent(doc *vfs.DirDoc) (err error) {
-	iter := sfs.DirIterator(doc, nil)
-	for {
-		d, f, erri := iter.Next()
-		if erri == vfs.ErrIteratorDone {
-			return
-		}
-		if erri != nil {
-			return erri
-		}
-		var errd error
-		if d != nil {
-			errd = sfs.destroyDirAndContent(d)
-		} else {
-			errd = sfs.destroyFile(f)
-		}
-		if errd != nil {
-			err = multierror.Append(err, errd)
-		}
-	}
-}
-
-func (sfs *swiftVFSV2) destroyDirAndContent(doc *vfs.DirDoc) error {
-	if err := sfs.destroyDirContent(doc); err != nil {
-		return err
-	}
-	return sfs.Indexer.DeleteDirDoc(doc)
-}
-
-func (sfs *swiftVFSV2) destroyFile(doc *vfs.FileDoc) error {
 	return sfs.Indexer.DeleteFileDoc(doc)
 }
 


### PR DESCRIPTION
This PR moves the "move to/from trash" logic in the indexer. It allows a more robust implementation of this process.