### PR TITLE
Allow connection to TLS 1.0 external sites

### DIFF
--- a/scripts/konnector-nsjail-node12-run.sh
+++ b/scripts/konnector-nsjail-node12-run.sh
@@ -22,7 +22,7 @@ else
   exit 1
 fi
 
-NODE_OPTS="--max-http-header-size=16384"
+NODE_OPTS="--max-http-header-size=16384 --tls-min-v1.0"
 
 if [ -z "${COZY_JOB_ID}" ]; then
   COZY_JOB_ID="unknown"


### PR DESCRIPTION
Node 12 [disable by default](https://github.com/nodejs/node/pull/23814) connection to TLS 1.0 and 1.1 https servers.

This PR updates the nsjail connector launch script to add an argument to nodejs12 to allow connection to external sites using only TLS 1.0 and/or 1.1