### PR TITLE
feat: Authorizes JSON API in remote doctypes

### DIFF
--- a/model/remote/remote.go
+++ b/model/remote/remote.go
@@ -383,6 +383,7 @@ func (remote *Remote) ProxyTo(doctype string, ins *instance.Instance, rw http.Re
 		ctype != "text/xml" &&
 		ctype != "text/plain" &&
 		ctype != "application/xml" &&
+		ctype != "application/vnd.api+json" &&
 		ctype != "application/sparql-results+json" {
 		class := strings.SplitN(ctype, "/", 2)[0]
 		if class != "image" && class != "audio" && class != "video" {


### PR DESCRIPTION
Remote doctypes do filter acceptable doctypes they are getting in
response from remote servers.

JSON was authorized as 'application/json' but not with the mime type
of JSON API ('application/vnd.api+json').

This change allows the JSON API response type in remote doctypes.