### PR TITLE
Fix push jobs on a server where workers are disabled

### DIFF
--- a/pkg/jobs/redis_broker.go
+++ b/pkg/jobs/redis_broker.go
@@ -46,12 +46,12 @@ func (b *redisBroker) StartWorkers(ws WorkersList) error {
 
 	for _, conf := range ws {
 		b.workersTypes = append(b.workersTypes, conf.WorkerType)
-		if conf.Concurrency <= 0 {
-			continue
-		}
 		ch := make(chan *Job)
 		w := NewWorker(conf)
 		b.workers = append(b.workers, w)
+		if conf.Concurrency <= 0 {
+			continue
+		}
 		if err := w.Start(ch); err != nil {
 			return err
 		}


### PR DESCRIPTION
It fixes a regression introduced by https://github.com/cozy/cozy-stack/pull/1435/commits/b9531f2ef40ca988812cdb3ecb07723e3cb572bd#diff-656325a475171641eede0030442145d6

On web servers, the workers are disabled and when we push a job, we try to find the worker from `b.workers` to execute the PreHook. So, we need to initialize `b.workers` even if the workers are disabled.