### PR TITLE
Don't send a mail when settings asks a bitwarden token

### DIFF
--- a/web/bitwarden/bitwarden.go
+++ b/web/bitwarden/bitwarden.go
@@ -285,6 +285,13 @@ func checkTwoFactor(c echo.Context, inst *instance.Instance) bool {
 		}
 	}
 
+	// Allow the settings webapp get a bitwarden token without the 2FA. It's OK
+	// from a security point of view as we still have 2 factors: the password
+	// and a valid session cookie.
+	if _, ok := middlewares.GetSession(c); ok {
+		return true
+	}
+
 	email, err := inst.SettingsEMail()
 	if err != nil {
 		_ = c.JSON(http.StatusInternalServerError, echo.Map{


### PR DESCRIPTION
Settings can ask a bitwarden token to reencrypt the ciphers when the user changes their password. If 2FA is activated, we can skip sending a code in an email, as we already have two factors: the hashed password and the session cookie.