### PR TITLE
Allow mobile apps to declare notifications

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -53,6 +53,13 @@ notification:
 }
 ```
 
+For mobile application, there are two cases:
+
+- if the mobile application is linked to a web app, it will use the same
+  declaration of notifications from the manifest of the web app
+- else, the mobile app will need to declare its notifications when
+  [registering its OAuth client](https://docs.cozy.io/en/cozy-stack/auth/#post-authregister).
+
 ## Creating a notification
 
 ### POST /notifications

--- a/model/notification/center/notification_center.go
+++ b/model/notification/center/notification_center.go
@@ -85,10 +85,18 @@ func Push(inst *instance.Instance, perm *permission.Permission, n *notification.
 	switch perm.Type {
 	case permission.TypeOauth:
 		c, ok := perm.Client.(*oauth.Client)
-		if !ok || c.Notifications == nil {
+		if !ok {
 			return ErrUnauthorized
 		}
-		p, ok = c.Notifications[n.Category]
+		if slug := oauth.GetLinkedAppSlug(c.SoftwareID); slug != "" {
+			m, err := app.GetWebappBySlug(inst, slug)
+			if err != nil || m.Notifications == nil {
+				return err
+			}
+			p, ok = m.Notifications[n.Category]
+		} else if c.Notifications != nil {
+			p, ok = c.Notifications[n.Category]
+		}
 		if !ok {
 			return ErrUnauthorized
 		}


### PR DESCRIPTION
The stack requires that apps declare their notifications before sending them. If a mobile app is linked to a web app, the stack will use the declaration from the web app manifest for it.