### PR TITLE
Allow mobile apps to install app

### DIFF
--- a/web/middlewares/permissions.go
+++ b/web/middlewares/permissions.go
@@ -342,6 +342,18 @@ func AllowInstallApp(c echo.Context, appType consts.AppType, sourceURL string, v
 		if !strings.HasPrefix(sourceURL, "registry://") {
 			return ErrForbidden
 		}
+	case permission.TypeOauth:
+		// If the context allow the app install from a permission, this
+		// permission can also be used by mobile apps to install apps from the
+		// registry.
+		inst := GetInstance(c)
+		ctxSettings, err := inst.SettingsContext()
+		if err != nil || ctxSettings["allow_install_via_a_permission"] != true {
+			return ErrForbidden
+		}
+		if !strings.HasPrefix(sourceURL, "registry://") {
+			return ErrForbidden
+		}
 	default:
 		return ErrForbidden
 	}

--- a/web/middlewares/permissions.go
+++ b/web/middlewares/permissions.go
@@ -343,7 +343,7 @@ func AllowInstallApp(c echo.Context, appType consts.AppType, sourceURL string, v
 			return ErrForbidden
 		}
 	case permission.TypeOauth:
-		// If the context allow the app install from a permission, this
+		// If the context allows to install an app via a permission, this
 		// permission can also be used by mobile apps to install apps from the
 		// registry.
 		inst := GetInstance(c)

--- a/web/registry/registry.go
+++ b/web/registry/registry.go
@@ -52,7 +52,11 @@ func proxyReq(auth authType, clientPermanentCache bool, proxyCacheControl regist
 
 func proxyListReq(c echo.Context) error {
 	i := middlewares.GetInstance(c)
-	if !middlewares.HasWebAppToken(c) {
+	pdoc, err := middlewares.GetPermission(c)
+	if err != nil {
+		return err
+	}
+	if pdoc.Type != permission.TypeWebapp && pdoc.Type != permission.TypeOauth {
 		return echo.NewHTTPError(http.StatusForbidden)
 	}
 	req := c.Request()


### PR DESCRIPTION
For cozy instances in a context where allow_install_via_a_permission is activated, the stack should allow a mobile app with the right permissions to install other apps. To do that, we need to check OAuth permissions documents on the endpoint for listing apps in the registry and installing an application.