### PR TITLE
Fix the revisions tracking for some special cases

### DIFF
--- a/model/sharing/revisions.go
+++ b/model/sharing/revisions.go
@@ -152,11 +152,19 @@ func (rt *RevsTree) InsertChain(chain []string) {
 	if len(chain) == 0 {
 		return
 	}
-	subtree, _ := rt.Find(chain[0])
+	common := 0
+	var subtree *RevsTree
+	for i, rev := range chain {
+		subtree, _ = rt.Find(rev)
+		if subtree != nil {
+			common = i
+			break
+		}
+	}
 	if subtree == nil {
 		subtree = rt.Add(chain[0])
 	}
-	for _, rev := range chain[1:] {
+	for _, rev := range chain[common+1:] {
 		if len(subtree.Branches) > 0 {
 			found := false
 			for i := range subtree.Branches {

--- a/model/sharing/revisions_test.go
+++ b/model/sharing/revisions_test.go
@@ -159,6 +159,21 @@ func TestRevsTreeInsertChain(t *testing.T) {
 	assert.Len(t, sub.Branches, 0)
 }
 
+func TestRevsTreeInsertChainStartingBefore(t *testing.T) {
+	tree := &RevsTree{Rev: "2-bbb"}
+	three := RevsTree{Rev: "3-ccc"}
+	tree.Branches = []RevsTree{three}
+	tree.InsertChain([]string{"1-aaa", "2-bbb", "3-ccc", "4-ddd"})
+	assert.Equal(t, tree.Rev, "2-bbb")
+	assert.Len(t, tree.Branches, 1)
+	sub := tree.Branches[0]
+	assert.Equal(t, sub.Rev, "3-ccc")
+	assert.Len(t, sub.Branches, 1)
+	sub = sub.Branches[0]
+	assert.Equal(t, sub.Rev, "4-ddd")
+	assert.Len(t, sub.Branches, 0)
+}
+
 func TestRevGeneration(t *testing.T) {
 	assert.Equal(t, 1, RevGeneration("1-aaa"))
 	assert.Equal(t, 3, RevGeneration("3-123"))


### PR DESCRIPTION
When a file or folder comes a sharing, is removed of the sharing, and
shared again, the stack can misinterpret the revisions tree of this
document. This commit makes the InsertChain method more robust for those
cases.