### PR TITLE
Limit the depth of the io.cozy.shared

### DIFF
--- a/model/sharing/replicator.go
+++ b/model/sharing/replicator.go
@@ -468,7 +468,7 @@ func (s *Sharing) ComputeRevsDiff(inst *instance.Instance, changed Changed) (*Mi
 		}
 		notFounds := changed[result.SID][:0]
 		for _, r := range changed[result.SID] {
-			if result.Revisions.Find(r) == nil {
+			if sub, _ := result.Revisions.Find(r); sub == nil {
 				notFounds = append(notFounds, r)
 			}
 		}
@@ -712,7 +712,7 @@ func (s *Sharing) filterDocsToUpdate(inst *instance.Instance, doctype string, do
 			infos, ok := refs[i].Infos[s.SID]
 			if ok && !infos.Removed {
 				rev := doc["_rev"].(string)
-				if refs[i].Revisions.Find(rev) == nil {
+				if sub, _ := refs[i].Revisions.Find(rev); sub == nil {
 					revs := revsMapToStruct(doc["_revisions"])
 					if revs != nil && len(revs.IDs) > 0 {
 						chain := revsStructToChain(*revs)

--- a/model/sharing/revisions_test.go
+++ b/model/sharing/revisions_test.go
@@ -25,11 +25,20 @@ func TestRevsTreeFind(t *testing.T) {
 	three := RevsTree{Rev: "3-ccc"}
 	twoB.Branches = []RevsTree{three}
 	tree.Branches = []RevsTree{twoA, twoB}
-	assert.Equal(t, tree, tree.Find("1-aaa"))
-	assert.Equal(t, &twoA, tree.Find("2-baa"))
-	assert.Equal(t, &twoB, tree.Find("2-bbb"))
-	assert.Equal(t, &three, tree.Find("3-ccc"))
-	assert.Equal(t, (*RevsTree)(nil), tree.Find("4-ddd"))
+	actual, depth := tree.Find("1-aaa")
+	assert.Equal(t, tree, actual)
+	assert.Equal(t, 1, depth)
+	actual, depth = tree.Find("2-baa")
+	assert.Equal(t, &twoA, actual)
+	assert.Equal(t, 2, depth)
+	actual, depth = tree.Find("2-bbb")
+	assert.Equal(t, &twoB, actual)
+	assert.Equal(t, 2, depth)
+	actual, depth = tree.Find("3-ccc")
+	assert.Equal(t, &three, actual)
+	assert.Equal(t, 3, depth)
+	actual, _ = tree.Find("4-ddd")
+	assert.Equal(t, (*RevsTree)(nil), actual)
 }
 
 func TestRevsTreeAdd(t *testing.T) {
@@ -101,6 +110,18 @@ func TestRevsTreeInsertAfter(t *testing.T) {
 	sub = sub.Branches[0]
 	assert.Equal(t, sub.Rev, "4-ddd")
 	assert.Len(t, sub.Branches, 0)
+}
+
+func TestRevsTreeInsertAfterMaxDepth(t *testing.T) {
+	tree := &RevsTree{Rev: "1-aaa"}
+	parent := tree.Rev
+	for i := 2; i < 2*MaxDepth; i++ {
+		next := fmt.Sprintf("%d-bbb", i)
+		tree.InsertAfter(next, parent)
+		parent = next
+	}
+	_, depth := tree.Find(parent)
+	assert.Equal(t, depth, MaxDepth)
 }
 
 func TestRevsTreeInsertChain(t *testing.T) {

--- a/model/sharing/setup.go
+++ b/model/sharing/setup.go
@@ -326,8 +326,8 @@ func (s *Sharing) buildReferences(inst *instance.Instance, rule Rule, r int, doc
 				Infos:     map[string]SharedInfo{s.SID: info},
 			}
 		} else {
-			found := srefs[i].Revisions.Find(rev) != nil
-			if found {
+			sub, _ := srefs[i].Revisions.Find(rev)
+			if sub != nil {
 				if _, ok := srefs[i].Infos[s.SID]; ok {
 					continue
 				}

--- a/model/sharing/shared.go
+++ b/model/sharing/shared.go
@@ -278,7 +278,7 @@ func UpdateShared(inst *instance.Instance, msg TrackMessage, evt TrackEvent) err
 
 	rev := evt.Doc.Rev()
 	if _, ok := ref.Infos[msg.SharingID]; ok {
-		if ref.Revisions.Find(rev) != nil {
+		if sub, _ := ref.Revisions.Find(rev); sub != nil {
 			return nil
 		}
 	} else {

--- a/model/sharing/upload.go
+++ b/model/sharing/upload.go
@@ -365,7 +365,7 @@ func (s *Sharing) SyncFile(inst *instance.Instance, target *FileDocWithRevisions
 	if _, ok := ref.Infos[s.SID]; !ok {
 		return nil, ErrSafety
 	}
-	if ref.Revisions.Find(target.DocRev) != nil {
+	if sub, _ := ref.Revisions.Find(target.DocRev); sub != nil {
 		// It's just the echo, there is nothing to do
 		return nil, nil
 	}

--- a/tests/integration/tests/loop_shared_file.rb
+++ b/tests/integration/tests/loop_shared_file.rb
@@ -1,0 +1,50 @@
+require_relative '../boot'
+require 'minitest/autorun'
+require 'pry-rescue/minitest' unless ENV['CI']
+
+describe "A sharing" do
+  it "is resilient to a lot of changes, like a loop from cozy-desktop" do
+    Helpers.scenario "loop_shared_file"
+    Helpers.start_mailhog
+
+    # Create the instances
+    inst_alice = Instance.create name: "Alice"
+    inst_bob = Instance.create name: "Bob"
+    contact_bob = Contact.create inst_alice, given_name: "Bob"
+
+    # Create the folder
+    folder = Folder.create inst_alice
+    folder.couch_id.wont_be_empty
+    filename = "#{Faker::Internet.slug}.txt"
+    file = CozyFile.create inst_alice, name: filename, dir_id: folder.couch_id
+
+    # Create the sharing
+    sharing = Sharing.new
+    sharing.rules << Rule.sync(folder)
+    sharing.members << inst_alice << contact_bob
+    inst_alice.register sharing
+
+    # Accept the sharing
+    sleep 1
+    inst_bob.accept sharing
+    sleep 1
+    file = CozyFile.find inst_alice, file.couch_id
+    path = CGI.escape "/#{Helpers::SHARED_WITH_ME}/#{folder.name}/#{file.name}"
+    file_bob = CozyFile.find_by_path inst_bob, path
+    assert_equal file.md5sum, file_bob.md5sum
+
+    # Simulate a bug of cozy-desktop where the file is renamed in a loop
+    250.times do |i|
+      name = "#{i}-#{filename}"
+      file.rename inst_alice, name
+    end
+    file.overwrite inst_alice, content: Faker::BackToTheFuture.quote
+
+    # Check that the changes are applied on Bob's instance
+    sleep 22
+    file = CozyFile.find inst_alice, file.couch_id
+    file_bob = CozyFile.find inst_bob, file_bob.couch_id
+    assert_equal file.name, file_bob.name
+    assert_equal file.md5sum, file_bob.md5sum
+  end
+end


### PR DESCRIPTION
Try to protect the stack and redis from being flooded when the desktop client send renaming in a conflict loop.