### PR TITLE
Migrate accounts when extension is installed

### DIFF
--- a/model/bitwarden/settings/settings.go
+++ b/model/bitwarden/settings/settings.go
@@ -35,6 +35,7 @@ type Settings struct {
 	EquivalentDomains       [][]string             `json:"equivalent_domains,omitempty"`
 	GlobalEquivalentDomains []int                  `json:"global_equivalent_domains,omitempty"`
 	Metadata                *metadata.CozyMetadata `json:"cozyMetadata,omitempty"`
+	ExtensionInstalled      bool                   `json:"extension_installed,omitempty"`
 }
 
 // ID returns the settings qualified identifier

--- a/web/bitwarden/bitwarden.go
+++ b/web/bitwarden/bitwarden.go
@@ -41,7 +41,7 @@ func migrateAccountsToCiphers(inst *instance.Instance) error {
 // hashing the master password.
 func Prelogin(c echo.Context) error {
 	inst := middlewares.GetInstance(c)
-	log := inst.Logger().WithField("nspace", "pre-login")
+	log := inst.Logger().WithField("nspace", "bitwarden")
 	settings, err := settings.Get(inst)
 	if err != nil {
 		return err
@@ -50,7 +50,7 @@ func Prelogin(c echo.Context) error {
 		// This is the first time the bitwarden extension is installed: make sure
 		// the user gets the existing accounts into the vault
 		if err := migrateAccountsToCiphers(inst); err != nil {
-			log.Errorf("Account migration failed : %s", err)
+			log.Errorf("Cannot push job for ciphers migration: %s", err)
 		}
 		settings.ExtensionInstalled = true
 		if err := settings.Save(inst); err != nil {

--- a/web/bitwarden/bitwarden_test.go
+++ b/web/bitwarden/bitwarden_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/cozy/cozy-stack/model/bitwarden"
+	"github.com/cozy/cozy-stack/model/bitwarden/settings"
 	"github.com/cozy/cozy-stack/model/instance"
 	"github.com/cozy/cozy-stack/model/instance/lifecycle"
 	"github.com/cozy/cozy-stack/pkg/config/config"
@@ -40,6 +41,10 @@ func TestPrelogin(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 0, result["Kdf"])
 	assert.Equal(t, crypto.DefaultPBKDF2Iterations, result["KdfIterations"])
+
+	settings, err := settings.Get(inst)
+	assert.NoError(t, err)
+	assert.Equal(t, settings.ExtensionInstalled, true)
 }
 
 func TestConnect(t *testing.T) {


### PR DESCRIPTION
When the extension is installed for the first time, we want the user to get its existing account. Therefore, we run the dedicated worker on the pre-login route, only if the `extension_installed` flag is set to false.