### PR TITLE
Add available apps for intents

### DIFF
--- a/docs/intents.md
+++ b/docs/intents.md
@@ -40,6 +40,7 @@ neither painful for the users nor the developers.
 -   **Client**: the client is the application that _starts_ an intent.
 -   **Service**: the service is the application that _handles_ an intent started
     by a client.
+-   **Available apps**: Uninstalled applications that _handles_ the intent.
 
 ## Proposal
 
@@ -227,6 +228,14 @@ The stack then stores the information for that intent:
 Finally, the service URL is suffixed with `?intent=` followed by the intent's
 id, and then sent to the client.
 
+### 4. Available apps
+
+In addition to the services that manage intents, a list of available (but not
+installed) applications of the instance that handles the intent is returned.
+This object list is called `availableApps` and contains:
+- The application `slug`
+- The application `name`
+
 #### Service choice
 
 If more than one service match the intent's criteria, the stack returns the list
@@ -250,11 +259,8 @@ aborted.
 #### No available service
 
 If no service is available to handle an intent, the stack returns an error to
-the client.
-
-At a later phase of this project, the stack may traverse the applications
-registered in a store to find suitable services, and prompt the user to install
-one.
+the client. However, some non-installed applications may handle the intent, and
+are listed in the `availableApps` field.
 
 ### 4. Handshake
 
@@ -369,6 +375,12 @@ Content-Type: application/vnd.api+json
                     "slug": "files",
                     "href": "https://files.cozy.example.net/pick?intent=77bcc42c-0fd8-11e7-ac95-8f605f6e8338"
                 }
+            ],
+            "availableApps": [
+                {
+                    "slug": "myapp",
+                    "name": "My App"
+                }
             ]
         },
         "links": {
@@ -416,6 +428,12 @@ Content-Type: application/vnd.api+json
                 {
                     "slug": "files",
                     "href": "https://files.cozy.example.net/pick?intent=77bcc42c-0fd8-11e7-ac95-8f605f6e8338"
+                }
+            ],
+            "availableApps": [
+                {
+                    "slug": "myapp",
+                    "name": "My App"
                 }
             ]
         },

