### PR TITLE
feat: add session encrypted attribute to accounts

### DIFF
--- a/web/data/accounts.go
+++ b/web/data/accounts.go
@@ -163,7 +163,7 @@ func encryptMap(m map[string]interface{}) (encrypted bool) {
 			if err == nil {
 				encrypted = true
 			}
-		case "secret", "dob", "code", "answer", "access_token", "refresh_token", "appSecret":
+		case "secret", "dob", "code", "answer", "access_token", "refresh_token", "appSecret", "session":
 			cloned[k+"_encrypted"], err = accounts.EncryptCredentialsData(v)
 			if err == nil {
 				encrypted = true


### PR DESCRIPTION
The connectors will soon be able to save their cookie in the associated io.cozy.account. This data
is as sensitive as the password and then should also be encrypted.

This PR is naive, I don't know if there are other files to update accordingly