### PR TITLE
feat: update push notification data shape

### DIFF
--- a/pkg/workers/push/push.go
+++ b/pkg/workers/push/push.go
@@ -149,11 +149,14 @@ func pushToAndroid(ctx *jobs.WorkerContext, msg *Message) error {
 		To:       msg.DeviceToken,
 		Priority: priority,
 		Notification: &fcm.Notification{
-			Body:  msg.Message,
-			Title: msg.Title,
 			Sound: msg.Sound,
 		},
-		Data: map[string]interface{}{"topic": msg.Topic},
+		Data: map[string]interface{}{
+			"topic":             msg.Topic,
+			"content-available": 1,
+			"title":             msg.Title,
+			"body":              msg.Message,
+		},
 	}
 	if len(msg.Data) > 0 {
 		for k, v := range msg.Data {


### PR DESCRIPTION
While working on push notifications on banks, I encountered some problem when I wanted to open the app on a particular route when the user tap on the notification in the notifications center.

I read the docs of the [phonegap-plugin-push](https://github.com/phonegap/phonegap-plugin-push/blob/master/docs/PAYLOAD.md#android-behaviour) which we are using to receive push notifications on the mobile app. It explains that we need to send a truthy `content-available` property and to put title and content under the data key, even if the Google docs says something different.

After some tests, I came with this shape for the push notification message object, which works for what we want to do on the app side.