### PR TITLE
Set the trigger last job informations earlier

### DIFF
--- a/pkg/jobs/scheduler.go
+++ b/pkg/jobs/scheduler.go
@@ -225,6 +225,7 @@ func GetTriggerState(db prefixer.Prefixer, triggerID string) (*TriggerState, err
 	for i := len(js) - 1; i >= 0; i-- {
 		j := js[i]
 		startedAt := &j.StartedAt
+		state.Status = j.State
 		switch j.State {
 		case Errored:
 			state.LastFailure = startedAt
@@ -243,7 +244,6 @@ func GetTriggerState(db prefixer.Prefixer, triggerID string) (*TriggerState, err
 		}
 		state.LastExecution = startedAt
 		state.LastExecutedJobID = j.ID()
-		state.Status = j.State
 	}
 
 	return &state, nil

--- a/pkg/jobs/scheduler.go
+++ b/pkg/jobs/scheduler.go
@@ -225,7 +225,16 @@ func GetTriggerState(db prefixer.Prefixer, triggerID string) (*TriggerState, err
 	for i := len(js) - 1; i >= 0; i-- {
 		j := js[i]
 		startedAt := &j.StartedAt
+
 		state.Status = j.State
+		state.LastExecution = startedAt
+		state.LastExecutedJobID = j.ID()
+
+		if j.Manual {
+			state.LastManualExecution = startedAt
+			state.LastManualJobID = j.ID()
+		}
+
 		switch j.State {
 		case Errored:
 			state.LastFailure = startedAt
@@ -238,12 +247,6 @@ func GetTriggerState(db prefixer.Prefixer, triggerID string) (*TriggerState, err
 			// skip any job that is not done or errored
 			continue
 		}
-		if j.Manual {
-			state.LastManualExecution = startedAt
-			state.LastManualJobID = j.ID()
-		}
-		state.LastExecution = startedAt
-		state.LastExecutedJobID = j.ID()
 	}
 
 	return &state, nil


### PR DESCRIPTION
In some cases, when no job has an "Errored" or "Done" state, the job is
skipped, preventing the status to be updated. In that case, the status
was set by default to "Done". This commit updates the status of the
trigger before checking the job state.