### PR TITLE
Fix login from bitwarden iOS app with 2FA

### DIFF
--- a/web/bitwarden/bitwarden.go
+++ b/web/bitwarden/bitwarden.go
@@ -363,8 +363,10 @@ func checkTwoFactor(c echo.Context, inst *instance.Instance) bool {
 		"error_description": "Two factor required.",
 		// 1 means email
 		// https://github.com/bitwarden/jslib/blob/master/src/enums/twoFactorProviderType.ts
-		"TwoFactorProviders":  []int{1},
-		"TwoFactorProviders2": map[string]string{"1": obscured},
+		"TwoFactorProviders": []int{1},
+		"TwoFactorProviders2": map[string]map[string]string{
+			"1": {"Email": obscured},
+		},
 	})
 	return false
 }


### PR DESCRIPTION
When the 2 factors authentication is enabled on a Cozy instance, the iOS bitwarden app crashs at the login. It looks like it is an issue with the format of the JSON response. The code of the official bitwarden server and clients didn't inspire me, but I've found those lines in bitwarden_rs:

```rust
// https://github.com/dani-garcia/bitwarden_rs/blob/5cabf4d0400e0db3dffabc2cdafb803d811a01de/src/api/identity.rs#L338-L340
result["TwoFactorProviders2"][provider.to_string()] = json!({
    "Email": email::obscure_email(&email_data.email),
})
```

So, let's try this format.