### PR TITLE
Improve show-prefix command

### DIFF
--- a/client/instances.go
+++ b/client/instances.go
@@ -101,6 +101,13 @@ type ImportOptions struct {
 	IncreaseQuota bool
 }
 
+func (i *Instance) DBPrefix() string {
+	if i.Attrs.Prefix != "" {
+		return i.Attrs.Prefix
+	}
+	return i.Attrs.Domain
+}
+
 // GetInstance returns the instance associated with the specified domain.
 func (c *Client) GetInstance(domain string) (*Instance, error) {
 	res, err := c.Req(&request.Options{

--- a/cmd/instances.go
+++ b/cmd/instances.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"reflect"
 	"strconv"
 	"strings"
 	"text/tabwriter"
@@ -16,6 +17,7 @@ import (
 	"github.com/cozy/cozy-stack/client"
 	"github.com/cozy/cozy-stack/client/request"
 	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/instance"
 	humanize "github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
@@ -50,6 +52,7 @@ var flagOnboardingFinished bool
 var flagExpire time.Duration
 var flagAllowLoginScope bool
 var flagFsckIndexIntegrity bool
+var flagAvailableFields bool
 
 // instanceCmdGroup represents the instances command
 var instanceCmdGroup = &cobra.Command{
@@ -118,7 +121,7 @@ given domain. The prefix is used for databases and VFS prefixing.
 		if in.Attrs.Prefix != "" {
 			fmt.Println(in.Attrs.Prefix)
 		} else {
-			fmt.Println(in.Attrs.Domain)
+			fmt.Println(couchdb.EscapeCouchdbName(in.Attrs.Domain))
 		}
 		return nil
 	},
@@ -328,18 +331,42 @@ by this server.
 		if err != nil {
 			return err
 		}
+		if flagAvailableFields {
+			instance := list[0]
+			val := reflect.ValueOf(instance.Attrs)
+			t := val.Type()
+			for i := 0; i < t.NumField(); i++ {
+				param := t.Field(i).Tag.Get("json")
+				fmt.Println(strings.TrimSuffix(param, ",omitempty"))
+			}
+			fmt.Println("db_prefix")
+			return nil
+		}
 		if flagJSON {
 			if len(flagListFields) > 0 {
 				for _, inst := range list {
-					var values []interface{}
+					var values map[string]interface{}
 					values, err = extractFields(inst.Attrs, flagListFields)
 					if err != nil {
 						return err
 					}
-					m := make(map[string]interface{}, len(flagListFields))
-					for i, fieldName := range flagListFields {
-						m[fieldName] = values[i]
+
+					// Insert the db_prefix value if needed
+					for _, v := range flagListFields {
+						if v == "db_prefix" {
+							values["db_prefix"] = couchdb.EscapeCouchdbName(inst.DBPrefix())
+						}
 					}
+
+					m := make(map[string]interface{}, len(flagListFields))
+					for _, fieldName := range flagListFields {
+						if v, ok := values[fieldName]; ok {
+							m[fieldName] = v
+						} else {
+							m[fieldName] = nil
+						}
+					}
+
 					if err = json.NewEncoder(os.Stdout).Encode(m); err != nil {
 						return err
 					}
@@ -357,20 +384,36 @@ by this server.
 				format := strings.Repeat("%v\t", len(flagListFields))
 				format = format[:len(format)-1] + "\n"
 				for _, inst := range list {
-					var values []interface{}
+					var values map[string]interface{}
+					var instancesLines []interface{}
+
 					values, err = extractFields(inst.Attrs, flagListFields)
 					if err != nil {
 						return err
 					}
-					fmt.Fprintf(w, format, values...)
+
+					// Insert the db_prefix value if needed
+					for _, v := range flagListFields {
+						if v == "db_prefix" {
+							values["db_prefix"] = couchdb.EscapeCouchdbName(inst.DBPrefix())
+						}
+					}
+					// We append to a list to print in the same order as
+					// requested
+					for _, fieldName := range flagListFields {
+						instancesLines = append(instancesLines, values[fieldName])
+					}
+
+					fmt.Fprintf(w, format, instancesLines...)
 				}
 			} else {
 				for _, i := range list {
 					prefix := i.Attrs.Prefix
+					DBPrefix := prefix
 					if prefix == "" {
-						prefix = i.Attrs.Domain
+						DBPrefix = couchdb.EscapeCouchdbName(i.Attrs.Domain)
 					}
-					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\tv%d\t%s\n",
+					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\tv%d\t%s\t%s\n",
 						i.Attrs.Domain,
 						i.Attrs.Locale,
 						formatSize(i.Attrs.BytesDiskQuota),
@@ -378,6 +421,7 @@ by this server.
 						formatOnboarded(i),
 						i.Attrs.IndexViewsVersion,
 						prefix,
+						DBPrefix,
 					)
 				}
 			}
@@ -387,7 +431,7 @@ by this server.
 	},
 }
 
-func extractFields(data interface{}, fieldsNames []string) (values []interface{}, err error) {
+func extractFields(data interface{}, fieldsNames []string) (values map[string]interface{}, err error) {
 	var m map[string]interface{}
 	var b []byte
 	b, err = json.Marshal(data)
@@ -397,10 +441,10 @@ func extractFields(data interface{}, fieldsNames []string) (values []interface{}
 	if err = json.Unmarshal(b, &m); err != nil {
 		return
 	}
-	values = make([]interface{}, len(fieldsNames))
-	for i, fieldName := range fieldsNames {
+	values = make(map[string]interface{}, len(fieldsNames))
+	for _, fieldName := range fieldsNames {
 		if v, ok := m[fieldName]; ok {
-			values[i] = v
+			values[fieldName] = v
 		}
 	}
 	return
@@ -852,6 +896,7 @@ func init() {
 	appTokenInstanceCmd.Flags().DurationVar(&flagExpire, "expire", 0, "Make the token expires in this amount of time")
 	lsInstanceCmd.Flags().BoolVar(&flagJSON, "json", false, "Show each line as a json representation of the instance")
 	lsInstanceCmd.Flags().StringSliceVar(&flagListFields, "fields", nil, "Arguments shown for each line in the list")
+	lsInstanceCmd.Flags().BoolVar(&flagAvailableFields, "available-fields", false, "List available fields for --fields option")
 	updateCmd.Flags().BoolVar(&flagAllDomains, "all-domains", false, "Work on all domains iterativelly")
 	updateCmd.Flags().StringVar(&flagDomain, "domain", "", "Specify the domain name of the instance")
 	updateCmd.Flags().StringVar(&flagContextName, "context-name", "", "Work only on the instances with the given context name")

--- a/cmd/instances.go
+++ b/cmd/instances.go
@@ -97,14 +97,14 @@ given domain.
 	},
 }
 
-var showPrefixInstanceCmd = &cobra.Command{
-	Use:   "show-prefix <domain>",
-	Short: "Show the instance prefix of the specified domain",
+var showDBPrefixInstanceCmd = &cobra.Command{
+	Use:   "show-db-prefix <domain>",
+	Short: "Show the instance DB prefix of the specified domain",
 	Long: `
 cozy-stack instances show allows to show the instance prefix on the cozy for a
 given domain. The prefix is used for databases and VFS prefixing.
 `,
-	Example: "$ cozy-stack instances show-prefix cozy.tools:8080",
+	Example: "$ cozy-stack instances show-db-prefix cozy.tools:8080",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			return cmd.Usage()
@@ -796,7 +796,7 @@ var showSwiftPrefixInstanceCmd = &cobra.Command{
 
 func init() {
 	instanceCmdGroup.AddCommand(showInstanceCmd)
-	instanceCmdGroup.AddCommand(showPrefixInstanceCmd)
+	instanceCmdGroup.AddCommand(showDBPrefixInstanceCmd)
 	instanceCmdGroup.AddCommand(addInstanceCmd)
 	instanceCmdGroup.AddCommand(modifyInstanceCmd)
 	instanceCmdGroup.AddCommand(lsInstanceCmd)

--- a/docs/cli/cozy-stack_instances.md
+++ b/docs/cli/cozy-stack_instances.md
@@ -51,7 +51,7 @@ cozy-stack instances <command> [flags]
 * [cozy-stack instances refresh-token-oauth](cozy-stack_instances_refresh-token-oauth.md)	 - Generate a new OAuth refresh token
 * [cozy-stack instances set-disk-quota](cozy-stack_instances_set-disk-quota.md)	 - Change the disk-quota of the instance
 * [cozy-stack instances show](cozy-stack_instances_show.md)	 - Show the instance of the specified domain
-* [cozy-stack instances show-prefix](cozy-stack_instances_show-prefix.md)	 - Show the instance prefix of the specified domain
+* [cozy-stack instances show-db-prefix](cozy-stack_instances_show-db-prefix.md)	 - Show the instance DB prefix of the specified domain
 * [cozy-stack instances show-swift-prefix](cozy-stack_instances_show-swift-prefix.md)	 - Show the instance swift prefix of the specified domain
 * [cozy-stack instances token-app](cozy-stack_instances_token-app.md)	 - Generate a new application token
 * [cozy-stack instances token-cli](cozy-stack_instances_token-cli.md)	 - Generate a new CLI access token (global access)

--- a/docs/cli/cozy-stack_instances_ls.md
+++ b/docs/cli/cozy-stack_instances_ls.md
@@ -16,9 +16,10 @@ cozy-stack instances ls [flags]
 ### Options
 
 ```
-      --fields strings   Arguments shown for each line in the list
-  -h, --help             help for ls
-      --json             Show each line as a json representation of the instance
+      --available-fields   List available fields for --fields option
+      --fields strings     Arguments shown for each line in the list
+  -h, --help               help for ls
+      --json               Show each line as a json representation of the instance
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/cozy-stack_instances_show-db-prefix.md
+++ b/docs/cli/cozy-stack_instances_show-db-prefix.md
@@ -1,6 +1,6 @@
-## cozy-stack instances show-prefix
+## cozy-stack instances show-db-prefix
 
-Show the instance prefix of the specified domain
+Show the instance DB prefix of the specified domain
 
 ### Synopsis
 
@@ -10,19 +10,19 @@ given domain. The prefix is used for databases and VFS prefixing.
 
 
 ```
-cozy-stack instances show-prefix <domain> [flags]
+cozy-stack instances show-db-prefix <domain> [flags]
 ```
 
 ### Examples
 
 ```
-$ cozy-stack instances show-prefix cozy.tools:8080
+$ cozy-stack instances show-db-prefix cozy.tools:8080
 ```
 
 ### Options
 
 ```
-  -h, --help   help for show-prefix
+  -h, --help   help for show-db-prefix
 ```
 
 ### Options inherited from parent commands

--- a/pkg/couchdb/couchdb.go
+++ b/pkg/couchdb/couchdb.go
@@ -232,23 +232,23 @@ func (j JSONDoc) Match(field, value string) bool {
 	return fmt.Sprintf("%v", j.Get(field)) == value
 }
 
-func unescapeCouchdbName(name string) string {
+func UnescapeCouchdbName(name string) string {
 	return strings.Replace(name, "-", ".", -1)
 }
 
-func escapeCouchdbName(name string) string {
+func EscapeCouchdbName(name string) string {
 	name = strings.Replace(name, ".", "-", -1)
 	name = strings.Replace(name, ":", "-", -1)
 	return strings.ToLower(name)
 }
 
 func makeDBName(db Database, doctype string) string {
-	dbname := escapeCouchdbName(db.DBPrefix() + "/" + doctype)
+	dbname := EscapeCouchdbName(db.DBPrefix() + "/" + doctype)
 	return url.PathEscape(dbname)
 }
 
 func dbNameHasPrefix(dbname, dbprefix string) (bool, string) {
-	dbprefix = escapeCouchdbName(dbprefix + "/")
+	dbprefix = EscapeCouchdbName(dbprefix + "/")
 	if !strings.HasPrefix(dbname, dbprefix) {
 		return false, ""
 	}
@@ -360,12 +360,12 @@ func AllDoctypes(db Database) ([]string, error) {
 	if err := makeRequest(db, "", http.MethodGet, "_all_dbs", nil, &dbs); err != nil {
 		return nil, err
 	}
-	prefix := escapeCouchdbName(db.DBPrefix())
+	prefix := EscapeCouchdbName(db.DBPrefix())
 	var doctypes []string
 	for _, dbname := range dbs {
 		parts := strings.Split(dbname, "/")
 		if len(parts) == 2 && parts[0] == prefix {
-			doctype := unescapeCouchdbName(parts[1])
+			doctype := UnescapeCouchdbName(parts[1])
 			doctypes = append(doctypes, doctype)
 		}
 	}


### PR DESCRIPTION
* Renamed `show-prefix` option to `show-db-prefix`
* Add `db_prefix` field
* Add `--available-fields` option to list available fields returned by `--fields` option for command `cozy-stack konnectors ls`
* Improve JSON output
