### PR TITLE
Block migration if another one already began

### DIFF
--- a/worker/migrations/migrations.go
+++ b/worker/migrations/migrations.go
@@ -1,6 +1,7 @@
 package migrations
 
 import (
+	"errors"
 	"fmt"
 	"runtime"
 	"time"
@@ -125,6 +126,10 @@ func migrateToSwiftV3(domain string) error {
 	defer mutex.Unlock()
 
 	dstContainer := swiftV3ContainerPrefix + inst.DBPrefix()
+	if _, _, err = c.Container(dstContainer); err != swift.ContainerNotFound {
+		log.Errorf("Destination container %s already exists or something went wrong. Migration canceled.", dstContainer)
+		return errors.New("Destination container busy")
+	}
 	if err = c.ContainerCreate(dstContainer, nil); err != nil {
 		return err
 	}


### PR DESCRIPTION
Avoid concurrency on swift v3 layout migration to block a scenario where 2 migrations can be launched at the same time on an instance, leading to data loss:
- first migration create new container, copy data from old to new container, then delete old container
- second migration copy data from old to new container while the first one is deleting old container, so it considers the migration failed and it deletes the new container

This PR block migration if the new container already exist (a previous migration is ongoing or failed without deleting the container).

Downside is if a migration fails and also fails to delete new container, then administrator will have to manually clean the new container before being able to launch the migration again on the considered instance.