### PR TITLE
Handle high number of jobs purging

### DIFF
--- a/model/job/broker.go
+++ b/model/job/broker.go
@@ -3,6 +3,7 @@ package job
 import (
 	"context"
 	"encoding/json"
+	"sort"
 	"time"
 
 	"github.com/cozy/cozy-stack/model/permission"
@@ -313,61 +314,86 @@ func GetQueuedJobs(db prefixer.Prefixer, workerType string) ([]*Job, error) {
 	return results, nil
 }
 
-// GetJobsBeforeDate returns alls jobs queued before the specified date
-func GetJobsBeforeDate(db prefixer.Prefixer, date time.Time) ([]*Job, error) {
-	var cursor int
-	var jobs []*Job
+func GetAllJobs(db prefixer.Prefixer) ([]*Job, error) {
+	var startkey string
+	var lastJob *Job
 
 	finalJobs := []*Job{}
+	remainingJobs := true
 
-	for cursor != -1 {
-		jobs = []*Job{}
-		req := &couchdb.FindRequest{
-			UseIndex: "by-queued-at",
-			Selector: mango.Lt("queued_at", date.Format(time.RFC3339Nano)),
-			Limit:    1000,
-			Skip:     cursor,
+	for remainingJobs {
+		jobs := []*Job{}
+		req := &couchdb.AllDocsRequest{
+			Limit:    10001,
+			StartKey: startkey,
 		}
-		err := couchdb.FindDocs(db, consts.Jobs, req, &jobs)
+		err := couchdb.GetAllDocs(db, consts.Jobs, req, &jobs)
+
 		if err != nil {
 			return nil, err
 		}
+
+		lastJob, jobs = jobs[len(jobs)-1], jobs[:len(jobs)-1]
+
+		// Startkey for the next request
+		startkey = lastJob.JobID
+
+		// Appending to the final jobs
 		finalJobs = append(finalJobs, jobs...)
 
+		// Only the startkey is present: we are in the last lap of the loop
+		// We have to append the startkey as the last element
 		if len(jobs) == 0 {
-			cursor = -1
-		} else {
-			cursor = len(finalJobs)
+			remainingJobs = false
+			finalJobs = append(finalJobs, lastJob)
 		}
 	}
 
 	return finalJobs, nil
 }
 
+// GetJobsBeforeDate returns alls jobs queued before the specified date
+func GetJobsBeforeDate(jobs []*Job, date time.Time) ([]*Job, error) {
+	// Filtering jobs
+	b := jobs[:0]
+	for _, x := range jobs {
+		if x.QueuedAt.Before(date) {
+			b = append(b, x)
+		}
+	}
+
+	return b, nil
+}
+
+// FilterByWorkerAndState filters a job slice by its workerType and State
+func FilterByWorkerAndState(jobs []*Job, workerType string, state State, limit int) []*Job {
+	// Step 1: Ordering
+	sort.Slice(jobs, func(i, j int) bool { return jobs[i].QueuedAt.Before(jobs[j].QueuedAt) })
+
+	// Step 2: Filtering
+	returned := []*Job{}
+	for _, j := range jobs {
+		if j.WorkerType == workerType && j.State == state {
+			returned = append(returned, j)
+			if len(returned) == limit {
+				return returned
+			}
+		}
+	}
+
+	return returned
+}
+
 // GetLastsJobs returns the N lasts job of each state for an instance/worker
 // type pair
-func GetLastsJobs(db prefixer.Prefixer, workerType string) ([]*Job, error) {
+func GetLastsJobs(jobs []*Job, workerType string) ([]*Job, error) {
 	var result []*Job
 
 	for _, state := range []State{Queued, Running, Done, Errored} {
-		jobs := []*Job{}
 		limit := defaultMaxLimits[state]
 
-		req := &couchdb.FindRequest{
-			Selector: mango.And(
-				mango.Equal("worker", workerType),
-				mango.Equal("state", state),
-			),
-			Sort: mango.SortBy{
-				{Field: "queued_at", Direction: mango.Desc},
-			},
-			Limit: limit,
-		}
-		err := couchdb.FindDocs(db, consts.Jobs, req, &jobs)
-		if err != nil {
-			return nil, err
-		}
-		result = append(result, jobs...)
+		filtered := FilterByWorkerAndState(jobs, workerType, state, limit)
+		result = append(result, filtered...)
 	}
 
 	return result, nil

--- a/model/job/broker.go
+++ b/model/job/broker.go
@@ -327,10 +327,14 @@ func GetAllJobs(db prefixer.Prefixer) ([]*Job, error) {
 			Limit:    10001,
 			StartKey: startkey,
 		}
-		err := couchdb.GetAllDocs(db, consts.Jobs, req, &jobs)
 
+		err := couchdb.GetAllDocs(db, consts.Jobs, req, &jobs)
 		if err != nil {
 			return nil, err
+		}
+
+		if len(jobs) == 0 {
+			return finalJobs, nil
 		}
 
 		lastJob, jobs = jobs[len(jobs)-1], jobs[:len(jobs)-1]

--- a/model/job/broker.go
+++ b/model/job/broker.go
@@ -370,10 +370,6 @@ func FilterJobsBeforeDate(jobs []*Job, date time.Time) []*Job {
 
 // FilterByWorkerAndState filters a job slice by its workerType and State
 func FilterByWorkerAndState(jobs []*Job, workerType string, state State, limit int) []*Job {
-	// Step 1: Ordering
-	sort.Slice(jobs, func(i, j int) bool { return jobs[i].QueuedAt.Before(jobs[j].QueuedAt) })
-
-	// Step 2: Filtering
 	returned := []*Job{}
 	for _, j := range jobs {
 		if j.WorkerType == workerType && j.State == state {
@@ -391,6 +387,9 @@ func FilterByWorkerAndState(jobs []*Job, workerType string, state State, limit i
 // type pair
 func GetLastsJobs(jobs []*Job, workerType string) ([]*Job, error) {
 	var result []*Job
+
+	// Ordering by QueuedAt before filtering jobs
+	sort.Slice(jobs, func(i, j int) bool { return jobs[i].QueuedAt.Before(jobs[j].QueuedAt) })
 
 	for _, state := range []State{Queued, Running, Done, Errored} {
 		limit := defaultMaxLimits[state]

--- a/model/job/broker.go
+++ b/model/job/broker.go
@@ -358,7 +358,8 @@ func GetAllJobs(db prefixer.Prefixer) ([]*Job, error) {
 
 // FilterJobsBeforeDate returns alls jobs queued before the specified date
 func FilterJobsBeforeDate(jobs []*Job, date time.Time) []*Job {
-	b := jobs[:0]
+	b := []*Job{}
+
 	for _, x := range jobs {
 		if x.QueuedAt.Before(date) {
 			b = append(b, x)

--- a/model/job/broker.go
+++ b/model/job/broker.go
@@ -356,9 +356,8 @@ func GetAllJobs(db prefixer.Prefixer) ([]*Job, error) {
 	return finalJobs, nil
 }
 
-// GetJobsBeforeDate returns alls jobs queued before the specified date
-func GetJobsBeforeDate(jobs []*Job, date time.Time) ([]*Job, error) {
-	// Filtering jobs
+// FilterJobsBeforeDate returns alls jobs queued before the specified date
+func FilterJobsBeforeDate(jobs []*Job, date time.Time) []*Job {
 	b := jobs[:0]
 	for _, x := range jobs {
 		if x.QueuedAt.Before(date) {
@@ -366,7 +365,7 @@ func GetJobsBeforeDate(jobs []*Job, date time.Time) ([]*Job, error) {
 		}
 	}
 
-	return b, nil
+	return b
 }
 
 // FilterByWorkerAndState filters a job slice by its workerType and State

--- a/model/job/broker_test.go
+++ b/model/job/broker_test.go
@@ -56,8 +56,7 @@ func TestGetJobsBeforeDate(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 3, len(allJobs))
 
-	jobs, err := jobs.GetJobsBeforeDate(allJobs, time.Now())
-	assert.NoError(t, err)
+	jobs := jobs.FilterJobsBeforeDate(allJobs, time.Now())
 
 	// We should have only 2 jobs :
 	// The first has been queued in the past: OK

--- a/model/job/broker_test.go
+++ b/model/job/broker_test.go
@@ -52,7 +52,11 @@ func TestGetJobsBeforeDate(t *testing.T) {
 	err = job3.Create()
 	assert.NoError(t, err)
 
-	jobs, err := jobs.GetJobsBeforeDate(testInstance, time.Now())
+	allJobs, err := jobs.GetAllJobs(testInstance)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(allJobs))
+
+	jobs, err := jobs.GetJobsBeforeDate(allJobs, time.Now())
 	assert.NoError(t, err)
 
 	// We should have only 2 jobs :
@@ -63,7 +67,9 @@ func TestGetJobsBeforeDate(t *testing.T) {
 }
 
 func TestGetLastsJobs(t *testing.T) {
-	j, err := jobs.GetLastsJobs(testInstance, "thumbnail")
+	allJobs, err := jobs.GetAllJobs(testInstance)
+	assert.NoError(t, err)
+	j, err := jobs.GetLastsJobs(allJobs, "thumbnail")
 	assert.NoError(t, err)
 	assert.Equal(t, 3, len(j))
 
@@ -79,7 +85,9 @@ func TestGetLastsJobs(t *testing.T) {
 	}
 	err = myJob.Create()
 	assert.NoError(t, err)
-	j, err = jobs.GetLastsJobs(testInstance, "thumbnail")
+	allJobs, err = jobs.GetAllJobs(testInstance)
+	assert.NoError(t, err)
+	j, err = jobs.GetLastsJobs(allJobs, "thumbnail")
 	assert.NoError(t, err)
 	assert.Equal(t, 4, len(j))
 
@@ -95,15 +103,21 @@ func TestGetLastsJobs(t *testing.T) {
 	}
 	err = myJob.Create()
 	assert.NoError(t, err)
-	j, err = jobs.GetLastsJobs(testInstance, "thumbnail")
+	allJobs, err = jobs.GetAllJobs(testInstance)
+	assert.NoError(t, err)
+	j, err = jobs.GetLastsJobs(allJobs, "thumbnail")
 	assert.NoError(t, err)
 	assert.Equal(t, 4, len(j))
-	j, err = jobs.GetLastsJobs(testInstance, "konnector")
+	allJobs, err = jobs.GetAllJobs(testInstance)
+	assert.NoError(t, err)
+	j, err = jobs.GetLastsJobs(allJobs, "konnector")
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(j))
 
 	// No jobs
-	j, err = jobs.GetLastsJobs(testInstance, "foobar")
+	allJobs, err = jobs.GetAllJobs(testInstance)
+	assert.NoError(t, err)
+	j, err = jobs.GetLastsJobs(allJobs, "foobar")
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(j))
 
@@ -123,7 +137,9 @@ func TestGetLastsJobs(t *testing.T) {
 	err = myJob.Create()
 	assert.NoError(t, err)
 
-	j, err = jobs.GetLastsJobs(testInstance, "thumbnail")
+	allJobs, err = jobs.GetAllJobs(testInstance)
+	assert.NoError(t, err)
+	j, err = jobs.GetLastsJobs(allJobs, "thumbnail")
 	assert.NoError(t, err)
 
 	// One running, one errored, three queued

--- a/web/jobs/jobs.go
+++ b/web/jobs/jobs.go
@@ -503,10 +503,7 @@ func purgeJobs(c echo.Context) error {
 	// Step 1: We want to get all the jobs prior to the date parameter.
 	// Jobs returned are the ones we want to remove
 	d := time.Now().Add(-dur)
-	jobsBeforeDate, err := job.GetJobsBeforeDate(allJobs, d)
-	if err != nil && err != job.ErrNotFoundJob {
-		return err
-	}
+	jobsBeforeDate := job.FilterJobsBeforeDate(allJobs, d)
 
 	// Step 2: We also want to keep a minimum number of jobs for each state.
 	// Jobs returned will be kept.


### PR DESCRIPTION
Some databases have a high number of jobs (250k+), leading to issues on
couch side. This commit should improve the purge by:

- Compute which jobs to delete on go-side instead of couch
- Use chunks for bulk deletes to prevent timeouts