### PR TITLE
Add logout event for bitwarden hub

### DIFF
--- a/web/bitwarden/bitwarden_test.go
+++ b/web/bitwarden/bitwarden_test.go
@@ -619,7 +619,7 @@ func assertDomainsReponse(t *testing.T, res *http.Response) {
 	}
 }
 
-func TestChangeSecurityHash(t *testing.T) {
+func TestChangeSecurityStamp(t *testing.T) {
 	email := inst.PassphraseSalt()
 	iter := crypto.DefaultPBKDF2Iterations
 	pass, _ := crypto.HashPassWithPBKDF2([]byte("cozy"), email, iter)


### PR DESCRIPTION
When the owner of a cozy instance changes its password, the stack must
send a realtime event (logout) to the bitwarden clients. It allows them
to know that they must ask the new password to the user.