### PR TITLE
Fix for installing apps with ALL+GET permissions

### DIFF
--- a/pkg/permissions/permissions_test.go
+++ b/pkg/permissions/permissions_test.go
@@ -174,7 +174,7 @@ func TestJSONSetVerbParsing(t *testing.T) {
     "contacts": {
       "type": "io.cozy.contacts",
       "description": "Required for autocompletion on @name",
-      "verbs": ["ALL"]
+      "verbs": ["ALL", "GET"]
     }
   }`)
 	err = json.Unmarshal(jsonSet, &s)

--- a/pkg/permissions/verbs.go
+++ b/pkg/permissions/verbs.go
@@ -95,9 +95,11 @@ func (vs *VerbSet) UnmarshalJSON(b []byte) error {
 	if err != nil {
 		return err
 	}
-	// empty set and ["ALL"] set = ALL
-	if len(s) == 0 || (len(s) == 1 && s[0] == allVerbs) {
-		return nil
+	// empty set means ALL
+	for _, v := range s {
+		if v == "ALL" {
+			return nil
+		}
 	}
 	for _, v := range s {
 		switch v {


### PR DESCRIPTION
If an application manifest contains a permission where the verbs contain ALL and other things, we should still allow to install the app and consider the permissions for ALL.

Resolves #1831