### PR TITLE
feat: add manual execution env var

### DIFF
--- a/docs/konnectors_workflow_example.md
+++ b/docs/konnectors_workflow_example.md
@@ -382,12 +382,15 @@ extended to all workers pre-validating worker arguments ?
 
 Start the konnector through Rkt, passing as ENV variables :
 
+    - `COZY_URL`:          the starting instance URL
     - `COZY_CREDENTIALS`:  security token to communicate with Cozy
     - `COZY_FIELDS`:       JSON-encoded worker_arguments
     - `COZY_PARAMETERS`:   JSON-encoded parameters associated with the konnector
     - `COZY_LANGUAGE`:     the language field of the konnector (eg. "node" etc.)
     - `COZY_LOCALE`:       the locale of the user (eg. "en" etc.)
-    - `COZY_URL`:          the starting instance URL
+    - `COZY_TIME_LIMIT`: how much time the konnector has to run
+    - `COZY_JOB_ID`: id of the job
+    - `COZY_JOB_MANUAL_EXECUTION`: whether the job was started manually (in Collect) or automatically (via a cron trigger or event)
 
 The konnector process can send events trough it's stdout (newline separated JSON
 object), the konnector worker pass these events to the realtime hub as

--- a/pkg/jobs/worker.go
+++ b/pkg/jobs/worker.go
@@ -188,6 +188,11 @@ func NewWorker(conf *WorkerConfig) *Worker {
 	}
 }
 
+// Manual returns if the job was started manually
+func (c *WorkerContext) Manual() bool {
+	return c.job.Manual
+}
+
 // Start is used to start the worker consumption of messages from its queue.
 func (w *Worker) Start(jobs chan *Job) error {
 	if !atomic.CompareAndSwapUint32(&w.running, 0, 1) {

--- a/pkg/workers/exec/konnector.go
+++ b/pkg/workers/exec/konnector.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"strconv"
 	"time"
 
 	"github.com/cozy/cozy-stack/pkg/apps"
@@ -231,6 +232,7 @@ func (w *konnectorWorker) PrepareCmdEnv(ctx *jobs.WorkerContext, i *instance.Ins
 		"COZY_LOCALE=" + i.Locale,
 		"COZY_TIME_LIMIT=" + ctxToTimeLimit(ctx),
 		"COZY_JOB_ID=" + ctx.ID(),
+		"COZY_JOB_MANUAL_EXECUTION=" + strconv.FormatBool(ctx.Manual()),
 	}
 	return
 }


### PR DESCRIPTION
Added the `COZY_JOB_MANUAL_EXECUTION` environment variable when executing
a konnector.

This can be useful for the konnector as some actions only need to be done
while executing manually.