### PR TITLE
Changes on the doctype for permissions

### DIFF
--- a/docs/doctype.md
+++ b/docs/doctype.md
@@ -17,6 +17,9 @@ If you have several related doctypes, it is common to nest them. For example,
 `io.cozy.contacts.accounts` is the accounts of external services used to
 synchronize the `io.cozy.accounts`.
 
+The name of the doctype must be composed of only lowercase letters, digits, `.`
+and `_` characters.
+
 ## Add documentation about your doctype
 
 The doctypes are documented on https://docs.cozy.io/en/cozy-doctypes/docs/

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -41,7 +41,7 @@ stack. It is defined by four components.
 
 ### Type
 
-`type` is the attribute used in JSON-API or the `docType` for the Data System.
+`type` is the attribute used in JSON-API or the `doctype` for the Data System.
 
 It is the only mandatory component. If just the `type` is specified, it gives
 access to all the operations on this `type`. For example, a permission on type
@@ -70,7 +70,7 @@ informations about the permission when it answers the request.
 
 ### Values
 
-It's possible to restrict the permissions to only some documents of a docType,
+It's possible to restrict the permissions to only some documents of a doctype,
 or to just some files and folders. You can give a list of ids in `values`.
 
 **Note**: a permission for a folder also gives permissions with same verbs for
@@ -505,9 +505,9 @@ Accept: application/vnd.api+json
 ```json
 {
   "data": [
-    { "type": "io.cozy.files", "id": "94375086-e2e2-11e6-81b9-5bc0b9dd4aa4" }
-    { "type": "io.cozy.files", "id": "4cfbd8be-8968-11e6-9708-ef55b7c20863" }
-    { "type": "io.cozy.files", "id": "a340d5e0-d647-11e6-b66c-5fc9ce1e17c6" }
+    { "type": "io.cozy.files", "id": "94375086-e2e2-11e6-81b9-5bc0b9dd4aa4" },
+    { "type": "io.cozy.files", "id": "4cfbd8be-8968-11e6-9708-ef55b7c20863" },
+    { "type": "io.cozy.files", "id": "a340d5e0-d647-11e6-b66c-5fc9ce1e17c6" },
     { "type": "io.cozy.files", "id": "94375086-e2e2-11e6-81b9-5bc0b9dd4aa4" }
   ]
 }
@@ -524,7 +524,7 @@ Content-Type: application/vnd.api+json
 {
   "data": [
     { "type": "io.cozy.files", "id": "94375086-e2e2-11e6-81b9-5bc0b9dd4aa4",
-      "verbs":["GET"] }
+      "verbs":["GET"] },
     { "type": "io.cozy.files", "id": "a340d5e0-d647-11e6-b66c-5fc9ce1e17c6",
       "verbs":["GET", "POST"] }
   ]

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -57,6 +57,11 @@ Some known types:
 -   `io.cozy.jobs` and `io.cozy.triggers`, for [jobs](jobs.md)
 -   `io.cozy.oauth.clients`, to list and revoke [OAuth 2 clients](auth.md)
 
+It is also possible to use a wildcard to use a doctype and its sub-doctypes.
+For example, `io.cozy.bank.*` will give access to `io.cozy.bank`,
+`io.cozy.bank.accounts`, `io.cozy.bank.accounts.stats`,
+`io.cozy.bank.settings`, etc.
+
 ### Verbs
 
 It says which HTTP verbs can be used for requests to the cozy-stack. `GET` will

--- a/docs/sharing.md
+++ b/docs/sharing.md
@@ -1322,7 +1322,7 @@ HTTP/1.1 204 No Content
 ## Real-time via websockets
 
 You can subscribe to the [realtime](realtime.md) API for the normal doctypes,
-but also for a special `io.cozy.sharings.initial-sync` doctype. For this
+but also for a special `io.cozy.sharings.initial_sync` doctype. For this
 doctype, you can give the id of a sharing and you will be notified when a file
 will be received during the initial synchronisation (`UPDATED`), and when the
 sync will be done (`DELETED`).
@@ -1333,11 +1333,11 @@ sync will be done (`DELETED`).
 client > {"method": "AUTH",
           "payload": "xxAppOrAuthTokenxx="}
 client > {"method": "SUBSCRIBE",
-          "payload": {"type": "io.cozy.sharings.initial-sync", "id": "ce8835a061d0ef68947afe69a0046722"}}
+          "payload": {"type": "io.cozy.sharings.initial_sync", "id": "ce8835a061d0ef68947afe69a0046722"}}
 server > {"event": "UPDATED",
-          "payload": {"id": "ce8835a061d0ef68947afe69a0046722", "type": "io.cozy.sharings.initial-sync", "doc": {"count": 12}}}
+          "payload": {"id": "ce8835a061d0ef68947afe69a0046722", "type": "io.cozy.sharings.initial_sync", "doc": {"count": 12}}}
 server > {"event": "UPDATED",
-          "payload": {"id": "ce8835a061d0ef68947afe69a0046722", "type": "io.cozy.sharings.initial-sync", "doc": {"count": 13}}}
+          "payload": {"id": "ce8835a061d0ef68947afe69a0046722", "type": "io.cozy.sharings.initial_sync", "doc": {"count": 13}}}
 server > {"event": "DELETED",
-          "payload": {"id": "ce8835a061d0ef68947afe69a0046722", "type": "io.cozy.sharings.initial-sync"}}
+          "payload": {"id": "ce8835a061d0ef68947afe69a0046722", "type": "io.cozy.sharings.initial_sync"}}
 ```

