### PR TITLE
Delete accounts when a konnector is uninstalled

### DIFF
--- a/docs/cli/cozy-stack_fixer.md
+++ b/docs/cli/cozy-stack_fixer.md
@@ -37,6 +37,7 @@ cozy-stack fixer <command> [flags]
 * [cozy-stack fixer md5](cozy-stack_fixer_md5.md)	 - Fix missing md5 from contents in the vfs
 * [cozy-stack fixer mime](cozy-stack_fixer_mime.md)	 - Fix the class computed from the mime-type
 * [cozy-stack fixer onboardings](cozy-stack_fixer_onboardings.md)	 - Add the onboarding_finished flag to user that have registered their passphrase
+* [cozy-stack fixer orphan-account](cozy-stack_fixer_orphan-account.md)	 - Rebuild scheduling data strucutures in redis
 * [cozy-stack fixer redis](cozy-stack_fixer_redis.md)	 - Rebuild scheduling data strucutures in redis
 * [cozy-stack fixer thumbnails](cozy-stack_fixer_thumbnails.md)	 - Rebuild thumbnails image for images files
 

--- a/docs/cli/cozy-stack_fixer_orphan-account.md
+++ b/docs/cli/cozy-stack_fixer_orphan-account.md
@@ -1,0 +1,32 @@
+## cozy-stack fixer orphan-account
+
+Rebuild scheduling data strucutures in redis
+
+### Synopsis
+
+Rebuild scheduling data strucutures in redis
+
+```
+cozy-stack fixer orphan-account <domain> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for orphan-account
+```
+
+### Options inherited from parent commands
+
+```
+      --admin-host string   administration server host (default "localhost")
+      --admin-port int      administration server port (default 6060)
+  -c, --config string       configuration file (default "$HOME/.cozy.yaml")
+      --host string         server host (default "localhost")
+  -p, --port int            server port (default 8080)
+```
+
+### SEE ALSO
+
+* [cozy-stack fixer](cozy-stack_fixer.md)	 - A set of tools to fix issues or migrate content for retro-compatibility.
+

--- a/docs/konnectors-workflow.md
+++ b/docs/konnectors-workflow.md
@@ -299,6 +299,12 @@ or returns with a non-zero status code.
 **Note:** debug and info level are not transmitted to syslog, except if the
 instance is in debug mode. It would be too verbose to do otherwise.
 
+### Account deleted
+
+When an account is deleted, or a konnector is going to be uninstalled, the
+konnector is executed with the `account_deleted` field to true, so it can clean
+the account remotely.
+
 
 ## OAuth (and service secrets)
 

--- a/docs/konnectors.md
+++ b/docs/konnectors.md
@@ -294,3 +294,13 @@ DELETE /konnectors/bank101 HTTP/1.1
 ```http
 HTTP/1.1 204 No Content
 ```
+
+Or, if the konnector has still some accounts configured:
+
+```http
+HTTP/1.1 202 Accepted
+```
+
+In this case, the stack will accept the uninstall request, then it will clean
+the accounts (locally and remotely), and only after that, the konnector will be
+removed.

--- a/model/account/accounts.go
+++ b/model/account/accounts.go
@@ -21,6 +21,14 @@ type Account struct {
 	Basic       *BasicInfo             `json:"auth,omitempty"`
 	Oauth       *OauthInfo             `json:"oauth,omitempty"`
 	Extras      map[string]interface{} `json:"oauth_callback_results,omitempty"`
+
+	// When an account is deleted, the stack cleans the triggers and calls its
+	// konnector to clean the account remotely (when available). It is done via
+	// a hook on deletion, but when the konnector is removed, this cleaning is
+	// done manually before uninstalling the konnector, and this flag is used
+	// to not try doing the cleaning in the hook as it is already too late (the
+	// konnector is no longer available).
+	ManualCleaning bool `json:"manual_cleaning,omitempty"`
 }
 
 // OauthInfo holds configuration information for an oauth account
@@ -79,37 +87,89 @@ func (ac *Account) Match(field, expected string) bool {
 	return field == "account_type" && expected == ac.AccountType
 }
 
