### PR TITLE
Sharing get doctypes

### DIFF
--- a/docs/sharing.md
+++ b/docs/sharing.md
@@ -310,6 +310,141 @@ Content-Type: application/vnd.api+json
 }
 ```
 
+### GET /sharings/doctype/:doctype
+
+Get information about all the sharings that have a rule for the given doctype. This includes the content of the rules, the members, as well as the already shared documents for this sharing.
+
+#### Request
+
+```http
+GET /sharings/doctype/io.cozy.files HTTP/1.1
+Host: alice.example.net
+Accept: application/vnd.api+json
+```
+
+#### Response
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/vnd.api+json
+```
+
+```json
+{
+  "data": null,
+  "meta": {
+    "count": 0
+  },
+  "included": [
+    {
+      "type": "io.cozy.sharings",
+      "id": "ce8835a061d0ef68947afe69a0046722",
+      "attributes": {
+        "description": "sharing test",
+        "preview_path": "/preview-sharing",
+        "app_slug": "drive",
+        "owner": true,
+        "created_at": "2018-01-04T12:35:08Z",
+        "updated_at": "2018-01-04T13:45:43Z",
+        "members": [
+          {
+            "status": "owner",
+            "name": "Alice",
+            "email": "alice@example.net",
+            "instance": "alice.example.net"
+          },
+          {
+            "status": "ready",
+            "name": "Bob",
+            "email": "bob@example.net"
+          }
+        ],
+        "rules": [
+          {
+            "title": "Hawaii",
+            "doctype": "io.cozy.files",
+            "values": ["612acf1c-1d72-11e8-b043-ef239d3074dd"],
+            "add": "sync",
+            "update": "sync",
+            "remove": "sync"
+          }
+        ],
+      },
+      "meta": {
+        "rev": "1-4859c6c755143adf0838d225c5e97882"
+      },
+      "links": {
+        "self": "/sharings/ce8835a061d0ef68947afe69a0046722"
+      },
+      "relationships": {
+        "shared_docs": {
+          "data": [
+            {
+              "id": "612acf1c-1d72-11e8-b043-ef239d3074dd",
+              "type": "io.cozy.files"
+            },
+            {
+              "id": "a34528d2-13fb-9482-8d20-bf1972531225",
+              "type": "io.cozy.files"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "io.cozy.sharings",
+      "id": "b4e58d039c03d01742085de5e505284e",
+      "attributes": {
+        "description": "another sharing test",
+        "preview_path": "/preview-sharing",
+        "app_slug": "drive",
+        "owner": true,
+        "created_at": "2018-02-04T12:35:08Z",
+        "updated_at": "2018-02-04T13:45:43Z",
+        "members": [
+          {
+            "status": "owner",
+            "name": "Alice",
+            "email": "alice@example.net",
+            "instance": "alice.example.net"
+          },
+          {
+            "status": "ready",
+            "name": "Bob",
+            "email": "bob@example.net"
+          }
+        ],
+        "rules": [
+          {
+            "title": "Singapore",
+            "doctype": "io.cozy.files",
+            "values": ["e18e30e2-8eda-1bde-afce-edafc6b1a91b"],
+            "add": "sync",
+            "update": "sync",
+            "remove": "sync"
+          }
+        ],
+      },
+      "meta": {
+        "rev": "1-7ac5f1252a0c513186a5d35b1a6fd350"
+      },
+      "links": {
+        "self": "/sharings/b4e58d039c03d01742085de5e505284e"
+      },
+      "relationships": {
+        "shared_docs": {
+          "data": [
+            {
+              "id": "dcc52bee-1277-a6b3-b36f-369ffd81a4ee",
+              "type": "io.cozy.files"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
 
 ### PUT /sharings/:sharing-id
 

--- a/docs/sharing.md
+++ b/docs/sharing.md
@@ -331,11 +331,7 @@ Content-Type: application/vnd.api+json
 
 ```json
 {
-  "data": null,
-  "meta": {
-    "count": 0
-  },
-  "included": [
+  "data": [
     {
       "type": "io.cozy.sharings",
       "id": "ce8835a061d0ef68947afe69a0046722",
@@ -442,7 +438,10 @@ Content-Type: application/vnd.api+json
         }
       }
     }
-  ]
+  ],
+  "meta": {
+    "count": 3
+  }
 }
 ```
 

--- a/pkg/consts/views.go
+++ b/pkg/consts/views.go
@@ -7,7 +7,7 @@ import (
 
 // IndexViewsVersion is the version of current definition of views & indexes.
 // This number should be incremented when this file changes.
-const IndexViewsVersion int = 17
+const IndexViewsVersion int = 16
 
 // GlobalIndexes is the index list required on the global databases to run
 // properly.
@@ -165,26 +165,6 @@ function(doc) {
 }`,
 }
 
