### PR TITLE
Fix a panic when updating the settings

### DIFF
--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -1103,7 +1104,7 @@ func (i *Instance) needsSettingsUpdate(newSettings map[string]interface{}) (bool
 		}
 		// Check if we have the key in old settings and the value is different,
 		// or if we don't have the key at all
-		if oldValue, ok := oldSettings.M[k]; !ok || oldValue != newValue {
+		if oldValue, ok := oldSettings.M[k]; !ok || !reflect.DeepEqual(oldValue, newValue) {
 			return true, nil
 		}
 	}


### PR DESCRIPTION
We were comparing the old and new values for the settings to know if we really need to persist the changed to CouchDB. But the comparison can panic if a value is a slice or a map. Using reflect.DeepEqual fix this.