### PR TITLE
 Add migrations to swift layout v3 

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -144,6 +144,9 @@ func init() {
 	flags.String("fs-url", defaultFsURL.String(), "filesystem url")
 	checkNoErr(viper.BindPFlag("fs.url", flags.Lookup("fs-url")))
 
+	flags.Int("fs-default-layout", -1, "Default layout for Swift (2 for layout v3)")
+	checkNoErr(viper.BindPFlag("fs.default_layout", flags.Lookup("fs-default-layout")))
+
 	flags.String("couchdb-url", "http://localhost:5984/", "CouchDB URL")
 	checkNoErr(viper.BindPFlag("couchdb.url", flags.Lookup("couchdb-url")))
 

--- a/cozy.example.yaml
+++ b/cozy.example.yaml
@@ -110,15 +110,16 @@ jobs:
   #
   #   - "export":          exporting data from a cozy instance
   #   - "konnector":       launching konnectors
+  #   - "migrations":      transforming a VFS with Swift to layout v3
   #   - "push":            sending push notifications
   #   - "sendmail":        sending mails
   #   - "service":         launching services
-  #   - "thumbnail":       creatings and deleting thumbnails for images
   #   - "share-replicate": for cozy to cozy sharing
   #   - "share-track":     idem
   #   - "share-upload":    idem
+  #   - "thumbnail":       creatings and deleting thumbnails for images
   #   - "unzip":           unzipping tarball
-  #   - "updates":         run updates for installed applications
+  #   - "updates":         run updates for installed applications (deprecated)
   #   - "zip":             creating a zip tarball
   #
   # When no configuration is given for a worker, a default configuration is

--- a/docs/cli/cozy-stack_serve.md
+++ b/docs/cli/cozy-stack_serve.md
@@ -46,6 +46,7 @@ example), you can use the --appdir flag like this:
       --disable-csp                      Disable the Content Security Policy (only available for development)
       --doctypes string                  path to the directory with the doctypes (for developing/testing a remote doctype)
       --downloads-url string             URL for the download secret storage, redis or in-memory
+      --fs-default-layout int            Default layout for Swift (2 for layout v3) (default -1)
       --fs-url string                    filesystem url (default "file:///storage")
       --geodb string                     define the location of the database for IP -> City lookups (default ".")
   -h, --help                             help for serve

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -282,13 +282,21 @@ optionaly the old version of this document.
 The message is composed of a sharing ID and a count of the number of errors
 (i.e. the number of times this job was retried).
 
+## migrations
+
+The `migrations` worker can be used to migrate a cozy instance that has its
+files in swift from a V1 or V2 layout to a V3 layout. Currently, it has a
+single option, `type`, with a single supported value, `to-swift-v3`.
+
+### Example
+
+It can be launched from command-line with:
+
+```sh
+$ cozy-stack jobs run migrations --domain example.mycozy.cloud --json '{"type": "to-swift-v3"}'
+```
+
 ## Deprecated workers
-
-### migrations
-
-The `migrations` worker was used for migrating cozy instance that had their
-files in swift from a V1 layout to a V2 layout. The code is probably not in
-a good shape, and it would be safer to rework it before using it.
 
 ### updates
 

--- a/model/vfs/vfs.go
+++ b/model/vfs/vfs.go
@@ -544,6 +544,12 @@ func WalkByID(fs Indexer, fileID string, walkFn WalkFn) error {
 	return walk(fs, root, dir, file, walkFn, 0)
 }
 
