### PR TITLE
Fix an issue when a file is uploaded twice

### DIFF
--- a/model/vfs/vfsswift/impl_v3.go
+++ b/model/vfs/vfsswift/impl_v3.go
@@ -669,6 +669,18 @@ func (f *swiftFileCreationV3) Close() (err error) {
 	}
 	defer f.fs.mu.Unlock()
 
+	// Check again that a file with the same path does not exist. It can happen
+	// when the same file is uploaded twice in parallel.
+	if olddoc == nil {
+		exists, err := f.fs.Indexer.DirChildExists(newdoc.DirID, newdoc.DocName)
+		if err != nil {
+			return err
+		}
+		if exists {
+			return os.ErrExist
+		}
+	}
+
 	var v *vfs.Version
 	if olddoc != nil {
 		v = vfs.NewVersion(olddoc)


### PR DESCRIPTION
In VFS Afero and Swift layout v3, if the same file is uploaded twice in parallel, it may corrupt the instance (with a duplicate file). The check to ensure the unicity of the path is made at the start of the upload, but the VFS lock is released during the upload, so we need to make again the check at the end of the upload (with the VFS lock held).