### PR TITLE
Use Max-Age for the cookie in the CSRF middleware

### DIFF
--- a/web/auth/auth.go
+++ b/web/auth/auth.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cozy/cozy-stack/pkg/utils"
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/labstack/echo/v4"
-	"github.com/labstack/echo/v4/middleware"
 	"github.com/mssola/user_agent"
 )
 
@@ -502,7 +501,7 @@ func checkRedirectParam(c echo.Context, defaultRedirect *url.URL) (*url.URL, err
 
 // Routes sets the routing for the status service
 func Routes(router *echo.Group) {
-	noCSRF := middleware.CSRFWithConfig(middleware.CSRFConfig{
+	noCSRF := middlewares.CSRFWithConfig(middlewares.CSRFConfig{
 		TokenLookup:    "form:csrf_token",
 		CookieMaxAge:   3600, // 1 hour
 		CookieHTTPOnly: true,

--- a/web/middlewares/csrf.go
+++ b/web/middlewares/csrf.go
@@ -1,0 +1,210 @@
+package middlewares
+
+import (
+	"crypto/subtle"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/cozy/cozy-stack/pkg/utils"
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+)
+
+type (
+	// CSRFConfig defines the config for CSRF middleware.
+	CSRFConfig struct {
+		// Skipper defines a function to skip middleware.
+		Skipper middleware.Skipper
+
+		// TokenLength is the length of the generated token.
+		TokenLength int `yaml:"token_length"`
+		// Optional. Default value 32.
+
+		// TokenLookup is a string in the form of "<source>:<key>" that is used
+		// to extract token from the request.
+		// Optional. Default value "header:X-CSRF-Token".
+		// Possible values:
+		// - "header:<name>"
+		// - "form:<name>"
+		// - "query:<name>"
+		TokenLookup string `yaml:"token_lookup"`
+
+		// Context key to store generated CSRF token into context.
+		// Optional. Default value "csrf".
+		ContextKey string `yaml:"context_key"`
+
+		// Name of the CSRF cookie. This cookie will store CSRF token.
+		// Optional. Default value "csrf".
+		CookieName string `yaml:"cookie_name"`
+
+		// Domain of the CSRF cookie.
+		// Optional. Default value none.
+		CookieDomain string `yaml:"cookie_domain"`
+
+		// Path of the CSRF cookie.
+		// Optional. Default value none.
+		CookiePath string `yaml:"cookie_path"`
+
+		// Max age (in seconds) of the CSRF cookie.
+		// Optional. Default value 86400 (24hr).
+		CookieMaxAge int `yaml:"cookie_max_age"`
+
+		// Indicates if CSRF cookie is secure.
+		// Optional. Default value false.
+		CookieSecure bool `yaml:"cookie_secure"`
+
+		// Indicates if CSRF cookie is HTTP only.
+		// Optional. Default value false.
+		CookieHTTPOnly bool `yaml:"cookie_http_only"`
+	}
+
+	// csrfTokenExtractor defines a function that takes `echo.Context` and returns
+	// either a token or an error.
+	csrfTokenExtractor func(echo.Context) (string, error)
+)
+
+var (
+	// DefaultCSRFConfig is the default CSRF middleware config.
+	DefaultCSRFConfig = CSRFConfig{
+		Skipper:      middleware.DefaultSkipper,
+		TokenLength:  32,
+		TokenLookup:  "header:" + echo.HeaderXCSRFToken,
+		ContextKey:   "csrf",
+		CookieName:   "_csrf",
+		CookieMaxAge: 86400,
+	}
+)
+
+// CSRF returns a Cross-Site Request Forgery (CSRF) middleware.
+// See: https://en.wikipedia.org/wiki/Cross-site_request_forgery
+func CSRF() echo.MiddlewareFunc {
+	c := DefaultCSRFConfig
+	return CSRFWithConfig(c)
+}
+
+// CSRFWithConfig returns a CSRF middleware with config.
+// See `CSRF()`.
+func CSRFWithConfig(config CSRFConfig) echo.MiddlewareFunc {
+	// Defaults
+	if config.Skipper == nil {
+		config.Skipper = DefaultCSRFConfig.Skipper
+	}
+	if config.TokenLength == 0 {
+		config.TokenLength = DefaultCSRFConfig.TokenLength
+	}
+	if config.TokenLookup == "" {
+		config.TokenLookup = DefaultCSRFConfig.TokenLookup
+	}
+	if config.ContextKey == "" {
+		config.ContextKey = DefaultCSRFConfig.ContextKey
+	}
+	if config.CookieName == "" {
+		config.CookieName = DefaultCSRFConfig.CookieName
+	}
+	if config.CookieMaxAge == 0 {
+		config.CookieMaxAge = DefaultCSRFConfig.CookieMaxAge
+	}
+
+	// Initialize
+	parts := strings.Split(config.TokenLookup, ":")
+	extractor := csrfTokenFromHeader(parts[1])
+	switch parts[0] {
+	case "form":
+		extractor = csrfTokenFromForm(parts[1])
+	case "query":
+		extractor = csrfTokenFromQuery(parts[1])
+	}
+
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			if config.Skipper(c) {
+				return next(c)
+			}
+
+			req := c.Request()
+			k, err := c.Cookie(config.CookieName)
+			token := ""
+
+			// Generate token
+			if err != nil {
+				token = utils.RandomString(config.TokenLength)
+			} else {
+				// Reuse token
+				token = k.Value
+			}
+
+			switch req.Method {
+			case http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodTrace:
+			default:
+				// Validate token only for requests which are not defined as 'safe' by RFC7231
+				clientToken, err := extractor(c)
+				if err != nil {
+					return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+				}
+				if !validateCSRFToken(token, clientToken) {
+					return echo.NewHTTPError(http.StatusForbidden, "invalid csrf token")
+				}
+			}
+
+			// Set CSRF cookie
+			cookie := new(http.Cookie)
+			cookie.Name = config.CookieName
+			cookie.Value = token
+			if config.CookiePath != "" {
+				cookie.Path = config.CookiePath
+			}
+			if config.CookieDomain != "" {
+				cookie.Domain = config.CookieDomain
+			}
+			cookie.MaxAge = config.CookieMaxAge
+			cookie.Secure = config.CookieSecure
+			cookie.HttpOnly = config.CookieHTTPOnly
+			c.SetCookie(cookie)
+
+			// Store token in the context
+			c.Set(config.ContextKey, token)
+
+			// Protect clients from caching the response
+			c.Response().Header().Add(echo.HeaderVary, echo.HeaderCookie)
+
+			return next(c)
+		}
+	}
+}
+
+// csrfTokenFromForm returns a `csrfTokenExtractor` that extracts token from the
+// provided request header.
+func csrfTokenFromHeader(header string) csrfTokenExtractor {
+	return func(c echo.Context) (string, error) {
+		return c.Request().Header.Get(header), nil
+	}
+}
+
+// csrfTokenFromForm returns a `csrfTokenExtractor` that extracts token from the
+// provided form parameter.
+func csrfTokenFromForm(param string) csrfTokenExtractor {
+	return func(c echo.Context) (string, error) {
+		token := c.FormValue(param)
+		if token == "" {
+			return "", errors.New("missing csrf token in the form parameter")
+		}
+		return token, nil
+	}
+}
+
+// csrfTokenFromQuery returns a `csrfTokenExtractor` that extracts token from the
+// provided query parameter.
+func csrfTokenFromQuery(param string) csrfTokenExtractor {
+	return func(c echo.Context) (string, error) {
+		token := c.QueryParam(param)
+		if token == "" {
+			return "", errors.New("missing csrf token in the query string")
+		}
+		return token, nil
+	}
+}
+
+func validateCSRFToken(token, clientToken string) bool {
+	return subtle.ConstantTimeCompare([]byte(token), []byte(clientToken)) == 1
+}

--- a/web/middlewares/csrf_test.go
+++ b/web/middlewares/csrf_test.go
@@ -1,0 +1,83 @@
+package middlewares
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/cozy/cozy-stack/pkg/utils"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCSRF(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	csrf := CSRFWithConfig(CSRFConfig{
+		TokenLength: 16,
+	})
+	h := csrf(func(c echo.Context) error {
+		return c.String(http.StatusOK, "test")
+	})
+
+	// Generate CSRF token
+	assert.NoError(t, h(c))
+	assert.Contains(t, rec.Header().Get(echo.HeaderSetCookie), "_csrf")
+
+	// Without CSRF cookie
+	req = httptest.NewRequest(http.MethodPost, "/", nil)
+	rec = httptest.NewRecorder()
+	c = e.NewContext(req, rec)
+	assert.Error(t, h(c))
+
+	// Empty/invalid CSRF token
+	req = httptest.NewRequest(http.MethodPost, "/", nil)
+	rec = httptest.NewRecorder()
+	c = e.NewContext(req, rec)
+	req.Header.Set(echo.HeaderXCSRFToken, "")
+	assert.Error(t, h(c))
+
+	// Valid CSRF token
+	token := utils.RandomString(16)
+	req.Header.Set(echo.HeaderCookie, "_csrf="+token)
+	req.Header.Set(echo.HeaderXCSRFToken, token)
+	if assert.NoError(t, h(c)) {
+		assert.Equal(t, http.StatusOK, rec.Code)
+	}
+}
+
+func TestCSRFTokenFromForm(t *testing.T) {
+	f := make(url.Values)
+	f.Set("csrf", "token")
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(f.Encode()))
+	req.Header.Add(echo.HeaderContentType, echo.MIMEApplicationForm)
+	c := e.NewContext(req, nil)
+	token, err := csrfTokenFromForm("csrf")(c)
+	if assert.NoError(t, err) {
+		assert.Equal(t, "token", token)
+	}
+	_, err = csrfTokenFromForm("invalid")(c)
+	assert.Error(t, err)
+}
+
+func TestCSRFTokenFromQuery(t *testing.T) {
+	q := make(url.Values)
+	q.Set("csrf", "token")
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Add(echo.HeaderContentType, echo.MIMEApplicationForm)
+	req.URL.RawQuery = q.Encode()
+	c := e.NewContext(req, nil)
+	token, err := csrfTokenFromQuery("csrf")(c)
+	if assert.NoError(t, err) {
+		assert.Equal(t, "token", token)
+	}
+	_, err = csrfTokenFromQuery("invalid")(c)
+	assert.Error(t, err)
+	csrfTokenFromQuery("csrf")
+}


### PR DESCRIPTION
Using Expires for the cookie in the CSRF middleware can lead to some
issues, that Max-Age doesn't have. With Expires, the server defines the
expiration date, and this date will be interpreted by the client. The
client and the server can be in different timezones, or the client can
be misconfigured (no NTP). If the MaxAge configuration from the
middleware is short (let's say hours, not days), it can happen that some
clients throw the cookie as expired when they received it.

To do that, we have copied the CSRF middleware from echo, and made a
pull request for this change upstream. See
https://github.com/labstack/echo/pull/1450