### PR TITLE
feat: allow dev release to use COZY_ADMIN_PASSWORD

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -76,9 +76,8 @@ func newClient(domain string, scopes ...string) *client.Client {
 }
 
 func newAdminClient() *client.Client {
-	var pass []byte
+	pass := []byte(os.Getenv("COZY_ADMIN_PASSWORD"))
 	if !config.IsDevRelease() {
-		pass = []byte(os.Getenv("COZY_ADMIN_PASSWORD"))
 		if len(pass) == 0 {
 			var err error
 			fmt.Printf("Password:")


### PR DESCRIPTION
Previously, only prod release would be able to use COZY_ADMIN_PASSWORD. It is useful
for cozy-stack to be able to use COZY_ADMIN_PASSWORD if we are targeting a remote stack
via ssh tunnel.