### PR TITLE
Remote doctypes translations

### DIFF
--- a/assets/locales/en.po
+++ b/assets/locales/en.po
@@ -365,6 +365,9 @@ msgstr "Insurance claims (Maif)"
 msgid "Permissions cc.cozycloud.autocategorization"
 msgstr "Categorization model enrichment file"
 
+msgid "Permissions cc.cozycloud.sentry"
+msgstr "The application logs"
+
 msgid "Mail Greeting"
 msgstr "Hello"
 

--- a/assets/locales/en.po
+++ b/assets/locales/en.po
@@ -362,6 +362,9 @@ msgstr "Societary (Maif)"
 msgid "Permissions org.fing.mesinfos.insuranceclaim"
 msgstr "Insurance claims (Maif)"
 
+msgid "Permissions cc.cozycloud.autocategorization"
+msgstr "Categorization model enrichment file"
+
 msgid "Mail Greeting"
 msgstr "Hello"
 


### PR DESCRIPTION
This add missing translations for two permissions:

* `cc.cozycloud.autocategorization`
* `cc.cozycloud.sentry`

I also added the french translations via transifex