### PR TITLE
fix: use ContentAvailable option from go-fcm instead of custom content-available

### DIFF
--- a/pkg/workers/push/push.go
+++ b/pkg/workers/push/push.go
@@ -165,14 +165,14 @@ func pushToAndroid(ctx *jobs.WorkerContext, msg *Message) error {
 	}
 
 	notification := &fcm.Message{
-		To:           msg.DeviceToken,
-		Priority:     priority,
-		Notification: &fcm.Notification{Sound: msg.Sound},
+		To:               msg.DeviceToken,
+		Priority:         priority,
+		ContentAvailable: true,
+		Notification:     &fcm.Notification{Sound: msg.Sound},
 		Data: map[string]interface{}{
 			// Fields required by phonegap-plugin-push
 			// see: https://github.com/phonegap/phonegap-plugin-push/blob/master/docs/PAYLOAD.md#android-behaviour
-			"content-available": 1,
-			"notId":             notID,
+			"notId": notID,
 
 			"title": msg.Title,
 			"body":  msg.Message,


### PR DESCRIPTION
After some investigation with @jinroh, we found that this option is not required for Android. But it is important for iOS. We keep it but we use the "official" option provided by go-fcm