### PR TITLE
Fix conflict on account migration

### DIFF
--- a/model/bitwarden/settings/settings.go
+++ b/model/bitwarden/settings/settings.go
@@ -146,7 +146,7 @@ func Get(inst *instance.Instance) (*Settings, error) {
 // UpdateRevisionDate updates the updatedAt field of the bitwarden settings
 // document. This field is used to know by some clients to know the date of the
 // last change on the server before doing a full sync.
-func UpdateRevisionDate(inst *instance.Instance, settings *Settings) {
+func UpdateRevisionDate(inst *instance.Instance, settings *Settings) error {
 	var err error
 	if settings == nil {
 		settings, err = Get(inst)
@@ -158,6 +158,7 @@ func UpdateRevisionDate(inst *instance.Instance, settings *Settings) {
 		inst.Logger().WithField("nspace", "bitwarden").
 			Infof("Cannot update revision date: %s", err)
 	}
+	return err
 }
 
 var _ couchdb.Doc = &Settings{}

--- a/web/bitwarden/ciphers.go
+++ b/web/bitwarden/ciphers.go
@@ -287,7 +287,7 @@ func CreateCipher(c echo.Context) error {
 		})
 	}
 
-	settings.UpdateRevisionDate(inst, setting)
+	_ = settings.UpdateRevisionDate(inst, setting)
 	res := newCipherResponse(cipher, setting)
 	return c.JSON(http.StatusOK, res)
 }
@@ -357,7 +357,7 @@ func CreateSharedCipher(c echo.Context) error {
 		})
 	}
 
-	settings.UpdateRevisionDate(inst, setting)
+	_ = settings.UpdateRevisionDate(inst, setting)
 	res := newCipherResponse(cipher, setting)
 	return c.JSON(http.StatusOK, res)
 }
@@ -476,7 +476,7 @@ func UpdateCipher(c echo.Context) error {
 		})
 	}
 
-	settings.UpdateRevisionDate(inst, setting)
+	_ = settings.UpdateRevisionDate(inst, setting)
 	res := newCipherResponse(cipher, setting)
 	return c.JSON(http.StatusOK, res)
 }
@@ -515,7 +515,7 @@ func DeleteCipher(c echo.Context) error {
 		})
 	}
 
-	settings.UpdateRevisionDate(inst, nil)
+	_ = settings.UpdateRevisionDate(inst, nil)
 	return c.NoContent(http.StatusOK)
 }
 
@@ -613,7 +613,7 @@ func ShareCipher(c echo.Context) error {
 		})
 	}
 
-	settings.UpdateRevisionDate(inst, setting)
+	_ = settings.UpdateRevisionDate(inst, setting)
 	res := newCipherResponse(cipher, setting)
 	return c.JSON(http.StatusOK, res)
 }

--- a/web/bitwarden/folders.go
+++ b/web/bitwarden/folders.go
@@ -108,7 +108,7 @@ func CreateFolder(c echo.Context) error {
 		})
 	}
 
-	settings.UpdateRevisionDate(inst, nil)
+	_ = settings.UpdateRevisionDate(inst, nil)
 	res := newFolderResponse(folder)
 	return c.JSON(http.StatusOK, res)
 }
@@ -198,7 +198,7 @@ func RenameFolder(c echo.Context) error {
 		})
 	}
 
-	settings.UpdateRevisionDate(inst, nil)
+	_ = settings.UpdateRevisionDate(inst, nil)
 	res := newFolderResponse(folder)
 	return c.JSON(http.StatusOK, res)
 }
@@ -263,6 +263,6 @@ func DeleteFolder(c echo.Context) error {
 		})
 	}
 
-	settings.UpdateRevisionDate(inst, nil)
+	_ = settings.UpdateRevisionDate(inst, nil)
 	return c.NoContent(http.StatusOK)
 }

--- a/worker/migrations/migrations.go
+++ b/worker/migrations/migrations.go
@@ -237,6 +237,12 @@ func migrateAccountsToOrganization(domain string) error {
 	setting.ExtensionInstalled = true
 	settings.UpdateRevisionDate(inst, setting)
 	if err != nil {
+		if couchdb.IsConflictError(err) {
+			// The settings have been updated elsewere: retry
+			setting, err = settings.Get(inst)
+			setting.ExtensionInstalled = true
+			settings.UpdateRevisionDate(inst, setting)
+		}
 		errm = multierror.Append(errm, err)
 	}
 	return errm


### PR DESCRIPTION
The setting update might fail at the end of the migration worker if the settings were updated during the process. 