### PR TITLE
feat: add toc.yml for cozy-docs-v3

### DIFF
--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -1,0 +1,36 @@
+- README: ./README.md
+- Architecture:
+  - "General overview": ./architecture.md
+  - Security: ./security.md
+- Usage:
+  - "Install the cozy-stack": ./INSTALL.md
+  - "Manpages of the command-line tool": ./cli/cozy-stack.md
+  - "Configuration file": ./config.md
+  - "Managing Instances": ./instance.md
+  - "Onboarding": ./onboarding.md
+- For developpers:
+  - "Develop a client-side app": ./client-app-dev.md
+  - "Running and building Docker images": ./docker.md
+  - "Build a release": ./release.md
+  - "The contributing guide": ./CONTRIBUTING.md
+- Services:
+  - "/auth - Authentication & OAuth": ./auth.md
+  - "/apps - Applications Management": ./apps.md
+  - "Apps registry": ./registry.md
+  - "/data - Data System": ./data-system.md
+  - "Mango": ./mango.md
+  - "Replication": ./replication.md
+  - "CouchDB Quirks": ./couchdb-quirks.md
+  - "/files - Virtual File System": ./files.md
+  - "References of documents in VFS": ./references-docs-in-vfs.md
+  - "/intents - Intents": ./intents.md
+  - "/jobs Jobs": ./jobs.md
+  - "Konnectors": ./konnectors.md
+  - "Workers": ./workers.md
+  - "/notifications - Notifications": ./notifications.md
+  - "/permissions - Permissions": ./permissions.md
+  - "/realtime - Realtime": ./realtime.md
+  - "/remote - Proxy for remote data/API": ./remote.md
+  - "/settings - Settings": ./settings.md
+  - "/sharings - Sharing": ./sharing.md
+  - "Request for comments": ./sharing-design.md


### PR DESCRIPTION
cozy-docs-v3 now pulls the doc automatically from several repos. Since the
doc is inside the repository, it seemed that having its table of contents
near the docs is better. This toc.yml is used during documentation build
and its result is the menu in References.

See the result on https://ptbrowne.github.io/cozy-docs-v3 (Menu Develop > References).