### PR TITLE
Fix cozy-app-dev container start-up behind proxy (#1925)

### DIFF
--- a/scripts/cozy-app-dev.sh
+++ b/scripts/cozy-app-dev.sh
@@ -76,7 +76,7 @@ do_start() {
 
 	trap 'kill $(jobs -p)' SIGINT SIGTERM EXIT
 
-	check_not_running ":${COZY_STACK_PORT}" "cozy-stack"
+	check_not_running "localhost:${COZY_STACK_PORT}" "cozy-stack"
 	do_check_couchdb
 
 	if [ -n "${appdir}" ]; then


### PR DESCRIPTION
When behind a corporate proxy, the start-up script inside the Docker
container used curl to query ":8080", which cannot match any `no_proxy`
item, and thus systematically goes through the corporate proxy when one
is configured, resulting in a start-up failure. This commit fixes this
query so that it succeeds in that kind of environment as long as
"localhost" is defined in `no_proxy`.