### PR TITLE
Fix cozies export

### DIFF
--- a/pkg/vfs/fsck.go
+++ b/pkg/vfs/fsck.go
@@ -89,9 +89,9 @@ type Tree struct {
 // in a tree-like representation of the index.
 type TreeFile struct {
 	DirOrFileDoc
-	FilesChildren     []*TreeFile `json:"-"`
-	FilesChildrenSize int64       `json:"-"`
-	DirsChildren      []*TreeFile `json:"-"`
+	FilesChildren     []*TreeFile `json:"children,omitempty"`
+	FilesChildrenSize int64       `json:"children_size,omitempty"`
+	DirsChildren      []*TreeFile `json:"directories,omitempty"`
 
 	IsDir    bool `json:"is_dir"`
 	IsOrphan bool `json:"is_orphan"`


### PR DESCRIPTION
With these unexported JSON fields, there were not written to the `files-index.json` metadata file during the export, thus not exported to the archive.