### PR TITLE
Feature flags on instances

### DIFF
--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -26,6 +26,9 @@ cozy-stack settings displays the settings.
 It can also take a list of settings to update.
 
 If you give a blank value, the setting will be removed.
+
+A setting prefixed with "feature." is treated as a feature flag.
+Defining a feature flag will erase every previously defined ones.
 `,
 	Example: "$ cozy-stack settings --domain cozy.tools:8080 context:beta,public_name:John,to_remove:",
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/docs/cli/cozy-stack_settings.md
+++ b/docs/cli/cozy-stack_settings.md
@@ -11,6 +11,8 @@ It can also take a list of settings to update.
 
 If you give a blank value, the setting will be removed.
 
+A setting prefixed with "feature." is treated as a feature flag.
+Defining a feature flag will erase every previously defined ones.
 
 ```
 cozy-stack settings [settings] [flags]


### PR DESCRIPTION
This is to be able to manage feature flags from Cloudery and ensure
correct values at the end in case of feature removal and so no more
specified on the command line.
Settings prefixed with `feature.` will be handle specially and any
change on one setting reset any existing feature-related settings