### PR TITLE
Fix Swift encoding

### DIFF
--- a/client/tlsclient/tlsclient.go
+++ b/client/tlsclient/tlsclient.go
@@ -29,6 +29,8 @@ type HTTPEndpoint struct {
 	ClientCertificateFiles ClientCertificateFilePair
 	PinnedKey              string
 	InsecureSkipValidation bool
+	MaxIdleConnsPerHost    int
+	DisableCompression     bool
 }
 
 type ClientCertificateFilePair struct {
@@ -98,9 +100,16 @@ func NewHTTPClient(opt HTTPEndpoint) (client *http.Client, u *url.URL, err error
 	if opt.InsecureSkipValidation {
 		c.SetInsecureSkipValidation()
 	}
+	tr := http.Transport{TLSClientConfig: c.Config()}
+	if opt.MaxIdleConnsPerHost > 0 {
+		tr.MaxIdleConnsPerHost = opt.MaxIdleConnsPerHost
+	}
+	if opt.DisableCompression {
+		tr.DisableCompression = true
+	}
 	client = &http.Client{
 		Timeout:   opt.Timeout,
-		Transport: &http.Transport{TLSClientConfig: c.Config()},
+		Transport: &tr,
 	}
 	return
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -447,6 +447,8 @@ func UseViper(v *viper.Viper) error {
 		},
 		PinnedKey:              v.GetString("fs.pinned_key"),
 		InsecureSkipValidation: v.GetBool("fs.insecure_skip_validation"),
+		MaxIdleConnsPerHost:    128,
+		DisableCompression:     true,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Disable Accept-Encoding for requests to Swift. For files with a gzipped
size inferior to the real size, a reverse-proxy between the stack and
Swift can gzip the response, and when it is the case, the stack may
return a 500 because it can no longer infer the file size from the
Content-Length, as http.ServeContent does.