### PR TITLE
Support bookmark pagination for normal_docs

### DIFF
--- a/docs/data-system.md
+++ b/docs/data-system.md
@@ -462,16 +462,19 @@ See
 The `_all_docs` endpoint sends the design docs in the response. It makes it hard
 to use pagination on it. We have added a non-standard `_normal_docs` endpoint.
 This new endpoint skip the design docs (and does not count them in the
-`total_rows`). It only accepts two parameters in the query string: `skip`
-(default: 0) and `limit` (default: 100).
+`total_rows`). It only accepts three parameters in the query string: `limit`
+(default: 100), `skip` (default: 0),  and `bookmark` (default: '').
 
 Note that the response format is a bit different, it looks more like a `_find`
-response with mango. And, like for `_find`, the limit cannot be more than 100.
+response with mango. And, like for `_find`, the limit cannot be more than 1000.
+The [pagination](https://github.com/cozy/cozy-stack/blob/master/docs/mango.md#pagination-cookbook)
+is also the same: both `bookmark` and `skip` can be used, but `bookmark` is
+recommended for performances.
 
 ### Request
 
 ```http
-GET /data/io.cozy.events/_normal_docs?skip=200&limit=100 HTTP/1.1
+GET /data/io.cozy.events/_normal_docs?limit=100&bookmark=g1AAAAB2eJzLYWBgYMpgSmHgKy5JLCrJTq2MT8lPzkzJBYorGKQYpVqaJRoZm1paWFiapFkamhknGpilJiampZkYJRmC9HHA9OUAdTASpS0rCwAlah76 HTTP/1.1
 Accept: application/json
 ```
 
@@ -494,11 +497,14 @@ Content-Type: application/json
             "_id": "f4ca7773ddea715afebc4b4b15d4f0b3",
             "_rev": "2-7051cbe5c8faecd085a3fa619e6e6337",
             "field": "other-value"
-        }
+        },
+        ...
     ],
-    "total_rows": 202
+    "total_rows": 202,
+    "bookmark": "g1AAAAB2eJzLYWBgYMpgSmHgKy5JLCrJTq2MT8lPzkzJBYorGKQYpVqaJRoZm1paWFiapFkamhknGpilJiampZkYJRmC9HHA9OUAdTASpS0rCwAlah76"
 }
 ```
+
 
 ## List the known doctypes
 

--- a/docs/data-system.md
+++ b/docs/data-system.md
@@ -462,7 +462,7 @@ See
 The `_all_docs` endpoint sends the design docs in the response. It makes it hard
 to use pagination on it. We have added a non-standard `_normal_docs` endpoint.
 This new endpoint skip the design docs (and does not count them in the
-`total_rows`). It only accepts three parameters in the query string: `limit`
+`total_rows`). It accepts three parameters in the query string: `limit`
 (default: 100), `skip` (default: 0),  and `bookmark` (default: '').
 
 Note that the response format is a bit different, it looks more like a `_find`

--- a/docs/mango.md
+++ b/docs/mango.md
@@ -142,17 +142,21 @@ query results to a maximum of 100 documents. This limit can be raised up to
 The limit applied to a query is visible in the HTTP response.
 
 If the limit cause some docs to not be returned, the response will have a
-`next=true` top level values.
+`next=true` top level values. Then, the returned `bookmark` value can be used in
+the next query to get the missing docs. It is also possible to use `skip`,
+to paginate, although this is not recommended for performances. For more details, see the
+[CouchDB documentation](https://docs.couchdb.org/en/latest/api/database/find.html#pagination).
 
 ```json
 {
     "limit": 100,
     "next": true,
     "docs": ["... first hundred docs ..."]
+    "bookmark": "g1AAAAB2eJzLYWBgYMpgSmHgKy5JLCrJTq2MT8lPzkzJBYorGKQYpVqaJRoZm1paWFiapFkamhknGpilJiampZkYJRmC9HHA9OUAdTASpS0rCwAlah76"
 }
 ```
 
-If the number of docs is lower or equal to the limit, next will be false
+If the number of docs is lower or equal to the limit, next will be false.
 
 ```json
 {
@@ -162,7 +166,6 @@ If the number of docs is lower or equal to the limit, next will be false
 }
 ```
 
-To paginate, the client should keep track of the value of the last index field.
 
 ### Example:
 
@@ -171,7 +174,7 @@ Index on io.cozy.events with fields `["calendar", "date"]`
 Try to get all events for a month:
 
 ```json
-selector: {
+"selector": {
   "calendar": "my-calendar",
   "date": { "$gt": "20161001", "$lt": "20161030" }
 }
@@ -181,12 +184,13 @@ If there is less than 100 events, the response `next` field will be false and
 there is nothing more to do. If there is more than 100 events for this month, we
 have a `next=true` in the response.
 
-To keep iterating, we can take the date from the last item we received in the
-results and use it as next request `$gte`
+To keep iterating, we can use the `bookmark` field we received in the next
+request.
 
 ```json
-selector: {
+"selector": {
   "calendar": "my-calendar",
-  "date": { "$gte": "20161023", "$lt": "20161030" }
-}
+  "date": { "$gte": "20161001", "$lt": "20161030" }
+},
+"bookmark": "g1AAAAB2eJzLYWBgYMpgSmHgKy5JLCrJTq2MT8lPzkzJBYorGKQYpVqaJRoZm1paWFiapFkamhknGpilJiampZkYJRmC9HHA9OUAdTASpS0rCwAlah76"
 ```

--- a/docs/mango.md
+++ b/docs/mango.md
@@ -151,7 +151,7 @@ to paginate, although this is not recommended for performances. For more details
 {
     "limit": 100,
     "next": true,
-    "docs": ["... first hundred docs ..."]
+    "docs": ["... first hundred docs ..."],
     "bookmark": "g1AAAAB2eJzLYWBgYMpgSmHgKy5JLCrJTq2MT8lPzkzJBYorGKQYpVqaJRoZm1paWFiapFkamhknGpilJiampZkYJRmC9HHA9OUAdTASpS0rCwAlah76"
 }
 ```

--- a/pkg/couchdb/couchdb.go
+++ b/pkg/couchdb/couchdb.go
@@ -862,7 +862,7 @@ func NormalDocs(db Database, doctype string, skip, limit int, bookmark string) (
 	res := NormalDocsResponse{
 		Rows: findRes.Docs,
 	}
-	if skip > 0 && len(res.Rows) < limit {
+	if bookmark == "" && len(res.Rows) < limit {
 		res.Total = skip + len(res.Rows)
 	} else {
 		var designRes ViewResponse

--- a/web/data/data.go
+++ b/web/data/data.go
@@ -386,11 +386,12 @@ func normalDocs(c echo.Context) error {
 	if err != nil || skip < 0 {
 		skip = 0
 	}
+	bookmark := c.QueryParam("bookmark")
 	limit, err := strconv.ParseInt(c.QueryParam("limit"), 10, 64)
 	if err != nil || limit < 0 || limit > consts.MaxItemsPerPageForMango {
 		limit = 100
 	}
-	res, err := couchdb.NormalDocs(instance, doctype, int(skip), int(limit))
+	res, err := couchdb.NormalDocs(instance, doctype, int(skip), int(limit), bookmark)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
#2190 allowed _find queries to use bookmark. This make it possible for normal_docs as well.