### PR TITLE
fix: Skip konnectors with no vendor_link

### DIFF
--- a/worker/migrations/migrations.go
+++ b/worker/migrations/migrations.go
@@ -145,6 +145,10 @@ func migrateAccountsToOrganization(domain string) error {
 			continue
 		}
 		var link string
+		if manifest.VendorLink == nil {
+			log.Warningf("No vendor_link in manifest for %s", msg.Slug)
+			continue
+		}
 		if err := json.Unmarshal(*manifest.VendorLink, &link); err != nil {
 			errm = multierror.Append(errm, err)
 		}


### PR DESCRIPTION
The migration script failed with a panic runtime error if no `vendor_link` exists in the konnector manifest, which is the case for few of them (which is being fixed).
As a workaround, we log a warning and skip this konnector migration if it has no `vendor_link`.