### PR TITLE
Fix overwritten sharings on new sharing creation

### DIFF
--- a/pkg/sharing/sharing.go
+++ b/pkg/sharing/sharing.go
@@ -152,7 +152,7 @@ func (s *Sharing) BeOwner(inst *instance.Instance, slug string) error {
 // CreatePreviewPermissions creates the permissions doc for previewing this sharing,
 // or updates it with the new codes if the document already exists
 func (s *Sharing) CreatePreviewPermissions(inst *instance.Instance) (map[string]string, error) {
-	doc, err := permissions.GetForSharePreview(inst, s.SID)
+	doc, _ := permissions.GetForSharePreview(inst, s.SID)
 
 	codes := make(map[string]string, len(s.Members)-1)
 	for i, m := range s.Members {
@@ -192,9 +192,9 @@ func (s *Sharing) CreatePreviewPermissions(inst *instance.Instance) (map[string]
 		}
 	}
 
-	if err == nil {
+	if doc != nil {
 		doc.Codes = codes
-		if err = couchdb.UpdateDoc(inst, doc); err != nil {
+		if err := couchdb.UpdateDoc(inst, doc); err != nil {
 			return nil, err
 		}
 	} else {

--- a/web/apps/serve.go
+++ b/web/apps/serve.go
@@ -112,7 +112,7 @@ func handleIntent(c echo.Context, i *instance.Instance, slug, intentID string) {
 // manifest and apps.FileServer context.
 //
 // It can be used to serve file application in another context than the VFS,
-// for instance for tests or development puposes where we want to serve an
+// for instance for tests or development purposes where we want to serve an
 // application that is not installed on the user's instance. However this
 // procedure should not be used for standard applications, use the Serve method
 // for that.


### PR DESCRIPTION
Already existing tokens where overwritten when a new token was generated
for a share. This fix should keep the old tokens.