### PR TITLE
Clean the old versions of the files

### DIFF
--- a/cozy.example.yaml
+++ b/cozy.example.yaml
@@ -68,6 +68,10 @@ fs:
   # pinned_key: 57c8ff33c9c0cfc3ef00e650a1cc910d7ee479a8bc509f6c9209a7c2a11399d6
   # insecure_skip_validation: true
 
+  # versioning:
+  #   max_number_of_versions_to_keep: 20
+  #   min_delay_between_two_versions: 15m
+
 # couchdb parameters
 couchdb:
   # CouchDB URL - flags: --couchdb-url

--- a/model/vfs/version_test.go
+++ b/model/vfs/version_test.go
@@ -1,0 +1,88 @@
+package vfs
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cozy/cozy-stack/pkg/utils"
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func uuidv4() string {
+	id, _ := uuid.NewV4()
+	return id.String()
+}
+
+func TestDetectVersionsToClean(t *testing.T) {
+	fileID := uuidv4()
+	now := time.Now()
+	genVersion := func(timeAgo time.Duration) Version {
+		v := Version{
+			DocID: fileID + "/" + utils.RandomString(16),
+		}
+		v.CozyMetadata.CreatedAt = now.Add(-1 * timeAgo)
+		return v
+	}
+
+	v0 := genVersion(120 * time.Minute)
+	v1 := genVersion(100 * time.Minute)
+	v2 := genVersion(80 * time.Minute)
+	v3 := genVersion(60 * time.Minute)
+	v4 := genVersion(40 * time.Minute)
+	v5 := genVersion(20 * time.Minute)
+	v6 := genVersion(2 * time.Minute)
+	candidate := genVersion(0 * time.Minute)
+
+	olds := []*Version{&v0, &v1, &v2}
+	cleanCandidate, toClean := detectVersionsToClean(&candidate, olds, 20, 1*time.Minute)
+	assert.False(t, cleanCandidate)
+	assert.Len(t, toClean, 0)
+
+	olds = []*Version{&v0, &v1, &v2, &v3, &v4, &v5, &v6}
+	cleanCandidate, toClean = detectVersionsToClean(&candidate, olds, 20, 15*time.Minute)
+	assert.True(t, cleanCandidate)
+	assert.Len(t, toClean, 0)
+
+	olds = []*Version{&v1, &v2, &v3, &v4, &v5}
+	cleanCandidate, toClean = detectVersionsToClean(&candidate, olds, 5, 30*time.Minute)
+	assert.True(t, cleanCandidate)
+	assert.Len(t, toClean, 1)
+	assert.Equal(t, &v1, toClean[0])
+
+	olds = []*Version{&v1, &v2, &v3, &v4}
+	cleanCandidate, toClean = detectVersionsToClean(&candidate, olds, 5, 15*time.Minute)
+	assert.False(t, cleanCandidate)
+	assert.Len(t, toClean, 1)
+	assert.Equal(t, &v1, toClean[0])
+
+	olds = []*Version{&v3, &v6, &v2, &v0, &v5, &v4, &v1}
+	cleanCandidate, toClean = detectVersionsToClean(&candidate, olds, 5, 1*time.Minute)
+	assert.False(t, cleanCandidate)
+	assert.Len(t, toClean, 4)
+	assert.Equal(t, &v0, toClean[0])
+	assert.Equal(t, &v1, toClean[1])
+	assert.Equal(t, &v2, toClean[2])
+	assert.Equal(t, &v3, toClean[3])
+
+	olds = []*Version{&v3, &v6, &v2, &v0, &v5, &v4, &v1}
+	cleanCandidate, toClean = detectVersionsToClean(&candidate, olds, 5, 10*time.Minute)
+	assert.True(t, cleanCandidate)
+	assert.Len(t, toClean, 3)
+	assert.Equal(t, &v0, toClean[0])
+	assert.Equal(t, &v1, toClean[1])
+	assert.Equal(t, &v2, toClean[2])
+
+	v0.Tags = []string{"foo"}
+	v2.Tags = []string{"bar", "baz"}
+	candidate.Tags = []string{"qux"}
+
+	olds = []*Version{&v3, &v6, &v2, &v0, &v5, &v4, &v1}
+	cleanCandidate, toClean = detectVersionsToClean(&candidate, olds, 5, 10*time.Minute)
+	assert.False(t, cleanCandidate)
+	assert.Len(t, toClean, 4)
+	assert.Equal(t, &v1, toClean[0])
+	assert.Equal(t, &v3, toClean[1])
+	assert.Equal(t, &v4, toClean[2])
+	assert.Equal(t, &v5, toClean[3])
+}

