### PR TITLE
Block old versions of Safari

### DIFF
--- a/web/middlewares/user_agent.go
+++ b/web/middlewares/user_agent.go
@@ -35,6 +35,10 @@ var minEdgeVersion = 17
 // We don't support Firefox before version 52
 var minFirefoxVersion = 52
 
+// We don't support Safari before version 11, as window.crypto is not
+// available.
+var minSafariVersion = 11
+
 var rules = []browser{
 	{
 		name: InternetExplorer,
@@ -46,6 +50,10 @@ var rules = []browser{
 	{
 		name:       Firefox,
 		minVersion: &minFirefoxVersion,
+	},
+	{
+		name:       Safari,
+		minVersion: &minSafariVersion,
 	},
 }
 


### PR DESCRIPTION
Before Safari 11, the window.crypto API was not available and it causes a JS error when trying to login.