--- a/model/intent/intents.go
+++ b/model/intent/intents.go
@@ -184,7 +184,7 @@ func (in *Intent) FillAvailableWebapps(inst *instance.Instance) error {
 
 	registries := inst.Registries()
 	for _, webapp := range endSlugs {
-		go func(webapp string, instance *instance.Instance) {
+		go func(webapp string) {
 			webappMan := app.WebappManifest{}
 			v, err := registry.GetLatestVersion(webapp, "stable", registries)
 			if err != nil {
@@ -198,7 +198,7 @@ func (in *Intent) FillAvailableWebapps(inst *instance.Instance) error {
 			}
 
 			versionsChan <- webappMan
-		}(webapp, inst)
+		}(webapp)
 	}
 
 	for range endSlugs {

--- a/model/intent/intents.go
+++ b/model/intent/intents.go
@@ -1,12 +1,20 @@
 package intent
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
 	"strings"
+	"sync"
 
 	"github.com/cozy/cozy-stack/model/app"
 	"github.com/cozy/cozy-stack/model/instance"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/registry"
+	"github.com/cozy/cozy-stack/pkg/utils"
 )
 
 // Service is a struct for an app that can serve an intent
@@ -15,16 +23,22 @@ type Service struct {
 	Href string `json:"href"`
 }
 
+type AvailableApp struct {
+	Slug string `json:"slug"`
+	Name string `json:"name"`
+}
+
 // Intent is a struct for a call from a client-side app to have another app do
 // something for it
 type Intent struct {
-	IID         string    `json:"_id,omitempty"`
-	IRev        string    `json:"_rev,omitempty"`
-	Action      string    `json:"action"`
-	Type        string    `json:"type"`
-	Permissions []string  `json:"permissions"`
-	Client      string    `json:"client"`
-	Services    []Service `json:"services"`
+	IID           string         `json:"_id,omitempty"`
+	IRev          string         `json:"_rev,omitempty"`
+	Action        string         `json:"action"`
+	Type          string         `json:"type"`
+	Permissions   []string       `json:"permissions"`
+	Client        string         `json:"client"`
+	Services      []Service      `json:"services"`
+	AvailableApps []AvailableApp `json:"availableApps"`
 }
 
 // ID is used to implement the couchdb.Doc interface
@@ -43,6 +57,8 @@ func (in *Intent) Clone() couchdb.Doc {
 	copy(cloned.Permissions, in.Permissions)
 	cloned.Services = make([]Service, len(in.Services))
 	copy(cloned.Services, in.Services)
+	cloned.AvailableApps = make([]AvailableApp, len(in.AvailableApps))
+	copy(cloned.AvailableApps, in.AvailableApps)
 	return &cloned
 }
 
@@ -88,6 +104,126 @@ func (in *Intent) FillServices(instance *instance.Instance) error {
 			in.Services = append(in.Services, service)
 		}
 	}
+	return nil
+}
+
+type JsonAPIWebapp struct {
+	Data  []*app.WebappManifest `json:"data"`
+	Count int                   `json:"count"`
+}
+
+// GetInstanceWebapps returns the list of available webapps for the instance by
+// iterating over its registries
+func GetInstanceWebapps(inst *instance.Instance) ([]string, error) {
+	man := JsonAPIWebapp{}
+	apps := []string{}
+
+	for _, regURL := range inst.Registries() {
+		url, err := url.Parse(regURL.String())
+		if err != nil {
+			return nil, err
+		}
+		url.Path = "registry"
+		url.RawQuery = "filter[type]=webapp"
+
+		req, err := http.NewRequest("GET", url.String(), nil)
+		if err != nil {
+			return nil, err
+		}
+		res, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+
+		err = json.NewDecoder(res.Body).Decode(&man)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, app := range man.Data {
+			slug := app.Slug()
+			if !utils.IsInArray(slug, apps) {
+				apps = append(apps, slug)
+			}
+		}
+	}
+
+	return apps, nil
+}
+
+// FindAvailableWebapps finds webapps which can answer to the intent from
+// non-installed instance webapps
+func (in *Intent) FindAvailableWebapps(inst *instance.Instance) error {
+	// Webapps to exclude
+	installedWebApps, err := app.ListWebapps(inst)
+	if err != nil {
+		return err
+	}
+
+	endSlugs := []string{}
+	webapps, err := GetInstanceWebapps(inst)
+	if err != nil {
+		return err
+	}
+	// Only appending the non-installed webapps
+	for _, wa := range webapps {
+		found := false
+		for _, iwa := range installedWebApps {
+			if wa == iwa.Slug() {
+				found = true
+				break
+			}
+		}
+		if !found {
+			endSlugs = append(endSlugs, wa)
+		}
+	}
+
+	var lastsVersions sync.Map
+	versionsChan := make(chan app.WebappManifest)
+	errorsChan := make(chan error)
+
+	for _, webapp := range endSlugs {
+		go func(webapp string, instance *instance.Instance) {
+			webappMan := app.WebappManifest{}
+			v, err := registry.GetLatestVersion(webapp, "stable", inst.Registries())
+			if err != nil {
+				errorsChan <- fmt.Errorf("Could not get last version for %s: %s", webapp, err)
+				return
+			}
+			err = json.NewDecoder(bytes.NewReader(v.Manifest)).Decode(&webappMan)
+			if err != nil {
+				errorsChan <- fmt.Errorf("Could not get decode manifest for %s: %s", webapp, err)
+				return
+			}
+
+			versionsChan <- webappMan
+		}(webapp, inst)
+	}
+
+	for i := 1; i <= len(endSlugs); i++ {
+		select {
+		case err := <-errorsChan:
+			inst.Logger().Errorf("intent: %s", err)
+		case version := <-versionsChan:
+			lastsVersions.Store(version.Slug(), version)
+		}
+	}
+	close(versionsChan)
+	close(errorsChan)
+
+	lastsVersions.Range(func(versionSlug, man interface{}) bool {
+		manif := man.(app.WebappManifest)
+		if intent := manif.FindIntent(in.Action, in.Type); intent != nil {
+			availableApp := AvailableApp{
+				Name: manif.Name,
+				Slug: manif.Slug(),
+			}
+			in.AvailableApps = append(in.AvailableApps, availableApp)
+		}
+		return true
+	})
+
 	return nil
 }
 

