### PR TITLE
feat: Add Sentry to allowed CSP url

### DIFF
--- a/web/routing.go
+++ b/web/routing.go
@@ -46,7 +46,7 @@ import (
 
 const (
 	// cspScriptSrcWhitelist is a whitelist for default allowed domains in CSP.
-	cspScriptSrcWhitelist = "https://piwik.cozycloud.cc https://matomo.cozycloud.cc"
+	cspScriptSrcWhitelist = "https://piwik.cozycloud.cc https://matomo.cozycloud.cc https://sentry.cozycloud.cc"
 
 	// cspImgSrcWhitelist is a whitelist of images domains that are allowed in
 	// CSP.


### PR DESCRIPTION
Currently, we need to use a remote doctype to be able to use the Sentry API when using a webapp. Since we don't need on mobile app, let's add this URL to our allowed list of domain. 

This way, it will be easier to use Sentry for our web apps