### PR TITLE
Increase session duration and use session cookies for app cookies

### DIFF
--- a/pkg/sessions/session.go
+++ b/pkg/sessions/session.go
@@ -18,14 +18,8 @@ import (
 // SessionCookieName is name of the cookie created by cozy
 const SessionCookieName = "cozysessid"
 
-const (
-	// SessionMaxAge is the maximum duration of the session in seconds
-	SessionMaxAge = 7 * 24 * time.Hour
-
-	// AppCookieMaxAge is the maximum duration of the application cookie in
-	// seconds
-	AppCookieMaxAge = 24 * time.Hour
-)
+// SessionMaxAge is the maximum duration of the session in seconds
+const SessionMaxAge = 30 * 24 * time.Hour
 
 var (
 	// ErrNoCookie is returned by GetSession if there is no cookie
@@ -234,7 +228,7 @@ func (s *Session) ToAppCookie(domain, slug string) (*http.Cookie, error) {
 	return &http.Cookie{
 		Name:     SessionCookieName,
 		Value:    string(encoded),
-		MaxAge:   int(AppCookieMaxAge.Seconds()),
+		MaxAge:   0, // "session cookie", expiring when the browser is closed
 		Path:     "/",
 		Domain:   utils.StripPort(domain),
 		Secure:   !s.Instance.Dev,
@@ -288,6 +282,5 @@ var cookieAppMACConfig = crypto.MACConfig{
 
 var cookieSessionMACConfig = crypto.MACConfig{
 	Name:   SessionCookieName,
-	MaxAge: AppCookieMaxAge,
 	MaxLen: 256,
 }

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -16,8 +16,6 @@ import (
 
 	"github.com/cozy/cozy-stack/pkg/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
-	"github.com/cozy/cozy-stack/pkg/couchdb"
-	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/pkg/vfs"
 	"github.com/cozy/cozy-stack/tests/testutils"
@@ -1753,35 +1751,6 @@ func TestThumbnail(t *testing.T) {
 	res4, _ := download(t, small, "")
 	assert.Equal(t, 200, res4.StatusCode)
 	assert.True(t, strings.HasPrefix(res4.Header.Get("Content-Type"), "image/jpeg"))
-}
-
-func TestFindFiles(t *testing.T) {
-	err := couchdb.DefineIndex(testInstance, mango.IndexOnFields(consts.Files, "by-class", []string{"class"}))
-	if !assert.NoError(t, err) {
-		return
-	}
-	var query = strings.NewReader(`{"selector" : {"class": "image"}}`)
-	req, _ := http.NewRequest("POST", ts.URL+"/files/_find", query)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	res, err := http.DefaultClient.Do(req)
-	if !assert.NoError(t, err) {
-		return
-	}
-	var out map[string]interface{}
-	err = extractJSONRes(res, &out)
-	if !assert.NoError(t, err) {
-		return
-	}
-	assert.NoError(t, err)
-	data := out["data"].([]interface{})
-	if !assert.True(t, len(data) > 0) {
-		return
-	}
-	first := data[0].(map[string]interface{})
-	links := first["links"].(map[string]interface{})
-	small := links["small"].(string)
-	assert.NotEmpty(t, small)
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
The session duration is now 30 days. The session cookies do not need an explicit expiration, they are defined as session cookies with the lifespan of the browser session.

The expiration only relies on our session expiration, and not on the cookie expiration.