### PR TITLE
feat: add extra a11y on figure elements

### DIFF
--- a/assets/templates/login.html
+++ b/assets/templates/login.html
@@ -31,7 +31,7 @@
               </div>
               {{end}}
               <header>
-                <figure>
+                <figure role="group">
                   <div class="svg-wrapper">
                     <svg>
                       <use xlink:href="#cozy-icon" />

--- a/assets/templates/need_onboarding.html
+++ b/assets/templates/need_onboarding.html
@@ -25,7 +25,7 @@
         <div class="login auth">
           <div class="main-wrapper">
             <header>
-              <figure>
+              <figure role="group">
                 <div class="svg-wrapper">
                   <svg>
                     <use xlink:href="#cozy-icon" />

--- a/assets/templates/passphrase_renew.html
+++ b/assets/templates/passphrase_renew.html
@@ -22,7 +22,7 @@
         <div class="login auth">
           <div class="main-wrapper">
             <header>
-              <figure>
+              <figure role="group">
                 <div class="svg-wrapper">
                   <svg>
                     <use xlink:href="#cozy-icon" />

--- a/assets/templates/passphrase_reset.html
+++ b/assets/templates/passphrase_reset.html
@@ -22,7 +22,7 @@
         <div class="login auth">
           <div class="main-wrapper">
             <header>
-              <figure>
+              <figure role="group">
                 <div class="svg-wrapper">
                   <svg>
                     <use xlink:href="#cozy-icon" />

--- a/assets/templates/sharing_discovery.html
+++ b/assets/templates/sharing_discovery.html
@@ -24,7 +24,7 @@
           <form method="POST" action="/sharings/{{.SharingID}}/discovery" class="login auth">
             <input type="hidden" name="state" value="{{.State}}" />
             <header>
-              <figure>
+              <figure role="group">
                 <div class="svg-wrapper">
                   <svg>
                     <use xlink:href="#cozy-icon" />


### PR DESCRIPTION
Quick & easy a11y enhancement.

`<figure>` element should have a `role="group"`attribute for accessibility reasons.