### PR TITLE
Use cache for dynamic assets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,8 @@ require (
 	github.com/leonelquinteros/gotext v1.4.0
 	github.com/magiconair/properties v1.8.1 // indirect
 	github.com/mitchellh/mapstructure v1.1.2
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/mssola/user_agent v0.5.0
 	github.com/ncw/swift v1.0.49
 	github.com/nightlyone/lockfile v0.0.0-20180618180623-0ad87eef1443

--- a/pkg/assets/dynamic/dynamic.go
+++ b/pkg/assets/dynamic/dynamic.go
@@ -93,7 +93,7 @@ func RegisterCustomExternals(opts []model.AssetOption, maxTryCount int) error {
 	assetsCh := make(chan model.AssetOption)
 	doneCh := make(chan error)
 
-	for i := 0; i < len(opts); i++ {
+	for range opts {
 		go func() {
 			var err error
 			sleepDuration := 500 * time.Millisecond

--- a/web/apps/serve.go
+++ b/web/apps/serve.go
@@ -188,10 +188,6 @@ func ServeAppFile(c echo.Context, i *instance.Instance, fs appfs.FileServer, web
 					_, err = io.Copy(c.Response(), f.Reader())
 					return err
 				}
-				if f, ok := assets.Get("/robots.txt", ""); ok {
-					_, err = io.Copy(c.Response(), f.Reader())
-					return err
-				}
 			}
 			return echo.NewHTTPError(http.StatusNotFound, "Asset not found")
 		}

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -21,7 +21,7 @@ import (
 	"github.com/cozy/cozy-stack/model/oauth"
 	"github.com/cozy/cozy-stack/model/permission"
 	"github.com/cozy/cozy-stack/model/vfs"
-	"github.com/cozy/cozy-stack/pkg/assets"
+	"github.com/cozy/cozy-stack/pkg/assets/statik"
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
@@ -720,8 +720,8 @@ func serveThumbnailPlaceholder(res http.ResponseWriter, req *http.Request, doc *
 	if !utils.IsInArray(format, thumbnail.FormatsNames) {
 		return echo.NewHTTPError(http.StatusNotFound, "Format does not exist")
 	}
-	f, ok := assets.Get("/placeholders/thumbnail-"+format+".png", "")
-	if !ok {
+	f := statik.GetAsset("/placeholders/thumbnail-" + format + ".png")
+	if f == nil {
 		return os.ErrNotExist
 	}
 	etag := f.Etag

--- a/web/public/public.go
+++ b/web/public/public.go
@@ -18,10 +18,7 @@ func Avatar(c echo.Context) error {
 	inst := middlewares.GetInstance(c)
 	f, ok := assets.Get("/images/default-avatar.png", inst.ContextName)
 	if !ok {
-		f, ok = assets.Get("/images/default-avatar.png", "")
-		if !ok {
-			return echo.NewHTTPError(http.StatusNotFound, "Page not found")
-		}
+		return echo.NewHTTPError(http.StatusNotFound, "Page not found")
 	}
 	handler := statik.NewHandler()
 	handler.ServeFile(c.Response(), c.Request(), f, true)

--- a/web/server.go
+++ b/web/server.go
@@ -49,7 +49,7 @@ func LoadSupportedLocales() error {
 	}
 
 	for _, locale := range consts.SupportedLocales {
-		f, err := assets.Open("/locales/" + locale + ".po")
+		f, err := assets.Open("/locales/"+locale+".po", config.DefaultInstanceContext)
 		if err != nil {
 			return fmt.Errorf("Can't load the po file for %s", locale)
 		}

--- a/web/statik/handler.go
+++ b/web/statik/handler.go
@@ -116,7 +116,7 @@ func NewRenderer() (AssetRenderer, error) {
 
 	for _, name := range templatesList {
 		tmpl := t.New(name).Funcs(middlewares.FuncsMap)
-		f, err := assets.Open("/templates/" + name)
+		f, err := assets.Open("/templates/"+name, config.DefaultInstanceContext)
 		if err != nil {
 			return nil, fmt.Errorf("Can't load asset %q: %s", name, err)
 		}
@@ -174,12 +174,12 @@ func (r *renderer) Render(w io.Writer, name string, data interface{}, c echo.Con
 
 // AssetPath return the fullpath with unique identifier for a given asset file.
 func AssetPath(domain, name string, context ...string) string {
-	f, ok := assets.Get(name, context...)
+	ctx := config.DefaultInstanceContext
+	if len(context) > 0 && context[0] != "" {
+		ctx = context[0]
+	}
+	f, ok := assets.Head(name, ctx)
 	if !ok {
-		ctx := config.DefaultInstanceContext
-		if len(context) > 0 && context[0] != "" {
-			ctx = context[0]
-		}
 		logger.WithNamespace("assets").WithFields(logrus.Fields{
 			"domain":  domain,
 			"name":    name,

--- a/worker/mails/exec.go
+++ b/worker/mails/exec.go
@@ -56,7 +56,7 @@ func prepareWorkDir() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	f, err := assets.Open("/js/cozy-mjml.js")
+	f, err := assets.Open("/js/cozy-mjml.js", config.DefaultInstanceContext)
 	if err != nil {
 		return "", err
 	}

--- a/worker/mails/mail_templates.go
+++ b/worker/mails/mail_templates.go
@@ -135,16 +135,9 @@ func buildHTML(name string, layout string, ctx *job.WorkerContext, context, loca
 }
 
 func loadTemplate(name, context string) ([]byte, error) {
-	var f *bytes.Reader
-	if context != "" {
-		f, _ = assets.Open(name, context)
-	}
-	if f == nil {
-		var err error
-		f, err = assets.Open(name) // Default context
-		if err != nil {
-			return nil, err
-		}
+	f, err := assets.Open(name, context)
+	if err != nil {
+		return nil, err
 	}
 	return ioutil.ReadAll(f)
 }


### PR DESCRIPTION
Loading the index.html of web apps can be slow because the stack loads the assets from the storage to compute their URLs. This commit adds a cache that should help to have faster response time.