### PR TITLE
Error case to auto-delete triggers

### DIFF
--- a/pkg/apps/webapp.go
+++ b/pkg/apps/webapp.go
@@ -29,6 +29,8 @@ type Routes map[string]Route
 
 // Service is a struct to define a service executed by the stack.
 type Service struct {
+	name string
+
 	Type           string `json:"type"`
 	File           string `json:"file"`
 	Debounce       string `json:"debounce"`
@@ -295,9 +297,11 @@ func diffServices(db couchdb.Database, slug string, oldServices, newServices Ser
 	var clone = make(Services)
 	for newName, newService := range newServices {
 		clone[newName] = newService
+		newService.name = newName
 	}
 
 	for name, oldService := range oldServices {
+		oldService.name = name
 		newService, ok := newServices[name]
 		if !ok {
 			deleted = append(deleted, oldService)
@@ -313,6 +317,7 @@ func diffServices(db couchdb.Database, slug string, oldServices, newServices Ser
 		} else {
 			*newService = *oldService
 		}
+		newService.name = name
 	}
 	for _, newService := range clone {
 		created = append(created, newService)
@@ -336,9 +341,8 @@ func diffServices(db couchdb.Database, slug string, oldServices, newServices Ser
 			triggerArgs = strings.TrimSpace(triggerOpts[1])
 		}
 		msg, err := jobs.NewMessage(map[string]string{
-			"slug":         slug,
-			"type":         service.Type,
-			"service_file": service.File,
+			"slug": slug,
+			"name": service.name,
 		})
 		if err != nil {
 			return err

--- a/pkg/jobs/errors.go
+++ b/pkg/jobs/errors.go
@@ -31,3 +31,13 @@ var (
 	// ErrMalformedTrigger is used to indicate the trigger is unparsable
 	ErrMalformedTrigger = echo.NewHTTPError(http.StatusBadRequest, "Trigger unparsable")
 )
+
+// ErrBadTrigger is an error conveying the information of a trigger that is not
+// valid, and could be deleted.
+type ErrBadTrigger struct {
+	Err error
+}
+
+func (e ErrBadTrigger) Error() string {
+	return e.Err.Error()
+}

--- a/pkg/workers/exec/konnector.go
+++ b/pkg/workers/exec/konnector.go
@@ -93,6 +93,9 @@ func (w *konnectorWorker) PrepareWorkDir(ctx *jobs.WorkerContext, i *instance.In
 	w.msg = &msg
 	w.man, err = apps.GetKonnectorBySlug(i, slug)
 	if err != nil {
+		if err == apps.ErrNotFound {
+			err = jobs.ErrBadTrigger{err}
+		}
 		return
 	}
 

--- a/pkg/workers/exec/konnector.go
+++ b/pkg/workers/exec/konnector.go
@@ -94,7 +94,7 @@ func (w *konnectorWorker) PrepareWorkDir(ctx *jobs.WorkerContext, i *instance.In
 	w.man, err = apps.GetKonnectorBySlug(i, slug)
 	if err != nil {
 		if err == apps.ErrNotFound {
-			err = jobs.ErrBadTrigger{err}
+			err = jobs.ErrBadTrigger{Err: err}
 		}
 		return
 	}

--- a/pkg/workers/exec/service.go
+++ b/pkg/workers/exec/service.go
@@ -45,7 +45,7 @@ func (w *serviceWorker) PrepareWorkDir(ctx *jobs.WorkerContext, i *instance.Inst
 	man, err := apps.GetWebappBySlug(i, slug)
 	if err != nil {
 		if err == apps.ErrNotFound {
-			err = jobs.ErrBadTrigger{err}
+			err = jobs.ErrBadTrigger{Err: err}
 		}
 		return
 	}
@@ -67,12 +67,12 @@ func (w *serviceWorker) PrepareWorkDir(ctx *jobs.WorkerContext, i *instance.Inst
 		}
 	}
 	if !ok {
-		err = jobs.ErrBadTrigger{fmt.Errorf("Service %q was not found", name)}
+		err = jobs.ErrBadTrigger{Err: fmt.Errorf("Service %q was not found", name)}
 		return
 	}
 	if triggerID, ok := ctx.TriggerID(); ok && service.TriggerID != "" {
 		if triggerID != service.TriggerID {
-			err = jobs.ErrBadTrigger{fmt.Errorf("Trigger %q is orphan", triggerID)}
+			err = jobs.ErrBadTrigger{Err: fmt.Errorf("Trigger %q is orphan", triggerID)}
 			return
 		}
 	}

--- a/pkg/workers/exec/service.go
+++ b/pkg/workers/exec/service.go
@@ -70,6 +70,12 @@ func (w *serviceWorker) PrepareWorkDir(ctx *jobs.WorkerContext, i *instance.Inst
 		err = jobs.ErrBadTrigger{fmt.Errorf("Service %q was not found", name)}
 		return
 	}
+	if triggerID, ok := ctx.TriggerID(); ok && service.TriggerID != "" {
+		if triggerID != service.TriggerID {
+			err = jobs.ErrBadTrigger{fmt.Errorf("Trigger %q is orphan", triggerID)}
+			return
+		}
+	}
 
 	w.man = man
 	w.slug = slug


### PR DESCRIPTION
Add error type to convey from the broker to the scheduler that a trigger can be removed. This is used for trigger executing konnector or service that is not installed anymore, or does not match the one defined in the service manifest document.