### PR TITLE
Drop Go 1.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ matrix:
       env: COMMAND=scripts/coverage.sh CODECOV=true
     - go: "1.9"
       env: COMMAND=scripts/unit-test.sh
-    - go: "1.8"
-      env: COMMAND=scripts/unit-test.sh
 
 before_install:
   - docker run -d -p 5984:5984 --net=host --name couch apache/couchdb:2.1

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -37,7 +37,7 @@ version` should show you the version if every thing is right.
 
 #### Using `go`
 
-[Install go](https://golang.org/doc/install), version >= 1.8. With `go`
+[Install go](https://golang.org/doc/install), version >= 1.9. With `go`
 installed and configured, you can run the following command:
 
 ```


### PR DESCRIPTION
The golang.org/x/crypto/ssh package now depends of math/bits that was
introduced in go 1.9. It seems safer to follow the updates and drop go
1.8 support from a security point of view.