### PR TITLE
Add generic prefix for database namespaces

### DIFF
--- a/.golinter
+++ b/.golinter
@@ -1,5 +1,5 @@
 {
-  "Disable":  ["errcheck", "gocyclo", "interfacer", "dupl", "gotypex", "gas"],
+  "Disable":  ["errcheck", "gocyclo", "interfacer", "dupl", "gotypex", "gas", "maligned"],
   "DuplThreshold": 70,
   "MinOccurrences": 4,
   "Deadline": "180s"

--- a/cmd/instances.go
+++ b/cmd/instances.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/cozy/cozy-stack/client"
 	"github.com/cozy/cozy-stack/pkg/consts"
-	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/instance"
 	humanize "github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
@@ -67,13 +66,7 @@ var cleanInstanceCmd = &cobra.Command{
 	Use:   "clean [domain]",
 	Short: "Clean badly removed instances",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) == 0 {
-			return cmd.Usage()
-		}
-
-		domain := args[0]
-		i := couchdb.SimpleDatabasePrefix(domain)
-		return couchdb.DeleteAllDBs(i)
+		return errors.New("This command is deprecated")
 	},
 }
 

--- a/pkg/accounts/accounts.go
+++ b/pkg/accounts/accounts.go
@@ -78,12 +78,12 @@ func (ac *Account) Match(field, expected string) bool {
 
 func init() {
 	couchdb.AddHook(consts.Accounts, couchdb.EventDelete,
-		func(domain string, doc couchdb.Doc, old couchdb.Doc) error {
+		func(db couchdb.Database, doc couchdb.Doc, old couchdb.Doc) error {
 			jobsSystem := jobs.System()
 
-			trigs, err := jobsSystem.GetAllTriggers(domain)
+			trigs, err := jobsSystem.GetAllTriggers(db)
 			if err != nil {
-				logger.WithDomain(domain).Error(
+				logger.WithDomain(db.DomainName()).Error(
 					"Failed to fetch triggers after account deletion: ", err)
 				return err
 			}
@@ -104,8 +104,8 @@ func init() {
 					toDelete = true
 				}
 				if toDelete {
-					if err := jobsSystem.DeleteTrigger(domain, t.ID()); err != nil {
-						logger.WithDomain(domain).Errorln("failed to delete orphan trigger", err)
+					if err := jobsSystem.DeleteTrigger(db, t.ID()); err != nil {
+						logger.WithDomain(db.DomainName()).Errorln("failed to delete orphan trigger", err)
 					}
 				}
 			}
@@ -120,7 +120,7 @@ func init() {
 			// process really specific to the deletion of an account, which is our
 			// only detailed usecase.
 			if old != nil {
-				log := logger.WithDomain(domain).
+				log := logger.WithDomain(db.DomainName()).
 					WithField("account_id", old.ID()).
 					WithField("account_rev", old.Rev())
 
@@ -157,8 +157,7 @@ func init() {
 				if err != nil {
 					return err
 				}
-				if _, err = jobsSystem.PushJob(&jobs.JobRequest{
-					Domain:     domain,
+				if _, err = jobsSystem.PushJob(db, &jobs.JobRequest{
 					WorkerType: "konnector",
 					Message:    msg,
 				}); err != nil {

--- a/pkg/accounts/accounts.go
+++ b/pkg/accounts/accounts.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/jobs"
 	"github.com/cozy/cozy-stack/pkg/logger"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 )
 
 // Account holds configuration information for an account
@@ -78,7 +79,7 @@ func (ac *Account) Match(field, expected string) bool {
 
 func init() {
 	couchdb.AddHook(consts.Accounts, couchdb.EventDelete,
-		func(db couchdb.Database, doc couchdb.Doc, old couchdb.Doc) error {
+		func(db prefixer.Prefixer, doc couchdb.Doc, old couchdb.Doc) error {
 			jobsSystem := jobs.System()
 
 			trigs, err := jobsSystem.GetAllTriggers(db)

--- a/pkg/apps/apps.go
+++ b/pkg/apps/apps.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/permissions"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 )
 
 const (
@@ -64,9 +65,9 @@ type Manifest interface {
 	Match(field, expected string) bool
 	ReadManifest(i io.Reader, slug, sourceURL string) error
 
-	Create(db couchdb.Database) error
-	Update(db couchdb.Database) error
-	Delete(db couchdb.Database) error
+	Create(db prefixer.Prefixer) error
+	Update(db prefixer.Prefixer) error
+	Delete(db prefixer.Prefixer) error
 
 	AppType() AppType
 	Permissions() permissions.Set
@@ -84,7 +85,7 @@ type Manifest interface {
 }
 
 // GetBySlug returns an app manifest identified by its slug
-func GetBySlug(db couchdb.Database, slug string, appType AppType) (Manifest, error) {
+func GetBySlug(db prefixer.Prefixer, slug string, appType AppType) (Manifest, error) {
 	var man Manifest
 	var err error
 	switch appType {

--- a/pkg/apps/installer.go
+++ b/pkg/apps/installer.go
@@ -227,10 +227,7 @@ func (i *Installer) Run() {
 	man := i.man.Clone().(Manifest)
 	if err != nil {
 		man.SetError(err)
-		realtime.GetHub().Publish(i.db, &realtime.Event{
-			Verb: realtime.EventUpdate,
-			Doc:  man.Clone(),
-		})
+		realtime.GetHub().Publish(i.db, realtime.EventUpdate, man.Clone(), nil)
 	}
 	i.manc <- man
 }
@@ -377,11 +374,7 @@ func (i *Installer) ReadManifest(state State) error {
 		}
 	}
 
-	realtime.GetHub().Publish(i.db, &realtime.Event{
-		Verb: realtime.EventUpdate,
-		Doc:  i.man.Clone(),
-	})
-
+	realtime.GetHub().Publish(i.db, realtime.EventUpdate, i.man.Clone(), nil)
 	return nil
 }
 

--- a/pkg/apps/installer.go
+++ b/pkg/apps/installer.go
@@ -227,11 +227,9 @@ func (i *Installer) Run() {
 	man := i.man.Clone().(Manifest)
 	if err != nil {
 		man.SetError(err)
-		realtime.GetHub().Publish(&realtime.Event{
-			Verb:   realtime.EventUpdate,
-			Doc:    man.Clone(),
-			Domain: i.db.DomainName(),
-			Prefix: i.db.DBPrefix(),
+		realtime.GetHub().Publish(i.db, &realtime.Event{
+			Verb: realtime.EventUpdate,
+			Doc:  man.Clone(),
 		})
 	}
 	i.manc <- man
@@ -379,11 +377,9 @@ func (i *Installer) ReadManifest(state State) error {
 		}
 	}
 
-	realtime.GetHub().Publish(&realtime.Event{
-		Verb:   realtime.EventUpdate,
-		Doc:    i.man.Clone(),
-		Domain: i.db.DomainName(),
-		Prefix: i.db.DBPrefix(),
+	realtime.GetHub().Publish(i.db, &realtime.Event{
+		Verb: realtime.EventUpdate,
+		Doc:  i.man.Clone(),
 	})
 
 	return nil

--- a/pkg/apps/installer.go
+++ b/pkg/apps/installer.go
@@ -7,9 +7,9 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/hooks"
 	"github.com/cozy/cozy-stack/pkg/logger"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/cozy/cozy-stack/pkg/realtime"
 	"github.com/cozy/cozy-stack/pkg/utils"
 	"github.com/sirupsen/logrus"
@@ -34,7 +34,7 @@ type Installer struct {
 	fetcher  Fetcher
 	op       Operation
 	fs       Copier
-	db       couchdb.Database
+	db       prefixer.Prefixer
 	endState State
 
 	overridenParameters *json.RawMessage
@@ -77,7 +77,7 @@ type Fetcher interface {
 }
 
 // NewInstaller creates a new Installer
-func NewInstaller(db couchdb.Database, fs Copier, opts *InstallerOptions) (*Installer, error) {
+func NewInstaller(db prefixer.Prefixer, fs Copier, opts *InstallerOptions) (*Installer, error) {
 	man, err := initManifest(db, opts)
 	if err != nil {
 		return nil, err
@@ -155,7 +155,7 @@ func NewInstaller(db couchdb.Database, fs Copier, opts *InstallerOptions) (*Inst
 	}, nil
 }
 
-func initManifest(db couchdb.Database, opts *InstallerOptions) (man Manifest, err error) {
+func initManifest(db prefixer.Prefixer, opts *InstallerOptions) (man Manifest, err error) {
 	if man = opts.Manifest; man != nil {
 		return man, nil
 	}

--- a/pkg/apps/installer_test.go
+++ b/pkg/apps/installer_test.go
@@ -151,7 +151,7 @@ func TestMain(m *testing.M) {
 		io.WriteString(w, manGen())
 	}))
 
-	db = couchdb.SimpleDatabasePrefix("apps-test")
+	db = couchdb.NewDatabase("apps-test")
 
 	err = couchdb.ResetDB(db, consts.Apps)
 	if err != nil {

--- a/pkg/apps/installer_test.go
+++ b/pkg/apps/installer_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/cozy/cozy-stack/pkg/stack"
 )
 
@@ -124,7 +125,7 @@ git checkout master`
 	}
 }
 
-var db couchdb.Database
+var db prefixer.Prefixer
 var fs apps.Copier
 var baseFS afero.Fs
 
@@ -151,7 +152,7 @@ func TestMain(m *testing.M) {
 		io.WriteString(w, manGen())
 	}))
 
-	db = couchdb.NewDatabase("apps-test")
+	db = prefixer.NewPrefixer("", "apps-test")
 
 	err = couchdb.ResetDB(db, consts.Apps)
 	if err != nil {

--- a/pkg/apps/konnector.go
+++ b/pkg/apps/konnector.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/permissions"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 )
 
 // KonnManifest contains all the informations associated with an installed
@@ -172,7 +173,7 @@ func (m *KonnManifest) ReadManifest(r io.Reader, slug, sourceURL string) error {
 }
 
 // Create is part of the Manifest interface
-func (m *KonnManifest) Create(db couchdb.Database) error {
+func (m *KonnManifest) Create(db prefixer.Prefixer) error {
 	m.CreatedAt = time.Now()
 	m.UpdatedAt = time.Now()
 	if err := couchdb.CreateNamedDocWithDB(db, m); err != nil {
@@ -183,7 +184,7 @@ func (m *KonnManifest) Create(db couchdb.Database) error {
 }
 
 // Update is part of the Manifest interface
-func (m *KonnManifest) Update(db couchdb.Database) error {
+func (m *KonnManifest) Update(db prefixer.Prefixer) error {
 	m.UpdatedAt = time.Now()
 	err := couchdb.UpdateDoc(db, m)
 	if err != nil {
@@ -194,7 +195,7 @@ func (m *KonnManifest) Update(db couchdb.Database) error {
 }
 
 // Delete is part of the Manifest interface
-func (m *KonnManifest) Delete(db couchdb.Database) error {
+func (m *KonnManifest) Delete(db prefixer.Prefixer) error {
 	err := permissions.DestroyKonnector(db, m.Slug())
 	if err != nil && !couchdb.IsNotFoundError(err) {
 		return err
@@ -204,7 +205,7 @@ func (m *KonnManifest) Delete(db couchdb.Database) error {
 
 // GetKonnectorBySlug fetch the manifest of a konnector from the database given
 // a slug.
-func GetKonnectorBySlug(db couchdb.Database, slug string) (*KonnManifest, error) {
+func GetKonnectorBySlug(db prefixer.Prefixer, slug string) (*KonnManifest, error) {
 	if slug == "" || !slugReg.MatchString(slug) {
 		return nil, ErrInvalidSlugName
 	}
@@ -222,7 +223,7 @@ func GetKonnectorBySlug(db couchdb.Database, slug string) (*KonnManifest, error)
 // ListKonnectors returns the list of installed konnectors applications.
 //
 // TODO: pagination
-func ListKonnectors(db couchdb.Database) ([]Manifest, error) {
+func ListKonnectors(db prefixer.Prefixer) ([]Manifest, error) {
 	var docs []*KonnManifest
 	req := &couchdb.AllDocsRequest{Limit: 100}
 	err := couchdb.GetAllDocs(db, consts.Konnectors, req, &docs)

--- a/pkg/apps/webapp.go
+++ b/pkg/apps/webapp.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/jobs"
 	"github.com/cozy/cozy-stack/pkg/notification"
 	"github.com/cozy/cozy-stack/pkg/permissions"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 )
 
 // Route is a struct to serve a folder inside an app
@@ -245,7 +246,7 @@ func (m *WebappManifest) ReadManifest(r io.Reader, slug, sourceURL string) error
 }
 
 // Create is part of the Manifest interface
-func (m *WebappManifest) Create(db couchdb.Database) error {
+func (m *WebappManifest) Create(db prefixer.Prefixer) error {
 	if err := diffServices(db, m.Slug(), nil, m.Services); err != nil {
 		return err
 	}
@@ -259,7 +260,7 @@ func (m *WebappManifest) Create(db couchdb.Database) error {
 }
 
 // Update is part of the Manifest interface
-func (m *WebappManifest) Update(db couchdb.Database) error {
+func (m *WebappManifest) Update(db prefixer.Prefixer) error {
 	if err := diffServices(db, m.Slug(), m.oldServices, m.Services); err != nil {
 		return err
 	}
@@ -272,7 +273,7 @@ func (m *WebappManifest) Update(db couchdb.Database) error {
 }
 
 // Delete is part of the Manifest interface
-func (m *WebappManifest) Delete(db couchdb.Database) error {
+func (m *WebappManifest) Delete(db prefixer.Prefixer) error {
 	err := diffServices(db, m.Slug(), m.Services, nil)
 	if err != nil {
 		return err
@@ -284,7 +285,7 @@ func (m *WebappManifest) Delete(db couchdb.Database) error {
 	return couchdb.DeleteDoc(db, m)
 }
 
-func diffServices(db couchdb.Database, slug string, oldServices, newServices Services) error {
+func diffServices(db prefixer.Prefixer, slug string, oldServices, newServices Services) error {
 	if oldServices == nil {
 		oldServices = make(Services)
 	}
@@ -415,7 +416,7 @@ func (m *WebappManifest) FindIntent(action, typ string) *Intent {
 }
 
 // GetWebappBySlug fetch the WebappManifest from the database given a slug.
-func GetWebappBySlug(db couchdb.Database, slug string) (*WebappManifest, error) {
+func GetWebappBySlug(db prefixer.Prefixer, slug string) (*WebappManifest, error) {
 	if slug == "" || !slugReg.MatchString(slug) {
 		return nil, ErrInvalidSlugName
 	}
@@ -433,7 +434,7 @@ func GetWebappBySlug(db couchdb.Database, slug string) (*WebappManifest, error) 
 // ListWebapps returns the list of installed web applications.
 //
 // TODO: pagination
-func ListWebapps(db couchdb.Database) ([]*WebappManifest, error) {
+func ListWebapps(db prefixer.Prefixer) ([]*WebappManifest, error) {
 	var docs []*WebappManifest
 	req := &couchdb.AllDocsRequest{Limit: 100}
 	err := couchdb.GetAllDocs(db, consts.Apps, req, &docs)

--- a/pkg/contacts/contacts.go
+++ b/pkg/contacts/contacts.go
@@ -3,6 +3,7 @@ package contacts
 import (
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/cozy/cozy-stack/pkg/workers/mails"
 )
 
@@ -139,7 +140,7 @@ func (c *Contact) PrimaryCozyURL() string {
 }
 
 // Find returns the contact stored in database from a given ID
-func Find(db couchdb.Database, contactID string) (*Contact, error) {
+func Find(db prefixer.Prefixer, contactID string) (*Contact, error) {
 	doc := &Contact{}
 	err := couchdb.GetDoc(db, consts.Contacts, contactID, doc)
 	return doc, err

--- a/pkg/couchdb/couchdb.go
+++ b/pkg/couchdb/couchdb.go
@@ -70,10 +70,8 @@ func RTEvent(db Database, verb string, doc, oldDoc Doc) {
 			Verb:   verb,
 			Doc:    doc.Clone(),
 			OldDoc: oldDoc,
-			Domain: db.DomainName(),
-			Prefix: db.DBPrefix(),
 		}
-		go realtime.GetHub().Publish(e)
+		go realtime.GetHub().Publish(db, e)
 	}
 }
 

--- a/pkg/couchdb/couchdb.go
+++ b/pkg/couchdb/couchdb.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/config"
 	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
 	"github.com/cozy/cozy-stack/pkg/logger"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/cozy/cozy-stack/pkg/realtime"
 	"github.com/sirupsen/logrus"
 )
@@ -42,21 +43,11 @@ type Doc interface {
 	SetRev(rev string)
 }
 
-// Database is the type passed to every function in couchdb package
-// for now it is just a string with the database prefix.
-type Database interface {
-	DBPrefix() string
-	DomainName() string
-}
+type Database prefixer.Prefixer
 
-type simpleDB string
-
-func (sdb simpleDB) DBPrefix() string   { return string(sdb) }
-func (sdb simpleDB) DomainName() string { return "unknown" }
-
-// NewDatabase returns a Database from a prefix, useful for test
-func NewDatabase(prefix string) Database {
-	return simpleDB(prefix)
+// newDatabase returns a Database from a prefix, useful for test
+func newDatabase(prefix string) prefixer.Prefixer {
+	return prefixer.NewPrefixer("", prefix)
 }
 
 // RTEvent published a realtime event for a couchDB change
@@ -72,11 +63,11 @@ func RTEvent(db Database, verb string, doc, oldDoc Doc) {
 }
 
 // GlobalDB is the prefix used for stack-scoped db
-var GlobalDB = NewDatabase("global")
+var GlobalDB = newDatabase("global")
 
 // GlobalSecretsDB is the the prefix used for db which hold
 // a cozy stack secrets.
-var GlobalSecretsDB = NewDatabase("secrets")
+var GlobalSecretsDB = newDatabase("secrets")
 
 // View is the map/reduce thing in CouchDB
 type View struct {

--- a/pkg/couchdb/couchdb.go
+++ b/pkg/couchdb/couchdb.go
@@ -66,12 +66,8 @@ func RTEvent(db Database, verb string, doc, oldDoc Doc) {
 			Errorf("error in hooks on %s %s %v\n", verb, doc.DocType(), err)
 	}
 	if db != GlobalDB && db != GlobalSecretsDB {
-		e := &realtime.Event{
-			Verb:   verb,
-			Doc:    doc.Clone(),
-			OldDoc: oldDoc,
-		}
-		go realtime.GetHub().Publish(db, e)
+		docClone := doc.Clone()
+		go realtime.GetHub().Publish(db, verb, docClone, oldDoc)
 	}
 }
 

--- a/pkg/couchdb/couchdb.go
+++ b/pkg/couchdb/couchdb.go
@@ -43,6 +43,8 @@ type Doc interface {
 	SetRev(rev string)
 }
 
+// Database is the type passed to every function in couchdb package
+// for now it is just a string with the database prefix.
 type Database prefixer.Prefixer
 
 // newDatabase returns a Database from a prefix, useful for test

--- a/pkg/couchdb/couchdb_test.go
+++ b/pkg/couchdb/couchdb_test.go
@@ -25,7 +25,7 @@ func TestErrors(t *testing.T) {
 
 const TestDoctype = "io.cozy.testobject"
 
-var TestPrefix = NewDatabase("couchdb-tests")
+var TestPrefix = newDatabase("couchdb-tests")
 var receivedEventsMutex sync.Mutex
 var receivedEvents map[string]struct{}
 

--- a/pkg/couchdb/couchdb_test.go
+++ b/pkg/couchdb/couchdb_test.go
@@ -25,7 +25,7 @@ func TestErrors(t *testing.T) {
 
 const TestDoctype = "io.cozy.testobject"
 
-var TestPrefix = SimpleDatabasePrefix("couchdb-tests")
+var TestPrefix = NewDatabase("couchdb-tests")
 var receivedEventsMutex sync.Mutex
 var receivedEvents map[string]struct{}
 
@@ -310,7 +310,7 @@ func TestMain(m *testing.M) {
 	}
 
 	receivedEvents = make(map[string]struct{})
-	eventChan := realtime.GetHub().Subscriber(TestPrefix.Prefix())
+	eventChan := realtime.GetHub().Subscriber(TestPrefix)
 	eventChan.Subscribe(TestDoctype)
 	go func() {
 		for ev := range eventChan.Channel {

--- a/pkg/couchdb/hooks.go
+++ b/pkg/couchdb/hooks.go
@@ -4,7 +4,7 @@ import "github.com/cozy/cozy-stack/pkg/realtime"
 
 // Hook is a function called before a change is made into
 // A hook can block the event by returning an error
-type listener func(domain string, doc Doc, old Doc) error
+type listener func(db Database, doc Doc, old Doc) error
 
 type key struct {
 	DocType string
@@ -21,10 +21,10 @@ const (
 )
 
 // Run runs all hooks for the given event.
-func runHooks(domain, event string, doc Doc, old Doc) error {
+func runHooks(db Database, event string, doc Doc, old Doc) error {
 	if hs, ok := hooks[key{doc.DocType(), event}]; ok {
 		for _, h := range hs {
-			err := h(domain, doc, old)
+			err := h(db, doc, old)
 			if err != nil {
 				return err
 			}

--- a/pkg/couchdb/hooks.go
+++ b/pkg/couchdb/hooks.go
@@ -1,10 +1,13 @@
 package couchdb
 
-import "github.com/cozy/cozy-stack/pkg/realtime"
+import (
+	"github.com/cozy/cozy-stack/pkg/prefixer"
+	"github.com/cozy/cozy-stack/pkg/realtime"
+)
 
 // Hook is a function called before a change is made into
 // A hook can block the event by returning an error
-type listener func(db Database, doc Doc, old Doc) error
+type listener func(db prefixer.Prefixer, doc Doc, old Doc) error
 
 type key struct {
 	DocType string

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -635,7 +635,7 @@ func CreateWithoutHooks(opts *Options) (*Instance, error) {
 	prefix := sha256.Sum256([]byte(domain))
 	i := new(Instance)
 	i.Domain = domain
-	i.Prefix = "c-" + hex.EncodeToString(prefix[:16])
+	i.Prefix = "cozy" + hex.EncodeToString(prefix[:16])
 	i.Locale = locale
 	i.UUID = opts.UUID
 	i.TOSSigned = opts.TOSSigned

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -84,6 +84,7 @@ type Instance struct {
 	DocID        string   `json:"_id,omitempty"`        // couchdb _id
 	DocRev       string   `json:"_rev,omitempty"`       // couchdb _rev
 	Domain       string   `json:"domain"`               // The main DNS domain, like example.cozycloud.cc
+	Prefix       string   `json:"prefix,omitempty"`     // Possible database prefix
 	Locale       string   `json:"locale"`               // The locale used on the server
 	UUID         string   `json:"uuid,omitempty"`       // UUID associated with the instance
 	ContextName  string   `json:"context,omitempty"`    // The context attached to the instance
@@ -191,9 +192,17 @@ func (i *Instance) Clone() couchdb.Doc {
 	return &cloned
 }
 
-// Prefix returns the prefix to use in database naming for the
+// DBPrefix returns the prefix to use in database naming for the
 // current instance
-func (i *Instance) Prefix() string {
+func (i *Instance) DBPrefix() string {
+	if i.Prefix != "" {
+		return i.Prefix
+	}
+	return i.Domain
+}
+
+// DomainName returns the main domain name of the instance.
+func (i *Instance) DomainName() string {
 	return i.Domain
 }
 
@@ -717,8 +726,8 @@ func CreateWithoutHooks(opts *Options) (*Instance, error) {
 		return nil, err
 	}
 	sched := jobs.System()
-	for _, trigger := range Triggers(i.Domain) {
-		t, err := jobs.NewTrigger(&trigger)
+	for _, trigger := range Triggers(i) {
+		t, err := jobs.NewTrigger(i, trigger, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -1076,23 +1085,22 @@ func DestroyWithoutHooks(domain string) error {
 	if err != nil {
 		return err
 	}
+	i, err := getFromCouch(domain)
+	if err != nil {
+		return err
+	}
 	sched := jobs.System()
-	triggers, err := sched.GetAllTriggers(domain)
+	triggers, err := sched.GetAllTriggers(i)
 	if err == nil {
 		for _, t := range triggers {
-			if err = sched.DeleteTrigger(domain, t.Infos().TID); err != nil {
+			if err = sched.DeleteTrigger(i, t.Infos().TID); err != nil {
 				logger.WithDomain(domain).Error(
 					"Failed to remove trigger: ", err)
 			}
 		}
 	}
-	i, err := getFromCouch(domain)
-	if err != nil {
-		return err
-	}
 	defer getCache().Revoke(domain)
-	db := couchdb.SimpleDatabasePrefix(domain)
-	if err = couchdb.DeleteAllDBs(db); err != nil {
+	if err = couchdb.DeleteAllDBs(i); err != nil {
 		return err
 	}
 	if err = i.VFS().Delete(); err != nil {
@@ -1181,8 +1189,7 @@ func (i *Instance) SendMail(m *Mail) error {
 	if err != nil {
 		return err
 	}
-	_, err = jobs.System().PushJob(&jobs.JobRequest{
-		Domain:     i.Domain,
+	_, err = jobs.System().PushJob(i, &jobs.JobRequest{
 		WorkerType: "sendmail",
 		Message:    msg,
 	})

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -1,6 +1,7 @@
 package instance
 
 import (
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
@@ -631,8 +632,10 @@ func CreateWithoutHooks(opts *Options) (*Instance, error) {
 	}
 
 	settings, _ := buildSettings(opts)
+	prefix := sha256.Sum256([]byte(domain))
 	i := new(Instance)
 	i.Domain = domain
+	i.Prefix = "c-" + hex.EncodeToString(prefix[:16])
 	i.Locale = locale
 	i.UUID = opts.UUID
 	i.TOSSigned = opts.TOSSigned

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -225,18 +225,18 @@ func (i *Instance) makeVFS() error {
 		return nil
 	}
 	fsURL := config.FsURL()
-	mutex := lock.ReadWrite(i.Domain + "/vfs")
+	mutex := lock.ReadWrite(i, "vfs")
 	index := vfs.NewCouchdbIndexer(i)
 	disk := vfs.DiskThresholder(i)
 	var err error
 	switch fsURL.Scheme {
 	case config.SchemeFile, config.SchemeMem:
-		i.vfs, err = vfsafero.New(i.Domain, index, disk, mutex, fsURL, i.DirName())
+		i.vfs, err = vfsafero.New(i, index, disk, mutex, fsURL, i.DirName())
 	case config.SchemeSwift:
 		if i.SwiftCluster > 0 {
-			i.vfs, err = vfsswift.NewV2(i.Domain, index, disk, mutex)
+			i.vfs, err = vfsswift.NewV2(i, index, disk, mutex)
 		} else {
-			i.vfs, err = vfsswift.New(i.Domain, index, disk, mutex)
+			i.vfs, err = vfsswift.New(i, index, disk, mutex)
 		}
 	default:
 		err = fmt.Errorf("instance: unknown storage provider %s", fsURL.Scheme)

--- a/pkg/instance/triggers.go
+++ b/pkg/instance/triggers.go
@@ -1,12 +1,12 @@
 package instance
 
 import (
-	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/jobs"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 )
 
 // Triggers returns the list of the triggers to add when an instance is created
-func Triggers(db couchdb.Database) []jobs.TriggerInfos {
+func Triggers(db prefixer.Prefixer) []jobs.TriggerInfos {
 	// Create/update/remove thumbnails when an image is created/updated/removed
 	return []jobs.TriggerInfos{
 		{

--- a/pkg/instance/triggers.go
+++ b/pkg/instance/triggers.go
@@ -1,15 +1,17 @@
 package instance
 
 import (
+	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/jobs"
 )
 
 // Triggers returns the list of the triggers to add when an instance is created
-func Triggers(domain string) []jobs.TriggerInfos {
+func Triggers(db couchdb.Database) []jobs.TriggerInfos {
 	// Create/update/remove thumbnails when an image is created/updated/removed
 	return []jobs.TriggerInfos{
 		{
-			Domain:     domain,
+			Domain:     db.DomainName(),
+			Prefix:     db.DBPrefix(),
 			Type:       "@event",
 			WorkerType: "thumbnail",
 			Arguments:  "io.cozy.files:CREATED,UPDATED,DELETED:image:class",

--- a/pkg/jobs/broker.go
+++ b/pkg/jobs/broker.go
@@ -101,6 +101,7 @@ type (
 
 var joblog = logger.WithNamespace("jobs")
 
+// DBPrefix implements the prefixer.Prefixer interface.
 func (j *Job) DBPrefix() string {
 	if j.Prefix != "" {
 		return j.Prefix
@@ -108,6 +109,7 @@ func (j *Job) DBPrefix() string {
 	return j.Domain
 }
 
+// DomainName implements the prefixer.Prefixer interface.
 func (j *Job) DomainName() string {
 	return j.Domain
 }

--- a/pkg/jobs/broker.go
+++ b/pkg/jobs/broker.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
 	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/cozy/cozy-stack/pkg/permissions"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/cozy/cozy-stack/pkg/realtime"
 	"github.com/sirupsen/logrus"
 )
@@ -40,7 +41,7 @@ type (
 
 		// PushJob will push try to push a new job from the specified job request.
 		// This method is asynchronous.
-		PushJob(db couchdb.Database, request *JobRequest) (*Job, error)
+		PushJob(db prefixer.Prefixer, request *JobRequest) (*Job, error)
 
 		// WorkerQueueLen returns the total element in the queue of the specified
 		// worker type.
@@ -244,7 +245,7 @@ func (m Message) MarshalJSON() ([]byte, error) {
 }
 
 // NewJob creates a new Job instance from a job request.
-func NewJob(db couchdb.Database, req *JobRequest) *Job {
+func NewJob(db prefixer.Prefixer, req *JobRequest) *Job {
 	return &Job{
 		Domain:     db.DomainName(),
 		Prefix:     db.DBPrefix(),
@@ -261,7 +262,7 @@ func NewJob(db couchdb.Database, req *JobRequest) *Job {
 }
 
 // Get returns the informations about a job.
-func Get(db couchdb.Database, jobID string) (*Job, error) {
+func Get(db prefixer.Prefixer, jobID string) (*Job, error) {
 	var job Job
 	if err := couchdb.GetDoc(db, consts.Jobs, jobID, &job); err != nil {
 		if couchdb.IsNotFoundError(err) {
@@ -273,7 +274,7 @@ func Get(db couchdb.Database, jobID string) (*Job, error) {
 }
 
 // GetQueuedJobs returns the list of jobs which states is "queued" or "running"
-func GetQueuedJobs(db couchdb.Database, workerType string) ([]*Job, error) {
+func GetQueuedJobs(db prefixer.Prefixer, workerType string) ([]*Job, error) {
 	var results []*Job
 	req := &couchdb.FindRequest{
 		UseIndex: "by-worker-and-state",

--- a/pkg/jobs/mem_broker.go
+++ b/pkg/jobs/mem_broker.go
@@ -8,7 +8,7 @@ import (
 	"sync/atomic"
 
 	"github.com/cozy/cozy-stack/pkg/config"
-	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/cozy/cozy-stack/pkg/utils"
 	multierror "github.com/hashicorp/go-multierror"
 )
@@ -148,7 +148,7 @@ func (b *memBroker) ShutdownWorkers(ctx context.Context) error {
 
 // PushJob will produce a new Job with the given options and enqueue the job in
 // the proper queue.
-func (b *memBroker) PushJob(db couchdb.Database, req *JobRequest) (*Job, error) {
+func (b *memBroker) PushJob(db prefixer.Prefixer, req *JobRequest) (*Job, error) {
 	if atomic.LoadUint32(&b.running) == 0 {
 		return nil, ErrClosed
 	}

--- a/pkg/jobs/mem_broker.go
+++ b/pkg/jobs/mem_broker.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 
 	"github.com/cozy/cozy-stack/pkg/config"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/utils"
 	multierror "github.com/hashicorp/go-multierror"
 )
@@ -147,7 +148,7 @@ func (b *memBroker) ShutdownWorkers(ctx context.Context) error {
 
 // PushJob will produce a new Job with the given options and enqueue the job in
 // the proper queue.
-func (b *memBroker) PushJob(req *JobRequest) (*Job, error) {
+func (b *memBroker) PushJob(db couchdb.Database, req *JobRequest) (*Job, error) {
 	if atomic.LoadUint32(&b.running) == 0 {
 		return nil, ErrClosed
 	}
@@ -159,7 +160,7 @@ func (b *memBroker) PushJob(req *JobRequest) (*Job, error) {
 	if !ok {
 		return nil, ErrUnknownWorker
 	}
-	job := NewJob(req)
+	job := NewJob(db, req)
 	if err := job.Create(); err != nil {
 		return nil, err
 	}

--- a/pkg/jobs/mem_scheduler.go
+++ b/pkg/jobs/mem_scheduler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/logger"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/sirupsen/logrus"
 )
 
@@ -124,7 +125,7 @@ func (s *memScheduler) AddTrigger(t Trigger) error {
 }
 
 // GetTrigger returns the trigger with the specified ID.
-func (s *memScheduler) GetTrigger(db couchdb.Database, id string) (Trigger, error) {
+func (s *memScheduler) GetTrigger(db prefixer.Prefixer, id string) (Trigger, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	t, ok := s.ts[db.DBPrefix()+"/"+id]
@@ -136,7 +137,7 @@ func (s *memScheduler) GetTrigger(db couchdb.Database, id string) (Trigger, erro
 
 // DeleteTrigger removes the trigger with the specified ID. The trigger is unscheduled
 // and remove from the storage.
-func (s *memScheduler) DeleteTrigger(db couchdb.Database, id string) error {
+func (s *memScheduler) DeleteTrigger(db prefixer.Prefixer, id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	t, ok := s.ts[db.DBPrefix()+"/"+id]
@@ -149,7 +150,7 @@ func (s *memScheduler) DeleteTrigger(db couchdb.Database, id string) error {
 }
 
 // GetAllTriggers returns all the running in-memory triggers.
-func (s *memScheduler) GetAllTriggers(db couchdb.Database) ([]Trigger, error) {
+func (s *memScheduler) GetAllTriggers(db prefixer.Prefixer) ([]Trigger, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	prefix := db.DBPrefix() + "/"
@@ -219,7 +220,7 @@ func (s *memScheduler) CleanRedis() error {
 
 // RebuildRedis does nothing for the in memory scheduler. It's just
 // here to implement the Scheduler interface.
-func (s *memScheduler) RebuildRedis(db couchdb.Database) error {
+func (s *memScheduler) RebuildRedis(db prefixer.Prefixer) error {
 	return errors.New("memScheduler does not use redis")
 }
 

--- a/pkg/jobs/mem_scheduler_test.go
+++ b/pkg/jobs/mem_scheduler_test.go
@@ -59,13 +59,14 @@ func TestMemSchedulerWithDebounce(t *testing.T) {
 		Message:    msg,
 	}
 
-	triggers := []TriggerInfos{ti}
+	var triggers []Trigger
+	triggersInfos := []TriggerInfos{ti}
 	sch := newMemScheduler()
 	sch.StartScheduler(bro)
 
 	db := prefixer.NewPrefixer("cozy.local.withdebounce", "cozy.local.withdebounce")
 
-	for _, infos := range triggers {
+	for _, infos := range triggersInfos {
 		trigger, err := NewTrigger(db, infos, msg)
 		if !assert.NoError(t, err) {
 			return
@@ -74,6 +75,7 @@ func TestMemSchedulerWithDebounce(t *testing.T) {
 		if !assert.NoError(t, err) {
 			return
 		}
+		triggers = append(triggers, trigger)
 	}
 
 	ts, err := sch.GetAllTriggers(db)
@@ -104,7 +106,7 @@ func TestMemSchedulerWithDebounce(t *testing.T) {
 	assert.Equal(t, 4, called)
 
 	for _, trigger := range triggers {
-		err = sch.DeleteTrigger(db, trigger.TID)
+		err = sch.DeleteTrigger(db, trigger.ID())
 		assert.NoError(t, err)
 	}
 

--- a/pkg/jobs/mem_scheduler_test.go
+++ b/pkg/jobs/mem_scheduler_test.go
@@ -6,30 +6,29 @@ import (
 	"time"
 
 	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/cozy/cozy-stack/pkg/realtime"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestTriggersBadArguments(t *testing.T) {
 	var err error
-	_, err = NewTrigger(&TriggerInfos{
-		Domain:    "cozy.local",
+	_, err = NewTrigger(localDB, TriggerInfos{
 		Type:      "@at",
 		Arguments: "garbage",
-	})
+	}, nil)
 	assert.Error(t, err)
 
-	_, err = NewTrigger(&TriggerInfos{
+	_, err = NewTrigger(localDB, TriggerInfos{
 		Type:      "@in",
 		Arguments: "garbage",
-	})
+	}, nil)
 	assert.Error(t, err)
 
-	_, err = NewTrigger(&TriggerInfos{
-		Domain:    "cozy.local",
+	_, err = NewTrigger(localDB, TriggerInfos{
 		Type:      "@unknown",
 		Arguments: "",
-	})
+	}, nil)
 	if assert.Error(t, err) {
 		assert.Equal(t, ErrUnknownTrigger, err)
 	}
@@ -52,21 +51,22 @@ func TestMemSchedulerWithDebounce(t *testing.T) {
 	})
 
 	msg, _ := NewMessage("@event")
-	ti := &TriggerInfos{
+	ti := TriggerInfos{
 		Type:       "@event",
-		Domain:     "cozy.local.withdebounce",
 		Arguments:  "io.cozy.testdebounce io.cozy.moredebounce",
 		Debounce:   "2s",
 		WorkerType: "worker",
 		Message:    msg,
 	}
 
-	triggers := []*TriggerInfos{ti}
+	triggers := []TriggerInfos{ti}
 	sch := newMemScheduler()
 	sch.StartScheduler(bro)
 
+	db := prefixer.NewPrefixer("cozy.local.withdebounce", "cozy.local.withdebounce")
+
 	for _, infos := range triggers {
-		trigger, err := NewTrigger(infos)
+		trigger, err := NewTrigger(db, infos, msg)
 		if !assert.NoError(t, err) {
 			return
 		}
@@ -76,7 +76,7 @@ func TestMemSchedulerWithDebounce(t *testing.T) {
 		}
 	}
 
-	ts, err := sch.GetAllTriggers("cozy.local.withdebounce")
+	ts, err := sch.GetAllTriggers(db)
 	assert.NoError(t, err)
 	assert.Len(t, ts, len(triggers))
 
@@ -88,28 +88,23 @@ func TestMemSchedulerWithDebounce(t *testing.T) {
 			"test": "value",
 		},
 	}
-	event := &realtime.Event{
-		Verb:   realtime.EventCreate,
-		Doc:    &doc,
-		Domain: "cozy.local.withdebounce",
-	}
 
 	for i := 0; i < 24; i++ {
 		time.Sleep(200 * time.Millisecond)
-		realtime.GetHub().Publish(event)
+		realtime.GetHub().Publish(db, realtime.EventCreate, &doc, nil)
 	}
 
 	time.Sleep(3000 * time.Millisecond)
 	assert.Equal(t, 3, called)
 
-	realtime.GetHub().Publish(event)
+	realtime.GetHub().Publish(db, realtime.EventCreate, &doc, nil)
 	doc.Type = "io.cozy.moredebounce"
-	realtime.GetHub().Publish(event)
+	realtime.GetHub().Publish(db, realtime.EventCreate, &doc, nil)
 	time.Sleep(3000 * time.Millisecond)
 	assert.Equal(t, 4, called)
 
 	for _, trigger := range triggers {
-		err = sch.DeleteTrigger(trigger.Domain, trigger.TID)
+		err = sch.DeleteTrigger(db, trigger.TID)
 		assert.NoError(t, err)
 	}
 

--- a/pkg/jobs/redis_broker.go
+++ b/pkg/jobs/redis_broker.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/cozy/cozy-stack/pkg/config"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/utils"
 	"github.com/go-redis/redis"
 	multierror "github.com/hashicorp/go-multierror"
@@ -159,8 +160,9 @@ func (b *redisBroker) pollLoop(key string, ch chan<- *Job) {
 			continue
 		}
 
-		domain, jobID := parts[0], parts[1]
-		job, err := Get(domain, jobID)
+		prefix, jobID := parts[0], parts[1]
+		db := couchdb.NewDatabase(prefix)
+		job, err := Get(db, jobID)
 		if err != nil {
 			joblog.Warnf("Cannot find job %s on domain %s: %s", parts[1], parts[0], err)
 			continue
@@ -172,7 +174,7 @@ func (b *redisBroker) pollLoop(key string, ch chan<- *Job) {
 
 // PushJob will produce a new Job with the given options and enqueue the job in
 // the proper queue.
-func (b *redisBroker) PushJob(req *JobRequest) (*Job, error) {
+func (b *redisBroker) PushJob(db couchdb.Database, req *JobRequest) (*Job, error) {
 	if atomic.LoadUint32(&b.running) == 0 {
 		return nil, ErrClosed
 	}
@@ -181,13 +183,13 @@ func (b *redisBroker) PushJob(req *JobRequest) (*Job, error) {
 		return nil, ErrUnknownWorker
 	}
 
-	job := NewJob(req)
+	job := NewJob(db, req)
 	if err := job.Create(); err != nil {
 		return nil, err
 	}
 
 	key := redisPrefix + job.WorkerType
-	val := job.Domain + "/" + job.JobID
+	val := job.DBPrefix() + "/" + job.JobID
 
 	// When the job is manual, it is being pushed in a specific prioritized
 	// queue.

--- a/pkg/jobs/redis_broker.go
+++ b/pkg/jobs/redis_broker.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/cozy/cozy-stack/pkg/config"
-	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/cozy/cozy-stack/pkg/utils"
 	"github.com/go-redis/redis"
@@ -162,8 +161,7 @@ func (b *redisBroker) pollLoop(key string, ch chan<- *Job) {
 		}
 
 		prefix, jobID := parts[0], parts[1]
-		db := couchdb.NewDatabase(prefix)
-		job, err := Get(db, jobID)
+		job, err := Get(prefixer.NewPrefixer("", prefix), jobID)
 		if err != nil {
 			joblog.Warnf("Cannot find job %s on domain %s: %s", parts[1], parts[0], err)
 			continue

--- a/pkg/jobs/redis_broker.go
+++ b/pkg/jobs/redis_broker.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cozy/cozy-stack/pkg/config"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/cozy/cozy-stack/pkg/utils"
 	"github.com/go-redis/redis"
 	multierror "github.com/hashicorp/go-multierror"
@@ -174,7 +175,7 @@ func (b *redisBroker) pollLoop(key string, ch chan<- *Job) {
 
 // PushJob will produce a new Job with the given options and enqueue the job in
 // the proper queue.
-func (b *redisBroker) PushJob(db couchdb.Database, req *JobRequest) (*Job, error) {
+func (b *redisBroker) PushJob(db prefixer.Prefixer, req *JobRequest) (*Job, error) {
 	if atomic.LoadUint32(&b.running) == 0 {
 		return nil, ErrClosed
 	}

--- a/pkg/jobs/redis_broker_test.go
+++ b/pkg/jobs/redis_broker_test.go
@@ -73,8 +73,7 @@ func TestRedisJobs(t *testing.T) {
 	assert.NoError(t, err)
 
 	msg, _ := NewMessage("z-0")
-	_, err = broker1.PushJob(&JobRequest{
-		Domain:     "cozy.local.redisjobs",
+	_, err = broker1.PushJob(localDB, &JobRequest{
 		WorkerType: "test",
 		Message:    msg,
 	})
@@ -83,8 +82,7 @@ func TestRedisJobs(t *testing.T) {
 	go func() {
 		for i := 0; i < n; i++ {
 			msg, _ := NewMessage("a-" + strconv.Itoa(i+1))
-			_, err = broker1.PushJob(&JobRequest{
-				Domain:     "cozy.local.redisjobs",
+			_, err = broker1.PushJob(localDB, &JobRequest{
 				WorkerType: "test",
 				Message:    msg,
 			})
@@ -96,8 +94,7 @@ func TestRedisJobs(t *testing.T) {
 	go func() {
 		for i := 0; i < n; i++ {
 			msg, _ := NewMessage("b-" + strconv.Itoa(i+1))
-			_, err = broker2.PushJob(&JobRequest{
-				Domain:     "cozy.local.redisjobs",
+			_, err = broker2.PushJob(localDB, &JobRequest{
 				WorkerType: "test",
 				Message:    msg,
 				Manual:     true,

--- a/pkg/jobs/redis_scheduler.go
+++ b/pkg/jobs/redis_scheduler.go
@@ -229,8 +229,9 @@ func (s *redisScheduler) PollScheduler(now int64) error {
 			s.client.ZRem(SchedKey, results[0])
 			return fmt.Errorf("Invalid key %s", res)
 		}
-		db := couchdb.NewDatabase(parts[0])
-		t, err := s.GetTrigger(db, parts[1])
+
+		prefix := parts[0]
+		t, err := s.GetTrigger(prefixer.NewPrefixer("", prefix), parts[1])
 		if err != nil {
 			if err == ErrNotFoundTrigger {
 				s.client.ZRem(SchedKey, results[0])

--- a/pkg/jobs/redis_scheduler_test.go
+++ b/pkg/jobs/redis_scheduler_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/pkg/jobs"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/cozy/cozy-stack/pkg/realtime"
 	"github.com/cozy/cozy-stack/pkg/utils"
 	"github.com/cozy/cozy-stack/pkg/vfs"
@@ -23,7 +24,6 @@ import (
 const redisURL = "redis://localhost:6379/15"
 
 var testInstance *instance.Instance
-var instanceName string
 
 type testDoc struct {
 	id      string
@@ -47,7 +47,7 @@ func (b *mockBroker) ShutdownWorkers(ctx context.Context) error {
 	return nil
 }
 
-func (b *mockBroker) PushJob(request *jobs.JobRequest) (*jobs.Job, error) {
+func (b *mockBroker) PushJob(db prefixer.Prefixer, request *jobs.JobRequest) (*jobs.Job, error) {
 	b.jobs = append(b.jobs, request)
 	return nil, nil
 }
@@ -98,19 +98,15 @@ func TestRedisSchedulerWithTimeTriggers(t *testing.T) {
 	wAt.Add(1) // 1 time in @at
 	wIn.Add(1) // 1 time in @in
 
-	at := &jobs.TriggerInfos{
+	at := jobs.TriggerInfos{
 		Type:       "@at",
-		Domain:     instanceName,
 		Arguments:  time.Now().Add(2 * time.Second).Format(time.RFC3339),
 		WorkerType: "worker",
-		Message:    msg1,
 	}
-	in := &jobs.TriggerInfos{
-		Domain:     instanceName,
+	in := jobs.TriggerInfos{
 		Type:       "@in",
 		Arguments:  "1s",
 		WorkerType: "worker",
-		Message:    msg2,
 	}
 
 	sch := jobs.System().(jobs.Scheduler)
@@ -118,19 +114,19 @@ func TestRedisSchedulerWithTimeTriggers(t *testing.T) {
 	sch.StartScheduler(bro)
 	time.Sleep(50 * time.Millisecond)
 
-	tat, err := jobs.NewTrigger(at)
+	tat, err := jobs.NewTrigger(testInstance, at, msg1)
 	assert.NoError(t, err)
 	err = sch.AddTrigger(tat)
 	assert.NoError(t, err)
 	atID := tat.Infos().TID
 
-	tin, err := jobs.NewTrigger(in)
+	tin, err := jobs.NewTrigger(testInstance, in, msg2)
 	assert.NoError(t, err)
 	err = sch.AddTrigger(tin)
 	assert.NoError(t, err)
 	inID := tin.Infos().TID
 
-	ts, err := sch.GetAllTriggers(instanceName)
+	ts, err := sch.GetAllTriggers(testInstance)
 	assert.NoError(t, err)
 	assert.Len(t, ts, 3) // 1 @event for thumbnails + 1 @at + 1 @in
 
@@ -170,11 +166,11 @@ func TestRedisSchedulerWithTimeTriggers(t *testing.T) {
 
 	time.Sleep(50 * time.Millisecond)
 
-	_, err = sch.GetTrigger(instanceName, atID)
+	_, err = sch.GetTrigger(testInstance, atID)
 	assert.Error(t, err)
 	assert.Equal(t, jobs.ErrNotFoundTrigger, err)
 
-	_, err = sch.GetTrigger(instanceName, inID)
+	_, err = sch.GetTrigger(testInstance, inID)
 	assert.Error(t, err)
 	assert.Equal(t, jobs.ErrNotFoundTrigger, err)
 }
@@ -194,14 +190,12 @@ func TestRedisSchedulerWithCronTriggers(t *testing.T) {
 
 	msg, _ := jobs.NewMessage("@cron")
 
-	infos := &jobs.TriggerInfos{
+	infos := jobs.TriggerInfos{
 		Type:       "@cron",
-		Domain:     instanceName,
 		Arguments:  "*/3 * * * * *",
 		WorkerType: "incr",
-		Message:    msg,
 	}
-	trigger, err := jobs.NewTrigger(infos)
+	trigger, err := jobs.NewTrigger(testInstance, infos, msg)
 	assert.NoError(t, err)
 	err = sch.AddTrigger(trigger)
 	assert.NoError(t, err)
@@ -233,17 +227,15 @@ func TestRedisPollFromSchedKey(t *testing.T) {
 
 	at := &jobs.TriggerInfos{
 		Type:       "@at",
-		Domain:     instanceName,
 		Arguments:  now.Format(time.RFC3339),
 		WorkerType: "incr",
 		Message:    msg,
 	}
-	db := couchdb.SimpleDatabasePrefix(instanceName)
-	err = couchdb.CreateDoc(db, at)
+	err = couchdb.CreateDoc(testInstance, at)
 	assert.NoError(t, err)
 
 	ts := now.UTC().Unix()
-	key := instanceName + "/" + at.TID
+	key := testInstance.Domain + "/" + at.TID
 	err = client.ZAdd(jobs.SchedKey, redis.Z{
 		Score:  float64(ts + 1),
 		Member: key,
@@ -275,24 +267,18 @@ func TestRedisTriggerEvent(t *testing.T) {
 	time.Sleep(1 * time.Second)
 	sch.StartScheduler(bro)
 
-	evTrigger := &jobs.TriggerInfos{
+	evTrigger := jobs.TriggerInfos{
 		Type:       "@event",
-		Domain:     instanceName,
 		Arguments:  "io.cozy.event-test:CREATED",
 		WorkerType: "incr",
 	}
-	tri, err := jobs.NewTrigger(evTrigger)
+
+	tri, err := jobs.NewTrigger(testInstance, evTrigger, nil)
 	assert.NoError(t, err)
 	sch.AddTrigger(tri)
 
-	realtime.GetHub().Publish(&realtime.Event{
-		Domain: instanceName,
-		Doc: &testDoc{
-			id:      "foo",
-			doctype: "io.cozy.event-test",
-		},
-		Verb: realtime.EventCreate,
-	})
+	realtime.GetHub().Publish(testInstance, realtime.EventCreate,
+		&testDoc{id: "foo", doctype: "io.cozy.event-test"}, nil)
 
 	time.Sleep(1 * time.Second)
 
@@ -303,6 +289,7 @@ func TestRedisTriggerEvent(t *testing.T) {
 
 	var evt struct {
 		Domain string `json:"domain"`
+		Prefix string `json:"prefix"`
 		Verb   string `json:"verb"`
 	}
 	var data string
@@ -311,26 +298,14 @@ func TestRedisTriggerEvent(t *testing.T) {
 	err = bro.jobs[0].Message.Unmarshal(&data)
 	assert.NoError(t, err)
 
-	assert.Equal(t, evt.Domain, instanceName)
+	assert.Equal(t, evt.Domain, testInstance.Domain)
 	assert.Equal(t, evt.Verb, "CREATED")
 
-	realtime.GetHub().Publish(&realtime.Event{
-		Domain: instanceName,
-		Doc: &testDoc{
-			id:      "foo",
-			doctype: "io.cozy.event-test",
-		},
-		Verb: realtime.EventUpdate,
-	})
+	realtime.GetHub().Publish(testInstance, realtime.EventUpdate,
+		&testDoc{id: "foo", doctype: "io.cozy.event-test"}, nil)
 
-	realtime.GetHub().Publish(&realtime.Event{
-		Domain: instanceName,
-		Doc: &testDoc{
-			id:      "foo",
-			doctype: "io.cozy.event-test.bad",
-		},
-		Verb: realtime.EventCreate,
-	})
+	realtime.GetHub().Publish(testInstance, realtime.EventCreate,
+		&testDoc{id: "foo", doctype: "io.cozy.event-test.bad"}, nil)
 
 	time.Sleep(10 * time.Millisecond)
 
@@ -370,13 +345,12 @@ func TestRedisTriggerEventForDirectories(t *testing.T) {
 	err = testInstance.VFS().CreateDirDoc(dir)
 	assert.NoError(t, err)
 
-	evTrigger := &jobs.TriggerInfos{
+	evTrigger := jobs.TriggerInfos{
 		Type:       "@event",
-		Domain:     instanceName,
 		Arguments:  "io.cozy.files:CREATED:" + dir.DocID,
 		WorkerType: "incr",
 	}
-	tri, err := jobs.NewTrigger(evTrigger)
+	tri, err := jobs.NewTrigger(testInstance, evTrigger, nil)
 	assert.NoError(t, err)
 	sch.AddTrigger(tri)
 
@@ -387,9 +361,8 @@ func TestRedisTriggerEventForDirectories(t *testing.T) {
 	}
 
 	barID := utils.RandomString(10)
-	realtime.GetHub().Publish(&realtime.Event{
-		Domain: instanceName,
-		Doc: &vfs.DirDoc{
+	realtime.GetHub().Publish(testInstance, realtime.EventCreate,
+		&vfs.DirDoc{
 			Type:      "directory",
 			DocID:     barID,
 			DocRev:    "1-" + utils.RandomString(10),
@@ -398,9 +371,7 @@ func TestRedisTriggerEventForDirectories(t *testing.T) {
 			CreatedAt: time.Now(),
 			UpdatedAt: time.Now(),
 			Fullpath:  "/foo/bar",
-		},
-		Verb: realtime.EventCreate,
-	})
+		}, nil)
 
 	time.Sleep(100 * time.Millisecond)
 	count, _ = bro.WorkerQueueLen("incr")
@@ -425,11 +396,7 @@ func TestRedisTriggerEventForDirectories(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "/foo/bar/baz", p)
 
-	realtime.GetHub().Publish(&realtime.Event{
-		Domain: instanceName,
-		Doc:    baz,
-		Verb:   realtime.EventCreate,
-	})
+	realtime.GetHub().Publish(testInstance, realtime.EventCreate, baz, nil)
 
 	time.Sleep(100 * time.Millisecond)
 	count, _ = bro.WorkerQueueLen("incr")
@@ -454,12 +421,7 @@ func TestRedisTriggerEventForDirectories(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "/quux", p)
 
-	realtime.GetHub().Publish(&realtime.Event{
-		Domain: instanceName,
-		Doc:    quux,
-		OldDoc: baz,
-		Verb:   realtime.EventCreate,
-	})
+	realtime.GetHub().Publish(testInstance, realtime.EventCreate, quux, baz)
 
 	time.Sleep(100 * time.Millisecond)
 	count, _ = bro.WorkerQueueLen("incr")
@@ -478,14 +440,13 @@ func TestRedisSchedulerWithDebounce(t *testing.T) {
 	time.Sleep(1 * time.Second)
 	sch.StartScheduler(bro)
 
-	evTrigger := &jobs.TriggerInfos{
+	evTrigger := jobs.TriggerInfos{
 		Type:       "@event",
-		Domain:     instanceName,
 		Arguments:  "io.cozy.debounce-test:CREATED io.cozy.debounce-more:CREATED",
 		WorkerType: "incr",
 		Debounce:   "4s",
 	}
-	tri, err := jobs.NewTrigger(evTrigger)
+	tri, err := jobs.NewTrigger(testInstance, evTrigger, nil)
 	assert.NoError(t, err)
 	sch.AddTrigger(tri)
 
@@ -493,24 +454,19 @@ func TestRedisSchedulerWithDebounce(t *testing.T) {
 		id:      "foo",
 		doctype: "io.cozy.debounce-test",
 	}
-	event := &realtime.Event{
-		Domain: instanceName,
-		Doc:    &doc,
-		Verb:   realtime.EventCreate,
-	}
 
 	for i := 0; i < 10; i++ {
 		time.Sleep(600 * time.Millisecond)
-		realtime.GetHub().Publish(event)
+		realtime.GetHub().Publish(testInstance, realtime.EventCreate, &doc, nil)
 	}
 
 	time.Sleep(5000 * time.Millisecond)
 	count, _ := bro.WorkerQueueLen("incr")
 	assert.Equal(t, 2, count)
 
-	realtime.GetHub().Publish(event)
+	realtime.GetHub().Publish(testInstance, realtime.EventCreate, &doc, nil)
 	doc.doctype = "io.cozy.debounce-more"
-	realtime.GetHub().Publish(event)
+	realtime.GetHub().Publish(testInstance, realtime.EventCreate, &doc, nil)
 	time.Sleep(5000 * time.Millisecond)
 	count, _ = bro.WorkerQueueLen("incr")
 	assert.Equal(t, 3, count)
@@ -530,7 +486,6 @@ func TestMain(m *testing.M) {
 	testutils.NeedCouchdb()
 	setup := testutils.NewSetup(m, "test_redis_scheduler")
 	testInstance = setup.GetTestInstance()
-	instanceName = testInstance.Domain
 
 	setup.AddCleanup(func() error {
 		cfg.Jobs.RedisConfig = was

--- a/pkg/jobs/redis_scheduler_test.go
+++ b/pkg/jobs/redis_scheduler_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cozy/cozy-stack/pkg/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/pkg/jobs"
 	"github.com/cozy/cozy-stack/pkg/prefixer"
@@ -233,7 +234,7 @@ func TestRedisPollFromSchedKey(t *testing.T) {
 	tat, err := jobs.NewTrigger(testInstance, at, msg)
 	assert.NoError(t, err)
 
-	err = sch.AddTrigger(tat)
+	err = couchdb.CreateDoc(testInstance, tat.Infos())
 	assert.NoError(t, err)
 
 	ts := now.UTC().Unix()

--- a/pkg/jobs/scheduler.go
+++ b/pkg/jobs/scheduler.go
@@ -46,7 +46,7 @@ type (
 		TID          string        `json:"_id,omitempty"`
 		TRev         string        `json:"_rev,omitempty"`
 		Domain       string        `json:"domain"`
-		Prefix       string        `json:"prefix"`
+		Prefix       string        `json:"prefix,omitempty"`
 		Type         string        `json:"type"`
 		WorkerType   string        `json:"worker"`
 		Arguments    string        `json:"arguments"`

--- a/pkg/jobs/scheduler.go
+++ b/pkg/jobs/scheduler.go
@@ -88,9 +88,13 @@ func (t *TriggerInfos) DomainName() string {
 // NewTrigger creates the trigger associates with the specified trigger
 // options.
 func NewTrigger(db prefixer.Prefixer, infos TriggerInfos, data interface{}) (Trigger, error) {
-	msg, err := NewMessage(data)
-	if err != nil {
-		return nil, err
+	var msg Message
+	var err error
+	if data != nil {
+		msg, err = NewMessage(data)
+		if err != nil {
+			return nil, err
+		}
 	}
 	infos.Message = msg
 	infos.Prefix = db.DBPrefix()

--- a/pkg/jobs/scheduler.go
+++ b/pkg/jobs/scheduler.go
@@ -72,6 +72,7 @@ type (
 	}
 )
 
+// DBPrefix implements the prefixer.Prefixer interface.
 func (t *TriggerInfos) DBPrefix() string {
 	if t.Prefix != "" {
 		return t.Prefix
@@ -79,6 +80,7 @@ func (t *TriggerInfos) DBPrefix() string {
 	return t.Domain
 }
 
+// DomainName implements the prefixer.Prefixer interface.
 func (t *TriggerInfos) DomainName() string {
 	return t.Domain
 }

--- a/pkg/jobs/scheduler.go
+++ b/pkg/jobs/scheduler.go
@@ -8,13 +8,14 @@ import (
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
 	"github.com/cozy/cozy-stack/pkg/permissions"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/cozy/cozy-stack/pkg/realtime"
 )
 
 type (
 	// Trigger interface is used to represent a trigger.
 	Trigger interface {
-		couchdb.Database
+		prefixer.Prefixer
 		permissions.Matcher
 		Type() string
 		Infos() *TriggerInfos
@@ -33,11 +34,11 @@ type (
 		ShutdownScheduler(ctx context.Context) error
 		PollScheduler(now int64) error
 		AddTrigger(trigger Trigger) error
-		GetTrigger(db couchdb.Database, id string) (Trigger, error)
-		DeleteTrigger(db couchdb.Database, id string) error
-		GetAllTriggers(db couchdb.Database) ([]Trigger, error)
+		GetTrigger(db prefixer.Prefixer, id string) (Trigger, error)
+		DeleteTrigger(db prefixer.Prefixer, id string) error
+		GetAllTriggers(db prefixer.Prefixer) ([]Trigger, error)
 		CleanRedis() error
-		RebuildRedis(db couchdb.Database) error
+		RebuildRedis(db prefixer.Prefixer) error
 	}
 
 	// TriggerInfos is a struct containing all the options of a trigger.
@@ -84,7 +85,7 @@ func (t *TriggerInfos) DomainName() string {
 
 // NewTrigger creates the trigger associates with the specified trigger
 // options.
-func NewTrigger(db couchdb.Database, infos TriggerInfos, data interface{}) (Trigger, error) {
+func NewTrigger(db prefixer.Prefixer, infos TriggerInfos, data interface{}) (Trigger, error) {
 	msg, err := NewMessage(data)
 	if err != nil {
 		return nil, err

--- a/pkg/jobs/trigger_cron.go
+++ b/pkg/jobs/trigger_cron.go
@@ -10,8 +10,8 @@ import (
 // CronTrigger implements the @cron trigger type. It schedules recurring jobs with
 // the weird but very used Cron syntax.
 type CronTrigger struct {
+	*TriggerInfos
 	sched cron.Schedule
-	infos *TriggerInfos
 	done  chan struct{}
 }
 
@@ -22,9 +22,9 @@ func NewCronTrigger(infos *TriggerInfos) (*CronTrigger, error) {
 		return nil, ErrMalformedTrigger
 	}
 	return &CronTrigger{
-		sched: schedule,
-		infos: infos,
-		done:  make(chan struct{}),
+		TriggerInfos: infos,
+		sched:        schedule,
+		done:         make(chan struct{}),
 	}, nil
 }
 
@@ -36,15 +36,15 @@ func NewEveryTrigger(infos *TriggerInfos) (*CronTrigger, error) {
 		return nil, ErrMalformedTrigger
 	}
 	return &CronTrigger{
-		sched: schedule,
-		infos: infos,
-		done:  make(chan struct{}),
+		TriggerInfos: infos,
+		sched:        schedule,
+		done:         make(chan struct{}),
 	}, nil
 }
 
 // Type implements the Type method of the Trigger interface.
 func (c *CronTrigger) Type() string {
-	return c.infos.Type
+	return c.TriggerInfos.Type
 }
 
 // DocType implements the permissions.Matcher interface
@@ -54,14 +54,14 @@ func (c *CronTrigger) DocType() string {
 
 // ID implements the permissions.Matcher interface
 func (c *CronTrigger) ID() string {
-	return c.infos.TID
+	return c.TriggerInfos.TID
 }
 
 // Match implements the permissions.Matcher interface
 func (c *CronTrigger) Match(key, value string) bool {
 	switch key {
 	case WorkerType:
-		return c.infos.WorkerType == value
+		return c.TriggerInfos.WorkerType == value
 	}
 	return false
 }
@@ -80,7 +80,7 @@ func (c *CronTrigger) Schedule() <-chan *JobRequest {
 			next = c.NextExecution(next)
 			select {
 			case <-time.After(-time.Since(next)):
-				ch <- c.infos.JobRequest()
+				ch <- c.TriggerInfos.JobRequest()
 			case <-c.done:
 				close(ch)
 				return
@@ -97,7 +97,7 @@ func (c *CronTrigger) Unschedule() {
 
 // Infos implements the Infos method of the Trigger interface.
 func (c *CronTrigger) Infos() *TriggerInfos {
-	return c.infos
+	return c.TriggerInfos
 }
 
 var _ Trigger = &CronTrigger{}

--- a/pkg/jobs/trigger_event.go
+++ b/pkg/jobs/trigger_event.go
@@ -66,7 +66,7 @@ func (t *EventTrigger) Match(key, value string) bool {
 func (t *EventTrigger) Schedule() <-chan *JobRequest {
 	ch := make(chan *JobRequest)
 	go func() {
-		sub := realtime.GetHub().Subscriber(t.TriggerInfos.Domain)
+		sub := realtime.GetHub().Subscriber(t)
 		for _, m := range t.mask {
 			sub.Subscribe(m.Type)
 		}

--- a/pkg/jobs/trigger_event_test.go
+++ b/pkg/jobs/trigger_event_test.go
@@ -56,7 +56,8 @@ func TestTriggerEvent(t *testing.T) {
 
 	db := prefixer.NewPrefixer("cozy.local.triggerevent", "cozy.local.triggerevent")
 
-	triggers := []TriggerInfos{
+	var triggers []Trigger
+	triggersInfos := []TriggerInfos{
 		{
 			Type:       "@event",
 			Arguments:  "io.cozy.testeventobject:DELETED",
@@ -92,7 +93,7 @@ func TestTriggerEvent(t *testing.T) {
 	sch := newMemScheduler()
 	sch.StartScheduler(bro)
 
-	for _, infos := range triggers {
+	for _, infos := range triggersInfos {
 		trigger, err := NewTrigger(db, infos, infos.Message)
 		if !assert.NoError(t, err) {
 			return
@@ -101,6 +102,7 @@ func TestTriggerEvent(t *testing.T) {
 		if !assert.NoError(t, err) {
 			return
 		}
+		triggers = append(triggers, trigger)
 	}
 
 	wg.Add(3)
@@ -126,7 +128,7 @@ func TestTriggerEvent(t *testing.T) {
 	assert.False(t, called["message-correct-verb-bad-value"])
 
 	for _, trigger := range triggers {
-		err := sch.DeleteTrigger(db, trigger.TID)
+		err := sch.DeleteTrigger(db, trigger.ID())
 		assert.NoError(t, err)
 	}
 

--- a/pkg/jobs/worker.go
+++ b/pkg/jobs/worker.go
@@ -279,7 +279,7 @@ func (w *Worker) work(workerID string, closed chan<- struct{}) {
 		// through the global job-system.
 		if job.TriggerID != "" && globalJobSystem != nil {
 			if _, ok := errRun.(ErrBadTrigger); ok {
-				globalJobSystem.DeleteTrigger(job.Domain, job.TriggerID)
+				globalJobSystem.DeleteTrigger(job, job.TriggerID)
 			}
 		}
 	}

--- a/pkg/lock/lock.go
+++ b/pkg/lock/lock.go
@@ -1,14 +1,17 @@
 package lock
 
-import "github.com/cozy/cozy-stack/pkg/config"
+import (
+	"github.com/cozy/cozy-stack/pkg/config"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+)
 
 // ReadWrite returns the read/write lock for the given name.
 // By convention, the name should be prefixed by the instance domain on which
 // it applies, then a slash and the package name (ie alice.example.net/vfs).
-func ReadWrite(name string) ErrorRWLocker {
+func ReadWrite(db couchdb.Database, name string) ErrorRWLocker {
 	cli := config.GetConfig().Lock.Client()
 	if cli != nil {
-		return getRedisReadWriteLock(cli, name)
+		return getRedisReadWriteLock(cli, db.DBPrefix()+"/"+name)
 	}
 	return getMemReadWriteLock(name)
 }

--- a/pkg/lock/lock.go
+++ b/pkg/lock/lock.go
@@ -2,13 +2,13 @@ package lock
 
 import (
 	"github.com/cozy/cozy-stack/pkg/config"
-	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 )
 
 // ReadWrite returns the read/write lock for the given name.
 // By convention, the name should be prefixed by the instance domain on which
 // it applies, then a slash and the package name (ie alice.example.net/vfs).
-func ReadWrite(db couchdb.Database, name string) ErrorRWLocker {
+func ReadWrite(db prefixer.Prefixer, name string) ErrorRWLocker {
 	cli := config.GetConfig().Lock.Client()
 	if cli != nil {
 		return getRedisReadWriteLock(cli, db.DBPrefix()+"/"+name)

--- a/pkg/lock/lock_test.go
+++ b/pkg/lock/lock_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/cozy/cozy-stack/pkg/config"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 )
 
 func reader(rwm ErrorRWLocker, iterations int, activity *int32, cdone chan bool) {
@@ -94,7 +95,8 @@ func TestMemLock(t *testing.T) {
 	}
 	defer func() { config.GetConfig().Lock = backconf }()
 	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(-1))
-	l := ReadWrite("test-mem")
+	db := prefixer.NewPrefixer("cozy.local", "cozy.local")
+	l := ReadWrite(db, "test-mem")
 	HammerRWMutex(l, 1, 1, n)
 	HammerRWMutex(l, 1, 3, n)
 	HammerRWMutex(l, 1, 10, n)
@@ -116,7 +118,8 @@ func TestRedisLock(t *testing.T) {
 	}
 	defer func() { config.GetConfig().Lock = backconf }()
 	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(-1))
-	l := ReadWrite("test-redis")
+	db := prefixer.NewPrefixer("cozy.local", "cozy.local")
+	l := ReadWrite(db, "test-redis")
 	// @TODO use HammerRWMutex when redisLock is RW lock
 	done := make(chan bool)
 	for i := 0; i < 10; i++ {

--- a/pkg/move/export_test.go
+++ b/pkg/move/export_test.go
@@ -20,8 +20,6 @@ import (
 var inst *instance.Instance
 var filename string
 
-var testdb couchdb.Database
-
 func TestTardir(t *testing.T) {
 	fs := inst.VFS()
 
@@ -47,7 +45,7 @@ func TestTardir(t *testing.T) {
 	m := testJsondoc.ToMapWithType()
 	m["name"] = "albumTest"
 	delete(testJsondoc.M, "_type")
-	err = couchdb.CreateDoc(testdb, testJsondoc)
+	err = couchdb.CreateDoc(inst, testJsondoc)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, testJsondoc.Rev(), testJsondoc.ID())
 
@@ -72,7 +70,7 @@ func TestTardir(t *testing.T) {
 	assert.NoError(t, err)
 
 	image.AddReferencedBy(*testAlbumref)
-	err = couchdb.UpdateDoc(testdb, image)
+	err = couchdb.UpdateDoc(inst, image)
 	assert.NoError(t, err)
 
 	filename, err = Export(inst)
@@ -139,7 +137,7 @@ func TestImport(t *testing.T) {
 	assert.NotNil(t, photo.ReferencedBy)
 
 	var results []map[string]interface{}
-	err = couchdb.GetAllDocs(testdb, consts.PhotosAlbums, &couchdb.AllDocsRequest{}, &results)
+	err = couchdb.GetAllDocs(inst, consts.PhotosAlbums, &couchdb.AllDocsRequest{}, &results)
 	assert.NoError(t, err)
 
 	for _, val := range results {
@@ -158,7 +156,6 @@ func TestMain(m *testing.M) {
 
 	setup := testutils.NewSetup(m, "export_test")
 	inst = setup.GetTestInstance()
-	testdb = couchdb.NewDatabase(inst.Domain)
 
 	os.Exit(setup.Run())
 }

--- a/pkg/move/export_test.go
+++ b/pkg/move/export_test.go
@@ -158,7 +158,7 @@ func TestMain(m *testing.M) {
 
 	setup := testutils.NewSetup(m, "export_test")
 	inst = setup.GetTestInstance()
-	testdb = couchdb.SimpleDatabasePrefix(inst.Domain)
+	testdb = couchdb.NewDatabase(inst.Domain)
 
 	os.Exit(setup.Run())
 }

--- a/pkg/move/import.go
+++ b/pkg/move/import.go
@@ -18,12 +18,13 @@ import (
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/pkg/logger"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/cozy/cozy-stack/pkg/utils"
 	"github.com/cozy/cozy-stack/pkg/vfs"
 	vcardParser "github.com/emersion/go-vcard"
 )
 
-func createContact(fs vfs.VFS, hdr *tar.Header, tr *tar.Reader, db couchdb.Database) error {
+func createContact(fs vfs.VFS, hdr *tar.Header, tr *tar.Reader, db prefixer.Prefixer) error {
 	decoder := vcardParser.NewDecoder(tr)
 	vcard, err := decoder.Decode()
 	if err != nil {

--- a/pkg/notification/center/notification_center.go
+++ b/pkg/notification/center/notification_center.go
@@ -231,8 +231,7 @@ func sendPush(inst *instance.Instance, p *notification.Properties, n *notificati
 	if err != nil {
 		return err
 	}
-	_, err = jobs.System().PushJob(&jobs.JobRequest{
-		Domain:     inst.Domain,
+	_, err = jobs.System().PushJob(inst, &jobs.JobRequest{
 		WorkerType: "push",
 		Message:    msg,
 	})
@@ -265,8 +264,7 @@ func sendMail(inst *instance.Instance, p *notification.Properties, n *notificati
 	if err != nil {
 		return err
 	}
-	_, err = jobs.System().PushJob(&jobs.JobRequest{
-		Domain:     inst.Domain,
+	_, err = jobs.System().PushJob(inst, &jobs.JobRequest{
 		WorkerType: "sendmail",
 		Message:    msg,
 	})

--- a/pkg/prefixer/prefixer.go
+++ b/pkg/prefixer/prefixer.go
@@ -12,8 +12,14 @@ type prefixer struct {
 	prefix string
 }
 
-func (p *prefixer) DBPrefix() string   { return p.prefix }
-func (p *prefixer) DomainName() string { return p.domain }
+func (p *prefixer) DBPrefix() string { return p.prefix }
+
+func (p *prefixer) DomainName() string {
+	if p.domain == "" {
+		return "<unknown>"
+	}
+	return p.domain
+}
 
 // NewPrefixer returns a prefixer with the specified domain and prefix values.
 func NewPrefixer(domain, prefix string) Prefixer {

--- a/pkg/prefixer/prefixer.go
+++ b/pkg/prefixer/prefixer.go
@@ -1,5 +1,7 @@
 package prefixer
 
+// Pefixer interface describes a handle for a specific instance by its domain
+// and a specific and unique prefix.
 type Prefixer interface {
 	DBPrefix() string
 	DomainName() string

--- a/pkg/prefixer/prefixer.go
+++ b/pkg/prefixer/prefixer.go
@@ -1,0 +1,22 @@
+package prefixer
+
+type Prefixer interface {
+	DBPrefix() string
+	DomainName() string
+}
+
+type prefixer struct {
+	domain string
+	prefix string
+}
+
+func (p *prefixer) DBPrefix() string   { return p.prefix }
+func (p *prefixer) DomainName() string { return p.domain }
+
+// NewPrefixer returns a prefixer with the specified domain and prefix values.
+func NewPrefixer(domain, prefix string) Prefixer {
+	return &prefixer{
+		domain: domain,
+		prefix: prefix,
+	}
+}

--- a/pkg/prefixer/prefixer.go
+++ b/pkg/prefixer/prefixer.go
@@ -1,6 +1,6 @@
 package prefixer
 
-// Pefixer interface describes a handle for a specific instance by its domain
+// Prefixer interface describes a handle for a specific instance by its domain
 // and a specific and unique prefix.
 type Prefixer interface {
 	DBPrefix() string

--- a/pkg/realtime/mem_realtime.go
+++ b/pkg/realtime/mem_realtime.go
@@ -17,7 +17,9 @@ func newMemHub() *memHub {
 	return &memHub{topics: make(map[string]*topic)}
 }
 
-func (h *memHub) Publish(e *Event) {
+func (h *memHub) Publish(db prefixer.Prefixer, e *Event) {
+	e.Domain = db.DomainName()
+	e.Prefix = db.DBPrefix()
 	topic := h.get(e, e.Doc.DocType())
 	if topic != nil {
 		topic.broadcast <- e

--- a/pkg/realtime/mem_realtime.go
+++ b/pkg/realtime/mem_realtime.go
@@ -17,10 +17,9 @@ func newMemHub() *memHub {
 	return &memHub{topics: make(map[string]*topic)}
 }
 
-func (h *memHub) Publish(db prefixer.Prefixer, e *Event) {
-	e.Domain = db.DomainName()
-	e.Prefix = db.DBPrefix()
-	topic := h.get(e, e.Doc.DocType())
+func (h *memHub) Publish(db prefixer.Prefixer, verb string, doc, oldDoc Doc) {
+	e := newEvent(db, verb, doc, oldDoc)
+	topic := h.get(e, doc.DocType())
 	if topic != nil {
 		topic.broadcast <- e
 	}

--- a/pkg/realtime/realtime.go
+++ b/pkg/realtime/realtime.go
@@ -31,6 +31,7 @@ type Event struct {
 	OldDoc Doc    `json:"old,omitempty"`
 }
 
+// DBPrefix implements the prefixer.Prefixer interface.
 func (e *Event) DBPrefix() string {
 	if e.Prefix != "" {
 		return e.Prefix
@@ -38,6 +39,7 @@ func (e *Event) DBPrefix() string {
 	return e.Domain
 }
 
+// DomainName implements the prefixer.Prefixer interface.
 func (e *Event) DomainName() string {
 	return e.Domain
 }
@@ -47,7 +49,7 @@ func (e *Event) DomainName() string {
 // Hub is an object which recive events and calls appropriate listener
 type Hub interface {
 	// Emit is used by publishers when an event occurs
-	Publish(event *Event)
+	Publish(db prefixer.Prefixer, event *Event)
 
 	// Subscriber creates a DynamicSubscriber that can subscribe to several
 	// doctypes. Call its Close method to Unsubscribe.

--- a/pkg/realtime/realtime.go
+++ b/pkg/realtime/realtime.go
@@ -31,6 +31,16 @@ type Event struct {
 	OldDoc Doc    `json:"old,omitempty"`
 }
 
+func newEvent(db prefixer.Prefixer, verb string, doc Doc, oldDoc Doc) *Event {
+	return &Event{
+		Domain: db.DomainName(),
+		Prefix: db.DBPrefix(),
+		Verb:   verb,
+		Doc:    doc,
+		OldDoc: oldDoc,
+	}
+}
+
 // DBPrefix implements the prefixer.Prefixer interface.
 func (e *Event) DBPrefix() string {
 	if e.Prefix != "" {
@@ -49,7 +59,7 @@ func (e *Event) DomainName() string {
 // Hub is an object which recive events and calls appropriate listener
 type Hub interface {
 	// Emit is used by publishers when an event occurs
-	Publish(db prefixer.Prefixer, event *Event)
+	Publish(db prefixer.Prefixer, verb string, doc Doc, oldDoc Doc)
 
 	// Subscriber creates a DynamicSubscriber that can subscribe to several
 	// doctypes. Call its Close method to Unsubscribe.

--- a/pkg/realtime/realtime.go
+++ b/pkg/realtime/realtime.go
@@ -24,9 +24,21 @@ type Doc interface {
 // Event is the basic message structure manipulated by the realtime package
 type Event struct {
 	Domain string `json:"domain"`
+	Prefix string `json:"prefix,omitempty"`
 	Verb   string `json:"verb"`
 	Doc    Doc    `json:"doc"`
 	OldDoc Doc    `json:"old,omitempty"`
+}
+
+func (e *Event) DBPrefix() string {
+	if e.Prefix != "" {
+		return e.Prefix
+	}
+	return e.Domain
+}
+
+func (e *Event) DomainName() string {
+	return e.Domain
 }
 
 // The following API is inspired by https://github.com/gocontrib/pubsub

--- a/pkg/realtime/redis_hub.go
+++ b/pkg/realtime/redis_hub.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/cozy/cozy-stack/pkg/logger"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 	redis "github.com/go-redis/redis"
 )
 
@@ -105,7 +106,7 @@ func (h *redisHub) start() {
 	}
 }
 
-func (h *redisHub) GetTopic(domain, doctype string) *topic {
+func (h *redisHub) GetTopic(db prefixer.Prefixer, doctype string) *topic {
 	return nil
 }
 
@@ -120,12 +121,12 @@ func (h *redisHub) Publish(e *Event) {
 	h.c.Publish(eventsRedisKey, e.Doc.DocType()+","+string(buf))
 }
 
-func (h *redisHub) Subscriber(domain string) *DynamicSubscriber {
-	return h.mem.Subscriber(domain)
+func (h *redisHub) Subscriber(db prefixer.Prefixer) *DynamicSubscriber {
+	return h.mem.Subscriber(db)
 }
 
 func (h *redisHub) SubscribeLocalAll() *DynamicSubscriber {
-	ds := newDynamicSubscriber(nil, "")
+	ds := newDynamicSubscriber(nil, globalPrefixer)
 	ds.addTopic(h.local, "")
 	return ds
 }

--- a/pkg/sessions/cache.go
+++ b/pkg/sessions/cache.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/cozy/cozy-stack/pkg/cache"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 )
 
 const sessionCacheKey = "session"
@@ -13,18 +14,18 @@ type sessionsCache struct {
 	base cache.Cache
 }
 
-func (ic *sessionsCache) Get(domain, id string) *Session {
+func (ic *sessionsCache) Get(db prefixer.Prefixer, id string) *Session {
 	var s Session
-	if ok := ic.base.Get(domain+id, &s); ok {
+	if ok := ic.base.Get(db.DBPrefix()+id, &s); ok {
 		return &s
 	}
 	return nil
 }
-func (ic *sessionsCache) Set(domain, id string, s *Session) {
-	ic.base.Set(domain+id, s)
+func (ic *sessionsCache) Set(db prefixer.Prefixer, id string, s *Session) {
+	ic.base.Set(db.DBPrefix()+id, s)
 }
-func (ic *sessionsCache) Revoke(domain, id string) {
-	ic.base.Del(domain + id)
+func (ic *sessionsCache) Revoke(db prefixer.Prefixer, id string) {
+	ic.base.Del(db.DBPrefix() + id)
 }
 
 var mu sync.Mutex

--- a/pkg/sessions/cache_test.go
+++ b/pkg/sessions/cache_test.go
@@ -4,8 +4,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/stretchr/testify/assert"
 )
+
+var testDB = prefixer.NewPrefixer("cached.cozy.tools", "cached.cozy.tools")
 
 func TestCache(t *testing.T) {
 	globalCache = nil
@@ -17,16 +20,16 @@ func TestCache(t *testing.T) {
 		DocID:    "2caafe00-8c05-11e7-bea5-0792f2ba5a60",
 		LastSeen: time.Now(),
 	}
-	getCache().Set("cached.cozy.tools", s.DocID, s)
+	getCache().Set(testDB, s.DocID, s)
 
-	s2 := getCache().Get("cached.cozy.tools", s.DocID)
+	s2 := getCache().Get(testDB, s.DocID)
 	assert.NotNil(t, s2)
 	assert.Equal(t, s.DocID, s2.DocID)
 	assert.Equal(t, s.LastSeen.Unix(), s2.LastSeen.Unix())
 
-	globalCache.Revoke("cached.cozy.tools", s.DocID)
+	globalCache.Revoke(testDB, s.DocID)
 
-	s3 := getCache().Get("cached.cozy.tools", s.DocID)
+	s3 := getCache().Get(testDB, s.DocID)
 	assert.Nil(t, s3)
 
 }

--- a/pkg/sessions/login_history.go
+++ b/pkg/sessions/login_history.go
@@ -129,7 +129,7 @@ func StoreNewLoginEntry(i *instance.Instance, sessionID, clientID string, req *h
 	}
 
 	if clientID != "" {
-		if err := PushLoginRegistration(i.Domain, l, clientID); err != nil {
+		if err := PushLoginRegistration(i, l, clientID); err != nil {
 			i.Logger().Errorf("Could not push login in registration queue: %s", err)
 		}
 	} else if notifEnabled {

--- a/pkg/sessions/registration_logins.go
+++ b/pkg/sessions/registration_logins.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/pkg/logger"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/cozy/cozy-stack/pkg/utils"
 )
 
@@ -85,9 +86,9 @@ func (s *sweeper) Shutdown(ctx context.Context) error {
 }
 
 // PushLoginRegistration pushes a new login into the registration queue.
-func PushLoginRegistration(domain string, login *LoginEntry, clientID string) error {
+func PushLoginRegistration(db prefixer.Prefixer, login *LoginEntry, clientID string) error {
 	entry := registrationEntry{
-		Domain:       domain,
+		Domain:       db.DomainName(),
 		ClientID:     clientID,
 		LoginEntryID: login.ID(),
 		Expire:       time.Now(),

--- a/pkg/sessions/session.go
+++ b/pkg/sessions/session.go
@@ -83,7 +83,7 @@ func New(i *instance.Instance) (*Session, error) {
 	if err := couchdb.CreateDoc(i, s); err != nil {
 		return nil, err
 	}
-	getCache().Set(i.Domain, s.DocID, s)
+	getCache().Set(i, s.DocID, s)
 	return s, nil
 }
 
@@ -91,7 +91,7 @@ func New(i *instance.Instance) (*Session, error) {
 func Get(i *instance.Instance, sessionID string) (*Session, error) {
 	updateCache := false
 
-	s := getCache().Get(i.Domain, sessionID)
+	s := getCache().Get(i, sessionID)
 	if s == nil {
 		s = &Session{}
 		err := couchdb.GetDoc(i, consts.Sessions, sessionID, s)
@@ -112,7 +112,7 @@ func Get(i *instance.Instance, sessionID string) (*Session, error) {
 		if err != nil {
 			i.Logger().Warn("[session] Failed to delete expired session:", err)
 		}
-		getCache().Revoke(i.Domain, s.DocID)
+		getCache().Revoke(i, s.DocID)
 		return nil, ErrExpired
 	}
 
@@ -133,7 +133,7 @@ func Get(i *instance.Instance, sessionID string) (*Session, error) {
 	}
 
 	if updateCache {
-		getCache().Set(i.Domain, s.DocID, s)
+		getCache().Set(i, s.DocID, s)
 	}
 
 	return s, nil
@@ -187,7 +187,7 @@ func GetAll(inst *instance.Instance) ([]*Session, error) {
 // and returns a cookie with a negative MaxAge to clear it
 func (s *Session) Delete(i *instance.Instance) *http.Cookie {
 	err := couchdb.DeleteDoc(i, s)
-	getCache().Revoke(i.Domain, s.DocID)
+	getCache().Revoke(i, s.DocID)
 	if err != nil {
 		i.Logger().Error("[session] Failed to delete session:", err)
 	}

--- a/pkg/sharing/indexer.go
+++ b/pkg/sharing/indexer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/crypto"
 	"github.com/cozy/cozy-stack/pkg/instance"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/cozy/cozy-stack/pkg/realtime"
 	"github.com/cozy/cozy-stack/pkg/vfs"
 )
@@ -18,7 +19,7 @@ type bulkRevs struct {
 }
 
 type sharingIndexer struct {
-	db       couchdb.Database
+	db       prefixer.Prefixer
 	indexer  vfs.Indexer
 	bulkRevs *bulkRevs
 	shared   *SharedRef

--- a/pkg/sharing/mail.go
+++ b/pkg/sharing/mail.go
@@ -93,8 +93,7 @@ func (m *Member) SendMail(inst *instance.Instance, s *Sharing, sharer, descripti
 	if err != nil {
 		return err
 	}
-	_, err = jobs.System().PushJob(&jobs.JobRequest{
-		Domain:     inst.Domain,
+	_, err = jobs.System().PushJob(inst, &jobs.JobRequest{
 		WorkerType: "sendmail",
 		Options:    nil,
 		Message:    msg,

--- a/pkg/sharing/member.go
+++ b/pkg/sharing/member.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/crypto"
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/pkg/permissions"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 )
 
 const (
@@ -99,7 +100,7 @@ func (s *Sharing) FindMemberByState(state string) (*Member, error) {
 
 // FindMemberBySharecode returns the member that is linked to the sharing by
 // the given sharecode
-func (s *Sharing) FindMemberBySharecode(db couchdb.Database, sharecode string) (*Member, error) {
+func (s *Sharing) FindMemberBySharecode(db prefixer.Prefixer, sharecode string) (*Member, error) {
 	if !s.Owner {
 		return nil, ErrInvalidSharing
 	}

--- a/pkg/sharing/replicator.go
+++ b/pkg/sharing/replicator.go
@@ -36,7 +36,7 @@ type ReplicateMsg struct {
 
 // Replicate starts a replicator on this sharing.
 func (s *Sharing) Replicate(inst *instance.Instance, errors int) error {
-	mu := lock.ReadWrite(inst.Domain + "/sharings/" + s.SID)
+	mu := lock.ReadWrite(inst, "sharings/"+s.SID)
 	mu.Lock()
 	defer mu.Unlock()
 

--- a/pkg/sharing/replicator.go
+++ b/pkg/sharing/replicator.go
@@ -80,8 +80,7 @@ func (s *Sharing) pushJob(inst *instance.Instance, worker string) {
 			Warnf("Error on push job to %s: %s", worker, err)
 		return
 	}
-	_, err = jobs.System().PushJob(&jobs.JobRequest{
-		Domain:     inst.Domain,
+	_, err = jobs.System().PushJob(inst, &jobs.JobRequest{
 		WorkerType: worker,
 		Message:    msg,
 	})
@@ -111,13 +110,11 @@ func (s *Sharing) retryWorker(inst *instance.Instance, worker string, errors int
 			Warnf("Error on retry to %s: %s", worker, err)
 		return
 	}
-	t, err := jobs.NewTrigger(&jobs.TriggerInfos{
-		Domain:     inst.Domain,
+	t, err := jobs.NewTrigger(inst, jobs.TriggerInfos{
 		Type:       "@in",
 		WorkerType: worker,
-		Message:    msg,
 		Arguments:  backoff.String(),
-	})
+	}, msg)
 	if err != nil {
 		inst.Logger().WithField("nspace", "replicator").
 			Warnf("Error on retry to %s: %s", worker, err)

--- a/pkg/sharing/setup.go
+++ b/pkg/sharing/setup.go
@@ -67,7 +67,7 @@ func (s *Sharing) Setup(inst *instance.Instance, m *Member) {
 		}
 	}()
 
-	mu := lock.ReadWrite(inst.Domain + "/sharings/" + s.SID)
+	mu := lock.ReadWrite(inst, "sharings/"+s.SID)
 	mu.Lock()
 	defer mu.Unlock()
 
@@ -189,7 +189,7 @@ func (s *Sharing) InitialCopy(inst *instance.Instance, rule Rule, r int) error {
 		return nil
 	}
 
-	mu := lock.ReadWrite(inst.Domain + "/shared")
+	mu := lock.ReadWrite(inst, "shared")
 	mu.Lock()
 	defer mu.Unlock()
 

--- a/pkg/sharing/setup.go
+++ b/pkg/sharing/setup.go
@@ -130,21 +130,16 @@ func (s *Sharing) AddTrackTriggers(inst *instance.Instance) error {
 		if args == "" {
 			continue
 		}
-		msg, err := jobs.NewMessage(&TrackMessage{
+		msg := &TrackMessage{
 			SharingID: s.SID,
 			RuleIndex: i,
 			DocType:   rule.DocType,
-		})
-		if err != nil {
-			return err
 		}
-		t, err := jobs.NewTrigger(&jobs.TriggerInfos{
-			Domain:     inst.Domain,
+		t, err := jobs.NewTrigger(inst, jobs.TriggerInfos{
 			Type:       "@event",
 			WorkerType: "share-track",
-			Message:    msg,
 			Arguments:  args,
-		})
+		}, msg)
 		if err != nil {
 			return err
 		}
@@ -163,22 +158,18 @@ func (s *Sharing) AddReplicateTrigger(inst *instance.Instance) error {
 	if s.Triggers.ReplicateID != "" {
 		return nil
 	}
-	msg, err := jobs.NewMessage(&ReplicateMsg{
+	msg := &ReplicateMsg{
 		SharingID: s.SID,
 		Errors:    0,
-	})
-	if err != nil {
-		return err
 	}
 	args := consts.Shared + ":CREATED,UPDATED:" + s.SID + ":sharing"
-	t, err := jobs.NewTrigger(&jobs.TriggerInfos{
+	t, err := jobs.NewTrigger(inst, jobs.TriggerInfos{
 		Domain:     inst.Domain,
 		Type:       "@event",
 		WorkerType: "share-replicate",
-		Message:    msg,
 		Arguments:  args,
 		Debounce:   "5s",
-	})
+	}, msg)
 	inst.Logger().WithField("nspace", "sharing").Infof("Create trigger %#v", t)
 	if err != nil {
 		return err
@@ -342,22 +333,18 @@ func (s *Sharing) AddUploadTrigger(inst *instance.Instance) error {
 	if s.Triggers.UploadID != "" {
 		return nil
 	}
-	msg, err := jobs.NewMessage(&UploadMsg{
+	msg := &UploadMsg{
 		SharingID: s.SID,
 		Errors:    0,
-	})
-	if err != nil {
-		return err
 	}
 	args := consts.Shared + ":CREATED,UPDATED:" + s.SID + ":sharing"
-	t, err := jobs.NewTrigger(&jobs.TriggerInfos{
+	t, err := jobs.NewTrigger(inst, jobs.TriggerInfos{
 		Domain:     inst.Domain,
 		Type:       "@event",
 		WorkerType: "share-upload",
-		Message:    msg,
 		Arguments:  args,
 		Debounce:   "5s",
-	})
+	}, msg)
 	inst.Logger().WithField("nspace", "sharing").Infof("Create trigger %#v", t)
 	if err != nil {
 		return err

--- a/pkg/sharing/shared.go
+++ b/pkg/sharing/shared.go
@@ -178,7 +178,7 @@ func isNoLongerShared(inst *instance.Instance, msg TrackMessage, evt TrackEvent)
 // UpdateShared updates the io.cozy.shared database when a document is
 // created/update/removed
 func UpdateShared(inst *instance.Instance, msg TrackMessage, evt TrackEvent) error {
-	mu := lock.ReadWrite(inst.Domain + "/shared")
+	mu := lock.ReadWrite(inst, "shared")
 	mu.Lock()
 	defer mu.Unlock()
 

--- a/pkg/sharing/sharing.go
+++ b/pkg/sharing/sharing.go
@@ -276,7 +276,7 @@ func (s *Sharing) RemoveTriggers(inst *instance.Instance) error {
 func removeSharingTrigger(inst *instance.Instance, triggerID string) error {
 	if triggerID != "" {
 		sched := jobs.System()
-		if err := sched.DeleteTrigger(inst.Domain, triggerID); err != nil {
+		if err := sched.DeleteTrigger(inst, triggerID); err != nil {
 			return err
 		}
 	}

--- a/pkg/sharing/sharing.go
+++ b/pkg/sharing/sharing.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/pkg/jobs"
 	"github.com/cozy/cozy-stack/pkg/permissions"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 	multierror "github.com/hashicorp/go-multierror"
 )
 
@@ -340,7 +341,7 @@ func (s *Sharing) NoMoreRecipient(inst *instance.Instance) error {
 }
 
 // FindSharing retrieves a sharing document from its ID
-func FindSharing(db couchdb.Database, sharingID string) (*Sharing, error) {
+func FindSharing(db prefixer.Prefixer, sharingID string) (*Sharing, error) {
 	res := &Sharing{}
 	err := couchdb.GetDoc(db, consts.Sharings, sharingID, res)
 	if err != nil {
@@ -350,7 +351,7 @@ func FindSharing(db couchdb.Database, sharingID string) (*Sharing, error) {
 }
 
 // FindSharings retrieves an array of sharing documents from their IDs
-func FindSharings(db couchdb.Database, sharingIDs []string) ([]*Sharing, error) {
+func FindSharings(db prefixer.Prefixer, sharingIDs []string) ([]*Sharing, error) {
 	var req = &couchdb.AllDocsRequest{
 		Keys: sharingIDs,
 	}

--- a/pkg/sharing/upload.go
+++ b/pkg/sharing/upload.go
@@ -26,7 +26,7 @@ type UploadMsg struct {
 
 // Upload starts uploading files for this sharing
 func (s *Sharing) Upload(inst *instance.Instance, errors int) error {
-	mu := lock.ReadWrite(inst.Domain + "/sharings/" + s.SID + "/upload")
+	mu := lock.ReadWrite(inst, "sharings/"+s.SID+"/upload")
 	mu.Lock()
 	defer mu.Unlock()
 
@@ -71,7 +71,7 @@ func (s *Sharing) Upload(inst *instance.Instance, errors int) error {
 
 // InitialUpload uploads files to just a member, for the first time
 func (s *Sharing) InitialUpload(inst *instance.Instance, m *Member) error {
-	mu := lock.ReadWrite(inst.Domain + "/sharings/" + s.SID + "/upload")
+	mu := lock.ReadWrite(inst, "sharings/"+s.SID+"/upload")
 	mu.Lock()
 	defer mu.Unlock()
 

--- a/pkg/sharing/upload.go
+++ b/pkg/sharing/upload.go
@@ -285,7 +285,7 @@ type KeyToUpload struct {
 }
 
 func (s *Sharing) createUploadKey(inst *instance.Instance, target *FileDocWithRevisions) (*KeyToUpload, error) {
-	key, err := getStore().Save(inst.Domain, target)
+	key, err := getStore().Save(inst, target)
 	if err != nil {
 		return nil, err
 	}
@@ -296,7 +296,7 @@ func (s *Sharing) createUploadKey(inst *instance.Instance, target *FileDocWithRe
 // it will return a key to upload the content.
 func (s *Sharing) SyncFile(inst *instance.Instance, target *FileDocWithRevisions) (*KeyToUpload, error) {
 	inst.Logger().WithField("nspace", "upload").Debugf("SyncFile %#v", target)
-	mu := lock.ReadWrite(inst.Domain + "/shared")
+	mu := lock.ReadWrite(inst, "shared")
 	mu.Lock()
 	defer mu.Unlock()
 
@@ -417,7 +417,7 @@ func (s *Sharing) updateFileMetadata(inst *instance.Instance, target *FileDocWit
 // the metadata was not enough.
 func (s *Sharing) HandleFileUpload(inst *instance.Instance, key string, body io.ReadCloser) error {
 	defer body.Close()
-	target, err := getStore().Get(inst.Domain, key)
+	target, err := getStore().Get(inst, key)
 	inst.Logger().WithField("nspace", "upload").Debugf("HandleFileUpload %#v", target)
 	if err != nil {
 		return err
@@ -425,7 +425,7 @@ func (s *Sharing) HandleFileUpload(inst *instance.Instance, key string, body io.
 	if target == nil {
 		return ErrMissingFileMetadata
 	}
-	mu := lock.ReadWrite(inst.Domain + "/shared")
+	mu := lock.ReadWrite(inst, "shared")
 	mu.Lock()
 	defer mu.Unlock()
 

--- a/pkg/vfs/couchdb_indexer.go
+++ b/pkg/vfs/couchdb_indexer.go
@@ -11,16 +11,17 @@ import (
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 	multierror "github.com/hashicorp/go-multierror"
 )
 
 type couchdbIndexer struct {
-	db couchdb.Database
+	db prefixer.Prefixer
 }
 
 // NewCouchdbIndexer creates an Indexer instance based on couchdb to store
 // files and directories metadata and index them.
-func NewCouchdbIndexer(db couchdb.Database) Indexer {
+func NewCouchdbIndexer(db prefixer.Prefixer) Indexer {
 	return &couchdbIndexer{
 		db: db,
 	}

--- a/pkg/vfs/download_store_test.go
+++ b/pkg/vfs/download_store_test.go
@@ -4,31 +4,32 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestDownloadStoreInMemory(t *testing.T) {
 	downloadStoreTTL = 100 * time.Millisecond
 
-	domainA := "alice.cozycloud.local"
-	domainB := "bob.cozycloud.local"
+	dbA := prefixer.NewPrefixer("alice.cozycloud.local", "alice.cozycloud.local")
+	dbB := prefixer.NewPrefixer("bob.cozycloud.local", "bob.cozycloud.local")
 	store := newMemStore()
 
 	path := "/test/random/path.txt"
-	key1, err := store.AddFile(domainA, path)
+	key1, err := store.AddFile(dbA, path)
 	assert.NoError(t, err)
 
-	path2, err := store.GetFile(domainB, key1)
+	path2, err := store.GetFile(dbB, key1)
 	assert.NoError(t, err)
 	assert.Zero(t, path2, "Inter-instances store leaking")
 
-	path3, err := store.GetFile(domainA, key1)
+	path3, err := store.GetFile(dbA, key1)
 	assert.NoError(t, err)
 	assert.Equal(t, path, path3)
 
 	time.Sleep(2 * downloadStoreTTL)
 
-	path4, err := store.GetFile(domainA, key1)
+	path4, err := store.GetFile(dbA, key1)
 	assert.NoError(t, err)
 	assert.Zero(t, path4, "no expiration")
 
@@ -39,16 +40,16 @@ func TestDownloadStoreInMemory(t *testing.T) {
 			"/archive/bar",
 		},
 	}
-	key2, err := store.AddArchive(domainA, a)
+	key2, err := store.AddArchive(dbA, a)
 	assert.NoError(t, err)
 
-	a2, err := store.GetArchive(domainA, key2)
+	a2, err := store.GetArchive(dbA, key2)
 	assert.NoError(t, err)
 	assert.Equal(t, a, a2)
 
 	time.Sleep(2 * downloadStoreTTL)
 
-	a3, err := store.GetArchive(domainA, key2)
+	a3, err := store.GetArchive(dbA, key2)
 	assert.NoError(t, err)
 	assert.Nil(t, a3, "no expiration")
 }
@@ -56,25 +57,25 @@ func TestDownloadStoreInMemory(t *testing.T) {
 func TestDownloadStoreInRedis(t *testing.T) {
 	downloadStoreTTL = 100 * time.Millisecond
 
-	domainA := "alice.cozycloud.local"
-	domainB := "bob.cozycloud.local"
+	dbA := prefixer.NewPrefixer("alice.cozycloud.local", "alice.cozycloud.local")
+	dbB := prefixer.NewPrefixer("bob.cozycloud.local", "bob.cozycloud.local")
 	store := GetStore()
 
 	path := "/test/random/path.txt"
-	key1, err := store.AddFile(domainA, path)
+	key1, err := store.AddFile(dbA, path)
 	assert.NoError(t, err)
 
-	path2, err := store.GetFile(domainB, key1)
+	path2, err := store.GetFile(dbB, key1)
 	assert.NoError(t, err)
 	assert.Zero(t, path2, "Inter-instances store leaking")
 
-	path3, err := store.GetFile(domainA, key1)
+	path3, err := store.GetFile(dbA, key1)
 	assert.NoError(t, err)
 	assert.Equal(t, path, path3)
 
 	time.Sleep(2 * downloadStoreTTL)
 
-	path4, err := store.GetFile(domainA, key1)
+	path4, err := store.GetFile(dbA, key1)
 	assert.NoError(t, err)
 	assert.Zero(t, path4, "no expiration")
 
@@ -85,16 +86,16 @@ func TestDownloadStoreInRedis(t *testing.T) {
 			"/archive/bar",
 		},
 	}
-	key2, err := store.AddArchive(domainA, a)
+	key2, err := store.AddArchive(dbA, a)
 	assert.NoError(t, err)
 
-	a2, err := store.GetArchive(domainA, key2)
+	a2, err := store.GetArchive(dbA, key2)
 	assert.NoError(t, err)
 	assert.Equal(t, a, a2)
 
 	time.Sleep(2 * downloadStoreTTL)
 
-	a3, err := store.GetArchive(domainA, key2)
+	a3, err := store.GetArchive(dbA, key2)
 	assert.NoError(t, err)
 	assert.Nil(t, a3, "no expiration")
 }

--- a/pkg/vfs/iter.go
+++ b/pkg/vfs/iter.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 )
 
 const iterMaxFetchSize = 256
@@ -13,7 +14,7 @@ const iterMaxFetchSize = 256
 // iter is a struct allowing to iterate over the children of a
 // directory. The iterator is not thread-safe.
 type iter struct {
-	db     couchdb.Database
+	db     prefixer.Prefixer
 	sel    mango.Filter
 	opt    *IteratorOptions
 	list   []*DirOrFileDoc
@@ -24,7 +25,7 @@ type iter struct {
 }
 
 // NewIterator return a new iterator.
-func NewIterator(db couchdb.Database, dir *DirDoc, opt *IteratorOptions) DirIterator {
+func NewIterator(db prefixer.Prefixer, dir *DirDoc, opt *IteratorOptions) DirIterator {
 	if opt == nil {
 		opt = &IteratorOptions{ByFetch: iterMaxFetchSize}
 	}

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -60,7 +60,7 @@ var ErrWalkOverflow = errors.New("vfs: walk overflow")
 // Fs is an interface providing a set of high-level methods to interact with
 // the file-system binaries and metadata.
 type Fs interface {
-	Domain() string
+	couchdb.Database
 	InitFs() error
 	Delete() error
 
@@ -670,7 +670,7 @@ func RegisterDiskQuotaAlertCallback(cb func(domain string, exceeded bool)) {
 // behind, its quota alert of 90% of its total capacity.
 func PushDiskQuotaAlert(fs VFS, exceeded bool) {
 	if cbDiskQuotaAlert != nil {
-		cbDiskQuotaAlert(fs.Domain(), exceeded)
+		cbDiskQuotaAlert(fs.DomainName(), exceeded)
 	}
 }
 

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 )
 
 // DefaultContentType is used for files uploaded with no content-type
@@ -60,7 +61,7 @@ var ErrWalkOverflow = errors.New("vfs: walk overflow")
 // Fs is an interface providing a set of high-level methods to interact with
 // the file-system binaries and metadata.
 type Fs interface {
-	couchdb.Database
+	prefixer.Prefixer
 	InitFs() error
 	Delete() error
 

--- a/pkg/vfs/vfs_test.go
+++ b/pkg/vfs/vfs_test.go
@@ -806,9 +806,9 @@ func makeAferoFS() (vfs.VFS, func(), error) {
 		return nil, nil, errors.New("could not create temporary directory")
 	}
 
-	db := couchdb.SimpleDatabasePrefix("io.cozy.vfs.test")
+	db := couchdb.NewDatabase("io.cozy.vfs.test")
 	index := vfs.NewCouchdbIndexer(db)
-	aferoFs, err := vfsafero.New("io.cozy.vfs.test", index, &diskImpl{}, lock.ReadWrite("io.cozy.vfs.test"),
+	aferoFs, err := vfsafero.New(db, index, &diskImpl{}, lock.ReadWrite(db, "vfs-afero-test"),
 		&url.URL{Scheme: "file", Host: "localhost", Path: tempdir}, "io.cozy.vfs.test")
 	if err != nil {
 		return nil, nil, err
@@ -840,7 +840,7 @@ func makeAferoFS() (vfs.VFS, func(), error) {
 }
 
 func makeSwiftFS(layoutV2 bool) (vfs.VFS, func(), error) {
-	db := couchdb.SimpleDatabasePrefix("io.cozy.vfs.test")
+	db := couchdb.NewDatabase("io.cozy.vfs.test")
 	index := vfs.NewCouchdbIndexer(db)
 	swiftSrv, err := swifttest.NewSwiftServer("localhost")
 	if err != nil {
@@ -858,11 +858,11 @@ func makeSwiftFS(layoutV2 bool) (vfs.VFS, func(), error) {
 
 	var swiftFs vfs.VFS
 	if layoutV2 {
-		swiftFs, err = vfsswift.NewV2("io.cozy.vfs.test",
-			index, &diskImpl{}, lock.ReadWrite("io.cozy.vfs.test"))
+		swiftFs, err = vfsswift.NewV2(db,
+			index, &diskImpl{}, lock.ReadWrite(db, "vfs-swiftv2-test"))
 	} else {
-		swiftFs, err = vfsswift.New("io.cozy.vfs.test",
-			index, &diskImpl{}, lock.ReadWrite("io.cozy.vfs.test"))
+		swiftFs, err = vfsswift.New(db,
+			index, &diskImpl{}, lock.ReadWrite(db, "vfs-swift-test"))
 	}
 	if err != nil {
 		return nil, nil, err

--- a/pkg/vfs/vfs_test.go
+++ b/pkg/vfs/vfs_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/crypto"
 	"github.com/cozy/cozy-stack/pkg/lock"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/cozy/cozy-stack/pkg/vfs"
 	"github.com/cozy/cozy-stack/pkg/vfs/vfsafero"
 	"github.com/cozy/cozy-stack/pkg/vfs/vfsswift"
@@ -806,7 +807,7 @@ func makeAferoFS() (vfs.VFS, func(), error) {
 		return nil, nil, errors.New("could not create temporary directory")
 	}
 
-	db := couchdb.NewDatabase("io.cozy.vfs.test")
+	db := prefixer.NewPrefixer("io.cozy.vfs.test", "io.cozy.vfs.test")
 	index := vfs.NewCouchdbIndexer(db)
 	aferoFs, err := vfsafero.New(db, index, &diskImpl{}, lock.ReadWrite(db, "vfs-afero-test"),
 		&url.URL{Scheme: "file", Host: "localhost", Path: tempdir}, "io.cozy.vfs.test")
@@ -840,7 +841,7 @@ func makeAferoFS() (vfs.VFS, func(), error) {
 }
 
 func makeSwiftFS(layoutV2 bool) (vfs.VFS, func(), error) {
-	db := couchdb.NewDatabase("io.cozy.vfs.test")
+	db := prefixer.NewPrefixer("io.cozy.vfs.test", "io.cozy.vfs.test")
 	index := vfs.NewCouchdbIndexer(db)
 	swiftSrv, err := swifttest.NewSwiftServer("localhost")
 	if err != nil {

--- a/pkg/vfs/vfsafero/impl.go
+++ b/pkg/vfs/vfsafero/impl.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/lock"
 	"github.com/cozy/cozy-stack/pkg/magic"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/cozy/cozy-stack/pkg/vfs"
 
 	"github.com/cozy/afero"
@@ -44,7 +45,7 @@ type aferoVFS struct {
 //
 // The supported scheme of the storage url are file://, for an OS-FS store, and
 // mem:// for an in-memory store. The backend used is the afero package.
-func New(db couchdb.Database, index vfs.Indexer, disk vfs.DiskThresholder, mu lock.ErrorRWLocker, fsURL *url.URL, pathSegment string) (vfs.VFS, error) {
+func New(db prefixer.Prefixer, index vfs.Indexer, disk vfs.DiskThresholder, mu lock.ErrorRWLocker, fsURL *url.URL, pathSegment string) (vfs.VFS, error) {
 	if fsURL.Scheme != "mem" && fsURL.Path == "" {
 		return nil, fmt.Errorf("vfsafero: please check the supplied fs url: %s",
 			fsURL.String())

--- a/pkg/vfs/vfsafero/impl.go
+++ b/pkg/vfs/vfsafero/impl.go
@@ -29,6 +29,7 @@ type aferoVFS struct {
 	vfs.DiskThresholder
 
 	domain string
+	prefix string
 	fs     afero.Fs
 	mu     lock.ErrorRWLocker
 	pth    string
@@ -43,7 +44,7 @@ type aferoVFS struct {
 //
 // The supported scheme of the storage url are file://, for an OS-FS store, and
 // mem:// for an in-memory store. The backend used is the afero package.
-func New(domain string, index vfs.Indexer, disk vfs.DiskThresholder, mu lock.ErrorRWLocker, fsURL *url.URL, pathSegment string) (vfs.VFS, error) {
+func New(db couchdb.Database, index vfs.Indexer, disk vfs.DiskThresholder, mu lock.ErrorRWLocker, fsURL *url.URL, pathSegment string) (vfs.VFS, error) {
 	if fsURL.Scheme != "mem" && fsURL.Path == "" {
 		return nil, fmt.Errorf("vfsafero: please check the supplied fs url: %s",
 			fsURL.String())
@@ -65,7 +66,8 @@ func New(domain string, index vfs.Indexer, disk vfs.DiskThresholder, mu lock.Err
 		Indexer:         index,
 		DiskThresholder: disk,
 
-		domain: domain,
+		domain: db.DomainName(),
+		prefix: db.DBPrefix(),
 		fs:     fs,
 		mu:     mu,
 		pth:    pth,
@@ -75,8 +77,12 @@ func New(domain string, index vfs.Indexer, disk vfs.DiskThresholder, mu lock.Err
 	}, nil
 }
 
-func (afs *aferoVFS) Domain() string {
+func (afs *aferoVFS) DomainName() string {
 	return afs.domain
+}
+
+func (afs *aferoVFS) DBPrefix() string {
+	return afs.prefix
 }
 
 func (afs *aferoVFS) UseSharingIndexer(index vfs.Indexer) vfs.VFS {

--- a/pkg/vfs/vfsswift/impl_v1.go
+++ b/pkg/vfs/vfsswift/impl_v1.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/lock"
 	"github.com/cozy/cozy-stack/pkg/logger"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/cozy/cozy-stack/pkg/vfs"
 	"github.com/cozy/swift"
 	multierror "github.com/hashicorp/go-multierror"
@@ -40,7 +41,7 @@ type swiftVFS struct {
 
 // New returns a vfs.VFS instance associated with the specified indexer and the
 // swift storage url.
-func New(db couchdb.Database, index vfs.Indexer, disk vfs.DiskThresholder, mu lock.ErrorRWLocker) (vfs.VFS, error) {
+func New(db prefixer.Prefixer, index vfs.Indexer, disk vfs.DiskThresholder, mu lock.ErrorRWLocker) (vfs.VFS, error) {
 	return &swiftVFS{
 		Indexer:         index,
 		DiskThresholder: disk,

--- a/pkg/vfs/vfsswift/impl_v2.go
+++ b/pkg/vfs/vfsswift/impl_v2.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/lock"
 	"github.com/cozy/cozy-stack/pkg/logger"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/cozy/cozy-stack/pkg/utils"
 	"github.com/cozy/cozy-stack/pkg/vfs"
 	"github.com/cozy/swift"
@@ -49,7 +50,7 @@ const (
 // This version implements a simpler layout where swift does not contain any
 // hierarchy: meaning no index informations. This help with index incoherency
 // and as many performance improvements regarding moving / renaming folders.
-func NewV2(db couchdb.Database, index vfs.Indexer, disk vfs.DiskThresholder, mu lock.ErrorRWLocker) (vfs.VFS, error) {
+func NewV2(db prefixer.Prefixer, index vfs.Indexer, disk vfs.DiskThresholder, mu lock.ErrorRWLocker) (vfs.VFS, error) {
 	return &swiftVFSV2{
 		Indexer:         index,
 		DiskThresholder: disk,

--- a/pkg/workers/exec/konnector.go
+++ b/pkg/workers/exec/konnector.go
@@ -328,7 +328,8 @@ func (w *konnectorWorker) ScanOutput(ctx *jobs.WorkerContext, i *instance.Instan
 	}
 
 	realtime.GetHub().Publish(&realtime.Event{
-		Domain: i.Domain,
+		Domain: i.DomainName(),
+		Prefix: i.DBPrefix(),
 		Verb:   realtime.EventCreate,
 		Doc: couchdb.JSONDoc{Type: consts.JobEvents, M: map[string]interface{}{
 			"type":    msg.Type,

--- a/pkg/workers/exec/konnector.go
+++ b/pkg/workers/exec/konnector.go
@@ -327,10 +327,8 @@ func (w *konnectorWorker) ScanOutput(ctx *jobs.WorkerContext, i *instance.Instan
 		log.Error(msg.Message)
 	}
 
-	realtime.GetHub().Publish(&realtime.Event{
-		Domain: i.DomainName(),
-		Prefix: i.DBPrefix(),
-		Verb:   realtime.EventCreate,
+	realtime.GetHub().Publish(i, &realtime.Event{
+		Verb: realtime.EventCreate,
 		Doc: couchdb.JSONDoc{Type: consts.JobEvents, M: map[string]interface{}{
 			"type":    msg.Type,
 			"message": msg.Message,

--- a/pkg/workers/exec/konnector.go
+++ b/pkg/workers/exec/konnector.go
@@ -327,13 +327,13 @@ func (w *konnectorWorker) ScanOutput(ctx *jobs.WorkerContext, i *instance.Instan
 		log.Error(msg.Message)
 	}
 
-	realtime.GetHub().Publish(i, &realtime.Event{
-		Verb: realtime.EventCreate,
-		Doc: couchdb.JSONDoc{Type: consts.JobEvents, M: map[string]interface{}{
+	realtime.GetHub().Publish(i,
+		realtime.EventCreate,
+		couchdb.JSONDoc{Type: consts.JobEvents, M: map[string]interface{}{
 			"type":    msg.Type,
 			"message": msg.Message,
 		}},
-	})
+		nil)
 	return nil
 }
 

--- a/pkg/workers/exec/konnector_test.go
+++ b/pkg/workers/exec/konnector_test.go
@@ -28,8 +28,8 @@ func TestUnknownDomain(t *testing.T) {
 		"konnector": "unknownapp",
 	})
 	assert.NoError(t, err)
-	j := jobs.NewJob(&jobs.JobRequest{
-		Domain:     "instance.does.not.exist",
+	db := couchdb.NewDatabase("instance.does.not.exist")
+	j := jobs.NewJob(db, &jobs.JobRequest{
 		Message:    msg,
 		WorkerType: "konnector",
 	})
@@ -44,8 +44,7 @@ func TestUnknownApp(t *testing.T) {
 		"konnector": "unknownapp",
 	})
 	assert.NoError(t, err)
-	j := jobs.NewJob(&jobs.JobRequest{
-		Domain:     inst.Domain,
+	j := jobs.NewJob(inst, &jobs.JobRequest{
 		Message:    msg,
 		WorkerType: "konnector",
 	})
@@ -80,8 +79,7 @@ func TestBadFileExec(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	j := jobs.NewJob(&jobs.JobRequest{
-		Domain:     inst.Domain,
+	j := jobs.NewJob(inst, &jobs.JobRequest{
 		Message:    msg,
 		WorkerType: "konnector",
 	})
@@ -144,7 +142,7 @@ echo "{\"type\": \"manifest\", \"message\": \"$(ls ${1}/manifest.konnector)\" }"
 	wg.Add(1)
 
 	go func() {
-		evCh := realtime.GetHub().Subscriber(inst.Domain)
+		evCh := realtime.GetHub().Subscriber(inst)
 		evCh.Subscribe(consts.JobEvents)
 		ch := evCh.Channel
 		ev1 := <-ch
@@ -182,8 +180,7 @@ echo "{\"type\": \"manifest\", \"message\": \"$(ls ${1}/manifest.konnector)\" }"
 	})
 	assert.NoError(t, err)
 
-	j := jobs.NewJob(&jobs.JobRequest{
-		Domain:     inst.Domain,
+	j := jobs.NewJob(inst, &jobs.JobRequest{
 		Message:    msg,
 		WorkerType: "konnector",
 	})

--- a/pkg/workers/exec/konnector_test.go
+++ b/pkg/workers/exec/konnector_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/pkg/jobs"
 	"github.com/cozy/cozy-stack/pkg/permissions"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/cozy/cozy-stack/pkg/realtime"
 	"github.com/cozy/cozy-stack/tests/testutils"
 	"github.com/stretchr/testify/assert"
@@ -28,7 +29,7 @@ func TestUnknownDomain(t *testing.T) {
 		"konnector": "unknownapp",
 	})
 	assert.NoError(t, err)
-	db := couchdb.NewDatabase("instance.does.not.exist")
+	db := prefixer.NewPrefixer("instance.does.not.exist", "instance.does.not.exist")
 	j := jobs.NewJob(db, &jobs.JobRequest{
 		Message:    msg,
 		WorkerType: "konnector",

--- a/pkg/workers/migrations/migrations.go
+++ b/pkg/workers/migrations/migrations.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/pkg/jobs"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/cozy/cozy-stack/pkg/vfs/vfsswift"
 	"github.com/cozy/swift"
 	multierror "github.com/hashicorp/go-multierror"
@@ -172,7 +173,7 @@ func readObjects(c *swift.Connection, objc chan object,
 	})
 }
 
-func copyObjects(c *swift.Connection, db couchdb.Database,
+func copyObjects(c *swift.Connection, db prefixer.Prefixer,
 	objc chan object,
 	errc chan error) {
 
@@ -196,7 +197,7 @@ func copyObjects(c *swift.Connection, db couchdb.Database,
 	errc <- nil
 }
 
-func copyFileDataObject(c *swift.Connection, db couchdb.Database,
+func copyFileDataObject(c *swift.Connection, db prefixer.Prefixer,
 	containerSrc, containerDst string,
 	objSrc swift.Object,
 	copyBuffer []byte) error {
@@ -222,7 +223,7 @@ func copyFileDataObject(c *swift.Connection, db couchdb.Database,
 	return copyObject(c, db, containerSrc, containerDst, objSrc, objNameDst, copyBuffer)
 }
 
-func copyThumbnailDataObject(c *swift.Connection, db couchdb.Database,
+func copyThumbnailDataObject(c *swift.Connection, db prefixer.Prefixer,
 	containerSrc, containerDst string,
 	objSrc swift.Object,
 	copyBuffer []byte) error {
@@ -235,7 +236,7 @@ func copyThumbnailDataObject(c *swift.Connection, db couchdb.Database,
 	return copyObject(c, db, containerSrc, containerDst, objSrc, objNameDst, copyBuffer)
 }
 
-func copyObject(c *swift.Connection, db couchdb.Database,
+func copyObject(c *swift.Connection, db prefixer.Prefixer,
 	containerSrc, containerDst string,
 	objSrc swift.Object, objNameDst string,
 	copyBuffer []byte) (err error) {

--- a/pkg/workers/move/export.go
+++ b/pkg/workers/move/export.go
@@ -440,7 +440,8 @@ func Export(i *instance.Instance, opts ExportOptions, archiver Archiver) (export
 		Verb:   realtime.EventCreate,
 		Doc:    exportDoc.Clone(),
 		OldDoc: nil,
-		Domain: i.Domain,
+		Domain: i.DomainName(),
+		Prefix: i.DBPrefix(),
 	})
 	defer func() {
 		newExportDoc := exportDoc.Clone().(*ExportDoc)
@@ -459,7 +460,8 @@ func Export(i *instance.Instance, opts ExportOptions, archiver Archiver) (export
 			Verb:   realtime.EventUpdate,
 			Doc:    newExportDoc.Clone(),
 			OldDoc: exportDoc.Clone(),
-			Domain: i.Domain,
+			Domain: i.DomainName(),
+			Prefix: i.DBPrefix(),
 		})
 	}()
 

--- a/pkg/workers/move/export.go
+++ b/pkg/workers/move/export.go
@@ -436,11 +436,7 @@ func Export(i *instance.Instance, opts ExportOptions, archiver Archiver) (export
 	if err = couchdb.CreateDoc(couchdb.GlobalDB, exportDoc); err != nil {
 		return
 	}
-	realtime.GetHub().Publish(i, &realtime.Event{
-		Verb:   realtime.EventCreate,
-		Doc:    exportDoc.Clone(),
-		OldDoc: nil,
-	})
+	realtime.GetHub().Publish(i, realtime.EventCreate, exportDoc.Clone(), nil)
 	defer func() {
 		newExportDoc := exportDoc.Clone().(*ExportDoc)
 		newExportDoc.CreationDuration = time.Since(createdAt)
@@ -454,11 +450,8 @@ func Export(i *instance.Instance, opts ExportOptions, archiver Archiver) (export
 		if erru := couchdb.UpdateDoc(couchdb.GlobalDB, newExportDoc); err == nil {
 			err = erru
 		}
-		realtime.GetHub().Publish(i, &realtime.Event{
-			Verb:   realtime.EventUpdate,
-			Doc:    newExportDoc.Clone(),
-			OldDoc: exportDoc.Clone(),
-		})
+		realtime.GetHub().Publish(i, realtime.EventUpdate,
+			newExportDoc.Clone(), exportDoc.Clone())
 	}()
 
 	out, err := archiver.CreateArchive(exportDoc)

--- a/pkg/workers/move/export.go
+++ b/pkg/workers/move/export.go
@@ -436,12 +436,10 @@ func Export(i *instance.Instance, opts ExportOptions, archiver Archiver) (export
 	if err = couchdb.CreateDoc(couchdb.GlobalDB, exportDoc); err != nil {
 		return
 	}
-	realtime.GetHub().Publish(&realtime.Event{
+	realtime.GetHub().Publish(i, &realtime.Event{
 		Verb:   realtime.EventCreate,
 		Doc:    exportDoc.Clone(),
 		OldDoc: nil,
-		Domain: i.DomainName(),
-		Prefix: i.DBPrefix(),
 	})
 	defer func() {
 		newExportDoc := exportDoc.Clone().(*ExportDoc)
@@ -456,12 +454,10 @@ func Export(i *instance.Instance, opts ExportOptions, archiver Archiver) (export
 		if erru := couchdb.UpdateDoc(couchdb.GlobalDB, newExportDoc); err == nil {
 			err = erru
 		}
-		realtime.GetHub().Publish(&realtime.Event{
+		realtime.GetHub().Publish(i, &realtime.Event{
 			Verb:   realtime.EventUpdate,
 			Doc:    newExportDoc.Clone(),
 			OldDoc: exportDoc.Clone(),
-			Domain: i.DomainName(),
-			Prefix: i.DBPrefix(),
 		})
 	}()
 

--- a/pkg/workers/move/workers.go
+++ b/pkg/workers/move/workers.go
@@ -61,8 +61,7 @@ func ExportWorker(c *jobs.WorkerContext) error {
 		return err
 	}
 
-	_, err = jobs.System().PushJob(&jobs.JobRequest{
-		Domain:     i.Domain,
+	_, err = jobs.System().PushJob(i, &jobs.JobRequest{
 		WorkerType: "sendmail",
 		Message:    msg,
 	})

--- a/tests/sharing/boot.rb
+++ b/tests/sharing/boot.rb
@@ -1,5 +1,6 @@
 require 'awesome_print'
 require 'date'
+require 'digest'
 require 'faker'
 require 'fileutils'
 require 'mimemagic'

--- a/tests/sharing/lib/accept.rb
+++ b/tests/sharing/lib/accept.rb
@@ -13,8 +13,8 @@ class Accept
   end
 
   def extract_state_code
-    db = "#{@owner.domain.gsub(/\W/, '-')}%2Fio-cozy-sharings"
-    doc = Couch.new.get_doc db, @sharing.couch_id
+    doctype = "io-cozy-sharings"
+    doc = Couch.new.get_doc @owner.domain, doctype, @sharing.couch_id
     idx = doc["members"].find_index { |m| %w(pending mail-not-sent).include? m["status"] }
     doc["credentials"][idx-1]["state"] if idx
   end

--- a/tests/sharing/lib/helpers.rb
+++ b/tests/sharing/lib/helpers.rb
@@ -62,11 +62,5 @@ module Helpers
     def file_exists_in_fs(path)
       File.exist?(path)
     end
-
-    def db_name(domain, type)
-      domain = domain.gsub(/[.:]/, '-')
-      type = type.gsub(/[.:]/, '-')
-      "#{domain}%2F#{type}"
-    end
   end
 end

--- a/tests/sharing/tests/revoke_sharing.rb
+++ b/tests/sharing/tests/revoke_sharing.rb
@@ -2,9 +2,9 @@ require_relative '../boot'
 require 'minitest/autorun'
 require 'pry-rescue/minitest' unless ENV['CI']
 
-def assert_not_found(db, id)
+def assert_not_found(domain, doctype, id)
   assert_raises RestClient::NotFound do
-    Helpers.couch.get_doc db, id
+    Helpers.couch.get_doc domain, doctype, id
   end
 end
 
@@ -17,13 +17,11 @@ def assert_triggers_not_empty(triggers_ids)
 end
 
 def assert_no_triggers(inst, triggers_ids)
-  db_triggers = Helpers.db_name inst.domain, "io.cozy.triggers"
-  triggers_ids.each { |id| assert_not_found db_triggers, id }
+  triggers_ids.each { |id| assert_not_found inst.domain, "io.cozy.triggers", id }
 end
 
 def assert_no_oauth_client(inst, client_id)
-  db_oauth = Helpers.db_name inst.domain, "io.cozy.oauth"
-  assert_not_found db_oauth, client_id
+  assert_not_found inst.domain, "io.cozy.oauth", client_id
 end
 
 def triggers_ids(sharing)
@@ -38,8 +36,7 @@ def inbound_client_id(sharing, index)
 end
 
 def assert_sharing_revoked(inst, sharing_id, is_sharer)
-  db = Helpers.db_name inst.domain, Sharing.doctype
-  doc = Helpers.couch.get_doc db, sharing_id
+  doc = Helpers.couch.get_doc inst.domain, Sharing.doctype, sharing_id
   assert_nil doc["active"]
   assert_empty doc["triggers"]
   if is_sharer
@@ -55,8 +52,7 @@ def assert_sharing_revoked(inst, sharing_id, is_sharer)
 end
 
 def assert_recipient_revoked(inst, sharing_id, index)
-  db = Helpers.db_name inst.domain, Sharing.doctype
-  doc = Helpers.couch.get_doc db, sharing_id
+  doc = Helpers.couch.get_doc inst.domain, Sharing.doctype, sharing_id
   assert doc["active"]
   refute_empty doc["triggers"]
   assert_empty doc.dig("credentials", index - 1)
@@ -101,15 +97,13 @@ describe "A sharing" do
     sleep 2
 
     # Get the clients id and triggers id
-    db = Helpers.db_name inst_alice.domain, Sharing.doctype
-    doc = Helpers.couch.get_doc db, sharing.couch_id
+    doc = Helpers.couch.get_doc inst_alice.domain, Sharing.doctype, sharing.couch_id
     client_id = inbound_client_id doc, 0
     tri_ids = triggers_ids doc
     assert_oauth_client_not_empty client_id
     assert_triggers_not_empty tri_ids
 
-    db = Helpers.db_name inst_bob.domain, Sharing.doctype
-    doc = Helpers.couch.get_doc db, sharing.couch_id
+    doc = Helpers.couch.get_doc inst_bob.domain, Sharing.doctype, sharing.couch_id
     client_id_recipient = inbound_client_id doc, 0
     tri_ids_recipient = triggers_ids doc
     assert_oauth_client_not_empty client_id_recipient
@@ -162,8 +156,7 @@ describe "A sharing" do
     sleep 2
 
     # Get the clients id and triggers id on alice side
-    db = Helpers.db_name inst_alice.domain, Sharing.doctype
-    doc = Helpers.couch.get_doc db, sharing.couch_id
+    doc = Helpers.couch.get_doc inst_alice.domain, Sharing.doctype, sharing.couch_id
     inb_bob_client_id = inbound_client_id doc, 0
     inb_charlie_client_id = inbound_client_id doc, 1
     tri_ids = triggers_ids doc
@@ -172,16 +165,14 @@ describe "A sharing" do
     assert_triggers_not_empty tri_ids
 
     # Get the clients id and triggers id on bob side
-    db = Helpers.db_name inst_bob.domain, Sharing.doctype
-    doc = Helpers.couch.get_doc db, sharing.couch_id
+    doc = Helpers.couch.get_doc inst_bob.domain, Sharing.doctype, sharing.couch_id
     client_id_bob = inbound_client_id doc, 0
     tri_ids_bob = triggers_ids doc
     assert_oauth_client_not_empty client_id_bob
     assert_triggers_not_empty tri_ids_bob
 
     # Get the clients id and triggers id on charlie side
-    db = Helpers.db_name inst_charlie.domain, Sharing.doctype
-    doc = Helpers.couch.get_doc db, sharing.couch_id
+    doc = Helpers.couch.get_doc inst_charlie.domain, Sharing.doctype, sharing.couch_id
     client_id_charlie = inbound_client_id doc, 0
     tri_ids_charlie = triggers_ids doc
     assert_oauth_client_not_empty client_id_charlie

--- a/tests/sharing/tests/sync.rb
+++ b/tests/sharing/tests/sync.rb
@@ -61,11 +61,10 @@ describe "A folder" do
     inst.register sharing
 
     # Manually set the xor_key
-    db = Helpers.db_name inst.domain, Sharing.doctype
-    doc = Helpers.couch.get_doc db, sharing.couch_id
+    doc = Helpers.couch.get_doc inst.domain, Sharing.doctype, sharing.couch_id
     key = make_xor_key
     doc["credentials"][0]["xor_key"] = key
-    Helpers.couch.update_doc db, doc
+    Helpers.couch.update_doc inst.domain, Sharing.doctype, doc
 
     # Accept the sharing
     sleep 1
@@ -142,9 +141,8 @@ describe "A folder" do
       created_at: "2018-05-11T12:18:37.558389182+02:00",
       updated_at: "2018-05-11T12:18:37.558389182+02:00"
     }
-    db = Helpers.db_name inst_recipient.domain, Folder.doctype
     id = xor_id(child2.couch_id, key)
-    Helpers.couch.create_named_doc db, id, doc
+    Helpers.couch.create_named_doc inst_recipient.domain, Folder.doctype, id, doc
 
     # Make an update
     child2.rename inst, Faker::Internet.slug

--- a/web/auth/auth_test.go
+++ b/web/auth/auth_test.go
@@ -209,7 +209,7 @@ func TestLoginWithGoodPassphrase(t *testing.T) {
 
 		var results []*sessions.LoginEntry
 		err = couchdb.GetAllDocs(
-			couchdb.SimpleDatabasePrefix(domain),
+			couchdb.NewDatabase(domain),
 			consts.SessionsLogins,
 			&couchdb.AllDocsRequest{Limit: 100},
 			&results,

--- a/web/auth/auth_test.go
+++ b/web/auth/auth_test.go
@@ -209,7 +209,7 @@ func TestLoginWithGoodPassphrase(t *testing.T) {
 
 		var results []*sessions.LoginEntry
 		err = couchdb.GetAllDocs(
-			couchdb.NewDatabase(domain),
+			testInstance,
 			consts.SessionsLogins,
 			&couchdb.AllDocsRequest{Limit: 100},
 			&results,

--- a/web/errors/errors.go
+++ b/web/errors/errors.go
@@ -48,7 +48,7 @@ func ErrorHandler(err error, c echo.Context) {
 
 	if config.IsDevRelease() {
 		var log *logrus.Entry
-		inst, ok := c.Get("instance").(*instance.Instance)
+		inst, ok := middlewares.GetInstanceSafe(c)
 		if ok {
 			log = inst.Logger().WithField("nspace", "http")
 		} else {
@@ -82,7 +82,7 @@ func HTMLErrorHandler(err error, c echo.Context) {
 	req := c.Request()
 
 	var log *logrus.Entry
-	inst, ok := c.Get("instance").(*instance.Instance)
+	inst, ok := middlewares.GetInstanceSafe(c)
 	if ok {
 		log = inst.Logger().WithField("nspace", "http")
 	} else {

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -414,7 +414,7 @@ func ThumbnailHandler(c echo.Context) error {
 	instance := middlewares.GetInstance(c)
 
 	secret := c.Param("secret")
-	path, err := vfs.GetStore().GetFile(instance.Domain, secret)
+	path, err := vfs.GetStore().GetFile(instance, secret)
 	if err != nil {
 		return WrapVfsError(err)
 	}
@@ -513,7 +513,7 @@ func ArchiveDownloadCreateHandler(c echo.Context) error {
 		return archive.Serve(instance.VFS(), c.Response())
 	}
 
-	secret, err := vfs.GetStore().AddArchive(instance.Domain, archive)
+	secret, err := vfs.GetStore().AddArchive(instance, archive)
 	if err != nil {
 		return WrapVfsError(err)
 	}
@@ -554,7 +554,7 @@ func FileDownloadCreateHandler(c echo.Context) error {
 		return err
 	}
 
-	secret, err := vfs.GetStore().AddFile(instance.Domain, path)
+	secret, err := vfs.GetStore().AddFile(instance, path)
 	if err != nil {
 		return WrapVfsError(err)
 	}
@@ -571,7 +571,7 @@ func FileDownloadCreateHandler(c echo.Context) error {
 func ArchiveDownloadHandler(c echo.Context) error {
 	instance := middlewares.GetInstance(c)
 	secret := c.Param("secret")
-	archive, err := vfs.GetStore().GetArchive(instance.Domain, secret)
+	archive, err := vfs.GetStore().GetArchive(instance, secret)
 	if err != nil {
 		return WrapVfsError(err)
 	}
@@ -586,7 +586,7 @@ func ArchiveDownloadHandler(c echo.Context) error {
 func FileDownloadHandler(c echo.Context) error {
 	instance := middlewares.GetInstance(c)
 	secret := c.Param("secret")
-	path, err := vfs.GetStore().GetFile(instance.Domain, secret)
+	path, err := vfs.GetStore().GetFile(instance, secret)
 	if err != nil {
 		return WrapVfsError(err)
 	}

--- a/web/files/paginated.go
+++ b/web/files/paginated.go
@@ -267,7 +267,7 @@ func (f *file) Links() *jsonapi.LinksList {
 	links := jsonapi.LinksList{Self: "/files/" + f.doc.DocID}
 	if f.doc.Class == "image" {
 		if path, err := f.doc.Path(f.instance.VFS()); err == nil {
-			if secret, err := vfs.GetStore().AddFile(f.instance.Domain, path); err == nil {
+			if secret, err := vfs.GetStore().AddFile(f.instance, path); err == nil {
 				links.Small = "/files/" + f.doc.DocID + "/thumbnails/" + secret + "/small"
 				links.Medium = "/files/" + f.doc.DocID + "/thumbnails/" + secret + "/medium"
 				links.Large = "/files/" + f.doc.DocID + "/thumbnails/" + secret + "/large"

--- a/web/instances/move.go
+++ b/web/instances/move.go
@@ -35,8 +35,7 @@ func exporter(c echo.Context) error {
 	}
 
 	broker := jobs.System()
-	_, err = broker.PushJob(&jobs.JobRequest{
-		Domain:     instance.Domain,
+	_, err = broker.PushJob(instance, &jobs.JobRequest{
 		WorkerType: "sendmail",
 		Message:    msg,
 	})

--- a/web/konnectorsauth/oauth.go
+++ b/web/konnectorsauth/oauth.go
@@ -140,6 +140,7 @@ func redirect(c echo.Context) error {
 	if err != nil {
 		return err
 	}
+
 	c.Set("instance", i)
 	return redirectToDataCollect(c, account, clientState)
 }

--- a/web/middlewares/middlewares_test.go
+++ b/web/middlewares/middlewares_test.go
@@ -13,25 +13,29 @@ func TestSplitHost(t *testing.T) {
 	was := cfg.Subdomains
 	defer func() { cfg.Subdomains = was }()
 
-	host, app, siblings := SplitHost("localhost")
+	host, app, siblings, ok := SplitHost("localhost")
 	assert.Equal(t, "localhost", host)
 	assert.Equal(t, "", app)
 	assert.Equal(t, "", siblings)
+	assert.True(t, ok)
 
 	cfg.Subdomains = config.NestedSubdomains
-	host, app, siblings = SplitHost("calendar.joe.example.net")
+	host, app, siblings, ok = SplitHost("calendar.joe.example.net")
 	assert.Equal(t, "joe.example.net", host)
 	assert.Equal(t, "calendar", app)
 	assert.Equal(t, "*.joe.example.net", siblings)
+	assert.True(t, ok)
 
 	cfg.Subdomains = config.FlatSubdomains
-	host, app, siblings = SplitHost("joe-calendar.example.net")
+	host, app, siblings, ok = SplitHost("joe-calendar.example.net")
 	assert.Equal(t, "joe.example.net", host)
 	assert.Equal(t, "calendar", app)
 	assert.Equal(t, "*.example.net", siblings)
+	assert.True(t, ok)
 
-	host, app, siblings = SplitHost("joe.example.net")
+	host, app, siblings, ok = SplitHost("joe.example.net")
 	assert.Equal(t, "joe.example.net", host)
 	assert.Equal(t, "", app)
 	assert.Equal(t, "", siblings)
+	assert.True(t, ok)
 }

--- a/web/middlewares/middlewares_test.go
+++ b/web/middlewares/middlewares_test.go
@@ -13,29 +13,25 @@ func TestSplitHost(t *testing.T) {
 	was := cfg.Subdomains
 	defer func() { cfg.Subdomains = was }()
 
-	host, app, siblings, ok := SplitHost("localhost")
+	host, app, siblings := SplitHost("localhost")
 	assert.Equal(t, "localhost", host)
 	assert.Equal(t, "", app)
 	assert.Equal(t, "", siblings)
-	assert.True(t, ok)
 
 	cfg.Subdomains = config.NestedSubdomains
-	host, app, siblings, ok = SplitHost("calendar.joe.example.net")
+	host, app, siblings = SplitHost("calendar.joe.example.net")
 	assert.Equal(t, "joe.example.net", host)
 	assert.Equal(t, "calendar", app)
 	assert.Equal(t, "*.joe.example.net", siblings)
-	assert.True(t, ok)
 
 	cfg.Subdomains = config.FlatSubdomains
-	host, app, siblings, ok = SplitHost("joe-calendar.example.net")
+	host, app, siblings = SplitHost("joe-calendar.example.net")
 	assert.Equal(t, "joe.example.net", host)
 	assert.Equal(t, "calendar", app)
 	assert.Equal(t, "*.example.net", siblings)
-	assert.True(t, ok)
 
-	host, app, siblings, ok = SplitHost("joe.example.net")
+	host, app, siblings = SplitHost("joe.example.net")
 	assert.Equal(t, "joe.example.net", host)
 	assert.Equal(t, "", app)
 	assert.Equal(t, "", siblings)
-	assert.True(t, ok)
 }

--- a/web/middlewares/secure.go
+++ b/web/middlewares/secure.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/echo"
 )
 
@@ -126,7 +125,7 @@ func Secure(conf *SecureConfig) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			isSecure := true
-			if in := c.Get("instance"); in != nil && in.(*instance.Instance).Dev {
+			if in, ok := GetInstanceSafe(c); ok && in.Dev {
 				isSecure = false
 			}
 			h := c.Response().Header()

--- a/web/move/move.go
+++ b/web/move/move.go
@@ -69,8 +69,7 @@ func createExport(c echo.Context) error {
 		return err
 	}
 
-	_, err = jobs.System().PushJob(&jobs.JobRequest{
-		Domain:     inst.Domain,
+	_, err = jobs.System().PushJob(inst, &jobs.JobRequest{
 		WorkerType: "export",
 		Message:    msg,
 	})

--- a/web/permissions/permissions.go
+++ b/web/permissions/permissions.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/permissions"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/cozy/cozy-stack/web/jsonapi"
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/cozy/echo"
@@ -65,7 +66,7 @@ func (p *APIPermission) Links() *jsonapi.LinksList {
 	return links
 }
 
-type getPermsFunc func(db couchdb.Database, id string) (*permissions.Permission, error)
+type getPermsFunc func(db prefixer.Prefixer, id string) (*permissions.Permission, error)
 
 func displayPermissions(c echo.Context) error {
 	doc, err := GetPermission(c)

--- a/web/realtime/realtime.go
+++ b/web/realtime/realtime.go
@@ -152,7 +152,7 @@ func readPump(ctx context.Context, c echo.Context, i *instance.Instance, ws *web
 		cmd := &command{}
 		if err = ws.ReadJSON(cmd); err != nil {
 			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseNoStatusReceived) {
-				logger.WithDomain(ds.Domain).WithField("nspace", "realtime").Infof("Error: %s", err)
+				logger.WithDomain(ds.DomainName()).WithField("nspace", "realtime").Infof("Error: %s", err)
 			}
 			break
 		}
@@ -176,7 +176,7 @@ func readPump(ctx context.Context, c echo.Context, i *instance.Instance, ws *web
 			err = ds.Watch(cmd.Payload.Type, cmd.Payload.ID)
 		}
 		if err != nil {
-			logger.WithDomain(ds.Domain).WithField("nspace", "realtime").Warnf("Error: %s", err)
+			logger.WithDomain(ds.DomainName()).WithField("nspace", "realtime").Warnf("Error: %s", err)
 		}
 	}
 }
@@ -198,7 +198,7 @@ func ws(c echo.Context) error {
 		return ws.SetReadDeadline(time.Now().Add(pongWait))
 	})
 
-	ds := realtime.GetHub().Subscriber(instance.Domain)
+	ds := realtime.GetHub().Subscriber(instance)
 	defer ds.Close()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/web/realtime/realtime_test.go
+++ b/web/realtime/realtime_test.go
@@ -118,14 +118,10 @@ func TestWSSuccess(t *testing.T) {
 	var res map[string]interface{}
 	time.Sleep(10 * time.Millisecond)
 
-	h.Publish(&realtime.Event{
-		Domain: inst.Domain,
-		Verb:   realtime.EventUpdate,
-		Doc: &testDoc{
-			doctype: "io.cozy.foos",
-			id:      "foo-one",
-		},
-	})
+	h.Publish(inst, realtime.EventUpdate, &testDoc{
+		doctype: "io.cozy.foos",
+		id:      "foo-one",
+	}, nil)
 	err = c.ReadJSON(&res)
 	assert.NoError(t, err)
 	assert.Equal(t, "UPDATED", res["event"])
@@ -133,14 +129,10 @@ func TestWSSuccess(t *testing.T) {
 	assert.Equal(t, "io.cozy.foos", payload["type"])
 	assert.Equal(t, "foo-one", payload["id"])
 
-	h.Publish(&realtime.Event{
-		Domain: inst.Domain,
-		Verb:   realtime.EventDelete,
-		Doc: &testDoc{
-			doctype: "io.cozy.foos",
-			id:      "foo-two",
-		},
-	})
+	h.Publish(inst, realtime.EventDelete, &testDoc{
+		doctype: "io.cozy.foos",
+		id:      "foo-two",
+	}, nil)
 	err = c.ReadJSON(&res)
 	assert.NoError(t, err)
 	assert.Equal(t, "DELETED", res["event"])
@@ -148,24 +140,16 @@ func TestWSSuccess(t *testing.T) {
 	assert.Equal(t, "io.cozy.foos", payload["type"])
 	assert.Equal(t, "foo-two", payload["id"])
 
-	h.Publish(&realtime.Event{
-		Domain: inst.Domain,
-		Verb:   realtime.EventCreate,
-		Doc: &testDoc{
-			doctype: "io.cozy.bars",
-			id:      "bar-two",
-		},
-	})
+	h.Publish(inst, realtime.EventCreate, &testDoc{
+		doctype: "io.cozy.bars",
+		id:      "bar-two",
+	}, nil)
 	// No event
 
-	h.Publish(&realtime.Event{
-		Domain: inst.Domain,
-		Verb:   realtime.EventCreate,
-		Doc: &testDoc{
-			doctype: "io.cozy.bars",
-			id:      "bar-one",
-		},
-	})
+	h.Publish(inst, realtime.EventCreate, &testDoc{
+		doctype: "io.cozy.bars",
+		id:      "bar-one",
+	}, nil)
 	err = c.ReadJSON(&res)
 	assert.NoError(t, err)
 	assert.Equal(t, "CREATED", res["event"])


### PR DESCRIPTION
Instead of using the domain name of instances as the prefix for our databases (couchdb, redis, vfs, ...), a generic prefix is generated at the instance creation and used as an identifier.