### PR TITLE
Block disk-quota requests with no token

### DIFF
--- a/web/middlewares/permissions.go
+++ b/web/middlewares/permissions.go
@@ -377,6 +377,11 @@ func GetSourceID(c echo.Context) (slug string, err error) {
 // AllowLogout checks if the current permission allows logging out.
 // all apps can trigger a logout.
 func AllowLogout(c echo.Context) bool {
+	return HasWebAppToken(c)
+}
+
+// HasWebAppToken returns true if the request comes from a web app (with a token).
+func HasWebAppToken(c echo.Context) bool {
 	pdoc, err := GetPermission(c)
 	if err != nil {
 		return false

--- a/web/registry/registry.go
+++ b/web/registry/registry.go
@@ -23,7 +23,7 @@ func proxyReq(auth authType, clientPermanentCache bool, proxyCacheControl regist
 		i := middlewares.GetInstance(c)
 		switch auth {
 		case authed:
-			if !middlewares.IsLoggedIn(c) {
+			if !middlewares.IsLoggedIn(c) || !middlewares.HasWebAppToken(c) {
 				if err := middlewares.AllowWholeType(c, permission.GET, consts.Apps); err != nil {
 					return echo.NewHTTPError(http.StatusForbidden)
 				}
@@ -52,8 +52,7 @@ func proxyReq(auth authType, clientPermanentCache bool, proxyCacheControl regist
 
 func proxyListReq(c echo.Context) error {
 	i := middlewares.GetInstance(c)
-	pdoc, err := middlewares.GetPermission(c)
-	if err != nil || pdoc.Type != permission.TypeWebapp {
+	if !middlewares.HasWebAppToken(c) {
 		return echo.NewHTTPError(http.StatusForbidden)
 	}
 	req := c.Request()

--- a/web/settings/context.go
+++ b/web/settings/context.go
@@ -111,6 +111,7 @@ func context(c echo.Context) error {
 	}
 
 	doc := &apiContext{ctx}
+	// Any request with a token can ask for the context (no permissions are required)
 	if _, err = middlewares.GetPermission(c); err != nil {
 		return echo.NewHTTPError(http.StatusForbidden)
 	}

--- a/web/settings/disk_usage.go
+++ b/web/settings/disk_usage.go
@@ -40,7 +40,7 @@ func diskUsage(c echo.Context) error {
 	// Check permissions, but also allow every request from the logged-in user
 	// as this route is used by the cozy-bar from all the client-side apps
 	if err := middlewares.Allow(c, permission.GET, &result); err != nil {
-		if !middlewares.IsLoggedIn(c) {
+		if !middlewares.IsLoggedIn(c) || !middlewares.HasWebAppToken(c) {
 			return err
 		}
 	}

--- a/web/settings/settings.go
+++ b/web/settings/settings.go
@@ -53,6 +53,7 @@ func getSessions(c echo.Context) error {
 func warnings(c echo.Context) error {
 	inst := middlewares.GetInstance(c)
 
+	// Any request with a token can ask for the context (no permissions are required)
 	if _, err := middlewares.GetPermission(c); err != nil {
 		return err
 	}


### PR DESCRIPTION
Before this change, the stack was checking only if the user was logged in. But, an attacker that knows the URL of the cozy can make a cross site request forgery on this endpoint. Now, the stack also checks that a web app token is also present. It should be compatible with the existant, as the cozy-bar was already sending this token.