### PR TITLE
Oauth: Set clientState when redirecting to app

### DIFF
--- a/web/accounts/oauth.go
+++ b/web/accounts/oauth.go
@@ -131,8 +131,9 @@ func redirect(c echo.Context) error {
 			if err != nil {
 				return err
 			}
-			clientState = state.ClientState
 		}
+
+		clientState = state.ClientState
 	}
 
 	err = couchdb.CreateDoc(i, acc)


### PR DESCRIPTION
When account type were not having a `token_endpoint` set up, the client state was not passed in the URL. As Home app use its value to retrieve information from localStorage and check consistency, the whole OAuth workflow was not working.