+// GetTriggers returns the list of triggers associated with the given
+// accountID. In particular, the the stack will need to remove them when the
+// account is deleted.
+func GetTriggers(jobsSystem job.JobSystem, db prefixer.Prefixer, accountID string) ([]job.Trigger, error) {
+	triggers, err := jobsSystem.GetAllTriggers(db)
+	if err != nil {
+		return nil, err
+	}
+
+	var toDelete []job.Trigger
+	for _, t := range triggers {
+		if t.Infos().WorkerType != "konnector" {
+			continue
+		}
+
+		var msg struct {
+			Account string `json:"account"`
+		}
+		err := t.Infos().Message.Unmarshal(&msg)
+		if err == nil && msg.Account == accountID {
+			toDelete = append(toDelete, t)
+		}
+	}
+	return toDelete, nil
+}
+
+// PushAccountDeletedJob adds a job for the given account and konnector with
+// the AccountDeleted flag, to allow the konnector to clear the account
+// remotely.
+func PushAccountDeletedJob(jobsSystem job.JobSystem, db prefixer.Prefixer, accountID, accountRev, konnector string) (*job.Job, error) {
+	logger.WithDomain(db.DomainName()).
+		WithField("account_id", accountID).
+		WithField("account_rev", accountRev).
+		WithField("konnector", konnector).
+		Info("Pushing job for konnector on_delete")
+
+	msg, err := job.NewMessage(struct {
+		Account        string `json:"account"`
+		AccountRev     string `json:"account_rev"`
+		Konnector      string `json:"konnector"`
+		AccountDeleted bool   `json:"account_deleted"`
+	}{
+		Account:        accountID,
+		AccountRev:     accountRev,
+		Konnector:      konnector,
+		AccountDeleted: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return jobsSystem.PushJob(db, &job.JobRequest{
+		WorkerType: "konnector",
+		Message:    msg,
+		Manual:     true, // Select high-priority for these jobs
+	})
+}
+
 func init() {
 	couchdb.AddHook(consts.Accounts, couchdb.EventDelete,
 		func(db prefixer.Prefixer, doc couchdb.Doc, old couchdb.Doc) error {
-			jobsSystem := job.System()
+			manualCleaning := false
+			switch v := doc.(type) {
+			case *Account:
+				manualCleaning = v.ManualCleaning
+			case *couchdb.JSONDoc:
+				manualCleaning, _ = v.M["manual_cleaning"].(bool)
+			case couchdb.JSONDoc:
+				manualCleaning, _ = v.M["manual_cleaning"].(bool)
+			}
+			if manualCleaning {
+				return nil
+			}
 
-			trigs, err := jobsSystem.GetAllTriggers(db)
+			jobsSystem := job.System()
+			triggers, err := GetTriggers(jobsSystem, db, doc.ID())
 			if err != nil {
 				logger.WithDomain(db.DomainName()).Error(
 					"Failed to fetch triggers after account deletion: ", err)
 				return err
 			}
-			for _, t := range trigs {
-				toDelete := false
-
-				if t.Infos().WorkerType != "konnector" {
-					continue
-				}
-
-				var msg struct {
-					Account string `json:"account"`
-				}
-				err := t.Infos().Message.Unmarshal(&msg)
-				if err != nil {
-					toDelete = true
-				} else if msg.Account == doc.ID() {
-					toDelete = true
-				}
-				if toDelete {
-					if err := jobsSystem.DeleteTrigger(db, t.ID()); err != nil {
-						logger.WithDomain(db.DomainName()).Errorln("failed to delete orphan trigger", err)
-					}
+			for _, t := range triggers {
+				if err := jobsSystem.DeleteTrigger(db, t.ID()); err != nil {
+					logger.WithDomain(db.DomainName()).Errorln("failed to delete orphan trigger", err)
 				}
 			}
 
@@ -122,53 +182,26 @@ func init() {
 			// cleanup or update their associated content. For now we make this
 			// process really specific to the deletion of an account, which is our
 			// only detailed usecase.
-			if old != nil {
-				log := logger.WithDomain(db.DomainName()).
-					WithField("account_id", old.ID()).
-					WithField("account_rev", old.Rev())
-
-				var konnector string
-				switch v := old.(type) {
-				case *Account:
-					konnector = v.AccountType
-				case *couchdb.JSONDoc:
-					konnector, _ = v.M["account_type"].(string)
-				case couchdb.JSONDoc:
-					konnector, _ = v.M["account_type"].(string)
-				}
-				if konnector == "" {
-					log.Info("No associated konnector for account: " +
-						"cannot create on_delete job")
-					return nil
-				}
-
-				log.
-					WithField("konnector", konnector).
-					Info("Pushing job for konnector on_delete")
-
-				msg, err := job.NewMessage(struct {
-					Account        string `json:"account"`
-					AccountRev     string `json:"account_rev"`
-					Konnector      string `json:"konnector"`
-					AccountDeleted bool   `json:"account_deleted"`
-				}{
-					Account:        old.ID(),
-					AccountRev:     old.Rev(),
-					Konnector:      konnector,
-					AccountDeleted: true,
-				})
-				if err != nil {
-					return err
-				}
-				if _, err = jobsSystem.PushJob(db, &job.JobRequest{
-					WorkerType: "konnector",
-					Message:    msg,
-					Manual:     true, // Select high-priority for these jobs
-				}); err != nil {
-					return err
-				}
+			if old == nil {
+				return nil
 			}
-
-			return nil
+			var konnector string
+			switch v := old.(type) {
+			case *Account:
+				konnector = v.AccountType
+			case *couchdb.JSONDoc:
+				konnector, _ = v.M["account_type"].(string)
+			case couchdb.JSONDoc:
+				konnector, _ = v.M["account_type"].(string)
+			}
+			if konnector == "" {
+				logger.WithDomain(db.DomainName()).
+					WithField("account_id", old.ID()).
+					WithField("account_rev", old.Rev()).
+					Info("No associated konnector for account: cannot create on_delete job")
+				return nil
+			}
+			_, err = PushAccountDeletedJob(jobsSystem, db, old.ID(), old.Rev(), konnector)
+			return err
 		})
 }


### PR DESCRIPTION
When a konnector is uninstalled, the stack looks at the triggers to see which accounts is tied to this konnector. Those accounts are deleted locally, and the konnector is launched to delete the account remotely. Only after that, the konnector can be removed from the instance.

Notes:
1. An account is expected to be linked to a single konnector, via its account_type property
2. The stack does this for all the konnectors, banking but also bills and others.

Next steps:
- [x] Update documentation
- [x] Add a fixer to clean the orphan accounts