### PR TITLE
Improve the way --appdir is handled

### DIFF
--- a/pkg/intents/intents.go
+++ b/pkg/intents/intents.go
@@ -77,8 +77,7 @@ func (in *Intent) GenerateHref(instance *instance.Instance, slug, target string)
 // FillServices looks at all the application that can answer this intent
 // and save them in the services field
 func (in *Intent) FillServices(instance *instance.Instance) error {
-	var res []apps.WebappManifest
-	err := couchdb.GetAllDocs(instance, consts.Apps, &couchdb.AllDocsRequest{}, &res)
+	res, err := apps.ListWebapps(instance)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The --appdir mechanism is now handled in a lower level. It allows to load intents for the apps loaded from an appdir, and to show those apps in the cozy-bar.