### PR TITLE
Do not block Electron

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,3 +55,5 @@ require (
 )
 
 replace github.com/spf13/afero => github.com/cozy/afero v1.2.3
+
+replace github.com/mssola/user_agent => github.com/cozy/user_agent v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/cozy/httpcache v0.0.0-20180914105234-d3dc4988de66 h1:b7VTmlsWlhYzJqGL
 github.com/cozy/httpcache v0.0.0-20180914105234-d3dc4988de66/go.mod h1:rLnjIcybyvs+PoCzi4+GmpOVp0+q+qdcuZKnKUKJoF4=
 github.com/cozy/prosemirror-go v0.4.6 h1:sRcnuB3xNJgFx61tX2I8xIMs77LDm2nV+MZ1doS76/M=
 github.com/cozy/prosemirror-go v0.4.6/go.mod h1:v15sN6s5qGHCgb1cgVGk2ZZ53lLzefVmFVwX53E3Lb8=
+github.com/cozy/user_agent v0.5.2 h1:UhoSV7uzlKHmqYcp/5OX4o8E/MS9fCvD43TKU0z2/Ig=
+github.com/cozy/user_agent v0.5.2/go.mod h1:TTPno8LPY3wAIEKRpAtkdMT0f8SE24pLRGPahjCH4uw=
 github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -161,8 +163,6 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJ
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
-github.com/mssola/user_agent v0.5.1 h1:sJUCUozh+j7c0dR2zMIUX5aJjoY/TNo/gXiNujoH5oY=
-github.com/mssola/user_agent v0.5.1/go.mod h1:TTPno8LPY3wAIEKRpAtkdMT0f8SE24pLRGPahjCH4uw=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/ncw/swift v1.0.49 h1:eQaKIjSt/PXLKfYgzg01nevmO+CMXfXGRhB1gOhDs7E=
 github.com/ncw/swift v1.0.49/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=

--- a/web/middlewares/user_agent.go
+++ b/web/middlewares/user_agent.go
@@ -20,6 +20,7 @@ const (
 	Opera            = "Opera"
 	Safari           = "Safari"
 	Android          = "Android"
+	Electron         = "Electron"
 )
 
 // browser is a struct with a name and a minimal version
@@ -110,8 +111,12 @@ func CryptoPolyfill(c echo.Context) bool {
 		return true
 	}
 	if build.IsDevRelease() {
-		// XXX electron is seen as Safari
-		return browser == Chrome || browser == Chromium || browser == Opera || browser == Safari || browser == Android
+		return browser == Chrome ||
+			browser == Chromium ||
+			browser == Opera ||
+			browser == Safari ||
+			browser == Android ||
+			browser == Electron
 	}
 	return false
 }


### PR DESCRIPTION
Electron was seen as an old version of Safari, and was blocked as such. It is now correctly detected and not blocked.

See https://github.com/mssola/user_agent/pull/62