### PR TITLE
Add versions total size to disk-usage endpoint

### DIFF
--- a/cmd/files.go
+++ b/cmd/files.go
@@ -136,6 +136,9 @@ var usageFilesCmd = &cobra.Command{
 		if count, ok := info["doc_count"]; ok {
 			fmt.Printf("Documents count: %v\n", count)
 		}
+		if count, ok := info["versions_count"]; ok {
+			fmt.Printf("Versions Documents count: %v\n", count)
+		}
 		return nil
 	},
 }

--- a/cmd/files.go
+++ b/cmd/files.go
@@ -122,6 +122,14 @@ var usageFilesCmd = &cobra.Command{
 			return err
 		}
 		fmt.Printf("Usage: %v\n", info["used"])
+
+		if files, ok := info["files"]; ok {
+			fmt.Printf("  Including latest version of files: %v\n", files)
+		}
+		if versions, ok := info["versions"]; ok {
+			fmt.Printf("  Including older versions of files: %v\n", versions)
+		}
+
 		if quota, ok := info["quota"]; ok {
 			fmt.Printf("Quota: %v\n", quota)
 		}

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -8,6 +8,7 @@
 
 Says how many bytes are available and used to store files. When not limited the
 `quota` field is omitted.
+Also says how many bytes are used by last version of files and how many bytes are taken by older versions.
 
 #### Request
 
@@ -33,7 +34,9 @@ Content-type: application/vnd.api+json
         "attributes": {
             "is_limited": true,
             "quota": "123456789",
-            "used": "12345678"
+            "used": "12345678",
+            "files": "10305070",
+            "versions": "2040608"
         }
     }
 }

--- a/model/sharing/indexer.go
+++ b/model/sharing/indexer.go
@@ -127,6 +127,14 @@ func (s *sharingIndexer) DiskUsage() (int64, error) {
 	return s.indexer.DiskUsage()
 }
 
+func (s *sharingIndexer) FilesUsage() (int64, error) {
+	return s.indexer.FilesUsage()
+}
+
+func (s *sharingIndexer) VersionsUsage() (int64, error) {
+	return s.indexer.VersionsUsage()
+}
+
 func (s *sharingIndexer) CreateFileDoc(doc *vfs.FileDoc) error {
 	return ErrInternalServerError
 }

--- a/model/vfs/couchdb_indexer.go
+++ b/model/vfs/couchdb_indexer.go
@@ -58,17 +58,16 @@ func (c *couchdbIndexer) InitIndex() error {
 }
 
 func (c *couchdbIndexer) DiskUsage() (int64, error) {
-	files, err := c.FilesUsage()
+	used, err := c.FilesUsage()
 	if err != nil {
 		return 0, err
 	}
 
-	versions, err := c.VersionsUsage()
-	if err != nil {
-		return 0, err
+
+	if versions, err := c.VersionsUsage(); err == nil {
+		used += versions
 	}
 
-	used := files + versions
 	return int64(used), nil
 }
 

--- a/model/vfs/couchdb_indexer.go
+++ b/model/vfs/couchdb_indexer.go
@@ -63,12 +63,11 @@ func (c *couchdbIndexer) DiskUsage() (int64, error) {
 		return 0, err
 	}
 
-
 	if versions, err := c.VersionsUsage(); err == nil {
 		used += versions
 	}
 
-	return int64(used), nil
+	return used, nil
 }
 
 // Return files total size (without versions)

