### PR TITLE
Fix swift layout v1 container names

### DIFF
--- a/model/vfs/vfsswift/impl_v1.go
+++ b/model/vfs/vfsswift/impl_v1.go
@@ -54,7 +54,7 @@ func New(db prefixer.Prefixer, index vfs.Indexer, disk vfs.DiskThresholder, mu l
 		prefix:        db.DBPrefix(),
 		container:     swiftV1ContainerPrefix + db.DBPrefix(),
 		version:       swiftV1ContainerPrefix + db.DBPrefix() + versionSuffix,
-		dataContainer: swiftV1DataContainerPrefix + db.DBPrefix(),
+		dataContainer: swiftV1DataContainerPrefix + db.DomainName(),
 		mu:            mu,
 		log:           logger.WithDomain(db.DomainName()).WithField("nspace", "vfsswift"),
 	}, nil

--- a/worker/migrations/migrations.go
+++ b/worker/migrations/migrations.go
@@ -88,9 +88,10 @@ func migrateToSwiftV3(domain string) error {
 	log := logger.WithDomain(inst.Domain).WithField("nspace", "migration")
 
 	var srcContainer, migratedFrom string
+	// TODO(XXX): Use ContainerNames() instead of duplicating the container names logic here
 	switch inst.SwiftLayout {
 	case 0: // layout v1
-		srcContainer = swiftV1ContainerPrefixCozy + domain
+		srcContainer = swiftV1ContainerPrefixCozy + inst.DBPrefix()
 		migratedFrom = "v1"
 	case 1: // layout v2
 		srcContainer = swiftV2ContainerPrefixCozy + inst.DBPrefix()
@@ -160,6 +161,7 @@ func copyTheFilesToSwiftV3(inst *instance.Instance, c *swift.Connection, root *v
 		WithField("nspace", "migration")
 
 	var thumbsContainer string
+	// TODO(XXX): Use ContainerNames() instead of duplicating the container names logic here
 	switch inst.SwiftLayout {
 	case 0: // layout v1
 		thumbsContainer = swiftV1ContainerPrefixData + inst.Domain


### PR DESCRIPTION
Fix swift layout v1 container names.

In particular, fix 
- https://github.com/cozy/cozy-stack/blob/master/model/vfs/vfsswift/impl_v1.go#L57 according to https://github.com/cozy/cozy-stack/blob/master/model/vfs/vfsswift/thumbs_v1.go#L15
- https://github.com/cozy/cozy-stack/blob/master/worker/migrations/migrations.go#L93 according to https://github.com/cozy/cozy-stack/blob/master/model/vfs/vfsswift/impl_v1.go#L55

This way, we can properly:
- Delete data container for instances in swift-layout v1 (`swift_cluster == 0`) with a not null prefix when removing the instance
- Migrate those instances (otherwise migration worker fails to find the files)

Note: After all v1 layout instances have been migrated to layout v3, we should either fix https://github.com/cozy/cozy-stack/blob/master/model/vfs/vfsswift/thumbs_v1.go#L15 to use DBprefix() like the files container or completely remove layout v1 code from cozy-stack. I chose to keep the bug here to avoid breaking existing instances.