### PR TITLE
Remove swift versionning from swift vfs impl v1 & v2

### DIFF
--- a/pkg/vfs/vfsswift/impl_v1.go
+++ b/pkg/vfs/vfsswift/impl_v1.go
@@ -92,7 +92,7 @@ func (sfs *swiftVFS) InitFs() error {
 	if err := sfs.Indexer.InitIndex(); err != nil {
 		return err
 	}
-	if err := sfs.c.ContainerCreate(sfs.container); err != nil {
+	if err := sfs.c.ContainerCreate(sfs.container, nil); err != nil {
 		sfs.log.Errorf("Could not create container %s: %s",
 			sfs.container, err.Error())
 		return err
@@ -362,7 +362,7 @@ func (sfs *swiftVFS) destroyDirAndContent(doc *vfs.DirDoc) (int64, error) {
 
 func (sfs *swiftVFS) destroyFile(doc *vfs.FileDoc) error {
 	objName := doc.DirID + "/" + doc.DocName
-	err = sfs.c.ObjectDelete(sfs.container, objName)
+	err := sfs.c.ObjectDelete(sfs.container, objName)
 	if err != nil && err != swift.ObjectNotFound {
 		return err
 	}

--- a/pkg/vfs/vfsswift/impl_v1.go
+++ b/pkg/vfs/vfsswift/impl_v1.go
@@ -103,7 +103,7 @@ func (sfs *swiftVFS) InitFs() error {
 
 func (sfs *swiftVFS) Delete() error {
 	containerMeta := swift.Metadata{"to-be-deleted": "1"}.ContainerHeaders()
-	sfs.log.Infof("Marking containers %q, %q and %q as to-be-deleted",
+	sfs.log.Infof("Marking containers %q and %q as to-be-deleted",
 		sfs.container, sfs.dataContainer)
 	err1 := sfs.c.ContainerUpdate(sfs.container, containerMeta)
 	err2 := sfs.c.ContainerUpdate(sfs.dataContainer, containerMeta)

--- a/pkg/vfs/vfsswift/impl_v2.go
+++ b/pkg/vfs/vfsswift/impl_v2.go
@@ -131,7 +131,7 @@ func (sfs *swiftVFSV2) InitFs() error {
 
 func (sfs *swiftVFSV2) Delete() error {
 	containerMeta := swift.Metadata{"to-be-deleted": "1"}.ContainerHeaders()
-	sfs.log.Infof("Marking containers %q, %q and %q as to-be-deleted",
+	sfs.log.Infof("Marking containers %q and %q as to-be-deleted",
 		sfs.container, sfs.dataContainer)
 	err1 := sfs.c.ContainerUpdate(sfs.container, containerMeta)
 	err2 := sfs.c.ContainerUpdate(sfs.dataContainer, containerMeta)

--- a/pkg/vfs/vfsswift/impl_v2.go
+++ b/pkg/vfs/vfsswift/impl_v2.go
@@ -115,7 +115,7 @@ func (sfs *swiftVFSV2) InitFs() error {
 	if err := sfs.Indexer.InitIndex(); err != nil {
 		return err
 	}
-	if err := sfs.c.ContainerCreate(sfs.container); err != nil {
+	if err := sfs.c.ContainerCreate(sfs.container, nil); err != nil {
 		sfs.log.Errorf("Could not create container %s: %s",
 			sfs.container, err.Error())
 		return err


### PR DESCRIPTION
Remove swift versionning in swift VFS (implementation v1 and v2).

Swift versionning causes a lot of problems with zero gain:
- There is a bug in file removal in swift implementation v2 which doesn't remove all file versions unlike it is done in implementation v1 (compare https://github.com/cozy/cozy-stack/blob/master/pkg/vfs/vfsswift/impl_v1.go#L383-L412 and https://github.com/cozy/cozy-stack/blob/master/pkg/vfs/vfsswift/impl_v2.go#L380-L394)
- There is a bug in openstack swift versions pior to 2.19.1 that prevent using unicode filenames in versionned containers: https://github.com/openstack/swift/commit/0e3e7b9b0953baaf7a0686881fd2348fde7d1e59

Simply removing container versionning is the quickest way to fix this.