### PR TITLE
fix: mail rendering on Gmail client

### DIFF
--- a/pkg/workers/mails/mail_templates.go
+++ b/pkg/workers/mails/mail_templates.go
@@ -512,7 +512,7 @@ func (dt *MailTheme) HTMLTemplate() string {
     }
     .body-sub a {
       word-break: break-all;
-      color:: #297EF1;
+      color: #297EF1;
       text-decoration: none;
     }
     .content-cell {


### PR DESCRIPTION
Gmail was failling its style parsing because of this extra character and therefore disregarding everything else in the `<style>` tag.