### PR TITLE
Add a way to discard a subscription in realtime

### DIFF
--- a/docs/realtime.md
+++ b/docs/realtime.md
@@ -37,6 +37,8 @@ server > {"event": "UPDATED",
           "payload": {"id": "idA", "rev": "2-705...", "type": "io.cozy.contacts", "doc": {embeded doc ...}}}
 server > {"event": "DELETED",
           "payload": {"id": "idA", "rev": "3-541...", "type": "io.cozy.contacts"}}
+client > {"method": "UNSUBSCRIBE",
+          "payload": {"type": "io.cozy.contacts"}}
 server > {"event": "UPDATED",
           "payload": {"id": "idB", "rev": "6-457...", "type": "io.cozy.files", "doc": {embeded doc ...}}}
 ```
@@ -72,6 +74,16 @@ server > {"event": "error",
             "title":"The Application can't subscribe to io.cozy.files"
             "source": {"method": "SUBSCRIBE", "payload": {"type":"io.cozy.files"} }
           }}
+```
+
+## UNSUBSCRIBE
+
+A client can send an UNSUBSCRIBE request to no longer be notified of changes
+from a previous request.
+
+```
+{"method": "UNSUBSCRIBE", "payload": {"type": "[desired doctype]"}}
+{"method": "UNSUBSCRIBE", "payload": {"type": "[desired doctype]", "id": "idA"}}
 ```
 
 ## Response messages

--- a/web/realtime/realtime.go
+++ b/web/realtime/realtime.go
@@ -168,7 +168,8 @@ func readPump(ctx context.Context, c echo.Context, i *instance.Instance, ws *web
 			break
 		}
 
-		if strings.ToUpper(cmd.Method) != "SUBSCRIBE" {
+		method := strings.ToUpper(cmd.Method)
+		if method != "SUBSCRIBE" && method != "UNSUBSCRIBE" {
 			sendErr(ctx, errc, unknownMethod(cmd.Method, cmd))
 			continue
 		}
@@ -196,10 +197,18 @@ func readPump(ctx context.Context, c echo.Context, i *instance.Instance, ws *web
 			}
 		}
 
-		if cmd.Payload.ID == "" {
-			err = ds.Subscribe(cmd.Payload.Type)
-		} else {
-			err = ds.Watch(cmd.Payload.Type, cmd.Payload.ID)
+		if method == "SUBSCRIBE" {
+			if cmd.Payload.ID == "" {
+				err = ds.Subscribe(cmd.Payload.Type)
+			} else {
+				err = ds.Watch(cmd.Payload.Type, cmd.Payload.ID)
+			}
+		} else if method == "UNSUBSCRIBE" {
+			if cmd.Payload.ID == "" {
+				err = ds.Unsubscribe(cmd.Payload.Type)
+			} else {
+				err = ds.Unwatch(cmd.Payload.Type, cmd.Payload.ID)
+			}
 		}
 		if err != nil {
 			logger.


### PR DESCRIPTION
When a `SUBSCRIBE` order is sent to the realtime websocket, it can be convenient to cancel it later without having to close the websocket. The new `UNSUBSCRIBE` order can be sent to do that. It takes the same parameters that the `SUBSCRIBE`.

Fix #1921