### PR TITLE
Add a function to filter job from the last error

### DIFF
--- a/pkg/jobs/worker.go
+++ b/pkg/jobs/worker.go
@@ -50,6 +50,11 @@ type (
 	// beforehand.
 	WorkerBeforeHook func(job *Job) (bool, error)
 
+	// JobErrorCheckerHook is an optional method called at the beginning of the
+	// job execution to prevent a retry according to the previous error
+	// (specifically useful in the retries loop)
+	JobErrorCheckerHook func(err error) bool
+
 	// WorkerConfig is the configuration parameter of a worker defined by the job
 	// system. It contains parameters of the worker along with the worker main
 	// function that perform the work against a job's message.
@@ -60,6 +65,7 @@ type (
 		WorkerCommit WorkerCommit
 		WorkerType   string
 		BeforeHook   WorkerBeforeHook
+		ErrorHook    JobErrorCheckerHook
 		Concurrency  int
 		MaxExecCount int
 		AdminOnly    bool
@@ -395,6 +401,12 @@ func (t *task) run() (err error) {
 	}()
 	for {
 		retry, delay, timeout := t.nextDelay(err)
+
+		// The optional ErrorHook function allows to prevent retries depending
+		// on the previous error
+		if retry == true && t.conf.ErrorHook != nil {
+			retry = t.conf.ErrorHook(err)
+		}
 		if !retry {
 			break
 		}

--- a/pkg/jobs/worker.go
+++ b/pkg/jobs/worker.go
@@ -404,7 +404,7 @@ func (t *task) run() (err error) {
 
 		// The optional ErrorHook function allows to prevent retries depending
 		// on the previous error
-		if retry == true && t.conf.ErrorHook != nil {
+		if retry && t.conf.ErrorHook != nil {
 			retry = t.conf.ErrorHook(err)
 		}
 		if !retry {

--- a/pkg/workers/exec/common.go
+++ b/pkg/workers/exec/common.go
@@ -27,6 +27,7 @@ func init() {
 			return ctx.WithCookie(&konnectorWorker{}), nil
 		},
 		BeforeHook:   beforeHookKonnector,
+		ErrorHook:    jobHookErrorCheckerKonnector,
 		WorkerFunc:   worker,
 		WorkerCommit: commit,
 		Concurrency:  runtime.NumCPU() * 2,

--- a/pkg/workers/exec/konnector.go
+++ b/pkg/workers/exec/konnector.go
@@ -75,6 +75,20 @@ func (m *KonnectorMessage) updateFolderToSave(dir string) {
 	m.data, _ = json.Marshal(d)
 }
 
+func jobHookErrorCheckerKonnector(err error) bool {
+	// If there was no previous error, we are fine to go on
+	if err == nil {
+		return true
+	}
+
+	lastError := err.Error()
+	if strings.HasPrefix(lastError, konnErrorLoginFailed) ||
+		strings.HasPrefix(lastError, konnErrorUserActionNeeded) {
+		return false
+	}
+	return true
+}
+
 // beforeHookKonnector skips jobs from trigger that are failing on certain
 // errors.
 func beforeHookKonnector(job *jobs.Job) (bool, error) {


### PR DESCRIPTION
This PR adds a function to check the error status between each job retry. 

We have to ensure that a job with a `LOGIN_FAILED` status will not be retried for the future 2FA konnectors.

The already existing `beforeHook` function filters the job before pushing it in the queue, but not between the retries. If the first attempt results in a `LOGIN_FAILED`, there will be no checks and the job will be retried regardless of the `LOGIN_FAILED` status.