### PR TITLE
Split swift layout v3 into v3a and v3b like v2

### DIFF
--- a/cmd/swift.go
+++ b/cmd/swift.go
@@ -27,7 +27,7 @@ var swiftCmdGroup = &cobra.Command{
 
 var lsLayoutsCmd = &cobra.Command{
 	Use:     "ls-layouts",
-	Short:   `Count layouts by types (v1, v2a, v2b, v3)`,
+	Short:   `Count layouts by types (v1, v2a, v2b, v3a, v3b)`,
 	Example: "$ cozy-stack swift ls-layouts",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		c := newAdminClient()

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -123,8 +123,11 @@ Accept: application/vnd.api+json
   "v2b": {
     "counter": 0
   },
-  "v3": {
+  "v3a": {
     "counter": 2
+  },
+  "v3b": {
+    "counter": 4
   }
 }
 ```
@@ -159,11 +162,20 @@ Accept: application/vnd.api+json
   "v2b": {
     "counter": 0
   },
-  "v3": {
+  "v3a": {
     "counter": 2,
     "domains": [
       "alice.cozy.tools:8081",
       "ru.cozy.tools:8081"
+    ]
+  },
+  "v3b": {
+    "counter": 4,
+    "domains": [
+      "foo.cozy.tools:8081",
+      "bar.cozy.tools:8081",
+      "baz.cozy.tools:8081",
+      "foobar.cozy.tools:8081"
     ]
   }
 }

--- a/docs/cli/cozy-stack_swift.md
+++ b/docs/cli/cozy-stack_swift.md
@@ -29,9 +29,8 @@ cozy-stack swift <command> [flags]
 ### SEE ALSO
 
 * [cozy-stack](cozy-stack.md)	 - cozy-stack is the main command
-* [cozy-stack swift get](cozy-stack_swift_get.md)	 - 
-* [cozy-stack swift ls](cozy-stack_swift_ls.md)	 - 
-* [cozy-stack swift ls-layouts](cozy-stack_swift_ls-layouts.md)	 - Count layouts by types (v1, v2a, v2b, v3)
+* [cozy-stack swift get](cozy-stack_swift_get.md)	 -
+* [cozy-stack swift ls](cozy-stack_swift_ls.md)	 -
 * [cozy-stack swift put](cozy-stack_swift_put.md)	 - 
-* [cozy-stack swift rm](cozy-stack_swift_rm.md)	 - 
-
+* [cozy-stack swift rm](cozy-stack_swift_rm.md)	 -
+* [cozy-stack swift ls-layouts](cozy-stack_swift_ls-layouts.md)	 - Count layouts by types (v1, v2a, v2b, v3a, v3b)

--- a/docs/cli/cozy-stack_swift_ls-layouts.md
+++ b/docs/cli/cozy-stack_swift_ls-layouts.md
@@ -1,10 +1,10 @@
 ## cozy-stack swift ls-layouts
 
-Count layouts by types (v1, v2a, v2b, v3)
+Count layouts by types (v1, v2a, v2b, v3a, v3b)
 
 ### Synopsis
 
-Count layouts by types (v1, v2a, v2b, v3)
+Count layouts by types (v1, v2a, v2b, v3a, v3b)
 
 ```
 cozy-stack swift ls-layouts [flags]
@@ -36,4 +36,3 @@ $ cozy-stack swift ls-layouts
 ### SEE ALSO
 
 * [cozy-stack swift](cozy-stack_swift.md)	 - Interact directly with OpenStack Swift object storage
-

--- a/scripts/completion/cozy-stack.zsh
+++ b/scripts/completion/cozy-stack.zsh
@@ -1355,7 +1355,7 @@ function _cozy-stack_swift {
     commands=(
       "get:"
       "ls:"
-      "ls-layouts:Count layouts by types (v1, v2a, v2b, v3)"
+      "ls-layouts:Count layouts by types (v1, v2a, v2b, v3a, v3b)"
       "put:"
       "rm:"
     )
@@ -1505,4 +1505,3 @@ function _cozy-stack_version {
     '--host[server host]:' \
     '(-p --port)'{-p,--port}'[server port]:'
 }
-

--- a/web/swift/swift.go
+++ b/web/swift/swift.go
@@ -20,7 +20,7 @@ func ListLayouts(c echo.Context) error {
 		Counter int      `json:"counter"`
 		Domains []string `json:"domains,omitempty"`
 	}
-	var layoutV1, layoutV2a, layoutV2b, layoutUnknown, layoutV3 layout
+	var layoutV1, layoutV2a, layoutV2b, layoutUnknown, layoutV3a, layoutV3b layout
 
 	flagShowDomains := false
 	flagParam := c.QueryParam("show_domains")
@@ -58,9 +58,22 @@ func ListLayouts(c echo.Context) error {
 				}
 			}
 		case 2:
-			layoutV3.Counter++
-			if flagShowDomains {
-				layoutV3.Domains = append(layoutV3.Domains, inst.Domain)
+			switch inst.DBPrefix() {
+			case inst.Domain:
+				layoutV3a.Counter++
+				if flagShowDomains {
+					layoutV3a.Domains = append(layoutV3a.Domains, inst.Domain)
+				}
+			case inst.Prefix:
+				layoutV3b.Counter++
+				if flagShowDomains {
+					layoutV3b.Domains = append(layoutV3b.Domains, inst.Domain)
+				}
+			default:
+				layoutUnknown.Counter++
+				if flagShowDomains {
+					layoutUnknown.Domains = append(layoutUnknown.Domains, inst.Domain)
+				}
 			}
 		default:
 			layoutUnknown.Counter++
@@ -75,8 +88,9 @@ func ListLayouts(c echo.Context) error {
 	output["v2a"] = layoutV2a
 	output["v2b"] = layoutV2b
 	output["unknown"] = layoutUnknown
-	output["v3"] = layoutV3
-	output["total"] = layoutV1.Counter + layoutV2a.Counter + layoutV2b.Counter + layoutUnknown.Counter + layoutV3.Counter
+	output["v3a"] = layoutV3a
+	output["v3b"] = layoutV3b
+	output["total"] = layoutV1.Counter + layoutV2a.Counter + layoutV2b.Counter + layoutUnknown.Counter + layoutV3a.Counter + layoutV3b.Counter
 
 	return c.JSON(http.StatusOK, output)
 }


### PR DESCRIPTION
We splitted layout v2 into v2a and v2b depending on the swift container name, wether with the instance FQDN or with a random hexadecimal prefix.

Let's do the same for layout v3 because we can have swift containers with instance FQDN instead of prefix for instances migrated from layout v1 or v2a.