--- a/model/app/installer.go
+++ b/model/app/installer.go
@@ -495,7 +495,7 @@ func (i *Installer) ReadManifest(state State) (Manifest, error) {
 
 	set := newManifest.Permissions()
 	for _, rule := range set {
-		if err := permission.CheckDoctypeName(rule.Type); err != nil {
+		if err := permission.CheckDoctypeName(rule.Type, true); err != nil {
 			return nil, err
 		}
 	}

--- a/model/app/installer.go
+++ b/model/app/installer.go
@@ -493,6 +493,13 @@ func (i *Installer) ReadManifest(state State) (Manifest, error) {
 	}
 	newManifest.SetState(state)
 
+	set := newManifest.Permissions()
+	for _, rule := range set {
+		if err := permission.CheckDoctypeName(rule.Type); err != nil {
+			return nil, err
+		}
+	}
+
 	shouldOverrideParameters := (i.overridenParameters != nil &&
 		i.man.AppType() == consts.KonnectorType &&
 		i.src.Scheme != "registry")

--- a/model/job/redis_scheduler_test.go
+++ b/model/job/redis_scheduler_test.go
@@ -294,7 +294,7 @@ func TestRedisTriggerEvent(t *testing.T) {
 
 	evTrigger := jobs.TriggerInfos{
 		Type:       "@event",
-		Arguments:  "io.cozy.event-test:CREATED",
+		Arguments:  "io.cozy.event.test:CREATED",
 		WorkerType: "incr",
 	}
 
@@ -303,7 +303,7 @@ func TestRedisTriggerEvent(t *testing.T) {
 	assert.NoError(t, sch.AddTrigger(tri))
 
 	realtime.GetHub().Publish(testInstance, realtime.EventCreate,
-		&testDoc{id: "foo", doctype: "io.cozy.event-test"}, nil)
+		&testDoc{id: "foo", doctype: "io.cozy.event.test"}, nil)
 
 	time.Sleep(1 * time.Second)
 
@@ -327,10 +327,10 @@ func TestRedisTriggerEvent(t *testing.T) {
 	assert.Equal(t, evt.Verb, "CREATED")
 
 	realtime.GetHub().Publish(testInstance, realtime.EventUpdate,
-		&testDoc{id: "foo", doctype: "io.cozy.event-test"}, nil)
+		&testDoc{id: "foo", doctype: "io.cozy.event.test"}, nil)
 
 	realtime.GetHub().Publish(testInstance, realtime.EventCreate,
-		&testDoc{id: "foo", doctype: "io.cozy.event-test.bad"}, nil)
+		&testDoc{id: "foo", doctype: "io.cozy.event.test.bad"}, nil)
 
 	time.Sleep(10 * time.Millisecond)
 
@@ -467,7 +467,7 @@ func TestRedisSchedulerWithDebounce(t *testing.T) {
 
 	evTrigger := jobs.TriggerInfos{
 		Type:       "@event",
-		Arguments:  "io.cozy.debounce-test:CREATED io.cozy.debounce-more:CREATED",
+		Arguments:  "io.cozy.debounce.test:CREATED io.cozy.debounce.more:CREATED",
 		WorkerType: "incr",
 		Debounce:   "4s",
 	}
@@ -477,7 +477,7 @@ func TestRedisSchedulerWithDebounce(t *testing.T) {
 
 	doc := testDoc{
 		id:      "foo",
-		doctype: "io.cozy.debounce-test",
+		doctype: "io.cozy.debounce.test",
 	}
 
 	for i := 0; i < 10; i++ {
@@ -490,7 +490,7 @@ func TestRedisSchedulerWithDebounce(t *testing.T) {
 	assert.Equal(t, 2, count)
 
 	realtime.GetHub().Publish(testInstance, realtime.EventCreate, &doc, nil)
-	doc.doctype = "io.cozy.debounce-more"
+	doc.doctype = "io.cozy.debounce.more"
 	realtime.GetHub().Publish(testInstance, realtime.EventCreate, &doc, nil)
 	time.Sleep(5000 * time.Millisecond)
 	count, _ = bro.WorkerQueueLen("incr")

--- a/model/permission/permissions_test.go
+++ b/model/permission/permissions_test.go
@@ -10,6 +10,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestCheckDoctypeName(t *testing.T) {
+	assert.NoError(t, CheckDoctypeName("io.cozy.files"))
+	assert.NoError(t, CheckDoctypeName("io.cozy.account_types"))
+	assert.Error(t, CheckDoctypeName("IO.COZY.FILES"))
+	assert.Error(t, CheckDoctypeName("io.cozy.account-types"))
+	assert.Error(t, CheckDoctypeName("io.cozy.files.*"))
+}
+
 func TestVerbToString(t *testing.T) {
 	vs := Verbs(GET, DELETE)
 	assert.Equal(t, "GET,DELETE", vs.String())

--- a/model/permission/rule.go
+++ b/model/permission/rule.go
@@ -73,7 +73,7 @@ func UnmarshalRuleString(in string) (Rule, error) {
 		out.Verbs = VerbSplit(parts[1])
 		fallthrough
 	case 1:
-		if CheckDoctypeName(parts[0]) != nil {
+		if CheckDoctypeName(parts[0], true) != nil {
 			return out, ErrBadScope
 		}
 		out.Type = parts[0]

--- a/model/permission/rule.go
+++ b/model/permission/rule.go
@@ -73,7 +73,7 @@ func UnmarshalRuleString(in string) (Rule, error) {
 		out.Verbs = VerbSplit(parts[1])
 		fallthrough
 	case 1:
-		if parts[0] == "" {
+		if CheckDoctypeName(parts[0]) != nil {
 			return out, ErrBadScope
 		}
 		out.Type = parts[0]

--- a/model/sharing/rule.go
+++ b/model/sharing/rule.go
@@ -52,7 +52,10 @@ func (s *Sharing) ValidateRules() error {
 		return ErrNoRules
 	}
 	for i, rule := range s.Rules {
-		if rule.Title == "" || rule.DocType == "" || len(rule.Values) == 0 {
+		if rule.Title == "" || len(rule.Values) == 0 {
+			return ErrInvalidRule
+		}
+		if permission.CheckDoctypeName(rule.DocType) != nil {
 			return ErrInvalidRule
 		}
 		if rule.DocType == consts.Files {

--- a/model/sharing/rule.go
+++ b/model/sharing/rule.go
@@ -55,7 +55,7 @@ func (s *Sharing) ValidateRules() error {
 		if rule.Title == "" || len(rule.Values) == 0 {
 			return ErrInvalidRule
 		}
-		if permission.CheckDoctypeName(rule.DocType) != nil {
+		if permission.CheckDoctypeName(rule.DocType, false) != nil {
 			return ErrInvalidRule
 		}
 		if rule.DocType == consts.Files {

--- a/model/vfs/permissions_test.go
+++ b/model/vfs/permissions_test.go
@@ -189,7 +189,7 @@ func TestPermissions(t *testing.T) {
 
 	psetWrongType := permission.Set{
 		permission.Rule{
-			Type:   "io.cozy.not-files",
+			Type:   "io.cozy.not.files",
 			Verbs:  permission.ALL,
 			Values: []string{A.ID()},
 		},

--- a/pkg/consts/doctype.go
+++ b/pkg/consts/doctype.go
@@ -66,7 +66,7 @@ const (
 	SharingsAnswer = "io.cozy.sharings.answer"
 	// SharingsInitialSync doc type for real-time events for initial sync of a
 	// sharing
-	SharingsInitialSync = "io.cozy.sharings.initial-sync"
+	SharingsInitialSync = "io.cozy.sharings.initial_sync"
 	// Triggers doc type for triggers, jobs launchers
 	Triggers = "io.cozy.triggers"
 	// TriggersState doc type for triggers current state, jobs launchers

--- a/tests/integration/tests/sharing_sync.rb
+++ b/tests/integration/tests/sharing_sync.rb
@@ -82,7 +82,7 @@ describe "A folder" do
         }.to_json)
         ws.send({
           method: "SUBSCRIBE",
-          payload: { type: "io.cozy.sharings.initial-sync", id: sharing.couch_id }
+          payload: { type: "io.cozy.sharings.initial_sync", id: sharing.couch_id }
         }.to_json)
       end
 

--- a/web/permissions/permissions.go
+++ b/web/permissions/permissions.go
@@ -290,7 +290,7 @@ func patchPermission(getPerms getPermsFunc, paramName string) echo.HandlerFunc {
 			for _, r := range patch.Permissions {
 				if r.Type == "" {
 					toPatch.RemoveRule(r)
-				} else if err := permission.CheckDoctypeName(r.Type); err != nil {
+				} else if err := permission.CheckDoctypeName(r.Type, true); err != nil {
 					return err
 				} else if current.Permissions.RuleInSubset(r) {
 					toPatch.AddRules(r)

--- a/web/permissions/permissions.go
+++ b/web/permissions/permissions.go
@@ -290,6 +290,8 @@ func patchPermission(getPerms getPermsFunc, paramName string) echo.HandlerFunc {
 			for _, r := range patch.Permissions {
 				if r.Type == "" {
 					toPatch.RemoveRule(r)
+				} else if err := permission.CheckDoctypeName(r.Type); err != nil {
+					return err
 				} else if current.Permissions.RuleInSubset(r) {
 					toPatch.AddRules(r)
 				} else {

--- a/web/permissions/permissions_test.go
+++ b/web/permissions/permissions_test.go
@@ -379,7 +379,7 @@ func TestBadPatchAddRuleForbidden(t *testing.T) {
 	    "attributes": {
 					"permissions": {
 						"otherperm": {
-							"type":"io.cozy.token-cant-do-this"
+							"type":"io.cozy.token.cant.do.this"
 						}
 					}
 				}

--- a/web/realtime/realtime.go
+++ b/web/realtime/realtime.go
@@ -182,7 +182,7 @@ func readPump(ctx context.Context, c echo.Context, i *instance.Instance, ws *web
 		if permType == consts.Thumbnails || permType == consts.NotesEvents {
 			permType = consts.Files
 		}
-		// XXX: no permissions are required for io.cozy.sharings.initial-sync
+		// XXX: no permissions are required for io.cozy.sharings.initial_sync
 		if withAuthentication && cmd.Payload.Type != consts.SharingsInitialSync {
 			var authorized bool
 			if cmd.Payload.ID == "" {


### PR DESCRIPTION
Now, we authorize a wildcard on the doctype for a permissions. For example, a permission on io.cozy.bank.* will give access to io.cozy.bank, io.cozy.bank.accounts, io.cozy.bank.settings, etc.

And we enforce new rules for the doctype names. In particular, they must be only be composed of lowercase letters, digits, . and _. It will avoid confusion, particularly between . and - that are mapped to the same CouchDB database.