### PR TITLE
Add pagination for /apps route

### DIFF
--- a/docs/apps.md
+++ b/docs/apps.md
@@ -426,7 +426,62 @@ Content-Type: application/vnd.api+json
       "icon": "/apps/calendar/icon",
       "related": "https://calendar.alice.example.com/"
     }
-  }]
+  }],
+  "links": {},
+  "meta": {
+    "count": 1
+  }
+}
+```
+
+This endpoint is paginated, default limit is currently `100`.
+Two flags are available to retreieve the other apps if there are more than `100`
+apps installed:
+- `limit`
+- `start_key`: The first following doc ID of the next apps
+
+The `links` object contains a `ǹext` generated-link for the next docs.
+
+#### Request
+
+```http
+GET /apps/?limit=50 HTTP/1.1
+Accept: application/vnd.api+json
+```
+
+#### Response
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/vnd.api+json
+```
+
+```json
+{
+  "data": [{
+    "id": "4cfbd8be-8968-11e6-9708-ef55b7c20863",
+    "type": "io.cozy.apps",
+    "meta": {
+      "rev": "2-bbfb0fc32dfcdb5333b28934f195b96a"
+    },
+    "attributes": {
+      "name": "calendar",
+      "state": "ready",
+      "slug": "calendar",
+      ...
+    },
+    "links": {
+      "self": "/apps/calendar",
+      "icon": "/apps/calendar/icon",
+      "related": "https://calendar.alice.example.com/"
+    }
+  }, {...}],
+  "links": {
+    "next": "http://alice.example.com/apps/?limit=50&start_key=io.cozy.apps%2Fhome"
+  },
+  "meta": {
+    "count": 50
+  }
 }
 ```
 

--- a/docs/konnectors.md
+++ b/docs/konnectors.md
@@ -218,7 +218,60 @@ Content-Type: application/vnd.api+json
     "links": {
       "self": "/konnectors/bank101"
     }
-  }]
+  }],
+  "links": {},
+  "meta": {
+    "count": 1
+  }
+}
+```
+
+This endpoint is paginated, default limit is currently `100`.
+Two flags are available to retreieve the other konnectors if there are more than
+`100` konnectors installed:
+- `limit`
+- `start_key`: The first following doc ID of the next konnectors
+
+The `links` object contains a `ǹext` generated-link for the next docs.
+
+#### Request
+
+```http
+GET /konnectors/?limit=50 HTTP/1.1
+Accept: application/vnd.api+json
+```
+
+#### Response
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/vnd.api+json
+```
+
+```json
+{
+  "data": [{
+    "id": "4cfbd8be-8968-11e6-9708-ef55b7c20863",
+    "type": "io.cozy.konnectors",
+    "meta": {
+      "rev": "1-7a1f918147df94580c92b47275e4604a"
+    },
+    "attributes": {
+      "name": "bank101",
+      "state": "installing",
+      "slug": "bank101",
+      ...
+    },
+    "links": {
+      "self": "/konnectors/bank101"
+    }
+  }, {...}],
+  "links": {
+    "next": "http://alice.example.com/konnectors/?limit=50&start_key=io.cozy.konnectors%2Ffookonnector"
+  },
+  "meta": {
+    "count": 50
+  }
 }
 ```
 
@@ -228,7 +281,7 @@ Content-Type: application/vnd.api+json
 
 ## Uninstall a konnector
 
-### DELETE /apps/:slug
+### DELETE /konnectors/:slug
 
 #### Request
 

--- a/model/app/konnector.go
+++ b/model/app/konnector.go
@@ -315,7 +315,7 @@ func ListKonnectorsWithPagination(db prefixer.Prefixer, limit int, startKey stri
 	}
 
 	nextID := ""
