### PR TITLE
Fix sending push notifications

### DIFF
--- a/model/notification/center/notification_center.go
+++ b/model/notification/center/notification_center.go
@@ -330,13 +330,5 @@ func ensureMailFallback(channels []string) []string {
 
 func hasNotifiableDevice(inst *instance.Instance) bool {
 	cs, err := oauth.GetNotifiables(inst)
-	if err != nil {
-		return false
-	}
-	for _, c := range cs {
-		if c.NotificationDeviceToken != "" {
-			return true
-		}
-	}
-	return false
+	return err == nil && len(cs) > 0
 }

--- a/model/oauth/client.go
+++ b/model/oauth/client.go
@@ -154,7 +154,10 @@ func GetNotifiables(i *instance.Instance) ([]*Client, error) {
 	var clients []*Client
 	req := &couchdb.FindRequest{
 		UseIndex: "by-notification-platform",
-		Selector: mango.Exists("notification_platform"),
+		Selector: mango.And(
+			mango.Exists("notification_platform"),
+			mango.Exists("notification_device_token"),
+		),
 	}
 	err := couchdb.FindDocs(i, consts.OAuthClients, req, &clients)
 	if err != nil {

--- a/worker/push/push.go
+++ b/worker/push/push.go
@@ -104,17 +104,19 @@ func Worker(ctx *job.WorkerContext) error {
 	if err != nil {
 		return err
 	}
+	if len(cs) > 10 {
+		ctx.Logger().Warnf("too many notifiable devices: %d", len(cs))
+		cs = cs[:10]
+	}
 	for _, c := range cs {
-		if c.NotificationDeviceToken != "" {
-			err = push(ctx, c, &msg)
-			if err != nil {
-				ctx.Logger().
-					WithFields(logrus.Fields{
-						"device_id":       c.ID(),
-						"device_platform": c.NotificationPlatform,
-					}).
-					Warnf("could not send notification on device: %s", err)
-			}
+		err = push(ctx, c, &msg)
+		if err != nil {
+			ctx.Logger().
+				WithFields(logrus.Fields{
+					"device_id":       c.ID(),
+					"device_platform": c.NotificationPlatform,
+				}).
+				Warnf("could not send notification on device: %s", err)
 		}
 	}
 	return nil


### PR DESCRIPTION
When there are many OAuth clients registered on an instance, but only a few of them has a notification_device_token, the stack can miss sending some push notifications. This issue comes from the pagination on the _find request to find the notifiable clients. By including a mango
selector to find only the OAuth clients with a notification_device_token, we can avoid this issue.