### PR TITLE
Deprecate the dev flag on instances

### DIFF
--- a/client/instances.go
+++ b/client/instances.go
@@ -31,7 +31,6 @@ type Instance struct {
 		AuthMode             int       `json:"auth_mode,omitempty"`
 		NoAutoUpdate         bool      `json:"no_auto_update,omitempty"`
 		Blocked              bool      `json:"blocked,omitempty"`
-		Dev                  bool      `json:"dev"`
 		OnboardingFinished   bool      `json:"onboarding_finished"`
 		BytesDiskQuota       int64     `json:"disk_quota,string,omitempty"`
 		IndexViewsVersion    int       `json:"indexes_version"`
@@ -62,7 +61,6 @@ type InstanceOptions struct {
 	Debug              *bool
 	Blocked            *bool
 	OnboardingFinished *bool
-	Dev                bool
 }
 
 // TokenOptions is a struct holding all the options to generate a token.
@@ -145,7 +143,6 @@ func (c *Client) CreateInstance(opts *InstanceOptions) (*Instance, error) {
 		"DiskQuota":    {strconv.FormatInt(opts.DiskQuota, 10)},
 		"Apps":         {strings.Join(opts.Apps, ",")},
 		"Passphrase":   {opts.Passphrase},
-		"Dev":          {strconv.FormatBool(opts.Dev)},
 	}
 	if opts.DomainAliases != nil {
 		q.Add("DomainAliases", strings.Join(opts.DomainAliases, ","))

--- a/cmd/instances.go
+++ b/cmd/instances.go
@@ -147,13 +147,16 @@ If the COZY_DISABLE_INSTANCES_ADD_RM env variable is set, creating and
 destroying instances will be desactivated and the content of this variable will
 be used as the error message.
 `,
-	Example: "$ cozy-stack instances add --dev --passphrase cozy --apps drive,photos,settings cozy.tools:8080",
+	Example: "$ cozy-stack instances add --passphrase cozy --apps drive,photos,settings cozy.tools:8080",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if reason := os.Getenv("COZY_DISABLE_INSTANCES_ADD_RM"); reason != "" {
 			return fmt.Errorf("Sorry, instances add is disabled: %s", reason)
 		}
 		if len(args) == 0 {
 			return cmd.Usage()
+		}
+		if flagDev {
+			errPrintfln("The --dev flag has been deprecated")
 		}
 
 		var diskQuota int64
@@ -182,7 +185,6 @@ be used as the error message.
 			DiskQuota:     diskQuota,
 			Apps:          flagApps,
 			Passphrase:    flagPassphrase,
-			Dev:           flagDev,
 		})
 		if err != nil {
 			errPrintfln(
@@ -474,11 +476,10 @@ by this server.
 					if prefix == "" {
 						DBPrefix = couchdb.EscapeCouchdbName(i.Attrs.Domain)
 					}
-					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\tv%d\t%s\t%s\n",
+					fmt.Fprintf(w, "%s\t%s\t%s\t%s\tv%d\t%s\t%s\n",
 						i.Attrs.Domain,
 						i.Attrs.Locale,
 						formatSize(i.Attrs.BytesDiskQuota),
-						formatDev(i.Attrs.Dev),
 						formatOnboarded(i),
 						i.Attrs.IndexViewsVersion,
 						prefix,
@@ -516,13 +517,6 @@ func formatSize(size int64) string {
 		return "unlimited"
 	}
 	return humanize.Bytes(uint64(size))
-}
-
-func formatDev(dev bool) string {
-	if dev {
-		return "dev"
-	}
-	return "prod"
 }
 
 func formatOnboarded(i *client.Instance) string {
@@ -1022,7 +1016,7 @@ func init() {
 	addInstanceCmd.Flags().IntVar(&flagSwiftCluster, "swift-cluster", 0, "Specify a cluster number for swift")
 	addInstanceCmd.Flags().StringVar(&flagDiskQuota, "disk-quota", "", "The quota allowed to the instance's VFS")
 	addInstanceCmd.Flags().StringSliceVar(&flagApps, "apps", nil, "Apps to be preinstalled")
-	addInstanceCmd.Flags().BoolVar(&flagDev, "dev", false, "To create a development instance")
+	addInstanceCmd.Flags().BoolVar(&flagDev, "dev", false, "To create a development instance (deprecated)")
 	addInstanceCmd.Flags().StringVar(&flagPassphrase, "passphrase", "", "Register the instance with this passphrase (useful for tests)")
 	modifyInstanceCmd.Flags().StringSliceVar(&flagDomainAliases, "domain-aliases", nil, "Specify one or more aliases domain for the instance (separated by ',')")
 	modifyInstanceCmd.Flags().StringVar(&flagLocale, "locale", "", "New locale")

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -206,7 +206,7 @@ func init() {
 	flags.String("password-reset-interval", "15m", "minimal duration between two password reset")
 	checkNoErr(viper.BindPFlag("password_reset_interval", flags.Lookup("password-reset-interval")))
 
-	flags.BoolVar(&flagDevMode, "dev", false, "Allow to run without in dev release mode (disabled by default)")
+	flags.BoolVar(&flagDevMode, "dev", false, "Allow to run in dev mode for a prod release (disabled by default)")
 	flags.BoolVar(&flagAllowRoot, "allow-root", false, "Allow to start as root (disabled by default)")
 	flags.StringSliceVar(&flagAppdirs, "appdir", nil, "Mount a directory as the 'app' application")
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -67,7 +67,7 @@ cozy-stack serve
 And then create an instance for development:
 
 ```bash
-cozy-stack instances add --dev --apps drive,photos,settings --passphrase cozy "cozy.tools:8080"
+cozy-stack instances add --apps drive,photos,settings --passphrase cozy "cozy.tools:8080"
 ```
 
 The cozy-stack server listens on http://cozy.tools:8080/ by default. See

--- a/docs/cli/cozy-stack_instances_add.md
+++ b/docs/cli/cozy-stack_instances_add.md
@@ -20,7 +20,7 @@ cozy-stack instances add <domain> [flags]
 ### Examples
 
 ```
-$ cozy-stack instances add --dev --passphrase cozy --apps drive,photos,settings cozy.tools:8080
+$ cozy-stack instances add --passphrase cozy --apps drive,photos,settings cozy.tools:8080
 ```
 
 ### Options
@@ -28,7 +28,7 @@ $ cozy-stack instances add --dev --passphrase cozy --apps drive,photos,settings 
 ```
       --apps strings             Apps to be preinstalled
       --context-name string      Context name of the instance
-      --dev                      To create a development instance
+      --dev                      To create a development instance (deprecated)
       --disk-quota string        The quota allowed to the instance's VFS
       --domain-aliases strings   Specify one or more aliases domain for the instance (separated by ',')
       --email string             The email of the owner

--- a/docs/cli/cozy-stack_serve.md
+++ b/docs/cli/cozy-stack_serve.md
@@ -42,7 +42,7 @@ example), you can use the --appdir flag like this:
       --assets string                    path to the directory with the assets (use the packed assets by default)
       --couchdb-url string               CouchDB URL (default "http://localhost:5984/")
       --csp-whitelist string             Whitelisted domains for the default allowed origins of the Content Secury Policy
-      --dev                              Allow to run without in dev release mode (disabled by default)
+      --dev                              Allow to run in dev mode for a prod release (disabled by default)
       --disable-csp                      Disable the Content Security Policy (only available for development)
       --doctypes string                  path to the directory with the doctypes (for developing/testing a remote doctype)
       --downloads-url string             URL for the download secret storage, redis or in-memory
@@ -64,6 +64,7 @@ example), you can use the --appdir flag like this:
       --mail-port int                    mail smtp port (default 465)
       --mail-username string             mail smtp username
       --password-reset-interval string   minimal duration between two password reset (default "15m")
