### PR TITLE
Prepare for registry publication

### DIFF
--- a/pkg/apps/fetcher_http.go
+++ b/pkg/apps/fetcher_http.go
@@ -19,7 +19,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var httpClient = http.Client{Timeout: 20 * time.Second}
+var httpClient = http.Client{
+	Timeout: 2 * 60 * time.Second,
+}
 
 type httpFetcher struct {
 	manFilename string

--- a/pkg/apps/installer.go
+++ b/pkg/apps/installer.go
@@ -193,6 +193,11 @@ func initManifest(db couchdb.Database, opts *InstallerOptions) (man Manifest, er
 	return man, nil
 }
 
+// Slug return the slug of the application being installed.
+func (i *Installer) Slug() string {
+	return i.slug
+}
+
 // Run will install, update or delete the application linked to the installer,
 // depending on specified operation. It will report its progress or error (see
 // Poll method) and should be run asynchronously.

--- a/pkg/instance/updates.go
+++ b/pkg/instance/updates.go
@@ -264,7 +264,10 @@ func createInstaller(inst *Instance, registries []*url.URL, man apps.Manifest, o
 			} else {
 				channel = "stable"
 			}
-			sourceURL = fmt.Sprintf("registry://%s/%s", man.Slug(), channel)
+			_, err := registry.GetLatestVersion(man.Slug(), channel, registries)
+			if err == nil {
+				sourceURL = fmt.Sprintf("registry://%s/%s", man.Slug(), channel)
+			}
 		}
 	}
 	return apps.NewInstaller(inst, inst.AppsCopier(man.AppType()),

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cozy/httpcache"
 	"github.com/cozy/echo"
+	"github.com/cozy/httpcache"
 )
 
 const defaultLimit = 50


### PR DESCRIPTION
This PR adds a check on the source change of our applications for the registry: the application slug must exist in the registry to perform the source swap.

Also improves the error reporting of the update script.