### PR TITLE
Update cozy-client to v0.12.1

### DIFF
--- a/assets/.externals
+++ b/assets/.externals
@@ -11,12 +11,12 @@
 #
 
 name    ./js/cozy-client.min.js
-url     https://raw.githubusercontent.com/cozy/cozy-client-js/v0.12.0/dist/cozy-client.min.js
-sha256  e60783405d2ae26605d1c74a529444bff9fdb1abc86326c377b4693282e51003
+url     https://raw.githubusercontent.com/cozy/cozy-client-js/v0.12.1/dist/cozy-client.min.js
+sha256  2c8fab17148a133a6ff3ad61445ef12f62cd9be6f392a0801f822d021a72e52d
 
 name    ./js/cozy-client.min.js.map
-url     https://raw.githubusercontent.com/cozy/cozy-client-js/v0.12.0/dist/cozy-client.min.js.map
-sha256  1a85d1b5cfc977667afd45ef0c8444bdd97dfc75580a52773c73af7e1574a5a1
+url     https://raw.githubusercontent.com/cozy/cozy-client-js/v0.12.1/dist/cozy-client.min.js.map
+sha256  290d9610010534cdc8454424825b29913303579b6ab63181100f84713439c0a5
 
 name    ./js/cozy-bar.min.js
 url     https://unpkg.com/cozy-bar@5.2.0/dist/cozy-bar.min.js


### PR DESCRIPTION
Should fix intents redirection incompatibilty. Thanks @nono for spotting this one.