### PR TITLE
Add a "safe" flag to app update cmd to prevent updates

### DIFF
--- a/client/apps.go
+++ b/client/apps.go
@@ -158,10 +158,10 @@ func (c *Client) InstallApp(opts *AppOptions) (*AppManifest, error) {
 }
 
 // UpdateApp is used to update an application.
-func (c *Client) UpdateApp(opts *AppOptions) (*AppManifest, error) {
+func (c *Client) UpdateApp(opts *AppOptions, safe bool) (*AppManifest, error) {
 	q := url.Values{
 		"Source":           {opts.SourceURL},
-		"PermissionsAcked": {strconv.FormatBool(true)},
+		"PermissionsAcked": {strconv.FormatBool(!safe)},
 	}
 	if opts.OverridenParameters != nil {
 		b, err := json.Marshal(opts.OverridenParameters)

--- a/cmd/apps.go
+++ b/cmd/apps.go
@@ -22,6 +22,7 @@ var errAppsMissingDomain = errors.New("Missing --domain flag, or COZY_DOMAIN env
 var flagAppsDomain string
 var flagAllDomains bool
 var flagAppsDeactivated bool
+var flagSafeUpdate bool
 
 var flagKonnectorAccountID string
 var flagKonnectorsParameters string
@@ -342,7 +343,7 @@ func updateApp(cmd *cobra.Command, args []string, appType string) error {
 				AppType:   appType,
 				Slug:      args[0],
 				SourceURL: src,
-			})
+			}, flagSafeUpdate)
 			if err != nil {
 				if err.Error() == "Application is not installed" {
 					return nil
@@ -371,7 +372,7 @@ func updateApp(cmd *cobra.Command, args []string, appType string) error {
 		SourceURL: src,
 
 		OverridenParameters: overridenParameters,
-	})
+	}, flagSafeUpdate)
 	if err != nil {
 		return err
 	}
@@ -624,6 +625,8 @@ func init() {
 	webappsCmdGroup.PersistentFlags().BoolVar(&flagAllDomains, "all-domains", false, "work on all domains iterativelly")
 
 	installWebappCmd.PersistentFlags().BoolVar(&flagAppsDeactivated, "ask-permissions", false, "specify that the application should not be activated after installation")
+	updateWebappCmd.PersistentFlags().BoolVar(&flagSafeUpdate, "safe", false, "do not upgrade if there are blocking changes")
+	updateKonnectorCmd.PersistentFlags().BoolVar(&flagSafeUpdate, "safe", false, "do not upgrade if there are blocking changes")
 
 	runKonnectorsCmd.PersistentFlags().StringVar(&flagKonnectorAccountID, "account-id", "", "specify the account ID to use for running the konnector")
 

--- a/docs/cli/cozy-stack_apps_update.md
+++ b/docs/cli/cozy-stack_apps_update.md
@@ -14,6 +14,7 @@ cozy-stack apps update <slug> [sourceurl] [flags]
 
 ```
   -h, --help   help for update
+      --safe   do not upgrade if there are blocking changes
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/cozy-stack_fixer.md
+++ b/docs/cli/cozy-stack_fixer.md
@@ -32,6 +32,7 @@ cozy-stack fixer <command> [flags]
 * [cozy-stack fixer albums-created-at](cozy-stack_fixer_albums-created-at.md)	 - Add a created_at field for albums where it's missing
 * [cozy-stack fixer contact-emails](cozy-stack_fixer_contact-emails.md)	 - Detect and try to fix invalid emails on contacts
 * [cozy-stack fixer jobs](cozy-stack_fixer_jobs.md)	 - Take a look at the consistency of the jobs
+* [cozy-stack fixer link-app](cozy-stack_fixer_link-app.md)	 - Link an old OAuth client to a webapp
 * [cozy-stack fixer md5](cozy-stack_fixer_md5.md)	 - Fix missing md5 from contents in the vfs
 * [cozy-stack fixer mime](cozy-stack_fixer_mime.md)	 - Fix the class computed from the mime-type
 * [cozy-stack fixer onboardings](cozy-stack_fixer_onboardings.md)	 - Add the onboarding_finished flag to user that have registered their passphrase

--- a/docs/cli/cozy-stack_fixer_link-app.md
+++ b/docs/cli/cozy-stack_fixer_link-app.md
@@ -1,0 +1,32 @@
+## cozy-stack fixer link-app
+
+Link an old OAuth client to a webapp
+
+### Synopsis
+
+Link an old OAuth client to a webapp
+
+```
+cozy-stack fixer link-app <domain> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for link-app
+```
+
+### Options inherited from parent commands
+
+```
+      --admin-host string   administration server host (default "localhost")
+      --admin-port int      administration server port (default 6060)
+  -c, --config string       configuration file (default "$HOME/.cozy.yaml")
+      --host string         server host (default "localhost")
+  -p, --port int            server port (default 8080)
+```
+
+### SEE ALSO
+
+* [cozy-stack fixer](cozy-stack_fixer.md)	 - A set of tools to fix issues or migrate content for retro-compatibility.
+

--- a/docs/cli/cozy-stack_konnectors_update.md
+++ b/docs/cli/cozy-stack_konnectors_update.md
@@ -14,6 +14,7 @@ cozy-stack konnectors update <slug> [sourceurl] [flags]
 
 ```
   -h, --help   help for update
+      --safe   do not upgrade if there are blocking changes
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
In case of blocking changes (TOS, new perms), we may want to block a
webapp/konnector update.