### PR TITLE
Improve rate limit exceeded check

### DIFF
--- a/pkg/limits/rate_limiting.go
+++ b/pkg/limits/rate_limiting.go
@@ -13,6 +13,8 @@ import (
 // CounterType os an enum for the type of counters used by rate-limiting.
 type CounterType int
 
+var ErrRateLimitExceeded = errors.New("Rate limit exceeded")
+
 const (
 	// AuthType is used for counting the number of login attempts.
 	AuthType CounterType = iota
@@ -191,7 +193,7 @@ func CheckRateLimitKey(customKey string, ct CounterType) error {
 		return err
 	}
 	if val > cfg.Limit {
-		return errors.New("Rate limit exceeded")
+		return ErrRateLimitExceeded
 	}
 	return nil
 }

--- a/web/auth/auth.go
+++ b/web/auth/auth.go
@@ -277,7 +277,7 @@ func login(c echo.Context) error {
 		// Handle 2FA failed
 		if !successfulAuthentication {
 			errCheckRateLimit = limits.CheckRateLimit(inst, limits.TwoFactorType)
-			if errCheckRateLimit != nil {
+			if errCheckRateLimit != nil && errCheckRateLimit == limits.ErrRateLimitExceeded {
 				if err = TwoFactorRateExceeded(inst); err != nil {
 					inst.Logger().WithField("nspace", "auth").Warning(err)
 				}
@@ -316,7 +316,7 @@ func login(c echo.Context) error {
 				successfulAuthentication = true
 			}
 		} else { // Bad login passphrase
-			if err := limits.CheckRateLimit(inst, limits.AuthType); err != nil {
+			if err := limits.CheckRateLimit(inst, limits.AuthType); err != nil && err == limits.ErrRateLimitExceeded {
 				if err = LoginRateExceeded(inst); err != nil {
 					inst.Logger().WithField("nspace", "auth").Warning(err)
 				}

--- a/web/auth/auth.go
+++ b/web/auth/auth.go
@@ -277,7 +277,7 @@ func login(c echo.Context) error {
 		// Handle 2FA failed
 		if !successfulAuthentication {
 			errCheckRateLimit = limits.CheckRateLimit(inst, limits.TwoFactorType)
-			if errCheckRateLimit != nil && errCheckRateLimit == limits.ErrRateLimitExceeded {
+			if errCheckRateLimit == limits.ErrRateLimitExceeded {
 				if err = TwoFactorRateExceeded(inst); err != nil {
 					inst.Logger().WithField("nspace", "auth").Warning(err)
 				}
@@ -316,7 +316,7 @@ func login(c echo.Context) error {
 				successfulAuthentication = true
 			}
 		} else { // Bad login passphrase
-			if err := limits.CheckRateLimit(inst, limits.AuthType); err != nil && err == limits.ErrRateLimitExceeded {
+			if err := limits.CheckRateLimit(inst, limits.AuthType); err == limits.ErrRateLimitExceeded {
 				if err = LoginRateExceeded(inst); err != nil {
 					inst.Logger().WithField("nspace", "auth").Warning(err)
 				}

--- a/web/auth/rate_limiting.go
+++ b/web/auth/rate_limiting.go
@@ -19,7 +19,7 @@ func LoginRateExceeded(i *instance.Instance) error {
 // TwoFactorRateExceeded regenerates a new 2FA passcode after too many failed
 // attempts to login
 func TwoFactorRateExceeded(i *instance.Instance) error {
-	if err := limits.CheckRateLimit(i, limits.TwoFactorGenerationType); err != nil && err == limits.ErrRateLimitExceeded {
+	if err := limits.CheckRateLimit(i, limits.TwoFactorGenerationType); err == limits.ErrRateLimitExceeded {
 		return TwoFactorGenerationExceeded(i)
 	}
 	// Reset the key and send a new passcode to the user

--- a/web/auth/rate_limiting.go
+++ b/web/auth/rate_limiting.go
@@ -19,7 +19,7 @@ func LoginRateExceeded(i *instance.Instance) error {
 // TwoFactorRateExceeded regenerates a new 2FA passcode after too many failed
 // attempts to login
 func TwoFactorRateExceeded(i *instance.Instance) error {
-	if err := limits.CheckRateLimit(i, limits.TwoFactorGenerationType); err != nil {
+	if err := limits.CheckRateLimit(i, limits.TwoFactorGenerationType); err != nil && err == limits.ErrRateLimitExceeded {
 		return TwoFactorGenerationExceeded(i)
 	}
 	// Reset the key and send a new passcode to the user

--- a/web/auth/register.go
+++ b/web/auth/register.go
@@ -15,7 +15,7 @@ import (
 
 func registerClient(c echo.Context) error {
 	instance := middlewares.GetInstance(c)
-	if err := limits.CheckRateLimit(instance, limits.OAuthClientType); err != nil {
+	if err := limits.CheckRateLimit(instance, limits.OAuthClientType); err != nil && err == limits.ErrRateLimitExceeded {
 		return echo.NewHTTPError(http.StatusNotFound, "Not found")
 	}
 	client := new(oauth.Client)
@@ -48,7 +48,7 @@ func readClient(c echo.Context) error {
 
 func updateClient(c echo.Context) error {
 	instance := middlewares.GetInstance(c)
-	if err := limits.CheckRateLimit(instance, limits.OAuthClientType); err != nil {
+	if err := limits.CheckRateLimit(instance, limits.OAuthClientType); err != nil && err == limits.ErrRateLimitExceeded {
 		return echo.NewHTTPError(http.StatusNotFound, "Not found")
 	}
 	client := new(oauth.Client)

--- a/web/auth/register.go
+++ b/web/auth/register.go
@@ -15,7 +15,7 @@ import (
 
 func registerClient(c echo.Context) error {
 	instance := middlewares.GetInstance(c)
-	if err := limits.CheckRateLimit(instance, limits.OAuthClientType); err != nil && err == limits.ErrRateLimitExceeded {
+	if err := limits.CheckRateLimit(instance, limits.OAuthClientType); err == limits.ErrRateLimitExceeded {
 		return echo.NewHTTPError(http.StatusNotFound, "Not found")
 	}
 	client := new(oauth.Client)
@@ -48,7 +48,7 @@ func readClient(c echo.Context) error {
 
 func updateClient(c echo.Context) error {
 	instance := middlewares.GetInstance(c)
-	if err := limits.CheckRateLimit(instance, limits.OAuthClientType); err != nil && err == limits.ErrRateLimitExceeded {
+	if err := limits.CheckRateLimit(instance, limits.OAuthClientType); err == limits.ErrRateLimitExceeded {
 		return echo.NewHTTPError(http.StatusNotFound, "Not found")
 	}
 	client := new(oauth.Client)

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -444,7 +444,7 @@ func ReadMetadataFromIDHandler(c echo.Context) error {
 	// Limiting the number of public share link consultations
 	if perm.Type == permission.TypeShareByLink {
 		err = limits.CheckRateLimitKey(fileID, limits.SharingPublicLinkType)
-		if err != nil && err == limits.ErrRateLimitExceeded {
+		if err == limits.ErrRateLimitExceeded {
 			return err
 		}
 	}

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -444,7 +444,7 @@ func ReadMetadataFromIDHandler(c echo.Context) error {
 	// Limiting the number of public share link consultations
 	if perm.Type == permission.TypeShareByLink {
 		err = limits.CheckRateLimitKey(fileID, limits.SharingPublicLinkType)
-		if err != nil {
+		if err != nil && err == limits.ErrRateLimitExceeded {
 			return err
 		}
 	}

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -198,7 +198,7 @@ func AnswerSharing(c echo.Context) error {
 // only knows their instance, and not their email address.
 func Invite(c echo.Context) error {
 	inst := middlewares.GetInstance(c)
-	if err := limits.CheckRateLimit(inst, limits.SharingInviteType); err != nil && err == limits.ErrRateLimitExceeded {
+	if err := limits.CheckRateLimit(inst, limits.SharingInviteType); err == limits.ErrRateLimitExceeded {
 		return wrapErrors(sharing.ErrMailNotSent)
 	}
 	var body sharing.InviteMsg

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -198,7 +198,7 @@ func AnswerSharing(c echo.Context) error {
 // only knows their instance, and not their email address.
 func Invite(c echo.Context) error {
 	inst := middlewares.GetInstance(c)
-	if err := limits.CheckRateLimit(inst, limits.SharingInviteType); err != nil {
+	if err := limits.CheckRateLimit(inst, limits.SharingInviteType); err != nil && err == limits.ErrRateLimitExceeded {
 		return wrapErrors(sharing.ErrMailNotSent)
 	}
 	var body sharing.InviteMsg


### PR DESCRIPTION
Before this change, any kind of error returned by the CheckRateLimit
function (like access error to cache for example) was interpreted as a
rate exceeded, resulting in the blocking of the instance. This commit
ensures the error is the good one before blocking the instance.