### PR TITLE
Add cozyMetadata to io.cozy.files

### DIFF
--- a/cmd/fixer.go
+++ b/cmd/fixer.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
-	"github.com/cozy/cozy-stack/web/auth"
 
 	"github.com/spf13/cobra"
 )
@@ -458,7 +457,7 @@ var linkedAppFixer = &cobra.Command{
 		for _, client := range clients {
 			for key, value := range softwareIDs {
 				if client.SoftwareID == key {
-					slug := auth.GetLinkedAppSlug(value)
+					slug := oauth.GetLinkedAppSlug(value)
 
 					// Change softwareID
 					client.SoftwareID = value

--- a/docs/files.md
+++ b/docs/files.md
@@ -281,7 +281,19 @@ A file is a binary content with some metadata.
 
 ### POST /files/:dir-id
 
-Upload a file
+Upload a file in the directory identified by `:dir-id`.
+
+The `created_at` field will be the first valid value in this list:
+
+- the datetime extracted from the EXIF for a photo
+- the `CreatedAt` parameter from the query-string
+- the `Date` HTTP header
+- the current time from the server.
+
+The `updated_at` field will be the first value in this list:
+
+- the `Date` HTTP header
+- the current time from the server.
 
 #### Query-String
 
@@ -754,7 +766,7 @@ Location: https://cozy.example.com/files/9152d568-7e7c-11e6-a377-37cbfb190b4b
             "size": 12,
             "executable": false,
             "class": "document",
-            "mime": "text/plain"
+            "mime": "text/plain",
             "cozyMetadata": {
                 "doctypeVersion": "1",
                 "metadataVersion": 1,

--- a/docs/files.md
+++ b/docs/files.md
@@ -257,6 +257,8 @@ Upload a file
 | Metadata                | a JSON with metadata on this file (_deprecated_)               |
 | MetadataID              | the identifier of a metadata object                            |
 | CreatedAt               | the creation date of the file                                  |
+| SourceAccount           | the id of the source account used by a konnector               |
+| SourceAccountIdentifier | the unique identifier of the account targeted by the connector |
 
 #### HTTP headers
 

--- a/docs/files.md
+++ b/docs/files.md
@@ -65,7 +65,7 @@ Date: Mon, 19 Sep 2016 12:35:08 GMT
 ```http
 HTTP/1.1 201 Created
 Content-Type: application/vnd.api+json
-Location: http://cozy.example.com/files/6494e0ac-dfcb-11e5-88c1-472e84a9cbee
+Location: https://cozy.example.com/files/6494e0ac-dfcb-11e5-88c1-472e84a9cbee
 ```
 
 ```json
@@ -82,7 +82,15 @@ Location: http://cozy.example.com/files/6494e0ac-dfcb-11e5-88c1-472e84a9cbee
             "path": "/Documents/phone",
             "created_at": "2016-09-19T12:35:08Z",
             "updated_at": "2016-09-19T12:35:08Z",
-            "tags": ["bills"]
+            "tags": ["bills", "konnectors"],
+            "cozyMetadata": {
+                "doctypeVersion": "1",
+                "metadataVersion": 1,
+                "createdAt": "2016-09-20T18:32:48Z",
+                "createdByApp": "drive",
+                "createdOn": "https://cozy.example.com/",
+                "updatedAt": "2016-09-20T18:32:48Z"
+            }
         },
         "relationships": {
             "parent": {
@@ -141,7 +149,15 @@ Content-Type: application/vnd.api+json
             "path": "/Documents",
             "created_at": "2016-09-19T12:35:00Z",
             "updated_at": "2016-09-19T12:35:00Z",
-            "tags": []
+            "tags": [],
+            "cozyMetadata": {
+                "doctypeVersion": "1",
+                "metadataVersion": 1,
+                "createdAt": "2016-09-20T18:32:47Z",
+                "createdByApp": "drive",
+                "createdOn": "https://cozy.example.com/",
+                "updatedAt": "2016-09-20T18:32:47Z"
+            }
         },
         "relationships": {
             "contents": {
@@ -174,7 +190,15 @@ Content-Type: application/vnd.api+json
                 "path": "/Documents/phone",
                 "created_at": "2016-09-19T12:35:08Z",
                 "updated_at": "2016-09-19T12:35:08Z",
-                "tags": ["bills"]
+                "tags": ["bills", "konnectors"],
+                "cozyMetadata": {
+                    "doctypeVersion": "1",
+                    "metadataVersion": 1,
+                    "createdAt": "2016-09-20T18:32:47Z",
+                    "createdByApp": "drive",
+                    "createdOn": "https://cozy.example.com/",
+                    "updatedAt": "2016-09-20T18:32:47Z"
+                }
             },
             "relationships": {
                 "parent": {
@@ -208,7 +232,20 @@ Content-Type: application/vnd.api+json
                 "size": 12,
                 "executable": false,
                 "class": "document",
-                "mime": "text/plain"
+                "mime": "text/plain",
+                "cozyMetadata": {
+                    "doctypeVersion": "1",
+                    "metadataVersion": 1,
+                    "createdAt": "2016-09-20T18:32:49Z",
+                    "createdByApp": "drive",
+                    "createdOn": "https://cozy.example.com/",
+                    "updatedAt": "2016-09-20T18:32:49Z",
+                    "uploadedAt": "2016-09-20T18:32:49Z",
+                    "uploadedOn": "https://cozy.example.com/",
+                    "uploadedBy": {
+                        "slug": "drive"
+                    }
+                }
             },
             "relationships": {
                 "parent": {
@@ -278,6 +315,7 @@ Content-Length: 12
 Content-MD5: hvsmnRkNLIX24EaM7KQqIA==
 Content-Type: text/plain
 Date: Mon, 19 Sep 2016 12:38:04 GMT
+Host: cozy.example.com
 
 Hello world!
 ```
@@ -298,7 +336,7 @@ Hello world!
 ```http
 HTTP/1.1 201 Created
 Content-Type: application/vnd.api+json
-Location: http://cozy.example.com/files/9152d568-7e7c-11e6-a377-37cbfb190b4b
+Location: https://cozy.example.com/files/9152d568-7e7c-11e6-a377-37cbfb190b4b
 ```
 
 ```json
@@ -325,7 +363,20 @@ Location: http://cozy.example.com/files/9152d568-7e7c-11e6-a377-37cbfb190b4b
             "size": 12,
             "executable": false,
             "class": "image",
-            "mime": "image/jpg"
+            "mime": "image/jpg",
+            "cozyMetadata": {
+                "doctypeVersion": "1",
+                "metadataVersion": 1,
+                "createdAt": "2016-09-20T18:32:49Z",
+                "createdByApp": "drive",
+                "createdOn": "https://cozy.example.com/",
+                "updatedAt": "2016-09-20T18:32:49Z",
+                "uploadedAt": "2016-09-20T18:32:49Z",
+                "uploadedOn": "https://cozy.example.com/",
+                "uploadedBy": {
+                    "slug": "drive"
+                }
+            }
         },
         "relationships": {
             "parent": {
@@ -476,7 +527,6 @@ Accept: application/vnd.api+json
 Content-Length: 12
 Content-MD5: hvsmnRkNLIX24EaM7KQqIA==
 Content-Type: text/plain
-Date: Mon, 20 Sep 2016 16:43:12 GMT
 If-Match: 1-0e6d5b72
 
 HELLO WORLD!
@@ -515,7 +565,20 @@ Content-Type: application/vnd.api+json
             "size": 12,
             "executable": false,
             "class": "document",
-            "mime": "text/plain"
+            "mime": "text/plain",
+            "cozyMetadata": {
+                "doctypeVersion": "1",
+                "metadataVersion": 1,
+                "createdAt": "2016-09-20T18:32:49Z",
+                "createdByApp": "drive",
+                "createdOn": "https://cozy.example.com/",
+                "updatedAt": "2016-09-21T04:27:50Z",
+                "uploadedAt": "2016-09-21T04:27:50Z",
+                "uploadedOn": "https://cozy.example.com/",
+                "uploadedBy": {
+                    "slug": "drive"
+                }
+            }
         },
         "relationships": {
             "parent": {
@@ -556,7 +619,7 @@ GET /files/metadata?Path=/Documents/hello.txt HTTP/1.1
 ```http
 HTTP/1.1 200 OK
 Content-Type: application/vnd.api+json
-Location: http://cozy.example.com/files/9152d568-7e7c-11e6-a377-37cbfb190b4b
+Location: https://cozy.example.com/files/9152d568-7e7c-11e6-a377-37cbfb190b4b
 ```
 
 ```json
@@ -578,7 +641,20 @@ Location: http://cozy.example.com/files/9152d568-7e7c-11e6-a377-37cbfb190b4b
             "size": 12,
             "executable": false,
             "class": "document",
-            "mime": "text/plain"
+            "mime": "text/plain",
+            "cozyMetadata": {
+                "doctypeVersion": "1",
+                "metadataVersion": 1,
+                "createdAt": "2016-09-20T18:32:49Z",
+                "createdByApp": "drive",
+                "createdOn": "https://cozy.example.com/",
+                "updatedAt": "2016-09-20T18:32:49Z",
+                "uploadedAt": "2016-09-20T18:32:49Z",
+                "uploadedOn": "https://cozy.example.com/",
+                "uploadedBy": {
+                    "slug": "drive"
+                }
+            }
         },
         "relationships": {
             "parent": {
@@ -656,7 +732,7 @@ Content-Type: application/vnd.api+json
 ```http
 HTTP/1.1 200 OK
 Content-Type: application/vnd.api+json
-Location: http://cozy.example.com/files/9152d568-7e7c-11e6-a377-37cbfb190b4b
+Location: https://cozy.example.com/files/9152d568-7e7c-11e6-a377-37cbfb190b4b
 ```
 
 ```json
@@ -679,6 +755,19 @@ Location: http://cozy.example.com/files/9152d568-7e7c-11e6-a377-37cbfb190b4b
             "executable": false,
             "class": "document",
             "mime": "text/plain"
+            "cozyMetadata": {
+                "doctypeVersion": "1",
+                "metadataVersion": 1,
+                "createdAt": "2016-09-20T18:32:49Z",
+                "createdByApp": "drive",
+                "createdOn": "https://cozy.example.com/",
+                "updatedAt": "2016-09-22T13:32:51Z",
+                "uploadedAt": "2016-09-21T04:27:50Z",
+                "uploadedOn": "https://cozy.example.com/",
+                "uploadedBy": {
+                    "slug": "drive"
+                }
+            }
         },
         "relationships": {
             "parent": {
@@ -881,7 +970,20 @@ Content-Type: application/vnd.api+json
                 "size": 123,
                 "executable": false,
                 "class": "document",
-                "mime": "text/plain"
+                "mime": "text/plain",
+                "cozyMetadata": {
+                    "doctypeVersion": "1",
+                    "metadataVersion": 1,
+                    "createdAt": "2016-09-20T18:32:49Z",
+                    "createdByApp": "drive",
+                    "createdOn": "https://cozy.example.com/",
+                    "updatedAt": "2016-09-20T18:32:49Z",
+                    "uploadedAt": "2016-09-20T18:32:49Z",
+                    "uploadedOn": "https://cozy.example.com/",
+                    "uploadedBy": {
+                        "slug": "drive"
+                    }
+                }
             },
             "links": {
                 "self": "/files/trash/df24aac0-7f3d-11e6-81c0-d38812bfa0a8"
@@ -904,7 +1006,20 @@ Content-Type: application/vnd.api+json
                 "size": 456,
                 "executable": false,
                 "class": "document",
-                "mime": "text/plain"
+                "mime": "text/plain",
+                "cozyMetadata": {
+                    "doctypeVersion": "1",
+                    "metadataVersion": 1,
+                    "createdAt": "2016-09-20T18:32:49Z",
+                    "createdByApp": "drive",
+                    "createdOn": "https://cozy.example.com/",
+                    "updatedAt": "2016-09-20T18:32:49Z",
+                    "uploadedAt": "2016-09-20T18:32:49Z",
+                    "uploadedOn": "https://cozy.example.com/",
+                    "uploadedBy": {
+                        "slug": "drive"
+                    }
+                }
             },
             "links": {
                 "self": "/files/trash/4a4fc582-7f3e-11e6-b9ca-278406b6ddd4"

--- a/docs/files.md
+++ b/docs/files.md
@@ -34,6 +34,7 @@ the directory is created at the root of the virtual file system.
 | Type      | `directory`        |
 | Name      | the directory name |
 | Tags      | an array of tags   |
+| CreatedAt | the creation date  |
 
 #### HTTP headers
 
@@ -247,14 +248,15 @@ Upload a file
 
 #### Query-String
 
-| Parameter  | Description                                        |
-| ---------- | -------------------------------------------------- |
-| Type       | `file`                                             |
-| Name       | the file name                                      |
-| Tags       | an array of tags                                   |
-| Executable | `true` if the file is executable (UNIX permission) |
-| Metadata   | a JSON with metadata on this file (_deprecated_)   |
-| MetadataID | the identifier of a metadata object                |
+| Parameter               | Description                                                    |
+| ----------------------- | -------------------------------------------------------------- |
+| Type                    | `file`                                                         |
+| Name                    | the file name                                                  |
+| Tags                    | an array of tags                                               |
+| Executable              | `true` if the file is executable (UNIX permission)             |
+| Metadata                | a JSON with metadata on this file (_deprecated_)               |
+| MetadataID              | the identifier of a metadata object                            |
+| CreatedAt               | the creation date of the file                                  |
 
 #### HTTP headers
 
@@ -268,7 +270,7 @@ Upload a file
 #### Request
 
 ```http
-POST /files/fce1a6c0-dfc5-11e5-8d1a-1f854d4aaf81?Type=file&Name=hello.txt HTTP/1.1
+POST /files/fce1a6c0-dfc5-11e5-8d1a-1f854d4aaf81?Type=file&Name=hello.txt&CreatedAt=2016-09-18T01:23:45Z HTTP/1.1
 Accept: application/vnd.api+json
 Content-Length: 12
 Content-MD5: hvsmnRkNLIX24EaM7KQqIA==
@@ -310,7 +312,7 @@ Location: http://cozy.example.com/files/9152d568-7e7c-11e6-a377-37cbfb190b4b
             "name": "sunset.jpg",
             "trashed": false,
             "md5sum": "ODZmYjI2OWQxOTBkMmM4NQo=",
-            "created_at": "2016-09-19T12:38:04Z",
+            "created_at": "2016-09-18T01:23:45Z",
             "updated_at": "2016-09-19T12:38:04Z",
             "tags": [],
             "metadata": {

--- a/model/instance/lifecycle/helpers.go
+++ b/model/instance/lifecycle/helpers.go
@@ -53,6 +53,7 @@ func createDefaultFilesTree(inst *instance.Instance) error {
 	var errf error
 
 	createDir := func(dir *vfs.DirDoc, err error) (*vfs.DirDoc, error) {
+		dir.CozyMetadata = vfs.NewCozyMetadata(inst.PageURL("/", nil))
 		if err != nil {
 			errf = multierror.Append(errf, err)
 			return nil, err

--- a/model/job/scheduler.go
+++ b/model/job/scheduler.go
@@ -59,7 +59,7 @@ type (
 		Options      *JobOptions            `json:"options"`
 		Message      Message                `json:"message"`
 		CurrentState *TriggerState          `json:"current_state,omitempty"`
-		Metadata     *metadata.CozyMetaData `json:"cozyMetadata,omitempty"`
+		Metadata     *metadata.CozyMetadata `json:"cozyMetadata,omitempty"`
 	}
 
 	// TriggerState represent the current state of the trigger
@@ -161,8 +161,7 @@ func (t *TriggerInfos) Clone() couchdb.Doc {
 		cloned.CurrentState = &tmp
 	}
 	if t.Metadata != nil {
-		tmp := t.Metadata.Clone()
-		cloned.Metadata = &tmp
+		cloned.Metadata = t.Metadata.Clone()
 	}
 	return &cloned
 }

--- a/model/move/import.go
+++ b/model/move/import.go
@@ -181,7 +181,8 @@ func createFile(fs vfs.VFS, hdr *tar.Header, tr *tar.Reader, dstDoc *vfs.DirDoc,
 	}
 
 	fileDoc.CozyMetadata = vfs.NewCozyMetadata("")
-	fileDoc.CozyMetadata.UploadedAt = fileDoc.CozyMetadata.CreatedAt
+	at := fileDoc.CozyMetadata.CreatedAt
+	fileDoc.CozyMetadata.UploadedAt = &at
 	file, err := fs.CreateFile(fileDoc, nil)
 	if err != nil {
 		ext := path.Ext(fileDoc.DocName)

--- a/model/move/import.go
+++ b/model/move/import.go
@@ -25,7 +25,7 @@ import (
 	vcardParser "github.com/emersion/go-vcard"
 )
 
-func createContact(fs vfs.VFS, hdr *tar.Header, tr *tar.Reader, db prefixer.Prefixer) error {
+func createContact(hdr *tar.Header, tr *tar.Reader, db prefixer.Prefixer) error {
 	decoder := vcardParser.NewDecoder(tr)
 	vcard, err := decoder.Decode()
 	if err != nil {
@@ -180,6 +180,8 @@ func createFile(fs vfs.VFS, hdr *tar.Header, tr *tar.Reader, dstDoc *vfs.DirDoc,
 		return err
 	}
 
+	fileDoc.CozyMetadata = vfs.NewCozyMetadata("")
+	fileDoc.CozyMetadata.UploadedAt = fileDoc.CozyMetadata.CreatedAt
 	file, err := fs.CreateFile(fileDoc, nil)
 	if err != nil {
 		ext := path.Ext(fileDoc.DocName)
@@ -268,7 +270,7 @@ func untar(r io.Reader, dst *vfs.DirDoc, instance *instance.Instance) error {
 					logger.WithDomain(instance.Domain).Errorf("Can't import album %s: %s", hdr.Name, err)
 				}
 			} else if doctype == "contacts" {
-				if err = createContact(fs, hdr, tgz, instance); err != nil {
+				if err = createContact(hdr, tgz, instance); err != nil {
 					logger.WithDomain(instance.Domain).Errorf("Can't import contact %s: %s", hdr.Name, err)
 				}
 			} else if doctype == "files" {

--- a/model/oauth/client.go
+++ b/model/oauth/client.go
@@ -82,7 +82,7 @@ type Client struct {
 	OnboardingPermissions string `json:"onboarding_permissions,omitempty"`
 	OnboardingState       string `json:"onboarding_state,omitempty"`
 
-	Metadata *metadata.CozyMetaData `json:"cozyMetadata,omitempty"`
+	Metadata *metadata.CozyMetadata `json:"cozyMetadata,omitempty"`
 }
 
 // ID returns the client qualified identifier
@@ -112,8 +112,7 @@ func (c *Client) Clone() couchdb.Doc {
 		cloned.Notifications[k] = *props
 	}
 	if cloned.Metadata != nil {
-		tmp := c.Metadata.Clone()
-		cloned.Metadata = &tmp
+		cloned.Metadata = c.Metadata.Clone()
 	}
 	return &cloned
 }
@@ -550,6 +549,24 @@ func (c *Client) ValidToken(i *instance.Instance, audience, token string) (permi
 		return claims, false
 	}
 	return claims, true
+}
+
+// IsLinkedApp checks if an OAuth client has a linked app
+func IsLinkedApp(softwareID string) bool {
+	return strings.HasPrefix(softwareID, "registry://")
+}
+
+// GetLinkedAppSlug returns a linked app slug from a softwareID
+func GetLinkedAppSlug(softwareID string) string {
+	if !IsLinkedApp(softwareID) {
+		return ""
+	}
+	return strings.TrimPrefix(softwareID, "registry://")
+}
+
+// BuildLinkedAppScope returns a formatted scope for a linked app
+func BuildLinkedAppScope(slug string) string {
+	return fmt.Sprintf("@%s/%s", consts.Apps, slug)
 }
 
 var (

--- a/model/permission/permissions.go
+++ b/model/permission/permissions.go
@@ -31,7 +31,7 @@ type Permission struct {
 	ShortCodes  map[string]string `json:"shortcodes,omitempty"`
 
 	Client   interface{}            `json:"-"` // Contains the *oauth.Client client pointer for Oauth permission type
-	Metadata *metadata.CozyMetaData `json:"cozyMetadata,omitempty"`
+	Metadata *metadata.CozyMetadata `json:"cozyMetadata,omitempty"`
 }
 
 const (
@@ -74,8 +74,7 @@ func (p *Permission) Clone() couchdb.Doc {
 	cloned.Codes = make(map[string]string)
 	cloned.ShortCodes = make(map[string]string)
 	if p.Metadata != nil {
-		md := p.Metadata.Clone()
-		cloned.Metadata = &md
+		cloned.Metadata = p.Metadata.Clone()
 	}
 	for k, v := range p.Codes {
 		cloned.Codes[k] = v
@@ -355,7 +354,7 @@ func CreateKonnectorSet(db prefixer.Prefixer, slug string, set Set, version stri
 	return createAppSet(db, TypeKonnector, consts.Konnectors, slug, set, md)
 }
 
-func createAppSet(db prefixer.Prefixer, typ, docType, slug string, set Set, md *metadata.CozyMetaData) (*Permission, error) {
+func createAppSet(db prefixer.Prefixer, typ, docType, slug string, set Set, md *metadata.CozyMetadata) (*Permission, error) {
 	doc := &Permission{
 		Type:        typ,
 		SourceID:    docType + "/" + slug,

--- a/model/sharing/files.go
+++ b/model/sharing/files.go
@@ -562,8 +562,8 @@ func copySafeFieldsToDir(target map[string]interface{}, dir *vfs.DirDoc) {
 		if version, ok := meta["doctypeVersion"].(string); ok {
 			dir.CozyMetadata.DocTypeVersion = version
 		}
-		if version, ok := meta["metadataVersion"].(int); ok {
-			dir.CozyMetadata.MetadataVersion = version
+		if version, ok := meta["metadataVersion"].(float64); ok {
+			dir.CozyMetadata.MetadataVersion = int(version)
 		}
 		if created, ok := meta["createdAt"].(string); ok {
 			if at, err := time.Parse(time.RFC3339Nano, created); err == nil {

--- a/model/sharing/files.go
+++ b/model/sharing/files.go
@@ -1051,7 +1051,8 @@ func fileToJSONDoc(file *vfs.FileDoc, instanceURL string) couchdb.JSONDoc {
 		fcm = vfs.NewCozyMetadata(instanceURL)
 		fcm.CreatedAt = file.CreatedAt
 		fcm.UpdatedAt = file.UpdatedAt
-		fcm.UploadedAt = file.CreatedAt
+		uploadedAt := file.CreatedAt
+		fcm.UploadedAt = &uploadedAt
 		fcm.UploadedOn = instanceURL
 	}
 	doc.M["cozyMetadata"] = fcm.ToJSONDoc()

--- a/model/sharing/files.go
+++ b/model/sharing/files.go
@@ -483,14 +483,14 @@ func buildReferencedBy(target, file *vfs.FileDoc, rule *Rule) []couchdb.DocRefer
 }
 
 func copySafeFieldsToFile(target, file *vfs.FileDoc) {
-	file.Tags = make([]string, len(target.Tags))
-	copy(file.Tags, target.Tags)
+	file.Tags = target.Tags
 	file.Metadata = target.Metadata
 	file.CreatedAt = target.CreatedAt
 	file.UpdatedAt = target.UpdatedAt
 	file.Mime = target.Mime
 	file.Class = target.Class
 	file.Executable = target.Executable
+	file.CozyMetadata = target.CozyMetadata
 }
 
 func copySafeFieldsToDir(target map[string]interface{}, dir *vfs.DirDoc) {
@@ -559,6 +559,14 @@ func copySafeFieldsToDir(target map[string]interface{}, dir *vfs.DirDoc) {
 					dir.CozyMetadata.UpdatedByApps = append(dir.CozyMetadata.UpdatedByApps, entry)
 				}
 			}
+		}
+
+		// No upload* for directories
+		if account, ok := meta["sourceAccount"].(string); ok {
+			dir.CozyMetadata.SourceAccount = account
+		}
+		if id, ok := meta["sourceAccountIdentifier"].(string); ok {
+			dir.CozyMetadata.SourceIdentifier = id
 		}
 	}
 }
@@ -978,6 +986,9 @@ func fileToJSONDoc(file *vfs.FileDoc) couchdb.JSONDoc {
 	}
 	if len(file.Metadata) > 0 {
 		doc.M["metadata"] = file.Metadata
+	}
+	if file.CozyMetadata != nil {
+		doc.M["cozyMetadata"] = file.CozyMetadata.ToJSONDoc()
 	}
 	return doc
 }

--- a/model/sharing/indexer.go
+++ b/model/sharing/indexer.go
@@ -197,6 +197,9 @@ func (s *sharingIndexer) bulkForceUpdateDoc(doc *vfs.FileDoc) error {
 	if doc.Metadata != nil {
 		docs[0]["metadata"] = doc.Metadata
 	}
+	if doc.CozyMetadata != nil {
+		docs[0]["cozyMetadata"] = doc.CozyMetadata
+	}
 	doc.SetRev(s.bulkRevs.Rev)
 	docs[0]["_rev"] = s.bulkRevs.Rev
 	docs[0]["_revisions"] = s.bulkRevs.Revisions
@@ -234,6 +237,9 @@ func (s *sharingIndexer) UpdateDirDoc(olddoc, doc *vfs.DirDoc) error {
 	}
 	if len(doc.ReferencedBy) > 0 {
 		docs[0][couchdb.SelectorReferencedBy] = doc.ReferencedBy
+	}
+	if doc.CozyMetadata != nil {
+		docs[0]["cozyMetadata"] = doc.CozyMetadata
 	}
 	doc.SetRev(s.bulkRevs.Rev)
 	docs[0]["_rev"] = s.bulkRevs.Rev

--- a/model/sharing/setup.go
+++ b/model/sharing/setup.go
@@ -229,6 +229,7 @@ func findDocsToCopy(inst *instance.Instance, rule Rule) ([]couchdb.JSONDoc, erro
 	var docs []couchdb.JSONDoc
 	if rule.Selector == "" || rule.Selector == "id" {
 		if rule.DocType == consts.Files {
+			instanceURL := inst.PageURL("/", nil)
 			for _, fileID := range rule.Values {
 				err := vfs.WalkByID(inst.VFS(), fileID, func(name string, dir *vfs.DirDoc, file *vfs.FileDoc, err error) error {
 					if err != nil {
@@ -236,10 +237,10 @@ func findDocsToCopy(inst *instance.Instance, rule Rule) ([]couchdb.JSONDoc, erro
 					}
 					if dir != nil {
 						if dir.DocID != fileID {
-							docs = append(docs, dirToJSONDoc(dir))
+							docs = append(docs, dirToJSONDoc(dir, instanceURL))
 						}
 					} else if file != nil {
-						docs = append(docs, fileToJSONDoc(file))
+						docs = append(docs, fileToJSONDoc(file, instanceURL))
 					}
 					return nil
 				})

--- a/model/vfs/cozy_metadata.go
+++ b/model/vfs/cozy_metadata.go
@@ -1,0 +1,98 @@
+package vfs
+
+import (
+	"time"
+
+	"github.com/cozy/cozy-stack/pkg/metadata"
+)
+
+// DocTypeVersion represents the doctype version. Each time this document
+// structure is modified, update this value
+const DocTypeVersion = "1"
+
+// FilesCozyMetadata is an extended version of cozyMetadata with some specific fields.
+type FilesCozyMetadata struct {
+	metadata.CozyMetadata
+	// Instance URL where the file has been created
+	CreatedOn string `json:"createdOn,omitempty"`
+}
+
+// NewCozyMetadata initializes a new FilesCozyMetadata struct
+func NewCozyMetadata(instance string) *FilesCozyMetadata {
+	now := time.Now()
+	return &FilesCozyMetadata{
+		CozyMetadata: metadata.CozyMetadata{
+			DocTypeVersion:  DocTypeVersion,
+			MetadataVersion: metadata.MetadataVersion,
+			CreatedAt:       now,
+			UpdatedAt:       now,
+		},
+		CreatedOn: instance,
+	}
+}
+
+// Clone clones a FileCozyMetadata struct
+func (fcm *FilesCozyMetadata) Clone() *FilesCozyMetadata {
+	cloned := *fcm
+	cloned.UpdatedByApps = make([]*metadata.UpdatedByAppEntry, len(fcm.UpdatedByApps))
+	copy(cloned.UpdatedByApps, fcm.UpdatedByApps)
+	return &cloned
+}
+
+// UpdatedByApp updates the list of UpdatedByApps entries with the new entry.
+// It ensures that each entry has a unique slug+instance, and the new entry
+// will be in the last position.
+func (fcm *FilesCozyMetadata) UpdatedByApp(entry *metadata.UpdatedByAppEntry) {
+	if entry.Slug == "" {
+		return
+	}
+
+	updated := fcm.UpdatedByApps
+	for _, app := range fcm.UpdatedByApps {
+		if app.Slug == entry.Slug && app.Instance == entry.Instance {
+			continue
+		}
+		updated = append(updated, app)
+	}
+
+	fcm.UpdatedByApps = append(updated, entry)
+}
+
+// ToJSONDoc returns a map with the cozyMetadata to be used inside a JSONDoc
+// (typically for sendings sharing updates).
+func (fcm *FilesCozyMetadata) ToJSONDoc() map[string]interface{} {
+	doc := make(map[string]interface{})
+	doc["doctypeVersion"] = fcm.DocTypeVersion
+	doc["metadataVersion"] = fcm.MetadataVersion
+	doc["createdAt"] = fcm.CreatedAt
+	if fcm.CreatedByApp != "" {
+		doc["createdByApp"] = fcm.CreatedByApp
+	}
+	if fcm.CreatedByAppVersion != "" {
+		doc["createdByAppVersion"] = fcm.CreatedByAppVersion
+	}
+	if fcm.CreatedOn != "" {
+		doc["createdOn"] = fcm.CreatedOn
+	}
+
+	doc["updatedAt"] = fcm.UpdatedAt
+	if len(fcm.UpdatedByApps) > 0 {
+		entries := make([]map[string]interface{}, len(fcm.UpdatedByApps))
+		for i, entry := range fcm.UpdatedByApps {
+			subdoc := map[string]interface{}{
+				"slug": entry.Slug,
+				"date": entry.Date,
+			}
+			if entry.Version != "" {
+				subdoc["version"] = entry.Version
+			}
+			if entry.Instance != "" {
+				subdoc["instance"] = entry.Instance
+			}
+			entries[i] = subdoc
+		}
+		doc["uploadedByApp"] = entries
+	}
+
+	return doc
+}

--- a/model/vfs/cozy_metadata.go
+++ b/model/vfs/cozy_metadata.go
@@ -24,7 +24,7 @@ type FilesCozyMetadata struct {
 	// Instance URL where the file has been created
 	CreatedOn string `json:"createdOn,omitempty"`
 	// Date of the last upload of a new content
-	UploadedAt time.Time `json:"uploadedAt"`
+	UploadedAt *time.Time `json:"uploadedAt,omitempty"`
 	// Information about the last time the content was uploaded
 	UploadedBy *UploadedByEntry `json:"uploadedBy,omitempty"`
 	// Instance URL where the content has been changed the last time
@@ -64,6 +64,10 @@ func (fcm *FilesCozyMetadata) Clone() *FilesCozyMetadata {
 			Version: fcm.UploadedBy.Version,
 			Client:  client,
 		}
+	}
+	if fcm.UploadedAt != nil {
+		at := *fcm.UploadedAt
+		cloned.UploadedAt = &at
 	}
 	return &cloned
 }
@@ -123,7 +127,9 @@ func (fcm *FilesCozyMetadata) ToJSONDoc() map[string]interface{} {
 		doc["uploadedByApp"] = entries
 	}
 
-	doc["uploadedAt"] = fcm.UploadedAt
+	if fcm.UploadedAt != nil {
+		doc["uploadedAt"] = *fcm.UploadedAt
+	}
 	if fcm.UploadedBy != nil {
 		uploaded := make(map[string]interface{})
 		if fcm.UploadedBy.Slug != "" {

--- a/model/vfs/directory.go
+++ b/model/vfs/directory.go
@@ -228,6 +228,7 @@ func ModifyDirMetadata(fs VFS, olddoc *DirDoc, patch *DocPatch) (*DirDoc, error)
 	newdoc.CreatedAt = cdate
 	newdoc.UpdatedAt = *patch.UpdatedAt
 	newdoc.ReferencedBy = olddoc.ReferencedBy
+	newdoc.CozyMetadata = olddoc.CozyMetadata
 
 	if err = fs.UpdateDirDoc(olddoc, newdoc); err != nil {
 		return nil, err
@@ -256,6 +257,7 @@ func TrashDir(fs VFS, olddoc *DirDoc) (*DirDoc, error) {
 		newdoc.RestorePath = restorePath
 		newdoc.DocName = name
 		newdoc.Fullpath = path.Join(TrashDirName, name)
+		newdoc.CozyMetadata = olddoc.CozyMetadata
 		return fs.UpdateDirDoc(olddoc, newdoc)
 	})
 	if err != nil {
@@ -285,6 +287,7 @@ func RestoreDir(fs VFS, olddoc *DirDoc) (*DirDoc, error) {
 		newdoc.RestorePath = ""
 		newdoc.DocName = name
 		newdoc.Fullpath = path.Join(restoreDir.Fullpath, name)
+		newdoc.CozyMetadata = olddoc.CozyMetadata
 		return fs.UpdateDirDoc(olddoc, newdoc)
 	})
 	if err != nil {

--- a/model/vfs/directory.go
+++ b/model/vfs/directory.go
@@ -37,6 +37,8 @@ type DirDoc struct {
 	Fullpath string `json:"path,omitempty"`
 
 	ReferencedBy []couchdb.DocReference `json:"referenced_by,omitempty"`
+
+	CozyMetadata *FilesCozyMetadata `json:"cozyMetadata,omitempty"`
 }
 
 // ID returns the directory qualified identifier
@@ -55,6 +57,9 @@ func (d *DirDoc) Clone() couchdb.Doc {
 	copy(cloned.Tags, d.Tags)
 	cloned.ReferencedBy = make([]couchdb.DocReference, len(d.ReferencedBy))
 	copy(cloned.ReferencedBy, d.ReferencedBy)
+	if d.CozyMetadata != nil {
+		cloned.CozyMetadata = d.CozyMetadata.Clone()
+	}
 	return &cloned
 }
 

--- a/model/vfs/file.go
+++ b/model/vfs/file.go
@@ -285,6 +285,7 @@ func ModifyFileMetadata(fs VFS, olddoc *FileDoc, patch *DocPatch) (*FileDoc, err
 	newdoc.UpdatedAt = *patch.UpdatedAt
 	newdoc.Metadata = olddoc.Metadata
 	newdoc.ReferencedBy = olddoc.ReferencedBy
+	newdoc.CozyMetadata = olddoc.CozyMetadata
 
 	if patch.MD5Sum != nil {
 		newdoc.MD5Sum = *patch.MD5Sum
@@ -318,6 +319,7 @@ func TrashFile(fs VFS, olddoc *FileDoc) (*FileDoc, error) {
 		newdoc.DocName = name
 		newdoc.Trashed = true
 		newdoc.fullpath = path.Join(TrashDirName, name)
+		newdoc.CozyMetadata = olddoc.CozyMetadata
 		return fs.UpdateFileDoc(olddoc, newdoc)
 	})
 
@@ -346,6 +348,7 @@ func RestoreFile(fs VFS, olddoc *FileDoc) (*FileDoc, error) {
 		newdoc.DocName = name
 		newdoc.Trashed = false
 		newdoc.fullpath = path.Join(restoreDir.Fullpath, name)
+		newdoc.CozyMetadata = olddoc.CozyMetadata
 		return fs.UpdateFileDoc(olddoc, newdoc)
 	})
 

--- a/model/vfs/file.go
+++ b/model/vfs/file.go
@@ -40,9 +40,10 @@ type FileDoc struct {
 	Trashed    bool     `json:"trashed"`
 	Tags       []string `json:"tags"`
 
-	Metadata Metadata `json:"metadata,omitempty"`
-
+	Metadata     Metadata               `json:"metadata,omitempty"`
 	ReferencedBy []couchdb.DocReference `json:"referenced_by,omitempty"`
+
+	CozyMetadata *FilesCozyMetadata `json:"cozyMetadata,omitempty"`
 
 	// Cache of the fullpath of the file. Should not have to be invalidated
 	// since we use FileDoc as immutable data-structures.
@@ -73,6 +74,9 @@ func (f *FileDoc) Clone() couchdb.Doc {
 	cloned.Metadata = make(Metadata, len(f.Metadata))
 	for k, v := range f.Metadata {
 		cloned.Metadata[k] = v
+	}
+	if f.CozyMetadata != nil {
+		cloned.CozyMetadata = f.CozyMetadata.Clone()
 	}
 	return &cloned
 }

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -36,7 +36,7 @@ type CozyMetadata struct {
 	// Last modification date of the cozy document
 	UpdatedAt time.Time `json:"updatedAt"`
 	// List of objects representing the applications which modified the cozy document
-	UpdatedByApps []*UpdatedByAppEntry `json:"updatedByApps"`
+	UpdatedByApps []*UpdatedByAppEntry `json:"updatedByApps,omitempty"`
 }
 
 // New initializes a new CozyMetadata structure

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -20,8 +20,8 @@ type UpdatedByAppEntry struct {
 	Version string    `json:"version,omitempty"` // Version identifier of the app
 }
 
-// CozyMetaData holds all the metadata of a document
-type CozyMetaData struct {
+// CozyMetadata holds all the metadata of a document
+type CozyMetadata struct {
 	// Name or identifier for the version of the schema used by this document
 	DocTypeVersion string `json:"doctypeVersion"`
 	// Version of the cozyMetadata
@@ -36,23 +36,21 @@ type CozyMetaData struct {
 	UpdatedAt time.Time `json:"updatedAt"`
 	// List of objects representing the applications which modified the cozy document
 	UpdatedByApps []*UpdatedByAppEntry `json:"updatedByApps"`
-	// Identifier of the account in io.cozy.accounts (for konnectors)
-	SourceAccount string `json:"sourceAccount,omitempty"`
 }
 
-// New initializes a new CozyMetaData structure
-func New() *CozyMetaData {
+// New initializes a new CozyMetadata structure
+func New() *CozyMetadata {
 	now := time.Now()
-	return &CozyMetaData{
+	return &CozyMetadata{
 		MetadataVersion: MetadataVersion,
 		CreatedAt:       now,
 		UpdatedAt:       now,
 	}
 }
 
-// NewWithApp initializes a CozyMetaData with a slug and a version
+// NewWithApp initializes a CozyMetadata with a slug and a version
 // Version is optional
-func NewWithApp(slug, version, doctypeVersion string) (*CozyMetaData, error) {
+func NewWithApp(slug, version, doctypeVersion string) (*CozyMetadata, error) {
 	if slug == "" {
 		return nil, ErrSlugEmpty
 	}
@@ -70,17 +68,17 @@ func NewWithApp(slug, version, doctypeVersion string) (*CozyMetaData, error) {
 	return md, nil
 }
 
-// Clone clones a CozyMetaData struct
-func (cm *CozyMetaData) Clone() CozyMetaData {
+// Clone clones a CozyMetadata struct
+func (cm *CozyMetadata) Clone() *CozyMetadata {
 	cloned := *cm
 	cloned.UpdatedByApps = make([]*UpdatedByAppEntry, len(cm.UpdatedByApps))
 	copy(cloned.UpdatedByApps, cm.UpdatedByApps)
-	return cloned
+	return &cloned
 }
 
 // EnsureCreatedFields ensures that empty fields are filled, otherwise use
 // the default metadata values during the creation process
-func (cm *CozyMetaData) EnsureCreatedFields(defaultMetadata *CozyMetaData) {
+func (cm *CozyMetadata) EnsureCreatedFields(defaultMetadata *CozyMetadata) {
 	if cm.UpdatedAt.IsZero() {
 		cm.UpdatedAt = defaultMetadata.UpdatedAt
 	}
@@ -99,13 +97,13 @@ func (cm *CozyMetaData) EnsureCreatedFields(defaultMetadata *CozyMetaData) {
 }
 
 // ChangeUpdatedAt updates the UpdatedAt timestamp
-func (cm *CozyMetaData) ChangeUpdatedAt() {
+func (cm *CozyMetadata) ChangeUpdatedAt() {
 	cm.UpdatedAt = time.Now()
 }
 
 // UpdatedByApp updates an entry either by updating the struct if the
 // slug/version already exists or by appending a new entry to the list
-func (cm *CozyMetaData) UpdatedByApp(slug, version string) error {
+func (cm *CozyMetadata) UpdatedByApp(slug, version string) error {
 	if slug == "" {
 		return ErrSlugEmpty
 	}

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -15,9 +15,10 @@ var ErrSlugEmpty = errors.New("Slug cannot be empty")
 // UpdatedByAppEntry represents a modification made by an application to the
 // document
 type UpdatedByAppEntry struct {
-	Slug    string    `json:"slug"`              // Slug of the app
-	Date    time.Time `json:"date"`              // Date of the update
-	Version string    `json:"version,omitempty"` // Version identifier of the app
+	Slug     string    `json:"slug"`               // Slug of the app
+	Date     time.Time `json:"date"`               // Date of the update
+	Version  string    `json:"version,omitempty"`  // Version identifier of the app
+	Instance string    `json:"instance,omitempty"` // URL of the instance
 }
 
 // CozyMetadata holds all the metadata of a document

--- a/tests/clone/generate_tests.go
+++ b/tests/clone/generate_tests.go
@@ -291,6 +291,9 @@ func generatorForType(typ types.Type) *generator {
 			// We consider that json.RawMessage and time.Time are not modifiable in our code
 			return nil
 		}
+		if named == "vfs.FilesCozyMetadata" {
+			return &filesCozyMetadataGenerator
+		}
 		if s, ok := t.Obj().Type().Underlying().(*types.Struct); ok {
 			return structGenerator(named, s)
 		}
@@ -349,6 +352,15 @@ var emptyInterfaceGenerator = generator{
 	Altered:  "2",
 	SubValue: "1",
 	Warning:  "interface{} can contain nested data!",
+}
+
+var filesCozyMetadataGenerator = generator{
+	Type:     "vfs.FilesCozyMetadata",
+	Key:      `"alice.cozy.tools"`,
+	Initial:  `vfs.FilesCozyMetadata{CreatedOn: "bob.cozy.tools"}`,
+	Altered:  `"charlie.cozy.tools"`,
+	SubValue: `"bob.cozy.tools"`,
+	SubKey:   `.CreatedOn`,
 }
 
 func structGenerator(name string, s *types.Struct) *generator {

--- a/tests/sharing/lib/cozy_file.rb
+++ b/tests/sharing/lib/cozy_file.rb
@@ -3,7 +3,7 @@ class CozyFile
   include Model::Files
 
   attr_reader :name, :dir_id, :mime, :trashed, :md5sum, :referenced_by,
-              :metadata, :size, :executable, :file_class
+              :metadata, :size, :executable, :file_class, :cozy_metadata
 
   def self.load_from_url(inst, path)
     opts = {
@@ -25,6 +25,7 @@ class CozyFile
       executable: j["executable"],
       file_class: j["class"],
       metadata: j["metadata"],
+      cozy_metadata: j["cozyMetadata"],
       referenced_by: referenced_by
     )
     f.couch_id = id
@@ -72,6 +73,7 @@ class CozyFile
     @size = opts[:size]
     @executable = opts[:executable]
     @file_class = opts[:file_class]
+    @cozy_metadata = opts[:cozy_metadata]
     @referenced_by = opts[:referenced_by]
   end
 
@@ -85,6 +87,7 @@ class CozyFile
     j = JSON.parse(res.body)["data"]
     @couch_id = j["id"]
     @couch_rev = j["meta"]["rev"]
+    @cozy_metadata = j["attributes"]["cozyMetadata"]
   end
 
   def overwrite(inst, opts = {})

--- a/tests/sharing/lib/folder.rb
+++ b/tests/sharing/lib/folder.rb
@@ -6,7 +6,7 @@ class Folder
 
   include Model::Files
 
-  attr_reader :name, :dir_id, :children, :path, :restore_path
+  attr_reader :name, :dir_id, :children, :path, :restore_path, :cozy_metadata
 
   def self.load_from_url(inst, path)
     opts = {
@@ -23,7 +23,8 @@ class Folder
       name: j["name"],
       dir_id: j["dir_id"],
       path: j["path"],
-      restore_path: j["restore_path"]
+      restore_path: j["restore_path"],
+      cozy_metadata: j["cozyMetadata"]
     )
     f.couch_id = id
     f.couch_rev = rev
@@ -52,7 +53,8 @@ class Folder
           name: child["name"],
           dir_id: child["dir_id"],
           path: child["path"],
-          restore_path: child["restore_path"]
+          restore_path: child["restore_path"],
+          cozy_metadata: child["cozyMetadata"]
         )
         dirs << f
       else
@@ -64,7 +66,8 @@ class Folder
           size: child["size"],
           executable: child["executable"],
           file_class: child["class"],
-          metadata: child["metadata"]
+          metadata: child["metadata"],
+          cozy_metadata: child["cozyMetadata"]
         )
         files << f
       end
@@ -90,6 +93,7 @@ class Folder
     @dir_id = opts[:dir_id] || ROOT_DIR
     @path = opts[:path] || "/#{@name}"
     @restore_path = opts[:restore_path]
+    @cozy_metadata = opts[:cozy_metadata]
     @children = []
   end
 
@@ -102,6 +106,7 @@ class Folder
     j = JSON.parse(res.body)["data"]
     @couch_id = j["id"]
     @couch_rev = j["rev"]
+    @cozy_metadata = j["attributes"]["cozyMetadata"]
   end
 
   def trashed

--- a/tests/sharing/lib/model.rb
+++ b/tests/sharing/lib/model.rb
@@ -96,6 +96,7 @@ module Model
       res = inst.client["/files/#{@couch_id}"].patch body.to_json, opts
       j = JSON.parse(res.body)["data"]
       @couch_rev = j["meta"]["rev"]
+      @cozy_metadata = j["attributes"]["cozyMetadata"]
     rescue RestClient::InternalServerError => e
       puts "InternalServerError: #{e.http_body}"
       raise e

--- a/tests/sharing/tests/sync.rb
+++ b/tests/sharing/tests/sync.rb
@@ -141,10 +141,12 @@ describe "A folder" do
     assert_equal child1.name, child1_recipient.name
     assert_equal child2.name, child2_recipient.name
     assert_equal child1_recipient.dir_id, child2_recipient.couch_id
+    assert_equal child1.cozy_metadata, child1_recipient.cozy_metadata
     assert_equal file.name, file_recipient.name
     assert_equal file.md5sum, file_recipient.md5sum
     assert_equal file.couch_rev, file_recipient.couch_rev
     assert_equal file.metadata, file_recipient.metadata
+    assert_equal file.cozy_metadata, file_recipient.cozy_metadata
 
     # Check the sync (create + update) recipient -> sharer
     child1_recipient.rename inst_recipient, Faker::Internet.slug

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -84,6 +84,11 @@ func createFileHandler(c echo.Context, fs vfs.VFS) (f *file, err error) {
 		return
 	}
 
+	if created := c.QueryParam("CreatedAt"); created != "" {
+		if at, err2 := time.Parse(time.RFC3339, created); err2 == nil {
+			doc.CreatedAt = at
+		}
+	}
 	doc.CozyMetadata = cozyMetadataFromClaims(c, true)
 
 	err = checkPerm(c, "POST", nil, doc)
@@ -144,6 +149,11 @@ func createDirHandler(c echo.Context, fs vfs.VFS) (*dir, error) {
 		if t, err2 := time.Parse(time.RFC1123, date); err2 == nil {
 			doc.CreatedAt = t
 			doc.UpdatedAt = t
+		}
+	}
+	if created := c.QueryParam("CreatedAt"); created != "" {
+		if at, err2 := time.Parse(time.RFC3339, created); err2 == nil {
+			doc.CreatedAt = at
 		}
 	}
 

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cozy/cozy-stack/model/oauth"
 	"github.com/cozy/cozy-stack/model/permission"
 	"github.com/cozy/cozy-stack/model/vfs"
 	"github.com/cozy/cozy-stack/pkg/config/config"
@@ -25,6 +26,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/jsonapi"
 	"github.com/cozy/cozy-stack/pkg/limits"
+	"github.com/cozy/cozy-stack/pkg/metadata"
 	statikFS "github.com/cozy/cozy-stack/pkg/statik/fs"
 	"github.com/cozy/cozy-stack/pkg/utils"
 	web_utils "github.com/cozy/cozy-stack/pkg/utils"
@@ -81,6 +83,8 @@ func createFileHandler(c echo.Context, fs vfs.VFS) (f *file, err error) {
 	if err != nil {
 		return
 	}
+
+	doc.CozyMetadata = cozyMetadataFromClaims(c, true)
 
 	err = checkPerm(c, "POST", nil, doc)
 	if err != nil {
@@ -143,6 +147,8 @@ func createDirHandler(c echo.Context, fs vfs.VFS) (*dir, error) {
 		}
 	}
 
+	doc.CozyMetadata = cozyMetadataFromClaims(c, false)
+
 	err = checkPerm(c, "POST", doc, nil)
 	if err != nil {
 		return nil, err
@@ -182,6 +188,11 @@ func OverwriteFileContentHandler(c echo.Context) (err error) {
 	if err = CheckIfMatch(c, olddoc.Rev()); err != nil {
 		return WrapVfsError(err)
 	}
+
+	if olddoc.CozyMetadata != nil {
+		newdoc.CozyMetadata = olddoc.CozyMetadata.Clone()
+	}
+	updateFileCozyMetadata(c, newdoc, true)
 
 	err = checkPerm(c, permission.PUT, nil, olddoc)
 	if err != nil {
@@ -375,14 +386,18 @@ func applyPatch(c echo.Context, fs vfs.VFS, patch *docPatch) (err error) {
 		}
 	} else if patch.Trash {
 		if dir != nil {
+			updateDirCozyMetadata(c, dir)
 			dir, err = vfs.TrashDir(fs, dir)
 		} else {
+			updateFileCozyMetadata(c, file, false)
 			file, err = vfs.TrashFile(fs, file)
 		}
 	} else {
 		if dir != nil {
+			updateDirCozyMetadata(c, dir)
 			dir, err = vfs.ModifyDirMetadata(fs, dir, &patch.DocPatch)
 		} else {
+			updateFileCozyMetadata(c, file, false)
 			file, err = vfs.ModifyFileMetadata(fs, file, &patch.DocPatch)
 		}
 	}
@@ -418,13 +433,17 @@ func applyPatches(c echo.Context, fs vfs.VFS, patches []*docPatch) (errors []*js
 			}
 		} else if patch.Trash {
 			if dir != nil {
+				updateDirCozyMetadata(c, dir)
 				_, errp = vfs.TrashDir(fs, dir)
 			} else if file != nil {
+				updateFileCozyMetadata(c, file, false)
 				_, errp = vfs.TrashFile(fs, file)
 			}
 		} else if dir != nil {
+			updateDirCozyMetadata(c, dir)
 			_, errp = vfs.ModifyDirMetadata(fs, dir, &patch.DocPatch)
 		} else if file != nil {
+			updateFileCozyMetadata(c, file, false)
 			_, errp = vfs.ModifyFileMetadata(fs, file, &patch.DocPatch)
 		}
 		if errp != nil {
@@ -800,6 +819,7 @@ func TrashHandler(c echo.Context) error {
 	}
 
 	if dir != nil {
+		updateDirCozyMetadata(c, dir)
 		doc, errt := vfs.TrashDir(instance.VFS(), dir)
 		if errt != nil {
 			return WrapVfsError(errt)
@@ -807,6 +827,7 @@ func TrashHandler(c echo.Context) error {
 		return dirData(c, http.StatusOK, doc)
 	}
 
+	updateFileCozyMetadata(c, file, false)
 	doc, errt := vfs.TrashFile(instance.VFS(), file)
 	if errt != nil {
 		return WrapVfsError(errt)
@@ -850,6 +871,7 @@ func RestoreTrashFileHandler(c echo.Context) error {
 	}
 
 	if dir != nil {
+		updateDirCozyMetadata(c, dir)
 		doc, errt := vfs.RestoreDir(instance.VFS(), dir)
 		if errt != nil {
 			return WrapVfsError(errt)
@@ -857,6 +879,7 @@ func RestoreTrashFileHandler(c echo.Context) error {
 		return dirData(c, http.StatusOK, doc)
 	}
 
+	updateFileCozyMetadata(c, file, false)
 	doc, errt := vfs.RestoreFile(instance.VFS(), file)
 	if errt != nil {
 		return WrapVfsError(errt)
@@ -1245,4 +1268,98 @@ func parseMD5Hash(md5B64 string) ([]byte, error) {
 	}
 
 	return md5Sum, nil
+}
+
+func instanceURL(c echo.Context) string {
+	return middlewares.GetInstance(c).PageURL("/", nil)
+}
+
+func updateDirCozyMetadata(c echo.Context, dir *vfs.DirDoc) {
+	fcm := cozyMetadataFromClaims(c, false)
+	if dir.CozyMetadata == nil {
+		fcm.CreatedAt = dir.CreatedAt
+		fcm.CreatedByApp = ""
+		fcm.CreatedByAppVersion = ""
+		dir.CozyMetadata = fcm
+	} else {
+		dir.CozyMetadata.UpdatedAt = fcm.UpdatedAt
+		if len(fcm.UpdatedByApps) > 0 {
+			dir.CozyMetadata.UpdatedByApp(fcm.UpdatedByApps[0])
+		}
+	}
+}
+
+func updateFileCozyMetadata(c echo.Context, file *vfs.FileDoc, setUploadFields bool) {
+	fcm := cozyMetadataFromClaims(c, setUploadFields)
+	if file.CozyMetadata == nil {
+		fcm.CreatedAt = file.CreatedAt
+		fcm.CreatedByApp = ""
+		fcm.CreatedByAppVersion = ""
+		fcm.UploadedAt = file.CreatedAt
+		file.CozyMetadata = fcm
+	} else {
+		file.CozyMetadata.UpdatedAt = fcm.UpdatedAt
+		if len(fcm.UpdatedByApps) > 0 {
+			file.CozyMetadata.UpdatedByApp(fcm.UpdatedByApps[0])
+		}
+	}
+}
+
+func cozyMetadataFromClaims(c echo.Context, setUploadFields bool) *vfs.FilesCozyMetadata {
+	fcm := vfs.NewCozyMetadata(instanceURL(c))
+
+	var slug, version string
+	var client map[string]string
+	if claims := c.Get("claims"); claims != nil {
+		cl := claims.(permission.Claims)
+		switch cl.Audience {
+		case consts.AppAudience, consts.KonnectorAudience:
+			slug = cl.Subject
+		case consts.AccessTokenAudience:
+			if perms, err := middlewares.GetPermission(c); err == nil {
+				if cli, ok := perms.Client.(*oauth.Client); ok {
+					slug = oauth.GetLinkedAppSlug(cli.SoftwareID)
+					// Special case for cozy-desktop: it is an OAuth app not linked
+					// to a web app, so it has no slug, but we still want to keep
+					// in cozyMetadata its changes, so we use a fake slug.
+					if slug == "" && strings.Contains(cli.SoftwareID, "cozy-desktop") {
+						slug = "cozy-desktop"
+					}
+					version = cli.SoftwareVersion
+					client = map[string]string{
+						"id":   cli.ID(),
+						"kind": cli.ClientKind,
+						"name": cli.ClientName,
+					}
+				}
+			}
+		}
+	}
+
+	if slug != "" {
+		fcm.CreatedByApp = slug
+		fcm.CreatedByAppVersion = version
+		fcm.UpdatedByApps = []*metadata.UpdatedByAppEntry{
+			{
+				Slug:     slug,
+				Version:  version,
+				Date:     fcm.UpdatedAt,
+				Instance: fcm.CreatedOn,
+			},
+		}
+	}
+
+	if setUploadFields {
+		fcm.UploadedAt = fcm.CreatedAt
+		fcm.UploadedOn = fcm.CreatedOn
+		if slug != "" {
+			fcm.UploadedBy = &vfs.UploadedByEntry{
+				Slug:    slug,
+				Version: version,
+				Client:  client,
+			}
+		}
+	}
+
+	return fcm
 }

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -1295,7 +1295,8 @@ func updateFileCozyMetadata(c echo.Context, file *vfs.FileDoc, setUploadFields b
 		fcm.CreatedAt = file.CreatedAt
 		fcm.CreatedByApp = ""
 		fcm.CreatedByAppVersion = ""
-		fcm.UploadedAt = file.CreatedAt
+		uploadedAt := file.CreatedAt
+		fcm.UploadedAt = &uploadedAt
 		file.CozyMetadata = fcm
 	} else {
 		file.CozyMetadata.UpdatedAt = fcm.UpdatedAt
@@ -1350,7 +1351,8 @@ func cozyMetadataFromClaims(c echo.Context, setUploadFields bool) *vfs.FilesCozy
 	}
 
 	if setUploadFields {
-		fcm.UploadedAt = fcm.CreatedAt
+		uploadedAt := fcm.CreatedAt
+		fcm.UploadedAt = &uploadedAt
 		fcm.UploadedOn = fcm.CreatedOn
 		if slug != "" {
 			fcm.UploadedBy = &vfs.UploadedByEntry{

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -1373,5 +1373,18 @@ func cozyMetadataFromClaims(c echo.Context, setUploadFields bool) *vfs.FilesCozy
 		}
 	}
 
+	if account := c.QueryParam("SourceAccount"); account != "" {
+		fcm.SourceAccount = account
+		// To ease the transition to cozyMetadata for io.cozy.files, we fill
+		// the CreatedByApp for konnectors that updates a file: the stack can
+		// recognize that by the presence of the SourceAccount.
+		if fcm.CreatedByApp == "" && slug != "" {
+			fcm.CreatedByApp = slug
+		}
+	}
+	if id := c.QueryParam("SourceAccountIdentifier"); id != "" {
+		fcm.SourceIdentifier = id
+	}
+
 	return fcm
 }

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -293,6 +293,13 @@ func TestCreateDirWithDateSuccess(t *testing.T) {
 	assert.Equal(t, "2016-09-19T12:35:08Z", createdAt)
 	updatedAt := attrs["updated_at"].(string)
 	assert.Equal(t, createdAt, updatedAt)
+	fcm := attrs["cozyMetadata"].(map[string]interface{})
+	assert.Equal(t, float64(1), fcm["metadataVersion"])
+	assert.Equal(t, "1", fcm["doctypeVersion"])
+	assert.Contains(t, fcm["createdOn"], testInstance.Domain)
+	assert.NotEmpty(t, fcm["createdAt"])
+	assert.NotEmpty(t, fcm["updatedAt"])
+	assert.NotContains(t, fcm, "uploadedAt")
 }
 
 func TestCreateDirWithParentSuccess(t *testing.T) {

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -426,6 +426,7 @@ func TestUploadImage(t *testing.T) {
 	gps := meta["gps"].(map[string]interface{})
 	assert.Equal(t, "Paris", gps["city"])
 	assert.Equal(t, "France", gps["country"])
+	assert.Contains(t, attrs["created_at"], "2016-09-10T")
 }
 
 func TestUploadWithParentSuccess(t *testing.T) {

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -541,6 +541,22 @@ func TestUploadWithMetadata(t *testing.T) {
 	assert.Equal(t, "2017-04-22T01:00:00-05:00", meta["datetime"])
 }
 
+func TestUploadWithSourceAccount(t *testing.T) {
+	buf := strings.NewReader("foo")
+	account := "0c5a0a1e-8eb1-11e9-93f3-934f3a2c181d"
+	identifier := "11f68e48"
+	req, err := http.NewRequest("POST", ts.URL+"/files/?Type=file&Name=with-sourceAccount&SourceAccount="+account+"&SourceAccountIdentifier="+identifier, buf)
+	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+	assert.NoError(t, err)
+	res, obj := doUploadOrMod(t, req, "text/plain", "rL0Y20zC+Fzt72VPzMSk2A==")
+	assert.Equal(t, 201, res.StatusCode)
+	data := obj["data"].(map[string]interface{})
+	attrs := data["attributes"].(map[string]interface{})
+	fcm := attrs["cozyMetadata"].(map[string]interface{})
+	assert.Equal(t, account, fcm["sourceAccount"])
+	assert.Equal(t, identifier, fcm["sourceAccountIdentifier"])
+}
+
 func TestModifyMetadataFileMove(t *testing.T) {
 	body := "foo"
 	res1, data1 := upload(t, "/files/?Type=file&Name=filemoveme&Tags=foo,bar", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -277,7 +277,7 @@ func TestCreateDirRootSuccess(t *testing.T) {
 }
 
 func TestCreateDirWithDateSuccess(t *testing.T) {
-	req, _ := http.NewRequest("POST", ts.URL+"/files/?Type=directory&Name=dir-with-date", strings.NewReader(""))
+	req, _ := http.NewRequest("POST", ts.URL+"/files/?Type=directory&Name=dir-with-date&CreatedAt=2016-09-18T10:24:53Z", strings.NewReader(""))
 	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
 	req.Header.Add("Date", "Mon, 19 Sep 2016 12:35:08 GMT")
 	res, err := http.DefaultClient.Do(req)
@@ -290,9 +290,9 @@ func TestCreateDirWithDateSuccess(t *testing.T) {
 	data := obj["data"].(map[string]interface{})
 	attrs := data["attributes"].(map[string]interface{})
 	createdAt := attrs["created_at"].(string)
-	assert.Equal(t, "2016-09-19T12:35:08Z", createdAt)
+	assert.Equal(t, "2016-09-18T10:24:53Z", createdAt)
 	updatedAt := attrs["updated_at"].(string)
-	assert.Equal(t, createdAt, updatedAt)
+	assert.Equal(t, "2016-09-19T12:35:08Z", updatedAt)
 	fcm := attrs["cozyMetadata"].(map[string]interface{})
 	assert.Equal(t, float64(1), fcm["metadataVersion"])
 	assert.Equal(t, "1", fcm["doctypeVersion"])
@@ -479,7 +479,7 @@ func TestUploadWithParentAlreadyExists(t *testing.T) {
 
 func TestUploadWithDate(t *testing.T) {
 	buf := strings.NewReader("foo")
-	req, err := http.NewRequest("POST", ts.URL+"/files/?Type=file&Name=withcdate", buf)
+	req, err := http.NewRequest("POST", ts.URL+"/files/?Type=file&Name=withcdate&CreatedAt=2016-09-18T10:24:53Z", buf)
 	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
 	assert.NoError(t, err)
 	req.Header.Add("Date", "Mon, 19 Sep 2016 12:38:04 GMT")
@@ -488,9 +488,9 @@ func TestUploadWithDate(t *testing.T) {
 	data := obj["data"].(map[string]interface{})
 	attrs := data["attributes"].(map[string]interface{})
 	createdAt := attrs["created_at"].(string)
-	assert.Equal(t, "2016-09-19T12:38:04Z", createdAt)
+	assert.Equal(t, "2016-09-18T10:24:53Z", createdAt)
 	updatedAt := attrs["updated_at"].(string)
-	assert.Equal(t, createdAt, updatedAt)
+	assert.Equal(t, "2016-09-19T12:38:04Z", updatedAt)
 }
 
 func TestUploadWithMetadata(t *testing.T) {

--- a/web/files/referencedby.go
+++ b/web/files/referencedby.go
@@ -33,12 +33,14 @@ func AddReferencedHandler(c echo.Context) error {
 		return WrapVfsError(err)
 	}
 
-	if dir == nil {
-		file.AddReferencedBy(references...)
-		err = couchdb.UpdateDoc(instance, file)
-	} else {
+	if dir != nil {
 		dir.AddReferencedBy(references...)
+		updateDirCozyMetadata(c, dir)
 		err = couchdb.UpdateDoc(instance, dir)
+	} else {
+		file.AddReferencedBy(references...)
+		updateFileCozyMetadata(c, file, false)
+		err = couchdb.UpdateDoc(instance, file)
 	}
 
 	if err != nil {
@@ -73,9 +75,11 @@ func RemoveReferencedHandler(c echo.Context) error {
 
 	if dir != nil {
 		dir.RemoveReferencedBy(references...)
+		updateDirCozyMetadata(c, dir)
 		err = couchdb.UpdateDoc(instance, dir)
 	} else {
 		file.RemoveReferencedBy(references...)
+		updateFileCozyMetadata(c, file, false)
 		err = couchdb.UpdateDoc(instance, file)
 	}
 

--- a/web/files/references.go
+++ b/web/files/references.go
@@ -169,14 +169,16 @@ func AddReferencesHandler(c echo.Context) error {
 		if errd != nil {
 			return WrapVfsError(errd)
 		}
-		if file == nil {
+		if dir != nil {
 			oldDir := dir.Clone()
 			dir.AddReferencedBy(docRef)
+			updateDirCozyMetadata(c, dir)
 			docs[i] = dir
 			oldDocs[i] = oldDir
 		} else {
 			oldFile := file.Clone()
 			file.AddReferencedBy(docRef)
+			updateFileCozyMetadata(c, file, false)
 			docs[i] = file
 			oldDocs[i] = oldFile
 		}
@@ -218,11 +220,13 @@ func RemoveReferencesHandler(c echo.Context) error {
 		if err != nil {
 			return WrapVfsError(err)
 		}
-		if file == nil {
+		if dir != nil {
 			dir.RemoveReferencedBy(docRef)
+			updateDirCozyMetadata(c, dir)
 			err = couchdb.UpdateDoc(instance, dir)
 		} else {
 			file.RemoveReferencedBy(docRef)
+			updateFileCozyMetadata(c, file, false)
 			err = couchdb.UpdateDoc(instance, file)
 		}
 		if err != nil {

--- a/web/jobs/jobs_test.go
+++ b/web/jobs/jobs_test.go
@@ -486,7 +486,8 @@ func SetToken(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		tok := middlewares.GetRequestToken(c)
 		// Forcing the token parsing to have the "claims" parameter in the
-		// context
+		// context (in production, it is done via
+		// middlewares.CheckInstanceBlocked)
 		_, err := middlewares.ParseJWT(c, testInstance, tok)
 		if err != nil {
 			return err

--- a/web/oidc/oidc.go
+++ b/web/oidc/oidc.go
@@ -163,12 +163,11 @@ func AccessToken(c echo.Context) error {
 		Type:  "bearer",
 		Scope: reqBody.Scope,
 	}
-	if auth.IsLinkedApp(client.SoftwareID) {
-		slug := auth.GetLinkedAppSlug(client.SoftwareID)
+	if slug := oauth.GetLinkedAppSlug(client.SoftwareID); slug != "" {
 		if err := auth.CheckLinkedAppInstalled(inst, slug); err != nil {
 			return err
 		}
-		out.Scope = auth.BuildLinkedAppScope(slug)
+		out.Scope = oauth.BuildLinkedAppScope(slug)
 	}
 	if out.Scope == "" {
 		return c.JSON(http.StatusBadRequest, echo.Map{

--- a/web/permissions/permissions.go
+++ b/web/permissions/permissions.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cozy/cozy-stack/pkg/jsonapi"
 	"github.com/cozy/cozy-stack/pkg/metadata"
 	"github.com/cozy/cozy-stack/pkg/prefixer"
-	"github.com/cozy/cozy-stack/web/auth"
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/cozy/echo"
 	"github.com/justincampbell/bigduration"
@@ -85,8 +84,7 @@ func createPermission(c echo.Context) error {
 	// Check if the permission is linked to an OAuth Client
 	if parent.Client != nil {
 		oauthClient := parent.Client.(*oauth.Client)
-		if auth.IsLinkedApp(oauthClient.SoftwareID) {
-			slug = auth.GetLinkedAppSlug(oauthClient.SoftwareID)
+		if slug = oauth.GetLinkedAppSlug(oauthClient.SoftwareID); slug != "" {
 			// Changing the sourceID from the OAuth clientID to the classic
 			// io.cozy.apps/slug one
 			sourceID = consts.Apps + "/" + slug
@@ -340,13 +338,10 @@ func revokePermission(c echo.Context) error {
 	if current.Client != nil {
 		oauthClient := current.Client.(*oauth.Client)
 
-		if auth.IsLinkedApp(oauthClient.SoftwareID) {
-			slug := auth.GetLinkedAppSlug(oauthClient.SoftwareID)
-
+		if slug := oauth.GetLinkedAppSlug(oauthClient.SoftwareID); slug != "" {
 			// Changing the sourceID from the OAuth clientID to the classic
 			// io.cozy.apps/slug one
 			current.SourceID = consts.Apps + "/" + slug
-
 		}
 	}
 

--- a/web/permissions/permissions_test.go
+++ b/web/permissions/permissions_test.go
@@ -829,7 +829,7 @@ func TestCreatePermissionWithoutMetadata(t *testing.T) {
 	assert.NoError(t, err)
 
 	type metaStruct struct {
-		Meta metadata.CozyMetaData `json:"cozyMetadata"`
+		Meta metadata.CozyMetadata `json:"cozyMetadata"`
 	}
 	type attrStruct struct {
 		Attributes metaStruct `json:"attributes"`
@@ -893,7 +893,7 @@ func TestCreatePermissionWithMetadata(t *testing.T) {
 	assert.NoError(t, err)
 
 	type metaStruct struct {
-		Meta metadata.CozyMetaData `json:"cozyMetadata"`
+		Meta metadata.CozyMetadata `json:"cozyMetadata"`
 	}
 	type attrStruct struct {
 		Attributes metaStruct `json:"attributes"`

--- a/worker/exec/konnector.go
+++ b/worker/exec/konnector.go
@@ -10,6 +10,7 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/cozy/afero"
 	"github.com/cozy/cozy-stack/model/account"
@@ -272,6 +273,11 @@ func (w *konnectorWorker) ensureFolderToSave(ctx *job.WorkerContext, inst *insta
 						Type: consts.Konnectors,
 						ID:   consts.Konnectors + "/" + w.slug,
 					})
+					if dir.CozyMetadata == nil {
+						dir.CozyMetadata = vfs.NewCozyMetadata(inst.PageURL("/", nil))
+					} else {
+						dir.CozyMetadata.UpdatedAt = time.Now()
+					}
 					_ = couchdb.UpdateDoc(inst, dir)
 				}
 				return nil

--- a/worker/thumbnail/thumbnail.go
+++ b/worker/thumbnail/thumbnail.go
@@ -144,6 +144,11 @@ func WorkerCheck(ctx *job.WorkerContext) error {
 			if meta != nil {
 				newImg := img.Clone().(*vfs.FileDoc)
 				newImg.Metadata = *meta
+				if newImg.CozyMetadata == nil {
+					newImg.CozyMetadata = vfs.NewCozyMetadata(ctx.Instance.PageURL("/", nil))
+				} else {
+					newImg.CozyMetadata.UpdatedAt = time.Now()
+				}
 				if err = fs.UpdateFileDoc(img, newImg); err != nil {
 					errm = multierror.Append(errm, err)
 				}

--- a/worker/unzip/unzip.go
+++ b/worker/unzip/unzip.go
@@ -100,7 +100,8 @@ func unzip(fs vfs.VFS, zipID, destination string) error {
 			return err
 		}
 		doc.CozyMetadata = vfs.NewCozyMetadata("")
-		doc.CozyMetadata.UploadedAt = doc.CozyMetadata.CreatedAt
+		at := doc.CozyMetadata.CreatedAt
+		doc.CozyMetadata.UploadedAt = &at
 		file, err := fs.CreateFile(doc, nil)
 		if err != nil {
 			if couchdb.IsConflictError(err) {

--- a/worker/unzip/unzip.go
+++ b/worker/unzip/unzip.go
@@ -99,6 +99,8 @@ func unzip(fs vfs.VFS, zipID, destination string) error {
 		if err != nil {
 			return err
 		}
+		doc.CozyMetadata = vfs.NewCozyMetadata("")
+		doc.CozyMetadata.UploadedAt = doc.CozyMetadata.CreatedAt
 		file, err := fs.CreateFile(doc, nil)
 		if err != nil {
 			if couchdb.IsConflictError(err) {


### PR DESCRIPTION
The goal of this pull request is to add cozyMetadata to the io.cozy.files doctype. It is a doctype managed by the stack, with custom routes. The clients have few things to do: only the konnectors can be interested by the `sourceAccount` and `sourceAccountIdentifier` that can't be automatically filled by the stack.

The `cozyMetadata` for the io.cozy.files have more fields than the standard: it has some fields like `createdOn` to know the instance on which the file was created, as it can be useful for files shared between several cozy instances, and has some fields related to the last upload (like `uploadedAt`). See https://github.com/cozy/cozy-doctypes/blob/master/docs/io.cozy.files.md#cozymetadata for more details.