### PR TITLE
Fix double-deletion in migration worker

### DIFF
--- a/worker/migrations/migrations.go
+++ b/worker/migrations/migrations.go
@@ -148,8 +148,14 @@ func migrateToSwiftV3(domain string) error {
 	if err = couchdb.UpdateDoc(couchdb.GlobalDB, inst); err != nil {
 		return err
 	}
-	if err = vfs.Delete(); err != nil {
-		log.Errorf("Failed to delete old %s containers: %s", migratedFrom, err)
+
+	// Migration done. Now clean-up oldies.
+
+	// WARNING: Don't call `err` any error below in this function or the defer func
+	//          will delete the new container even if the migration was successful
+
+	if deleteErr := vfs.Delete(); deleteErr != nil {
+		log.Errorf("Failed to delete old %s containers: %s", migratedFrom, deleteErr)
 	}
 	return nil
 }


### PR DESCRIPTION
#2136 introduced a bug in migration worker while adding log on older container deletion. By using the `err` variable to store error on older container deletion, this triggers the deletion of the new container by the defer func after the migration has finished.

This PR fixes that bug and add a warning comment in the code.