### PR TITLE
Make vfs.Walk faster by using CouchDB bookmark

### DIFF
--- a/web/data/data.go
+++ b/web/data/data.go
@@ -343,15 +343,16 @@ func findDocuments(c echo.Context) error {
 	findRequest["limit"] = limit + 1
 
 	var results []couchdb.JSONDoc
-	err := couchdb.FindDocsRaw(instance, doctype, &findRequest, &results)
+	resp, err := couchdb.FindDocsRaw(instance, doctype, &findRequest, &results)
 	if err != nil {
 		return err
 	}
 
 	out := echo.Map{
-		"docs":  results,
-		"limit": limit,
-		"next":  false,
+		"docs":     results,
+		"limit":    limit,
+		"next":     false,
+		"bookmark": resp.Bookmark,
 	}
 	if len(results) > int(limit) {
 		out["docs"] = results[:len(results)-1]

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -1193,7 +1193,7 @@ func FindFilesMango(c echo.Context) error {
 	findRequest["limit"] = limit + 1
 
 	var results []vfs.DirOrFileDoc
-	err := couchdb.FindDocsRaw(instance, consts.Files, &findRequest, &results)
+	_, err := couchdb.FindDocsRaw(instance, consts.Files, &findRequest, &results)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The worker for migration to Swift layout v3 can fail for instances with a lot of files/folders in the same directory. With this change, the requests to CouchDB for walking the VFS should be faster. They will use a bookmark instead of a skip parameter.