### PR TITLE
Decrypt account if include param is credentials

### DIFF
--- a/docs/konnectors-workflow.md
+++ b/docs/konnectors-workflow.md
@@ -29,6 +29,13 @@ saved in CouchDB, but we will show them as the konnectors will see them):
 
 Accounts are manipulated through the `/data/` API.
 
+#### Decryption
+
+The decryption of the credentials is reserved to requests coming from konnectors
+and services. For services, it is only available on
+`/data/io.cozy.acconts/:account-id` with an additional `include=credentials`
+parameter.
+
 #### Aggregator accounts
 
 Some konnectors are based on an aggregator service. An aggregator is declared

--- a/web/data/accounts.go
+++ b/web/data/accounts.go
@@ -54,7 +54,9 @@ func getAccount(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	if perm.Type == permission.TypeKonnector {
+	if perm.Type == permission.TypeKonnector ||
+		(c.QueryParam("include") == "credentials" && perm.Type == permission.TypeWebapp) {
+		// The account decryption is allowed for konnectors or for apps services
 		decryptAccount(out)
 	}
 


### PR DESCRIPTION
The account decryption was reserved to konnectors only. We make it possible for the apps services to do it as well if they pass an `include=credentials` parameter.