### PR TITLE
Allow clients to update the metadata on file uploads

### DIFF
--- a/docs/files.md
+++ b/docs/files.md
@@ -253,7 +253,8 @@ Upload a file
 | Name       | the file name                                      |
 | Tags       | an array of tags                                   |
 | Executable | `true` if the file is executable (UNIX permission) |
-| Metadata   | a JSON with metadata on this file (gps, persons)   |
+| Metadata   | a JSON with metadata on this file (_deprecated_)   |
+| MetadataID | the identifier of a metadata object                |
 
 #### HTTP headers
 
@@ -357,6 +358,54 @@ Location: http://cozy.example.com/files/9152d568-7e7c-11e6-a377-37cbfb190b4b
 **Note**: see [references of documents in VFS](references-docs-in-vfs.md) for
 more informations about the references field.
 
+### POST /files/upload/metadata
+
+Send a metadata object that can be associated to a file uploaded after that,
+via the `MetadataID` query parameter.
+
+#### Request
+
+```http
+POST /files/upload/metadata HTTP/1.1
+Content-Type: application/vnd.api+json
+```
+
+```json
+{
+    "data": {
+        "type": "io.cozy.files.metadata",
+        "attributes": {
+            "category": "report",
+            "subCategory": "theft",
+            "datetime": "2017-04-22T01:00:00-05:00",
+            "label": "foobar"
+        }
+    }
+}
+```
+
+#### Response
+
+```http
+HTTP/1.1 201 Created
+Content-Type: application/vnd.api+json
+```
+
+```json
+{
+    "data": {
+        "type": "io.cozy.files.metadata",
+        "id": "42E6BD48",
+        "attributes": {
+            "category": "report",
+            "subCategory": "theft",
+            "datetime": "2017-04-22T01:00:00-05:00",
+            "label": "foobar"
+        }
+    }
+}
+```
+
 ### GET /files/download/:file-id
 
 Download the file content.
@@ -402,6 +451,13 @@ Get a thumbnail of a file (for an image only). `:format` can be `small`
 ### PUT /files/:file-id
 
 Overwrite a file
+
+#### Query-String
+
+| Parameter  | Description                         |
+| ---------- | ------------------------------------|
+| Tags       | an array of tags                    |
+| MetadataID | the identifier of a metadata object |
 
 #### HTTP headers
 
@@ -686,7 +742,6 @@ the `files` array).
 
 ```http
 POST /files/archive HTTP/1.1
-Accept: application/zip
 Content-Type: application/vnd.api+json
 ```
 

