### PR TITLE
Fix sharing from Drive Mobile

### DIFF
--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cozy/cozy-stack/model/contact"
 	"github.com/cozy/cozy-stack/model/instance"
+	"github.com/cozy/cozy-stack/model/oauth"
 	"github.com/cozy/cozy-stack/model/permission"
 	"github.com/cozy/cozy-stack/model/sharing"
 	"github.com/cozy/cozy-stack/model/vfs"
@@ -544,6 +545,12 @@ func checkCreatePermissions(c echo.Context, s *sharing.Sharing) (string, error) 
 		}
 	}
 	if requestPerm.Type == permission.TypeOauth {
+		if requestPerm.Client != nil {
+			oauthClient := requestPerm.Client.(*oauth.Client)
+			if slug := oauth.GetLinkedAppSlug(oauthClient.SoftwareID); slug != "" {
+				return slug, nil
+			}
+		}
 		return "", nil
 	}
 	return extractSlugFromSourceID(requestPerm.SourceID)


### PR DESCRIPTION
When a sharing is created from an OAuth app that is linked to a web app, the stack should use this app slug to create the link sent in the mail.