### PR TITLE
Avoid losing custom permissions during a webapp/konnector update 

### DIFF
--- a/pkg/apps/apps.go
+++ b/pkg/apps/apps.go
@@ -56,7 +56,7 @@ type Manifest interface {
 	ReadManifest(i io.Reader, slug, sourceURL string) (Manifest, error)
 
 	Create(db prefixer.Prefixer) error
-	Update(db prefixer.Prefixer) error
+	Update(db prefixer.Prefixer, extraPerms permissions.Set) error
 	Delete(db prefixer.Prefixer) error
 
 	AppType() consts.AppType

--- a/pkg/apps/installer.go
+++ b/pkg/apps/installer.go
@@ -402,14 +402,11 @@ func (i *Installer) update() error {
 			// Check if perms were added on the old manifest
 			if i.man.AppType() == consts.WebappType {
 				alteredPerms, err = permissions.GetForWebapp(inst, i.man.Slug())
-				if err != nil {
-					return err
-				}
 			} else if i.man.AppType() == consts.KonnectorType {
 				alteredPerms, err = permissions.GetForKonnector(inst, i.man.Slug())
-				if err != nil {
-					return err
-				}
+			}
+			if err != nil {
+				return err
 			}
 			// The "extraPerms" set represents the post-install alterations of
 			// the permissions between the oldManifest and the current

--- a/pkg/apps/installer.go
+++ b/pkg/apps/installer.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/hooks"
 	"github.com/cozy/cozy-stack/pkg/instance"
 	"github.com/cozy/cozy-stack/pkg/logger"
+	"github.com/cozy/cozy-stack/pkg/permissions"
 	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/cozy/cozy-stack/pkg/realtime"
 	"github.com/cozy/cozy-stack/pkg/registry"
@@ -390,8 +391,35 @@ func (i *Installer) update() error {
 		availableVersion = newManifest.Version()
 	}
 
+	extraPerms := permissions.Set{}
 	if makeUpdate {
 		i.man = newManifest
+
+		var alteredPerms *permissions.Permission
+
+		inst, err := instance.GetFromCouch(i.Domain())
+		if err == nil {
+			// Check if perms were added on the old manifest
+			if i.man.AppType() == consts.WebappType {
+				alteredPerms, err = permissions.GetForWebapp(inst, i.man.Slug())
+				if err != nil {
+					return err
+				}
+			} else if i.man.AppType() == consts.KonnectorType {
+				alteredPerms, err = permissions.GetForKonnector(inst, i.man.Slug())
+				if err != nil {
+					return err
+				}
+			}
+			// The "extraPerms" set represents the post-install alterations of
+			// the permissions between the oldManifest and the current
+			// permissions
+			extraPerms, err = permissions.Diff(oldManifest.Permissions(), alteredPerms.Permissions)
+			if err != nil {
+				return err
+			}
+		}
+
 		i.sendRealtimeEvent()
 		i.notifyChannel()
 		if err := i.fetcher.Fetch(i.src, i.fs, i.man); err != nil {
@@ -408,7 +436,7 @@ func (i *Installer) update() error {
 		i.notifyChannel()
 	}
 
-	return i.man.Update(i.db)
+	return i.man.Update(i.db, extraPerms)
 }
 
 func (i *Installer) notifyChannel() {

--- a/pkg/apps/installer_webapp_test.go
+++ b/pkg/apps/installer_webapp_test.go
@@ -206,6 +206,15 @@ func TestWebappInstallSuccessfulWithExtraPerms(t *testing.T) {
 	// Altering permissions by adding a value and a verb
 	newPerms, err := permissions.UnmarshalScopeString("io.cozy.files:GET,POST:foobar,foobar2")
 	assert.NoError(t, err)
+
+	customRule := permissions.Rule{
+		Title:  "myCustomRule",
+		Verbs:  permissions.Verbs(permissions.PUT),
+		Type:   "io.cozy.custom",
+		Values: []string{"myCustomValue"},
+	}
+	newPerms = append(newPerms, customRule)
+
 	_, err = permissions.UpdateWebappSet(instance, "mini-test-perms", newPerms)
 	assert.NoError(t, err)
 
@@ -232,7 +241,6 @@ func TestWebappInstallSuccessfulWithExtraPerms(t *testing.T) {
 	// Assert the rules were kept
 	assert.False(t, p2.Permissions.HasSameRules(man.Permissions()))
 	assert.True(t, p1.Permissions.HasSameRules(p2.Permissions))
-
 }
 
 func TestWebappUpgradeNotExist(t *testing.T) {

--- a/pkg/apps/installer_webapp_test.go
+++ b/pkg/apps/installer_webapp_test.go
@@ -205,6 +205,7 @@ func TestWebappInstallSuccessfulWithExtraPerms(t *testing.T) {
 
 	// Altering permissions by adding a value and a verb
 	newPerms, err := permissions.UnmarshalScopeString("io.cozy.files:GET,POST:foobar,foobar2")
+	assert.NoError(t, err)
 	_, err = permissions.UpdateWebappSet(instance, "mini-test-perms", newPerms)
 	assert.NoError(t, err)
 
@@ -220,6 +221,7 @@ func TestWebappInstallSuccessfulWithExtraPerms(t *testing.T) {
 		Slug:      "mini-test-perms",
 		SourceURL: "git://localhost/",
 	})
+	assert.NoError(t, err)
 
 	man, err = inst2.RunSync()
 	assert.NoError(t, err)

--- a/pkg/apps/installer_webapp_test.go
+++ b/pkg/apps/installer_webapp_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/cozy/afero"
 	"github.com/cozy/cozy-stack/pkg/apps"
 	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/instance/lifecycle"
+	"github.com/cozy/cozy-stack/pkg/permissions"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -129,6 +131,106 @@ func TestWebappInstallSuccessful(t *testing.T) {
 	})
 	assert.Nil(t, inst2)
 	assert.Equal(t, apps.ErrAlreadyExists, err)
+}
+
+func TestWebappInstallSuccessfulWithExtraPerms(t *testing.T) {
+	manifest1 := func() string {
+		return ` {
+"description": "A mini app to test cozy-stack-v2",
+"developer": {
+	"name": "Cozy",
+	"url": "cozy.io"
+},
+"license": "MIT",
+"name": "mini-app",
+"permissions": {
+  "rule0": {
+	"type": "io.cozy.files",
+	"verbs": ["GET"],
+	"values": ["foobar"]
+  }
+},
+"slug": "mini-test-perms",
+"type": "webapp",
+"version": "1.0.0"
+}`
+	}
+
+	manifest2 := func() string {
+		return ` {
+"description": "A mini app to test cozy-stack-v2",
+"developer": {
+	"name": "Cozy",
+	"url": "cozy.io"
+},
+"license": "MIT",
+"name": "mini-app",
+"permissions": {
+	"rule0": {
+		"type": "io.cozy.files",
+		"verbs": ["GET"],
+		"values": ["foobar"]
+	}
+},
+"slug": "mini-test-perms",
+"type": "webapp",
+"version": "2.0.0"
+}`
+	}
+	manGen = manifest1
+	manName = apps.WebappManifestName
+	finished := true
+
+	instance, err := lifecycle.Create(&lifecycle.Options{
+		Domain:             "test-keep-perms",
+		OnboardingFinished: &finished,
+	})
+	assert.NoError(t, err)
+
+	defer lifecycle.Destroy("test-keep-perms")
+
+	inst, err := apps.NewInstaller(instance, fs, &apps.InstallerOptions{
+		Operation: apps.Install,
+		Type:      consts.WebappType,
+		Slug:      "mini-test-perms",
+		SourceURL: "git://localhost/",
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	man, err := inst.RunSync()
+	assert.NoError(t, err)
+	assert.Contains(t, man.Version(), "1.0.0")
+
+	// Altering permissions by adding a value and a verb
+	newPerms, err := permissions.UnmarshalScopeString("io.cozy.files:GET,POST:foobar,foobar2")
+	_, err = permissions.UpdateWebappSet(instance, "mini-test-perms", newPerms)
+	assert.NoError(t, err)
+
+	p1, err := permissions.GetForWebapp(instance, "mini-test-perms")
+	assert.NoError(t, err)
+	assert.False(t, p1.Permissions.HasSameRules(man.Permissions()))
+
+	// Update the app
+	manGen = manifest2
+	inst2, err := apps.NewInstaller(instance, fs, &apps.InstallerOptions{
+		Operation: apps.Update,
+		Type:      consts.WebappType,
+		Slug:      "mini-test-perms",
+		SourceURL: "git://localhost/",
+	})
+
+	man, err = inst2.RunSync()
+	assert.NoError(t, err)
+
+	p2, err := permissions.GetForWebapp(instance, "mini-test-perms")
+	assert.NoError(t, err)
+	assert.Contains(t, man.Version(), "2.0.0")
+	// Assert the rules were kept
+	assert.False(t, p2.Permissions.HasSameRules(man.Permissions()))
+	assert.True(t, p1.Permissions.HasSameRules(p2.Permissions))
+
 }
 
 func TestWebappUpgradeNotExist(t *testing.T) {

--- a/pkg/apps/konnector.go
+++ b/pkg/apps/konnector.go
@@ -222,13 +222,23 @@ func (m *KonnManifest) Create(db prefixer.Prefixer) error {
 }
 
 // Update is part of the Manifest interface
-func (m *KonnManifest) Update(db prefixer.Prefixer) error {
+func (m *KonnManifest) Update(db prefixer.Prefixer, extraPerms permissions.Set) error {
 	m.UpdatedAt = time.Now()
 	err := couchdb.UpdateDoc(db, m)
 	if err != nil {
 		return err
 	}
-	_, err = permissions.UpdateKonnectorSet(db, m.Slug(), m.Permissions())
+
+	perms := m.Permissions()
+
+	// Merging the potential extra permissions
+	if extraPerms != nil {
+		perms, err = permissions.MergeExtraPermissions(perms, extraPerms)
+		if err != nil {
+			return err
+		}
+	}
+	_, err = permissions.UpdateKonnectorSet(db, m.Slug(), perms)
 	return err
 }
 

--- a/pkg/permissions/permissions.go
+++ b/pkg/permissions/permissions.go
@@ -353,6 +353,21 @@ func createAppSet(db prefixer.Prefixer, typ, docType, slug string, set Set) (*Pe
 func MergeExtraPermissions(perms, extraPermissions Set) (Set, error) {
 	var permissions Set
 
+	// Appending the extraPermissions which are not in the target permissions
+	for _, ep := range extraPermissions {
+		found := false
+		for _, p := range perms {
+			if ep.Title == p.Title {
+				found = true
+				break
+			}
+		}
+		if !found {
+			permissions = append(permissions, ep)
+		}
+	}
+
+	// Merging the rules already existing
 	for _, rule := range perms {
 		for _, newRule := range extraPermissions {
 			if rule.Title == newRule.Title {

--- a/pkg/permissions/permissions.go
+++ b/pkg/permissions/permissions.go
@@ -351,14 +351,12 @@ func createAppSet(db prefixer.Prefixer, typ, docType, slug string, set Set) (*Pe
 // MergeExtraPermissions merges rules from "extraPermissions" set by adding them
 // in the "perms" one
 func MergeExtraPermissions(perms, extraPermissions Set) (Set, error) {
-	var err error
-	var mergedRule *Rule
 	var permissions Set
 
 	for _, rule := range perms {
 		for _, newRule := range extraPermissions {
 			if rule.Title == newRule.Title {
-				mergedRule, err = rule.Merge(newRule)
+				mergedRule, err := rule.Merge(newRule)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/permissions/permissions.go
+++ b/pkg/permissions/permissions.go
@@ -348,6 +348,30 @@ func createAppSet(db prefixer.Prefixer, typ, docType, slug string, set Set) (*Pe
 	return doc, nil
 }
 
+// MergeExtraPermissions merges rules from "extraPermissions" set by adding them
+// in the "perms" one
+func MergeExtraPermissions(perms, extraPermissions Set) (Set, error) {
+	var err error
+	var mergedRule *Rule
+	var permissions Set
+
+	for _, rule := range perms {
+		for _, newRule := range extraPermissions {
+			if rule.Type == newRule.Type {
+				mergedRule, err = rule.Merge(newRule)
+				if err != nil {
+					return nil, err
+				}
+				permissions = append(permissions, *mergedRule)
+				continue
+			}
+			permissions = append(permissions, rule)
+		}
+	}
+
+	return permissions, nil
+}
+
 // UpdateWebappSet creates a Permission doc for an app
 func UpdateWebappSet(db prefixer.Prefixer, slug string, set Set) (*Permission, error) {
 	doc, err := GetForWebapp(db, slug)

--- a/pkg/permissions/permissions.go
+++ b/pkg/permissions/permissions.go
@@ -357,7 +357,7 @@ func MergeExtraPermissions(perms, extraPermissions Set) (Set, error) {
 
 	for _, rule := range perms {
 		for _, newRule := range extraPermissions {
-			if rule.Type == newRule.Type {
+			if rule.Title == newRule.Title {
 				mergedRule, err = rule.Merge(newRule)
 				if err != nil {
 					return nil, err

--- a/pkg/permissions/rule.go
+++ b/pkg/permissions/rule.go
@@ -1,6 +1,7 @@
 package permissions
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/cozy/cozy-stack/pkg/consts"
@@ -132,4 +133,29 @@ func (r Rule) TranslationKey() string {
 		// TODO a specific folder (io.cozy.files)
 	}
 	return "Permissions " + r.Type
+}
+
+// Merge merges the rule2 in rule1
+// Rule1 name & description are kept
+func (r Rule) Merge(r2 Rule) (*Rule, error) {
+	if r.Type != r2.Type {
+		return nil, fmt.Errorf("Cannot merge these rules, type is different")
+	}
+
+	newRule := &r
+
+	// Verbs
+	for verb, content := range r2.Verbs {
+		if !newRule.Verbs.Contains(verb) {
+			newRule.Verbs[verb] = content
+		}
+	}
+
+	for _, value := range r2.Values {
+		if !newRule.ValuesContain(value) {
+			newRule.Values = append(newRule.Values, value)
+		}
+	}
+
+	return newRule, nil
 }

--- a/pkg/permissions/rule_test.go
+++ b/pkg/permissions/rule_test.go
@@ -1,0 +1,82 @@
+package permissions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMergeRulesIdentical(t *testing.T) {
+	rule1 := Rule{
+		Title:       "myrule1",
+		Type:        "io.cozy.files",
+		Description: "description of rule1",
+		Verbs:       Verbs(GET),
+		Values:      []string{},
+	}
+
+	rule2 := Rule{
+		Title:       "myrule1",
+		Type:        "io.cozy.files",
+		Description: "description of rule1",
+		Verbs:       Verbs(GET),
+		Values:      []string{},
+	}
+
+	newRule, err := rule1.Merge(rule2)
+	assert.NoError(t, err)
+	assert.Equal(t, &rule2, newRule)
+}
+func TestMergeRules(t *testing.T) {
+
+	rule1 := Rule{
+		Title:       "myrule1",
+		Type:        "io.cozy.files",
+		Description: "description of rule1",
+		Verbs:       Verbs(GET),
+		Values:      []string{},
+	}
+
+	rule2 := Rule{
+		Title:       "myrule2",
+		Type:        "io.cozy.files",
+		Description: "description of rule2",
+		Verbs:       Verbs(GET, POST),
+		Values:      []string{"io"},
+	}
+
+	expectedRule := &Rule{
+		Title:       "myrule1",
+		Type:        "io.cozy.files",
+		Description: "description of rule1",
+		Verbs:       Verbs(GET, POST),
+		Values:      []string{"io"},
+	}
+
+	newRule, err := rule1.Merge(rule2)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedRule, newRule)
+}
+
+func TestMergeRulesBadType(t *testing.T) {
+	rule1 := Rule{
+		Title:       "myrule1",
+		Type:        "io.cozy.files",
+		Description: "description of rule1",
+		Verbs:       Verbs(GET),
+		Values:      []string{},
+	}
+
+	rule2 := Rule{
+		Title:       "myrule2",
+		Type:        "io.cozy.contacts",
+		Description: "description of rule2",
+		Verbs:       Verbs(GET, POST),
+		Values:      []string{"io"},
+	}
+
+	newRule, err := rule1.Merge(rule2)
+	assert.Error(t, err)
+	assert.Nil(t, newRule)
+	assert.Contains(t, err.Error(), "type is different")
+}

--- a/pkg/permissions/set.go
+++ b/pkg/permissions/set.go
@@ -232,6 +232,7 @@ func Diff(set1, set2 Set) (Set, error) {
 		for _, rule2 := range set2 {
 			if rule1.Title == rule2.Title { // Same rule, we are going to compute differences
 				newRule := Rule{
+					Title:  rule1.Title,
 					Type:   rule1.Type,
 					Verbs:  map[Verb]struct{}{},
 					Values: []string{},

--- a/pkg/permissions/set.go
+++ b/pkg/permissions/set.go
@@ -217,8 +217,7 @@ func (ps Set) HasSameRules(other Set) bool {
 // permissions and now.
 //
 // TODO: We are ignoring removed values/verbs between rule 1 and rule 2.
-// - At the moment, it onlys show the added values & verbs
-// - It does not handle new rules added
+// - At the moment, it onlys show the added values, verbs and rules
 func Diff(set1, set2 Set) (Set, error) {
 	// If sets are the same, do not compute
 	if set1.HasSameRules(set2) {
@@ -226,6 +225,23 @@ func Diff(set1, set2 Set) (Set, error) {
 	}
 
 	newSet := Set{}
+
+	// Appending not existing rules
+	for _, r2 := range set2 {
+		found := false
+
+		for _, r := range set1 {
+			if r.Title == r2.Title {
+				// Rule exist
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			newSet = append(newSet, r2)
+		}
+	}
 
 	// Compare each key
 	for _, rule1 := range set1 {

--- a/pkg/permissions/set.go
+++ b/pkg/permissions/set.go
@@ -237,8 +237,9 @@ func Diff(set1, set2 Set) (Set, error) {
 					Values: []string{},
 				}
 
-				// Handle verbs Here we are going to find verbs in set2 that are
-				// not present in set1, meaning they were added
+				// Handle verbs. Here we are going to find verbs in set2 that
+				// are not present in set1, meaning they were added later by an
+				// external human action
 				for verb2, content2 := range rule2.Verbs {
 					if !rule1.Verbs.Contains(verb2) {
 						newRule.Verbs[verb2] = content2

--- a/pkg/permissions/set_test.go
+++ b/pkg/permissions/set_test.go
@@ -1,0 +1,118 @@
+package permissions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDiffSameSets(t *testing.T) {
+	set1 := Set{
+		Rule{
+			Title:  "rule1",
+			Verbs:  Verbs(GET),
+			Type:   "io.cozy.files",
+			Values: []string{"io.cozy.files.music-dir"},
+		},
+	}
+
+	set2 := Set{
+		Rule{
+			Title:  "rule2",
+			Verbs:  Verbs(GET),
+			Type:   "io.cozy.files",
+			Values: []string{"io.cozy.files.music-dir"},
+		},
+	}
+
+	d, err := Diff(set1, set2)
+	assert.NoError(t, err)
+	assert.True(t, set1.HasSameRules(d))
+}
+
+func TestDiffNotSameSets(t *testing.T) {
+	set1 := Set{
+		Rule{
+			Title:  "rule1",
+			Verbs:  Verbs(GET),
+			Type:   "io.cozy.files",
+			Values: []string{"io.cozy.files.music-dir"},
+		},
+	}
+
+	set2 := Set{
+		Rule{
+			Title:  "rule1",
+			Verbs:  Verbs(GET, POST),
+			Type:   "io.cozy.files",
+			Values: []string{"io.cozy.files.music-dir"},
+		},
+	}
+
+	d, err := Diff(set1, set2)
+	assert.NoError(t, err)
+	assert.False(t, set1.HasSameRules(d))
+
+	expectedSet := Set{
+		Rule{
+			Title:  "",
+			Verbs:  Verbs(POST), // Only the POST has been added
+			Type:   "io.cozy.files",
+			Values: []string{}, // No addition has been made
+		},
+	}
+
+	assert.Equal(t, expectedSet, d)
+}
+
+func TestDiffMultipleRules(t *testing.T) {
+	set1 := Set{
+		Rule{
+			Title:  "rule1",
+			Verbs:  Verbs(GET),
+			Type:   "io.cozy.files",
+			Values: []string{"io.cozy.files.music-dir"},
+		},
+		Rule{
+			Title:  "rule2",
+			Verbs:  Verbs(PATCH, DELETE),
+			Type:   "io.cozy.foobar",
+			Values: []string{"io.cozy.files.music-dir"},
+		},
+	}
+
+	set2 := Set{
+		Rule{
+			Title:  "rule1",
+			Verbs:  Verbs(GET, POST),
+			Type:   "io.cozy.files",
+			Values: []string{"io.cozy.files.music-dir"},
+		},
+		Rule{
+			Title:  "rule2",
+			Verbs:  Verbs(PATCH, DELETE, GET, POST),
+			Type:   "io.cozy.foobar",
+			Values: []string{"io.cozy.files.music-dir", "io.cozy.files.foobar-dir"},
+		},
+	}
+
+	d, err := Diff(set1, set2)
+	assert.NoError(t, err)
+	assert.False(t, set1.HasSameRules(d))
+
+	expectedSet := Set{
+		Rule{
+			Title:  "",
+			Verbs:  Verbs(POST), // Only the POST has been added
+			Type:   "io.cozy.files",
+			Values: []string{}, // No addition has been made
+		},
+		Rule{
+			Title:  "",
+			Verbs:  Verbs(GET, POST), // GET & POST has been added
+			Type:   "io.cozy.foobar",
+			Values: []string{"io.cozy.files.foobar-dir"}, // A new folder was added
+		},
+	}
+	assert.Equal(t, expectedSet, d)
+}

--- a/pkg/permissions/set_test.go
+++ b/pkg/permissions/set_test.go
@@ -116,3 +116,48 @@ func TestDiffMultipleRules(t *testing.T) {
 	}
 	assert.Equal(t, expectedSet, d)
 }
+
+func TestDiffNotSameSetsNewRule(t *testing.T) {
+	set1 := Set{
+		Rule{
+			Title:  "rule1",
+			Verbs:  Verbs(GET),
+			Type:   "io.cozy.files",
+			Values: []string{"io.cozy.files.music-dir"},
+		},
+	}
+
+	set2 := Set{
+		Rule{
+			Title:  "rule1",
+			Verbs:  Verbs(GET, POST),
+			Type:   "io.cozy.files",
+			Values: []string{"io.cozy.files.music-dir"},
+		},
+		Rule{
+			Title: "myNewRule",
+			Verbs: Verbs(GET, POST),
+			Type:  "io.cozy.ducky",
+		},
+	}
+
+	d, err := Diff(set1, set2)
+	assert.NoError(t, err)
+	assert.False(t, set1.HasSameRules(d))
+
+	expectedSet := Set{
+		Rule{
+			Title: "myNewRule",
+			Verbs: Verbs(GET, POST),
+			Type:  "io.cozy.ducky",
+		},
+		Rule{
+			Title:  "rule1",
+			Verbs:  Verbs(POST), // Only the POST has been added
+			Type:   "io.cozy.files",
+			Values: []string{}, // No addition has been made
+		},
+	}
+
+	assert.Equal(t, expectedSet, d)
+}

--- a/pkg/permissions/set_test.go
+++ b/pkg/permissions/set_test.go
@@ -55,7 +55,7 @@ func TestDiffNotSameSets(t *testing.T) {
 
 	expectedSet := Set{
 		Rule{
-			Title:  "",
+			Title:  "rule1",
 			Verbs:  Verbs(POST), // Only the POST has been added
 			Type:   "io.cozy.files",
 			Values: []string{}, // No addition has been made
@@ -102,13 +102,13 @@ func TestDiffMultipleRules(t *testing.T) {
 
 	expectedSet := Set{
 		Rule{
-			Title:  "",
+			Title:  "rule1",
 			Verbs:  Verbs(POST), // Only the POST has been added
 			Type:   "io.cozy.files",
 			Values: []string{}, // No addition has been made
 		},
 		Rule{
-			Title:  "",
+			Title:  "rule2",
 			Verbs:  Verbs(GET, POST), // GET & POST has been added
 			Type:   "io.cozy.foobar",
 			Values: []string{"io.cozy.files.foobar-dir"}, // A new folder was added

--- a/web/auth/auth.go
+++ b/web/auth/auth.go
@@ -933,7 +933,7 @@ func authorizeApp(c echo.Context) error {
 	}
 
 	app.SetState(apps.Ready)
-	err = app.Update(instance)
+	err = app.Update(instance, nil)
 	if err != nil {
 		msg := instance.Translate("Could not activate application: %s", err.Error())
 		return renderError(c, http.StatusUnauthorized, msg)


### PR DESCRIPTION
This PR allows to keep the extra-permissions added to a webapp or konnector during updates. 

Here is the workflow:
1 - A diff is made between the app/konnector original manifest and the actual permissions doc of the app. This diff contains the added `verbs` or `values` of each `Rule` of the `Set`
2 - The webapp/konnector is updated, this diff is given to the update function
3 - Once the app is updated, the diff is applied to the permissions of the app