--- a/model/sharing/files.go
+++ b/model/sharing/files.go
@@ -484,6 +484,7 @@ func buildReferencedBy(target, file *vfs.FileDoc, rule *Rule) []couchdb.DocRefer
 func copySafeFieldsToFile(target, file *vfs.FileDoc) {
 	file.Tags = make([]string, len(target.Tags))
 	copy(file.Tags, target.Tags)
+	file.Metadata = target.Metadata
 	file.CreatedAt = target.CreatedAt
 	file.UpdatedAt = target.UpdatedAt
 	file.Mime = target.Mime

--- a/model/vfs/file.go
+++ b/model/vfs/file.go
@@ -355,17 +355,6 @@ func getFileMode(executable bool) os.FileMode {
 	return 0644 // -rw-r--r--
 }
 
-// MergeMetadata takes a metadata map and merges it in the FileDoc
-func MergeMetadata(doc *FileDoc, meta Metadata) {
-	if doc.Metadata == nil {
-		doc.Metadata = meta
-	} else {
-		for k, v := range meta {
-			doc.Metadata[k] = v
-		}
-	}
-}
-
 var (
 	_ couchdb.Doc = &FileDoc{}
 	_ os.FileInfo = &FileDoc{}

--- a/model/vfs/metadata.go
+++ b/model/vfs/metadata.go
@@ -38,6 +38,17 @@ func NewMetadata() Metadata {
 	return m
 }
 
+// MergeMetadata takes a metadata map and merges it in the FileDoc
+func MergeMetadata(doc *FileDoc, meta Metadata) {
+	if doc.Metadata == nil {
+		doc.Metadata = meta
+	} else {
+		for k, v := range meta {
+			doc.Metadata[k] = v
+		}
+	}
+}
+
 // MetaExtractor is an interface for extracting metadata from a file
 type MetaExtractor interface {
 	io.WriteCloser

--- a/model/vfs/store.go
+++ b/model/vfs/store.go
@@ -12,31 +12,29 @@ import (
 	"github.com/go-redis/redis"
 )
 
-// A DownloadStore is essentially an object to store Archives & Files by keys
-type DownloadStore interface {
+// Store is essentially a place to store transient objects between two HTTP
+// requests: it can be a secret for downloading a file, a list of files in an
+// archive, or a metadata object for an upcoming upload.
+type Store interface {
 	AddFile(db prefixer.Prefixer, filePath string) (string, error)
 	AddArchive(db prefixer.Prefixer, archive *Archive) (string, error)
+	AddMetadata(db prefixer.Prefixer, metadata *Metadata) (string, error)
 	GetFile(db prefixer.Prefixer, key string) (string, error)
 	GetArchive(db prefixer.Prefixer, key string) (*Archive, error)
+	GetMetadata(db prefixer.Prefixer, key string) (*Metadata, error)
 }
 
-// downloadStoreTTL is the time an Archive stay alive
-var downloadStoreTTL = 1 * time.Hour
+// storeTTL is time after which the data in the store will be considered stale.
+var storeTTL = 10 * time.Minute
 
-// downloadStoreCleanInterval is the time interval between each download
-// cleanup.
-var downloadStoreCleanInterval = 1 * time.Hour
+// storeCleanInterval is the time interval between each download cleanup.
+var storeCleanInterval = 1 * time.Hour
 
 var globalStoreMu sync.Mutex
-var globalStore DownloadStore
+var globalStore Store
 
-type memRef struct {
-	val interface{}
-	exp time.Time
-}
-
-// GetStore returns the DownloadStore.
-func GetStore() DownloadStore {
+// GetStore returns the global Store.
+func GetStore() Store {
 	globalStoreMu.Lock()
 	defer globalStoreMu.Unlock()
 	if globalStore != nil {
@@ -46,12 +44,12 @@ func GetStore() DownloadStore {
 	if cli == nil {
 		globalStore = newMemStore()
 	} else {
-		globalStore = &redisStore{cli}
+		globalStore = newRedisStore(cli)
 	}
 	return globalStore
 }
 
-func newMemStore() DownloadStore {
+func newMemStore() Store {
 	store := &memStore{vals: make(map[string]*memRef)}
 	go store.cleaner()
 	return store
@@ -62,8 +60,13 @@ type memStore struct {
 	vals map[string]*memRef
 }
 
+type memRef struct {
+	val interface{}
+	exp time.Time
+}
+
 func (s *memStore) cleaner() {
-	for range time.Tick(downloadStoreCleanInterval) {
+	for range time.Tick(storeCleanInterval) {
 		now := time.Now()
 		for k, v := range s.vals {
 			if now.After(v.exp) {
@@ -79,7 +82,7 @@ func (s *memStore) AddFile(db prefixer.Prefixer, filePath string) (string, error
 	defer s.mu.Unlock()
 	s.vals[db.DBPrefix()+":"+key] = &memRef{
 		val: filePath,
-		exp: time.Now().Add(downloadStoreTTL),
+		exp: time.Now().Add(storeTTL),
 	}
 	return key, nil
 }
@@ -90,7 +93,18 @@ func (s *memStore) AddArchive(db prefixer.Prefixer, archive *Archive) (string, e
 	defer s.mu.Unlock()
 	s.vals[db.DBPrefix()+":"+key] = &memRef{
 		val: archive,
-		exp: time.Now().Add(downloadStoreTTL),
+		exp: time.Now().Add(storeTTL),
+	}
+	return key, nil
+}
+
+func (s *memStore) AddMetadata(db prefixer.Prefixer, metadata *Metadata) (string, error) {
+	key := makeSecret()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.vals[db.DBPrefix()+":"+key] = &memRef{
+		val: metadata,
+		exp: time.Now().Add(storeTTL),
 	}
 	return key, nil
 }
@@ -133,13 +147,36 @@ func (s *memStore) GetArchive(db prefixer.Prefixer, key string) (*Archive, error
 	return a, nil
 }
 
+func (s *memStore) GetMetadata(db prefixer.Prefixer, key string) (*Metadata, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key = db.DBPrefix() + ":" + key
+	ref, ok := s.vals[key]
+	if !ok {
+		return nil, nil
+	}
+	if time.Now().After(ref.exp) {
+		delete(s.vals, key)
+		return nil, nil
+	}
+	m, ok := ref.val.(*Metadata)
+	if !ok {
+		return nil, nil
+	}
+	return m, nil
+}
+
 type redisStore struct {
 	c redis.UniversalClient
 }
 
+func newRedisStore(cli redis.UniversalClient) Store {
+	return &redisStore{cli}
+}
+
 func (s *redisStore) AddFile(db prefixer.Prefixer, filePath string) (string, error) {
 	key := makeSecret()
-	if err := s.c.Set(db.DBPrefix()+":"+key, filePath, downloadStoreTTL).Err(); err != nil {
+	if err := s.c.Set(db.DBPrefix()+":"+key, filePath, storeTTL).Err(); err != nil {
 		return "", err
 	}
 	return key, nil
@@ -151,7 +188,19 @@ func (s *redisStore) AddArchive(db prefixer.Prefixer, archive *Archive) (string,
 		return "", err
 	}
 	key := makeSecret()
-	if err = s.c.Set(db.DBPrefix()+":"+key, v, downloadStoreTTL).Err(); err != nil {
+	if err = s.c.Set(db.DBPrefix()+":"+key, v, storeTTL).Err(); err != nil {
+		return "", err
+	}
+	return key, nil
+}
+
+func (s *redisStore) AddMetadata(db prefixer.Prefixer, metadata *Metadata) (string, error) {
+	v, err := json.Marshal(metadata)
+	if err != nil {
+		return "", err
+	}
+	key := makeSecret()
+	if err = s.c.Set(db.DBPrefix()+":"+key, v, storeTTL).Err(); err != nil {
 		return "", err
 	}
 	return key, nil
@@ -177,10 +226,25 @@ func (s *redisStore) GetArchive(db prefixer.Prefixer, key string) (*Archive, err
 		return nil, err
 	}
 	arch := &Archive{}
-	if err = json.Unmarshal(b, &arch); err != nil {
+	if err = json.Unmarshal(b, arch); err != nil {
 		return nil, err
 	}
 	return arch, nil
+}
+
+func (s *redisStore) GetMetadata(db prefixer.Prefixer, key string) (*Metadata, error) {
+	b, err := s.c.Get(db.DBPrefix() + ":" + key).Bytes()
+	if err == redis.Nil {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	meta := &Metadata{}
+	if err = json.Unmarshal(b, meta); err != nil {
+		return nil, err
+	}
+	return meta, nil
 }
 
 func makeSecret() string {

--- a/model/vfs/store_test.go
+++ b/model/vfs/store_test.go
@@ -5,11 +5,14 @@ import (
 	"time"
 
 	"github.com/cozy/cozy-stack/pkg/prefixer"
+	"github.com/go-redis/redis"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDownloadStoreInMemory(t *testing.T) {
-	downloadStoreTTL = 100 * time.Millisecond
+func TestStoreInMemory(t *testing.T) {
+	wasStoreTTL := storeTTL
+	storeTTL = 100 * time.Millisecond
+	defer func() { storeTTL = wasStoreTTL }()
 
 	dbA := prefixer.NewPrefixer("alice.cozycloud.local", "alice.cozycloud.local")
 	dbB := prefixer.NewPrefixer("bob.cozycloud.local", "bob.cozycloud.local")
@@ -27,7 +30,7 @@ func TestDownloadStoreInMemory(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, path, path3)
 
-	time.Sleep(2 * downloadStoreTTL)
+	time.Sleep(2 * storeTTL)
 
 	path4, err := store.GetFile(dbA, key1)
 	assert.NoError(t, err)
@@ -47,19 +50,38 @@ func TestDownloadStoreInMemory(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, a, a2)
 
-	time.Sleep(2 * downloadStoreTTL)
+	time.Sleep(2 * storeTTL)
 
 	a3, err := store.GetArchive(dbA, key2)
 	assert.NoError(t, err)
 	assert.Nil(t, a3, "no expiration")
+
+	m := &Metadata{"foo": "bar"}
+	key3, err := store.AddMetadata(dbA, m)
+	assert.NoError(t, err)
+
+	m2, err := store.GetMetadata(dbA, key3)
+	assert.NoError(t, err)
+	assert.Equal(t, m, m2)
+
+	time.Sleep(2 * storeTTL)
+
+	m3, err := store.GetArchive(dbA, key3)
+	assert.NoError(t, err)
+	assert.Nil(t, m3, "no expiration")
 }
 
-func TestDownloadStoreInRedis(t *testing.T) {
-	downloadStoreTTL = 100 * time.Millisecond
+func TestStoreInRedis(t *testing.T) {
+	wasStoreTTL := storeTTL
+	storeTTL = 100 * time.Millisecond
+	defer func() { storeTTL = wasStoreTTL }()
 
 	dbA := prefixer.NewPrefixer("alice.cozycloud.local", "alice.cozycloud.local")
 	dbB := prefixer.NewPrefixer("bob.cozycloud.local", "bob.cozycloud.local")
-	store := GetStore()
+	opt, err := redis.ParseURL("redis://localhost:6379/15")
+	assert.NoError(t, err)
+	cli := redis.NewClient(opt)
+	store := newRedisStore(cli)
 
 	path := "/test/random/path.txt"
 	key1, err := store.AddFile(dbA, path)
@@ -73,7 +95,7 @@ func TestDownloadStoreInRedis(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, path, path3)
 
-	time.Sleep(2 * downloadStoreTTL)
+	time.Sleep(2 * storeTTL)
 
 	path4, err := store.GetFile(dbA, key1)
 	assert.NoError(t, err)
@@ -93,9 +115,23 @@ func TestDownloadStoreInRedis(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, a, a2)
 
-	time.Sleep(2 * downloadStoreTTL)
+	time.Sleep(2 * storeTTL)
 
 	a3, err := store.GetArchive(dbA, key2)
 	assert.NoError(t, err)
 	assert.Nil(t, a3, "no expiration")
+
+	m := &Metadata{"foo": "bar"}
+	key3, err := store.AddMetadata(dbA, m)
+	assert.NoError(t, err)
+
+	m2, err := store.GetMetadata(dbA, key3)
+	assert.NoError(t, err)
+	assert.Equal(t, m, m2)
+
+	time.Sleep(2 * storeTTL)
+
+	m3, err := store.GetArchive(dbA, key3)
+	assert.NoError(t, err)
+	assert.Nil(t, m3, "no expiration")
 }

--- a/pkg/consts/doctype.go
+++ b/pkg/consts/doctype.go
@@ -23,6 +23,8 @@ const (
 	Doctypes = "io.cozy.doctypes"
 	// Files doc type for type for files and directories
 	Files = "io.cozy.files"
+	// FilesMetadata doc type for metadata of files
+	FilesMetadata = "io.cozy.files.metadata"
 	// PhotosAlbums doc type for photos albums
 	PhotosAlbums = "io.cozy.photos.albums"
 	// Intents doc type for intents persisted in couchdb

--- a/tests/sharing/tests/sync.rb
+++ b/tests/sharing/tests/sync.rb
@@ -127,7 +127,9 @@ describe "A folder" do
     child1.rename inst, Faker::Internet.slug
     child2 = Folder.create inst, dir_id: folder.couch_id
     child1.move_to inst, child2.couch_id
-    file.overwrite inst, mime: 'text/plain'
+    opts = CozyFile.metadata_options_for(inst, label: Faker::Simpsons.quote)
+    opts[:mime] = 'text/plain'
+    file.overwrite inst, opts
     file.rename inst, "#{Faker::Internet.slug}.txt"
     sleep 7
 
@@ -142,6 +144,7 @@ describe "A folder" do
     assert_equal file.name, file_recipient.name
     assert_equal file.md5sum, file_recipient.md5sum
     assert_equal file.couch_rev, file_recipient.couch_rev
+    assert_equal file.metadata, file_recipient.metadata
 
     # Check the sync (create + update) recipient -> sharer
     child1_recipient.rename inst_recipient, Faker::Internet.slug

--- a/web/files/paginated.go
+++ b/web/files/paginated.go
@@ -32,6 +32,11 @@ type apiArchive struct {
 	*vfs.Archive
 }
 
+type apiMetadata struct {
+	*vfs.Metadata
+	secret string
+}
+
 func newDir(doc *vfs.DirDoc) *dir {
 	return &dir{doc: doc}
 }
@@ -206,6 +211,7 @@ func fileData(c echo.Context, statusCode int, doc *vfs.FileDoc, links *jsonapi.L
 
 var (
 	_ jsonapi.Object = (*apiArchive)(nil)
+	_ jsonapi.Object = (*apiMetadata)(nil)
 	_ jsonapi.Object = (*dir)(nil)
 	_ jsonapi.Object = (*file)(nil)
 )
@@ -229,6 +235,17 @@ func (a *apiArchive) MarshalJSON() ([]byte, error)           { return json.Marsh
 func (a *apiArchive) Links() *jsonapi.LinksList {
 	return &jsonapi.LinksList{Self: "/files/archive/" + a.Secret}
 }
+
+func (m *apiMetadata) ID() string                             { return m.secret }
+func (m *apiMetadata) Rev() string                            { return "" }
+func (m *apiMetadata) SetID(id string)                        { m.secret = id }
+func (m *apiMetadata) SetRev(rev string)                      {}
+func (m *apiMetadata) DocType() string                        { return consts.FilesMetadata }
+func (m *apiMetadata) Clone() couchdb.Doc                     { cloned := *m; return &cloned }
+func (m *apiMetadata) Relationships() jsonapi.RelationshipMap { return nil }
+func (m *apiMetadata) Included() []jsonapi.Object             { return nil }
+func (m *apiMetadata) MarshalJSON() ([]byte, error)           { return json.Marshal(m.Metadata) }
+func (m *apiMetadata) Links() *jsonapi.LinksList              { return nil }
 
 func (f *file) ID() string         { return f.doc.ID() }
 func (f *file) Rev() string        { return f.doc.Rev() }


### PR DESCRIPTION
When a client uploads a file, it can use the MetadataID query parameter to give the key for a metadata object that was created just before. It works for new files, but also when uploading a new version of an existing file.