### PR TITLE
Use the swift container for assets for /status

### DIFF
--- a/pkg/assets/dynamic/fs.go
+++ b/pkg/assets/dynamic/fs.go
@@ -233,6 +233,6 @@ func (s *SwiftFS) List() (map[string][]*model.Asset, error) {
 }
 
 func (s *SwiftFS) CheckStatus() error {
-	_, err := s.swiftConn.QueryInfo()
+	_, _, err := s.swiftConn.Container(DynamicAssetsContainerName)
 	return err
 }


### PR DESCRIPTION
The /status endpoint checks the connection to swift, among other things.
Before this commit, it was done via /info, but the Swift Restful API
implemeted by Ceph does not expose this endpoint. We will query the
container used by the stack for the dynamic assets for /status now, to
fix the compatibility with Ceph.