### PR TITLE
Fix for upstream breaking change in redis lib

### DIFF
--- a/model/job/redis_scheduler.go
+++ b/model/job/redis_scheduler.go
@@ -165,7 +165,7 @@ func (s *redisScheduler) eventLoop(eventsCh <-chan *realtime.Event) {
 				var d time.Duration
 				if d, err = time.ParseDuration(et.Infos().Debounce); err == nil {
 					timestamp := time.Now().Add(d)
-					s.client.ZAddNX(TriggersKey, redis.Z{
+					s.client.ZAddNX(TriggersKey, &redis.Z{
 						Score:  float64(timestamp.UTC().Unix()),
 						Member: redisKey(t),
 					})
@@ -311,7 +311,7 @@ func (s *redisScheduler) addToRedis(t Trigger, prev time.Time) error {
 		return errors.New("Not implemented yet")
 	}
 	pipe := s.client.Pipeline()
-	err := pipe.ZAdd(TriggersKey, redis.Z{
+	err := pipe.ZAdd(TriggersKey, &redis.Z{
 		Score:  float64(timestamp.UTC().Unix()),
 		Member: redisKey(t),
 	}).Err()

--- a/model/job/redis_scheduler_test.go
+++ b/model/job/redis_scheduler_test.go
@@ -257,7 +257,7 @@ func TestRedisPollFromSchedKey(t *testing.T) {
 
 	ts := now.UTC().Unix()
 	key := testInstance.DBPrefix() + "/" + tat.ID()
-	err = client.ZAdd(jobs.SchedKey, redis.Z{
+	err = client.ZAdd(jobs.SchedKey, &redis.Z{
 		Score:  float64(ts + 1),
 		Member: key,
 	}).Err()


### PR DESCRIPTION
The github.com/go-redis/redis library has made a breaking change, and as we are not yet using go modules (even if it is planned), we need to fix how we use this library in our code.