### PR TITLE
feat: add notification id so all notifications can be shown client side

### DIFF
--- a/pkg/workers/push/push.go
+++ b/pkg/workers/push/push.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math/rand"
 	"path/filepath"
 	"runtime"
 	"time"
@@ -159,6 +160,7 @@ func pushToAndroid(ctx *jobs.WorkerContext, msg *Message) error {
 
 			"title": msg.Title,
 			"body":  msg.Message,
+			"notId": rand.Intn(100),
 		},
 	}
 	if msg.Collapsible {


### PR DESCRIPTION
On Banks app, I got only the last sent notifications while I was expecting to get 3. According to the [phonegap-plugin-push documentation](https://github.com/phonegap/phonegap-plugin-push/blob/master/docs/PAYLOAD.md#stacking) this was because we didn't provide a `notId` property to the notifications. I added it as a random int.