### PR TITLE
doc: Create links

### DIFF
--- a/docs/doctype.md
+++ b/docs/doctype.md
@@ -42,11 +42,11 @@ the doctype, localized on transifex, and an icon to illustrate it.
 
 Here are the relevant places:
 
-- https://github.com/cozy/cozy-store/blob/master/src/locales/en.json
-- https://github.com/cozy/cozy-store/blob/master/src/config/permissionsIcons.json
-- https://github.com/cozy/cozy-store/tree/master/src/assets/icons/permissions
-- https://github.com/cozy/cozy-stack/blob/master/assets/locales/en.po
-- https://github.com/cozy/cozy-stack/blob/master/assets/styles/stack.css
+- [https://github.com/cozy/cozy-store/blob/master/src/locales/en.json](https://github.com/cozy/cozy-store/blob/master/src/locales/en.json)
+- [https://github.com/cozy/cozy-store/blob/master/src/config/permissionsIcons.json](https://github.com/cozy/cozy-store/blob/master/src/config/permissionsIcons.json)
+- [https://github.com/cozy/cozy-store/tree/master/src/assets/icons/permissions](https://github.com/cozy/cozy-store/tree/master/src/assets/icons/permissions)
+- [https://github.com/cozy/cozy-stack/blob/master/assets/locales/en.po](https://github.com/cozy/cozy-stack/blob/master/assets/locales/en.po)
+- [https://github.com/cozy/cozy-stack/blob/master/assets/styles/stack.css](https://github.com/cozy/cozy-stack/blob/master/assets/styles/stack.css)
 
 ## Using the doctype in your application
 


### PR DESCRIPTION
Links are working on github but not on our doc's website (https://docs.cozy.io/en/cozy-stack/doctype/) 

Hope that fix the issue