### PR TITLE
Fix for same app/version but not code from 2 registries

### DIFF
--- a/pkg/apps/apps.go
+++ b/pkg/apps/apps.go
@@ -73,7 +73,7 @@ type Manifest interface {
 	Permissions() permissions.Set
 	Source() string
 	Version() string
-	SetAvailableVersion(version string)
+	Checksum() string
 	Slug() string
 	State() State
 	LastUpdate() time.Time
@@ -85,6 +85,8 @@ type Manifest interface {
 	SetSource(src *url.URL)
 	SetState(state State)
 	SetVersion(version string)
+	SetAvailableVersion(version string)
+	SetChecksum(shasum string)
 }
 
 // GetBySlug returns an app manifest identified by its slug

--- a/pkg/apps/copier.go
+++ b/pkg/apps/copier.go
@@ -18,7 +18,7 @@ import (
 // Copier is an interface defining a common set of functions for the installer
 // to copy the application into an unknown storage.
 type Copier interface {
-	Start(slug, version string) (exists bool, err error)
+	Start(slug, version, shasum string) (exists bool, err error)
 	Copy(stat os.FileInfo, src io.Reader) error
 	Abort() error
 	Commit() error
@@ -47,8 +47,11 @@ func NewSwiftCopier(conn *swift.Connection, appsType AppType) Copier {
 	}
 }
 
-func (f *swiftCopier) Start(slug, version string) (bool, error) {
+func (f *swiftCopier) Start(slug, version, shasum string) (bool, error) {
 	f.appObj = path.Join(slug, version)
+	if shasum != "" {
+		f.appObj += "-" + shasum
+	}
 	_, _, err := f.c.Object(f.container, f.appObj)
 	if err == nil {
 		return true, nil
@@ -151,8 +154,11 @@ func NewAferoCopier(fs afero.Fs) Copier {
 	return &aferoCopier{fs: fs}
 }
 
-func (f *aferoCopier) Start(slug, version string) (bool, error) {
+func (f *aferoCopier) Start(slug, version, shasum string) (bool, error) {
 	f.appDir = path.Join("/", slug, version)
+	if shasum != "" {
+		f.appDir += "-" + shasum
+	}
 	exists, err := afero.DirExists(f.fs, f.appDir)
 	if err != nil || exists {
 		return exists, err

--- a/pkg/apps/fetcher_file.go
+++ b/pkg/apps/fetcher_file.go
@@ -41,7 +41,7 @@ func (f *fileFetcher) FetchManifest(src *url.URL) (io.ReadCloser, error) {
 func (f *fileFetcher) Fetch(src *url.URL, fs Copier, man Manifest) (err error) {
 	version := man.Version() + "-" + utils.RandomString(10)
 	man.SetVersion(version)
-	exists, err := fs.Start(man.Slug(), man.Version())
+	exists, err := fs.Start(man.Slug(), man.Version(), "")
 	if err != nil || exists {
 		return err
 	}

--- a/pkg/apps/fetcher_git.go
+++ b/pkg/apps/fetcher_git.go
@@ -215,7 +215,7 @@ func (g *gitFetcher) fetchWithGit(gitFs afero.Fs, gitDir string, src *url.URL, f
 	man.SetVersion(version)
 
 	// If the application folder already exists, we can bail early.
-	exists, err := fs.Start(slug, version)
+	exists, err := fs.Start(slug, version, "")
 	if err != nil || exists {
 		return err
 	}
@@ -319,7 +319,7 @@ func (g *gitFetcher) fetchWithGoGit(gitDir string, src *url.URL, fs Copier, man 
 	man.SetVersion(version)
 
 	// If the application folder already exists, we can bail early.
-	exists, err := fs.Start(slug, version)
+	exists, err := fs.Start(slug, version, "")
 	if err != nil || exists {
 		return err
 	}

--- a/pkg/apps/fetcher_http.go
+++ b/pkg/apps/fetcher_http.go
@@ -103,7 +103,7 @@ func (f *httpFetcher) Fetch(src *url.URL, fs Copier, man Manifest) (err error) {
 }
 
 func fetchHTTP(src *url.URL, shasum []byte, fs Copier, man Manifest, prefix string) (err error) {
-	exists, err := fs.Start(man.Slug(), man.Version())
+	exists, err := fs.Start(man.Slug(), man.Version(), man.Checksum())
 	if err != nil || exists {
 		return err
 	}

--- a/pkg/apps/fetcher_registry.go
+++ b/pkg/apps/fetcher_registry.go
@@ -59,6 +59,7 @@ func (f *registryFetcher) Fetch(src *url.URL, fs Copier, man Manifest) error {
 		return err
 	}
 	man.SetVersion(v.Version)
+	man.SetChecksum(v.Sha256)
 	return fetchHTTP(u, shasum, fs, man, v.TarPrefix)
 }
 

--- a/pkg/apps/konnector.go
+++ b/pkg/apps/konnector.go
@@ -57,6 +57,7 @@ type KonnManifest struct {
 	DocState         State           `json:"state"`
 	DocSource        string          `json:"source"`
 	DocVersion       string          `json:"version"`
+	DocChecksum      string          `json:"checksum"`
 	DocPermissions   permissions.Set `json:"permissions"`
 	AvailableVersion string          `json:"available_version,omitempty"`
 	DocTerms         Terms           `json:"terms,omitempty"`
@@ -127,6 +128,9 @@ func (m *KonnManifest) Source() string { return m.DocSource }
 // Version is part of the Manifest interface
 func (m *KonnManifest) Version() string { return m.DocVersion }
 
+// Checksum is part of the Manifest interface
+func (m *KonnManifest) Checksum() string { return m.DocChecksum }
+
 // Slug is part of the Manifest interface
 func (m *KonnManifest) Slug() string { return m.DocSlug }
 
@@ -144,6 +148,9 @@ func (m *KonnManifest) SetVersion(version string) { m.DocVersion = version }
 
 // SetAvailableVersion is part of the Manifest interface
 func (m *KonnManifest) SetAvailableVersion(version string) { m.AvailableVersion = version }
+
+// SetChecksum is part of the Manifest interface
+func (m *KonnManifest) SetChecksum(shasum string) { m.DocChecksum = shasum }
 
 // AppType is part of the Manifest interface
 func (m *KonnManifest) AppType() AppType { return Konnector }

--- a/pkg/apps/webapp.go
+++ b/pkg/apps/webapp.go
@@ -87,6 +87,7 @@ type WebappManifest struct {
 	DocSlug          string          `json:"slug"`
 	DocState         State           `json:"state"`
 	DocSource        string          `json:"source"`
+	DocChecksum      string          `json:"checksum"`
 	DocVersion       string          `json:"version"`
 	DocPermissions   permissions.Set `json:"permissions"`
 	AvailableVersion string          `json:"available_version,omitempty"`
@@ -174,6 +175,9 @@ func (m *WebappManifest) Source() string { return m.DocSource }
 // Version is part of the Manifest interface
 func (m *WebappManifest) Version() string { return m.DocVersion }
 
+// Checksum is part of the Manifest interface
+func (m *WebappManifest) Checksum() string { return m.DocChecksum }
+
 // Slug is part of the Manifest interface
 func (m *WebappManifest) Slug() string { return m.DocSlug }
 
@@ -191,6 +195,9 @@ func (m *WebappManifest) SetVersion(version string) { m.DocVersion = version }
 
 // SetAvailableVersion is part of the Manifest interface
 func (m *WebappManifest) SetAvailableVersion(version string) { m.AvailableVersion = version }
+
+// SetChecksum is part of the Manifest interface
+func (m *WebappManifest) SetChecksum(shasum string) { m.DocChecksum = shasum }
 
 // AppType is part of the Manifest interface
 func (m *WebappManifest) AppType() AppType { return Webapp }

--- a/pkg/workers/exec/service.go
+++ b/pkg/workers/exec/service.go
@@ -91,7 +91,7 @@ func (w *serviceWorker) PrepareWorkDir(ctx *jobs.WorkerContext, i *instance.Inst
 	workFS := afero.NewBasePathFs(osFS, workDir)
 
 	fs := i.AppsFileServer()
-	src, err := fs.Open(man.Slug(), man.Version(), path.Join("/", service.File))
+	src, err := fs.Open(man.Slug(), man.Version(), man.Checksum(), path.Join("/", service.File))
 	if err != nil {
 		return
 	}

--- a/web/apps/apps.go
+++ b/web/apps/apps.go
@@ -348,7 +348,7 @@ func iconHandler(appType apps.AppType) echo.HandlerFunc {
 		}
 
 		err = fs.ServeFileContent(c.Response(), c.Request(),
-			app.Slug(), app.Version(), filepath)
+			app.Slug(), app.Version(), app.Checksum(), filepath)
 		if os.IsNotExist(err) {
 			return echo.NewHTTPError(http.StatusNotFound, err)
 		}

--- a/web/server.go
+++ b/web/server.go
@@ -121,7 +121,7 @@ func ListenAndServeWithAppDir(appsdir map[string]string) (*Servers, error) {
 		}
 		webapp := app.(*apps.WebappManifest)
 		i := middlewares.GetInstance(c)
-		f := apps.NewAferoFileServer(fs, func(_, _, file string) string {
+		f := apps.NewAferoFileServer(fs, func(_, _, _, file string) string {
 			return path.Join("/", file)
 		})
 		// Save permissions in couchdb before loading an index page


### PR DESCRIPTION
When an app is available on two registry spaces, at the same version
number, but not with the same code (customized app for example), the
stack was serving the code from the first version installed. With
this fix, we can differentiate these cases and serve the right code
for the webapp/konnector.