### PR TITLE
Set oldServices field to manifest in case of no updates

### DIFF
--- a/model/app/installer.go
+++ b/model/app/installer.go
@@ -430,6 +430,9 @@ func (i *Installer) update() error {
 		i.man.SetAvailableVersion("")
 		i.man.SetState(i.endState)
 	} else {
+		if i.man.AppType() == consts.WebappType {
+			i.man.(*WebappManifest).OldServices = i.man.(*WebappManifest).Services
+		}
 		i.man.SetSource(i.src)
 		if availableVersion != "" {
 			i.man.SetAvailableVersion(availableVersion)

--- a/model/app/installer.go
+++ b/model/app/installer.go
@@ -431,7 +431,7 @@ func (i *Installer) update() error {
 		i.man.SetState(i.endState)
 	} else {
 		if i.man.AppType() == consts.WebappType {
-			i.man.(*WebappManifest).OldServices = i.man.(*WebappManifest).Services
+			i.man.(*WebappManifest).oldServices = i.man.(*WebappManifest).Services
 		}
 		i.man.SetSource(i.src)
 		if availableVersion != "" {

--- a/model/app/webapp.go
+++ b/model/app/webapp.go
@@ -109,7 +109,7 @@ type WebappManifest struct {
 	FromAppsDir bool        `json:"-"` // Used in development
 	Instance    SubDomainer `json:"-"` // Used for JSON-API links
 
-	OldServices Services `json:"-"` // Used to diff against when updating the app
+	oldServices Services // Used to diff against when updating the app
 
 	Err string `json:"error,omitempty"`
 	err error
@@ -269,7 +269,7 @@ func (m *WebappManifest) ReadManifest(r io.Reader, slug, sourceURL string) (Mani
 	newManifest.Instance = m.Instance
 	newManifest.DocSlug = slug
 	newManifest.DocSource = sourceURL
-	newManifest.OldServices = m.Services
+	newManifest.oldServices = m.Services
 	if newManifest.Routes == nil {
 		newManifest.Routes = make(Routes)
 		newManifest.Routes["/"] = Route{
@@ -299,7 +299,7 @@ func (m *WebappManifest) Create(db prefixer.Prefixer) error {
 
 // Update is part of the Manifest interface
 func (m *WebappManifest) Update(db prefixer.Prefixer, extraPerms permission.Set) error {
-	if err := diffServices(db, m.Slug(), m.OldServices, m.Services); err != nil {
+	if err := diffServices(db, m.Slug(), m.oldServices, m.Services); err != nil {
 		return err
 	}
 	m.UpdatedAt = time.Now()

--- a/model/app/webapp.go
+++ b/model/app/webapp.go
@@ -109,7 +109,7 @@ type WebappManifest struct {
 	FromAppsDir bool        `json:"-"` // Used in development
 	Instance    SubDomainer `json:"-"` // Used for JSON-API links
 
-	OldServices Services // Used to diff against when updating the app
+	OldServices Services `json:"-"` // Used to diff against when updating the app
 
 	Err string `json:"error,omitempty"`
 	err error

--- a/model/app/webapp.go
+++ b/model/app/webapp.go
@@ -109,7 +109,7 @@ type WebappManifest struct {
 	FromAppsDir bool        `json:"-"` // Used in development
 	Instance    SubDomainer `json:"-"` // Used for JSON-API links
 
-	oldServices Services // Used to diff against when updating the app
+	OldServices Services // Used to diff against when updating the app
 
 	Err string `json:"error,omitempty"`
 	err error
@@ -269,7 +269,7 @@ func (m *WebappManifest) ReadManifest(r io.Reader, slug, sourceURL string) (Mani
 	newManifest.Instance = m.Instance
 	newManifest.DocSlug = slug
 	newManifest.DocSource = sourceURL
-	newManifest.oldServices = m.Services
+	newManifest.OldServices = m.Services
 	if newManifest.Routes == nil {
 		newManifest.Routes = make(Routes)
 		newManifest.Routes["/"] = Route{
@@ -299,7 +299,7 @@ func (m *WebappManifest) Create(db prefixer.Prefixer) error {
 
 // Update is part of the Manifest interface
 func (m *WebappManifest) Update(db prefixer.Prefixer, extraPerms permission.Set) error {
-	if err := diffServices(db, m.Slug(), m.oldServices, m.Services); err != nil {
+	if err := diffServices(db, m.Slug(), m.OldServices, m.Services); err != nil {
 		return err
 	}
 	m.UpdatedAt = time.Now()


### PR DESCRIPTION
When an app update is being performed, a diff is done on `services` declared in the both old and new manifests. This diff result is applied at the end the update.
The comparison is done by setting an `oldServices` field in the `newManifest`, containing the `oldManifest` services.

In the event of a blocking update (new permissions, terms added, ...) or an unneeded update (same version), the manifest `Update` function is still called, but with the current manifest. 
The manifest field `oldServices` is therefore not set, causing a diff with an empty `oldServices` field. This results in the stack believing that a service has been added, and creates a new trigger.