### PR TITLE
Always check the checksum when uploading to swift

### DIFF
--- a/pkg/apps/copier.go
+++ b/pkg/apps/copier.go
@@ -85,7 +85,7 @@ func (f *swiftCopier) Copy(stat os.FileInfo, src io.Reader) (err error) {
 		contentType = "application/octet-stream"
 	}
 
-	file, err := f.c.ObjectCreate(f.container, objName, false, "",
+	file, err := f.c.ObjectCreate(f.container, objName, true, "",
 		contentType, objMeta.ObjectHeaders())
 	if err != nil {
 		return err
@@ -135,7 +135,7 @@ func (f *swiftCopier) Commit() error {
 			return f.Abort()
 		}
 	}
-	o, err := f.c.ObjectCreate(f.container, f.appObj, false, "", "", nil)
+	o, err := f.c.ObjectCreate(f.container, f.appObj, true, "", "", nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/vfs/vfsswift/impl_v1.go
+++ b/pkg/vfs/vfsswift/impl_v1.go
@@ -172,7 +172,7 @@ func (sfs *swiftVFS) CreateDir(doc *vfs.DirDoc) error {
 	objName := doc.DirID + "/" + doc.DocName
 	f, err := sfs.c.ObjectCreate(sfs.container,
 		objName,
-		false,
+		true,
 		"",
 		dirContentType,
 		nil,
@@ -270,7 +270,7 @@ func (sfs *swiftVFS) CreateFile(newdoc, olddoc *vfs.FileDoc) (vfs.File, error) {
 	f, err := sfs.c.ObjectCreate(
 		sfs.container,
 		objName,
-		hash != "",
+		true,
 		hash,
 		newdoc.Mime,
 		nil,
@@ -618,7 +618,7 @@ func (sfs *swiftVFS) fsckPrune(logbook []*vfs.FsckLog, dryrun bool) {
 				}
 				_, err = sfs.c.ObjectCreate(sfs.container,
 					olddoc.DirID+"/"+olddoc.DocName,
-					false,
+					true,
 					"",
 					dirContentType,
 					nil,

--- a/pkg/vfs/vfsswift/impl_v2.go
+++ b/pkg/vfs/vfsswift/impl_v2.go
@@ -291,7 +291,7 @@ func (sfs *swiftVFSV2) CreateFile(newdoc, olddoc *vfs.FileDoc) (vfs.File, error)
 	f, err := sfs.c.ObjectCreate(
 		sfs.container,
 		objName,
-		hash != "",
+		true,
 		hash,
 		newdoc.Mime,
 		objMeta.ObjectHeaders(),

--- a/pkg/vfs/vfsswift/thumbs_v1.go
+++ b/pkg/vfs/vfsswift/thumbs_v1.go
@@ -27,7 +27,7 @@ func (t *thumbs) CreateThumb(img *vfs.FileDoc, format string) (vfs.ThumbFiler, e
 		return nil, err
 	}
 	name := t.makeName(img, format)
-	obj, err := t.c.ObjectCreate(t.container, name, false, "", "", nil)
+	obj, err := t.c.ObjectCreate(t.container, name, true, "", "", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/vfs/vfsswift/thumbs_v2.go
+++ b/pkg/vfs/vfsswift/thumbs_v2.go
@@ -56,7 +56,7 @@ func (t *thumbsV2) CreateThumb(img *vfs.FileDoc, format string) (vfs.ThumbFiler,
 	objMeta := swift.Metadata{
 		"file-md5": hex.EncodeToString(img.MD5Sum),
 	}
-	obj, err := t.c.ObjectCreate(t.container, name, false, "", img.Mime,
+	obj, err := t.c.ObjectCreate(t.container, name, true, "", img.Mime,
 		objMeta.ObjectHeaders())
 	if err != nil {
 		if _, _, errc := t.c.Container(t.container); errc == swift.ContainerNotFound {

--- a/pkg/workers/move/archiver.go
+++ b/pkg/workers/move/archiver.go
@@ -141,7 +141,7 @@ func (a *switfArchiver) CreateArchive(exportDoc *ExportDoc) (io.WriteCloser, err
 	}
 	headers := objectMeta.ObjectHeaders()
 	headers["X-Delete-At"] = strconv.FormatInt(exportDoc.ExpiresAt.Unix(), 10)
-	return a.c.ObjectCreate(a.container, objectName, false, "",
+	return a.c.ObjectCreate(a.container, objectName, true, "",
 		"application/tar+gzip", headers)
 }
 


### PR DESCRIPTION
We had a wrong interpretation of the checkHash properties defined by ncw/swift. This checkHash does not mean "check against the given hash" but "check against the calculated hash from streaming the content".

Force this argument to true, so that we always have a checksum checked as we thought.