### PR TITLE
Add a hub for bitwarden clients

### DIFF
--- a/docs/bitwarden.md
+++ b/docs/bitwarden.md
@@ -268,6 +268,27 @@ Content-Type: application/json
 HTTP/1.1 204 No Content
 ```
 
+### GET /bitwarden/api/accounts/revision-date
+
+It returns the date of the last change on the server, as a number of
+milliseconds since epoch (sic). It is used by the clients to know if they have
+to do a sync or if they are already up-to-date.
+
+#### Request
+
+```http
+GET /bitwarden/api/accounts/revision-date HTTP/1.1
+Host: alice.example.com
+```
+
+#### Response
+
+```http
+HTTP/1.1 200 OK
+
+1569571388892
+```
+
 ### PUT /bitwarden/api/settings/domains
 
 This route is also available via a `POST`, for compatibility with the web vault.

--- a/docs/bitwarden.md
+++ b/docs/bitwarden.md
@@ -1000,3 +1000,45 @@ bitwarden clients. No authorization token is required.
 GET /bitwarden/icons/cozy.io/icon.png HTTP/1.1
 Host: alice.example.com
 ```
+
+## Hub
+
+The hub is a way to get notifications in real-time about cipher and folder
+changes.
+
+### POST /bitwarden/notifications/hub/negotiate
+
+Before connecting to the hub, the client make a request to this endpoint to
+know what are the transports and formats supported by the server.
+
+#### Request
+
+```http
+POST /bitwarden/notifications/hub/negotiate HTTP/1.1
+Host: alice.example.com
+```
+
+#### Response
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+```
+
+```json
+{
+  "connectionId": "NzhhYjU4NjgtZTA1NC0xMWU5LWIzNzAtM2I1YzM3YWQyOTc1Cg",
+  "availableTransports": [
+    { "Transport": "WebSockets", "Formats": ["Binary"] }
+  ]
+}
+```
+
+### GET /bitwarden/notifications/hub
+
+This endpoint is used for WebSockets to get the notifications in real-time. The
+client must do 3 things, in this order:
+
+1. Make the HTTP request, with the token in the query string (`access_token`)
+2. Upgrade the connection to WebSockets
+3. Send JSON payload with `{"protocol": "messagepack", "version": 1}`.

--- a/docs/bitwarden.md
+++ b/docs/bitwarden.md
@@ -953,7 +953,7 @@ Host: alice.example.com
 #### Response
 
 ```http
