### PR TITLE
Fix shutdown of redis broker

### DIFF
--- a/pkg/jobs/redis_broker.go
+++ b/pkg/jobs/redis_broker.go
@@ -46,12 +46,12 @@ func (b *redisBroker) StartWorkers(ws WorkersList) error {
 
 	for _, conf := range ws {
 		b.workersTypes = append(b.workersTypes, conf.WorkerType)
-		ch := make(chan *Job)
-		w := NewWorker(conf)
-		b.workers = append(b.workers, w)
 		if conf.Concurrency <= 0 {
 			continue
 		}
+		ch := make(chan *Job)
+		w := NewWorker(conf)
+		b.workers = append(b.workers, w)
 		if err := w.Start(ch); err != nil {
 			return err
 		}


### PR DESCRIPTION
The redis broker is waiting in the shutdown for all the workers to stop polling redis for new jobs. Before this commit, in the list of workers, there were also workers with concurrency at 0, and for those workers, we didn't start the polling. So, on a server where some workers were disabled, we were forced to wait until the context timeout on shutdown even if there was no more activity.