### PR TITLE
Migration edge cases

### DIFF
--- a/worker/migrations/migrations.go
+++ b/worker/migrations/migrations.go
@@ -178,9 +178,10 @@ func migrateAccountsToOrganization(domain string) error {
 		if err != nil || msg.Account == "" || msg.Slug == "" {
 			continue
 		}
+
 		manifest, err := app.GetKonnectorBySlug(inst, msg.Slug)
 		if err != nil {
-			errm = multierror.Append(errm, err)
+			log.Warningf("Could not get manifest for %s", msg.Slug)
 			continue
 		}
 		var link string

--- a/worker/migrations/migrations.go
+++ b/worker/migrations/migrations.go
@@ -233,7 +233,6 @@ func migrateAccountsToOrganization(domain string) error {
 			errm = multierror.Append(errm, err)
 		}
 	}
-	settings.UpdateRevisionDate(inst, setting)
 	return errm
 }
 


### PR DESCRIPTION
This fixes 2 errors that happened after a test:
* A konnector trigger without the associated manifest will raise an `Application not found` error: we log a warning instead
* A conflict might occur on the bitwarden settings doc, as we were trying to write it in 2 different places, and the job is run asynchronously: we now only update the doc after the job is pushed