### PR TITLE
Optimize the references request

### DIFF
--- a/model/vfs/store.go
+++ b/model/vfs/store.go
@@ -17,10 +17,12 @@ import (
 // archive, or a metadata object for an upcoming upload.
 type Store interface {
 	AddFile(db prefixer.Prefixer, filePath string) (string, error)
+	AddThumb(db prefixer.Prefixer, fileID string) (string, error)
 	AddVersion(db prefixer.Prefixer, versionID string) (string, error)
 	AddArchive(db prefixer.Prefixer, archive *Archive) (string, error)
 	AddMetadata(db prefixer.Prefixer, metadata *Metadata) (string, error)
 	GetFile(db prefixer.Prefixer, key string) (string, error)
+	GetThumb(db prefixer.Prefixer, key string) (string, error)
 	GetVersion(db prefixer.Prefixer, key string) (string, error)
 	GetArchive(db prefixer.Prefixer, key string) (*Archive, error)
 	GetMetadata(db prefixer.Prefixer, key string) (*Metadata, error)
@@ -89,6 +91,17 @@ func (s *memStore) AddFile(db prefixer.Prefixer, filePath string) (string, error
 	return key, nil
 }
 
+func (s *memStore) AddThumb(db prefixer.Prefixer, fileID string) (string, error) {
+	key := makeSecret()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.vals[db.DBPrefix()+":"+key] = &memRef{
+		val: fileID,
+		exp: time.Now().Add(storeTTL),
+	}
+	return key, nil
+}
+
 func (s *memStore) AddVersion(db prefixer.Prefixer, versionID string) (string, error) {
 	key := makeSecret()
 	s.mu.Lock()
@@ -123,6 +136,25 @@ func (s *memStore) AddMetadata(db prefixer.Prefixer, metadata *Metadata) (string
 }
 
 func (s *memStore) GetFile(db prefixer.Prefixer, key string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key = db.DBPrefix() + ":" + key
+	ref, ok := s.vals[key]
+	if !ok {
+		return "", nil
+	}
+	if time.Now().After(ref.exp) {
+		delete(s.vals, key)
+		return "", nil
+	}
+	f, ok := ref.val.(string)
+	if !ok {
+		return "", nil
+	}
+	return f, nil
+}
+
+func (s *memStore) GetThumb(db prefixer.Prefixer, key string) (string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	key = db.DBPrefix() + ":" + key
@@ -214,6 +246,14 @@ func (s *redisStore) AddFile(db prefixer.Prefixer, filePath string) (string, err
 	return key, nil
 }
 
+func (s *redisStore) AddThumb(db prefixer.Prefixer, fileID string) (string, error) {
+	key := makeSecret()
+	if err := s.c.Set(db.DBPrefix()+":"+key, fileID, storeTTL).Err(); err != nil {
+		return "", err
+	}
+	return key, nil
+}
+
 func (s *redisStore) AddVersion(db prefixer.Prefixer, versionID string) (string, error) {
 	key := makeSecret()
 	if err := s.c.Set(db.DBPrefix()+":"+key, versionID, storeTTL).Err(); err != nil {
@@ -247,6 +287,17 @@ func (s *redisStore) AddMetadata(db prefixer.Prefixer, metadata *Metadata) (stri
 }
 
 func (s *redisStore) GetFile(db prefixer.Prefixer, key string) (string, error) {
+	f, err := s.c.Get(db.DBPrefix() + ":" + key).Result()
+	if err == redis.Nil {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return f, nil
+}
+
+func (s *redisStore) GetThumb(db prefixer.Prefixer, key string) (string, error) {
 	f, err := s.c.Get(db.DBPrefix() + ":" + key).Result()
 	if err == redis.Nil {
 		return "", nil

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -746,25 +746,17 @@ func ThumbnailHandler(c echo.Context) error {
 	instance := middlewares.GetInstance(c)
 
 	secret := c.Param("secret")
-	path, err := vfs.GetStore().GetFile(instance, secret)
+	fileID, err := vfs.GetStore().GetThumb(instance, secret)
 	if err != nil {
 		return WrapVfsError(err)
 	}
-	if path == "" {
+	if fileID == "" || c.Param("file-id") != fileID {
 		return jsonapi.NewError(http.StatusBadRequest, "Wrong download token")
 	}
 
-	doc, err := instance.VFS().FileByID(c.Param("file-id"))
+	doc, err := instance.VFS().FileByID(fileID)
 	if err != nil {
 		return WrapVfsError(err)
-	}
-
-	expected, err := doc.Path(instance.VFS())
-	if err != nil {
-		return WrapVfsError(err)
-	}
-	if expected != path {
-		return jsonapi.NewError(http.StatusBadRequest, "Wrong download token")
 	}
 
 	fs := lifecycle.ThumbsFS(instance)

--- a/web/files/paginated.go
+++ b/web/files/paginated.go
@@ -312,12 +312,10 @@ func (f *file) MarshalJSON() ([]byte, error) {
 func (f *file) Links() *jsonapi.LinksList {
 	links := jsonapi.LinksList{Self: "/files/" + f.doc.DocID}
 	if f.doc.Class == "image" {
-		if path, err := f.doc.Path(f.instance.VFS()); err == nil {
-			if secret, err := vfs.GetStore().AddFile(f.instance, path); err == nil {
-				links.Small = "/files/" + f.doc.DocID + "/thumbnails/" + secret + "/small"
-				links.Medium = "/files/" + f.doc.DocID + "/thumbnails/" + secret + "/medium"
-				links.Large = "/files/" + f.doc.DocID + "/thumbnails/" + secret + "/large"
-			}
+		if secret, err := vfs.GetStore().AddThumb(f.instance, f.doc.DocID); err == nil {
+			links.Small = "/files/" + f.doc.DocID + "/thumbnails/" + secret + "/small"
+			links.Medium = "/files/" + f.doc.DocID + "/thumbnails/" + secret + "/medium"
+			links.Large = "/files/" + f.doc.DocID + "/thumbnails/" + secret + "/large"
 		}
 	}
 	return &links


### PR DESCRIPTION
The transformation of a list of referenced files to JSON-API was slow because it involves requests to CouchDB to compute the path of the files. This commit removes this request by using an id instead of a path for storing the secrets for thumbnails.

See #1902 