### PR TITLE
Add a deleting flag on instance

### DIFF
--- a/model/instance/errors.go
+++ b/model/instance/errors.go
@@ -29,4 +29,6 @@ var (
 	ErrBadTOSVersion = errors.New("Bad format for TOS version")
 	// ErrInvalidSwiftLayout is returned when the Swift layout is unknown.
 	ErrInvalidSwiftLayout = errors.New("Invalid Swift layout")
+	// ErrDeletionAlreadyRequested is returned when a deletion has already been requested.
+	ErrDeletionAlreadyRequested = errors.New("The deletion has already been requested")
 )

--- a/model/instance/instance.go
+++ b/model/instance/instance.go
@@ -47,6 +47,7 @@ type Instance struct {
 	TOSSigned      string   `json:"tos,omitempty"`        // Terms of Service signed version
 	TOSLatest      string   `json:"tos_latest,omitempty"` // Terms of Service latest version
 	AuthMode       AuthMode `json:"auth_mode,omitempty"`
+	Deleting       bool     `json:"deleting,omitempty"`
 	Blocked        bool     `json:"blocked,omitempty"`         // Whether or not the instance is blocked
 	BlockingReason string   `json:"blocking_reason,omitempty"` // Why the instance is blocked
 	NoAutoUpdate   bool     `json:"no_auto_update,omitempty"`  // Whether or not the instance has auto updates for its applications

--- a/web/middlewares/instance.go
+++ b/web/middlewares/instance.go
@@ -18,10 +18,10 @@ func NeedInstance(next echo.HandlerFunc) echo.HandlerFunc {
 			return next(c)
 		}
 		i, err := lifecycle.GetInstance(c.Request().Host)
-		if err != nil {
+		if err != nil || i.Deleting {
 			var errHTTP *echo.HTTPError
 			switch err {
-			case instance.ErrNotFound, instance.ErrIllegalDomain:
+			case instance.ErrNotFound, instance.ErrIllegalDomain, nil:
 				err = instance.ErrNotFound
 				errHTTP = echo.NewHTTPError(http.StatusNotFound, err)
 			default:


### PR DESCRIPTION
When deleting an instance, the first step is to clean the accounts. This step must not run twice in parallel if the instance deletion is runned twice. And if it fails, it must be manually managed. So, we have added a `deleting` flag on the instance to avoid those issues.