### PR TITLE
Do not use long filenames in sharing tests

### DIFF
--- a/tests/sharing/lib/sharing.rb
+++ b/tests/sharing/lib/sharing.rb
@@ -78,7 +78,7 @@ class Sharing
   end
 
   def initialize(opts = {})
-    @description = opts[:description] || Faker::HitchhikersGuideToTheGalaxy.marvin_quote
+    @description = opts[:description] || Faker::DrWho.catch_phrase
     @app_slug = opts[:app_slug] || ""
     @rules = []
     @members = [] # Owner's instance + recipients contacts

--- a/tests/sharing/tests/read_only.rb
+++ b/tests/sharing/tests/read_only.rb
@@ -50,7 +50,7 @@ describe "A sharing" do
     code = sharing.read_only inst_bob, 2
     assert_equal 204, code
     sleep 8
-    name2b = "#{Faker::HitchhikersGuideToTheGalaxy.marvin_quote}.txt"
+    name2b = "#{Faker::DrWho.villian}.txt"
     file2_charlie.rename inst_charlie, name2b
     sleep 8
 
@@ -71,7 +71,7 @@ describe "A sharing" do
     code = sharing.read_write inst_bob, 2
     assert_equal 204, code
     sleep 1
-    name1c = "#{Faker::DrWho.quote}.txt"
+    name1c = "#{Faker::DrWho.specie}.txt"
     file1_charlie.rename inst_charlie, name1c
     sleep 6
     file1 = CozyFile.find inst_alice, file1.couch_id


### PR DESCRIPTION
Using quotes for filenames in the sharing tests can make them break on travis.