### PR TITLE
Make cozy-stack instances ls faster

### DIFF
--- a/model/instance/instance.go
+++ b/model/instance/instance.go
@@ -588,7 +588,7 @@ func List() ([]*Instance, error) {
 
 // ForeachInstances execute the given callback for each instances.
 func ForeachInstances(fn func(*Instance) error) error {
-	return couchdb.ForeachDocs(couchdb.GlobalDB, consts.Instances, func(_ string, data json.RawMessage) error {
+	return couchdb.ForeachDocsWithCustomPagination(couchdb.GlobalDB, consts.Instances, 10000, func(_ string, data json.RawMessage) error {
 		var doc *Instance
 		if err := json.Unmarshal(data, &doc); err != nil {
 			return err

--- a/pkg/couchdb/bulk.go
+++ b/pkg/couchdb/bulk.go
@@ -110,8 +110,14 @@ func GetAllDocs(db Database, doctype string, req *AllDocsRequest, results interf
 // ForeachDocs traverse all the documents from the given database with the
 // specified doctype and calls a function for each document.
 func ForeachDocs(db Database, doctype string, fn func(id string, doc json.RawMessage) error) error {
+	return ForeachDocsWithCustomPagination(db, doctype, 100, fn)
+}
+
+// ForeachDocsWithCustomPagination traverse all the documents from the given
+// database, and calls a function for each document. The documents are fetched
+// from CouchDB with a pagination with a custom number of items per page.
+func ForeachDocsWithCustomPagination(db Database, doctype string, limit int, fn func(id string, doc json.RawMessage) error) error {
 	var startKey string
-	limit := 100
 	for {
 		skip := 0
 		if startKey != "" {


### PR DESCRIPTION
Listing instances is done by fetching the instance information from CouchDB with pagination. By fetching 100 instances per page, we are making a lot of calls, and each call has a fixed latency that makes the
whole slow. We want to keep to pagination to avoid timeouts, but we can increase the number of items per page to 10000 to make the listing faster.