--- a/pkg/config/config/config.go
+++ b/pkg/config/config/config.go
@@ -155,9 +155,16 @@ func (v *Vault) CredentialsDecryptorKey() *keymgmt.NACLKey {
 
 // Fs contains the configuration values of the file-system
 type Fs struct {
-	Auth      *url.Userinfo
-	URL       *url.URL
-	Transport http.RoundTripper
+	Auth       *url.Userinfo
+	URL        *url.URL
+	Transport  http.RoundTripper
+	Versioning FsVersioning
+}
+
+// FsVersioning contains the configuration for the versioning of files
+type FsVersioning struct {
+	MaxNumberToKeep            int
+	MinDelayBetweenTwoVersions time.Duration
 }
 
 // CouchDB contains the configuration values of the database
@@ -385,6 +392,8 @@ func applyDefaults(v *viper.Viper) {
 	v.SetDefault("jobs.defaultDurationToKeep", "2W")
 	v.SetDefault("assets_polling_disabled", false)
 	v.SetDefault("assets_polling_interval", 2*time.Minute)
+	v.SetDefault("fs.versioning.max_number_of_versions_to_keep", 20)
+	v.SetDefault("fs.versioning.min_delay_between_two_versions", 15*time.Minute)
 }
 
 func envMap() map[string]string {
@@ -623,6 +632,10 @@ func UseViper(v *viper.Viper) error {
 		Fs: Fs{
 			URL:       fsURL,
 			Transport: fsClient.Transport,
+			Versioning: FsVersioning{
+				MaxNumberToKeep:            v.GetInt("fs.versioning.max_number_of_versions_to_keep"),
+				MinDelayBetweenTwoVersions: v.GetDuration("fs.versioning.min_delay_between_two_versions"),
+			},
 		},
 		CouchDB: CouchDB{
 			Auth:   couchAuth,

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -1036,17 +1036,26 @@ func TestGetDirMetadataFromID(t *testing.T) {
 }
 
 func TestVersions(t *testing.T) {
+	cfg := config.GetConfig()
+	oldDelay := cfg.Fs.Versioning.MinDelayBetweenTwoVersions
+	cfg.Fs.Versioning.MinDelayBetweenTwoVersions = 10 * time.Millisecond
+	defer func() {
+		cfg.Fs.Versioning.MinDelayBetweenTwoVersions = oldDelay
+	}()
+
 	res1, body1 := upload(t, "/files/?Type=file&Name=versioned", "text/plain", "one", "")
 	assert.Equal(t, 201, res1.StatusCode)
 	data1 := body1["data"].(map[string]interface{})
 	attr1 := data1["attributes"].(map[string]interface{})
 	sum1 := attr1["md5sum"]
 	fileID := data1["id"].(string)
+	time.Sleep(20 * time.Millisecond)
 	res2, body2 := uploadMod(t, "/files/"+fileID, "text/plain", "two", "")
 	assert.Equal(t, 200, res2.StatusCode)
 	data2 := body2["data"].(map[string]interface{})
 	attr2 := data2["attributes"].(map[string]interface{})
 	sum2 := attr2["md5sum"]
+	time.Sleep(20 * time.Millisecond)
 	res3, body3 := uploadMod(t, "/files/"+fileID, "text/plain", "three", "")
 	assert.Equal(t, 200, res3.StatusCode)
 	data3 := body3["data"].(map[string]interface{})


### PR DESCRIPTION
When a file is changed, a new version is created, and the stack also checks if old versions should be cleaned.

1. The versions that are tagged are always kept.
2. If two versions are too close in time, the latter is cleaned (15 minutes by default, configurable)
3. When there are too many versions for a file, the old versions are cleaned, except if they were tagged (20 versions by default, configurable).