-	if len(docs) > 0 && len(docs) == limit+1 { // There is still documents to fetch
+	if len(docs) > 0 && len(docs) == limit+1 { // There are still documents to fetch
 		nextDoc := docs[len(docs)-1]
 		nextID = nextDoc.ID()
 		docs = docs[:len(docs)-1]

--- a/model/app/konnector.go
+++ b/model/app/konnector.go
@@ -280,22 +280,6 @@ func GetKonnectorBySlugAndUpdate(db prefixer.Prefixer, slug string, copier appfs
 	return DoLazyUpdate(db, man, copier, registries).(*KonnManifest), nil
 }
 
-// ListKonnectors returns the list of installed konnectors applications.
-//
-func ListKonnectors(db prefixer.Prefixer) ([]Manifest, error) {
-	var docs []*KonnManifest
-	req := &couchdb.AllDocsRequest{Limit: 100}
-	err := couchdb.GetAllDocs(db, consts.Konnectors, req, &docs)
-	if err != nil {
-		return nil, err
-	}
-	mans := make([]Manifest, len(docs))
-	for i, m := range docs {
-		mans[i] = m
-	}
-	return mans, nil
-}
-
 // ListKonnectorsWithPagination returns the list of installed konnectors with a
 // pagination
 func ListKonnectorsWithPagination(db prefixer.Prefixer, limit int, startKey string) ([]*KonnManifest, string, error) {

--- a/model/app/webapp.go
+++ b/model/app/webapp.go
@@ -552,23 +552,6 @@ func GetWebappBySlugAndUpdate(db prefixer.Prefixer, slug string, copier appfs.Co
 	return DoLazyUpdate(db, man, copier, registries).(*WebappManifest), nil
 }
 
-// ListWebapps returns the list of installed web applications.
-//
-func ListWebapps(db prefixer.Prefixer) ([]*WebappManifest, error) {
-	var docs []*WebappManifest
-	req := &couchdb.AllDocsRequest{Limit: 100}
-	err := couchdb.GetAllDocs(db, consts.Apps, req, &docs)
-	if err != nil {
-		return nil, err
-	}
-	for slug := range appsdir {
-		if man, err := loadManifestFromDir(slug); err == nil {
-			docs = append(docs, man)
-		}
-	}
-	return docs, nil
-}
-
 // ListWebappsWithPagination returns the list of installed web applications with
 // a pagination
 func ListWebappsWithPagination(db prefixer.Prefixer, limit int, startKey string) ([]*WebappManifest, string, error) {

--- a/model/app/webapp.go
+++ b/model/app/webapp.go
@@ -588,7 +588,7 @@ func ListWebappsWithPagination(db prefixer.Prefixer, limit int, startKey string)
 	}
 
 	nextID := ""
-	if len(docs) > 0 && len(docs) == limit+1 { // There is still documents to fetch
+	if len(docs) > 0 && len(docs) == limit+1 { // There are still documents to fetch
 		nextDoc := docs[len(docs)-1]
 		nextID = nextDoc.ID()
 		docs = docs[:len(docs)-1]

--- a/model/app/webapp_test.go
+++ b/model/app/webapp_test.go
@@ -19,7 +19,9 @@ func TestListWebappsWithPagination(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	defer lifecycle.Destroy(testInstance.Domain)
+	defer func() {
+		_ = lifecycle.Destroy(testInstance.Domain)
+	}()
 
 	// Install the apps
 	for _, a := range []string{"drive", "home", "settings"} {

--- a/model/app/webapp_test.go
+++ b/model/app/webapp_test.go
@@ -1,0 +1,62 @@
+package app_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cozy/cozy-stack/model/app"
+	"github.com/cozy/cozy-stack/model/instance/lifecycle"
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListWebappsWithPagination(t *testing.T) {
+	of := true
+	testInstance, err := lifecycle.Create(&lifecycle.Options{
+		Domain:             "test-list-webapp-pagination",
+		ContextName:        "foocontext",
+		OnboardingFinished: &of,
+	})
+	assert.NoError(t, err)
+
+	defer lifecycle.Destroy(testInstance.Domain)
+
+	// Install the apps
+	for _, a := range []string{"drive", "home", "settings"} {
+		installer, err := app.NewInstaller(testInstance, testInstance.AppsCopier(consts.WebappType), &app.InstallerOptions{
+			Operation:  app.Install,
+			Type:       consts.WebappType,
+			SourceURL:  fmt.Sprintf("registry://%s", a),
+			Slug:       a,
+			Registries: testInstance.Registries(),
+		})
+		assert.NoError(t, err)
+		_, err = installer.RunSync()
+		assert.NoError(t, err)
+	}
+
+	// Test the pagination
+	apps, next, err := app.ListWebappsWithPagination(testInstance, 1, "")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(apps))
+	assert.NotEqual(t, "", next)
+
+	// Retreiving the first two apps
+	apps, next, err = app.ListWebappsWithPagination(testInstance, 2, "")
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(apps))
+	assert.NotEqual(t, "", next)
+
+	// Same limit as before, we should get the last app
+	apps, next, err = app.ListWebappsWithPagination(testInstance, 2, next)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(apps))
+	assert.Equal(t, "", next)
+
+	// With limit = 0, the default limit will be applied, we should get all the
+	// apps
+	apps, next, err = app.ListWebappsWithPagination(testInstance, 0, next)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(apps))
+	assert.Equal(t, "", next)
+}

--- a/model/intent/intents.go
+++ b/model/intent/intents.go
@@ -92,7 +92,7 @@ func (in *Intent) GenerateHref(instance *instance.Instance, slug, target string)
 // FillServices looks at all the application that can answer this intent
 // and save them in the services field
 func (in *Intent) FillServices(instance *instance.Instance) error {
-	res, err := app.ListWebapps(instance)
+	res, _, err := app.ListWebappsWithPagination(instance, 0, "")
 	if err != nil {
 		return err
 	}
@@ -154,7 +154,7 @@ func GetInstanceWebapps(inst *instance.Instance) ([]string, error) {
 // non-installed instance webapps
 func (in *Intent) FillAvailableWebapps(inst *instance.Instance) error {
 	// Webapps to exclude
-	installedWebApps, err := app.ListWebapps(inst)
+	installedWebApps, _, err := app.ListWebappsWithPagination(inst, 0, "")
 	if err != nil {
 		return err
 	}

--- a/web/apps/apps.go
+++ b/web/apps/apps.go
@@ -328,7 +328,7 @@ func listWebappsHandler(c echo.Context) error {
 
 	// Generating links list for the next apps
 	links := &jsonapi.LinksList{}
-	if next != "" { // Do not generate the next URL if there is no next apps
+	if next != "" { // Do not generate the next URL if there are no next apps
 		links.Next = generateNextURL(c, limit, next)
 	}
 
@@ -367,7 +367,7 @@ func listKonnectorsHandler(c echo.Context) error {
 
 	// Generating links list for the next konnectors
 	links := &jsonapi.LinksList{}
-	if next != "" { // Do not generate the next URL if there is no next konnectors
+	if next != "" { // Do not generate the next URL if there are no next konnectors
 		links.Next = generateNextURL(c, limit, next)
 	}
 

--- a/web/apps/apps.go
+++ b/web/apps/apps.go
@@ -303,10 +303,7 @@ func listWebappsHandler(c echo.Context) error {
 	}
 
 	// Adding the startKey if it is given in the request
-	var startKey string
-	if sk := c.QueryParam("start_key"); sk != "" {
-		startKey = sk
-	}
+	startKey := c.QueryParam("start_key")
 
 	// Same for the limit
 	var limit int
@@ -327,10 +324,7 @@ func listWebappsHandler(c echo.Context) error {
 	}
 
 	// Generating links list for the next apps
-	links := &jsonapi.LinksList{}
-	if next != "" { // Do not generate the next URL if there are no next apps
-		links.Next = generateNextURL(c, limit, next)
-	}
+	links := generateLinksList(c, next, limit, next)
 
 	return jsonapi.DataList(c, http.StatusOK, objs, links)
 }
@@ -366,26 +360,27 @@ func listKonnectorsHandler(c echo.Context) error {
 	}
 
 	// Generating links list for the next konnectors
-	links := &jsonapi.LinksList{}
-	if next != "" { // Do not generate the next URL if there are no next konnectors
-		links.Next = generateNextURL(c, limit, next)
-	}
+	links := generateLinksList(c, next, limit, next)
 
 	return jsonapi.DataList(c, http.StatusOK, objs, links)
 }
 
-func generateNextURL(c echo.Context, limit int, nextID string) string {
-	nextURL := &url.URL{
-		Scheme: c.Scheme(),
-		Host:   c.Request().Host,
-		Path:   c.Path(),
-	}
-	values := nextURL.Query()
-	values.Set("start_key", nextID)
-	values.Set("limit", strconv.Itoa(limit))
-	nextURL.RawQuery = values.Encode()
+func generateLinksList(c echo.Context, next string, limit int, nextID string) *jsonapi.LinksList {
+	links := &jsonapi.LinksList{}
+	if next != "" { // Do not generate the next URL if there are no next konnectors
+		nextURL := &url.URL{
+			Scheme: c.Scheme(),
+			Host:   c.Request().Host,
+			Path:   c.Path(),
+		}
+		values := nextURL.Query()
+		values.Set("start_key", nextID)
+		values.Set("limit", strconv.Itoa(limit))
+		nextURL.RawQuery = values.Encode()
 
-	return nextURL.String()
+		links.Next = nextURL.String()
+	}
+	return links
 }
 
 // iconHandler gives the icon of an application

--- a/web/apps/apps.go
+++ b/web/apps/apps.go
@@ -327,20 +327,9 @@ func listWebappsHandler(c echo.Context) error {
 	}
 
 	// Generating links list for the next apps
-	nextURL := &url.URL{}
-
+	links := &jsonapi.LinksList{}
 	if next != "" { // Do not generate the next URL if there is no next apps
-		nextURL, _ = url.Parse(c.Scheme() + "://" + c.Request().Host + c.Path())
-		values := nextURL.Query()
-		values.Set("start_key", next)
-		if limit != 0 {
-			values.Set("limit", strconv.Itoa(limit))
-		}
-		nextURL.RawQuery = values.Encode()
-	}
-
-	links := &jsonapi.LinksList{
-		Next: nextURL.String(),
+		links.Next = generateNextURL(c, limit, next)
 	}
 
 	return jsonapi.DataList(c, http.StatusOK, objs, links)
@@ -377,23 +366,26 @@ func listKonnectorsHandler(c echo.Context) error {
 	}
 
 	// Generating links list for the next konnectors
-	nextURL := &url.URL{}
-
+	links := &jsonapi.LinksList{}
 	if next != "" { // Do not generate the next URL if there is no next konnectors
-		nextURL, _ = url.Parse(c.Scheme() + "://" + c.Request().Host + c.Path())
-		values := nextURL.Query()
-		values.Set("start_key", next)
-		if limit != 0 {
-			values.Set("limit", strconv.Itoa(limit))
-		}
-		nextURL.RawQuery = values.Encode()
-	}
-
-	links := &jsonapi.LinksList{
-		Next: nextURL.String(),
+		links.Next = generateNextURL(c, limit, next)
 	}
 
 	return jsonapi.DataList(c, http.StatusOK, objs, links)
+}
+
+func generateNextURL(c echo.Context, limit int, nextID string) string {
+	nextURL := &url.URL{
+		Scheme: c.Scheme(),
+		Host:   c.Request().Host,
+		Path:   c.Path(),
+	}
+	values := nextURL.Query()
+	values.Set("start_key", nextID)
+	values.Set("limit", strconv.Itoa(limit))
+	nextURL.RawQuery = values.Encode()
+
+	return nextURL.String()
 }
 
 // iconHandler gives the icon of an application

--- a/web/instances/instances.go
+++ b/web/instances/instances.go
@@ -312,7 +312,7 @@ func cleanOrphanAccounts(c echo.Context) error {
 		return err
 	}
 
-	konnectors, err := app.ListKonnectors(db)
+	konnectors, _, err := app.ListKonnectorsWithPagination(db, 0, "")
 	if couchdb.IsNoDatabaseError(err) {
 		return c.JSON(http.StatusOK, results)
 	}

--- a/worker/updates/updates.go
+++ b/worker/updates/updates.go
@@ -239,7 +239,7 @@ func installerPush(inst *instance.Instance, insc chan *app.Installer, errc chan 
 
 	go func() {
 		defer g.Done()
-		webapps, err := app.ListWebapps(inst)
+		webapps, _, err := app.ListWebappsWithPagination(inst, 0, "")
 		if err != nil {
 			errc <- &updateError{
 				domain: inst.Domain,
@@ -271,7 +271,7 @@ func installerPush(inst *instance.Instance, insc chan *app.Installer, errc chan 
 
 	go func() {
 		defer g.Done()
-		konnectors, err := app.ListKonnectors(inst)
+		konnectors, _, err := app.ListKonnectorsWithPagination(inst, 0, "")
 		if err != nil {
 			errc <- &updateError{
 				domain: inst.Domain,


### PR DESCRIPTION
This PR adds a pagination for /apps route. The legacy limit is kept, but a custom limit can now be specified if needed 