### PR TITLE
fix: Pass the correct _rev to account deletion job

### DIFF
--- a/cmd/fixer.go
+++ b/cmd/fixer.go
@@ -686,10 +686,11 @@ var orphanAccountFixer = &cobra.Command{
 					continue
 				}
 				acc.ManualCleaning = true
+				oldRev := acc.Rev() // The deletion job needs the rev just before the deletion
 				if err := couchdb.DeleteDoc(inst, acc); err != nil {
 					log.Errorf("Cannot delete account: %v", err)
 				}
-				j, err := account.PushAccountDeletedJob(jobsSystem, inst, acc.ID(), acc.Rev(), slug)
+				j, err := account.PushAccountDeletedJob(jobsSystem, inst, acc.ID(), oldRev, slug)
 				if err != nil {
 					log.Errorf("Cannot push a job for account deletion: %v", err)
 				}

--- a/web/apps/apps.go
+++ b/web/apps/apps.go
@@ -325,11 +325,12 @@ func deleteKonnectorWithAccounts(instance *instance.Instance, slug string, toDel
 		for _, entry := range toDelete {
 			acc := entry.account
 			acc.ManualCleaning = true
+			oldRev := acc.Rev() // The deletion job needs the rev just before the deletion
 			if err := couchdb.DeleteDoc(instance, acc); err != nil {
 				log.Errorf("Cannot delete account: %v", err)
 				return
 			}
-			j, err := account.PushAccountDeletedJob(jobsSystem, instance, acc.ID(), acc.Rev(), slug)
+			j, err := account.PushAccountDeletedJob(jobsSystem, instance, acc.ID(), oldRev, slug)
 			if err != nil {
 				log.Errorf("Cannot push a job for account deletion: %v", err)
 				return


### PR DESCRIPTION
The job for deletion needs the _rev just before the deletion to correctly work.