### PR TITLE
Include the check deeplink JS only when useful

### DIFF
--- a/assets/templates/authorize.html
+++ b/assets/templates/authorize.html
@@ -92,7 +92,7 @@
       </section>
     </main>
     <script src="{{asset .Domain "/scripts/cancel-button.js"}}"></script>
-    {{if .RedirectIsDeeplink}}
+    {{if .HasFallback}}
       <script src="{{asset .Domain "/scripts/check-deeplink.js"}}"></script>
     {{end}}
   </body>

--- a/web/auth/auth.go
+++ b/web/auth/auth.go
@@ -699,28 +699,23 @@ func authorizeForm(c echo.Context) error {
 		}
 	}
 
-	redirectURL, err := url.Parse(params.redirectURI)
-	if err != nil {
-		return err
-	}
-	isDeeplink := strings.Contains(redirectURL.Scheme, "cozy")
-
+	hasFallback := c.QueryParam("fallback_uri") != ""
 	return c.Render(http.StatusOK, "authorize.html", echo.Map{
-		"CozyUI":             middlewares.CozyUI(instance),
-		"ThemeCSS":           middlewares.ThemeCSS(instance),
-		"Domain":             instance.ContextualDomain(),
-		"ContextName":        instance.ContextName,
-		"ClientDomain":       clientDomain,
-		"Locale":             instance.Locale,
-		"Client":             params.client,
-		"State":              params.state,
-		"RedirectURI":        params.redirectURI,
-		"Scope":              params.scope,
-		"Permissions":        permissions,
-		"ReadOnly":           readOnly,
-		"CSRF":               c.Get("csrf"),
-		"RedirectIsDeeplink": isDeeplink,
-		"Webapp":             params.webapp,
+		"CozyUI":       middlewares.CozyUI(instance),
+		"ThemeCSS":     middlewares.ThemeCSS(instance),
+		"Domain":       instance.ContextualDomain(),
+		"ContextName":  instance.ContextName,
+		"ClientDomain": clientDomain,
+		"Locale":       instance.Locale,
+		"Client":       params.client,
+		"State":        params.state,
+		"RedirectURI":  params.redirectURI,
+		"Scope":        params.scope,
+		"Permissions":  permissions,
+		"ReadOnly":     readOnly,
+		"CSRF":         c.Get("csrf"),
+		"HasFallback":  hasFallback,
+		"Webapp":       params.webapp,
 	})
 }
 


### PR DESCRIPTION
If we don't have a fallback URI, it is useless to try to detect if the device can handle a deeplink or not, as we can't do anything if it does not. So, let's include this script only if needed.