### PR TITLE
fix: Remove 'the' in cc.cozycloud.sentry translation

### DIFF
--- a/assets/locales/en.po
+++ b/assets/locales/en.po
@@ -366,7 +366,7 @@ msgid "Permissions cc.cozycloud.autocategorization"
 msgstr "Categorization model enrichment file"
 
 msgid "Permissions cc.cozycloud.sentry"
-msgstr "The application logs"
+msgstr "Application logs"
 
 msgid "Mail Greeting"
 msgstr "Hello"


### PR DESCRIPTION
I copy/pasted the translations of the store in https://github.com/cozy/cozy-stack/pull/1465, but we don't prefix the translations with 'The' in the stack.