### PR TITLE
fix: Typo on Cozy not found page

### DIFF
--- a/assets/locales/en.po
+++ b/assets/locales/en.po
@@ -277,7 +277,7 @@ msgid "Error Instance not found Title"
 msgstr "Address of this Cozy does not exist"
 
 msgid "Error Instance not found Message"
-msgstr "You may have entered a wrong address form a typing mistake. To make sure, please check the address of your Cozy sent to you by e-mail during its creation."
+msgstr "You may have entered a wrong address from a typing mistake. To make sure, please check the address of your Cozy sent to you by e-mail during its creation."
 
 msgid "Error Application not found Title"
 msgstr "Application not yet available"


### PR DESCRIPTION
s/form a typing mistake/from a typing mistake