--- a/model/intent/intents.go
+++ b/model/intent/intents.go
@@ -151,9 +151,9 @@ func GetInstanceWebapps(inst *instance.Instance) ([]string, error) {
 	return apps, nil
 }
 
-// FindAvailableWebapps finds webapps which can answer to the intent from
+// FillAvailableWebapps finds webapps which can answer to the intent from
 // non-installed instance webapps
-func (in *Intent) FindAvailableWebapps(inst *instance.Instance) error {
+func (in *Intent) FillAvailableWebapps(inst *instance.Instance) error {
 	// Webapps to exclude
 	installedWebApps, err := app.ListWebapps(inst)
 	if err != nil {

--- a/model/intent/intents_test.go
+++ b/model/intent/intents_test.go
@@ -108,13 +108,13 @@ func TestFillServices(t *testing.T) {
 
 }
 
-func TestFindAvailableWebapps(t *testing.T) {
+func TestFillAvailableWebapps(t *testing.T) {
 	intent := &Intent{
 		IID:    "6b44d8d0-148b-11e7-a1cf-a38d75a77df6",
 		Action: "REDIRECT",
 		Type:   "io.cozy.accounts",
 	}
-	err := intent.FindAvailableWebapps(ins)
+	err := intent.FillAvailableWebapps(ins)
 	assert.NoError(t, err)
 
 	// Should have Home and Collect

--- a/model/intent/intents_test.go
+++ b/model/intent/intents_test.go
@@ -108,6 +108,27 @@ func TestFillServices(t *testing.T) {
 
 }
 
+func TestFindAvailableWebapps(t *testing.T) {
+	intent := &Intent{
+		IID:    "6b44d8d0-148b-11e7-a1cf-a38d75a77df6",
+		Action: "REDIRECT",
+		Type:   "io.cozy.accounts",
+	}
+	err := intent.FindAvailableWebapps(ins)
+	assert.NoError(t, err)
+
+	// Should have Home and Collect
+	assert.Equal(t, 2, len(intent.AvailableApps))
+
+	res := map[string]interface{}{}
+	for _, v := range intent.AvailableApps {
+		res[v.Slug] = struct{}{}
+	}
+
+	assert.Contains(t, res, "home")
+	assert.Contains(t, res, "collect")
+}
+
 func TestMain(m *testing.M) {
 	config.UseTestFile()
 

--- a/web/intents/intents.go
+++ b/web/intents/intents.go
@@ -87,6 +87,9 @@ func createIntent(c echo.Context) error {
 	if err = intent.FillServices(instance); err != nil {
 		return wrapIntentsError(err)
 	}
+	if err = intent.FindAvailableWebapps(instance); err != nil {
+		return wrapIntentsError(err)
+	}
 	if err = intent.Save(instance); err != nil {
 		return wrapIntentsError(err)
 	}

--- a/web/intents/intents.go
+++ b/web/intents/intents.go
@@ -87,8 +87,11 @@ func createIntent(c echo.Context) error {
 	if err = intent.FillServices(instance); err != nil {
 		return wrapIntentsError(err)
 	}
-	if err = intent.FindAvailableWebapps(instance); err != nil {
-		return wrapIntentsError(err)
+	// Fill available webapps only if there are no services found
+	if len(intent.Services) == 0 {
+		if err = intent.FillAvailableWebapps(instance); err != nil {
+			return wrapIntentsError(err)
+		}
 	}
 	if err = intent.Save(instance); err != nil {
 		return wrapIntentsError(err)


### PR DESCRIPTION
This PR adds an API field that lists non-installed apps that handles the intent.

The `icon` field has not been added alongside the `slug` and `name` ones as it is easy to retrieve by the stack proxy: `http://<instance>/registry/<slug>/icon`.