### PR TITLE
Fix show-swift-prefix cmd

### DIFF
--- a/cmd/instances.go
+++ b/cmd/instances.go
@@ -765,7 +765,7 @@ var showSwiftPrefixInstanceCmd = &cobra.Command{
 	Short:   "Show the instance swift prefix of the specified domain",
 	Example: "$ cozy-stack instances show-swift-prefix cozy.tools:8080",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		var v string
+		var v []string
 
 		c := newAdminClient()
 		if len(args) < 1 {


### PR DESCRIPTION
```bash
root@gozy-adm-int:~# cozy-stack instances show-swift-prefix sblaisot.cozy.works
Error: json: cannot unmarshal array into Go value of type string
```