### PR TITLE
Fix real-time and triggers on replication

### DIFF
--- a/pkg/couchdb/proxy.go
+++ b/pkg/couchdb/proxy.go
@@ -98,6 +98,7 @@ func ProxyBulkDocs(db Database, doctype string, req *http.Request) (*httputil.Re
 			// expect no error.
 			if reqValue.NewEdits != nil && !*reqValue.NewEdits {
 				for _, doc := range reqValue.Docs {
+					doc.Type = doctype
 					rev := doc.Rev()
 					var event string
 					if strings.HasPrefix(rev, "1-") {


### PR DESCRIPTION
When using the Pouch->Couch replication to push changes to the Cozy, we have to set the doctype in the stack to make the real-time and the triggers work correctly.