### PR TITLE
Tweak the Cozy to Cozy sharing parameters

### DIFF
--- a/model/sharing/replicator.go
+++ b/model/sharing/replicator.go
@@ -19,11 +19,11 @@ import (
 )
 
 // MaxRetries is the maximal number of retries for a replicator
-const MaxRetries = 10
+const MaxRetries = 5
 
 // InitialBackoffPeriod is the initial duration to wait for the first retry
 // (each next retry will wait 4 times longer than its previous retry)
-const InitialBackoffPeriod = 15 * time.Second
+const InitialBackoffPeriod = 1 * time.Minute
 
 // BatchSize is the maximal number of documents mainpulated at once by the replicator
 const BatchSize = 100

--- a/model/sharing/setup.go
+++ b/model/sharing/setup.go
@@ -359,7 +359,7 @@ func (s *Sharing) AddUploadTrigger(inst *instance.Instance) error {
 		Type:       "@event",
 		WorkerType: "share-upload",
 		Arguments:  args,
-		Debounce:   "5s",
+		Debounce:   "10s",
 	}, msg)
 	inst.Logger().WithField("nspace", "sharing").Infof("Create trigger %#v", t)
 	if err != nil {

--- a/pkg/lock/simple_redis.go
+++ b/pkg/lock/simple_redis.go
@@ -43,7 +43,7 @@ const (
 var (
 	// ErrTooManyRetries is the error returned when despite several tries
 	// we never managed to get a lock
-	ErrTooManyRetries = errors.New("too many retry")
+	ErrTooManyRetries = errors.New("abort after too many failures without getting the lock")
 )
 
 type redisLock struct {


### PR DESCRIPTION
When we have seen in the logs some cases where there a lot of failures
of the sharing workers in a short period of time, related to the lock.
They probably come of an accumulation of retry jobs. This commit tries
to tweak the parameters to avoid this cascading failure:

- decrease the number of retries
- increase the initial backoff period
- increase the debounce for the share-upload trigger
- increase the sequence number if the last try for uploading a file
  fails (to allow to skip a corrupted file).