### PR TITLE
fix: Do not trash files inside a no longer shared dir

### DIFF
--- a/pkg/sharing/revisions.go
+++ b/pkg/sharing/revisions.go
@@ -82,6 +82,11 @@ func (rt *RevsTree) Find(rev string) *RevsTree {
 func (rt *RevsTree) Add(rev string) *RevsTree {
 	// TODO check generations (conflicts)
 	if len(rt.Branches) > 0 {
+		// XXX This condition shouldn't be true, but it can help to limit
+		// damage in case bugs happen.
+		if rt.Branches[0].Rev == rev {
+			return &rt.Branches[0]
+		}
 		return rt.Branches[0].Add(rev)
 	}
 	rt.Branches = []RevsTree{

--- a/pkg/sharing/shared.go
+++ b/pkg/sharing/shared.go
@@ -246,7 +246,6 @@ func updateRemovedForFiles(inst *instance.Instance, sharingID, dirID string, rul
 				ref.Revisions = &RevsTree{Rev: rev}
 				err = couchdb.CreateNamedDoc(inst, &ref)
 			} else {
-				ref.Revisions.Add(rev)
 				err = couchdb.UpdateDoc(inst, &ref)
 			}
 			if err != nil {

--- a/tests/sharing/lib/folder.rb
+++ b/tests/sharing/lib/folder.rb
@@ -1,6 +1,7 @@
 class Folder
   ROOT_DIR = "io.cozy.files.root-dir".freeze
   TRASH_DIR = "io.cozy.files.trash-dir".freeze
+  TRASH_PATH = "/.cozy_trash/".freeze
   NO_LONGER_SHARED_DIR = "io.cozy.files.no-longer-shared-dir".freeze
 
   include Model::Files
@@ -101,5 +102,9 @@ class Folder
     j = JSON.parse(res.body)["data"]
     @couch_id = j["id"]
     @couch_rev = j["rev"]
+  end
+
+  def trashed
+    @path.start_with? TRASH_PATH
   end
 end

--- a/tests/sharing/tests/remove_folder.rb
+++ b/tests/sharing/tests/remove_folder.rb
@@ -72,22 +72,20 @@ describe "A shared folder" do
 
     child2_recipient = Folder.find inst_recipient, child2_recipient_id
     child3_recipient = Folder.find inst_recipient, child3_recipient_id
-    assert_equal "/.cozy_trash/#{child2_recipient.name}", child2_recipient.path
-    assert_equal "/.cozy_trash/#{child2_recipient.name}/#{child3_recipient.name}", child3_recipient.path
+    assert child2_recipient.trashed
+    assert child3_recipient.trashed
     assert_equal "/#{Helpers::SHARED_WITH_ME}/#{folder.name}", child2_recipient.restore_path
-    assert_equal "#{Folder::TRASH_DIR}", child2_recipient.dir_id
-    assert_equal "#{child2_recipient_id}", child3_recipient.dir_id
-    assert(child2.name != child2_recipient.name)
+    refute_equal child2.name, child2_recipient.name
 
     f1_recipient = CozyFile.find inst_recipient, f1_recipient_id
-    assert_equal true, f1_recipient.trashed
+    assert f1_recipient.trashed
 
     # Check that when a folder is moved out of a sharing, the retroaction
     # doesn't trash the files inside it
     sleep 7
     f3_recipient = CozyFile.find inst_recipient, f3_recipient_id
-    assert_equal true, f3_recipient.trashed
+    assert f3_recipient.trashed
     f3_sharer = CozyFile.find inst, f3.couch_id
-    assert_equal false, f3_sharer.trashed
+    refute f3_sharer.trashed
   end
 end


### PR DESCRIPTION
When a directory is inside a shared folder and is moved outside of it, the files of the directory must not be put in the trash by retroaction. This commit fixes the removed flag of the io.cozy.shared documents.