### PR TITLE
Fork go-redis to have a stable API

### DIFF
--- a/model/job/redis_broker.go
+++ b/model/job/redis_broker.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/prefixer"
-	"github.com/go-redis/redis"
+	"github.com/cozy/redis"
 	multierror "github.com/hashicorp/go-multierror"
 )
 

--- a/model/job/redis_broker_test.go
+++ b/model/job/redis_broker_test.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	jobs "github.com/cozy/cozy-stack/model/job"
-	"github.com/go-redis/redis"
+	"github.com/cozy/redis"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/model/job/redis_scheduler.go
+++ b/model/job/redis_scheduler.go
@@ -15,7 +15,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/cozy/cozy-stack/pkg/realtime"
-	"github.com/go-redis/redis"
+	"github.com/cozy/redis"
 	"github.com/sirupsen/logrus"
 )
 

--- a/model/job/redis_scheduler_test.go
+++ b/model/job/redis_scheduler_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/realtime"
 	"github.com/cozy/cozy-stack/pkg/utils"
 	"github.com/cozy/cozy-stack/tests/testutils"
-	"github.com/go-redis/redis"
+	"github.com/cozy/redis"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/model/session/code_storage.go
+++ b/model/session/code_storage.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/logger"
-	"github.com/go-redis/redis"
+	"github.com/cozy/redis"
 )
 
 type codeStorage interface {

--- a/model/sharing/upload_store.go
+++ b/model/sharing/upload_store.go
@@ -9,7 +9,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/crypto"
 	"github.com/cozy/cozy-stack/pkg/prefixer"
-	"github.com/go-redis/redis"
+	"github.com/cozy/redis"
 )
 
 // A UploadStore is essentially an object to store files metadata by key

--- a/model/vfs/store.go
+++ b/model/vfs/store.go
@@ -9,7 +9,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/crypto"
 	"github.com/cozy/cozy-stack/pkg/prefixer"
-	"github.com/go-redis/redis"
+	"github.com/cozy/redis"
 )
 
 // Store is essentially a place to store transient objects between two HTTP

--- a/model/vfs/store_test.go
+++ b/model/vfs/store_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/cozy/cozy-stack/pkg/prefixer"
-	"github.com/go-redis/redis"
+	"github.com/cozy/redis"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-redis/redis"
+	"github.com/cozy/redis"
 )
 
 type cacheEntry struct {

--- a/pkg/config/config/config.go
+++ b/pkg/config/config/config.go
@@ -24,7 +24,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/tlsclient"
 	"github.com/cozy/cozy-stack/pkg/utils"
 	"github.com/cozy/gomail"
-	"github.com/go-redis/redis"
+	"github.com/cozy/redis"
 	"github.com/spf13/viper"
 )
 

--- a/pkg/config/dynamic/assets_test.go
+++ b/pkg/config/dynamic/assets_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/cache"
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/statik/fs"
-	"github.com/go-redis/redis"
+	"github.com/cozy/redis"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/limits/rate_limiting.go
+++ b/pkg/limits/rate_limiting.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/prefixer"
-	"github.com/go-redis/redis"
+	"github.com/cozy/redis"
 )
 
 // CounterType os an enum for the type of counters used by rate-limiting.

--- a/pkg/limits/rate_limiting_test.go
+++ b/pkg/limits/rate_limiting_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/cozy/cozy-stack/pkg/prefixer"
-	"github.com/go-redis/redis"
+	"github.com/cozy/redis"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/lock/simple_redis.go
+++ b/pkg/lock/simple_redis.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/cozy/cozy-stack/pkg/utils"
-	"github.com/go-redis/redis"
+	"github.com/cozy/redis"
 	"github.com/sirupsen/logrus"
 )
 

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -4,7 +4,7 @@ import (
 	"io/ioutil"
 	"sync"
 
-	"github.com/go-redis/redis"
+	"github.com/cozy/redis"
 	"github.com/sirupsen/logrus"
 )
 

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-redis/redis"
+	"github.com/cozy/redis"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )

--- a/pkg/realtime/realtime_test.go
+++ b/pkg/realtime/realtime_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/cozy/cozy-stack/pkg/prefixer"
-	"github.com/go-redis/redis"
+	"github.com/cozy/redis"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/realtime/redis_hub.go
+++ b/pkg/realtime/redis_hub.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/cozy/cozy-stack/pkg/prefixer"
-	redis "github.com/go-redis/redis"
+	redis "github.com/cozy/redis"
 )
 
 const eventsRedisKey = "realtime:events"

--- a/pkg/statik/fs/fs_test.go
+++ b/pkg/statik/fs/fs_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	"github.com/cozy/cozy-stack/pkg/cache"
-	"github.com/go-redis/redis"
+	"github.com/cozy/redis"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -7,6 +7,7 @@ if git grep -l \
   -e 'github.com/labstack/echo' \
   -e 'github.com/spf13/afero' \
   -e 'github.com/cozy/statik' \
+  -e 'github.com/go-redis/redis' \
   -- '*.go'; then
   echo "Forbidden packages"
   exit 1

--- a/web/accounts/statestore.go
+++ b/web/accounts/statestore.go
@@ -9,7 +9,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/crypto"
 	"github.com/cozy/cozy-stack/pkg/logger"
-	"github.com/go-redis/redis"
+	"github.com/cozy/redis"
 )
 
 const stateTTL = 15 * time.Minute

--- a/web/oidc/statestore.go
+++ b/web/oidc/statestore.go
@@ -9,7 +9,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/crypto"
 	"github.com/cozy/cozy-stack/pkg/logger"
-	"github.com/go-redis/redis"
+	"github.com/cozy/redis"
 )
 
 const stateTTL = 15 * time.Minute


### PR DESCRIPTION
Currently, github.com/go-redis/redis is in the work of a new version (v7), and it introduces some breaking changes. There are no known stable version, so let's fork it to have a stable API, at least until we have go modules or the new version is stable.