### PR TITLE
Add bitwarden's permissions

### DIFF
--- a/model/bitwarden/oauth.go
+++ b/model/bitwarden/oauth.go
@@ -20,6 +20,8 @@ var BitwardenScope = strings.Join([]string{
 	consts.BitwardenCiphers,
 	consts.BitwardenFolders,
 	consts.BitwardenOrganizations,
+	consts.Konnectors,
+	consts.AppsSuggestion,
 }, " ")
 
 // ParseBitwardenDeviceType takes a deviceType (Bitwarden) and transforms it

--- a/pkg/consts/doctype.go
+++ b/pkg/consts/doctype.go
@@ -9,6 +9,8 @@ const Configs = "configs"
 const (
 	// Apps doc type for client-side application manifests
 	Apps = "io.cozy.apps"
+	// AppsSuggestion doc type for suggesting apps to the user
+	AppsSuggestion = "io.cozy.apps.suggestions"
 	// Konnectors doc type for konnector application manifests
 	Konnectors = "io.cozy.konnectors"
 	// Versions doc type for apps versions from the registries


### PR DESCRIPTION
We need new permissions for the bitwarden's token to be able to get the konnectors list and create new suggestions from the browser extension.
