### PR TITLE
Small improvements for universal links

### DIFF
--- a/web/auth/auth.go
+++ b/web/auth/auth.go
@@ -785,7 +785,7 @@ func authorize(c echo.Context) error {
 		}
 		params.scope = BuildLinkedAppScope(slug)
 		if u.Scheme == "http" || u.Scheme == "https" {
-			q.Set("fallback", instance.PageURL(slug, nil))
+			q.Set("fallback", instance.SubDomain(slug).String())
 		}
 	}
 

--- a/web/settings/context.go
+++ b/web/settings/context.go
@@ -76,9 +76,15 @@ func finishOnboarding(c echo.Context) error {
 		if err != nil {
 			return err
 		}
-		appSlug := strings.TrimLeft(r.Scheme, "cozy")
-		fallbackURI := i.SubDomain(appSlug).String()
-
+		// If the redirectURI scheme is not starting with cozy<app>://, it means
+		// that we probably are on a recent mobile, handling universal/android
+		// links. We won't provide a fallbackURI because the redirectURI should
+		// be enough to handle the redirection on the mobile-side
+		var fallbackURI string
+		if strings.HasPrefix(r.Scheme, "cozy") {
+			appSlug := strings.TrimLeft(r.Scheme, "cozy")
+			fallbackURI = i.SubDomain(appSlug).String()
+		}
 		// Redirection
 		queryParams := url.Values{
 			"client_id":     {client.CouchID},


### PR DESCRIPTION
* Do not generate a `fallbackURI` if the `redirectURI` is not a deeplink. This allows to handle both the universal links and the deeplinks.
* Use `instance.SubDomain()` instead of `instance.PageURL()` for app url generation