### PR TITLE
fix: Save settings in the account migration

### DIFF
--- a/web/bitwarden/bitwarden.go
+++ b/web/bitwarden/bitwarden.go
@@ -52,8 +52,6 @@ func Prelogin(c echo.Context) error {
 		if err := migrateAccountsToCiphers(inst); err != nil {
 			log.Errorf("Cannot push job for ciphers migration: %s", err)
 		}
-		setting.ExtensionInstalled = true
-		settings.UpdateRevisionDate(inst, setting)
 	}
 	return c.JSON(http.StatusOK, echo.Map{
 		"Kdf":           setting.PassphraseKdf,

--- a/web/bitwarden/bitwarden_test.go
+++ b/web/bitwarden/bitwarden_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/cozy/cozy-stack/model/bitwarden"
-	"github.com/cozy/cozy-stack/model/bitwarden/settings"
 	"github.com/cozy/cozy-stack/model/instance"
 	"github.com/cozy/cozy-stack/model/instance/lifecycle"
 	"github.com/cozy/cozy-stack/pkg/config/config"
@@ -41,10 +40,6 @@ func TestPrelogin(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 0, result["Kdf"])
 	assert.Equal(t, crypto.DefaultPBKDF2Iterations, result["KdfIterations"])
-
-	settings, err := settings.Get(inst)
-	assert.NoError(t, err)
-	assert.Equal(t, settings.ExtensionInstalled, true)
 }
 
 func TestConnect(t *testing.T) {

--- a/worker/migrations/migrations.go
+++ b/worker/migrations/migrations.go
@@ -233,6 +233,12 @@ func migrateAccountsToOrganization(domain string) error {
 			errm = multierror.Append(errm, err)
 		}
 	}
+	// This flag is checked at the extension pre-login to run the migration or not
+	setting.ExtensionInstalled = true
+	settings.UpdateRevisionDate(inst, setting)
+	if err != nil {
+		errm = multierror.Append(errm, err)
+	}
 	return errm
 }
 


### PR DESCRIPTION
The `accounts-to-organization` migration creates the organization key if it does not exist. However, the settings were not saved in database in the migration: the organization key was therefore lost and replaced by another one later, making all the migrated ciphers to be impossible to decrypt.