-// SharedDocsByDocType is the view for fetching a list of sharingid
-// associated with a docType. The reduce function is to avoid duplicates
-var SharedDocsByDocType = &couchdb.View{
-	Name:    "sharingids-by-doctype",
-	Doctype: Shared,
-	Map: `
-function(doc) {
-  if (doc.infos) {
-    var s = doc._id.split('/');
-    if (s.length === 2) {
-      var docType = s[0];
-      var docID = s[1];
-      Object.keys(doc.infos).forEach(function(k) {
-        emit(docType, k);
-      });
-    }
-  }
-}`,
-}
-
 // Views is the list of all views that are created by the stack.
 var Views = []*couchdb.View{
 	DiskUsageView,
@@ -195,7 +175,6 @@ var Views = []*couchdb.View{
 	PermissionsShareByDocView,
 	PermissionsByDoctype,
 	SharedDocsBySharingID,
-	SharedDocsByDocType,
 }
 
 // ViewsByDoctype returns the list of views for a specified doc type.

--- a/pkg/consts/views.go
+++ b/pkg/consts/views.go
@@ -7,7 +7,7 @@ import (
 
 // IndexViewsVersion is the version of current definition of views & indexes.
 // This number should be incremented when this file changes.
-const IndexViewsVersion int = 16
+const IndexViewsVersion int = 17
 
 // GlobalIndexes is the index list required on the global databases to run
 // properly.
@@ -165,6 +165,26 @@ function(doc) {
 }`,
 }
 
+// SharedDocsByDocType is the view for fetching a list of sharingid
+// associated with a docType. The reduce function is to avoid duplicates
+var SharedDocsByDocType = &couchdb.View{
+	Name:    "sharingids-by-doctype",
+	Doctype: Shared,
+	Map: `
+function(doc) {
+  if (doc.infos) {
+    var s = doc._id.split('/');
+    if (s.length === 2) {
+      var docType = s[0];
+      var docID = s[1];
+      Object.keys(doc.infos).forEach(function(k) {
+        emit(docType, k);
+      });
+    }
+  }
+}`,
+}
+
 // Views is the list of all views that are created by the stack.
 var Views = []*couchdb.View{
 	DiskUsageView,
@@ -175,6 +195,7 @@ var Views = []*couchdb.View{
 	PermissionsShareByDocView,
 	PermissionsByDoctype,
 	SharedDocsBySharingID,
+	SharedDocsByDocType,
 }
 
 // ViewsByDoctype returns the list of views for a specified doc type.

--- a/pkg/couchdb/bulk.go
+++ b/pkg/couchdb/bulk.go
@@ -67,16 +67,12 @@ func GetAllDocs(db Database, doctype string, req *AllDocsRequest, results interf
 		return err
 	}
 	v.Add("include_docs", "true")
-
 	var response AllDocsResponse
 	if req == nil || len(req.Keys) == 0 {
 		url := "_all_docs?" + v.Encode()
 		err = makeRequest(db, doctype, http.MethodGet, url, nil, &response)
 	} else {
 		v.Del("keys")
-		// startkey and endkey are not compatible with keys parameter
-		v.Del("startkey")
-		v.Del("endkey")
 		url := "_all_docs?" + v.Encode()
 		body := struct {
 			Keys []string `json:"keys"`

--- a/pkg/couchdb/bulk.go
+++ b/pkg/couchdb/bulk.go
@@ -62,7 +62,7 @@ func CountAllDocs(db Database, doctype string) (int, error) {
 // GetAllDocs returns all documents of a specified doctype. It filters
 // out the possible _design document.
 func GetAllDocs(db Database, doctype string, req *AllDocsRequest, results interface{}) error {
-	v, err := query.Values(req)
+	v, err := req.Values()
 	if err != nil {
 		return err
 	}
@@ -74,6 +74,9 @@ func GetAllDocs(db Database, doctype string, req *AllDocsRequest, results interf
 		err = makeRequest(db, doctype, http.MethodGet, url, nil, &response)
 	} else {
 		v.Del("keys")
+		// startkey and endkey are not compatible with keys parameter
+		v.Del("startkey")
+		v.Del("endkey")
 		url := "_all_docs?" + v.Encode()
 		body := struct {
 			Keys []string `json:"keys"`

--- a/pkg/couchdb/encoding.go
+++ b/pkg/couchdb/encoding.go
@@ -8,7 +8,7 @@ import (
 )
 
 func maybeSet(u url.Values, k string, v interface{}) error {
-	if v == nil {
+	if v == nil || v == "" {
 		return nil
 	}
 

--- a/pkg/couchdb/encoding.go
+++ b/pkg/couchdb/encoding.go
@@ -49,3 +49,29 @@ func (vr *ViewRequest) Values() (url.Values, error) {
 
 	return v, nil
 }
+
+// Values transforms a AllDocsRequest into a query string suitable for couchdb
+// ie, where non-scalar fields have been JSON+URL encoded.
+func (adr *AllDocsRequest) Values() (url.Values, error) {
+
+	var v url.Values
+
+	v, err := query.Values(adr)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(adr.Keys) > 0 {
+		if err := maybeSet(v, "keys", adr.Keys); err != nil {
+			return nil, err
+		}
+	}
+	if err := maybeSet(v, "startkey", adr.StartKey); err != nil {
+		return nil, err
+	}
+	if err := maybeSet(v, "endkey", adr.EndKey); err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}

--- a/pkg/sharing/api_sharing.go
+++ b/pkg/sharing/api_sharing.go
@@ -1,10 +1,28 @@
 package sharing
 
 import (
+	"net/http"
+
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/web/jsonapi"
+	"github.com/cozy/echo"
 )
+
+type InfoByDocType struct {
+	included []jsonapi.Object
+}
+
+func InfoByDocTypeData(c echo.Context, statusCode int, sharings []*APISharing) error {
+	included := make([]jsonapi.Object, len(sharings))
+
+	for i, s := range sharings {
+		included[i] = s
+	}
+
+	return jsonapi.DataRelations(c, http.StatusOK, nil, 0, nil, included)
+
+}
 
 // APISharing is used to serialize a Sharing to JSON-API
 type APISharing struct {

--- a/pkg/sharing/api_sharing.go
+++ b/pkg/sharing/api_sharing.go
@@ -9,10 +9,7 @@ import (
 	"github.com/cozy/echo"
 )
 
-type InfoByDocType struct {
-	included []jsonapi.Object
-}
-
+// InfoByDocTypeData returns the sharings info as included in the JSON-API format
 func InfoByDocTypeData(c echo.Context, statusCode int, sharings []*APISharing) error {
 	included := make([]jsonapi.Object, len(sharings))
 

--- a/pkg/sharing/api_sharing.go
+++ b/pkg/sharing/api_sharing.go
@@ -9,16 +9,13 @@ import (
 	"github.com/cozy/echo"
 )
 
-// InfoByDocTypeData returns the sharings info as included in the JSON-API format
+// InfoByDocTypeData returns the sharings info as data array in the JSON-API format
 func InfoByDocTypeData(c echo.Context, statusCode int, sharings []*APISharing) error {
-	included := make([]jsonapi.Object, len(sharings))
-
+	data := make([]jsonapi.Object, len(sharings))
 	for i, s := range sharings {
-		included[i] = s
+		data[i] = s
 	}
-
-	return jsonapi.DataRelations(c, http.StatusOK, nil, 0, nil, included)
-
+	return jsonapi.DataList(c, http.StatusOK, data, nil)
 }
 
 // APISharing is used to serialize a Sharing to JSON-API

--- a/pkg/sharing/shared.go
+++ b/pkg/sharing/shared.go
@@ -178,4 +178,23 @@ func GetSharedDocsBySharingID(inst *instance.Instance, sharingID string) ([]couc
 	return result, nil
 }
 
+// GetSharingsByDocType returns the sharingids related to the
+// given docType
+func GetSharingsByDocType(inst *instance.Instance, docType string) ([]string, error) {
+	var req = &couchdb.ViewRequest{
+		Key:         docType,
+		IncludeDocs: false,
+	}
+	var res couchdb.ViewResponse
+	err := couchdb.ExecView(inst, consts.SharedDocsByDocType, req, &res)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]string, len(res.Rows))
+	for i, row := range res.Rows {
+		result[i] = row.Value.(string)
+	}
+	return result, nil
+}
+
 var _ couchdb.Doc = &SharedRef{}

--- a/pkg/sharing/sharing.go
+++ b/pkg/sharing/sharing.go
@@ -201,4 +201,17 @@ func FindSharing(db couchdb.Database, sharingID string) (*Sharing, error) {
 	return res, nil
 }
 
+// FindSharings retrieves an array of sharing documents from their IDs
+func FindSharings(db couchdb.Database, sharingIDs []string) ([]*Sharing, error) {
+	var req = &couchdb.AllDocsRequest{
+		Keys: sharingIDs,
+	}
+	var res []*Sharing
+	err := couchdb.GetAllDocs(db, consts.Sharings, req, &res)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
 var _ couchdb.Doc = &Sharing{}

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -117,28 +117,31 @@ func GetSharing(c echo.Context) error {
 func GetSharingsInfoByDocType(c echo.Context) error {
 	inst := middlewares.GetInstance(c)
 	docType := c.Param("doctype")
-	sharingIDs, err := sharing.GetSharingsByDocType(inst, docType)
+	sharingsInfo, err := sharing.GetSharingsByDocType(inst, docType)
 	if err != nil {
 		return wrapErrors(err)
 	}
-	res := make([]*sharing.APISharing, len(sharingIDs))
+	sharingIDs := make([]string, len(sharingsInfo))
+	i := 0
+	for sharingID := range sharingsInfo {
+		sharingIDs[i] = sharingID
+		i++
+	}
 
 	sharings, err := sharing.FindSharings(inst, sharingIDs)
 	if err != nil {
 		return wrapErrors(err)
 	}
+	res := make([]*sharing.APISharing, len(sharings))
+
 	for i, s := range sharings {
 		if err = checkGetPermissions(c, s); err != nil {
-			return wrapErrors(err)
-		}
-		docs, err := sharing.GetSharedDocsBySharingID(inst, s.ID())
-		if err != nil {
 			return wrapErrors(err)
 		}
 		as := &sharing.APISharing{
 			Sharing:     s,
 			Credentials: nil,
-			SharedDocs:  docs,
+			SharedDocs:  sharingsInfo[s.ID()],
 		}
 		res[i] = as
 	}


### PR DESCRIPTION
This PR is based on #1333.

This is a naive implementation to get the the sharing info from a doctype. Actually, this will returns as many sharing info as there are a shared documents, i.e. a sharing involving 5 docs will be returned 5 times. We might use a smarter map function and/or a reduce.

I am not confident on the json-api format either.