### PR TITLE
Fix the error handling in the konnector worker

### DIFF
--- a/pkg/workers/exec/konnector.go
+++ b/pkg/workers/exec/konnector.go
@@ -476,6 +476,10 @@ func (w *konnectorWorker) Logger(ctx *jobs.WorkerContext) *logrus.Entry {
 }
 
 func (w *konnectorWorker) ScanOutput(ctx *jobs.WorkerContext, i *instance.Instance, line []byte) error {
+	// Reset the errors from previous runs on retries
+	w.err = nil
+	w.lastErr = nil
+
 	var msg struct {
 		Type    string `json:"type"`
 		Message string `json:"message"`


### PR DESCRIPTION
It a konnector fails on the first, and then succeeds on a next retry, we should reset the error from the previous run to not see it as a whole failure.