### PR TITLE
feat(assets): Update cozy-bar to v7.1.0

### DIFF
--- a/assets/.externals
+++ b/assets/.externals
@@ -23,8 +23,8 @@ url     https://unpkg.com/cozy-ui@19.22.0/dist/cozy-ui.min.css
 sha256  2fe34fe5d0dc7e2657829c22af38590048c099c77ef6af390c73f0ec4d31b329
 
 name    ./js/cozy-bar.min.js
-url     https://unpkg.com/cozy-bar@6.25.7/dist/cozy-bar.min.js
-sha256  30e9da347bfc896cada4bc19309e904927fd37d221b381c723ff0582c83c725c
+url     https://unpkg.com/cozy-bar@7.1.0/dist/cozy-bar.min.js
+sha256  e4db9b5b622153c5e1ef1ca955dffef995732baffcbec8e28f8ea2e1be53d8e1
 
 name    ./css/cozy-bar.min.css
 url     https://unpkg.com/cozy-bar@6.25.7/dist/cozy-bar.min.css


### PR DESCRIPTION
This version fixes a bug we had because we used the transpiled version of cozy-ui. For more informations about the fix, please see https://github.com/cozy/cozy-bar/pull/582