### PR TITLE
Install couchdb via apt instead of docker for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,8 @@ on:
       - 'docs/**'
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     services:
-      couchdb:
-        image: apache/couchdb:2.3
-        ports:
-          - 5984:5984
       redis:
         image: redis
         ports:
@@ -24,6 +20,13 @@ jobs:
       matrix:
         go-version: [1.12.x, 1.13.x]
     steps:
+      - name: Install CouchDB
+        run: |
+          sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 379CE192D401AB61
+          echo "deb https://apache.bintray.com/couchdb-deb bionic main" | sudo tee -a /etc/apt/sources.list
+          sudo apt-get update
+          echo -ne "couchdb couchdb/mode select standalone\ncouchdb couchdb/mode seen true\ncouchdb couchdb/bindaddress string 127.0.0.1\ncouchdb couchdb/bindaddress seen true\ncouchdb couchdb/adminpass password \ncouchdb couchdb/adminpass seen true\ncouchdb couchdb/adminpass_again password \ncouchdb couchdb/adminpass_again seen true\n" | sudo debconf-set-selections
+          DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --force-yes couchdb
       - name: Install Go
         uses: actions/setup-go@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,18 @@ jobs:
       - name: Install CouchDB
         run: |
           sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 379CE192D401AB61
-          echo "deb https://apache.bintray.com/couchdb-deb bionic main" | sudo tee -a /etc/apt/sources.list
+          echo "deb https://apache.bintray.com/couchdb-deb $(lsb_release -c -s) main" | sudo tee -a /etc/apt/sources.list
           sudo apt-get update
-          echo -ne "couchdb couchdb/mode select standalone\ncouchdb couchdb/mode seen true\ncouchdb couchdb/bindaddress string 127.0.0.1\ncouchdb couchdb/bindaddress seen true\ncouchdb couchdb/adminpass password \ncouchdb couchdb/adminpass seen true\ncouchdb couchdb/adminpass_again password \ncouchdb couchdb/adminpass_again seen true\n" | sudo debconf-set-selections
+          sudo debconf-set-selections <<-EOF
+          	couchdb couchdb/mode select standalone
+          	couchdb couchdb/mode seen true
+          	couchdb couchdb/bindaddress string 127.0.0.1
+          	couchdb couchdb/bindaddress seen true
+          	couchdb couchdb/adminpass password
+          	couchdb couchdb/adminpass seen true
+          	couchdb couchdb/adminpass_again password
+          	couchdb couchdb/adminpass_again seen true
+          EOF
           DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --force-yes couchdb
       - name: Install Go
         uses: actions/setup-go@v1

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,9 +19,18 @@ jobs:
       - name: Install CouchDB
         run: |
           sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 379CE192D401AB61
-          echo "deb https://apache.bintray.com/couchdb-deb bionic main" | sudo tee -a /etc/apt/sources.list
+          echo "deb https://apache.bintray.com/couchdb-deb $(lsb_release -c -s) main" | sudo tee -a /etc/apt/sources.list
           sudo apt-get update
-          echo -ne "couchdb couchdb/mode select standalone\ncouchdb couchdb/mode seen true\ncouchdb couchdb/bindaddress string 127.0.0.1\ncouchdb couchdb/bindaddress seen true\ncouchdb couchdb/adminpass password \ncouchdb couchdb/adminpass seen true\ncouchdb couchdb/adminpass_again password \ncouchdb couchdb/adminpass_again seen true\n" | sudo debconf-set-selections
+          sudo debconf-set-selections <<-EOF
+          	couchdb couchdb/mode select standalone
+          	couchdb couchdb/mode seen true
+          	couchdb couchdb/bindaddress string 127.0.0.1
+          	couchdb couchdb/bindaddress seen true
+          	couchdb couchdb/adminpass password
+          	couchdb couchdb/adminpass seen true
+          	couchdb couchdb/adminpass_again password
+          	couchdb couchdb/adminpass_again seen true
+          EOF
           DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --force-yes couchdb
       - name: Install Go
         uses: actions/setup-go@v1

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,20 +8,21 @@ on:
       - 'docs/**'
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     services:
-      couchdb:
-        image: apache/couchdb:2.3
-        ports:
-          - 5984:5984
       mailhog:
         image: mailhog/mailhog
         ports:
           - 1025:1025
           - 8025:8025
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v1
+      - name: Install CouchDB
+        run: |
+          sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 379CE192D401AB61
+          echo "deb https://apache.bintray.com/couchdb-deb bionic main" | sudo tee -a /etc/apt/sources.list
+          sudo apt-get update
+          echo -ne "couchdb couchdb/mode select standalone\ncouchdb couchdb/mode seen true\ncouchdb couchdb/bindaddress string 127.0.0.1\ncouchdb couchdb/bindaddress seen true\ncouchdb couchdb/adminpass password \ncouchdb couchdb/adminpass seen true\ncouchdb couchdb/adminpass_again password \ncouchdb couchdb/adminpass_again seen true\n" | sudo debconf-set-selections
+          DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --force-yes couchdb
       - name: Install Go
         uses: actions/setup-go@v1
         with:
@@ -30,6 +31,8 @@ jobs:
         uses: actions/setup-ruby@v1
         with:
           ruby-version: '2.x'
+      - name: Checkout code
+        uses: actions/checkout@v1
       - name: Install
         run: |
           curl -X PUT http://127.0.0.1:5984/{_users,_replicator}


### PR DESCRIPTION
We had a lot of badmatch/badarg errors on CI with CouchDB in Docker. Let's see if it works better with CouchDB installed as a debian package.