### PR TITLE
Make apps install/update more reliable

### DIFF
--- a/pkg/apps/appfs/copier.go
+++ b/pkg/apps/appfs/copier.go
@@ -114,7 +114,8 @@ func (f *swiftCopier) Copy(stat os.FileInfo, src io.Reader) (err error) {
 
 func (f *swiftCopier) Abort() error {
 	objectNames, err := f.c.ObjectNamesAll(f.container, &swift.ObjectsOpts{
-		Prefix: f.tmpObj,
+		Prefix:  f.tmpObj,
+		Headers: swift.Headers{"X-Newest": "true"},
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
When installing or updating an application in Swift, the stack puts its file in a temporary directory, and if everything is fine, copies them to their final destination. To know the list of files to copy, the stack calls ObjectNamesAll of the swift library. Using the X-Newest flag should improve reliability by ensuring a consistent response from Swift.