### PR TITLE
Fsck: check and repare index integrity in a first pass of the process

### DIFF
--- a/pkg/couchdb/bulk.go
+++ b/pkg/couchdb/bulk.go
@@ -200,7 +200,7 @@ func BulkUpdateDocs(db Database, doctype string, docs []interface{}) error {
 }
 
 // BulkDeleteDocs is used to delete serveral documents in one call.
-func BulkDeleteDocs(db Database, doctype string, docs []interface{}) error {
+func BulkDeleteDocs(db Database, doctype string, docs []Doc) error {
 	if len(docs) == 0 {
 		return nil
 	}
@@ -210,11 +210,9 @@ func BulkDeleteDocs(db Database, doctype string, docs []interface{}) error {
 		Docs: make([]json.RawMessage, 0, len(docs)),
 	}
 	for _, doc := range docs {
-		if d, ok := doc.(Doc); ok {
-			body.Docs = append(body.Docs, json.RawMessage(
-				fmt.Sprintf(`{"_id":"%s","_rev":"%s","_deleted":true}`, d.ID(), d.Rev()),
-			))
-		}
+		body.Docs = append(body.Docs, json.RawMessage(
+			fmt.Sprintf(`{"_id":"%s","_rev":"%s","_deleted":true}`, doc.ID(), doc.Rev()),
+		))
 	}
 	var res []UpdateResponse
 	if err := makeRequest(db, doctype, http.MethodPost, "_bulk_docs", body, &res); err != nil {

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -85,8 +85,13 @@ type Fs interface {
 	OpenFile(doc *FileDoc) (File, error)
 
 	// Fsck return the list of inconsistencies in the VFS
-	Fsck() (logbook []*FsckLog, err error)
-	FsckPrune(logbook []*FsckLog, dryrun bool)
+	Fsck(opts FsckOptions) (logbook []*FsckLog, err error)
+}
+
+// FsckOptions contains the options for the filesystem check process.
+type FsckOptions struct {
+	Prune  bool
+	DryRun bool
 }
 
 // File is a reader, writer, seeker, closer iterface representing an opened
@@ -176,6 +181,9 @@ type Indexer interface {
 	DirBatch(*DirDoc, couchdb.Cursor) ([]DirOrFileDoc, error)
 	DirLength(*DirDoc) (int, error)
 	DirChildExists(dirID, filename string) (bool, error)
+	BatchDelete([]couchdb.Doc) error
+
+	CheckIndexIntegrity() ([]*FsckLog, error)
 }
 
 // DiskThresholder it an interface that can be implemeted to known how many space

--- a/web/instances/instances.go
+++ b/web/instances/instances.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/jobs"
 	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/cozy/cozy-stack/pkg/utils"
+	"github.com/cozy/cozy-stack/pkg/vfs"
 	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/labstack/echo"
 )
@@ -201,12 +202,12 @@ func fsckHandler(c echo.Context) error {
 	prune, _ := strconv.ParseBool(c.QueryParam("Prune"))
 	dryRun, _ := strconv.ParseBool(c.QueryParam("DryRun"))
 	fs := i.VFS()
-	logbook, err := fs.Fsck()
+	logbook, err := fs.Fsck(vfs.FsckOptions{
+		Prune:  prune,
+		DryRun: dryRun,
+	})
 	if err != nil {
 		return wrapError(err)
-	}
-	if prune {
-		fs.FsckPrune(logbook, dryRun)
 	}
 	return c.JSON(http.StatusOK, logbook)
 }


### PR DESCRIPTION
Checking the index integrity means:

  - checking that no cycle exists
  - checking that all trees are linked to the root tree (no orphans)
  - checking that `path` fields in the directory match the hierarchy

A pass checking this integrity is performed before the second pass, consisting in checking the data coherence between the index and the data layer.

When using the `--prune` option of the `fsck` command, the fsck process tries to fix possible integrity issues encountered. Some issues are not solved automatically: if these non-solved issues are recurrent, we can add more intelligent solvers from these concrete cases.