### PR TITLE
Fix sharing a single note from Drive web

### DIFF
--- a/model/sharing/rule.go
+++ b/model/sharing/rule.go
@@ -169,10 +169,11 @@ func (r Rule) TriggerArgs() string {
 	if r.Local {
 		return ""
 	}
-	verbs := make([]string, 0, 3)
-	if r.Add == ActionRuleSync || r.Add == ActionRulePush {
-		verbs = append(verbs, "CREATED")
-	}
+	verbs := make([]string, 1, 3)
+	// We always need the CREATED verb to have io.cozy.shared for all the
+	// shared documents, as the io.cozy.shared documents are needed to
+	// accept the updates and deletes later.
+	verbs[0] = "CREATED"
 	if r.Update == ActionRuleSync || r.Update == ActionRulePush {
 		verbs = append(verbs, "UPDATED")
 	}

--- a/model/sharing/rule_test.go
+++ b/model/sharing/rule_test.go
@@ -174,7 +174,7 @@ func TestTriggersArgs(t *testing.T) {
 		Values:   []string{"io.cozy.playlists/list1"},
 		Update:   "sync",
 	}
-	expected := "io.cozy.files:UPDATED:io.cozy.playlists/list1:referenced_by"
+	expected := "io.cozy.files:CREATED,UPDATED:io.cozy.playlists/list1:referenced_by"
 	assert.Equal(t, expected, r.TriggerArgs())
 
 	doctype := "io.cozy.test.foos"


### PR DESCRIPTION
When the Drive web app shares a single note to a set of recipients in read-write mode, it creates a sharing with a rule:
- add: none
- update: sync
- delete: revoke.

With this rule, the stack didn't create an io.cozy.shared for the note on the recipient instance, and thus, the note wasn't seen as part of the sharing. It means that later updates of this note made on the sharer instance are not accepted by the recipients, and the open route for notes sent parameters as if the note was local, not shared. With this commit, the io.cozy.shared is correctly created, which fixes our issues.