### PR TITLE
Notifications one job per push

### DIFF
--- a/pkg/workers/push/push.go
+++ b/pkg/workers/push/push.go
@@ -47,7 +47,6 @@ func init() {
 type Message struct {
 	NotificationID string `json:"notification_id"`
 	Source         string `json:"source"`
-	ClientID       string `json:"client_id,omitempty"`
 	Title          string `json:"title,omitempty"`
 	Message        string `json:"message,omitempty"`
 	Priority       string `json:"priority,omitempty"`
@@ -117,16 +116,7 @@ func Worker(ctx *jobs.WorkerContext) error {
 	if err != nil {
 		return err
 	}
-	var cs []*oauth.Client
-	if msg.ClientID != "" {
-		var c *oauth.Client
-		c, err = oauth.FindClient(inst, msg.ClientID)
-		if err == nil {
-			cs = []*oauth.Client{c}
-		}
-	} else {
-		cs, err = oauth.GetNotifiables(inst)
-	}
+	cs, err := oauth.GetNotifiables(inst)
 	if err != nil {
 		return err
 	}

--- a/pkg/workers/push/push.go
+++ b/pkg/workers/push/push.go
@@ -168,12 +168,13 @@ func pushToAndroid(ctx *jobs.WorkerContext, msg *Message) error {
 		To:               msg.DeviceToken,
 		Priority:         priority,
 		ContentAvailable: true,
-		Notification:     &fcm.Notification{Sound: msg.Sound},
+		Notification: &fcm.Notification{
+			Sound: msg.Sound,
+		},
 		Data: map[string]interface{}{
 			// Fields required by phonegap-plugin-push
 			// see: https://github.com/phonegap/phonegap-plugin-push/blob/master/docs/PAYLOAD.md#android-behaviour
 			"notId": notID,
-
 			"title": msg.Title,
 			"body":  msg.Message,
 		},


### PR DESCRIPTION
With one job, send all the necessary push to the clients. The worker handle finding the necessary clients instead on creating one job per client.

Also, this way we do not need to store the device token into the persisted job message value.