### PR TITLE
Print useful message instead of manifest when (un)-installing apps/konnectors

### DIFF
--- a/cmd/apps.go
+++ b/cmd/apps.go
@@ -316,11 +316,8 @@ func installApp(cmd *cobra.Command, args []string, appType string) error {
 	if err != nil {
 		return err
 	}
-	json, err := json.MarshalIndent(manifest.Attrs, "", "  ")
-	if err != nil {
-		return err
-	}
-	fmt.Println(string(json))
+	fmt.Printf("%s has been installed (%s)\n", manifest.Attrs.Slug, manifest.Attrs.Version)
+
 	return nil
 }
 
@@ -402,11 +399,7 @@ func uninstallApp(cmd *cobra.Command, args []string, appType string) error {
 	if err != nil {
 		return err
 	}
-	json, err := json.MarshalIndent(manifest.Attrs, "", "  ")
-	if err != nil {
-		return err
-	}
-	fmt.Println(string(json))
+	fmt.Printf("%s has been uninstalled\n", manifest.Attrs.Slug)
 	return nil
 }
 


### PR DESCRIPTION
This PR aims at printing a useful message on stdout when installing or uninstalling apps or konnectors : 

```
./cozy-stack apps install --domain "cozy.tools:8080" drive
drive has been installed (1.18.23)
```

```
./cozy-stack apps uninstall --domain "cozy.tools:8080" drive
drive has been uninstalled
```