### PR TITLE
Clean code for handling the onboarding app

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -69,9 +69,6 @@ const (
 )
 
 const (
-	// OnboardingSlug is the slug of the onboarding app, where the user is
-	// redirected when he has no passphrase.
-	OnboardingSlug = "onboarding"
 	// StoreSlug is the slug of the store application: it can install
 	// konnectors and applications.
 	StoreSlug = "store"


### PR DESCRIPTION
The onboarding webapp has been deprecated a few months ago. We can remove the guard that were left to ease the transition.