### PR TITLE
Send the old doc to the realtime for swift migrations

### DIFF
--- a/worker/migrations/migrations.go
+++ b/worker/migrations/migrations.go
@@ -274,10 +274,12 @@ func getSrcName(inst *instance.Instance, f *vfs.FileDoc) string {
 	return srcName
 }
 
+// XXX the f FileDoc can be modified to add an InternalID
 func getDstName(inst *instance.Instance, f *vfs.FileDoc) string {
 	if f.InternalID == "" {
+		old := f.Clone().(*vfs.FileDoc)
 		f.InternalID = vfsswift.NewInternalID()
-		if err := couchdb.UpdateDoc(inst, f); err != nil {
+		if err := couchdb.UpdateDocWithOld(inst, f, old); err != nil {
 			return ""
 		}
 	}


### PR DESCRIPTION
When a cozy instance is migrating to Swift layout v3, its CouchDB
documents for io.cozy.files are updated to add the internal_id
attribute. The trigger for thumbnails add a job. But as we were giving
only the new document, and not the old one, the sameImg comparison in
the thumbnail worker would fail, and a new thumbnail may be recreated.
And, as we can have a race condition between getting the Swift container
for the thumbnails and locking the VFS, it could be put in the old data
container.