### PR TITLE
Document cozy-app-dev container usage behind proxy (#1925)

### DIFF
--- a/docs/client-app-dev.md
+++ b/docs/client-app-dev.md
@@ -59,6 +59,23 @@ To download the latest version, you can run this command:
 docker pull cozy/cozy-app-dev
 ```
 
+If you work behind a corporate proxy, and Docker is configured to inject proxy
+configuration into the containers, you need to ensure that both `localhost` and
+`cozy.tools` are configured not to use the proxy. Following is the minimal
+`~/.docker/config.json` configuration that has been shown to work:
+
+```json
+{
+    "proxies": {
+        "default": {
+            "httpProxy": "MY_CORPORATE_PROXY",
+            "httpsProxy": "MY_CORPORATE_PROXY",
+            "noProxy": "localhost,cozy.tools"
+        }
+    }
+}
+```
+
 To run a ephemeral instance, on the `$HOME/myapp` directory, use the following
 command (warning: all the data stored by your application in couchdb and the VFS
 won't remain after):


### PR DESCRIPTION
A specific Docker configuration is required for the containers to work
correctly behind a corporate proxy.

This addition to the documentation is valid as long as a Docker image containing the change applied by pull request #1926 is available (otherwise container start-up will fail even with a correct proxy configuration).