### PR TITLE
Fix renaming a file from NFC to NFD

### DIFF
--- a/tests/integration/lib/instance.rb
+++ b/tests/integration/lib/instance.rb
@@ -71,4 +71,8 @@ class Instance
     @stack.install_app self, "home"
     Accept.new(sharing, sharer).on self
   end
+
+  def fsck
+    @stack.fsck self
+  end
 end

--- a/tests/integration/lib/stack.rb
+++ b/tests/integration/lib/stack.rb
@@ -69,4 +69,10 @@ class Stack
     puts cmd.join(" ").green
     `#{cmd.join(" ")}`.chomp
   end
+
+  def fsck(inst)
+    cmd = ["cozy-stack", "instances", "fsck", inst.domain, "--admin-port", @admin]
+    puts cmd.join(" ").green
+    `#{cmd.join(" ")}`.chomp
+  end
 end

--- a/tests/integration/tests/filepath_encoding.rb
+++ b/tests/integration/tests/filepath_encoding.rb
@@ -1,0 +1,52 @@
+require_relative '../boot'
+require 'minitest/autorun'
+require 'pry-rescue/minitest' unless ENV['CI']
+
+describe "The VFS" do
+  it "is able to deal with special cases on filepath encoding" do
+    Helpers.scenario "filepath_encoding"
+    Helpers.start_mailhog
+
+    # Create the instance
+    inst = Instance.create name: "Alice"
+
+    # Create a folder
+    dirname = "this"
+    folder = Folder.create inst
+    folder.couch_id.wont_be_empty
+    sub = Folder.create inst, dir_id: folder.couch_id
+    3.times do
+      CozyFile.create inst, dir_id: sub.couch_id
+      CozyFile.create inst, dir_id: folder.couch_id
+    end
+    # Create a lot of folders to force pagination
+    500.times do |i|
+      Folder.create inst, name: "foo-#{i}", dir_id: sub.couch_id
+    end
+
+    # Trying stupids tricks
+    before = File.join Helpers.current_dir, inst.domain
+    # Renaming to the same name
+    folder.rename inst, dirname rescue nil
+    # Moving inside its-self
+    folder.move_to inst, folder.couch_id rescue nil
+    # Moving inside a sub-directory
+    folder.move_to inst, sub.couch_id rescue nil
+    after = File.join Helpers.current_dir, inst.domain
+    diff = Helpers.fsdiff before, after
+    diff.must_be_empty
+    assert_equal inst.fsck, ""
+
+    # Play with NFC and NFD unicode normalization
+    ["Pièces pour ampèremètre", "Diplômes", "Reçus"].each do |name|
+      nfc = name.unicode_normalize(:nfc)
+      nfd = name.unicode_normalize(:nfd)
+      folder.rename inst, nfc
+      assert_equal inst.fsck, ""
+      folder.rename inst, nfd
+      assert_equal inst.fsck, ""
+      folder.rename inst, nfc
+      assert_equal inst.fsck, ""
+    end
+  end
+end


### PR DESCRIPTION
When a file is renamed, its name is different, but it can be very subtle. For example, it can have the same unicode meaning but just with two different normalizations, like NFC and NFD. CouchDB does a unicode normalization when using strings in mango selector, so we had to make the selector more robust for this case to avoid a loop where the same sub-directories where renamed.