### PR TITLE
Fix a regression for instance in deleting state

### DIFF
--- a/web/middlewares/instance.go
+++ b/web/middlewares/instance.go
@@ -29,13 +29,21 @@ func NeedInstance(next echo.HandlerFunc) echo.HandlerFunc {
 			}
 			errHTTP.Internal = err
 			return errHTTP
-		} else if i.Deleting {
-			err = instance.ErrNotFound
+		}
+		c.Set("instance", i.WithContextualDomain(c.Request().Host))
+		return next(c)
+	}
+}
+
+func CheckInstanceDeleting(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		i := GetInstance(c)
+		if i.Deleting {
+			err := instance.ErrNotFound
 			errHTTP := echo.NewHTTPError(http.StatusNotFound, err)
 			errHTTP.Internal = err
 			return errHTTP
 		}
-		c.Set("instance", i.WithContextualDomain(c.Request().Host))
 		return next(c)
 	}
 }

--- a/web/routing.go
+++ b/web/routing.go
@@ -73,6 +73,7 @@ func SetupAppsHandler(appsHandler echo.HandlerFunc) echo.HandlerFunc {
 			DefaultContentTypeOffer: echo.MIMETextHTML,
 		}),
 		middlewares.CheckInstanceBlocked,
+		middlewares.CheckInstanceDeleting,
 		middlewares.CheckTOSDeadlineExpired,
 	}
 
@@ -156,6 +157,7 @@ func SetupRoutes(router *echo.Echo) error {
 			}),
 			middlewares.CheckUserAgent,
 			middlewares.CheckInstanceBlocked,
+			middlewares.CheckInstanceDeleting,
 		}
 
 		router.GET("/", auth.Home, mws...)


### PR DESCRIPTION
When an instance is being deleted, it is marked as "deleting", which blocks access from a user and instance deletion retry from the manager. But it also blocks the API requests from the konnectors to clean the accounts, which is bad. This commit fixes this regression.