### PR TITLE
Improve the app not found error page

### DIFF
--- a/assets/locales/en.po
+++ b/assets/locales/en.po
@@ -288,6 +288,9 @@ msgstr "We are sorry. This application is not yet available in your Cozy."
 msgid "Error Application not found Action"
 msgstr "Go to your home"
 
+msgid "Error Application not found Button"
+msgstr "Install this application"
+
 msgid "Error Contact us"
 msgstr "A problem, a question ? Contact us at"
 


### PR DESCRIPTION
When a user tries to access an app that is not yet installed, we will show them an error page with a link to the store where they can install the app.