### PR TITLE
Fix realtime for apps

### DIFF
--- a/pkg/apps/installer.go
+++ b/pkg/apps/installer.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver"
+	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/hooks"
 	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/cozy/cozy-stack/pkg/prefixer"
@@ -195,9 +196,15 @@ func initManifest(db prefixer.Prefixer, opts *InstallerOptions) (man Manifest, e
 		}
 		switch opts.Type {
 		case Webapp:
-			man = &WebappManifest{DocSlug: slug}
+			man = &WebappManifest{
+				DocID:   consts.Apps + "/" + slug,
+				DocSlug: slug,
+			}
 		case Konnector:
-			man = &KonnManifest{DocSlug: slug}
+			man = &KonnManifest{
+				DocID:   consts.Konnectors + "/" + slug,
+				DocSlug: slug,
+			}
 		}
 	} else {
 		man, err = GetBySlug(db, slug, opts.Type)

--- a/pkg/apps/konnector.go
+++ b/pkg/apps/konnector.go
@@ -15,6 +15,7 @@ import (
 // KonnManifest contains all the informations associated with an installed
 // konnector.
 type KonnManifest struct {
+	DocID  string `json:"_id,omitempty"`
 	DocRev string `json:"_rev,omitempty"`
 
 	Name       string `json:"name"`
@@ -70,7 +71,7 @@ type KonnManifest struct {
 }
 
 // ID is part of the Manifest interface
-func (m *KonnManifest) ID() string { return m.DocType() + "/" + m.DocSlug }
+func (m *KonnManifest) ID() string { return m.DocID }
 
 // Rev is part of the Manifest interface
 func (m *KonnManifest) Rev() string { return m.DocRev }
@@ -114,7 +115,7 @@ func (m *KonnManifest) Clone() couchdb.Doc {
 }
 
 // SetID is part of the Manifest interface
-func (m *KonnManifest) SetID(id string) {}
+func (m *KonnManifest) SetID(id string) { m.DocID = id }
 
 // SetRev is part of the Manifest interface
 func (m *KonnManifest) SetRev(rev string) { m.DocRev = rev }
@@ -194,7 +195,7 @@ func (m *KonnManifest) ReadManifest(r io.Reader, slug, sourceURL string) (Manife
 		return nil, ErrBadManifest
 	}
 
-	newManifest.SetID(m.ID())
+	newManifest.SetID(consts.Konnectors + "/" + slug)
 	newManifest.SetRev(m.Rev())
 	newManifest.SetState(m.State())
 	newManifest.CreatedAt = m.CreatedAt
@@ -209,6 +210,7 @@ func (m *KonnManifest) ReadManifest(r io.Reader, slug, sourceURL string) (Manife
 
 // Create is part of the Manifest interface
 func (m *KonnManifest) Create(db prefixer.Prefixer) error {
+	m.DocID = consts.Konnectors + "/" + m.DocSlug
 	m.CreatedAt = time.Now()
 	m.UpdatedAt = time.Now()
 	if err := couchdb.CreateNamedDocWithDB(db, m); err != nil {

--- a/pkg/apps/webapp.go
+++ b/pkg/apps/webapp.go
@@ -63,6 +63,7 @@ type Terms struct {
 // WebappManifest contains all the informations associated with an installed web
 // application.
 type WebappManifest struct {
+	DocID  string `json:"_id,omitempty"`
 	DocRev string `json:"_rev,omitempty"`
 
 	Name       string `json:"name"`
@@ -113,7 +114,7 @@ type WebappManifest struct {
 }
 
 // ID is part of the Manifest interface
-func (m *WebappManifest) ID() string { return m.DocType() + "/" + m.DocSlug }
+func (m *WebappManifest) ID() string { return m.DocID }
 
 // Rev is part of the Manifest interface
 func (m *WebappManifest) Rev() string { return m.DocRev }
@@ -161,7 +162,7 @@ func (m *WebappManifest) Clone() couchdb.Doc {
 }
 
 // SetID is part of the Manifest interface
-func (m *WebappManifest) SetID(id string) {}
+func (m *WebappManifest) SetID(id string) { m.DocID = id }
 
 // SetRev is part of the Manifest interface
 func (m *WebappManifest) SetRev(rev string) { m.DocRev = rev }
@@ -256,7 +257,7 @@ func (m *WebappManifest) ReadManifest(r io.Reader, slug, sourceURL string) (Mani
 		return nil, ErrBadManifest
 	}
 
-	newManifest.SetID(m.ID())
+	newManifest.SetID(consts.Apps + "/" + slug)
 	newManifest.SetRev(m.Rev())
 	newManifest.SetState(m.State())
 	newManifest.CreatedAt = m.CreatedAt
@@ -281,6 +282,7 @@ func (m *WebappManifest) Create(db prefixer.Prefixer) error {
 	if err := diffServices(db, m.Slug(), nil, m.Services); err != nil {
 		return err
 	}
+	m.DocID = consts.Apps + "/" + m.DocSlug
 	m.CreatedAt = time.Now()
 	m.UpdatedAt = time.Now()
 	if err := couchdb.CreateNamedDocWithDB(db, m); err != nil {

--- a/pkg/instance/instance_test.go
+++ b/pkg/instance/instance_test.go
@@ -187,6 +187,7 @@ func TestInstanceHasIndexes(t *testing.T) {
 
 func TestBuildAppToken(t *testing.T) {
 	manifest := &apps.WebappManifest{
+		DocID:   consts.Apps + "/my-app",
 		DocSlug: "my-app",
 	}
 	i := &instance.Instance{

--- a/pkg/intents/intents_test.go
+++ b/pkg/intents/intents_test.go
@@ -27,6 +27,7 @@ func TestGenerateHref(t *testing.T) {
 
 func TestFillServices(t *testing.T) {
 	files := &apps.WebappManifest{
+		DocID:   consts.Apps + "/files",
 		DocSlug: "files",
 		Intents: []apps.Intent{
 			{
@@ -39,6 +40,7 @@ func TestFillServices(t *testing.T) {
 	err := couchdb.CreateNamedDoc(ins, files)
 	assert.NoError(t, err)
 	photos := &apps.WebappManifest{
+		DocID:   consts.Apps + "/photos",
 		DocSlug: "photos",
 		Intents: []apps.Intent{
 			{

--- a/web/apps/apps_test.go
+++ b/web/apps/apps_test.go
@@ -62,6 +62,7 @@ func createFile(dir, filename, content string) error {
 
 func installMiniApp() error {
 	manifest = &apps.WebappManifest{
+		DocID:     consts.Apps + "/" + slug,
 		Name:      "Mini",
 		Icon:      "icon.svg",
 		DocSlug:   slug,

--- a/web/auth/auth_test.go
+++ b/web/auth/auth_test.go
@@ -1272,7 +1272,10 @@ func TestLogoutNoToken(t *testing.T) {
 }
 
 func TestLogoutSuccess(t *testing.T) {
-	a := app.WebappManifest{DocSlug: "home"}
+	a := app.WebappManifest{
+		DocID:   consts.Apps + "/home",
+		DocSlug: "home",
+	}
 	token := testInstance.BuildAppToken(&a, getSessionID(jar.Cookies(nil)))
 	permissions.CreateWebappSet(testInstance, a.Slug(), permissions.Set{})
 	req, _ := http.NewRequest("DELETE", ts.URL+"/auth/login", nil)
@@ -1331,7 +1334,10 @@ func TestLogoutOthers(t *testing.T) {
 	cookies2 := res2.Cookies()
 	assert.Len(t, cookies2, 2)
 
-	a := app.WebappManifest{DocSlug: "home"}
+	a := app.WebappManifest{
+		DocID:   consts.Apps + "/home",
+		DocSlug: "home",
+	}
 	token := testInstance.BuildAppToken(&a, getSessionID(cookies1))
 	permissions.CreateWebappSet(testInstance, a.Slug(), permissions.Set{})
 

--- a/web/intents/intents_test.go
+++ b/web/intents/intents_test.go
@@ -122,6 +122,7 @@ func TestMain(m *testing.M) {
 	_, token = setup.GetTestClient(consts.Settings)
 
 	app := &apps.WebappManifest{
+		DocID:          consts.Apps + "/app",
 		DocSlug:        "app",
 		DocPermissions: permissions.Set{},
 	}
@@ -137,6 +138,7 @@ func TestMain(m *testing.M) {
 	}
 	appToken = ins.BuildAppToken(app, "")
 	files := &apps.WebappManifest{
+		DocID:          consts.Apps + "/files",
 		DocSlug:        "files",
 		DocPermissions: permissions.Set{},
 		Intents: []apps.Intent{

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -1075,6 +1075,7 @@ func generateAppToken(inst *instance.Instance, slug string) string {
 		return ""
 	}
 	manifest := &apps.WebappManifest{
+		DocID:          consts.Apps + "/" + slug,
 		DocSlug:        slug,
 		DocPermissions: rules,
 	}


### PR DESCRIPTION
The id field was missing in the websocket message of /realtime for webapps and konnectors when the stack was using redis. It was due to JSON serialization issues, and fixed by adding an explicit DocID for those two structs.