### PR TITLE
Fix opening notes in a shared directory

### DIFF
--- a/web/notes/notes.go
+++ b/web/notes/notes.go
@@ -270,6 +270,11 @@ func OpenNoteURL(c echo.Context) error {
 			return middlewares.ErrForbidden
 		}
 	}
+	// If a directory is shared by link and contains a note, the note can be
+	// opened with the same sharecode as the directory.
+	if pdoc.Type == permission.TypeShareByLink {
+		code = middlewares.GetRequestToken(c)
+	}
 
 	doc, err := note.Open(inst, file, code)
 	if err != nil {


### PR DESCRIPTION
If a directory contains a note, and is shared by link, a user with this link should be able to open the note via the `GET /notes/:id/open route`. It was not the case, as the `sharecode` was not put in the response, but it is fixed in this commit.