### PR TITLE
Add a route /notes/:id/open

### DIFF
--- a/docs/notes.md
+++ b/docs/notes.md
@@ -916,6 +916,36 @@ POST /notes/f48d9370-e1ec-0137-8547-543d7eb8149c/sync HTTP/1.1
 HTTP/1.1 204 No Content
 ```
 
+### GET /notes/:id/open
+
+It return the URL where the note can be opened. It can be on the same cozy
+instance, or on another instance if the note is shared.
+
+#### Request
+
+```http
+GET /notes/f48d9370-e1ec-0137-8547-543d7eb8149c/open HTTP/1.1
+Host: bob.cozy.example
+```
+
+#### Response
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/vnd.api+json
+```
+
+```json
+{
+  "data": {
+    "type": "io.cozy.notes.open",
+    "id": "f48d9370-e1ec-0137-8547-543d7eb8149c",
+    "attributes": {
+        "url": "https://alice.cozy.example/?sharecode=543d7eb8149c&username=bob#/n/05781bea244247fb38f2cd50262c07b5"
+    }
+}
+```
+
 ## Real-time via websockets
 
 You can subscribe to the [realtime](realtime.md) API for a document with the

--- a/docs/notes.md
+++ b/docs/notes.md
@@ -921,6 +921,9 @@ HTTP/1.1 204 No Content
 It return the parameters to build the URL where the note can be opened. It can
 be on the same cozy instance, or on another instance if the note is shared.
 
+If the identifier doesn't give a note, the response will be a `404 Page not
+found`.
+
 #### Request
 
 ```http

--- a/docs/notes.md
+++ b/docs/notes.md
@@ -918,8 +918,8 @@ HTTP/1.1 204 No Content
 
 ### GET /notes/:id/open
 
-It return the URL where the note can be opened. It can be on the same cozy
-instance, or on another instance if the note is shared.
+It return the parameters to build the URL where the note can be opened. It can
+be on the same cozy instance, or on another instance if the note is shared.
 
 #### Request
 
@@ -938,11 +938,16 @@ Content-Type: application/vnd.api+json
 ```json
 {
   "data": {
-    "type": "io.cozy.notes.open",
+    "type": "io.cozy.notes.url",
     "id": "f48d9370-e1ec-0137-8547-543d7eb8149c",
     "attributes": {
-        "url": "https://alice.cozy.example/?sharecode=543d7eb8149c&username=bob#/n/05781bea244247fb38f2cd50262c07b5"
+      "note_id": "05781bea244247fb38f2cd50262c07b5",
+      "subdomain": "flat",
+      "instance": "alice.cozy.example",
+      "sharecode": "543d7eb8149c",
+      "public_name": "Bob"
     }
+  }
 }
 ```
 

--- a/model/note/open.go
+++ b/model/note/open.go
@@ -1,0 +1,52 @@
+package note
+
+import (
+	"github.com/cozy/cozy-stack/model/instance"
+	"github.com/cozy/cozy-stack/pkg/config/config"
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/jsonapi"
+)
+
+type apiNoteURL struct {
+	DocID      string `json:"_id,omitempty"`
+	NoteID     string `json:"note_id"`
+	Subdomain  string `json:"subdomain"`
+	Instance   string `json:"instance"`
+	Sharecode  string `json:"sharecode,omitempty"`
+	PublicName string `json:"public_name,omitempty"`
+}
+
+func (n *apiNoteURL) ID() string                             { return n.DocID }
+func (n *apiNoteURL) Rev() string                            { return "" }
+func (n *apiNoteURL) DocType() string                        { return consts.NotesURL }
+func (n *apiNoteURL) Clone() couchdb.Doc                     { cloned := *n; return &cloned }
+func (n *apiNoteURL) SetID(id string)                        { n.DocID = id }
+func (n *apiNoteURL) SetRev(rev string)                      {}
+func (n *apiNoteURL) Relationships() jsonapi.RelationshipMap { return nil }
+func (n *apiNoteURL) Included() []jsonapi.Object             { return nil }
+func (n *apiNoteURL) Links() *jsonapi.LinksList              { return nil }
+func (n *apiNoteURL) Fetch(field string) []string            { return nil }
+
+// Open returns the parameters to create the URL where the note can be opened.
+func Open(inst *instance.Instance, fileID string) (*apiNoteURL, error) {
+	doc := &apiNoteURL{
+		DocID:    fileID,
+		NoteID:   fileID,
+		Instance: inst.ContextualDomain(),
+	}
+	switch config.GetConfig().Subdomains {
+	case config.FlatSubdomains:
+		doc.Subdomain = "flat"
+	case config.NestedSubdomains:
+		doc.Subdomain = "nested"
+	}
+
+	if name, err := inst.PublicName(); err == nil {
+		doc.PublicName = name
+	}
+
+	// TODO check if the note is shared, and if it is the case, get info from the sharer
+
+	return doc, nil
+}