-HTTP/1.1 204 No Content
+HTTP/1.1 200 OK
 ```
 
 ## Cozy Organization

--- a/go.mod
+++ b/go.mod
@@ -29,8 +29,6 @@ require (
 	github.com/leonelquinteros/gotext v1.4.0
 	github.com/magiconair/properties v1.8.1 // indirect
 	github.com/mitchellh/mapstructure v1.1.2
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/mssola/user_agent v0.5.0
 	github.com/ncw/swift v1.0.49
 	github.com/nightlyone/lockfile v0.0.0-20180618180623-0ad87eef1443

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.4.0
+	github.com/ugorji/go/codec v1.1.7
 	golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7
 	golang.org/x/image v0.0.0-20190910094157-69e4b8554b2a
 	golang.org/x/net v0.0.0-20190916140828-c8589233b77d

--- a/go.sum
+++ b/go.sum
@@ -230,7 +230,11 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
+github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
+github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
+github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=
+github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.0.1 h1:tY9CJiPnMXf1ERmG2EyK7gNUd+c6RKGD0IfU8WdUSz8=

--- a/model/bitwarden/settings/settings.go
+++ b/model/bitwarden/settings/settings.go
@@ -137,4 +137,21 @@ func Get(inst *instance.Instance) (*Settings, error) {
 	return settings, nil
 }
 
+// UpdateRevisionDate updates the updatedAt field of the bitwarden settings
+// document. This field is used to know by some clients to know the date of the
+// last change on the server before doing a full sync.
+func UpdateRevisionDate(inst *instance.Instance, settings *Settings) {
+	var err error
+	if settings == nil {
+		settings, err = Get(inst)
+	}
+	if err == nil {
+		err = settings.Save(inst)
+	}
+	if err != nil {
+		inst.Logger().WithField("nspace", "bitwarden").
+			Infof("Cannot update revision date: %s", err)
+	}
+}
+
 var _ couchdb.Doc = &Settings{}

--- a/tests/integration/lib/bitwarden.rb
+++ b/tests/integration/lib/bitwarden.rb
@@ -37,7 +37,7 @@ class Bitwarden
   end
 
   def sync
-    exec "sync --force"
+    exec "sync"
   end
 
   def json_exec(cmd)

--- a/web/bitwarden/bitwarden.go
+++ b/web/bitwarden/bitwarden.go
@@ -446,6 +446,10 @@ func Routes(router *echo.Group) {
 	folders.DELETE("/:id", DeleteFolder)
 	folders.POST("/:id/delete", DeleteFolder)
 
+	hub := router.Group("/notifications/hub")
+	hub.GET("", WebsocketHub)
+	hub.POST("/negotiate", NegotiateHub)
+
 	orgs := router.Group("/organizations")
 	orgs.GET("/cozy", GetCozy)
 

--- a/web/bitwarden/bitwarden_test.go
+++ b/web/bitwarden/bitwarden_test.go
@@ -216,7 +216,7 @@ func TestDeleteFolder(t *testing.T) {
 	req.Header.Add("Authorization", "Bearer "+token)
 	res, err = http.DefaultClient.Do(req)
 	assert.NoError(t, err)
-	assert.Equal(t, 204, res.StatusCode)
+	assert.Equal(t, 200, res.StatusCode)
 
 	// Check that the cipher in this folder has been moved out
 	req, _ = http.NewRequest("GET", ts.URL+"/bitwarden/api/ciphers/"+cID, nil)

--- a/web/bitwarden/folders.go
+++ b/web/bitwarden/folders.go
@@ -253,5 +253,5 @@ func DeleteFolder(c echo.Context) error {
 			"error": err.Error(),
 		})
 	}
-	return c.NoContent(http.StatusNoContent)
+	return c.NoContent(http.StatusOK)
 }

--- a/web/bitwarden/folders.go
+++ b/web/bitwarden/folders.go
@@ -248,6 +248,12 @@ func DeleteFolder(c echo.Context) error {
 		})
 	}
 
+	if folder.Metadata == nil {
+		md := metadata.New()
+		md.DocTypeVersion = bitwarden.DocTypeVersion
+		folder.Metadata = md
+	}
+	folder.Metadata.ChangeUpdatedAt()
 	if err := couchdb.DeleteDoc(inst, folder); err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{
 			"error": err.Error(),

--- a/web/bitwarden/folders.go
+++ b/web/bitwarden/folders.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/cozy/cozy-stack/model/bitwarden"
+	"github.com/cozy/cozy-stack/model/bitwarden/settings"
 	"github.com/cozy/cozy-stack/model/permission"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
@@ -107,6 +108,7 @@ func CreateFolder(c echo.Context) error {
 		})
 	}
 
+	settings.UpdateRevisionDate(inst, nil)
 	res := newFolderResponse(folder)
 	return c.JSON(http.StatusOK, res)
 }
@@ -196,6 +198,7 @@ func RenameFolder(c echo.Context) error {
 		})
 	}
 
+	settings.UpdateRevisionDate(inst, nil)
 	res := newFolderResponse(folder)
 	return c.JSON(http.StatusOK, res)
 }
@@ -259,5 +262,7 @@ func DeleteFolder(c echo.Context) error {
 			"error": err.Error(),
 		})
 	}
+
+	settings.UpdateRevisionDate(inst, nil)
 	return c.NoContent(http.StatusOK)
 }

--- a/web/bitwarden/hub.go
+++ b/web/bitwarden/hub.go
@@ -204,16 +204,16 @@ type notification []interface{}
 const (
 	hubCipherUpdate = 0
 	hubCipherCreate = 1
-	hubLoginDelete  = 2
+	// hubLoginDelete  = 2
 	hubFolderDelete = 3
-	hubCiphers      = 4
-	hubVault        = 5
-	hubOrgKeys      = 6
+	// hubCiphers      = 4
+	// hubVault        = 5
+	// hubOrgKeys      = 6
 	hubFolderCreate = 7
 	hubFolderUpdate = 8
 	hubCipherDelete = 9
-	hubSettings     = 10
-	hubLogOut       = 11
+	// hubSettings     = 10
+	// hubLogOut       = 11
 )
 
 func buildNotification(e *realtime.Event, userID string, settings *settings.Settings) *notification {

--- a/web/bitwarden/hub.go
+++ b/web/bitwarden/hub.go
@@ -96,7 +96,7 @@ var upgrader = websocket.Upgrader{
 }
 
 func upgradeWebsocket(c echo.Context, inst *instance.Instance, userID string) (*wsNotifier, error) {
-	settings, err := settings.Get(inst)
+	setting, err := settings.Get(inst)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +119,7 @@ func upgradeWebsocket(c echo.Context, inst *instance.Instance, userID string) (*
 	ds := realtime.GetHub().Subscriber(inst)
 	notifier := wsNotifier{
 		UserID:    userID,
-		Settings:  settings,
+		Settings:  setting,
 		WS:        ws,
 		DS:        ds,
 		Responses: responses,
@@ -248,7 +248,7 @@ const (
 	// hubLogOut       = 11
 )
 
-func buildNotification(e *realtime.Event, userID string, settings *settings.Settings) *notification {
+func buildNotification(e *realtime.Event, userID string, setting *settings.Settings) *notification {
 	if e == nil || e.Doc == nil {
 		return nil
 	}
@@ -267,7 +267,7 @@ func buildNotification(e *realtime.Event, userID string, settings *settings.Sett
 			t = hubFolderDelete
 		}
 	} else if doctype == consts.BitwardenCiphers {
-		payload = buildCipherPayload(e, userID, settings)
+		payload = buildCipherPayload(e, userID, setting)
 		switch e.Verb {
 		case realtime.EventCreate:
 			t = hubCipherCreate
@@ -325,7 +325,7 @@ func buildFolderPayload(e *realtime.Event, userID string) map[string]interface{}
 	}
 }
 
-func buildCipherPayload(e *realtime.Event, userID string, settings *settings.Settings) map[string]interface{} {
+func buildCipherPayload(e *realtime.Event, userID string, setting *settings.Settings) map[string]interface{} {
 	var sharedWithCozy bool
 	var updatedAt interface{}
 	var date string
@@ -353,8 +353,8 @@ func buildCipherPayload(e *realtime.Event, userID string, settings *settings.Set
 	}
 	var orgID, collIDs interface{}
 	if sharedWithCozy {
-		orgID = settings.OrganizationID
-		collIDs = []string{settings.CollectionID}
+		orgID = setting.OrganizationID
+		collIDs = []string{setting.CollectionID}
 	}
 	return map[string]interface{}{
 		"Id":             e.Doc.ID(),

--- a/web/bitwarden/hub.go
+++ b/web/bitwarden/hub.go
@@ -21,7 +21,7 @@ type transport struct {
 	Formats   []string `json:"transferFormats"`
 }
 
-// NegotiateHub is the handler for negociating between the server and the
+// NegotiateHub is the handler for negotiating between the server and the
 // client which transport to use for bitwarden notifications. Currently,
 // only websocket is supported.
 func NegotiateHub(c echo.Context) error {
@@ -94,6 +94,7 @@ func WebsocketHub(c echo.Context) error {
 	go readPump(ws, ds, responses)
 
 	handle := new(codec.MsgpackHandle)
+	handle.WriteExt = true
 	ticker := time.NewTicker(pingPeriod)
 	defer ticker.Stop()
 
@@ -197,7 +198,7 @@ func buildNotification(e *realtime.Event, userID string) *notification {
 	payload := map[string]interface{}{
 		"Id":           e.Doc.ID(),
 		"UserId":       userID,
-		"RevisionDate": time.Now().String(),
+		"RevisionDate": time.Now(),
 	}
 	t := 3 // TODO https://github.com/bitwarden/jslib/blob/master/src/enums/notificationType.ts
 	arg := notificationResponse{

--- a/web/bitwarden/hub.go
+++ b/web/bitwarden/hub.go
@@ -1,0 +1,162 @@
+package bitwarden
+
+import (
+	"encoding/base64"
+	"net/http"
+	"time"
+
+	"github.com/cozy/cozy-stack/model/permission"
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/crypto"
+	"github.com/cozy/cozy-stack/pkg/logger"
+	"github.com/cozy/cozy-stack/pkg/realtime"
+	"github.com/cozy/cozy-stack/web/middlewares"
+	"github.com/gorilla/websocket"
+	"github.com/labstack/echo/v4"
+)
+
+type transport struct {
+	Transport string   `json:"transport"`
+	Formats   []string `json:"transferFormats"`
+}
+
+// NegotiateHub is the handler for negociating between the server and the
+// client which transport to use for bitwarden notifications. Currently,
+// only websocket is supported.
+func NegotiateHub(c echo.Context) error {
+	if err := middlewares.AllowWholeType(c, permission.GET, consts.BitwardenCiphers); err != nil {
+		return c.JSON(http.StatusUnauthorized, echo.Map{
+			"error": "invalid token",
+		})
+	}
+
+	transports := []transport{
+		// Bitwarden jslib supports only msgpack (Binary), not JSON (Text)
+		{Transport: "WebSockets", Formats: []string{"Binary"}},
+	}
+
+	connID := crypto.GenerateRandomBytes(16)
+	return c.JSON(http.StatusOK, echo.Map{
+		"connectionId":        base64.URLEncoding.EncodeToString(connID),
+		"availableTransports": transports,
+	})
+}
+
+const (
+	// Time allowed to write a message to the peer
+	writeWait = 10 * time.Second
+	// Time allowed to read the next pong message from the peer
+	pongWait = 20 * time.Second
+	// Send pings to peer with this period (must be less than pongWait)
+	pingPeriod = 15 * time.Second
+	// Maximum message size allowed from peer
+	maxMessageSize = 1024
+)
+
+var upgrader = websocket.Upgrader{
+	// Don't check the origin of the connexion
+	CheckOrigin:     func(r *http.Request) bool { return true },
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+}
+
+// WebsocketHub is the websocket handler for the hub to send notifications in
+// real-time for bitwarden stuff.
+func WebsocketHub(c echo.Context) error {
+	inst := middlewares.GetInstance(c)
+	token := c.QueryParam("access_token")
+	pdoc, err := middlewares.ParseJWT(c, inst, token)
+	if err != nil || !pdoc.Permissions.AllowWholeType(permission.GET, consts.BitwardenCiphers) {
+		return c.JSON(http.StatusUnauthorized, echo.Map{
+			"error": "invalid token",
+		})
+	}
+
+	ws, err := upgrader.Upgrade(c.Response(), c.Request(), nil)
+	if err != nil {
+		return err
+	}
+	defer ws.Close()
+
+	ws.SetReadLimit(maxMessageSize)
+	if err = ws.SetReadDeadline(time.Now().Add(pongWait)); err != nil {
+		return nil
+	}
+	ws.SetPongHandler(func(string) error {
+		return ws.SetReadDeadline(time.Now().Add(pongWait))
+	})
+
+	ds := realtime.GetHub().Subscriber(inst)
+	defer ds.Close()
+	go readPump(ws, ds)
+
+	ticker := time.NewTicker(pingPeriod)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case e := <-ds.Channel:
+			if err := ws.SetWriteDeadline(time.Now().Add(writeWait)); err != nil {
+				return err
+			}
+			res := map[string]interface{}{
+				"ID": e.Doc.ID(),
+			}
+			if err := ws.WriteJSON(res); err != nil {
+				return nil
+			}
+		case <-ticker.C:
+			if err := ws.SetWriteDeadline(time.Now().Add(writeWait)); err != nil {
+				return err
+			}
+			if err := ws.WriteMessage(websocket.PingMessage, []byte{}); err != nil {
+				return nil
+			}
+		}
+	}
+}
+
+var initialResponse = []byte{0x7b, 0x7d, 0x1e} // {}<RS>
+
+func readPump(ws *websocket.Conn, ds *realtime.DynamicSubscriber) {
+	var msg struct {
+		Protocol string `json:"protocol"`
+		Version  int    `json:"version"`
+	}
+	if err := ws.ReadJSON(&msg); err != nil {
+		if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseNoStatusReceived) {
+			logger.WithDomain(ds.DomainName()).WithField("nspace", "bitwarden").
+				Infof("Read error: %s", err)
+		}
+		return
+	}
+	if msg.Protocol != "messagepack" || msg.Version != 1 {
+		logger.WithDomain(ds.DomainName()).WithField("nspace", "bitwarden").
+			Infof("Unexpected message: %v", msg)
+		return
+	}
+	if err := ws.WriteMessage(websocket.BinaryMessage, initialResponse); err != nil {
+		logger.WithDomain(ds.DomainName()).WithField("nspace", "bitwarden").
+			Infof("Write error: %s", err)
+		return
+	}
+
+	// Just send back the pings from the client
+	for {
+		msgType, p, err := ws.ReadMessage()
+		if err != nil {
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseNoStatusReceived) {
+				logger.WithDomain(ds.DomainName()).WithField("nspace", "bitwarden").
+					Infof("Read error: %s", err)
+			}
+			return
+		}
+		if err := ws.WriteMessage(msgType, p); err != nil {
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseNoStatusReceived) {
+				logger.WithDomain(ds.DomainName()).WithField("nspace", "bitwarden").
+					Infof("Write error: %s", err)
+				return
+			}
+		}
+	}
+}

--- a/web/bitwarden/organization.go
+++ b/web/bitwarden/organization.go
@@ -33,17 +33,17 @@ type organizationResponse struct {
 	Object         string `json:"Object"`
 }
 
-func getCozyOrganizationResponse(inst *instance.Instance, settings *settings.Settings) (*organizationResponse, error) {
-	if settings == nil || settings.PublicKey == "" {
+func getCozyOrganizationResponse(inst *instance.Instance, setting *settings.Settings) (*organizationResponse, error) {
+	if setting == nil || setting.PublicKey == "" {
 		return nil, errors.New("No public key")
 	}
-	orgKey, err := settings.OrganizationKey()
+	orgKey, err := setting.OrganizationKey()
 	if err != nil {
 		inst.Logger().WithField("nspace", "bitwarden").
 			Infof("Cannot read the organization key: %s", err)
 		return nil, err
 	}
-	key, err := crypto.EncryptWithRSA(settings.PublicKey, orgKey)
+	key, err := crypto.EncryptWithRSA(setting.PublicKey, orgKey)
 	if err != nil {
 		inst.Logger().WithField("nspace", "bitwarden").
 			Infof("Cannot encrypt with RSA: %s", err)
@@ -52,7 +52,7 @@ func getCozyOrganizationResponse(inst *instance.Instance, settings *settings.Set
 
 	email := inst.PassphraseSalt()
 	return &organizationResponse{
-		ID:             settings.OrganizationID,
+		ID:             setting.OrganizationID,
 		Name:           consts.BitwardenCozyOrganizationName,
 		Key:            key,
 		Email:          string(email),
@@ -83,8 +83,8 @@ type collectionResponse struct {
 	Object         string `json:"Object"`
 }
 
-func getCozyCollectionResponse(settings *settings.Settings) (*collectionResponse, error) {
-	orgKey, err := settings.OrganizationKey()
+func getCozyCollectionResponse(setting *settings.Settings) (*collectionResponse, error) {
+	orgKey, err := setting.OrganizationKey()
 	if err != nil || len(orgKey) != 64 {
 		return nil, errors.New("Missing organization key")
 	}
@@ -95,8 +95,8 @@ func getCozyCollectionResponse(settings *settings.Settings) (*collectionResponse
 		return nil, err
 	}
 	return &collectionResponse{
-		ID:             settings.CollectionID,
-		OrganizationID: settings.OrganizationID,
+		ID:             setting.CollectionID,
+		OrganizationID: setting.OrganizationID,
 		Name:           name,
 		Object:         "collection",
 	}, nil

--- a/web/bitwarden/settings.go
+++ b/web/bitwarden/settings.go
@@ -26,11 +26,11 @@ type domainsResponse struct {
 	Object                  string                 `json:"Object"`
 }
 
-func newDomainsResponse(settings *settings.Settings) *domainsResponse {
+func newDomainsResponse(setting *settings.Settings) *domainsResponse {
 	globals := make([]globalDomainsReponse, 0, len(bitwarden.GlobalDomains))
 	for k, v := range bitwarden.GlobalDomains {
 		excluded := false
-		for _, domain := range settings.GlobalEquivalentDomains {
+		for _, domain := range setting.GlobalEquivalentDomains {
 			if bitwarden.GlobalEquivalentDomainsType(domain) == k {
 				excluded = true
 				break
@@ -43,7 +43,7 @@ func newDomainsResponse(settings *settings.Settings) *domainsResponse {
 		})
 	}
 	return &domainsResponse{
-		EquivalentDomains:       settings.EquivalentDomains,
+		EquivalentDomains:       setting.EquivalentDomains,
 		GlobalEquivalentDomains: globals,
 		Object:                  "domains",
 	}
@@ -57,12 +57,12 @@ func GetDomains(c echo.Context) error {
 			"error": "invalid token",
 		})
 	}
-	settings, err := settings.Get(inst)
+	setting, err := settings.Get(inst)
 	if err != nil {
 		return err
 	}
 
-	domains := newDomainsResponse(settings)
+	domains := newDomainsResponse(setting)
 	return c.JSON(http.StatusOK, domains)
 }
 
@@ -85,19 +85,19 @@ func UpdateDomains(c echo.Context) error {
 		})
 	}
 
-	settings, err := settings.Get(inst)
+	setting, err := settings.Get(inst)
 	if err != nil {
 		return err
 	}
 
-	settings.EquivalentDomains = req.Equivalent
-	settings.GlobalEquivalentDomains = req.Global
-	if err := settings.Save(inst); err != nil {
+	setting.EquivalentDomains = req.Equivalent
+	setting.GlobalEquivalentDomains = req.Global
+	if err := setting.Save(inst); err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{
 			"error": err.Error(),
 		})
 	}
 
-	domains := newDomainsResponse(settings)
+	domains := newDomainsResponse(setting)
 	return c.JSON(http.StatusOK, domains)
 }


### PR DESCRIPTION
It allows the client to listen with a websocket, and the server can send them notifications about ciphers and folders.