### PR TITLE
Enforce minimum redis pool size

### DIFF
--- a/cozy.example.yaml
+++ b/cozy.example.yaml
@@ -222,7 +222,7 @@ redis:
   # dial_timeout: 5s
   # read_timeout: 3s
   # write_timeout: 3s
-  # pool_size: 10 * runtime.NumCPU()
+  # pool_size: max(25, 10 * runtime.NumCPU())  # pool_size cannot be below 25
   # pool_timeout: 3s
   # idle_timeout: 5m
   # idle_check_frequency: 1m


### PR DESCRIPTION
A standalone full-featured stack has 15 worker types. Consequently, when using redis, it opens least 19 redis connections (15 worker types + 4).
Default redis pool size is `10 * runtime.NumCPU()` which is too short on a single-CPU computer.

The stack starts but can't do anything due to lack of available redis connections.

This PR enforces a minimum redis pool size of 25 slots and keeps the default `10 * runtime.NumCPU()` value if it is larger.