### PR TITLE
Fix a possible deadlock

### DIFF
--- a/pkg/workers/mails/mail_templates.go
+++ b/pkg/workers/mails/mail_templates.go
@@ -189,6 +189,7 @@ func (m *MailTemplater) Execute(name, locale string, recipientName string, data 
 	var c *mailCache
 	{
 		tpl.cacheMu.Lock()
+		defer tpl.cacheMu.Unlock()
 
 		if tpl.cache == nil {
 			tpl.cache = make(map[string]*mailCache)
@@ -244,8 +245,6 @@ func (m *MailTemplater) Execute(name, locale string, recipientName string, data 
 			}
 			tpl.cache[locale] = c
 		}
-
-		tpl.cacheMu.Unlock()
 	}
 
 	body, err := c.ToBody(recipientName, data)


### PR DESCRIPTION
There are a few `return`s between `Lock` and `Unlock` that can happen if a translation is missing for a mail. We should release the lock if it happens to let the other mails to be sent.