### PR TITLE
Add a login domain for OIDC

### DIFF
--- a/assets/templates/oidc_login.html
+++ b/assets/templates/oidc_login.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="{{.Locale}}">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="3600">
+    <title>{{.Title}}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="{{asset .Domain "/fonts/fonts.css"}}">
+    {{.CozyUI}}
+    {{.ThemeCSS}}
+    {{.Favicon}}
+  </head>
+  <body>
+    <div role="application">
+      <main class="wizard">
+        <form id="login-form" method="POST" action="/auth/login" class="wizard-wrapper" data-iterations="{{.Iterations}}" data-salt="{{.Salt}}">
+          <div role="region" class="wizard-main" id="login-field">
+            <div class="c-avatar u-mh-auto u-mv-0-m u-mv-1">
+              <img class="c-avatar-image" src="{{asset .Domain "/images/default-avatar.png"}}" alt="" />
+            </div>
+            <h1 class="wizard-title password-form">{{.Title}}</h1>
+            <footer class="wizard-footer u-pb-half-m u-pb-2">
+              <button id="login-submit" class="c-btn c-btn--full wizard-button" form="login-form" type="submit">
+                <span class="password-form">{{t "Login Submit"}}</span>
+              </button>
+            </footer>
+          </div>
+        </form>
+      </main>
+    </div>
+  </body>
+</html>

--- a/docs/delegated-auth.md
+++ b/docs/delegated-auth.md
@@ -38,6 +38,7 @@ authentication:
       client_id: aClientID
       client_secret: s3cret3
       scope: openid profile
+      login_domain: login.mycozy.cloud
       redirect_uri: https://oauthcallback.mycozy.cloud/oidc/redirect
       authorize_url: https://identity-prodiver/path/to/authorize
       token_url: https://identity-prodiver/path/to/token
@@ -59,6 +60,8 @@ And in the `oidc` section, we have:
 - `client_id` and `client_secret` are the OAuth client that will be used to
   talk to the identity provider
 - `scope` is the OAuth scope parameter (it is often `openid profile`)
+- `login_domain` is a domain that is not tied to an instance, but allows to
+  login with OIDC with the provider configured on this context
 - `redirect_uri` is where the user will be redirected by the identity provider
   after login (it must often be declared when creating the OAuth client, and we
   have to use a static hostname, not the hostname of a cozy instance)

--- a/web/statik/handler.go
+++ b/web/statik/handler.go
@@ -36,6 +36,7 @@ var (
 		"error.html",
 		"login.html",
 		"need_onboarding.html",
+		"oidc_login.html",
 		"passphrase_reset.html",
 		"passphrase_renew.html",
 		"passphrase_onboarding.html",


### PR DESCRIPTION
When OIDC is configured on a context, we can now have a special domainthat users can remember easily. This domain will only serve an HTML page with a login button to start the OIDC connection process.