--- a/model/vfs/couchdb_indexer.go
+++ b/model/vfs/couchdb_indexer.go
@@ -58,6 +58,22 @@ func (c *couchdbIndexer) InitIndex() error {
 }
 
 func (c *couchdbIndexer) DiskUsage() (int64, error) {
+	files, err := c.FilesUsage()
+	if err != nil {
+		return 0, err
+	}
+
+	versions, err := c.VersionsUsage()
+	if err != nil {
+		return 0, err
+	}
+
+	used := files + versions
+	return int64(used), nil
+}
+
+// Return files total size (without versions)
+func (c *couchdbIndexer) FilesUsage() (int64, error) {
 	var doc couchdb.ViewResponse
 	err := couchdb.ExecView(c.db, couchdb.DiskUsageView, &couchdb.ViewRequest{
 		Reduce: true,
@@ -74,14 +90,25 @@ func (c *couchdbIndexer) DiskUsage() (int64, error) {
 		return 0, ErrWrongCouchdbState
 	}
 
-	// Count also the disk used by the old versions
-	err = couchdb.ExecView(c.db, couchdb.OldVersionsDiskUsageView, &couchdb.ViewRequest{
+	return int64(used), nil
+}
+
+// Return old file versions total size (not including current version)
+func (c *couchdbIndexer) VersionsUsage() (int64, error) {
+	var doc couchdb.ViewResponse
+	err := couchdb.ExecView(c.db, couchdb.OldVersionsDiskUsageView, &couchdb.ViewRequest{
 		Reduce: true,
 	}, &doc)
-	if err == nil && len(doc.Rows) > 0 {
-		if more, ok := doc.Rows[0].Value.(float64); ok {
-			used += more
-		}
+	if err != nil {
+		return 0, err
+	}
+	if len(doc.Rows) == 0 {
+		return 0, nil
+	}
+	// Reduce of _count should give us a number value
+	used, ok := doc.Rows[0].Value.(float64)
+	if !ok {
+		return 0, ErrWrongCouchdbState
 	}
 
 	return int64(used), nil

--- a/model/vfs/vfs.go
+++ b/model/vfs/vfs.go
@@ -125,8 +125,15 @@ type Indexer interface {
 
 	FilePather
 
-	// DiskUsage computes the total size of the files contained in the VFS.
+	// DiskUsage computes the total size of the files contained in the VFS,
+	// including versions.
 	DiskUsage() (int64, error)
+	// FilesUsage computes the total size of the files contained in the VFS,
+	// excluding versions.
+	FilesUsage() (int64, error)
+	// VersionsUsage computes the total size of the old file versions contained
+	// in the VFS, not including latest version.
+	VersionsUsage() (int64, error)
 
 	// CreateFileDoc creates and add in the index a new file document.
 	CreateFileDoc(doc *FileDoc) error

--- a/web/instances/instances.go
+++ b/web/instances/instances.go
@@ -319,9 +319,11 @@ func setAuthMode(c echo.Context) error {
 }
 
 type diskUsageResult struct {
-	Used  int64 `json:"used,string"`
-	Quota int64 `json:"quota,string,omitempty"`
-	Count int   `json:"doc_count,omitempty"`
+	Used     int64 `json:"used,string"`
+	Quota    int64 `json:"quota,string,omitempty"`
+	Count    int   `json:"doc_count,omitempty"`
+	Files    int64 `json:"files,string,omitempty"`
+	Versions int64 `json:"versions,string,omitempty"`
 }
 
 func diskUsage(c echo.Context) error {
@@ -332,12 +334,19 @@ func diskUsage(c echo.Context) error {
 	}
 	fs := instance.VFS()
 
-	used, err := fs.DiskUsage()
+	files, err := fs.FilesUsage()
 	if err != nil {
 		return err
 	}
+	versions, err := fs.VersionsUsage()
+	if err != nil {
+		return err
+	}
+	used := files + versions
 	result := &diskUsageResult{}
 	result.Used = used
+	result.Files = files
+	result.Versions = versions
 	result.Quota = fs.DiskQuota()
 	if stats, err := couchdb.DBStatus(instance, consts.Files); err == nil {
 		result.Count = stats.DocCount

--- a/web/instances/instances.go
+++ b/web/instances/instances.go
@@ -319,11 +319,12 @@ func setAuthMode(c echo.Context) error {
 }
 
 type diskUsageResult struct {
-	Used     int64 `json:"used,string"`
-	Quota    int64 `json:"quota,string,omitempty"`
-	Count    int   `json:"doc_count,omitempty"`
-	Files    int64 `json:"files,string,omitempty"`
-	Versions int64 `json:"versions,string,omitempty"`
+	Used          int64 `json:"used,string"`
+	Quota         int64 `json:"quota,string,omitempty"`
+	Count         int   `json:"doc_count,omitempty"`
+	Files         int64 `json:"files,string,omitempty"`
+	Versions      int64 `json:"versions,string,omitempty"`
+	VersionsCount int   `json:"versions_count,string,omitempty"`
 }
 
 func diskUsage(c echo.Context) error {
@@ -338,18 +339,22 @@ func diskUsage(c echo.Context) error {
 	if err != nil {
 		return err
 	}
+
 	versions, err := fs.VersionsUsage()
 	if err != nil {
 		return err
 	}
-	used := files + versions
+
 	result := &diskUsageResult{}
-	result.Used = used
+	result.Used = files + versions
 	result.Files = files
 	result.Versions = versions
 	result.Quota = fs.DiskQuota()
 	if stats, err := couchdb.DBStatus(instance, consts.Files); err == nil {
 		result.Count = stats.DocCount
+	}
+	if stats, err := couchdb.DBStatus(instance, consts.FilesVersions); err == nil {
+		result.VersionsCount = stats.DocCount
 	}
 	return c.JSON(http.StatusOK, result)
 }

--- a/web/settings/disk_usage.go
+++ b/web/settings/disk_usage.go
@@ -16,8 +16,8 @@ import (
 type apiDiskUsage struct {
 	Used     int64 `json:"used,string"`
 	Quota    int64 `json:"quota,string,omitempty"`
-	Files    int64 `json:"files,string,omitempty"`
-	Versions int64 `json:"versions,string,omitempty"`
+	Files    int64 `json:"files,string"`
+	Versions int64 `json:"versions,string"`
 }
 
 func (j *apiDiskUsage) ID() string                             { return consts.DiskUsageID }
@@ -60,7 +60,6 @@ func diskUsage(c echo.Context) error {
 	}
 
 	used := files + versions
-
 	quota := fs.DiskQuota()
 
 	result.Used = used

--- a/web/settings/disk_usage.go
+++ b/web/settings/disk_usage.go
@@ -14,8 +14,10 @@ import (
 )
 
 type apiDiskUsage struct {
-	Used  int64 `json:"used,string"`
-	Quota int64 `json:"quota,string,omitempty"`
+	Used     int64 `json:"used,string"`
+	Quota    int64 `json:"quota,string,omitempty"`
+	Files    int64 `json:"files,string,omitempty"`
+	Versions int64 `json:"versions,string,omitempty"`
 }
 
 func (j *apiDiskUsage) ID() string                             { return consts.DiskUsageID }
@@ -46,14 +48,24 @@ func diskUsage(c echo.Context) error {
 	}
 
 	fs := instance.VFS()
-	used, err := fs.DiskUsage()
+
+	versions, err := fs.VersionsUsage()
 	if err != nil {
 		return err
 	}
+
+	files, err := fs.FilesUsage()
+	if err != nil {
+		return err
+	}
+
+	used := files + versions
 
 	quota := fs.DiskQuota()
 
 	result.Used = used
 	result.Quota = quota
+	result.Files = files
+	result.Versions = versions
 	return jsonapi.Data(c, http.StatusOK, &result, nil)
 }

--- a/web/settings/settings_test.go
+++ b/web/settings/settings_test.go
@@ -163,6 +163,12 @@ func TestDiskUsage(t *testing.T) {
 	used, ok := attrs["used"].(string)
 	assert.True(t, ok)
 	assert.Equal(t, "0", used)
+	files, ok := attrs["files"].(string)
+	assert.True(t, ok)
+	assert.Equal(t, "0", files)
+	versions, ok := attrs["versions"].(string)
+	assert.True(t, ok)
+	assert.Equal(t, "0", versions)
 }
 
 func TestRegisterPassphraseWrongToken(t *testing.T) {


### PR DESCRIPTION
File older versions can take a significant amount of disk size. 
Using the `disk-usage` endpoint, it is not currently possible to know what part of `used` size is taken by current version of the files and what part comes from old versions.

This PR adds information on the disk size taken by only the last version of files and the total size of older versions.

This will be available to frontend applications that will be able to show this information to the end user, allowing the user to take the right decision when dealing with space issues. It will also be available in `cozy-stack files usage` command to allow support to explain users how the disk space is used.