+// WalkAlreadyLocked walks the file tree rooted on the given directory. It is
+// the responsibility of the caller to ensure the VFS is already locked (read).
+func WalkAlreadyLocked(fs Indexer, dir *DirDoc, walkFn WalkFn) error {
+	return walk(fs, dir.Fullpath, dir, nil, walkFn, 0)
+}
+
 func walk(fs Indexer, name string, dir *DirDoc, file *FileDoc, walkFn WalkFn, count int) error {
 	if count >= maxWalkRecursive {
 		return ErrWalkOverflow

--- a/model/vfs/vfsswift/impl_v1.go
+++ b/model/vfs/vfsswift/impl_v1.go
@@ -137,13 +137,13 @@ func (sfs *swiftVFS) Delete() error {
 			sfs.container, err)
 	}
 	var errm error
-	if err = deleteContainer(sfs.c, sfs.version); err != nil {
+	if err = DeleteContainer(sfs.c, sfs.version); err != nil {
 		errm = multierror.Append(errm, err)
 	}
-	if err = deleteContainer(sfs.c, sfs.container); err != nil {
+	if err = DeleteContainer(sfs.c, sfs.container); err != nil {
 		errm = multierror.Append(errm, err)
 	}
-	if err = deleteContainer(sfs.c, sfs.dataContainer); err != nil {
+	if err = DeleteContainer(sfs.c, sfs.dataContainer); err != nil {
 		errm = multierror.Append(errm, err)
 	}
 	return errm

--- a/model/vfs/vfsswift/impl_v2.go
+++ b/model/vfs/vfsswift/impl_v2.go
@@ -162,13 +162,13 @@ func (sfs *swiftVFSV2) Delete() error {
 			sfs.container, err)
 	}
 	var errm error
-	if err = deleteContainer(sfs.c, sfs.version); err != nil {
+	if err = DeleteContainer(sfs.c, sfs.version); err != nil {
 		errm = multierror.Append(errm, err)
 	}
-	if err = deleteContainer(sfs.c, sfs.container); err != nil {
+	if err = DeleteContainer(sfs.c, sfs.container); err != nil {
 		errm = multierror.Append(errm, err)
 	}
-	if err = deleteContainer(sfs.c, sfs.dataContainer); err != nil {
+	if err = DeleteContainer(sfs.c, sfs.dataContainer); err != nil {
 		errm = multierror.Append(errm, err)
 	}
 	return errm

--- a/model/vfs/vfsswift/impl_v3.go
+++ b/model/vfs/vfsswift/impl_v3.go
@@ -58,8 +58,8 @@ func NewV3(db prefixer.Prefixer, index vfs.Indexer, disk vfs.DiskThresholder, mu
 	}, nil
 }
 
-// newInternalID returns a random string that can be used as an internal_vfs_id.
-func newInternalID() string {
+// NewInternalID returns a random string that can be used as an internal_vfs_id.
+func NewInternalID() string {
 	return utils.RandomString(16)
 }
 
@@ -135,7 +135,7 @@ func (sfs *swiftVFSV3) Delete() error {
 		sfs.log.Errorf("Could not mark container %q as to-be-deleted: %s",
 			sfs.container, err)
 	}
-	return deleteContainer(sfs.c, sfs.container)
+	return DeleteContainer(sfs.c, sfs.container)
 }
 
 func (sfs *swiftVFSV3) CreateDir(doc *vfs.DirDoc) error {
@@ -212,7 +212,7 @@ func (sfs *swiftVFSV3) CreateFile(newdoc, olddoc *vfs.FileDoc) (vfs.File, error)
 		}
 	}
 
-	newdoc.InternalID = newInternalID()
+	newdoc.InternalID = NewInternalID()
 	objName := MakeObjectNameV3(newdoc.DocID, newdoc.InternalID)
 	objMeta := swift.Metadata{
 		"creation-name": newdoc.Name(),

--- a/model/vfs/vfsswift/swift.go
+++ b/model/vfs/vfsswift/swift.go
@@ -13,7 +13,9 @@ const maxNbFilesToDelete = 8000
 // delete files in the same container.
 const maxSimultaneousCalls = 8
 
-func deleteContainer(c *swift.Connection, container string) error {
+// DeleteContainer removes all the files inside the given container, and then
+// deletes it.
+func DeleteContainer(c *swift.Connection, container string) error {
 	_, _, err := c.Container(container)
 	if err == swift.ContainerNotFound {
 		return nil


### PR DESCRIPTION
The migration worker can now migrate instances in Swift layout v1 and Swift layout v2 to Swift layout v3.