### PR TITLE
Fix space between givenName and familyName

### DIFF
--- a/pkg/contacts/contacts.go
+++ b/pkg/contacts/contacts.go
@@ -76,7 +76,7 @@ func (c *Contact) PrimaryName() string {
 	}
 	if family, ok := name["familyName"].(string); ok && family != "" {
 		if primary != "" {
-			primary += ""
+			primary += " "
 		}
 		primary += family
 	}


### PR DESCRIPTION
Since https://github.com/cozy/cozy-stack/commit/952f8d06a538abcc024cfea029ddb1455309580f#diff-684de99eacb2392110a923ff3d31fdcaR79 There was a missing space between `givenName` and `familyName` for contacts without `fullname`. This PR fixes it. 

(I tried to write a test but I struggle to instantiate a simple contact to use `PrimaryName` on)