### PR TITLE
Allow wss scheme in CSP whitelist

### DIFF
--- a/web/middlewares/secure.go
+++ b/web/middlewares/secure.go
@@ -168,7 +168,11 @@ func validCSPList(sources, defaults []CSPSource, whitelist string) ([]CSPSource,
 			continue
 		}
 		if !config.IsDevRelease() {
-			u.Scheme = "https"
+			if u.Scheme == "ws" || u.Scheme == "wss" {
+				u.Scheme = "wss"
+			} else {
+				u.Scheme = "https"
+			}
 		}
 		if u.Path == "" {
 			u.Path = "/"


### PR DESCRIPTION
Adding a websocket `wss://` url in the configuration file under csp whitelist result in the url to be converted to `https://` scheme. This PR preserves the `wss://` configured scheme in CSP whitelist.