### PR TITLE
Improve instance blocked checking

### DIFF
--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -1549,7 +1549,7 @@ func (i *Instance) CreateShareCode(subject string) (string, error) {
 }
 
 // Block function blocks an instance with an optional reason parameter
-func (i *Instance) Block(reason ...string) (bool, error) {
+func (i *Instance) Block(reason ...string) error {
 	var r string
 
 	if len(reason) == 1 {
@@ -1564,9 +1564,9 @@ func (i *Instance) Block(reason ...string) (bool, error) {
 		BlockingReason: r,
 	})
 	if err != nil {
-		return false, err
+		return err
 	}
-	return true, nil
+	return nil
 }
 
 func validateDomain(domain string) (string, error) {

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -79,23 +79,39 @@ var (
 	ErrBadTOSVersion = errors.New("Bad format for TOS version")
 )
 
+// BlockingReason structs holds a reason why an instance had been blocked
+type BlockingReason struct {
+	Code    string
+	Message string
+}
+
+var (
+	// BlockedLoginFailed is used when a security issue has been detected on the instance
+	BlockedLoginFailed = BlockingReason{Code: "LOGIN_FAILED", Message: "The instance was block because of too many login failed attempts"}
+	// BlockedPaymentFailed is used when a payment is missing for the instance
+	BlockedPaymentFailed = BlockingReason{Code: "PAYMENT_FAILED", Message: "The instance requires a payment"}
+	// BlockedUnknown is used when an instance is blocked but the reason is unknown
+	BlockedUnknown = BlockingReason{Code: "UNKNOWN", Message: "This instance is blocked for an unknown reason"}
+)
+
 // An Instance has the informations relatives to the logical cozy instance,
 // like the domain, the locale or the access to the databases and files storage
 // It is a couchdb.Doc to be persisted in couchdb.
 type Instance struct {
-	DocID         string   `json:"_id,omitempty"`  // couchdb _id
-	DocRev        string   `json:"_rev,omitempty"` // couchdb _rev
-	Domain        string   `json:"domain"`         // The main DNS domain, like example.cozycloud.cc
-	DomainAliases []string `json:"domain_aliases,omitempty"`
-	Prefix        string   `json:"prefix,omitempty"`     // Possible database prefix
-	Locale        string   `json:"locale"`               // The locale used on the server
-	UUID          string   `json:"uuid,omitempty"`       // UUID associated with the instance
-	ContextName   string   `json:"context,omitempty"`    // The context attached to the instance
-	TOSSigned     string   `json:"tos,omitempty"`        // Terms of Service signed version
-	TOSLatest     string   `json:"tos_latest,omitempty"` // Terms of Service latest version
-	AuthMode      AuthMode `json:"auth_mode,omitempty"`
-	Blocked       bool     `json:"blocked,omitempty"`        // Whether or not the instance is blocked
-	NoAutoUpdate  bool     `json:"no_auto_update,omitempty"` // Whether or not the instance has auto updates for its applications
+	DocID          string   `json:"_id,omitempty"`  // couchdb _id
+	DocRev         string   `json:"_rev,omitempty"` // couchdb _rev
+	Domain         string   `json:"domain"`         // The main DNS domain, like example.cozycloud.cc
+	DomainAliases  []string `json:"domain_aliases,omitempty"`
+	Prefix         string   `json:"prefix,omitempty"`     // Possible database prefix
+	Locale         string   `json:"locale"`               // The locale used on the server
+	UUID           string   `json:"uuid,omitempty"`       // UUID associated with the instance
+	ContextName    string   `json:"context,omitempty"`    // The context attached to the instance
+	TOSSigned      string   `json:"tos,omitempty"`        // Terms of Service signed version
+	TOSLatest      string   `json:"tos_latest,omitempty"` // Terms of Service latest version
+	AuthMode       AuthMode `json:"auth_mode,omitempty"`
+	Blocked        bool     `json:"blocked,omitempty"`         // Whether or not the instance is blocked
+	BlockingReason string   `json:"blocking_reason,omitempty"` // Why the instance is blocked
+	NoAutoUpdate   bool     `json:"no_auto_update,omitempty"`  // Whether or not the instance has auto updates for its applications
 
 	OnboardingFinished bool  `json:"onboarding_finished,omitempty"` // Whether or not the onboarding is complete.
 	BytesDiskQuota     int64 `json:"disk_quota,string,omitempty"`   // The total size in bytes allowed to the user

--- a/pkg/instance/warnings.go
+++ b/pkg/instance/warnings.go
@@ -41,10 +41,7 @@ const (
 // CheckInstanceBlocked returns whether or not the instance is currently in a
 // blocked state: meaning it should be accessible.
 func (i *Instance) CheckInstanceBlocked() bool {
-	if i.Blocked {
-		return true
-	}
-	return false
+	return i.Blocked
 }
 
 // CheckTOSNotSigned checks whether or not the current Term of Services have

--- a/pkg/instance/warnings.go
+++ b/pkg/instance/warnings.go
@@ -44,11 +44,7 @@ func (i *Instance) CheckInstanceBlocked() bool {
 	if i.Blocked {
 		return true
 	}
-	if len(i.RegisterToken) > 0 {
-		return false
-	}
-	_, deadline := i.CheckTOSNotSignedAndDeadline()
-	return deadline == TOSBlocked
+	return false
 }
 
 // CheckTOSNotSigned checks whether or not the current Term of Services have

--- a/web/apps/serve.go
+++ b/web/apps/serve.go
@@ -47,16 +47,6 @@ func Serve(c echo.Context) error {
 		}
 	}
 
-	if i.CheckInstanceBlocked() {
-		var redirect string
-		if i.Blocked {
-			redirect, _ = i.ManagerURL(instance.ManagerBlockedURL)
-		} else {
-			redirect, _ = i.ManagerURL(instance.ManagerTOSURL)
-		}
-		return c.Redirect(http.StatusFound, redirect)
-	}
-
 	app, err := apps.GetWebappBySlug(i, slug)
 	if err != nil {
 		// Used for the "collect" => "home" renaming

--- a/web/auth/rate_limiting.go
+++ b/web/auth/rate_limiting.go
@@ -153,10 +153,8 @@ func CheckRateLimit(inst *instance.Instance, passwordType string) error {
 func LoginRateExceeded(i *instance.Instance) error {
 	err := fmt.Errorf("Instance was blocked because of too many login failed attempts")
 	i.Logger().WithField("nspace", "rate_limiting").Warning(err)
-	t := true
-	return instance.Patch(i, &instance.Options{
-		Blocked: &t,
-	})
+	_, err = i.Block(instance.BlockedLoginFailed.Code)
+	return err
 }
 
 // TwoFactorRateExceeded regenerates a new 2FA passcode after too many failed
@@ -178,8 +176,7 @@ func TwoFactorRateExceeded(i *instance.Instance) error {
 func TwoFactorGenerationExceeded(i *instance.Instance) error {
 	err := fmt.Errorf("Instance was blocked because of too many 2FA passcode generations")
 	i.Logger().WithField("nspace", "rate_limiting").Warning(err)
-	t := true
-	return instance.Patch(i, &instance.Options{
-		Blocked: &t,
-	})
+
+	_, err = i.Block(instance.BlockedLoginFailed.Code)
+	return err
 }

--- a/web/auth/rate_limiting.go
+++ b/web/auth/rate_limiting.go
@@ -153,8 +153,7 @@ func CheckRateLimit(inst *instance.Instance, passwordType string) error {
 func LoginRateExceeded(i *instance.Instance) error {
 	err := fmt.Errorf("Instance was blocked because of too many login failed attempts")
 	i.Logger().WithField("nspace", "rate_limiting").Warning(err)
-	_, err = i.Block(instance.BlockedLoginFailed.Code)
-	return err
+	return i.Block(instance.BlockedLoginFailed.Code)
 }
 
 // TwoFactorRateExceeded regenerates a new 2FA passcode after too many failed
@@ -177,6 +176,5 @@ func TwoFactorGenerationExceeded(i *instance.Instance) error {
 	err := fmt.Errorf("Instance was blocked because of too many 2FA passcode generations")
 	i.Logger().WithField("nspace", "rate_limiting").Warning(err)
 
-	_, err = i.Block(instance.BlockedLoginFailed.Code)
-	return err
+	return i.Block(instance.BlockedLoginFailed.Code)
 }

--- a/web/middlewares/instance.go
+++ b/web/middlewares/instance.go
@@ -56,20 +56,15 @@ func CheckInstanceBlocked(next echo.HandlerFunc) echo.HandlerFunc {
 			}
 
 			// Fallback by trying to determine the blocking reason
-			var returnCode int
 			reason := i.BlockingReason
+			returnCode := http.StatusPaymentRequired
 
-			switch i.BlockingReason {
-			case instance.BlockedPaymentFailed.Code:
-				returnCode = http.StatusPaymentRequired
+			if reason == "" {
+				reason = http.StatusText(http.StatusPaymentRequired)
+			} else if reason == instance.BlockedPaymentFailed.Code {
 				reason = instance.BlockedPaymentFailed.Message
-			default:
-				// Used for retro-compatibility reasons. Will be deprecated.
-				returnCode = http.StatusPaymentRequired
-				if reason == "" {
-					reason = http.StatusText(http.StatusPaymentRequired)
-				}
 			}
+
 			contentType := AcceptedContentType(c)
 			switch contentType {
 			case jsonapi.ContentType, echo.MIMEApplicationJSON:

--- a/web/middlewares/instance.go
+++ b/web/middlewares/instance.go
@@ -46,17 +46,20 @@ func CheckInstanceBlocked(next echo.HandlerFunc) echo.HandlerFunc {
 			return next(c)
 		}
 		if i.CheckInstanceBlocked() {
-			if url, _ := i.ManagerURL(instance.ManagerBlockedURL); url != "" {
+			// Standard checks
+			if i.BlockingReason == instance.BlockedLoginFailed.Code {
+				return echo.NewHTTPError(http.StatusServiceUnavailable, instance.BlockedLoginFailed.Message)
+			}
+
+			if url, _ := i.ManagerURL(instance.ManagerBlockedURL); url != "" && IsLoggedIn(c) {
 				return c.Redirect(http.StatusFound, url)
 			}
 
+			// Fallback by trying to determine the blocking reason
 			var returnCode int
 			reason := i.BlockingReason
 
 			switch i.BlockingReason {
-			case instance.BlockedLoginFailed.Code:
-				returnCode = http.StatusUnavailableForLegalReasons
-				reason = instance.BlockedLoginFailed.Message
 			case instance.BlockedPaymentFailed.Code:
 				returnCode = http.StatusPaymentRequired
 				reason = instance.BlockedPaymentFailed.Message
@@ -67,7 +70,6 @@ func CheckInstanceBlocked(next echo.HandlerFunc) echo.HandlerFunc {
 					reason = http.StatusText(http.StatusPaymentRequired)
 				}
 			}
-
 			contentType := AcceptedContentType(c)
 			switch contentType {
 			case jsonapi.ContentType, echo.MIMEApplicationJSON:
@@ -85,16 +87,18 @@ func CheckInstanceBlocked(next echo.HandlerFunc) echo.HandlerFunc {
 func CheckTOSDeadlineExpired(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		i := GetInstance(c)
-		if len(i.RegisterToken) > 0 {
+
+		redirect, _ := i.ManagerURL(instance.ManagerTOSURL)
+
+		// Skip check if the instance does not have a ManagerURL or a
+		// registerToken
+		if len(i.RegisterToken) > 0 || redirect == "" {
 			return next(c)
 		}
+
 		notSigned, deadline := i.CheckTOSNotSignedAndDeadline()
 		if notSigned && deadline == instance.TOSBlocked {
-			redirect, _ := i.ManagerURL(instance.ManagerTOSURL)
-			if redirect != "" {
-				return c.Redirect(http.StatusFound, redirect)
-			}
-			return echo.NewHTTPError(http.StatusPaymentRequired) // Compatibility reasons
+			return c.Redirect(http.StatusFound, redirect)
 		}
 		return next(c)
 	}

--- a/web/middlewares/instance.go
+++ b/web/middlewares/instance.go
@@ -85,6 +85,9 @@ func CheckInstanceBlocked(next echo.HandlerFunc) echo.HandlerFunc {
 func CheckTOSDeadlineExpired(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		i := GetInstance(c)
+		if len(i.RegisterToken) > 0 {
+			return next(c)
+		}
 		notSigned, deadline := i.CheckTOSNotSignedAndDeadline()
 		if notSigned && deadline == instance.TOSBlocked {
 			redirect, _ := i.ManagerURL(instance.ManagerTOSURL)

--- a/web/routing.go
+++ b/web/routing.go
@@ -57,6 +57,11 @@ func SetupAppsHandler(appsHandler echo.HandlerFunc) echo.HandlerFunc {
 	mws := []echo.MiddlewareFunc{
 		middlewares.LoadAppSession,
 		middlewares.CheckIE,
+		middlewares.Accept(middlewares.AcceptOptions{
+			DefaultContentTypeOffer: echo.MIMETextHTML,
+		}),
+		middlewares.CheckInstanceBlocked,
+		middlewares.CheckTOSDeadlineExpired,
 	}
 	if !config.GetConfig().CSPDisabled {
 		secure := middlewares.Secure(&middlewares.SecureConfig{


### PR DESCRIPTION
- Split the notion of "blocked instance" in really "blocked" state and "ToS not signed and deadline exceeded". It implies that a user can access his login page and connect even if his ToS deadline is in error. He will be redirected to his `ManagerURL` later

- Add a field `blocking_reason` in Instance to store the information about the blocking reason
