### PR TITLE
Conflicts tests

### DIFF
--- a/tests/sharing/lib/cozy_file.rb
+++ b/tests/sharing/lib/cozy_file.rb
@@ -32,6 +32,16 @@ class CozyFile
     f
   end
 
+  def restore_from_trash(inst)
+    opts = {
+      authorization: "Bearer #{inst.token_for doctype}"
+    }
+    res = inst.client["/files/trash/#{@couch_id}"].post nil, opts
+    j = JSON.parse(res.body)["data"]
+    @trashed = false
+    @dir_id = j.dig "attributes", "dir_id"
+  end
+
   def self.options_from_fixture(filename, opts = {})
     opts = opts.dup
     opts[:content] = File.read filename

--- a/tests/sharing/lib/folder.rb
+++ b/tests/sharing/lib/folder.rb
@@ -41,7 +41,7 @@ class Folder
 
     (j || []).map do |child|
       id = child["id"]
-      rev = child["rev"]
+      rev = child.dig "meta", "rev"
       child = child["attributes"]
       type = child["type"]
       if type == "directory"
@@ -63,9 +63,9 @@ class Folder
           metadata: child["metadata"]
         )
       end
-        f.couch_id = id
-        f.couch_rev = rev
-        f
+      f.couch_id = id
+      f.couch_rev = rev
+      f
     end
   end
 

--- a/tests/sharing/lib/folder.rb
+++ b/tests/sharing/lib/folder.rb
@@ -69,6 +69,17 @@ class Folder
     end
   end
 
+  def restore_from_trash(inst)
+    opts = {
+      authorization: "Bearer #{inst.token_for doctype}"
+    }
+    res = inst.client["/files/trash/#{@couch_id}"].post nil, opts
+    j = JSON.parse(res.body)["data"]
+    @restore_path = nil
+    @path = j.dig "attributes", "path"
+    @dir_id = j.dig "attributes", "dir_id"
+  end
+
   def initialize(opts = {})
     @name = opts[:name] || Faker::Internet.slug
     @dir_id = opts[:dir_id] || ROOT_DIR

--- a/tests/sharing/lib/folder.rb
+++ b/tests/sharing/lib/folder.rb
@@ -16,7 +16,7 @@ class Folder
     res = inst.client[path].get opts
     j = JSON.parse(res.body)["data"]
     id = j["id"]
