### PR TITLE
Fsck improvements

### DIFF
--- a/client/instances.go
+++ b/client/instances.go
@@ -220,29 +220,6 @@ func (c *Client) DestroyInstance(domain string) error {
 	return err
 }
 
-// FsckInstance returns the list of the inconsistencies in the VFS.
-func (c *Client) FsckInstance(domain string, prune, dryRun bool) ([]map[string]string, error) {
-	if !validDomain(domain) {
-		return nil, fmt.Errorf("Invalid domain: %s", domain)
-	}
-	res, err := c.Req(&request.Options{
-		Method: "GET",
-		Path:   "/instances/" + url.PathEscape(domain) + "/fsck",
-		Queries: url.Values{
-			"Prune":  {strconv.FormatBool(prune)},
-			"DryRun": {strconv.FormatBool(dryRun)},
-		},
-	})
-	if err != nil {
-		return nil, err
-	}
-	var list []map[string]string
-	if err = json.NewDecoder(res.Body).Decode(&list); err != nil {
-		return nil, err
-	}
-	return list, nil
-}
-
 // GetToken is used to generate a toke with the specified options.
 func (c *Client) GetToken(opts *TokenOptions) (string, error) {
 	q := url.Values{

--- a/cmd/instances.go
+++ b/cmd/instances.go
@@ -35,8 +35,6 @@ var flagBlocked bool
 var flagDev bool
 var flagPassphrase string
 var flagForce bool
-var flagFsckDry bool
-var flagFsckPrune bool
 var flagJSON bool
 var flagDirectory string
 var flagIncreaseQuota bool
@@ -512,19 +510,11 @@ in swift/localfs but not couchdb.
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 		err = i.VFS().Fsck(func(log *vfs.FsckLog) {
 			hasError = true
-			var swiftLayout, swiftContainer string
-			if i.SwiftCluster > 0 {
-				swiftLayout = "v2"
-				swiftContainer = "cozy-v2-" + i.DBPrefix()
-			} else {
-				swiftLayout = "v1"
-				swiftContainer = "cozy-" + i.DBPrefix()
-			}
 			switch log.Type {
 			case vfs.ContentMismatch:
-				fmt.Fprintf(w, "%s;%s;%s;%s;%s;%s;%s;%s;%d;%d;%d\n",
-					i.Domain, swiftContainer, swiftLayout,
-					log.Filename,
+				fmt.Fprintf(w, "%s;%s;%s;%s;%s;%s;%d;%d\n",
+					i.Domain,
+					log.FileDoc.Fullpath,
 					log.FileDoc.DocID,
 					log.FileDoc.DocRev,
 					hex.EncodeToString(log.ContentMismatch.MD5SumIndex),
@@ -792,8 +782,6 @@ func init() {
 	modifyInstanceCmd.Flags().BoolVar(&flagBlocked, "blocked", false, "Block the instance")
 	modifyInstanceCmd.Flags().BoolVar(&flagOnboardingFinished, "onboarding-finished", false, "Force the finishing of the onboarding")
 	destroyInstanceCmd.Flags().BoolVar(&flagForce, "force", false, "Force the deletion without asking for confirmation")
-	fsckInstanceCmd.Flags().BoolVar(&flagFsckDry, "dry", false, "Don't modify the VFS, only show the inconsistencies")
-	fsckInstanceCmd.Flags().BoolVar(&flagFsckPrune, "prune", false, "Try to solve inconsistencies by modifying the file system")
 	oauthClientInstanceCmd.Flags().BoolVar(&flagJSON, "json", false, "Output more informations in JSON format")
 	oauthClientInstanceCmd.Flags().BoolVar(&flagAllowLoginScope, "allow-login-scope", false, "Allow login scope")
 	oauthTokenInstanceCmd.Flags().DurationVar(&flagExpire, "expire", 0, "Make the token expires in this amount of time")

--- a/pkg/sharing/indexer.go
+++ b/pkg/sharing/indexer.go
@@ -310,12 +310,12 @@ func (s *sharingIndexer) DirChildExists(dirID, name string) (bool, error) {
 	return s.indexer.DirChildExists(dirID, name)
 }
 
-func (s *sharingIndexer) BuildTree() (*vfs.TreeFile, error) {
-	return nil, ErrInternalServerError
+func (s *sharingIndexer) BuildTree(each ...func(*vfs.TreeFile)) (root *vfs.TreeFile, dirsmap map[string]*vfs.TreeFile, orphans map[string][]*vfs.TreeFile, err error) {
+	return nil, nil, nil, ErrInternalServerError
 }
 
-func (s *sharingIndexer) CheckIndexIntegrity() ([]*vfs.FsckLog, error) {
-	return nil, ErrInternalServerError
+func (s *sharingIndexer) CheckIndexIntegrity(predicate func(*vfs.FsckLog)) error {
+	return ErrInternalServerError
 }
 
 var _ vfs.Indexer = (*sharingIndexer)(nil)

--- a/pkg/sharing/indexer.go
+++ b/pkg/sharing/indexer.go
@@ -310,8 +310,8 @@ func (s *sharingIndexer) DirChildExists(dirID, name string) (bool, error) {
 	return s.indexer.DirChildExists(dirID, name)
 }
 
-func (s *sharingIndexer) BuildTree(each ...func(*vfs.TreeFile)) (root *vfs.TreeFile, dirsmap map[string]*vfs.TreeFile, orphans map[string][]*vfs.TreeFile, err error) {
-	return nil, nil, nil, ErrInternalServerError
+func (s *sharingIndexer) BuildTree(each ...func(*vfs.TreeFile)) (t *vfs.Tree, err error) {
+	return nil, ErrInternalServerError
 }
 
 func (s *sharingIndexer) CheckIndexIntegrity(predicate func(*vfs.FsckLog)) error {

--- a/pkg/vfs/couchdb_indexer.go
+++ b/pkg/vfs/couchdb_indexer.go
@@ -514,18 +514,14 @@ func (c *couchdbIndexer) CheckIndexIntegrity(predicate func(*FsckLog)) (err erro
 				predicate(&FsckLog{
 					Type:    IndexOrphanTree,
 					IsFile:  true,
-					FileDoc: orphan.AsFile(),
+					FileDoc: orphan,
 				})
 			} else {
-				log := &FsckLog{
-					Type:     IndexOrphanTree,
-					DirDoc:   orphan.AsDir(),
-					Filename: orphan.Fullpath,
-				}
-				if orphan.hasCycle || strings.HasPrefix(orphan.Fullpath, TrashDirName) {
-					log.Deletions = listChildren(orphan, nil)
-				}
-				predicate(log)
+				predicate(&FsckLog{
+					Type:   IndexOrphanTree,
+					IsFile: false,
+					DirDoc: orphan,
+				})
 			}
 		}
 	}
@@ -599,9 +595,9 @@ func cleanDirsMap(parent *TreeFile, dirsmap map[string]*TreeFile, predicate func
 		expected := path.Join(parent.Fullpath, child.DocName)
 		if expected != child.Fullpath {
 			predicate(&FsckLog{
-				Type:     IndexBadFullpath,
-				DirDoc:   child.AsDir(),
-				Filename: expected,
+				Type:             IndexBadFullpath,
+				DirDoc:           child,
+				ExpectedFullpath: expected,
 			})
 		}
 		cleanDirsMap(child, dirsmap, predicate)

--- a/pkg/vfs/couchdb_indexer.go
+++ b/pkg/vfs/couchdb_indexer.go
@@ -604,17 +604,17 @@ func cleanDirsMap(parent *TreeFile, dirsmap map[string]*TreeFile, predicate func
 	}
 }
 
-func listChildren(root *TreeFile, files []couchdb.Doc) []couchdb.Doc {
-	if !root.visited {
-		files = append(files, root)
-		// avoid stackoverflow on cycles
-		root.visited = true
-		for _, child := range root.DirsChildren {
-			files = listChildren(child, files)
-		}
-		for _, child := range root.FilesChildren {
-			files = append(files, child)
-		}
-	}
-	return files
-}
+// func listChildren(root *TreeFile, files []couchdb.Doc) []couchdb.Doc {
+// 	if !root.visited {
+// 		files = append(files, root)
+// 		// avoid stackoverflow on cycles
+// 		root.visited = true
+// 		for _, child := range root.DirsChildren {
+// 			files = listChildren(child, files)
+// 		}
+// 		for _, child := range root.FilesChildren {
+// 			files = append(files, child)
+// 		}
+// 	}
+// 	return files
+// }

--- a/pkg/vfs/fsck.go
+++ b/pkg/vfs/fsck.go
@@ -95,9 +95,7 @@ type TreeFile struct {
 
 	IsDir    bool `json:"is_dir"`
 	IsOrphan bool `json:"is_orphan"`
-
-	hasCycle bool
-	visited  bool
+	HasCycle bool `json:"has_cycle"`
 }
 
 func (t *TreeFile) AsFile() *FileDoc {

--- a/pkg/vfs/fsck.go
+++ b/pkg/vfs/fsck.go
@@ -12,20 +12,20 @@ const (
 	IndexMissingRoot FsckLogType = "index_missing_root"
 	// IndexOrphanTree used when a part of the tree is detached from the main
 	// root of the index.
-	IndexOrphanTree = "index_orphan_tree"
+	IndexOrphanTree FsckLogType = "index_orphan_tree"
 	// IndexBadFullpath used when a directory does not have the correct path
 	// field given its position in the index.
-	IndexBadFullpath = "index_bad_fullpath"
+	IndexBadFullpath FsckLogType = "index_bad_fullpath"
 	// FileMissing used when a file data is missing from its index entry.
-	FileMissing = "file_missing"
+	FileMissing FsckLogType = "file_missing"
 	// IndexMissing is used when the index entry is missing from a file data.
-	IndexMissing = "index_missing"
+	IndexMissing FsckLogType = "index_missing"
 	// TypeMismatch is used when a document type does not match in the index and
 	// underlying filesystem.
-	TypeMismatch = "type_mismatch"
+	TypeMismatch FsckLogType = "type_mismatch"
 	// ContentMismatch is used when a document content checksum does not match
 	// with the one in the underlying fs.
-	ContentMismatch = "content_mismatch"
+	ContentMismatch FsckLogType = "content_mismatch"
 )
 
 // FsckLog is a struct for an inconsistency in the VFS
@@ -71,8 +71,8 @@ func (f *FsckLog) String() string {
 type FsckContentMismatch struct {
 	SizeIndex   int64  `json:"size_index"`
 	SizeFile    int64  `json:"size_file"`
-	MD5SumIndex []byte `json:"md5sum_index`
-	MD5SumFile  []byte `json:"md5sum_file`
+	MD5SumIndex []byte `json:"md5sum_index"`
+	MD5SumFile  []byte `json:"md5sum_file"`
 }
 
 // TreeFile represent a subset of a file/directory structure that can be used
@@ -85,7 +85,7 @@ type TreeFile struct {
 	IsDir             bool        `json:"-"`
 
 	hasCycle bool
-	visited  bool
+	// visited  bool
 }
 
 func (t *TreeFile) AsFile() *FileDoc {

--- a/pkg/vfs/fsck.go
+++ b/pkg/vfs/fsck.go
@@ -92,10 +92,12 @@ type TreeFile struct {
 	FilesChildren     []*TreeFile `json:"-"`
 	FilesChildrenSize int64       `json:"-"`
 	DirsChildren      []*TreeFile `json:"-"`
-	IsDir             bool        `json:"-"`
+
+	IsDir    bool `json:"is_dir"`
+	IsOrphan bool `json:"is_orphan"`
 
 	hasCycle bool
-	// visited  bool
+	visited  bool
 }
 
 func (t *TreeFile) AsFile() *FileDoc {

--- a/pkg/vfs/fsck.go
+++ b/pkg/vfs/fsck.go
@@ -30,15 +30,12 @@ const (
 
 // FsckLog is a struct for an inconsistency in the VFS
 type FsckLog struct {
-	Type            FsckLogType          `json:"type"`
-	FileDoc         *FileDoc             `json:"file_doc,omitempty"`
-	DirDoc          *DirDoc              `json:"dir_doc,omitempty"`
-	Deletions       []couchdb.Doc        `json:"deletions,omitempty"`
-	IsFile          bool                 `json:"is_file"`
-	Filename        string               `json:"filename,omitempty"`
-	PruneAction     string               `json:"prune_action,omitempty"`
-	PruneError      error                `json:"prune_error,omitempty"`
-	ContentMismatch *FsckContentMismatch `json:"content_mismatch,omitempty"`
+	Type             FsckLogType          `json:"type"`
+	FileDoc          *TreeFile            `json:"file_doc,omitempty"`
+	DirDoc           *TreeFile            `json:"dir_doc,omitempty"`
+	IsFile           bool                 `json:"is_file"`
+	ContentMismatch  *FsckContentMismatch `json:"content_mismatch,omitempty"`
+	ExpectedFullpath string               `json:"expected_fullpath,omitempty"`
 }
 
 // String returns a string describing the FsckLog
@@ -82,9 +79,9 @@ type FsckContentMismatch struct {
 // in a tree-like representation of the index.
 type TreeFile struct {
 	DirOrFileDoc
-	FilesChildren     []*TreeFile `json:"children,omitempty"`
-	FilesChildrenSize int64       `json:"children_size,omitempty"`
-	DirsChildren      []*TreeFile `json:"directories,omitempty"`
+	FilesChildren     []*TreeFile `json:"-"`
+	FilesChildrenSize int64       `json:"-"`
+	DirsChildren      []*TreeFile `json:"-"`
 	IsDir             bool        `json:"-"`
 
 	hasCycle bool

--- a/pkg/vfs/fsck.go
+++ b/pkg/vfs/fsck.go
@@ -75,6 +75,16 @@ type FsckContentMismatch struct {
 	MD5SumFile  []byte `json:"md5sum_file"`
 }
 
+// Tree is returned by the BuildTree method on the indexes. In containes a
+// pointer to the root element of the tree, a map of directories indexed by
+// their ID, and a map of a potential list of orphan file or directories
+// indexed by their DirID.
+type Tree struct {
+	Root    *TreeFile
+	DirsMap map[string]*TreeFile
+	Orphans map[string][]*TreeFile
+}
+
 // TreeFile represent a subset of a file/directory structure that can be used
 // in a tree-like representation of the index.
 type TreeFile struct {

--- a/pkg/vfs/fsck.go
+++ b/pkg/vfs/fsck.go
@@ -1,50 +1,44 @@
 package vfs
 
 import (
-	"encoding/json"
-	"fmt"
-	"os"
-	"path"
-
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 )
 
 // FsckLogType is the type of a FsckLog
-type FsckLogType int
+type FsckLogType string
 
 const (
 	// IndexMissingRoot is used when the index does not have a root object
-	IndexMissingRoot FsckLogType = iota
+	IndexMissingRoot FsckLogType = "index_missing_root"
 	// IndexOrphanTree used when a part of the tree is detached from the main
 	// root of the index.
-	IndexOrphanTree
+	IndexOrphanTree = "index_orphan_tree"
 	// IndexBadFullpath used when a directory does not have the correct path
 	// field given its position in the index.
-	IndexBadFullpath
+	IndexBadFullpath = "index_bad_fullpath"
 	// FileMissing used when a file data is missing from its index entry.
-	FileMissing
+	FileMissing = "file_missing"
 	// IndexMissing is used when the index entry is missing from a file data.
-	IndexMissing
+	IndexMissing = "index_missing"
 	// TypeMismatch is used when a document type does not match in the index and
 	// underlying filesystem.
-	TypeMismatch
+	TypeMismatch = "type_mismatch"
 	// ContentMismatch is used when a document content checksum does not match
 	// with the one in the underlying fs.
-	ContentMismatch
+	ContentMismatch = "content_mismatch"
 )
 
 // FsckLog is a struct for an inconsistency in the VFS
 type FsckLog struct {
-	Type        FsckLogType
-	FileDoc     *FileDoc
-	OldFileDoc  *FileDoc
-	DirDoc      *DirDoc
-	OldDirDoc   *DirDoc
-	Deletions   []couchdb.Doc
-	IsFile      bool
-	Filename    string
-	PruneAction string
-	PruneError  error
+	Type            FsckLogType          `json:"type"`
+	FileDoc         *FileDoc             `json:"file_doc,omitempty"`
+	DirDoc          *DirDoc              `json:"dir_doc,omitempty"`
+	Deletions       []couchdb.Doc        `json:"deletions,omitempty"`
+	IsFile          bool                 `json:"is_file"`
+	Filename        string               `json:"filename,omitempty"`
+	PruneAction     string               `json:"prune_action,omitempty"`
+	PruneError      error                `json:"prune_error,omitempty"`
+	ContentMismatch *FsckContentMismatch `json:"content_mismatch,omitempty"`
 }
 
 // String returns a string describing the FsckLog
@@ -72,131 +66,49 @@ func (f *FsckLog) String() string {
 	case IndexMissing:
 		return "the document is present on the local filesystem but not in the index"
 	case ContentMismatch:
-		return "then document content does not match the store content checksum"
+		return "the document content does not match the store content checksum"
 	}
 	panic("bad FsckLog type")
 }
 
-// MarshalJSON implements the json.Marshaler interface
-func (f *FsckLog) MarshalJSON() ([]byte, error) {
-	v := map[string]string{
-		"filename": f.Filename,
-		"message":  f.String(),
-	}
-	if f.IsFile {
-		v["file_id"] = f.FileDoc.ID()
-	} else {
-		v["file_id"] = f.DirDoc.ID()
-	}
-	if f.PruneAction != "" {
-		v["prune_action"] = f.PruneAction
-		if f.PruneError != nil {
-			v["prune_error"] = f.PruneError.Error()
-		}
-	}
-	return json.Marshal(v)
+type FsckContentMismatch struct {
+	SizeIndex   int64  `json:"size_index"`
+	SizeFile    int64  `json:"size_file"`
+	MD5SumIndex []byte `json:"md5sum_index`
+	MD5SumFile  []byte `json:"md5sum_file`
 }
 
-// FsckPrune tries to fix the given entry in the VFS
-func FsckPrune(fs VFS, indexer Indexer, entry *FsckLog, dryrun bool) {
-	switch entry.Type {
-	case IndexMissingRoot:
-		entry.PruneAction = "no action: requires manual inspection"
-	case IndexOrphanTree:
-		if entry.IsFile {
-			if entry.FileDoc.Trashed {
-				entry.PruneAction = "deleting the entry"
-				if !dryrun {
-					if err := indexer.DeleteFileDoc(entry.FileDoc); err != nil {
-						entry.PruneError = err
-					}
-				}
-			} else {
-				entry.PruneAction = "no action: requires manual inspection"
-			}
-		} else {
-			if len(entry.Deletions) > 0 {
-				entry.PruneAction = "deleting the orphan directory and its children from the index"
-				if !dryrun {
-					if err := indexer.BatchDelete(entry.Deletions); err != nil {
-						entry.PruneError = err
-					}
-				}
-			} else {
-				entry.PruneAction = "no action: requires manual inspection"
-			}
-		}
-	case IndexBadFullpath:
-		entry.PruneAction = fmt.Sprintf("updating the path attribute of the directory to: %q",
-			entry.Filename)
-		if !dryrun {
-			if err := indexer.UpdateDirDoc(entry.OldDirDoc, entry.DirDoc); err != nil {
-				entry.PruneError = err
-			}
-		}
-	case FileMissing:
-		entry.PruneAction = "deleting entry from index"
-		if dryrun {
-			return
-		}
-		if entry.IsFile {
-			if err := indexer.DeleteFileDoc(entry.FileDoc); err != nil {
-				entry.PruneError = err
-			}
-		} else {
-			if err := indexer.DeleteDirDoc(entry.DirDoc); err != nil {
-				entry.PruneError = err
-			}
-		}
-	case IndexMissing:
-		if !entry.IsFile {
-			return
-		}
-		fileDoc := entry.FileDoc
-		var orphan bool
-		if fileDoc.DirID == "" {
-			orphan = true
-		} else {
-			parentDir, err := indexer.DirByID(fileDoc.DirID)
-			if os.IsNotExist(err) {
-				orphan = true
-			} else if err != nil {
-				entry.PruneError = err
-				return
-			} else {
-				fullpath := path.Join(parentDir.Fullpath, fileDoc.Name())
-				if _, err := indexer.FileByPath(fullpath); err != nil {
-					entry.PruneError = err
-					return
-				}
-			}
-		}
-		if orphan {
-			entry.PruneAction = "creating index entry in orphan directory"
-		} else {
-			entry.PruneAction = "creating index entry in-place"
-		}
-		if dryrun {
-			return
-		}
-		if orphan {
-			orphanDir, err := Mkdir(fs, OrphansDirName, nil)
-			if err != nil {
-				entry.PruneError = err
-				return
-			}
-			fileDoc.DirID = orphanDir.ID()
-		}
-		if err := indexer.CreateFileDoc(fileDoc); err != nil {
-			entry.PruneError = err
-		}
-	case ContentMismatch:
-		if !entry.IsFile {
-			return
-		}
-		entry.PruneAction = "updating the index informations to match the stored data"
-		if err := indexer.UpdateFileDoc(entry.OldFileDoc, entry.FileDoc); err != nil {
-			entry.PruneError = err
-		}
-	}
+// TreeFile represent a subset of a file/directory structure that can be used
+// in a tree-like representation of the index.
+type TreeFile struct {
+	DirOrFileDoc
+	FilesChildren     []*TreeFile `json:"children,omitempty"`
+	FilesChildrenSize int64       `json:"children_size,omitempty"`
+	DirsChildren      []*TreeFile `json:"directories,omitempty"`
+	IsDir             bool        `json:"-"`
+
+	hasCycle bool
+	visited  bool
 }
+
+func (t *TreeFile) AsFile() *FileDoc {
+	if t.IsDir {
+		panic("calling AsFile on a directory")
+	}
+	_, fileDoc := t.DirOrFileDoc.Refine()
+	return fileDoc
+}
+
+func (t *TreeFile) AsDir() *DirDoc {
+	if !t.IsDir {
+		panic("calling AsDir on a file")
+	}
+	return t.DirDoc.Clone().(*DirDoc)
+}
+
+// Clone is part of the couchdb.Doc interface
+func (t *TreeFile) Clone() couchdb.Doc {
+	panic("TreeFile must not be cloned")
+}
+
+var _ couchdb.Doc = &TreeFile{}

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -177,7 +177,7 @@ type Indexer interface {
 	DirChildExists(dirID, filename string) (bool, error)
 	BatchDelete([]couchdb.Doc) error
 
-	BuildTree(each ...func(*TreeFile)) (root *TreeFile, dirsmap map[string]*TreeFile, orphans map[string][]*TreeFile, err error)
+	BuildTree(each ...func(*TreeFile)) (tree *Tree, err error)
 	CheckIndexIntegrity(func(*FsckLog)) error
 }
 

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -87,13 +87,7 @@ type Fs interface {
 	DestroyFile(doc *FileDoc) error
 
 	// Fsck return the list of inconsistencies in the VFS
-	Fsck(opts FsckOptions) (logbook []*FsckLog, err error)
-}
-
-// FsckOptions contains the options for the filesystem check process.
-type FsckOptions struct {
-	Prune  bool
-	DryRun bool
+	Fsck(func(log *FsckLog)) (err error)
 }
 
 // File is a reader, writer, seeker, closer iterface representing an opened
@@ -183,8 +177,8 @@ type Indexer interface {
 	DirChildExists(dirID, filename string) (bool, error)
 	BatchDelete([]couchdb.Doc) error
 
-	BuildTree() (*TreeFile, error)
-	CheckIndexIntegrity() ([]*FsckLog, error)
+	BuildTree(each ...func(*TreeFile)) (root *TreeFile, dirsmap map[string]*TreeFile, orphans map[string][]*TreeFile, err error)
+	CheckIndexIntegrity(func(*FsckLog)) error
 }
 
 // DiskThresholder it an interface that can be implemeted to known how many space

--- a/pkg/vfs/vfsafero/impl.go
+++ b/pkg/vfs/vfsafero/impl.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/lock"
 	"github.com/cozy/cozy-stack/pkg/logger"
@@ -447,6 +448,7 @@ func fileInfosToDirDoc(fullpath string, fileinfo os.FileInfo) *vfs.TreeFile {
 	return &vfs.TreeFile{
 		DirOrFileDoc: vfs.DirOrFileDoc{
 			DirDoc: &vfs.DirDoc{
+				Type:      consts.DirType,
 				DocName:   fileinfo.Name(),
 				DirID:     "",
 				CreatedAt: fileinfo.ModTime(),
@@ -464,6 +466,7 @@ func fileInfosToFileDoc(fullpath string, fileinfo os.FileInfo) *vfs.TreeFile {
 	return &vfs.TreeFile{
 		DirOrFileDoc: vfs.DirOrFileDoc{
 			DirDoc: &vfs.DirDoc{
+				Type:      consts.FileType,
 				DocName:   fileinfo.Name(),
 				DirID:     "",
 				CreatedAt: fileinfo.ModTime(),

--- a/pkg/vfs/vfsafero/impl.go
+++ b/pkg/vfs/vfsafero/impl.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -343,137 +344,138 @@ func (afs *aferoVFS) OpenFile(doc *vfs.FileDoc) (vfs.File, error) {
 }
 
 func (afs *aferoVFS) Fsck(predicate func(log *vfs.FsckLog)) (err error) {
-	root, err := afs.Indexer.DirByPath("/")
+	entries := make(map[string]*vfs.TreeFile, 1024)
+	_, _, _, err = afs.BuildTree(func(f *vfs.TreeFile) {
+		entries[f.Fullpath] = f
+	})
 	if err != nil {
-		return err
+		return
 	}
-	return afs.fsckWalk(root, predicate)
-}
 
-func (afs *aferoVFS) fsckWalk(dir *vfs.DirDoc, predicate func(log *vfs.FsckLog)) error {
-	entries := make(map[string]struct{})
-	iter := afs.Indexer.DirIterator(dir, nil)
-	for {
-		d, f, err := iter.Next()
-		if err == vfs.ErrIteratorDone {
-			break
-		}
+	err = afero.Walk(afs.fs, "/", func(fullpath string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
-		var fullpath string
-		if f != nil {
-			var stat os.FileInfo
-			entries[f.DocName] = struct{}{}
-			fullpath = path.Join(dir.Fullpath, f.DocName)
-			stat, err = afs.fs.Stat(fullpath)
-			if _, ok := err.(*os.PathError); ok {
+
+		if fullpath == vfs.WebappsDirName ||
+			fullpath == vfs.KonnectorsDirName ||
+			fullpath == vfs.ThumbsDirName {
+			return filepath.SkipDir
+		}
+
+		f, ok := entries[fullpath]
+		if !ok {
+			predicate(&vfs.FsckLog{
+				Type:    vfs.IndexMissing,
+				IsFile:  true,
+				FileDoc: fileInfosToFileDoc(fullpath, info),
+			})
+		} else if f.IsDir != info.IsDir() {
+			if f.IsDir {
 				predicate(&vfs.FsckLog{
-					Type:     vfs.FileMissing,
-					IsFile:   true,
-					FileDoc:  f,
-					Filename: fullpath,
-				})
-			} else if err != nil {
-				return err
-			} else if stat.IsDir() {
-				var dirDoc *vfs.DirDoc
-				dirDoc, err = vfs.NewDirDocWithParent(f.DocName, dir, nil)
-				if err != nil {
-					return err
-				}
-				predicate(&vfs.FsckLog{
-					Type:     vfs.TypeMismatch,
-					IsFile:   true,
-					DirDoc:   dirDoc,
-					FileDoc:  f,
-					Filename: fullpath,
-				})
-			}
-		} else {
-			entries[d.DocName] = struct{}{}
-			var stat os.FileInfo
-			stat, err = afs.fs.Stat(d.Fullpath)
-			if _, ok := err.(*os.PathError); ok {
-				predicate(&vfs.FsckLog{
-					Type:     vfs.FileMissing,
-					IsFile:   false,
-					DirDoc:   d,
-					Filename: d.Fullpath,
-				})
-			} else if err != nil {
-				return err
-			} else if !stat.IsDir() {
-				var fileDoc *vfs.FileDoc
-				fileDoc, err = fileInfosToFileDoc(dir, d.Fullpath, stat)
-				if err != nil {
-					return err
-				}
-				predicate(&vfs.FsckLog{
-					Type:     vfs.TypeMismatch,
-					IsFile:   false,
-					FileDoc:  fileDoc,
-					DirDoc:   d,
-					Filename: d.Fullpath,
+					Type:    vfs.TypeMismatch,
+					IsFile:  true,
+					FileDoc: f,
+					DirDoc:  fileInfosToDirDoc(fullpath, info),
 				})
 			} else {
-				if err = afs.fsckWalk(d, predicate); err != nil {
-					return err
-				}
+				predicate(&vfs.FsckLog{
+					Type:    vfs.TypeMismatch,
+					IsFile:  false,
+					DirDoc:  f,
+					FileDoc: fileInfosToFileDoc(fullpath, info),
+				})
+			}
+		} else if !f.IsDir {
+			var fd afero.File
+			fd, err = afs.fs.Open(fullpath)
+			if err != nil {
+				return err
+			}
+			h := md5.New()
+			if _, err = io.Copy(h, fd); err != nil {
+				fd.Close()
+				return err
+			}
+			if err = fd.Close(); err != nil {
+				return err
+			}
+			md5sum := h.Sum(nil)
+			if !bytes.Equal(md5sum, f.MD5Sum) {
+				predicate(&vfs.FsckLog{
+					Type:    vfs.ContentMismatch,
+					IsFile:  true,
+					FileDoc: f,
+					ContentMismatch: &vfs.FsckContentMismatch{
+						SizeFile:    info.Size(),
+						SizeIndex:   f.ByteSize,
+						MD5SumFile:  md5sum,
+						MD5SumIndex: f.MD5Sum,
+					},
+				})
 			}
 		}
-	}
-
-	fileinfos, err := afero.ReadDir(afs.fs, dir.Fullpath)
+		delete(entries, fullpath)
+		return nil
+	})
 	if err != nil {
-		return err
+		return
 	}
 
-	for _, fileinfo := range fileinfos {
-		if _, ok := entries[fileinfo.Name()]; !ok {
-			filename := path.Join(dir.Fullpath, fileinfo.Name())
-			if filename == vfs.WebappsDirName ||
-				filename == vfs.KonnectorsDirName ||
-				filename == vfs.ThumbsDirName {
-				continue
-			}
-			if fileinfo.Size() == 0 {
-				continue
-			}
-			fileDoc, err := fileInfosToFileDoc(dir, filename, fileinfo)
-			if err != nil {
-				continue
-			}
+	for _, f := range entries {
+		if f.IsDir {
 			predicate(&vfs.FsckLog{
-				Type:     vfs.IndexMissing,
-				IsFile:   true,
-				FileDoc:  fileDoc,
-				Filename: filename,
+				Type:   vfs.FileMissing,
+				IsFile: false,
+				DirDoc: f,
+			})
+		} else {
+			predicate(&vfs.FsckLog{
+				Type:    vfs.FileMissing,
+				IsFile:  true,
+				FileDoc: f,
 			})
 		}
 	}
 
-	return nil
+	return
 }
 
-func fileInfosToFileDoc(dir *vfs.DirDoc, fullpath string, fileinfo os.FileInfo) (*vfs.FileDoc, error) {
-	trashed := strings.HasPrefix(fullpath, vfs.TrashDirName)
-	contentType, md5sum, err := extractContentTypeAndMD5(fullpath)
-	if err != nil {
-		return nil, err
+func fileInfosToDirDoc(fullpath string, fileinfo os.FileInfo) *vfs.TreeFile {
+	return &vfs.TreeFile{
+		DirOrFileDoc: vfs.DirOrFileDoc{
+			DirDoc: &vfs.DirDoc{
+				DocName:   fileinfo.Name(),
+				DirID:     "",
+				CreatedAt: fileinfo.ModTime(),
+				UpdatedAt: fileinfo.ModTime(),
+				Fullpath:  fullpath,
+			},
+		},
 	}
+}
+
+func fileInfosToFileDoc(fullpath string, fileinfo os.FileInfo) *vfs.TreeFile {
+	trashed := strings.HasPrefix(fullpath, vfs.TrashDirName)
+	contentType, md5sum, _ := extractContentTypeAndMD5(fullpath)
 	mime, class := vfs.ExtractMimeAndClass(contentType)
-	return vfs.NewFileDoc(
-		fileinfo.Name(),
-		dir.DocID,
-		fileinfo.Size(),
-		md5sum,
-		mime,
-		class,
-		fileinfo.ModTime(),
-		false,
-		trashed,
-		nil)
+	return &vfs.TreeFile{
+		DirOrFileDoc: vfs.DirOrFileDoc{
+			DirDoc: &vfs.DirDoc{
+				DocName:   fileinfo.Name(),
+				DirID:     "",
+				CreatedAt: fileinfo.ModTime(),
+				UpdatedAt: fileinfo.ModTime(),
+				Fullpath:  fullpath,
+			},
+			ByteSize:   fileinfo.Size(),
+			Mime:       mime,
+			Class:      class,
+			Executable: int(fileinfo.Mode()|0111) > 0,
+			MD5Sum:     md5sum,
+			Trashed:    trashed,
+		},
+	}
 }
 
 // UpdateFileDoc overrides the indexer's one since the afero.Fs is by essence

--- a/pkg/vfs/vfsafero/impl.go
+++ b/pkg/vfs/vfsafero/impl.go
@@ -10,7 +10,6 @@ import (
 	"net/url"
 	"os"
 	"path"
-	"sort"
 	"strings"
 	"sync"
 
@@ -343,38 +342,15 @@ func (afs *aferoVFS) OpenFile(doc *vfs.FileDoc) (vfs.File, error) {
 	return &aferoFileOpen{f}, nil
 }
 
-func (afs *aferoVFS) Fsck(opts vfs.FsckOptions) (logbook []*vfs.FsckLog, err error) {
-	if lockerr := afs.mu.Lock(); lockerr != nil {
-		return nil, lockerr
-	}
-	defer afs.mu.Unlock()
-	logbook, err = afs.Indexer.CheckIndexIntegrity()
-	if err != nil {
-		return
-	}
-	if opts.Prune {
-		afs.fsckPrune(logbook, opts.DryRun)
-	}
+func (afs *aferoVFS) Fsck(predicate func(log *vfs.FsckLog)) (err error) {
 	root, err := afs.Indexer.DirByPath("/")
 	if err != nil {
-		return nil, err
+		return err
 	}
-	var newLogs []*vfs.FsckLog
-	newLogs, err = afs.fsckWalk(root, newLogs)
-	if err != nil {
-		return nil, err
-	}
-	sort.Slice(newLogs, func(i, j int) bool {
-		return newLogs[i].Filename < newLogs[j].Filename
-	})
-	logbook = append(logbook, newLogs...)
-	if opts.Prune {
-		afs.fsckPrune(newLogs, opts.DryRun)
-	}
-	return logbook, nil
+	return afs.fsckWalk(root, predicate)
 }
 
-func (afs *aferoVFS) fsckWalk(dir *vfs.DirDoc, logbook []*vfs.FsckLog) ([]*vfs.FsckLog, error) {
+func (afs *aferoVFS) fsckWalk(dir *vfs.DirDoc, predicate func(log *vfs.FsckLog)) error {
 	entries := make(map[string]struct{})
 	iter := afs.Indexer.DirIterator(dir, nil)
 	for {
@@ -383,7 +359,7 @@ func (afs *aferoVFS) fsckWalk(dir *vfs.DirDoc, logbook []*vfs.FsckLog) ([]*vfs.F
 			break
 		}
 		if err != nil {
-			return nil, err
+			return err
 		}
 		var fullpath string
 		if f != nil {
@@ -392,21 +368,21 @@ func (afs *aferoVFS) fsckWalk(dir *vfs.DirDoc, logbook []*vfs.FsckLog) ([]*vfs.F
 			fullpath = path.Join(dir.Fullpath, f.DocName)
 			stat, err = afs.fs.Stat(fullpath)
 			if _, ok := err.(*os.PathError); ok {
-				logbook = append(logbook, &vfs.FsckLog{
+				predicate(&vfs.FsckLog{
 					Type:     vfs.FileMissing,
 					IsFile:   true,
 					FileDoc:  f,
 					Filename: fullpath,
 				})
 			} else if err != nil {
-				return nil, err
+				return err
 			} else if stat.IsDir() {
 				var dirDoc *vfs.DirDoc
 				dirDoc, err = vfs.NewDirDocWithParent(f.DocName, dir, nil)
 				if err != nil {
-					return nil, err
+					return err
 				}
-				logbook = append(logbook, &vfs.FsckLog{
+				predicate(&vfs.FsckLog{
 					Type:     vfs.TypeMismatch,
 					IsFile:   true,
 					DirDoc:   dirDoc,
@@ -419,21 +395,21 @@ func (afs *aferoVFS) fsckWalk(dir *vfs.DirDoc, logbook []*vfs.FsckLog) ([]*vfs.F
 			var stat os.FileInfo
 			stat, err = afs.fs.Stat(d.Fullpath)
 			if _, ok := err.(*os.PathError); ok {
-				logbook = append(logbook, &vfs.FsckLog{
+				predicate(&vfs.FsckLog{
 					Type:     vfs.FileMissing,
 					IsFile:   false,
 					DirDoc:   d,
 					Filename: d.Fullpath,
 				})
 			} else if err != nil {
-				return nil, err
+				return err
 			} else if !stat.IsDir() {
 				var fileDoc *vfs.FileDoc
 				fileDoc, err = fileInfosToFileDoc(dir, d.Fullpath, stat)
 				if err != nil {
-					return nil, err
+					return err
 				}
-				logbook = append(logbook, &vfs.FsckLog{
+				predicate(&vfs.FsckLog{
 					Type:     vfs.TypeMismatch,
 					IsFile:   false,
 					FileDoc:  fileDoc,
@@ -441,8 +417,8 @@ func (afs *aferoVFS) fsckWalk(dir *vfs.DirDoc, logbook []*vfs.FsckLog) ([]*vfs.F
 					Filename: d.Fullpath,
 				})
 			} else {
-				if logbook, err = afs.fsckWalk(d, logbook); err != nil {
-					return nil, err
+				if err = afs.fsckWalk(d, predicate); err != nil {
+					return err
 				}
 			}
 		}
@@ -450,7 +426,7 @@ func (afs *aferoVFS) fsckWalk(dir *vfs.DirDoc, logbook []*vfs.FsckLog) ([]*vfs.F
 
 	fileinfos, err := afero.ReadDir(afs.fs, dir.Fullpath)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, fileinfo := range fileinfos {
@@ -468,7 +444,7 @@ func (afs *aferoVFS) fsckWalk(dir *vfs.DirDoc, logbook []*vfs.FsckLog) ([]*vfs.F
 			if err != nil {
 				continue
 			}
-			logbook = append(logbook, &vfs.FsckLog{
+			predicate(&vfs.FsckLog{
 				Type:     vfs.IndexMissing,
 				IsFile:   true,
 				FileDoc:  fileDoc,
@@ -477,7 +453,7 @@ func (afs *aferoVFS) fsckWalk(dir *vfs.DirDoc, logbook []*vfs.FsckLog) ([]*vfs.F
 		}
 	}
 
-	return logbook, nil
+	return nil
 }
 
 func fileInfosToFileDoc(dir *vfs.DirDoc, fullpath string, fileinfo os.FileInfo) (*vfs.FileDoc, error) {
@@ -498,58 +474,6 @@ func fileInfosToFileDoc(dir *vfs.DirDoc, fullpath string, fileinfo os.FileInfo) 
 		false,
 		trashed,
 		nil)
-}
-
-// fsckPrune tries to fix the given list on inconsistencies in the VFS
-func (afs *aferoVFS) fsckPrune(logbook []*vfs.FsckLog, dryrun bool) {
-	for _, entry := range logbook {
-		switch entry.Type {
-		case vfs.IndexOrphanTree, vfs.IndexBadFullpath, vfs.FileMissing, vfs.IndexMissing:
-			vfs.FsckPrune(afs, afs.Indexer, entry, dryrun)
-		case vfs.TypeMismatch:
-			if entry.IsFile {
-				// file on couchdb and directory on swift: we update the index to
-				// remove the file index and create a directory one
-				err := afs.Indexer.DeleteFileDoc(entry.FileDoc)
-				if err != nil {
-					entry.PruneError = err
-				}
-				err = afs.Indexer.CreateDirDoc(entry.DirDoc)
-				if err != nil {
-					entry.PruneError = err
-				}
-			} else {
-				// directory on couchdb and file on filesystem: we keep the directory
-				// and move the object into the orphan directory and create a new index
-				// associated with it.
-				orphanDir, err := vfs.Mkdir(afs, vfs.OrphansDirName, nil)
-				if err != nil {
-					entry.PruneError = err
-					continue
-				}
-				oldname := entry.Filename
-				newname := path.Join(vfs.OrphansDirName, entry.FileDoc.Name())
-				err = afs.fs.Rename(oldname, newname)
-				if err != nil {
-					entry.PruneError = err
-					continue
-				}
-				err = afs.fs.Mkdir(oldname, 0755)
-				if err != nil {
-					entry.PruneError = err
-					continue
-				}
-				newdoc := entry.FileDoc.Clone().(*vfs.FileDoc)
-				newdoc.DirID = orphanDir.ID()
-				newdoc.ResetFullpath()
-				err = afs.Indexer.CreateFileDoc(newdoc)
-				if err != nil {
-					entry.PruneError = err
-					continue
-				}
-			}
-		}
-	}
 }
 
 // UpdateFileDoc overrides the indexer's one since the afero.Fs is by essence

--- a/pkg/vfs/vfsafero/impl.go
+++ b/pkg/vfs/vfsafero/impl.go
@@ -346,7 +346,9 @@ func (afs *aferoVFS) OpenFile(doc *vfs.FileDoc) (vfs.File, error) {
 func (afs *aferoVFS) Fsck(accumulate func(log *vfs.FsckLog)) (err error) {
 	entries := make(map[string]*vfs.TreeFile, 1024)
 	_, err = afs.BuildTree(func(f *vfs.TreeFile) {
-		entries[f.Fullpath] = f
+		if !f.IsOrphan {
+			entries[f.Fullpath] = f
+		}
 	})
 	if err != nil {
 		return

--- a/pkg/vfs/vfsswift/impl_v1.go
+++ b/pkg/vfs/vfsswift/impl_v1.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path"
 	"strings"
 
 	"github.com/cozy/cozy-stack/pkg/config"
@@ -472,29 +471,6 @@ func (sfs *swiftVFS) Fsck(predicate func(log *vfs.FsckLog)) (err error) {
 		})
 	}
 
-	return
-}
-
-func objectToFileDocV1(dir *vfs.DirDoc, object swift.Object) (filePath string, fileDoc *vfs.FileDoc, err error) {
-	trashed := strings.HasPrefix(dir.Fullpath, vfs.TrashDirName)
-	dirID := dir.DocID
-	filePath = path.Join(dir.Fullpath, path.Base(object.Name))
-	md5sum, err := hex.DecodeString(object.Hash)
-	if err != nil {
-		return
-	}
-	mime, class := vfs.ExtractMimeAndClass(object.ContentType)
-	fileDoc, err = vfs.NewFileDoc(
-		path.Base(object.Name),
-		dirID,
-		object.Bytes,
-		md5sum,
-		mime,
-		class,
-		object.LastModified,
-		false,
-		trashed,
-		nil)
 	return
 }
 

--- a/pkg/vfs/vfsswift/impl_v1.go
+++ b/pkg/vfs/vfsswift/impl_v1.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"sort"
 	"strings"
 
 	"github.com/cozy/cozy-stack/pkg/config"
@@ -417,141 +416,65 @@ func (sfs *swiftVFS) OpenFile(doc *vfs.FileDoc) (vfs.File, error) {
 	return &swiftFileOpen{f, nil}, nil
 }
 
-func (sfs *swiftVFS) Fsck(opts vfs.FsckOptions) (logbook []*vfs.FsckLog, err error) {
-	if lockerr := sfs.mu.RLock(); lockerr != nil {
-		return nil, lockerr
-	}
-	defer sfs.mu.RUnlock()
-	logbook, err = sfs.Indexer.CheckIndexIntegrity()
-	if err != nil {
-		return
-	}
-	if opts.Prune {
-		sfs.fsckPrune(logbook, opts.DryRun)
-	}
-	root, err := sfs.Indexer.DirByPath("/")
-	if err != nil {
-		return
-	}
-	var newLogs []*vfs.FsckLog
-	newLogs, err = sfs.fsckWalk(root, newLogs)
-	if err != nil {
-		return
-	}
-	sort.Slice(newLogs, func(i, j int) bool {
-		return newLogs[i].Filename < newLogs[j].Filename
-	})
-	logbook = append(logbook, newLogs...)
-	if opts.Prune {
-		sfs.fsckPrune(newLogs, opts.DryRun)
-	}
-	return
-}
-
-func (sfs *swiftVFS) fsckWalk(dir *vfs.DirDoc, logbook []*vfs.FsckLog) ([]*vfs.FsckLog, error) {
-	entries := make(map[string]struct{})
-	iter := sfs.Indexer.DirIterator(dir, nil)
-	for {
-		d, f, err := iter.Next()
-		if err == vfs.ErrIteratorDone {
-			break
+func (sfs *swiftVFS) Fsck(predicate func(log *vfs.FsckLog)) (err error) {
+	entries := make(map[string]*vfs.TreeFile, 1024)
+	_, _, _, err = sfs.BuildTree(func(f *vfs.TreeFile) {
+		if !f.IsDir {
+			entries[f.DirID+"/"+f.DocName] = f
 		}
+	})
+	if err != nil {
+		return
+	}
+
+	var orphansObjs []swift.Object
+
+	err = sfs.c.ObjectsWalk(sfs.container, nil, func(opts *swift.ObjectsOpts) (interface{}, error) {
+		var objs []swift.Object
+		objs, err = sfs.c.Objects(sfs.container, opts)
 		if err != nil {
 			return nil, err
 		}
-
-		if f != nil {
-			var info swift.Object
-			fullpath := path.Join(dir.Fullpath, f.DocName)
-			entries[f.DocName] = struct{}{}
-			info, _, err = sfs.c.Object(sfs.container, f.DirID+"/"+f.DocName)
-			if err == swift.ObjectNotFound {
-				logbook = append(logbook, &vfs.FsckLog{
-					Type:     vfs.FileMissing,
-					IsFile:   true,
-					FileDoc:  f,
-					Filename: fullpath,
-				})
-			} else if err != nil {
-				return nil, err
-			} else if info.ContentType == dirContentType {
-				var dirDoc *vfs.DirDoc
-				name := path.Base(info.Name)
-				dirDoc, err = vfs.NewDirDocWithParent(name, dir, nil)
-				if err != nil {
-					return nil, err
-				}
-				logbook = append(logbook, &vfs.FsckLog{
-					Type:     vfs.TypeMismatch,
-					IsFile:   true,
-					DirDoc:   dirDoc,
-					FileDoc:  f,
-					Filename: fullpath,
-				})
-			}
-		} else {
-			entries[d.DocName] = struct{}{}
-			if d.Fullpath == vfs.TrashDirName {
-				continue
-			}
-			var info swift.Object
-			info, _, err = sfs.c.Object(sfs.container, d.DirID+"/"+d.DocName)
-			if err == swift.ObjectNotFound {
-				logbook = append(logbook, &vfs.FsckLog{
-					Type:     vfs.FileMissing,
-					IsFile:   false,
-					DirDoc:   d,
-					Filename: d.Fullpath,
-				})
-			} else if err != nil {
-				return nil, err
-			} else if info.ContentType != dirContentType {
-				var fileDoc *vfs.FileDoc
-				_, fileDoc, err = objectToFileDocV1(dir, info)
-				if err != nil {
-					continue
-				}
-				logbook = append(logbook, &vfs.FsckLog{
-					Type:     vfs.TypeMismatch,
-					IsFile:   false,
-					DirDoc:   d,
-					FileDoc:  fileDoc,
-					Filename: d.Fullpath,
-				})
+		for _, obj := range objs {
+			f, ok := entries[obj.Name]
+			if !ok {
+				orphansObjs = append(orphansObjs, obj)
 			} else {
-				if logbook, err = sfs.fsckWalk(d, logbook); err != nil {
+				var md5sum []byte
+				md5sum, err = hex.DecodeString(obj.Hash)
+				if err != nil {
 					return nil, err
 				}
+				if !bytes.Equal(md5sum, f.MD5Sum) || f.ByteSize != obj.Bytes {
+					predicate(&vfs.FsckLog{
+						Type:     vfs.ContentMismatch,
+						IsFile:   true,
+						FileDoc:  f.AsFile(),
+						Filename: f.Fullpath,
+						ContentMismatch: &vfs.FsckContentMismatch{
+							SizeFile:    obj.Bytes,
+							SizeIndex:   f.ByteSize,
+							MD5SumFile:  md5sum,
+							MD5SumIndex: f.MD5Sum,
+						},
+					})
+				}
+				delete(entries, obj.Name)
 			}
 		}
-	}
-
-	objects, err := sfs.c.ObjectsAll(sfs.container, &swift.ObjectsOpts{
-		Path: dir.DocID,
+		return objs, err
 	})
-	if err != nil {
-		return nil, err
-	}
-	for _, object := range objects {
-		name := path.Base(object.Name)
-		if _, ok := entries[name]; !ok {
-			if object.Bytes == 0 {
-				continue
-			}
-			filePath, fileDoc, err := objectToFileDocV1(dir, object)
-			if err != nil {
-				continue
-			}
-			logbook = append(logbook, &vfs.FsckLog{
-				Type:     vfs.IndexMissing,
-				IsFile:   true,
-				FileDoc:  fileDoc,
-				Filename: filePath,
-			})
-		}
+
+	for _, f := range entries {
+		predicate(&vfs.FsckLog{
+			Type:     vfs.FileMissing,
+			IsFile:   true,
+			FileDoc:  f.AsFile(),
+			Filename: f.Fullpath,
+		})
 	}
 
-	return logbook, nil
+	return
 }
 
 func objectToFileDocV1(dir *vfs.DirDoc, object swift.Object) (filePath string, fileDoc *vfs.FileDoc, err error) {
@@ -575,66 +498,6 @@ func objectToFileDocV1(dir *vfs.DirDoc, object swift.Object) (filePath string, f
 		trashed,
 		nil)
 	return
-}
-
-// fsckPrune tries to fix the given list on inconsistencies in the VFS
-func (sfs *swiftVFS) fsckPrune(logbook []*vfs.FsckLog, dryrun bool) {
-	for _, entry := range logbook {
-		switch entry.Type {
-		case vfs.IndexOrphanTree, vfs.IndexBadFullpath, vfs.FileMissing, vfs.IndexMissing:
-			vfs.FsckPrune(sfs, sfs.Indexer, entry, dryrun)
-		case vfs.TypeMismatch:
-			if entry.IsFile {
-				// file on couchdb and directory on swift: we update the index to
-				// remove the file index and create a directory one
-				err := sfs.Indexer.DeleteFileDoc(entry.FileDoc)
-				if err != nil {
-					entry.PruneError = err
-				}
-				err = sfs.Indexer.CreateDirDoc(entry.DirDoc)
-				if err != nil {
-					entry.PruneError = err
-				}
-			} else {
-				// directory on couchdb and file on swift: we keep the directory and
-				// move the object into the orphan directory and create a new index
-				// associated with it.
-				orphanDir, err := vfs.Mkdir(sfs, vfs.OrphansDirName, nil)
-				if err != nil {
-					entry.PruneError = err
-					continue
-				}
-				olddoc := entry.FileDoc
-				newdoc := entry.FileDoc.Clone().(*vfs.FileDoc)
-				newdoc.DirID = orphanDir.DirID
-				newdoc.ResetFullpath()
-				err = sfs.c.ObjectMove(
-					sfs.container, olddoc.DirID+"/"+olddoc.DocName,
-					sfs.container, newdoc.DirID+"/"+newdoc.DocName,
-				)
-				if err != nil {
-					entry.PruneError = err
-					continue
-				}
-				_, err = sfs.c.ObjectCreate(sfs.container,
-					olddoc.DirID+"/"+olddoc.DocName,
-					true,
-					"",
-					dirContentType,
-					nil,
-				)
-				if err != nil {
-					entry.PruneError = err
-					continue
-				}
-				err = sfs.Indexer.CreateFileDoc(newdoc)
-				if err != nil {
-					entry.PruneError = err
-					continue
-				}
-			}
-		}
-	}
 }
 
 // UpdateFileDoc overrides the indexer's one since the swift fs indexes files

--- a/pkg/vfs/vfsswift/impl_v1.go
+++ b/pkg/vfs/vfsswift/impl_v1.go
@@ -447,10 +447,9 @@ func (sfs *swiftVFS) Fsck(predicate func(log *vfs.FsckLog)) (err error) {
 				}
 				if !bytes.Equal(md5sum, f.MD5Sum) || f.ByteSize != obj.Bytes {
 					predicate(&vfs.FsckLog{
-						Type:     vfs.ContentMismatch,
-						IsFile:   true,
-						FileDoc:  f.AsFile(),
-						Filename: f.Fullpath,
+						Type:    vfs.ContentMismatch,
+						IsFile:  true,
+						FileDoc: f,
 						ContentMismatch: &vfs.FsckContentMismatch{
 							SizeFile:    obj.Bytes,
 							SizeIndex:   f.ByteSize,
@@ -467,10 +466,9 @@ func (sfs *swiftVFS) Fsck(predicate func(log *vfs.FsckLog)) (err error) {
 
 	for _, f := range entries {
 		predicate(&vfs.FsckLog{
-			Type:     vfs.FileMissing,
-			IsFile:   true,
-			FileDoc:  f.AsFile(),
-			Filename: f.Fullpath,
+			Type:    vfs.FileMissing,
+			IsFile:  true,
+			FileDoc: f,
 		})
 	}
 

--- a/pkg/vfs/vfsswift/impl_v2.go
+++ b/pkg/vfs/vfsswift/impl_v2.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/cozy/cozy-stack/pkg/config"
+	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/lock"
 	"github.com/cozy/cozy-stack/pkg/logger"
@@ -419,7 +420,7 @@ func (sfs *swiftVFSV2) Fsck(accumulate func(log *vfs.FsckLog)) (err error) {
 				accumulate(&vfs.FsckLog{
 					Type:    vfs.IndexMissing,
 					IsFile:  true,
-					FileDoc: objectToFileDocV2(sfs.c, sfs.container, obj),
+					FileDoc: objectToFileDocV2(sfs.container, obj),
 				})
 			} else {
 				var md5sum []byte
@@ -760,19 +761,19 @@ func (f *swiftFileOpenV2) Close() error {
 	return f.f.Close()
 }
 
-func objectToFileDocV2(c *swift.Connection, container string, object swift.Object) *vfs.TreeFile {
+func objectToFileDocV2(container string, object swift.Object) *vfs.TreeFile {
 	md5sum, _ := hex.DecodeString(object.Hash)
 	name := "unknown"
-	cdate := time.Now()
 	mime, class := vfs.ExtractMimeAndClass(object.ContentType)
 	return &vfs.TreeFile{
 		DirOrFileDoc: vfs.DirOrFileDoc{
 			DirDoc: &vfs.DirDoc{
+				Type:      consts.FileType,
 				DocID:     makeDocID(object.Name),
 				DocName:   name,
 				DirID:     "",
-				CreatedAt: cdate,
-				UpdatedAt: cdate,
+				CreatedAt: object.LastModified,
+				UpdatedAt: object.LastModified,
 				Fullpath:  path.Join(vfs.OrphansDirName, name),
 			},
 			ByteSize:   object.Bytes,

--- a/pkg/vfs/vfsswift/impl_v2.go
+++ b/pkg/vfs/vfsswift/impl_v2.go
@@ -395,11 +395,6 @@ func (sfs *swiftVFSV2) OpenFile(doc *vfs.FileDoc) (vfs.File, error) {
 	return &swiftFileOpenV2{f, nil}, nil
 }
 
-type fsckFile struct {
-	file     *vfs.FileDoc
-	fullpath string
-}
-
 func (sfs *swiftVFSV2) Fsck(predicate func(log *vfs.FsckLog)) (err error) {
 	entries := make(map[string]*vfs.TreeFile, 1024)
 	_, _, _, err = sfs.BuildTree(func(f *vfs.TreeFile) {

--- a/pkg/workers/move/export.go
+++ b/pkg/workers/move/export.go
@@ -490,18 +490,18 @@ func Export(i *instance.Instance, opts ExportOptions, archiver Archiver) (export
 	size += n
 
 	if !opts.WithoutFiles {
-		var root *vfs.TreeFile
-		root, _, _, err = i.VFS().BuildTree()
+		var tree *vfs.Tree
+		tree, err = i.VFS().BuildTree()
 		if err != nil {
 			return
 		}
-		n, err = writeDoc("", "files-index", root, createdAt, tw)
+		n, err = writeDoc("", "files-index", tree.Root, createdAt, tw)
 		if err != nil {
 			return
 		}
 		size += n
 
-		exportDoc.PartsCursors, _ = splitFilesIndex(root, nil, nil, exportDoc.PartsSize, exportDoc.PartsSize)
+		exportDoc.PartsCursors, _ = splitFilesIndex(tree.Root, nil, nil, exportDoc.PartsSize, exportDoc.PartsSize)
 	}
 
 	n, err = exportDocs(i, opts.WithDoctypes, createdAt, tw)

--- a/pkg/workers/move/export.go
+++ b/pkg/workers/move/export.go
@@ -491,7 +491,7 @@ func Export(i *instance.Instance, opts ExportOptions, archiver Archiver) (export
 
 	if !opts.WithoutFiles {
 		var root *vfs.TreeFile
-		root, err = i.VFS().BuildTree()
+		root, _, _, err = i.VFS().BuildTree()
 		if err != nil {
 			return
 		}

--- a/web/instances/instances.go
+++ b/web/instances/instances.go
@@ -190,13 +190,20 @@ func fsckHandler(c echo.Context) error {
 	if err != nil {
 		return wrapError(err)
 	}
-	prune, _ := strconv.ParseBool(c.QueryParam("Prune"))
-	dryRun, _ := strconv.ParseBool(c.QueryParam("DryRun"))
+
+	indexIntegrityCheck, _ := strconv.ParseBool(c.QueryParam("IndexIntegrity"))
+
+	var logbook []*vfs.FsckLog
+	accumulate := func(log *vfs.FsckLog) {
+		logbook = append(logbook, log)
+	}
+
 	fs := i.VFS()
-	logbook, err := fs.Fsck(vfs.FsckOptions{
-		Prune:  prune,
-		DryRun: dryRun,
-	})
+	if indexIntegrityCheck {
+		err = fs.CheckIndexIntegrity(accumulate)
+	} else {
+		err = fs.Fsck(accumulate)
+	}
 	if err != nil {
 		return wrapError(err)
 	}


### PR DESCRIPTION
Another round of improvements on the FSCK analysis:
  - more uniform method between VFS: two-pass check on index and objet storage
  - faster analysis
  - a route on `/files/fsck` to access to the analysis

The `prune`ing parts have been removed for now. They have not shown to be useful or applicable for now.
