### PR TITLE
Make sure error do not contain sensitive informations

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -84,7 +84,8 @@ func newAdminClient() *client.Client {
 			fmt.Printf("Password:")
 			pass, err = gopass.GetPasswdMasked()
 			if err != nil {
-				panic(err)
+				errPrintf("Could not get password from standard input: %s", err)
+				os.Exit(1)
 			}
 		}
 	}

--- a/pkg/couchdb/errors.go
+++ b/pkg/couchdb/errors.go
@@ -220,12 +220,17 @@ func cleanURLError(err error) error {
 	if erru, ok := err.(*url.Error); ok {
 		u, err := url.Parse(erru.URL)
 		if err != nil {
-			erru.URL = ""
+			return erru
+		}
+		if u.User == nil {
 			return erru
 		}
 		u.User = nil
-		erru.URL = u.String()
-		return erru
+		return &url.Error{
+			Op:  erru.Op,
+			URL: u.String(),
+			Err: erru.Err,
+		}
 	}
 	return err
 }

--- a/pkg/couchdb/errors.go
+++ b/pkg/couchdb/errors.go
@@ -216,8 +216,8 @@ func newCouchdbError(statusCode int, couchdbJSON []byte) error {
 	return err
 }
 
-func cleanURLError(err error) error {
-	if erru, ok := err.(*url.Error); ok {
+func cleanURLError(e error) error {
+	if erru, ok := e.(*url.Error); ok {
 		u, err := url.Parse(erru.URL)
 		if err != nil {
 			return erru
@@ -232,5 +232,5 @@ func cleanURLError(err error) error {
 			Err: erru.Err,
 		}
 	}
-	return err
+	return e
 }

--- a/pkg/couchdb/proxy.go
+++ b/pkg/couchdb/proxy.go
@@ -137,7 +137,7 @@ type bulkTransport struct {
 func (t *bulkTransport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
 	resp, err = t.RoundTripper.RoundTrip(req)
 	if err != nil {
-		return nil, err
+		return nil, newConnectionError(err)
 	}
 	defer func() {
 		if errc := resp.Body.Close(); err == nil && errc != nil {


### PR DESCRIPTION
Clean up URL that may be contained in errors form CouchDB to make sure they do not contain sensitive informations.