--- a/model/note/open.go
+++ b/model/note/open.go
@@ -1,7 +1,13 @@
 package note
 
 import (
+	"net/http"
+	"net/url"
+
+	"github.com/cozy/cozy-stack/client/request"
 	"github.com/cozy/cozy-stack/model/instance"
+	"github.com/cozy/cozy-stack/model/permission"
+	"github.com/cozy/cozy-stack/model/sharing"
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
@@ -30,8 +36,91 @@ func (n *apiNoteURL) Fetch(field string) []string            { return nil }
 
 // Open returns the parameters to create the URL where the note can be opened.
 func Open(inst *instance.Instance, fileID string) (*apiNoteURL, error) {
+	sharing, err := getSharing(inst, fileID)
+	if err != nil {
+		return nil, err
+	}
+
+	var doc *apiNoteURL
+	if sharing == nil || sharing.Owner {
+		doc = openLocalNote(inst, fileID)
+	} else {
+		doc, err = openSharedNote(inst, sharing, fileID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	doc.DocID = fileID
+	if name, err := inst.PublicName(); err == nil {
+		doc.PublicName = name
+	}
+	return doc, nil
+}
+
+func getSharing(inst *instance.Instance, fileID string) (*sharing.Sharing, error) {
+	sid := consts.Files + "/" + fileID
+	var ref sharing.SharedRef
+	if err := couchdb.GetDoc(inst, consts.Shared, sid, &ref); err != nil {
+		if couchdb.IsNotFoundError(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	for sharingID, info := range ref.Infos {
+		if info.Removed {
+			continue
+		}
+		var sharing sharing.Sharing
+		if err := couchdb.GetDoc(inst, consts.Sharings, sharingID, &sharing); err != nil {
+			return nil, err
+		}
+		if sharing.Active {
+			return &sharing, nil
+		}
+	}
+	return nil, nil
+}
+
+func openSharedNote(inst *instance.Instance, s *sharing.Sharing, fileID string) (*apiNoteURL, error) {
+	xoredID := sharing.XorID(fileID, s.Credentials[0].XorKey)
+	u, err := url.Parse(s.Members[0].Instance)
+	if err != nil {
+		return nil, err
+	}
+	c := &s.Credentials[0]
+	opts := &request.Options{
+		Method:  http.MethodGet,
+		Scheme:  u.Scheme,
+		Domain:  u.Host,
+		Path:    "/notes/" + xoredID,
+		Queries: url.Values{"SharingID": {s.ID()}},
+		Headers: request.Headers{
+			"Accept":        "application/vnd.api+json",
+			"Authorization": "Bearer " + c.AccessToken.AccessToken,
+		},
+	}
+	res, err := request.Req(opts)
+	if res != nil && res.StatusCode/100 == 4 {
+		res, err = sharing.RefreshToken(inst, s, &s.Members[0], c, opts, nil)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return nil, sharing.ErrInternalServerError
+	}
+	var doc apiNoteURL
+	if _, err := jsonapi.Bind(res.Body, &doc); err != nil {
+		return nil, err
+	}
+	return &doc, nil
+}
+
+func openLocalNote(inst *instance.Instance, fileID string) *apiNoteURL {
 	doc := &apiNoteURL{
-		DocID:    fileID,
 		NoteID:   fileID,
 		Instance: inst.ContextualDomain(),
 	}
@@ -41,12 +130,27 @@ func Open(inst *instance.Instance, fileID string) (*apiNoteURL, error) {
 	case config.NestedSubdomains:
 		doc.Subdomain = "nested"
 	}
+	return doc
+}
 
-	if name, err := inst.PublicName(); err == nil {
-		doc.PublicName = name
+// AddSharecodeToNoteURL adds a sharecode to allow recipients to open a shared
+// note.
+func AddSharecodeToNoteURL(inst *instance.Instance, n *apiNoteURL, sharingID, clientID string) {
+	var s sharing.Sharing
+	if err := couchdb.GetDoc(inst, consts.Sharings, sharingID, &s); err != nil {
+		return
 	}
-
-	// TODO check if the note is shared, and if it is the case, get info from the sharer
-
-	return doc, nil
+	member, err := s.FindMemberByInboundClientID(clientID)
+	if err != nil {
+		return
+	}
+	preview, err := permission.GetForSharePreview(inst, sharingID)
+	if err != nil {
+		return
+	}
+	for key, code := range preview.Codes {
+		if key == member.Instance || key == member.Email {
+			n.Sharecode = code
+		}
+	}
 }

--- a/model/permission/permissions.go
+++ b/model/permission/permissions.go
@@ -3,6 +3,7 @@ package permission
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -232,7 +233,11 @@ func getFromSource(db prefixer.Prefixer, permType, docType, slug string) (*Permi
 		}
 	}
 	if len(res) == 0 {
-		return nil, fmt.Errorf("no permission doc for %v", slug)
+		return nil, &couchdb.Error{
+			StatusCode: http.StatusNotFound,
+			Name:       "not_found",
+			Reason:     fmt.Sprintf("no permission doc for %v", slug),
+		}
 	}
 	perm := &res[0]
 	if perm.Expired() {

--- a/pkg/consts/doctype.go
+++ b/pkg/consts/doctype.go
@@ -95,4 +95,6 @@ const (
 	// NotesEvents doc type is used for realtime events related to a note, like
 	// a change of title.
 	NotesEvents = "io.cozy.notes.events"
+	// NotesURL doc type is used to return the URL where a note can be edited.
+	NotesURL = "io.cozy.notes.url"
 )

--- a/tests/integration/lib/cozy_file.rb
+++ b/tests/integration/lib/cozy_file.rb
@@ -5,13 +5,8 @@ class CozyFile
   attr_reader :name, :dir_id, :mime, :trashed, :md5sum, :referenced_by,
               :metadata, :size, :executable, :file_class, :cozy_metadata
 
-  def self.load_from_url(inst, path)
-    opts = {
-      accept: "application/vnd.api+json",
-      authorization: "Bearer #{inst.token_for doctype}"
-    }
-    res = inst.client[path].get opts
-    j = JSON.parse(res.body)["data"]
+  def self.parse_jsonapi(body)
+    j = JSON.parse(body)["data"]
     id = j["id"]
     rev = j.dig "meta", "rev"
     referenced_by = j.dig "relationships", "referenced_by", "data"
@@ -31,6 +26,15 @@ class CozyFile
     f.couch_id = id
     f.couch_rev = rev
     f
+  end
+
+  def self.load_from_url(inst, path)
+    opts = {
+      accept: "application/vnd.api+json",
+      authorization: "Bearer #{inst.token_for doctype}"
+    }
+    res = inst.client[path].get opts
+    parse_jsonapi res.body
   end
 
   def restore_from_trash(inst)

--- a/tests/integration/lib/note.rb
+++ b/tests/integration/lib/note.rb
@@ -1,0 +1,66 @@
+class Note
+  attr_reader :file, :title, :dir_id, :schema
+
+  include Model
+
+  def self.doctype
+    "io.cozy.notes.documents"
+  end
+
+  def self.default_schema
+    {
+      "nodes": [
+        ["doc", { "content": "block+" }],
+        ["paragraph", { "content": "inline*", "group": "block" }],
+        ["blockquote", { "content": "block+", "group": "block" }],
+        ["horizontal_rule", { "group": "block" }],
+        ["heading", { "content": "inline*", "group": "block" }],
+        ["text", { "group": "inline" }],
+        ["hard_break", { "group": "inline", "inline": true }]
+      ],
+      "marks": [
+        ["link", { "attrs": { "href": {}, "title": {} }, "inclusive": false }],
+        ["em", {}],
+        ["strong", {}],
+        ["code", {}]
+      ],
+      "topNode": "doc"
+    }
+  end
+
+  def self.open(inst, id)
+    opts = {
+      accept: 'application/vnd.api+json',
+      authorization: "Bearer #{inst.token_for CozyFile.doctype}"
+    }
+    res = inst.client["/notes/#{id}/open"].get opts
+    JSON.parse(res.body).dig "data", "attributes"
+  end
+
+  def initialize(opts = {})
+    @title = opts[:title] || Faker::DrWho.quote
+    @dir_id = opts[:dir_id] || Folder::ROOT_DIR
+    @schema = opts[:schema] || Note.default_schema
+  end
+
+  def save(inst)
+    opts = {
+      content_type: 'application/vnd.api+json',
+      authorization: "Bearer #{inst.token_for CozyFile.doctype}"
+    }
+    res = inst.client["/notes"].post to_jsonapi, opts
+    @file = CozyFile.parse_jsonapi(res.body)
+  end
+
+  def as_json
+    {
+      title: @title,
+      dir_id: @dir_id,
+      schema: @schema
+    }
+  end
+
+  def to_jsonapi
+    JSON.generate data: { type: Note.doctype, attributes: as_json }
+  end
+end

--- a/web/notes/notes_test.go
+++ b/web/notes/notes_test.go
@@ -109,6 +109,25 @@ func TestGetNote(t *testing.T) {
 	assertInitialNote(t, result)
 }
 
+func TestOpenNote(t *testing.T) {
+	req, _ := http.NewRequest("GET", ts.URL+"/notes/"+noteID+"/open", nil)
+	req.Header.Add("Authorization", "Bearer "+token)
+	res, err := http.DefaultClient.Do(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, res.StatusCode)
+	var doc map[string]interface{}
+	err = json.NewDecoder(res.Body).Decode(&doc)
+	assert.NoError(t, err)
+	data, _ := doc["data"].(map[string]interface{})
+	assert.Equal(t, consts.NotesURL, data["type"])
+	assert.Equal(t, noteID, data["id"])
+	attrs, _ := data["attributes"].(map[string]interface{})
+	assert.Equal(t, noteID, attrs["note_id"])
+	assert.Equal(t, "nested", attrs["subdomain"])
+	assert.Equal(t, inst.Domain, attrs["instance"])
+	assert.NotEmpty(t, attrs["public_name"])
+}
+
 func assertInitialNote(t *testing.T, result map[string]interface{}) {
 	data, _ := result["data"].(map[string]interface{})
 	assert.Equal(t, "io.cozy.files", data["type"])

--- a/web/permissions/permissions_test.go
+++ b/web/permissions/permissions_test.go
@@ -735,6 +735,7 @@ func TestListPermission(t *testing.T) {
 		return
 	}
 	defer res.Body.Close()
+	assert.Equal(t, 200, res.StatusCode)
 	body, err := ioutil.ReadAll(res.Body)
 	if !assert.NoError(t, err) {
 		return
@@ -742,6 +743,9 @@ func TestListPermission(t *testing.T) {
 	var out jsonapi.Document
 	err = json.Unmarshal(body, &out)
 	if !assert.NoError(t, err) {
+		return
+	}
+	if !assert.NotNil(t, out.Data) {
 		return
 	}
 	var results []refAndVerb


### PR DESCRIPTION
This route can be used by clients to get information about a note and build the URL where the note can be opened.