+      --rate-limiting-url string         URL for rate-limiting counters, redis or in-memory
       --realtime-url string              URL for realtime in the browser via webocket, redis or in-memory
       --sessions-url string              URL for the sessions storage, redis or in-memory
       --subdomains string                how to structure the subdomains for apps (can be nested or flat) (default "nested")

--- a/docs/instance.md
+++ b/docs/instance.md
@@ -8,18 +8,6 @@ A single cozy-stack can manage several instances. Requests to different
 instances are identified through the `Host` HTTP Header, any reverse proxy
 placed in front of the cozy-stack should forward this header.
 
-To simplify development, a `dev` instance name is used when no Host Header is
-provided. This behaviour will be kept when the stack is started in dev mode but
-will be blocked in production environment.
-
-**Exemple:**
-
--   `curl -H "Host: bob.cozycloud.cc" localhost:8080` →
-    `localhost:5984/bob-cozycloud.cc`
--   `curl -H "Host: alice.cozycloud.cc" localhost:8080` →
-    `localhost:5984/alice-cozycloud.cc`
--   `curl localhost:8080` → `localhost:5984/dev` (in dev mode only)
-
 ## Creation
 
 An instance is created on the command line:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -799,6 +799,7 @@ func createTestViper() *viper.Viper {
 // from a cozy.test.* file. If it can not find this file in your
 // $HOME/.cozy directory it will use the default one.
 func UseTestFile() {
+	BuildMode = ModeProd
 	v := createTestViper()
 
 	if err := v.ReadInConfig(); err != nil {

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -96,7 +96,6 @@ type Instance struct {
 	AuthMode      AuthMode `json:"auth_mode,omitempty"`
 	Blocked       bool     `json:"blocked,omitempty"`        // Whether or not the instance is blocked
 	NoAutoUpdate  bool     `json:"no_auto_update,omitempty"` // Whether or not the instance has auto updates for its applications
-	Dev           bool     `json:"dev,omitempty"`            // Whether or not the instance is for development
 
 	OnboardingFinished bool  `json:"onboarding_finished,omitempty"` // Whether or not the onboarding is complete.
 	BytesDiskQuota     int64 `json:"disk_quota,string,omitempty"`   // The total size in bytes allowed to the user
@@ -150,7 +149,6 @@ type Options struct {
 	AutoUpdate    *bool
 	Debug         *bool
 	Blocked       *bool
-	Dev           bool
 
 	OnboardingFinished *bool
 }
@@ -438,7 +436,7 @@ func (i *Instance) WithContextualDomain(domain string) *Instance {
 // Scheme returns the scheme used for URLs. It is https by default and http
 // for development instances.
 func (i *Instance) Scheme() string {
-	if i.Dev {
+	if config.IsDevRelease() {
 		return "http"
 	}
 	return "https"
@@ -677,7 +675,6 @@ func CreateWithoutHooks(opts *Options) (*Instance, error) {
 	i.TOSLatest = opts.TOSLatest
 	i.ContextName = opts.ContextName
 	i.BytesDiskQuota = opts.DiskQuota
-	i.Dev = opts.Dev
 	i.IndexViewsVersion = consts.IndexViewsVersion
 	i.RegisterToken = crypto.GenerateRandomBytes(RegisterTokenLen)
 	i.SessionSecret = crypto.GenerateRandomBytes(SessionSecretLen)

--- a/pkg/sessions/session.go
+++ b/pkg/sessions/session.go
@@ -204,7 +204,7 @@ func (s *Session) ToCookie() (*http.Cookie, error) {
 		MaxAge:   maxAge,
 		Path:     "/",
 		Domain:   utils.StripPort("." + s.Instance.ContextualDomain()),
-		Secure:   !s.Instance.Dev,
+		Secure:   !config.IsDevRelease(),
 		HttpOnly: true,
 	}, nil
 }
@@ -222,7 +222,7 @@ func (s *Session) ToAppCookie(domain, slug string) (*http.Cookie, error) {
 		MaxAge:   0, // "session cookie", expiring when the browser is closed
 		Path:     "/",
 		Domain:   utils.StripPort(domain),
-		Secure:   !s.Instance.Dev,
+		Secure:   !config.IsDevRelease(),
 		HttpOnly: true,
 	}, nil
 }

--- a/scripts/cozy-app-dev.sh
+++ b/scripts/cozy-app-dev.sh
@@ -167,7 +167,6 @@ do_create_instances() {
 	add_instance_val=$(
 		${COZY_STACK_PATH} instances add \
 			--context-name dev \
-			--dev \
 			--email dev@cozy.io \
 			--public-name "Jane Doe" \
 			--passphrase ${COZY_STACK_PASS} \

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -3,7 +3,7 @@
 go build
 ./cozy-stack serve &
 sleep 5
-./cozy-stack instances add --dev --passphrase cozytest localhost:8080
+./cozy-stack instances add --passphrase cozytest localhost:8080
 
 export CLIENT_ID=$(./cozy-stack instances client-oauth localhost:8080 http://localhost/ test github.com/cozy/cozy-stack/integration)
 export TEST_TOKEN=$(./cozy-stack instances token-oauth localhost:8080 $CLIENT_ID io.cozy.pouchtestobject)

--- a/tests/sharing/lib/stack.rb
+++ b/tests/sharing/lib/stack.rb
@@ -27,7 +27,7 @@ class Stack
   end
 
   def create_instance(inst)
-    cmd = ["cozy-stack", "instances", "add", inst.domain, "--dev",
+    cmd = ["cozy-stack", "instances", "add", inst.domain,
            "--passphrase", inst.passphrase, "--public-name", inst.name,
            "--email", inst.email, "--settings", "context:test",
            "--admin-port", @admin.to_s, "--locale", "fr"]

--- a/web/instances/instances.go
+++ b/web/instances/instances.go
@@ -66,7 +66,6 @@ func createHandler(c echo.Context) error {
 		AuthMode:    c.QueryParam("AuthMode"),
 		Passphrase:  c.QueryParam("Passphrase"),
 		Apps:        utils.SplitTrimString(c.QueryParam("Apps"), ","),
-		Dev:         (c.QueryParam("Dev") == "true"),
 	}
 	if domainAliases := c.QueryParam("DomainAliases"); domainAliases != "" {
 		opts.DomainAliases = strings.Split(domainAliases, ",")

--- a/web/konnectorsauth/oauth_test.go
+++ b/web/konnectorsauth/oauth_test.go
@@ -222,7 +222,6 @@ func TestMain(m *testing.M) {
 	ts = setup.GetTestServer("/accounts", Routes)
 	testInstance = setup.GetTestInstance(&instance.Options{
 		Domain: strings.Replace(ts.URL, "http://127.0.0.1", "cozy.tools", 1),
-		Dev:    true,
 	})
 	couchdb.ResetDB(couchdb.GlobalSecretsDB, consts.AccountTypes)
 	setup.AddCleanup(func() error {

--- a/web/konnectorsauth/oauth_test.go
+++ b/web/konnectorsauth/oauth_test.go
@@ -216,6 +216,7 @@ func TestFixedRedirectURIOauthFlow(t *testing.T) {
 
 func TestMain(m *testing.M) {
 	config.UseTestFile()
+	config.BuildMode = config.ModeDev
 	testutils.NeedCouchdb()
 
 	setup = testutils.NewSetup(m, "oauth-konnectors")

--- a/web/middlewares/secure.go
+++ b/web/middlewares/secure.go
@@ -107,10 +107,7 @@ func Secure(conf *SecureConfig) echo.MiddlewareFunc {
 
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
-			isSecure := true
-			if in, ok := GetInstanceSafe(c); ok && in.Dev {
-				isSecure = false
-			}
+			isSecure := !config.IsDevRelease()
 			h := c.Response().Header()
 			if isSecure && hstsHeader != "" {
 				h.Set(echo.HeaderStrictTransportSecurity, hstsHeader)


### PR DESCRIPTION
A stack can be built in two release modes: dev and prod. We also has a flag per instance, but it was confusing to have both and, in practice, using a prod release with a dev instance didn't work.

Note that a prod release can be used as a dev release by starting the server like this:

	$ cozy-stack serve --dev