### PR TITLE
Allow to trigger a job on a changed value

### DIFF
--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -135,17 +135,23 @@ Examples:
 ### `@event` syntax
 
 The `@event` syntax allows to trigger a job when something occurs in the stack.
-It follows the same syntax than permissions scope string:
+It follows the same syntax than [permissions
+scope](https://docs.cozy.io/en/cozy-stack/permissions/#what-is-a-permission)
+string:
 
 `type[:verb][:values][:selector]`
 
 Unlike for permissions string, the verb should be one of `CREATED`, `DELETED`,
-`UPDATED`.
+`UPDATED`. It is possible to put several verbs, separated by a comma.
+
+There is also a special value `!=`. It means that a job will be trigger only if
+the value for the given selector has changed (ie the value before the update and
+the value after that are different).
 
 The job worker will receive a compound message including original trigger_infos
 messages and the event which has triggered it.
 
-Examples
+Examples:
 
 ```
 @event io.cozy.files // anything happens on files
@@ -153,6 +159,7 @@ Examples
 @event io.cozy.files:DELETED:image/jpg:mime // an image was deleted
 @event io.cozy.bank.operations:CREATED io.cozy.bank.bills:CREATED // a bank operation or a bill
 @event io.cozy.bank.operations:CREATED,UPDATED // a bank operation created or updated
+@event io.cozy.bank.operations:UPDATED:!=:category // a change of category for a bank operation
 ```
 
 ## Error Handling

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,8 @@ require (
 	github.com/leonelquinteros/gotext v1.4.0
 	github.com/magiconair/properties v1.8.1 // indirect
 	github.com/mitchellh/mapstructure v1.1.2
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/mssola/user_agent v0.5.0
 	github.com/ncw/swift v1.0.49
 	github.com/nightlyone/lockfile v0.0.0-20180618180623-0ad87eef1443

--- a/model/account/accounts.go
+++ b/model/account/accounts.go
@@ -158,8 +158,6 @@ func init() {
 				manualCleaning = v.ManualCleaning
 			case *couchdb.JSONDoc:
 				manualCleaning, _ = v.M["manual_cleaning"].(bool)
-			case couchdb.JSONDoc:
-				manualCleaning, _ = v.M["manual_cleaning"].(bool)
 			}
 			if manualCleaning {
 				return nil
@@ -195,8 +193,6 @@ func init() {
 			case *Account:
 				konnector = v.AccountType
 			case *couchdb.JSONDoc:
-				konnector, _ = v.M["account_type"].(string)
-			case couchdb.JSONDoc:
 				konnector, _ = v.M["account_type"].(string)
 			}
 			if konnector == "" {

--- a/model/account/accounts.go
+++ b/model/account/accounts.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/cozy/cozy-stack/model/job"
+	"github.com/cozy/cozy-stack/model/permission"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/logger"
@@ -82,9 +83,13 @@ func (ac *Account) Clone() couchdb.Doc {
 	return &cloned
 }
 
-// Match implements permissions.Matcher
-func (ac *Account) Match(field, expected string) bool {
-	return field == "account_type" && expected == ac.AccountType
+// Fetch implements permission.Fetcher
+func (ac *Account) Fetch(field string) []string {
+	switch field {
+	case "account_type":
+		return []string{ac.AccountType}
+	}
+	return nil
 }
 
 // GetTriggers returns the list of triggers associated with the given
@@ -205,3 +210,5 @@ func init() {
 			return err
 		})
 }
+
+var _ permission.Fetcher = &Account{}

--- a/model/app/apps.go
+++ b/model/app/apps.go
@@ -53,7 +53,7 @@ type SubDomainer interface {
 // that can represent either a webapp or konnector manifest
 type Manifest interface {
 	couchdb.Doc
-	Match(field, expected string) bool
+	Fetch(field string) []string
 	ReadManifest(i io.Reader, slug, sourceURL string) (Manifest, error)
 
 	Create(db prefixer.Prefixer) error

--- a/model/app/konnector.go
+++ b/model/app/konnector.go
@@ -178,15 +178,15 @@ func (m *KonnManifest) SetError(err error) {
 // Error is part of the Manifest interface
 func (m *KonnManifest) Error() error { return m.err }
 
-// Match is part of the Manifest interface
-func (m *KonnManifest) Match(field, value string) bool {
+// Fetch is part of the Manifest interface
+func (m *KonnManifest) Fetch(field string) []string {
 	switch field {
 	case "slug":
-		return m.DocSlug == value
+		return []string{m.DocSlug}
 	case "state":
-		return m.DocState == State(value)
+		return []string{string(m.DocState)}
 	}
-	return false
+	return nil
 }
 
 // ReadManifest is part of the Manifest interface

--- a/model/app/webapp.go
+++ b/model/app/webapp.go
@@ -233,15 +233,15 @@ func (m *WebappManifest) SetError(err error) {
 // Error is part of the Manifest interface
 func (m *WebappManifest) Error() error { return m.err }
 
-// Match is part of the Manifest interface
-func (m *WebappManifest) Match(field, value string) bool {
+// Fetch is part of the Manifest interface
+func (m *WebappManifest) Fetch(field string) []string {
 	switch field {
 	case "slug":
-		return m.DocSlug == value
+		return []string{m.DocSlug}
 	case "state":
-		return m.DocState == State(value)
+		return []string{string(m.DocState)}
 	}
-	return false
+	return nil
 }
 
 // NameLocalized returns the name of the app in the given locale

--- a/model/job/broker.go
+++ b/model/job/broker.go
@@ -166,28 +166,28 @@ func (j *Job) SetID(id string) { j.JobID = id }
 // SetRev implements the couchdb.Doc interface
 func (j *Job) SetRev(rev string) { j.JobRev = rev }
 
-// Match implements the permission.Matcher interface
-func (j *Job) Match(key, value string) bool {
-	switch key {
+// Fetch implements the permission.Fetcher interface
+func (j *Job) Fetch(field string) []string {
+	switch field {
 	case WorkerType:
-		return j.WorkerType == value
+		return []string{j.WorkerType}
 	}
-	return false
+	return nil
 }
 
-// ID implements the permission.Matcher interface
+// ID implements the permission.Getter interface
 func (jr *JobRequest) ID() string { return "" }
 
-// DocType implements the permission.Matcher interface
+// DocType implements the permission.Getter interface
 func (jr *JobRequest) DocType() string { return consts.Jobs }
 
-// Match implements the permission.Matcher interface
-func (jr *JobRequest) Match(key, value string) bool {
-	switch key {
+// Fetch implements the permission.Fetcher interface
+func (jr *JobRequest) Fetch(field string) []string {
+	switch field {
 	case WorkerType:
-		return jr.WorkerType == value
+		return []string{jr.WorkerType}
 	}
-	return false
+	return nil
 }
 
 // Logger returns a logger associated with the job domain
@@ -485,6 +485,6 @@ func (e Event) Unmarshal(evt interface{}) error {
 }
 
 var (
-	_ permission.Matcher = (*JobRequest)(nil)
-	_ permission.Matcher = (*Job)(nil)
+	_ permission.Fetcher = (*JobRequest)(nil)
+	_ permission.Fetcher = (*Job)(nil)
 )

--- a/model/job/mem_scheduler_test.go
+++ b/model/job/mem_scheduler_test.go
@@ -93,7 +93,7 @@ func TestMemSchedulerWithDebounce(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, ts, len(triggers))
 
-	doc := couchdb.JSONDoc{
+	doc := &couchdb.JSONDoc{
 		Type: "io.cozy.testdebounce",
 		M: map[string]interface{}{
 			"_id":  "test-id",
@@ -104,16 +104,16 @@ func TestMemSchedulerWithDebounce(t *testing.T) {
 
 	for i := 0; i < 24; i++ {
 		time.Sleep(200 * time.Millisecond)
-		realtime.GetHub().Publish(testInstance, realtime.EventCreate, &doc, nil)
+		realtime.GetHub().Publish(testInstance, realtime.EventCreate, doc, nil)
 	}
 
 	time.Sleep(3000 * time.Millisecond)
 	assert.Equal(t, 3, called)
 
-	doc2 := doc.Clone().(couchdb.JSONDoc)
+	doc2 := doc.Clone().(*couchdb.JSONDoc)
 	doc2.Type = "io.cozy.moredebounce"
-	realtime.GetHub().Publish(testInstance, realtime.EventCreate, &doc, nil)
-	realtime.GetHub().Publish(testInstance, realtime.EventCreate, &doc2, nil)
+	realtime.GetHub().Publish(testInstance, realtime.EventCreate, doc, nil)
+	realtime.GetHub().Publish(testInstance, realtime.EventCreate, doc2, nil)
 	time.Sleep(3000 * time.Millisecond)
 	assert.Equal(t, 4, called)
 

--- a/model/job/scheduler.go
+++ b/model/job/scheduler.go
@@ -21,7 +21,7 @@ type (
 	// Trigger interface is used to represent a trigger.
 	Trigger interface {
 		prefixer.Prefixer
-		permission.Matcher
+		permission.Fetcher
 		Type() string
 		Infos() *TriggerInfos
 		// Schedule should return a channel on which the trigger can send job
@@ -196,13 +196,13 @@ func (t *TriggerInfos) SetID(id string) { t.TID = id }
 // SetRev implements the couchdb.Doc interface
 func (t *TriggerInfos) SetRev(rev string) { t.TRev = rev }
 
-// Match implements the permission.Matcher interface
-func (t *TriggerInfos) Match(key, value string) bool {
-	switch key {
+// Fetch implements the permission.Fetcher interface
+func (t *TriggerInfos) Fetch(field string) []string {
+	switch field {
 	case "worker":
-		return t.WorkerType == value
+		return []string{t.WorkerType}
 	}
-	return false
+	return nil
 }
 
 // GetJobs returns the jobs launched by the given trigger.
@@ -272,3 +272,4 @@ func GetTriggerState(db prefixer.Prefixer, triggerID string) (*TriggerState, err
 }
 
 var _ couchdb.Doc = &TriggerInfos{}
+var _ permission.Fetcher = &TriggerInfos{}

--- a/model/job/trigger_at.go
+++ b/model/job/trigger_at.go
@@ -2,8 +2,6 @@ package job
 
 import (
 	"time"
-
-	"github.com/cozy/cozy-stack/pkg/consts"
 )
 
 // maxPastTriggerTime is the maximum duration in the past for which the at
@@ -50,25 +48,6 @@ func NewInTrigger(infos *TriggerInfos) (*AtTrigger, error) {
 // Type implements the Type method of the Trigger interface.
 func (a *AtTrigger) Type() string {
 	return a.TriggerInfos.Type
-}
-
-// DocType implements the permissions.Matcher interface
-func (a *AtTrigger) DocType() string {
-	return consts.Triggers
-}
-
-// ID implements the permissions.Matcher interface
-func (a *AtTrigger) ID() string {
-	return a.TriggerInfos.TID
-}
-
-// Match implements the permissions.Matcher interface
-func (a *AtTrigger) Match(key, value string) bool {
-	switch key {
-	case WorkerType:
-		return a.TriggerInfos.WorkerType == value
-	}
-	return false
 }
 
 // Schedule implements the Schedule method of the Trigger interface.

--- a/model/job/trigger_cron.go
+++ b/model/job/trigger_cron.go
@@ -3,7 +3,6 @@ package job
 import (
 	"time"
 
-	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/robfig/cron/v3"
 )
 
@@ -47,25 +46,6 @@ func NewEveryTrigger(infos *TriggerInfos) (*CronTrigger, error) {
 // Type implements the Type method of the Trigger interface.
 func (c *CronTrigger) Type() string {
 	return c.TriggerInfos.Type
-}
-
-// DocType implements the permissions.Matcher interface
-func (c *CronTrigger) DocType() string {
-	return consts.Triggers
-}
-
-// ID implements the permissions.Matcher interface
-func (c *CronTrigger) ID() string {
-	return c.TriggerInfos.TID
-}
-
-// Match implements the permissions.Matcher interface
-func (c *CronTrigger) Match(key, value string) bool {
-	switch key {
-	case WorkerType:
-		return c.TriggerInfos.WorkerType == value
-	}
-	return false
 }
 
 // NextExecution returns the next time when a job should be fired for this trigger

--- a/model/job/trigger_event.go
+++ b/model/job/trigger_event.go
@@ -2,7 +2,6 @@ package job
 
 import (
 	"errors"
-	"reflect"
 	"strings"
 
 	"github.com/cozy/cozy-stack/model/permission"
@@ -142,10 +141,8 @@ func eventMatchRule(e *realtime.Event, rule *permission.Rule) bool {
 			return false
 		}
 		if doc, ok := e.Doc.(permission.Fetcher); ok {
-			value := doc.Fetch(rule.Selector)
 			if old, ok := e.OldDoc.(permission.Fetcher); ok {
-				was := old.Fetch(rule.Selector)
-				return !reflect.DeepEqual(value, was)
+				return rule.ValuesChanged(old, doc)
 			}
 		}
 	} else {

--- a/model/job/trigger_event.go
+++ b/model/job/trigger_event.go
@@ -43,25 +43,6 @@ func (t *EventTrigger) Type() string {
 	return t.TriggerInfos.Type
 }
 
-// DocType implements the permission.Matcher interface
-func (t *EventTrigger) DocType() string {
-	return consts.Triggers
-}
-
-// ID implements the permission.Matcher interface
-func (t *EventTrigger) ID() string {
-	return t.TriggerInfos.TID
-}
-
-// Match implements the permission.Matcher interface
-func (t *EventTrigger) Match(key, value string) bool {
-	switch key {
-	case WorkerType:
-		return t.TriggerInfos.WorkerType == value
-	}
-	return false
-}
-
 // Schedule implements the Schedule method of the Trigger interface.
 func (t *EventTrigger) Schedule() <-chan *JobRequest {
 	ch := make(chan *JobRequest)
@@ -151,13 +132,13 @@ func eventMatchRule(e *realtime.Event, rule *permission.Rule) bool {
 		return false
 	}
 
-	if v, ok := e.Doc.(permission.Matcher); ok {
+	if v, ok := e.Doc.(permission.Fetcher); ok {
 		if rule.ValuesMatch(v) {
 			return true
 		}
 		// Particular case where the new doc is not valid but the old one was.
 		if e.OldDoc != nil {
-			if vOld, okOld := e.OldDoc.(permission.Matcher); okOld {
+			if vOld, okOld := e.OldDoc.(permission.Fetcher); okOld {
 				return rule.ValuesMatch(vOld)
 			}
 		}
@@ -201,3 +182,5 @@ func testPath(dir *vfs.DirDoc, doc realtime.Doc) bool {
 	}
 	return false
 }
+
+var _ Trigger = &EventTrigger{}

--- a/model/notification/notifications.go
+++ b/model/notification/notifications.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cozy/cozy-stack/model/permission"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 )
@@ -88,8 +89,8 @@ func (n *Notification) SetID(id string) { n.NID = id }
 // SetRev is used to implement the couchdb.Doc interface
 func (n *Notification) SetRev(rev string) { n.NRev = rev }
 
-// Match implements permissions.Matcher
-func (n *Notification) Match(k, f string) bool { return false }
+// Fetch implements permissions.Fetcher
+func (n *Notification) Fetch(field string) []string { return nil }
 
 // Source returns the complete normalized source value. This should be recorded
 // in the `source_id` field.
@@ -100,3 +101,6 @@ func (n *Notification) Source() string {
 		n.Category,
 		n.CategoryID)
 }
+
+var _ couchdb.Doc = &Notification{}
+var _ permission.Fetcher = &Notification{}

--- a/model/permission/match.go
+++ b/model/permission/match.go
@@ -1,13 +1,13 @@
 package permission
 
-// Matcher is an interface for a object than can be matched by a Set
-type Matcher interface {
+// Fetcher is an interface for an object to see if it matches a rule.
+type Fetcher interface {
 	ID() string
 	DocType() string
-	Match(field, expected string) bool
+	Fetch(field string) []string
 }
 
-func matchValues(r Rule, o Matcher) bool {
+func matchValues(r Rule, o Fetcher) bool {
 	// empty r.Values = any value
 	if len(r.Values) == 0 {
 		return true
@@ -18,7 +18,7 @@ func matchValues(r Rule, o Matcher) bool {
 	return r.ValuesMatch(o)
 }
 
-func matchOnFields(r Rule, o Matcher, fields ...string) bool {
+func matchOnFields(r Rule, o Fetcher, fields ...string) bool {
 	// in this case, if r.Values is empty the selector is considered too wide and
 	// is forbidden
 	if len(r.Values) == 0 || r.Selector == "" {
@@ -65,7 +65,7 @@ func (s Set) AllowID(v Verb, doctype, id string) bool {
 }
 
 // Allow returns true if the set allows to apply verb to given doc
-func (s Set) Allow(v Verb, o Matcher) bool {
+func (s Set) Allow(v Verb, o Fetcher) bool {
 	return s.Some(func(r Rule) bool {
 		return matchVerbAndType(r, v, o.DocType()) && matchValues(r, o)
 	})
@@ -73,7 +73,7 @@ func (s Set) Allow(v Verb, o Matcher) bool {
 
 // AllowOnFields returns true if the set allows to apply verb to given doc on
 // the specified fields.
-func (s Set) AllowOnFields(v Verb, o Matcher, fields ...string) bool {
+func (s Set) AllowOnFields(v Verb, o Fetcher, fields ...string) bool {
 	return s.Some(func(r Rule) bool {
 		return matchVerbAndType(r, v, o.DocType()) && matchOnFields(r, o, fields...)
 	})

--- a/model/permission/permissions_test.go
+++ b/model/permission/permissions_test.go
@@ -353,9 +353,11 @@ type validable struct {
 	values  map[string]string
 }
 
-func (t *validable) ID() string             { return t.id }
-func (t *validable) DocType() string        { return t.doctype }
-func (t *validable) Match(f, e string) bool { return t.values[f] == e }
+func (t *validable) ID() string      { return t.id }
+func (t *validable) DocType() string { return t.doctype }
+func (t *validable) Fetch(field string) []string {
+	return []string{t.values[field]}
+}
 
 type validableFile struct {
 	path string
@@ -363,6 +365,15 @@ type validableFile struct {
 
 func (t *validableFile) ID() string      { return t.path }
 func (t *validableFile) DocType() string { return "io.cozy.files" }
-func (t *validableFile) Match(f, e string) bool {
-	return f == "path" && strings.HasPrefix(t.path, e)
+func (t *validableFile) Fetch(field string) []string {
+	if field != "path" {
+		return nil
+	}
+	var prefixes []string
+	parts := strings.Split(t.path, "/")
+	for i := 1; i < len(parts); i++ {
+		prefix := strings.Join(parts[:i], "/") + "/"
+		prefixes = append(prefixes, prefix)
+	}
+	return prefixes
 }

--- a/model/permission/rule.go
+++ b/model/permission/rule.go
@@ -2,6 +2,7 @@ package permission
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/cozy/cozy-stack/pkg/consts"
@@ -126,6 +127,13 @@ func (r Rule) ValuesContain(values ...string) bool {
 		}
 	}
 	return true
+}
+
+// ValuesChanged returns true if the value for the given selector has changed
+func (r Rule) ValuesChanged(old, current Fetcher) bool {
+	value := current.Fetch(r.Selector)
+	was := old.Fetch(r.Selector)
+	return !reflect.DeepEqual(value, was)
 }
 
 // TranslationKey returns a string that can be used as a key for translating a

--- a/model/permission/rule.go
+++ b/model/permission/rule.go
@@ -92,10 +92,20 @@ func (r Rule) SomeValue(predicate func(v string) bool) bool {
 	return false
 }
 
+func contains(haystack []string, needle string) bool {
+	for _, v := range haystack {
+		if needle == v {
+			return true
+		}
+	}
+	return false
+}
+
 // ValuesMatch returns true if any value statisfy the predicate
-func (r Rule) ValuesMatch(o Matcher) bool {
+func (r Rule) ValuesMatch(o Fetcher) bool {
+	candidates := o.Fetch(r.Selector)
 	for _, v := range r.Values {
-		if o.Match(r.Selector, v) {
+		if contains(candidates, v) {
 			return true
 		}
 	}

--- a/model/sharing/shared.go
+++ b/model/sharing/shared.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/cozy/cozy-stack/model/instance"
+	"github.com/cozy/cozy-stack/model/permission"
 	"github.com/cozy/cozy-stack/model/vfs"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
@@ -83,14 +84,17 @@ func (s *SharedRef) Clone() couchdb.Doc {
 	return &cloned
 }
 
-// Match implements the permissions.Matcher interface
-func (s *SharedRef) Match(key, value string) bool {
-	switch key {
+// Fetch implements the permission.Fetcher interface
+func (s *SharedRef) Fetch(field string) []string {
+	switch field {
 	case "sharing":
-		_, ok := s.Infos[value]
-		return ok
+		var keys []string
+		for key := range s.Infos {
+			keys = append(keys, key)
+		}
+		return keys
 	}
-	return false
+	return nil
 }
 
 // FindReferences returns the io.cozy.shared references to the given identifiers
@@ -456,3 +460,4 @@ func extractDocReferenceFromID(id string) *couchdb.DocReference {
 }
 
 var _ couchdb.Doc = &SharedRef{}
+var _ permission.Fetcher = &SharedRef{}

--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -594,7 +594,7 @@ func (s *Sharing) EndInitial(inst *instance.Instance) error {
 		Type: consts.SharingsInitialSync,
 		M:    map[string]interface{}{"_id": s.SID},
 	}
-	realtime.GetHub().Publish(inst, realtime.EventDelete, doc, nil)
+	realtime.GetHub().Publish(inst, realtime.EventDelete, &doc, nil)
 	return nil
 }
 

--- a/model/sharing/upload.go
+++ b/model/sharing/upload.go
@@ -598,7 +598,7 @@ func (s *Sharing) countReceivedFiles(inst *instance.Instance) {
 			"count": count,
 		},
 	}
-	realtime.GetHub().Publish(inst, realtime.EventUpdate, doc, nil)
+	realtime.GetHub().Publish(inst, realtime.EventUpdate, &doc, nil)
 }
 
 // UploadExistingFile is used to receive new content for an existing file.

--- a/pkg/couchdb/couchdb.go
+++ b/pkg/couchdb/couchdb.go
@@ -86,7 +86,7 @@ type JSONDoc struct {
 
 // ID returns the identifier field of the document
 //   "io.cozy.event/123abc123" == doc.ID()
-func (j JSONDoc) ID() string {
+func (j *JSONDoc) ID() string {
 	id, ok := j.M["_id"].(string)
 	if ok {
 		return id
@@ -96,7 +96,7 @@ func (j JSONDoc) ID() string {
 
 // Rev returns the revision field of the document
 //   "3-1234def1234" == doc.Rev()
-func (j JSONDoc) Rev() string {
+func (j *JSONDoc) Rev() string {
 	rev, ok := j.M["_rev"].(string)
 	if ok {
 		return rev
@@ -106,12 +106,12 @@ func (j JSONDoc) Rev() string {
 
 // DocType returns the document type of the document
 //   "io.cozy.event" == doc.Doctype()
-func (j JSONDoc) DocType() string {
+func (j *JSONDoc) DocType() string {
 	return j.Type
 }
 
 // SetID is used to set the identifier of the document
-func (j JSONDoc) SetID(id string) {
+func (j *JSONDoc) SetID(id string) {
 	if id == "" {
 		delete(j.M, "_id")
 	} else {
@@ -120,7 +120,7 @@ func (j JSONDoc) SetID(id string) {
 }
 
 // SetRev is used to set the revision of the document
-func (j JSONDoc) SetRev(rev string) {
+func (j *JSONDoc) SetRev(rev string) {
 	if rev == "" {
 		delete(j.M, "_rev")
 	} else {
@@ -129,10 +129,10 @@ func (j JSONDoc) SetRev(rev string) {
 }
 
 // Clone is used to create a copy of the document
-func (j JSONDoc) Clone() Doc {
+func (j *JSONDoc) Clone() Doc {
 	cloned := JSONDoc{Type: j.Type}
 	cloned.M = deepClone(j.M)
-	return cloned
+	return &cloned
 }
 
 func deepClone(m map[string]interface{}) map[string]interface{} {
@@ -164,7 +164,7 @@ func deepCloneSlice(s []interface{}) []interface{} {
 }
 
 // MarshalJSON implements json.Marshaller by proxying to internal map
-func (j JSONDoc) MarshalJSON() ([]byte, error) {
+func (j *JSONDoc) MarshalJSON() ([]byte, error) {
 	return json.Marshal(j.M)
 }
 
@@ -190,7 +190,7 @@ func (j *JSONDoc) ToMapWithType() map[string]interface{} {
 }
 
 // Get returns the value of one of the db fields
-func (j JSONDoc) Get(key string) interface{} {
+func (j *JSONDoc) Get(key string) interface{} {
 	return j.M[key]
 }
 
@@ -203,7 +203,7 @@ func (j JSONDoc) Get(key string) interface{} {
 //     {"type": "doctype1", "id": "id1"},
 //     {"type": "doctype2", "id": "id2"},
 // ]
-func (j JSONDoc) Fetch(field string) []string {
+func (j *JSONDoc) Fetch(field string) []string {
 	if field == SelectorReferencedBy {
 		rawReferences := j.Get(field)
 		references, ok := rawReferences.([]interface{})

--- a/pkg/couchdb/couchdb.go
+++ b/pkg/couchdb/couchdb.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"reflect"
 	"strings"
 	"time"
 
@@ -507,6 +508,19 @@ func DeleteDoc(db Database, doc Doc) error {
 	return nil
 }
 
+// NewEmptyObjectOfSameType takes an object and returns a new object of the
+// same type. For example, if NewEmptyObjectOfSameType is called with a pointer
+// to a JSONDoc, it will return a pointer to an empty JSONDoc (and not a nil
+// pointer).
+func NewEmptyObjectOfSameType(obj interface{}) interface{} {
+	typ := reflect.TypeOf(obj)
+	if typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+	}
+	value := reflect.New(typ)
+	return value.Interface()
+}
+
 // UpdateDoc update a document. The document ID and Rev should be filled.
 // The doc SetRev function will be called with the new rev.
 func UpdateDoc(db Database, doc Doc) error {
@@ -522,7 +536,7 @@ func UpdateDoc(db Database, doc Doc) error {
 	url := url.PathEscape(id)
 	// The old doc is requested to be emitted thought RTEvent.
 	// This is useful to keep track of the modifications for the triggers.
-	oldDoc := doc.Clone()
+	oldDoc := NewEmptyObjectOfSameType(doc).(Doc)
 	err = makeRequest(db, doctype, http.MethodGet, url, nil, oldDoc)
 	if err != nil {
 		return err

--- a/pkg/couchdb/couchdb_test.go
+++ b/pkg/couchdb/couchdb_test.go
@@ -26,7 +26,7 @@ const TestDoctype = "io.cozy.testobject"
 
 var TestPrefix = newDatabase("couchdb-tests")
 var receivedEventsMutex sync.Mutex
-var receivedEvents map[string]struct{}
+var receivedEvents map[string]*realtime.Event
 
 type testDoc struct {
 	TestID  string `json:"_id,omitempty"`
@@ -98,7 +98,10 @@ func TestCreateDoc(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEqual(t, revBackup, updated.Rev())
 	assert.Equal(t, "changedvalue", updated.Test)
-	assertGotEvent(t, realtime.EventUpdate, doc.ID())
+	evt := assertGotEvent(t, realtime.EventUpdate, doc.ID())
+	assert.NotNil(t, evt.OldDoc)
+	assert.Equal(t, "somevalue", evt.OldDoc.(*testDoc).Test)
+	assert.Equal(t, "changedvalue", evt.Doc.(*testDoc).Test)
 
 	// Refetch it and see if its match
 	fetched2 := &testDoc{}
@@ -298,6 +301,42 @@ func TestUUID(t *testing.T) {
 	assert.Len(t, uuid, 32)
 }
 
+func TestUpdateJSONDoc(t *testing.T) {
+	var err error
+
+	doc := &JSONDoc{
+		Type: TestDoctype,
+		M: map[string]interface{}{
+			"test": "1",
+		},
+	}
+	assert.Empty(t, doc.Rev(), doc.ID())
+
+	// Create the document
+	err = CreateDoc(TestPrefix, doc)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, doc.Rev(), doc.ID())
+	assertGotEvent(t, realtime.EventCreate, doc.ID())
+
+	// Update it
+	updated := &JSONDoc{
+		Type: TestDoctype,
+		M: map[string]interface{}{
+			"_id":  doc.ID(),
+			"_rev": doc.Rev(),
+			"test": "2",
+		},
+	}
+	err = UpdateDoc(TestPrefix, updated)
+	assert.NoError(t, err)
+	assert.NotEqual(t, doc.Rev(), updated.Rev())
+	assert.Equal(t, "2", updated.M["test"])
+	evt := assertGotEvent(t, realtime.EventUpdate, doc.ID())
+	assert.NotNil(t, evt.OldDoc)
+	assert.Equal(t, "1", evt.OldDoc.(*JSONDoc).M["test"])
+	assert.Equal(t, "2", evt.Doc.(*JSONDoc).M["test"])
+}
+
 func TestMain(m *testing.M) {
 	config.UseTestFile()
 
@@ -312,13 +351,13 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	receivedEvents = make(map[string]struct{})
+	receivedEvents = make(map[string]*realtime.Event)
 	eventChan := realtime.GetHub().Subscriber(TestPrefix)
 	_ = eventChan.Subscribe(TestDoctype)
 	go func() {
 		for ev := range eventChan.Channel {
 			receivedEventsMutex.Lock()
-			receivedEvents[ev.Verb+ev.Doc.ID()] = struct{}{}
+			receivedEvents[ev.Verb+ev.Doc.ID()] = ev
 			receivedEventsMutex.Unlock()
 		}
 	}()
@@ -354,7 +393,7 @@ func TestJSONDocClone(t *testing.T) {
 		Type: "toto",
 		M:    m,
 	}
-	j2 := j1.Clone().(JSONDoc)
+	j2 := j1.Clone().(*JSONDoc)
 
 	assert.Equal(t, j1.Type, j2.Type)
 	assert.True(t, reflect.DeepEqual(j1.M, j2.M))
@@ -404,14 +443,15 @@ func TestLocalDocuments(t *testing.T) {
 	assert.True(t, IsNotFoundError(err))
 }
 
-func assertGotEvent(t *testing.T, eventType, id string) bool {
+func assertGotEvent(t *testing.T, eventType, id string) *realtime.Event {
+	var event *realtime.Event
 	receivedEventsMutex.Lock()
 	_, ok := receivedEvents[eventType+id]
 	if !ok {
 		receivedEventsMutex.Unlock()
 		time.Sleep(time.Millisecond)
 		receivedEventsMutex.Lock()
-		_, ok = receivedEvents[eventType+id]
+		event, ok = receivedEvents[eventType+id]
 	}
 
 	if ok {
@@ -419,5 +459,6 @@ func assertGotEvent(t *testing.T, eventType, id string) bool {
 	}
 	receivedEventsMutex.Unlock()
 
-	return assert.True(t, ok, "Expected event %s:%s", eventType, id)
+	assert.True(t, ok, "Expected event %s:%s", eventType, id)
+	return event
 }

--- a/pkg/couchdb/proxy.go
+++ b/pkg/couchdb/proxy.go
@@ -106,7 +106,7 @@ func ProxyBulkDocs(db Database, doctype string, req *http.Request) (*httputil.Re
 					} else {
 						event = realtime.EventUpdate
 					}
-					RTEvent(db, event, doc, nil)
+					RTEvent(db, event, &doc, nil)
 				}
 			} else {
 				var respValues []*respValue
@@ -136,7 +136,7 @@ func ProxyBulkDocs(db Database, doctype string, req *http.Request) (*httputil.Re
 						event = realtime.EventUpdate
 					}
 					doc.SetRev(r.Rev)
-					RTEvent(db, event, doc, nil)
+					RTEvent(db, event, &doc, nil)
 				}
 			}
 		},

--- a/web/data/accounts.go
+++ b/web/data/accounts.go
@@ -45,7 +45,7 @@ func getAccount(c echo.Context) error {
 	}
 
 	if encryptAccount(out) {
-		if err = couchdb.UpdateDoc(instance, out); err != nil {
+		if err = couchdb.UpdateDoc(instance, &out); err != nil {
 			return err
 		}
 	}
@@ -109,7 +109,7 @@ func updateAccount(c echo.Context) error {
 
 	encryptAccount(doc)
 
-	errUpdate := couchdb.UpdateDoc(instance, doc)
+	errUpdate := couchdb.UpdateDoc(instance, &doc)
 	if errUpdate != nil {
 		return fixErrorNoDatabaseIsWrongDoctype(errUpdate)
 	}
@@ -241,7 +241,7 @@ func createAccount(c echo.Context) error {
 
 	encryptAccount(doc)
 
-	if err := couchdb.CreateDoc(instance, doc); err != nil {
+	if err := couchdb.CreateDoc(instance, &doc); err != nil {
 		return err
 	}
 

--- a/web/data/data.go
+++ b/web/data/data.go
@@ -129,7 +129,7 @@ func createDoc(c echo.Context) error {
 		return err
 	}
 
-	if err := couchdb.CreateDoc(instance, doc); err != nil {
+	if err := couchdb.CreateDoc(instance, &doc); err != nil {
 		return err
 	}
 
@@ -150,7 +150,7 @@ func createNamedDoc(c echo.Context, doc couchdb.JSONDoc) error {
 		return err
 	}
 
-	err = couchdb.CreateNamedDocWithDB(instance, doc)
+	err = couchdb.CreateNamedDocWithDB(instance, &doc)
 	if err != nil {
 		return fixErrorNoDatabaseIsWrongDoctype(err)
 	}
@@ -223,7 +223,7 @@ func UpdateDoc(c echo.Context) error {
 		}
 	}
 
-	errUpdate := couchdb.UpdateDoc(instance, doc)
+	errUpdate := couchdb.UpdateDoc(instance, &doc)
 	if errUpdate != nil {
 		return fixErrorNoDatabaseIsWrongDoctype(errUpdate)
 	}

--- a/web/data/data_test.go
+++ b/web/data/data_test.go
@@ -69,10 +69,10 @@ func doRequest(req *http.Request, out interface{}) (jsonres map[string]interface
 
 }
 
-func getDocForTest() couchdb.JSONDoc {
+func getDocForTest() *couchdb.JSONDoc {
 	doc := couchdb.JSONDoc{Type: Type, M: map[string]interface{}{"test": "value"}}
 	_ = couchdb.CreateDoc(testInstance, &doc)
-	return doc
+	return &doc
 }
 
 func TestMain(m *testing.M) {

--- a/web/jobs/jobs.go
+++ b/web/jobs/jobs.go
@@ -83,12 +83,12 @@ func (j apiJob) MarshalJSON() ([]byte, error) {
 
 func (q apiQueue) ID() string      { return q.workerType }
 func (q apiQueue) DocType() string { return consts.Jobs }
-func (q apiQueue) Match(key, value string) bool {
-	switch key {
+func (q apiQueue) Fetch(field string) []string {
+	switch field {
 	case "worker":
-		return q.workerType == value
+		return []string{q.workerType}
 	}
-	return false
+	return nil
 }
 
 func (t apiTrigger) ID() string                             { return t.t.TID }

--- a/web/middlewares/permissions.go
+++ b/web/middlewares/permissions.go
@@ -257,7 +257,7 @@ func AllowWholeType(c echo.Context, v permission.Verb, doctype string) error {
 }
 
 // Allow validates the validable object against the context permission set
-func Allow(c echo.Context, v permission.Verb, o permission.Matcher) error {
+func Allow(c echo.Context, v permission.Verb, o permission.Fetcher) error {
 	pdoc, err := GetPermission(c)
 	if err != nil {
 		return err
@@ -270,7 +270,7 @@ func Allow(c echo.Context, v permission.Verb, o permission.Matcher) error {
 
 // AllowOnFields validates the validable object againt the context permission
 // set and ensure the selector validates the given fields.
-func AllowOnFields(c echo.Context, v permission.Verb, o permission.Matcher, fields ...string) error {
+func AllowOnFields(c echo.Context, v permission.Verb, o permission.Fetcher, fields ...string) error {
 	pdoc, err := GetPermission(c)
 	if err != nil {
 		return err
@@ -293,8 +293,8 @@ func AllowTypeAndID(c echo.Context, v permission.Verb, doctype, id string) error
 	return nil
 }
 
-// AllowVFS validates a vfs.Matcher against the context permission set
-func AllowVFS(c echo.Context, v permission.Verb, o vfs.Matcher) error {
+// AllowVFS validates a vfs.Fetcher against the context permission set
+func AllowVFS(c echo.Context, v permission.Verb, o vfs.Fetcher) error {
 	instance := GetInstance(c)
 	pdoc, err := GetPermission(c)
 	if err != nil {
@@ -365,7 +365,7 @@ func AllowInstallApp(c echo.Context, appType consts.AppType, sourceURL string, v
 
 // AllowForApp checks that the permissions is valid and comes from an
 // application. If valid, the application's slug is returned.
-func AllowForApp(c echo.Context, v permission.Verb, o permission.Matcher) (slug string, err error) {
+func AllowForApp(c echo.Context, v permission.Verb, o permission.Fetcher) (slug string, err error) {
 	pdoc, err := GetPermission(c)
 	if err != nil {
 		return "", err

--- a/web/settings/context.go
+++ b/web/settings/context.go
@@ -23,6 +23,7 @@ type apiContext struct {
 func (c *apiContext) ID() string                             { return consts.ContextSettingsID }
 func (c *apiContext) Rev() string                            { return "" }
 func (c *apiContext) DocType() string                        { return consts.Settings }
+func (c *apiContext) Fetch(field string) []string            { return nil }
 func (c *apiContext) Clone() couchdb.Doc                     { return c }
 func (c *apiContext) SetID(id string)                        {}
 func (c *apiContext) SetRev(rev string)                      {}
@@ -33,9 +34,6 @@ func (c *apiContext) Links() *jsonapi.LinksList {
 }
 func (c *apiContext) MarshalJSON() ([]byte, error) {
 	return json.Marshal(c.doc)
-}
-func (c *apiContext) Match(field, expected string) bool {
-	return false
 }
 
 func onboarded(c echo.Context) error {

--- a/web/settings/disk_usage.go
+++ b/web/settings/disk_usage.go
@@ -31,7 +31,7 @@ func (j *apiDiskUsage) Links() *jsonapi.LinksList {
 }
 
 // Settings objects permissions are only on ID
-func (j *apiDiskUsage) Match(k, f string) bool { return false }
+func (j *apiDiskUsage) Fetch(field string) []string { return nil }
 
 func diskUsage(c echo.Context) error {
 	instance := middlewares.GetInstance(c)

--- a/worker/exec/konnector.go
+++ b/worker/exec/konnector.go
@@ -560,7 +560,7 @@ func (w *konnectorWorker) ScanOutput(ctx *job.WorkerContext, i *instance.Instanc
 
 	realtime.GetHub().Publish(i,
 		realtime.EventCreate,
-		couchdb.JSONDoc{Type: consts.JobEvents, M: map[string]interface{}{
+		&couchdb.JSONDoc{Type: consts.JobEvents, M: map[string]interface{}{
 			"type":    msg.Type,
 			"message": msg.Message,
 		}},

--- a/worker/exec/konnector_test.go
+++ b/worker/exec/konnector_test.go
@@ -153,8 +153,8 @@ echo "{\"type\": \"manifest\", \"message\": \"$(ls ${1}/manifest.konnector)\" }"
 		ev2 := <-ch
 		err = evCh.Close()
 		assert.NoError(t, err)
-		doc1 := ev1.Doc.(couchdb.JSONDoc)
-		doc2 := ev2.Doc.(couchdb.JSONDoc)
+		doc1 := ev1.Doc.(*couchdb.JSONDoc)
+		doc2 := ev2.Doc.(*couchdb.JSONDoc)
 
 		assert.Equal(t, inst.Domain, ev1.Domain)
 		assert.Equal(t, inst.Domain, ev2.Domain)
@@ -264,7 +264,7 @@ echo "{\"type\": \"params\", \"message\": ${SECRET} }"
 		ev1 := <-ch
 		err = evCh.Close()
 		assert.NoError(t, err)
-		doc1 := ev1.Doc.(couchdb.JSONDoc)
+		doc1 := ev1.Doc.(*couchdb.JSONDoc)
 
 		assert.Equal(t, inst.Domain, ev1.Domain)
 		assert.Equal(t, "params", doc1.M["type"])


### PR DESCRIPTION
Add a special `!=` for trigger values to indicate that a job should be triggered only the value for the selected field has changed on the document.
    
For example, a trigger on `io.cozy.bank.operations:UPDATED:!=:category` will be fired only if the category has changed.
    
See https://github.com/cozy/cozy-banks/pull/1508