### PR TITLE
Use a map for contacts

### DIFF
--- a/cmd/fixer.go
+++ b/cmd/fixer.go
@@ -347,8 +347,19 @@ var contactEmailsFixer = &cobra.Command{
 				}
 
 				changed := false
-				for _, email := range contact.Email {
-					address := email.Address
+				emails, ok := contact.Get("emails").([]interface{})
+				if !ok {
+					continue
+				}
+				for i := range emails {
+					email, ok := emails[i].(map[string]interface{})
+					if !ok {
+						continue
+					}
+					address, ok := email["address"].(string)
+					if !ok {
+						continue
+					}
 					_, err := mail.ParseAddress(address)
 					if err != nil {
 						old := address
@@ -374,7 +385,7 @@ var contactEmailsFixer = &cobra.Command{
 						if err == nil {
 							fmt.Printf("    Email fixed: \"%s\" → \"%s\"\n", old, address)
 							changed = true
-							email.Address = address
+							email["address"] = address
 						} else {
 							fmt.Printf("    Invalid email: \"%s\" → \"%s\"\n", old, address)
 						}
@@ -382,6 +393,7 @@ var contactEmailsFixer = &cobra.Command{
 				}
 
 				if changed {
+					contact.M["email"] = emails
 					json, err := json.Marshal(contact)
 					if err != nil {
 						return err

--- a/pkg/sharing/member.go
+++ b/pkg/sharing/member.go
@@ -366,14 +366,7 @@ func PersistInstanceURL(inst *instance.Instance, email, cozyURL string) {
 	if err != nil {
 		return
 	}
-	for _, cozy := range contact.Cozy {
-		if cozy.URL == cozyURL {
-			return
-		}
-	}
-	cozy := contacts.Cozy{URL: cozyURL}
-	contact.Cozy = append([]contacts.Cozy{cozy}, contact.Cozy...)
-	if err := couchdb.UpdateDoc(inst, contact); err != nil {
+	if err := contact.AddCozyURL(inst, cozyURL); err != nil {
 		inst.Logger().WithField("nspace", "sharing").
 			Warnf("Error on saving contact: %s", err)
 	}


### PR DESCRIPTION
We were using structs for the contacts doctype, but it forces to have exactly the same mapping as the front applications. It can be dangerous and lead to data loss. For example, if a contact was added to a group, and she accepts a sharing, the contact will be removed from the group.