### PR TITLE
Fix bookmark paginated queries for _find

### DIFF
--- a/docs/mango.md
+++ b/docs/mango.md
@@ -156,7 +156,7 @@ to paginate, although this is not recommended for performances. For more details
 }
 ```
 
-If the number of docs is lower or equal to the limit, next will be false.
+If the number of docs is lower than the limit, next will be false.
 
 ```json
 {

--- a/web/data/data_test.go
+++ b/web/data/data_test.go
@@ -631,16 +631,23 @@ func TestFindDocumentsPaginatedBookmark(t *testing.T) {
 	req, _ = http.NewRequest("POST", url2, jsonReader(&query2))
 	req.Header.Add("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
-	var out3 struct {
-		Limit int
-		Next  bool
-		Docs  []couchdb.JSONDoc `json:"docs"`
-	}
-	_, res, err = doRequest(req, &out3)
+
+	_, res, err = doRequest(req, &out2)
 	assert.Equal(t, "200 OK", res.Status, "should get a 200")
 	assert.NoError(t, err)
-	assert.Equal(t, 100, out3.Limit)
-	assert.Equal(t, false, out3.Next)
+	assert.Len(t, out2.Docs, 100)
+	assert.Equal(t, 100, out2.Limit)
+	assert.Equal(t, true, out2.Next)
+
+	var query3 = M{"selector": M{"test": "value"}, "bookmark": out2.Bookmark}
+	req, _ = http.NewRequest("POST", url2, jsonReader(&query3))
+	req.Header.Add("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	_, res, err = doRequest(req, &out2)
+	assert.Equal(t, "200 OK", res.Status, "should get a 200")
+	assert.NoError(t, err)
+	assert.Len(t, out2.Docs, 0)
+	assert.Equal(t, false, out2.Next)
 }
 
 func TestFindDocumentsWithoutIndex(t *testing.T) {


### PR DESCRIPTION
We used to add 1 to the limit in order to ensure there are more docs to
query. However, the returned bookmark was consequently the one for this
additional doc. As a result, the client was missing one doc for each
paginated query.
This PR removes this limit increment ; the downside is an additional query from the client when the result docs length is exactly the limit, as we cannot know there are actually no more docs. 