### PR TITLE
Show 404 error page for app domain

### DIFF
--- a/web/middlewares/instance.go
+++ b/web/middlewares/instance.go
@@ -21,10 +21,9 @@ func NeedInstance(next echo.HandlerFunc) echo.HandlerFunc {
 		if err != nil {
 			var errHTTP *echo.HTTPError
 			switch err {
-			case instance.ErrNotFound:
+			case instance.ErrNotFound, instance.ErrIllegalDomain:
+				err = instance.ErrNotFound
 				errHTTP = echo.NewHTTPError(http.StatusNotFound, err)
-			case instance.ErrIllegalDomain:
-				errHTTP = echo.NewHTTPError(http.StatusBadRequest, err)
 			default:
 				errHTTP = echo.NewHTTPError(http.StatusInternalServerError, err)
 			}


### PR DESCRIPTION
When a stack is configured with flat subdomains, and an instance has been deleted, a request on `https://<slug>-<app>.mycozy.cloud/` should return a 404 error page.