### PR TITLE
feat: Serve domain type to html

### DIFF
--- a/docs/client-app-dev.md
+++ b/docs/client-app-dev.md
@@ -168,6 +168,7 @@ a template and will insert the relevant values.
     assets](https://docs.cozy.io/en/cozy-stack/cli/cozy-stack_config_insert-asset/)
     for more informations.
 -   `{{.Favicon}}` will be replaced by the favicon served by the stack.
+-   `{{.SubDomain}}` will be replaced by `flat` or `nested`.
 
 So, the `index.html` should probably looks like:
 

--- a/web/apps/serve.go
+++ b/web/apps/serve.go
@@ -240,6 +240,7 @@ func ServeAppFile(c echo.Context, i *instance.Instance, fs appfs.FileServer, web
 	res.Header().Set("Content-Type", "text/html; charset=utf-8")
 	res.Header().Set("Cache-Control", "private, no-store, must-revalidate")
 	res.WriteHeader(http.StatusOK)
+	var subdomainsType = config.GetConfig().Subdomains
 	return tmpl.Execute(res, echo.Map{
 		"Token":         token,
 		"Domain":        i.ContextualDomain(),
@@ -255,6 +256,7 @@ func ServeAppFile(c echo.Context, i *instance.Instance, fs appfs.FileServer, web
 		"ThemeCSS":      middlewares.ThemeCSS(i),
 		"Tracking":      tracking,
 		"Favicon":       middlewares.Favicon(i),
+		"SubDomain": 	 subdomainsType,
 	})
 }
 

--- a/web/apps/serve.go
+++ b/web/apps/serve.go
@@ -240,7 +240,7 @@ func ServeAppFile(c echo.Context, i *instance.Instance, fs appfs.FileServer, web
 	res.Header().Set("Content-Type", "text/html; charset=utf-8")
 	res.Header().Set("Cache-Control", "private, no-store, must-revalidate")
 	res.WriteHeader(http.StatusOK)
-	var subdomainsType = config.GetConfig().Subdomains
+	subdomainsType := config.GetConfig().Subdomains
 	return tmpl.Execute(res, echo.Map{
 		"Token":         token,
 		"Domain":        i.ContextualDomain(),
@@ -256,7 +256,7 @@ func ServeAppFile(c echo.Context, i *instance.Instance, fs appfs.FileServer, web
 		"ThemeCSS":      middlewares.ThemeCSS(i),
 		"Tracking":      tracking,
 		"Favicon":       middlewares.Favicon(i),
-		"SubDomain": 	 subdomainsType,
+		"SubDomain":     subdomainsType,
 	})
 }
 


### PR DESCRIPTION
Since we don't used anymore the intent system to redirect the user to the right route we need to provide to our front application the information about the domain type. It can be flated or nested. With this info in the HTML, our front app can create the right URL without having to do a network request. 

I'm not familiar enough with Go, I don't know if I really need to create a `var` for that but it seems to work. 