-    rev = j["rev"]
+    rev = j.dig "meta", "rev"
     j = j["attributes"]
     f = Folder.new(
       name: j["name"],

--- a/tests/sharing/lib/model.rb
+++ b/tests/sharing/lib/model.rb
@@ -97,5 +97,9 @@ module Model
       j = JSON.parse(res.body)["data"]
       @couch_rev = j["meta"]["rev"]
     end
+
+    def restore(inst)
+      restore_from_trash inst
+    end
   end
 end

--- a/tests/sharing/tests/conflicts.rb
+++ b/tests/sharing/tests/conflicts.rb
@@ -76,8 +76,6 @@ describe "A sharing" do
     path = CGI.escape "/#{Helpers::SHARED_WITH_ME}/#{folder.name}/#{child5.name}"
     child5_recipient = Folder.find_by_path inst_recipient, path
 
-
-
     # Create and trash a file for later use
     filename_trash = "#{Faker::Internet.slug}.txt"
     file_to_trash = CozyFile.create inst, name: filename_trash, dir_id: child5.couch_id
@@ -95,11 +93,6 @@ describe "A sharing" do
     file2.remove inst
     file2_recipient.overwrite inst_recipient
 
-    # Create a file and remove the folder on the other side
-    filename = "#{Faker::Internet.slug}.txt"
-    file3 = CozyFile.create inst, name: filename, dir_id: child2.couch_id
-    child2_recipient.remove inst_recipient
-
     # Rename file and folder on both sides and write file on one side
     2.times do
       child1.rename inst, Faker::Internet.slug
@@ -109,7 +102,7 @@ describe "A sharing" do
       file1_recipient.rename inst_recipient, "#{Faker::Internet.slug}.txt"
     end
 
-    sleep 20
+    sleep 15
     # Check the files and diretories are even
     file1 = CozyFile.find inst, file1.couch_id
     file2 = CozyFile.find inst, file2.couch_id
@@ -128,24 +121,11 @@ describe "A sharing" do
     assert file2.trashed
     assert file2_recipient.trashed
 
-    # FIXME: child2 and its child file3 are in the trash
-    # file3 = CozyFile.find inst, file3.couch_id 
-    # child2 = Folder.find inst, child2.couch_id
-    # refute_equal Folder::TRASH_DIR, child2.dir_id
-    # refute_equal Folder::TRASH_DIR, file3.dir_id
-
     da = File.join Helpers.current_dir, inst.domain, folder.name
     db = File.join Helpers.current_dir, inst_recipient.domain,
                    Helpers::SHARED_WITH_ME, folder.name
     diff = Helpers.fsdiff da, db
     diff.must_be_empty
-
-    # DEBUG
-    puts "child 1 : #{child1.name}"
-    puts "child 2 : #{child2.name}"
-    puts "child 3 : #{child3.name}"
-    puts "child 4 : #{child4.name}"
-    puts "child 5 : #{child5.name}"
 
     # Generate conflicts with no reconciliation
 
@@ -162,7 +142,7 @@ describe "A sharing" do
     file5.rename inst, file6.name
 
     # Create a file on a side and restore a file with same name on other side
-    file7 = CozyFile.create inst_recipient, name: filename_trash, dir_id: child5_recipient.couch_id
+    CozyFile.create inst_recipient, name: filename_trash, dir_id: child5_recipient.couch_id
     file_to_trash.restore inst
 
     # Write the same file on both sides
@@ -171,8 +151,7 @@ describe "A sharing" do
       file1_recipient.overwrite inst_recipient
     end
 
-    sleep 20
-
+    sleep 15
     # Check the conflicted files
     children = Folder.children inst, parent_file.path
     conflict_file = children.find { |c| c.name.include? "conflict" }

--- a/tests/sharing/tests/conflicts.rb
+++ b/tests/sharing/tests/conflicts.rb
@@ -1,0 +1,73 @@
+require_relative '../boot'
+require 'minitest/autorun'
+require 'pry-rescue/minitest' unless ENV['CI']
+
+describe "A sharing" do
+  Helpers.scenario "conflicts"
+  Helpers.start_mailhog
+
+  it "can handle conflicts on the folder" do
+    recipient_name = "Bob"
+
+    # Create the instance
+    inst = Instance.create name: "Alice"
+    inst_recipient = Instance.create name: recipient_name
+
+    # Create hierarchy
+    folder = Folder.create inst
+    folder.couch_id.wont_be_empty
+    child1 = Folder.create inst, dir_id: folder.couch_id
+    file_name = "#{Faker::Internet.slug}.txt"
+    file = CozyFile.create inst, name: file_name, dir_id: folder.couch_id
+
+    # Create the sharing
+    contact = Contact.create inst, givenName: recipient_name
+    sharing = Sharing.new
+    sharing.rules << Rule.push(folder)
+    sharing.members << inst << contact
+    inst.register sharing
+
+    # Accept the sharing
+    sleep 1
+    inst_recipient.accept sharing
+    sleep 2
+
+    # Generate conflicts with reconciliation
+    path = CGI.escape "/#{Helpers::SHARED_WITH_ME}/#{folder.name}/#{child1.name}"
+    child1_recipient = Folder.find_by_path inst_recipient, path
+    assert_equal child1_recipient.name, child1.name
+
+    2.times do
+      child1.rename inst, Faker::Internet.slug
+      child1_recipient.rename inst_recipient, Faker::Internet.slug
+    end
+
+    sleep 10
+    # Check the names are equal in db and disk
+    child1 = Folder.find inst, child1.couch_id
+    child1_recipient = Folder.find inst_recipient, child1_recipient.couch_id
+    assert_equal child1.name, child1_recipient.name
+    assert_equal child1.rev, child1_recipient.rev
+
+    da = File.join Helpers.current_dir, inst.domain, folder.name
+    db = File.join Helpers.current_dir, inst_recipient.domain,
+                   Helpers::SHARED_WITH_ME, folder.name
+    diff = Helpers.fsdiff da, db
+    diff.must_be_empty
+
+
+    # Generate conflicts with no reconciliation
+    path = CGI.escape "/#{Helpers::SHARED_WITH_ME}/#{folder.name}/#{file.name}"
+    file_recipient = CozyFile.find_by_path inst_recipient, path
+    assert_equal file_recipient.name, file.name
+
+    2.times do
+      file.overwrite inst
+      file_recipient.overwrite inst_recipient
+    end
+
+    sleep 10
+    # TODO assert
+
+  end
+end

--- a/tests/sharing/tests/conflicts.rb
+++ b/tests/sharing/tests/conflicts.rb
@@ -23,7 +23,7 @@ describe "A sharing" do
     # Create the sharing
     contact = Contact.create inst, givenName: recipient_name
     sharing = Sharing.new
-    sharing.rules << Rule.push(folder)
+    sharing.rules << Rule.sync(folder)
     sharing.members << inst << contact
     inst.register sharing
 
@@ -42,12 +42,12 @@ describe "A sharing" do
       child1_recipient.rename inst_recipient, Faker::Internet.slug
     end
 
-    sleep 10
+    sleep 12
     # Check the names are equal in db and disk
     child1 = Folder.find inst, child1.couch_id
     child1_recipient = Folder.find inst_recipient, child1_recipient.couch_id
     assert_equal child1.name, child1_recipient.name
-    assert_equal child1.rev, child1_recipient.rev
+    assert_equal child1.couch_rev, child1_recipient.couch_rev
 
     da = File.join Helpers.current_dir, inst.domain, folder.name
     db = File.join Helpers.current_dir, inst_recipient.domain,
@@ -55,8 +55,7 @@ describe "A sharing" do
     diff = Helpers.fsdiff da, db
     diff.must_be_empty
 
-
-    # Generate conflicts with no reconciliation
+    # Generate conflicts with no reconciliation
     path = CGI.escape "/#{Helpers::SHARED_WITH_ME}/#{folder.name}/#{file.name}"
     file_recipient = CozyFile.find_by_path inst_recipient, path
     assert_equal file_recipient.name, file.name
@@ -66,7 +65,7 @@ describe "A sharing" do
       file_recipient.overwrite inst_recipient
     end
 
-    sleep 10
+    sleep 12
     # TODO assert
 
   end

--- a/tests/sharing/tests/conflicts.rb
+++ b/tests/sharing/tests/conflicts.rb
@@ -6,7 +6,7 @@ describe "A sharing" do
   Helpers.scenario "conflicts"
   Helpers.start_mailhog
 
-  it "can handle conflicts on the folder" do
+  it "can handle conflicts" do
     recipient_name = "Bob"
 
     # Create the instance
@@ -17,6 +17,7 @@ describe "A sharing" do
     folder = Folder.create inst
     folder.couch_id.wont_be_empty
     child1 = Folder.create inst, dir_id: folder.couch_id
+    child2 = Folder.create inst, dir_id: folder.couch_id
     file_name = "#{Faker::Internet.slug}.txt"
     file = CozyFile.create inst, name: file_name, dir_id: folder.couch_id
 
@@ -33,19 +34,33 @@ describe "A sharing" do
     sleep 2
 
     # Generate conflicts with reconciliation
+    path = CGI.escape "/#{Helpers::SHARED_WITH_ME}/#{folder.name}/#{file.name}"
+    file_recipient = CozyFile.find_by_path inst_recipient, path
     path = CGI.escape "/#{Helpers::SHARED_WITH_ME}/#{folder.name}/#{child1.name}"
     child1_recipient = Folder.find_by_path inst_recipient, path
-    assert_equal child1_recipient.name, child1.name
+    path = CGI.escape "/#{Helpers::SHARED_WITH_ME}/#{folder.name}/#{child2.name}"
+    child2_recipient = CozyFile.find_by_path inst_recipient, path
+
+    file.move_to inst, child1.couch_id
+    file_recipient.move_to inst_recipient, child2_recipient.couch_id
+    file.move_to inst, folder.couch_id
+    file_recipient.move_to inst_recipient, child1_recipient.couch_id
 
     2.times do
       child1.rename inst, Faker::Internet.slug
       child1_recipient.rename inst_recipient, Faker::Internet.slug
     end
 
-    sleep 12
-    # Check the names are equal in db and disk
+    sleep 15
+    # Check the files and diretories are even
+    file = CozyFile.find inst, file.couch_id
+    parent_file = Folder.find inst, file.dir_id
+    file_recipient = CozyFile.find inst_recipient, file_recipient.couch_id
+    parent_file_recipient = Folder.find inst_recipient, file_recipient.dir_id
     child1 = Folder.find inst, child1.couch_id
     child1_recipient = Folder.find inst_recipient, child1_recipient.couch_id
+    assert_equal parent_file.name, parent_file_recipient.name
+    assert_equal file.couch_rev, file_recipient.couch_rev
     assert_equal child1.name, child1_recipient.name
     assert_equal child1.couch_rev, child1_recipient.couch_rev
 
@@ -56,17 +71,23 @@ describe "A sharing" do
     diff.must_be_empty
 
     # Generate conflicts with no reconciliation
-    path = CGI.escape "/#{Helpers::SHARED_WITH_ME}/#{folder.name}/#{file.name}"
-    file_recipient = CozyFile.find_by_path inst_recipient, path
-    assert_equal file_recipient.name, file.name
-
-    2.times do
+    4.times do
       file.overwrite inst
       file_recipient.overwrite inst_recipient
     end
 
-    sleep 12
-    # TODO assert
+    sleep 15
+    # Check the conflicted files
+    children = Folder.children inst, parent_file.path
+    conflict_file = children.find { |c| c.name.include? "conflict" }
+    refute_nil conflict_file
+    path = CGI.escape "#{parent_file_recipient.path}/#{conflict_file.name}"
+    conflict_file_recipient = CozyFile.find_by_path inst_recipient, path
+    assert_equal conflict_file_recipient.name, conflict_file.name
+    assert_equal conflict_file_recipient.couch_rev, conflict_file.couch_rev
+    assert_equal conflict_file_recipient.md5sum, conflict_file.md5sum
 
+    diff = Helpers.fsdiff da, db
+    diff.must_be_empty
   end
 end

--- a/tests/sharing/tests/conflicts.rb
+++ b/tests/sharing/tests/conflicts.rb
@@ -2,6 +2,30 @@ require_relative '../boot'
 require 'minitest/autorun'
 require 'pry-rescue/minitest' unless ENV['CI']
 
+def children_by_parent_id(inst, parent_id)
+  parent = Folder.find inst, parent_id
+  Folder.children inst, CGI.escape(parent.path)
+end
+
+def assert_conflict_children(inst_a, inst_b, parent_id_a, parent_id_b, filename)
+  children_a = children_by_parent_id inst_a, parent_id_a
+  assert 2, children_a.length
+  children_a.each { |child| assert child.name.include? filename }
+
+  children_b = children_by_parent_id inst_b, parent_id_b
+  assert 2, children_b.length
+  children_b.each { |child| assert child.name.include? filename }
+
+  assert_equal children_a[0].name, children_b[0].name
+  assert_equal children_a[1].name, children_b[1].name
+
+  assert_equal children_a[0].md5sum, children_b[0].md5sum
+  assert_equal children_a[1].md5sum, children_b[1].md5sum
+
+  assert_equal children_a[0].couch_rev, children_b[0].couch_rev
+  assert_equal children_a[1].couch_rev, children_b[1].couch_rev
+end
+
 describe "A sharing" do
   Helpers.scenario "conflicts"
   Helpers.start_mailhog
@@ -20,6 +44,7 @@ describe "A sharing" do
     child2 = Folder.create inst, dir_id: folder.couch_id
     child3 = Folder.create inst, dir_id: folder.couch_id
     child4 = Folder.create inst, dir_id: folder.couch_id
+    child5 = Folder.create inst, dir_id: folder.couch_id
     filename1 = "#{Faker::Internet.slug}.txt"
     filename2 = "#{Faker::Internet.slug}.txt"
     file1 = CozyFile.create inst, name: filename1, dir_id: folder.couch_id
@@ -48,6 +73,15 @@ describe "A sharing" do
     child3_recipient = Folder.find_by_path inst_recipient, path
     path = CGI.escape "/#{Helpers::SHARED_WITH_ME}/#{folder.name}/#{child4.name}"
     child4_recipient = Folder.find_by_path inst_recipient, path
+    path = CGI.escape "/#{Helpers::SHARED_WITH_ME}/#{folder.name}/#{child5.name}"
+    child5_recipient = Folder.find_by_path inst_recipient, path
+
+
+
+    # Create and trash a file for later use
+    filename_trash = "#{Faker::Internet.slug}.txt"
+    file_to_trash = CozyFile.create inst, name: filename_trash, dir_id: child5.couch_id
+    file_to_trash.remove inst
 
     # Generate conflicts with reconciliation
 
@@ -70,10 +104,7 @@ describe "A sharing" do
     2.times do
       child1.rename inst, Faker::Internet.slug
       file1.rename inst, "#{Faker::Internet.slug}.txt"
-      # FIXME: the overwrite does not seem to be properly handled: the file is
-      # going to have a 'conflict - xxx' name,  with a 'xxx' different on
-      # both sides
-      # file1.overwrite inst
+      file1.overwrite inst
       child1_recipient.rename inst_recipient, Faker::Internet.slug
       file1_recipient.rename inst_recipient, "#{Faker::Internet.slug}.txt"
     end
@@ -82,7 +113,6 @@ describe "A sharing" do
     # Check the files and diretories are even
     file1 = CozyFile.find inst, file1.couch_id
     file2 = CozyFile.find inst, file2.couch_id
-    file3 = CozyFile.find inst, file3.couch_id
     parent_file = Folder.find inst, file1.dir_id
     file1_recipient = CozyFile.find inst_recipient, file1_recipient.couch_id
     file2_recipient = CozyFile.find inst_recipient, file2_recipient.couch_id
@@ -99,7 +129,7 @@ describe "A sharing" do
     assert file2_recipient.trashed
 
     # FIXME: child2 and its child file3 are in the trash
-    # puts "child2 #{child2.name}"
+    # file3 = CozyFile.find inst, file3.couch_id 
     # child2 = Folder.find inst, child2.couch_id
     # refute_equal Folder::TRASH_DIR, child2.dir_id
     # refute_equal Folder::TRASH_DIR, file3.dir_id
@@ -110,22 +140,30 @@ describe "A sharing" do
     diff = Helpers.fsdiff da, db
     diff.must_be_empty
 
+    # DEBUG
+    puts "child 1 : #{child1.name}"
+    puts "child 2 : #{child2.name}"
+    puts "child 3 : #{child3.name}"
+    puts "child 4 : #{child4.name}"
+    puts "child 5 : #{child5.name}"
+
     # Generate conflicts with no reconciliation
 
     # Create 2 differents files with same name
-
     filename = "#{Faker::Internet.slug}.txt"
     file4 = CozyFile.create inst, name: filename, dir_id: child3.couch_id
     CozyFile.create inst_recipient, name: filename, dir_id: child3_recipient.couch_id
 
     # Create a file and rename an existing one with the newly created name
-    # FIXME : file5 and file6 end up (sometimes) with several '- conflict' in their name
-    # puts "child 4 : #{child4.name}"
     filename = "#{Faker::Internet.slug}.txt"
     file5 = CozyFile.create inst, name: filename, dir_id: child4.couch_id
     filename = "#{Faker::Internet.slug}.txt"
     file6 = CozyFile.create inst_recipient, name: filename, dir_id: child4_recipient.couch_id
     file5.rename inst, file6.name
+
+    # Create a file on a side and restore a file with same name on other side
+    file7 = CozyFile.create inst_recipient, name: filename_trash, dir_id: child5_recipient.couch_id
+    file_to_trash.restore inst
 
     # Write the same file on both sides
     2.times do
@@ -133,7 +171,8 @@ describe "A sharing" do
       file1_recipient.overwrite inst_recipient
     end
 
-    sleep 15
+    sleep 20
+
     # Check the conflicted files
     children = Folder.children inst, parent_file.path
     conflict_file = children.find { |c| c.name.include? "conflict" }
@@ -144,11 +183,9 @@ describe "A sharing" do
     assert_equal conflict_file_recipient.couch_rev, conflict_file.couch_rev
     assert_equal conflict_file_recipient.md5sum, conflict_file.md5sum
 
-    child3 = Folder.find inst, child3.couch_id
-    children = Folder.children inst, child3.path
-    assert 2, children.length
-    children.each { |child| assert child.name.include? file4.name }
-
+    assert_conflict_children inst, inst_recipient, child3.couch_id, child3_recipient.couch_id, file4.name
+    assert_conflict_children inst, inst_recipient, child4.couch_id, child4_recipient.couch_id, file6.name
+    assert_conflict_children inst, inst_recipient, child5.couch_id, child5_recipient.couch_id, file_to_trash.name
 
     diff = Helpers.fsdiff da, db
     diff.must_be_empty

--- a/tests/sharing/tests/conflicts.rb
+++ b/tests/sharing/tests/conflicts.rb
@@ -18,8 +18,12 @@ describe "A sharing" do
     folder.couch_id.wont_be_empty
     child1 = Folder.create inst, dir_id: folder.couch_id
     child2 = Folder.create inst, dir_id: folder.couch_id
-    file_name = "#{Faker::Internet.slug}.txt"
-    file = CozyFile.create inst, name: file_name, dir_id: folder.couch_id
+    child3 = Folder.create inst, dir_id: folder.couch_id
+    child4 = Folder.create inst, dir_id: folder.couch_id
+    filename1 = "#{Faker::Internet.slug}.txt"
+    filename2 = "#{Faker::Internet.slug}.txt"
+    file1 = CozyFile.create inst, name: filename1, dir_id: folder.couch_id
+    file2 = CozyFile.create inst, name: filename2, dir_id: folder.couch_id
 
     # Create the sharing
     contact = Contact.create inst, givenName: recipient_name
@@ -32,37 +36,73 @@ describe "A sharing" do
     sleep 1
     inst_recipient.accept sharing
     sleep 2
-
-    # Generate conflicts with reconciliation
-    path = CGI.escape "/#{Helpers::SHARED_WITH_ME}/#{folder.name}/#{file.name}"
-    file_recipient = CozyFile.find_by_path inst_recipient, path
+    path = CGI.escape "/#{Helpers::SHARED_WITH_ME}/#{folder.name}/#{file1.name}"
+    file1_recipient = CozyFile.find_by_path inst_recipient, path
+    path = CGI.escape "/#{Helpers::SHARED_WITH_ME}/#{folder.name}/#{file2.name}"
+    file2_recipient = CozyFile.find_by_path inst_recipient, path
     path = CGI.escape "/#{Helpers::SHARED_WITH_ME}/#{folder.name}/#{child1.name}"
     child1_recipient = Folder.find_by_path inst_recipient, path
     path = CGI.escape "/#{Helpers::SHARED_WITH_ME}/#{folder.name}/#{child2.name}"
-    child2_recipient = CozyFile.find_by_path inst_recipient, path
+    child2_recipient = Folder.find_by_path inst_recipient, path
+    path = CGI.escape "/#{Helpers::SHARED_WITH_ME}/#{folder.name}/#{child3.name}"
+    child3_recipient = Folder.find_by_path inst_recipient, path
+    path = CGI.escape "/#{Helpers::SHARED_WITH_ME}/#{folder.name}/#{child4.name}"
+    child4_recipient = Folder.find_by_path inst_recipient, path
 
-    file.move_to inst, child1.couch_id
-    file_recipient.move_to inst_recipient, child2_recipient.couch_id
-    file.move_to inst, folder.couch_id
-    file_recipient.move_to inst_recipient, child1_recipient.couch_id
+    # Generate conflicts with reconciliation
 
+    # Move the file on both sides
+    file1.move_to inst, child1.couch_id
+    file1_recipient.move_to inst_recipient, child2_recipient.couch_id
+    file1.move_to inst, folder.couch_id
+    file1_recipient.move_to inst_recipient, child1_recipient.couch_id
+
+    # Remove a file and write it on the other side
+    file2.remove inst
+    file2_recipient.overwrite inst_recipient
+
+    # Create a file and remove the folder on the other side
+    filename = "#{Faker::Internet.slug}.txt"
+    file3 = CozyFile.create inst, name: filename, dir_id: child2.couch_id
+    child2_recipient.remove inst_recipient
+
+    # Rename file and folder on both sides and write file on one side
     2.times do
       child1.rename inst, Faker::Internet.slug
+      file1.rename inst, "#{Faker::Internet.slug}.txt"
+      # FIXME: the overwrite does not seem to be properly handled: the file is
+      # going to have a 'conflict - xxx' name,  with a 'xxx' different on
+      # both sides
+      # file1.overwrite inst
       child1_recipient.rename inst_recipient, Faker::Internet.slug
+      file1_recipient.rename inst_recipient, "#{Faker::Internet.slug}.txt"
     end
 
-    sleep 15
+    sleep 20
     # Check the files and diretories are even
-    file = CozyFile.find inst, file.couch_id
-    parent_file = Folder.find inst, file.dir_id
-    file_recipient = CozyFile.find inst_recipient, file_recipient.couch_id
-    parent_file_recipient = Folder.find inst_recipient, file_recipient.dir_id
+    file1 = CozyFile.find inst, file1.couch_id
+    file2 = CozyFile.find inst, file2.couch_id
+    file3 = CozyFile.find inst, file3.couch_id
+    parent_file = Folder.find inst, file1.dir_id
+    file1_recipient = CozyFile.find inst_recipient, file1_recipient.couch_id
+    file2_recipient = CozyFile.find inst_recipient, file2_recipient.couch_id
+    parent_file_recipient = Folder.find inst_recipient, file1_recipient.dir_id
     child1 = Folder.find inst, child1.couch_id
     child1_recipient = Folder.find inst_recipient, child1_recipient.couch_id
     assert_equal parent_file.name, parent_file_recipient.name
-    assert_equal file.couch_rev, file_recipient.couch_rev
+    assert_equal file1.name, file1_recipient.name
+    assert_equal file1.couch_rev, file1_recipient.couch_rev
+    assert_equal file1.md5sum, file1_recipient.md5sum
     assert_equal child1.name, child1_recipient.name
     assert_equal child1.couch_rev, child1_recipient.couch_rev
+    assert file2.trashed
+    assert file2_recipient.trashed
+
+    # FIXME: child2 and its child file3 are in the trash
+    # puts "child2 #{child2.name}"
+    # child2 = Folder.find inst, child2.couch_id
+    # refute_equal Folder::TRASH_DIR, child2.dir_id
+    # refute_equal Folder::TRASH_DIR, file3.dir_id
 
     da = File.join Helpers.current_dir, inst.domain, folder.name
     db = File.join Helpers.current_dir, inst_recipient.domain,
@@ -71,9 +111,26 @@ describe "A sharing" do
     diff.must_be_empty
 
     # Generate conflicts with no reconciliation
-    4.times do
-      file.overwrite inst
-      file_recipient.overwrite inst_recipient
+
+    # Create 2 differents files with same name
+
+    filename = "#{Faker::Internet.slug}.txt"
+    file4 = CozyFile.create inst, name: filename, dir_id: child3.couch_id
+    CozyFile.create inst_recipient, name: filename, dir_id: child3_recipient.couch_id
+
+    # Create a file and rename an existing one with the newly created name
+    # FIXME : file5 and file6 end up (sometimes) with several '- conflict' in their name
+    # puts "child 4 : #{child4.name}"
+    filename = "#{Faker::Internet.slug}.txt"
+    file5 = CozyFile.create inst, name: filename, dir_id: child4.couch_id
+    filename = "#{Faker::Internet.slug}.txt"
+    file6 = CozyFile.create inst_recipient, name: filename, dir_id: child4_recipient.couch_id
+    file5.rename inst, file6.name
+
+    # Write the same file on both sides
+    2.times do
+      file1.overwrite inst
+      file1_recipient.overwrite inst_recipient
     end
 
     sleep 15
@@ -86,6 +143,12 @@ describe "A sharing" do
     assert_equal conflict_file_recipient.name, conflict_file.name
     assert_equal conflict_file_recipient.couch_rev, conflict_file.couch_rev
     assert_equal conflict_file_recipient.md5sum, conflict_file.md5sum
+
+    child3 = Folder.find inst, child3.couch_id
+    children = Folder.children inst, child3.path
+    assert 2, children.length
+    children.each { |child| assert child.name.include? file4.name }
+
 
     diff = Helpers.fsdiff da, db
     diff.must_be_empty


### PR DESCRIPTION
The revisions are not propagated after a conflict, therefore the tests fails on `assert_equal child1.name, child1_recipient.name` (lost conflit) or  `assert_equal child1.rev, child1_recipient.rev` (won conflict). I don't see any error in the logs.