### PR TITLE
Add JS polyfill for inapp browser in dev

### DIFF
--- a/web/middlewares/user_agent.go
+++ b/web/middlewares/user_agent.go
@@ -19,6 +19,7 @@ const (
 	Chromium         = "Chromium"
 	Opera            = "Opera"
 	Safari           = "Safari"
+	Android          = "Android"
 )
 
 // browser is a struct with a name and a minimal version
@@ -102,7 +103,7 @@ func CryptoPolyfill(c echo.Context) bool {
 	}
 	if build.IsDevRelease() {
 		// XXX electron is seen as Safari
-		return browser == Chrome || browser == Chromium || browser == Opera || browser == Safari
+		return browser == Chrome || browser == Chromium || browser == Opera || browser == Safari || browser == Android
 	}
 	return false
 }


### PR DESCRIPTION
When developing in local with the Android emulator, it can be convenient to have the JS polyfill for subtle crypto as the inapp browser gives access to them only for secure domains.