### PR TITLE
Do not add share-replicate trigger on receiver side if one-way sharing

### DIFF
--- a/pkg/sharing/rule.go
+++ b/pkg/sharing/rule.go
@@ -155,3 +155,14 @@ func (r Rule) TriggerArgs(owner bool) string {
 	}
 	return args
 }
+
+// RuleHasSync returns true if at least one rule has an ActionRuleSync defined
+func (s *Sharing) RuleHasSync() bool {
+	for _, r := range s.Rules {
+		if r.Add == ActionRuleSync || r.Update == ActionRuleSync ||
+			r.Remove == ActionRuleSync {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/sharing/rule.go
+++ b/pkg/sharing/rule.go
@@ -156,7 +156,7 @@ func (r Rule) TriggerArgs(owner bool) string {
 	return args
 }
 
-// RuleHasSync returns true if at least one rule has an ActionRuleSync defined
+// TwoWays returns true if at least one rule has an ActionRuleSync defined
 func (s *Sharing) TwoWays() bool {
 	for _, r := range s.Rules {
 		if r.Add == ActionRuleSync || r.Update == ActionRuleSync ||

--- a/pkg/sharing/rule.go
+++ b/pkg/sharing/rule.go
@@ -157,7 +157,7 @@ func (r Rule) TriggerArgs(owner bool) string {
 }
 
 // RuleHasSync returns true if at least one rule has an ActionRuleSync defined
-func (s *Sharing) RuleHasSync() bool {
+func (s *Sharing) TwoWays() bool {
 	for _, r := range s.Rules {
 		if r.Add == ActionRuleSync || r.Update == ActionRuleSync ||
 			r.Remove == ActionRuleSync {

--- a/pkg/sharing/setup.go
+++ b/pkg/sharing/setup.go
@@ -24,9 +24,8 @@ func (s *Sharing) SetupReceiver(inst *instance.Instance) error {
 	if err := s.AddTrackTriggers(inst); err != nil {
 		return err
 	}
-	// TODO do not add the share-replicate trigger for a one-way sharing
-	if err := s.AddReplicateTrigger(inst); err != nil {
-		return err
+	if s.RuleHasSync() {
+		return s.AddReplicateTrigger(inst)
 	}
 	return nil
 }

--- a/pkg/sharing/setup.go
+++ b/pkg/sharing/setup.go
@@ -24,7 +24,7 @@ func (s *Sharing) SetupReceiver(inst *instance.Instance) error {
 	if err := s.AddTrackTriggers(inst); err != nil {
 		return err
 	}
-	if s.RuleHasSync() {
+	if s.TwoWays() {
 		return s.AddReplicateTrigger(inst)
 	}
 	return nil


### PR DESCRIPTION
This prevents a nil exception on the receiver side for `push` sharings