### PR TITLE
docs: Add clarification about references

### DIFF
--- a/docs/references-docs-in-vfs.md
+++ b/docs/references-docs-in-vfs.md
@@ -158,7 +158,7 @@ Content-Type: application/vnd.api+json
 
 ### GET /data/:type/:doc-id/relationships/references
 
-Returns all the files associated to an album or playlist.
+Returns all the files id associated to an album or playlist.
 
 Contents is paginated following [jsonapi conventions](jsonapi.md#pagination).
 The default limit is 100 entries.


### PR DESCRIPTION
After reading the documentation, I was expecting to get the whole `file object` with its own attributes. But in fact, we just get id and type (as described in the example).