### PR TITLE
feat: event delete is correctly broadcasted

### DIFF
--- a/pkg/couchdb/proxy.go
+++ b/pkg/couchdb/proxy.go
@@ -114,6 +114,8 @@ func ProxyBulkDocs(db Database, doctype string, req *http.Request) (*httputil.Re
 					var event string
 					if doc.Rev() == "" {
 						event = realtime.EventCreate
+					} else if doc.Get("_deleted") == true {
+						event = realtime.EventDelete
 					} else {
 						event = realtime.EventUpdate
 					}


### PR DESCRIPTION
Deleting via `_bulk_docs` would not send realtime events as
deletions but as updates. Here we check if `_deleted` is set
to true to correctly broadcast the Delete event.