### PR TITLE
Fix migrated container metadata

### DIFF
--- a/worker/migrations/migrations.go
+++ b/worker/migrations/migrations.go
@@ -92,7 +92,14 @@ func migrateToSwiftV3(domain string) error {
 		migratedFrom = "v1"
 	case 1: // layout v2
 		srcContainer = swiftV2ContainerPrefixCozy + inst.DBPrefix()
-		migratedFrom = "v2"
+		switch inst.DBPrefix() {
+		case inst.Domain:
+			migratedFrom = "v2a"
+		case inst.Prefix:
+			migratedFrom = "v2b"
+		default:
+			return instance.ErrInvalidSwiftLayout
+		}
 	case 2: // layout v3
 		return nil // Nothing to do!
 	default:

--- a/worker/migrations/migrations.go
+++ b/worker/migrations/migrations.go
@@ -129,7 +129,7 @@ func migrateToSwiftV3(domain string) error {
 	}
 
 	meta := &swift.Metadata{"cozy-migrated-from": migratedFrom}
-	_ = c.ContainerUpdate(srcContainer, meta.ContainerHeaders())
+	_ = c.ContainerUpdate(dstContainer, meta.ContainerHeaders())
 	if in, err := instance.GetFromCouch(domain); err == nil {
 		inst = in
 	}


### PR DESCRIPTION
When migrating an instance from swift layout v1 or v2 to swift layout v3, we add a "cozy-migrated-from" metadata.

This PR fixes the metadata which was wrongly added to source container rather than the destination container.

This PR also add storing more specific informations about which v2 layout (v2a or v2b) the instance was migrated from