### PR TITLE
Allow usage of HTTPs for admin client

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -141,13 +141,13 @@ func sslClient() *http.Client {
 		clientCertificate = cert
 	}
 
-	if envKeyPinned := os.Getenv("COZY_ADMIN_HTTPS_CLIENT_KEYPINNED_FINGERPRINT"); envKeyPinned != "" {
+	if envKeyPinned := os.Getenv("COZY_ADMIN_HTTPS_CLIENT_PINNED_KEY"); envKeyPinned != "" {
 		pinnedFingerPrint, err := base64.StdEncoding.DecodeString(envKeyPinned)
 		if err != nil {
-			errFatalf("Invalid encoding for COZY_ADMIN_HTTPS_CLIENT_KEYPINNED_FINGERPRINT")
+			errFatalf("Invalid encoding for COZY_ADMIN_HTTPS_CLIENT_PINNED_KEY")
 		}
 		if len(pinnedFingerPrint) != sha256.Size {
-			errFatalf("Invalid size for COZY_ADMIN_HTTPS_CLIENT_KEYPINNED: expected %d got %d",
+			errFatalf("Invalid size for COZY_ADMIN_HTTPS_CLIENT_PINNED_KEY: expected %d got %d",
 				sha256.Size, len(pinnedFingerPrint))
 		}
 		verifyPeerCertificate = sslVerifyPinnedKey(pinnedFingerPrint)


### PR DESCRIPTION
Choosing the root CA and client certificate as an option.

New env variables are:
  - `COZY_ADMIN_HTTPS_CLIENT` (set to `1` or `true` to activate https)
  - `COZY_ADMIN_HTTPS_CLIENT_ROOTCA_FILE`
  - `COZY_ADMIN_HTTPS_CLIENT_CERT_FILE`
  - `COZY_ADMIN_HTTPS_CLIENT_KEY_FILE`
  - `COZY_ADMIN_HTTPS_CLIENT_PINNED_KEY`