### PR TITLE
feat: Ability to run FCM against a fake FCM server

### DIFF
--- a/cozy.example.yaml
+++ b/cozy.example.yaml
@@ -256,6 +256,8 @@ notifications:
 
   # Firebase Cloud Messaging API Key for Android notifications
   # android_api_key: ""
+  # Use this key to run end to test with a fake FCM server
+  # fcm_server: "http://localhost:3001"
 
   # APNS/2 certificates for iOS notifications
   # ios_certificate_key_path: path/to/certificate.p12

--- a/pkg/config/config/config.go
+++ b/pkg/config/config/config.go
@@ -210,6 +210,7 @@ type Notifications struct {
 	Development bool
 
 	AndroidAPIKey string
+	FCMServer     string
 
 	IOSCertificateKeyPath  string
 	IOSCertificatePassword string
@@ -691,6 +692,7 @@ func UseViper(v *viper.Viper) error {
 		Notifications: Notifications{
 			Development: v.GetBool("notifications.development"),
 
+			FCMServer:     v.GetString("notifications.fcm_server"),
 			AndroidAPIKey: v.GetString("notifications.android_api_key"),
 
 			IOSCertificateKeyPath:  v.GetString("notifications.ios_certificate_key_path"),

--- a/worker/push/push.go
+++ b/worker/push/push.go
@@ -48,9 +48,14 @@ func Init() (err error) {
 	conf := config.GetConfig().Notifications
 
 	if conf.AndroidAPIKey != "" {
-		fcmClient, err = fcm.NewClient(conf.AndroidAPIKey)
+		if conf.FCMServer != "" {
+			fcmClient, err = fcm.NewClient(conf.AndroidAPIKey, fcm.WithEndpoint(conf.FCMServer))
+		} else {
+			fcmClient, err = fcm.NewClient(conf.AndroidAPIKey)
+		}
 		logger.WithNamespace("push").Infof("Initialized FCM client with Android API Key")
 		if err != nil {
+			logger.WithNamespace("push").Warnf("%s", err)
 			return
 		}
 	}


### PR DESCRIPTION
When testing push notifications with a end to end test, it is quite
handy to be able to have the stack connect to a fake FCM server (for
example to check the received notifications against expected notifications).

Here, we add a configuration key to configure the FCM server used by the
stack.