### PR TITLE
Fix behavior when an instance is blocked for TOS

### DIFF
--- a/web/routing.go
+++ b/web/routing.go
@@ -169,7 +169,9 @@ func SetupRoutes(router *echo.Echo) error {
 				DefaultContentTypeOffer: jsonapi.ContentType,
 			}),
 		}
-		mws := append(mwsNotBlocked, middlewares.CheckInstanceBlocked, middlewares.CheckTOSDeadlineExpired)
+		mws := append(mwsNotBlocked,
+			middlewares.CheckInstanceBlocked,
+			middlewares.CheckTOSDeadlineExpired)
 		registry.Routes(router.Group("/registry", mws...))
 		data.Routes(router.Group("/data", mws...))
 		files.Routes(router.Group("/files", mws...))


### PR DESCRIPTION
If an instance is blocked because the user hasn't signed the terms of services, the requests to this instance are rejected. They were always redirected to the manager, but now, only the requests for an HTML page are redirected. The requests for a JSON API are rejected with 402 Payment required, and a JSON message.