### PR TITLE
Add accounts to organization migration

### DIFF
--- a/docs/workers.md
+++ b/docs/workers.md
@@ -306,7 +306,7 @@ The message is composed of a sharing ID and a count of the number of errors
 ## migrations
 
 The `migrations` worker can be used to migrate a cozy instance. Currently, it
-has a single option, `type`, with two supported value:
+has a single option, `type`, with two supported values:
 * `to-swift-v3`: migrate a cozy instance that has files in swift from a V1 or V2 layout to a V3 layout.
 * `accounts-to-organization`: create [ciphers](https://docs.cozy.io/en/cozy-doctypes/docs/com.bitwarden.ciphers/)
  from [accounts](https://docs.cozy.io/en/cozy-doctypes/docs/io.cozy.accounts/),

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -305,9 +305,14 @@ The message is composed of a sharing ID and a count of the number of errors
 
 ## migrations
 
-The `migrations` worker can be used to migrate a cozy instance that has its
-files in swift from a V1 or V2 layout to a V3 layout. Currently, it has a
-single option, `type`, with a single supported value, `to-swift-v3`.
+The `migrations` worker can be used to migrate a cozy instance. Currently, it
+has a single option, `type`, with two supported value:
+* `to-swift-v3`: migrate a cozy instance that has files in swift from a V1 or V2 layout to a V3 layout.
+* `accounts-to-organization`: create [ciphers](https://docs.cozy.io/en/cozy-doctypes/docs/com.bitwarden.ciphers/)
+ from [accounts](https://docs.cozy.io/en/cozy-doctypes/docs/io.cozy.accounts/),
+ re-encrypted with the organization key.
+
+
 
 ### Example
 

--- a/model/account/accounts.go
+++ b/model/account/accounts.go
@@ -47,9 +47,10 @@ type OauthInfo struct {
 
 // BasicInfo holds configuration information for an user/pass account
 type BasicInfo struct {
-	Login      string `json:"login,omitempty"`
-	Password   string `json:"password,omitempty"`
-	FolderPath string `json:"folderPath,omitempty"`
+	Login                string `json:"login,omitempty"`
+	Password             string `json:"password,omitempty"` // used when no encryption
+	EncryptedCredentials string `json:"credentials_encrypted"`
+	FolderPath           string `json:"folderPath,omitempty"`
 }
 
 // ID is used to implement the couchdb.Doc interface

--- a/model/account/accounts.go
+++ b/model/account/accounts.go
@@ -49,7 +49,7 @@ type OauthInfo struct {
 type BasicInfo struct {
 	Login                string `json:"login,omitempty"`
 	Password             string `json:"password,omitempty"` // used when no encryption
-	EncryptedCredentials string `json:"credentials_encrypted"`
+	EncryptedCredentials string `json:"credentials_encrypted,omitempty"`
 	FolderPath           string `json:"folderPath,omitempty"`
 }
 

--- a/model/account/accounts.go
+++ b/model/account/accounts.go
@@ -10,21 +10,23 @@ import (
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/logger"
+	"github.com/cozy/cozy-stack/pkg/metadata"
 	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/hashicorp/go-multierror"
 )
 
 // Account holds configuration information for an account
 type Account struct {
-	DocID       string                 `json:"_id,omitempty"`
-	DocRev      string                 `json:"_rev,omitempty"`
-	Name        string                 `json:"name"`
-	AccountType string                 `json:"account_type"`
-	FolderPath  string                 `json:"folderPath,omitempty"`
-	Basic       *BasicInfo             `json:"auth,omitempty"`
-	Oauth       *OauthInfo             `json:"oauth,omitempty"`
-	Extras      map[string]interface{} `json:"oauth_callback_results,omitempty"`
-
+	DocID         string                 `json:"_id,omitempty"`
+	DocRev        string                 `json:"_rev,omitempty"`
+	Name          string                 `json:"name"`
+	AccountType   string                 `json:"account_type"`
+	FolderPath    string                 `json:"folderPath,omitempty"`
+	Basic         *BasicInfo             `json:"auth,omitempty"`
+	Oauth         *OauthInfo             `json:"oauth,omitempty"`
+	Extras        map[string]interface{} `json:"oauth_callback_results,omitempty"`
+	Relationships map[string]interface{} `json:"relationships,omitempty"`
+	Metadata      *metadata.CozyMetadata `json:"cozyMetadata,omitempty"`
 	// When an account is deleted, the stack cleans the triggers and calls its
 	// konnector to clean the account remotely (when available). It is done via
 	// a hook on deletion, but when the konnector is removed, this cleaning is
@@ -82,6 +84,10 @@ func (ac *Account) Clone() couchdb.Doc {
 	cloned.Extras = make(map[string]interface{})
 	for k, v := range ac.Extras {
 		cloned.Extras[k] = v
+	}
+	cloned.Relationships = make(map[string]interface{})
+	for k, v := range ac.Relationships {
+		cloned.Relationships[k] = v
 	}
 	return &cloned
 }

--- a/model/account/credentials.go
+++ b/model/account/credentials.go
@@ -136,7 +136,6 @@ func DecryptCredentialsWithKey(decryptorKey *keymgmt.NACLKey, encryptedCreds []b
 
 	// skip the nonce
 	encryptedCreds = encryptedCreds[nonceLen:]
-
 	// decrypt the cipher text and check that the plain text is more the 4 bytes
 	// long, to contain the login length
 	creds, ok := box.Open(nil, encryptedCreds, &nonce, decryptorKey.PublicKey(), decryptorKey.PrivateKey())

--- a/model/bitwarden/settings/settings.go
+++ b/model/bitwarden/settings/settings.go
@@ -16,6 +16,9 @@ import (
 // structure is modified, update this value
 const DocTypeVersion = "1"
 
+// ErrMissingOrgKey is used when the organization key does not exist
+var ErrMissingOrgKey = errors.New("No organization key")
+
 // Settings is the struct that holds the birwarden settings
 type Settings struct {
 	CouchRev                string                 `json:"_rev,omitempty"`
@@ -114,7 +117,7 @@ func (s *Settings) EnsureCozyOrganization(inst *instance.Instance) error {
 // OrganizationKey returns the organization key (in clear, not encrypted).
 func (s *Settings) OrganizationKey() ([]byte, error) {
 	if len(s.EncryptedOrgKey) == 0 {
-		return nil, errors.New("No organization key")
+		return nil, ErrMissingOrgKey
 	}
 	decrypted, err := account.DecryptCredentialsData(s.EncryptedOrgKey)
 	if err != nil {

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -58,6 +58,11 @@ const (
 	// BitwardenCozyCollectionName is the name of the collection used to
 	// share passwords between Cozy and Bitwarden clients.
 	BitwardenCozyCollectionName = "Cozy Connectors"
+
+	// BitwardenProtocol is the name of the bitwarden protocol
+	BitwardenProtocol = "Bitwarden"
+	// BitwardenCipherRelationship is the name of the account-cipher relationship
+	BitwardenCipherRelationship = "vaultCipher"
 )
 
 // MaxItemsPerPageForMango is the maximal value accepted for the limit

--- a/worker/migrations/migrations.go
+++ b/worker/migrations/migrations.go
@@ -151,10 +151,12 @@ func migrateAccountsToOrganization(domain string) error {
 		login, password, err := account.DecryptCredentials(encryptedCreds)
 		if err != nil {
 			errm = multierror.Append(errm, err)
+			continue
 		}
 		cipher, err := buildCipher(orgKey, msg.Slug, login, password, link)
 		if err != nil {
 			errm = multierror.Append(errm, err)
+			continue
 		}
 		if err := couchdb.CreateDoc(inst, cipher); err != nil {
 			errm = multierror.Append(errm, err)

--- a/worker/migrations/migrations.go
+++ b/worker/migrations/migrations.go
@@ -135,6 +135,7 @@ func migrateAccountsToOrganization(domain string) error {
 		manifest, err := app.GetKonnectorBySlug(inst, msg.Slug)
 		if err != nil {
 			errm = multierror.Append(errm, err)
+			continue
 		}
 		var link string
 		if err := json.Unmarshal(*manifest.VendorLink, &link); err != nil {
@@ -144,13 +145,14 @@ func migrateAccountsToOrganization(domain string) error {
 		acc := &account.Account{}
 		if err := couchdb.GetDoc(inst, consts.Accounts, msg.Account, acc); err != nil {
 			errm = multierror.Append(errm, err)
+			continue
 		}
 		encryptedCreds := acc.Basic.EncryptedCredentials
 		login, password, err := account.DecryptCredentials(encryptedCreds)
 		if err != nil {
 			errm = multierror.Append(errm, err)
 		}
-		cipher, err := buildCipher(orgKey, msg.Slug, login, password, string(link))
+		cipher, err := buildCipher(orgKey, msg.Slug, login, password, link)
 		if err != nil {
 			errm = multierror.Append(errm, err)
 		}


### PR DESCRIPTION
This migrates all accounts from an instance to an encrypted cipher which belong to the cozy organization, so the password manager retrieve them automatically.