### PR TITLE
Add support for IDNA

### DIFF
--- a/model/instance/lifecycle/helpers.go
+++ b/model/instance/lifecycle/helpers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/utils"
 	multierror "github.com/hashicorp/go-multierror"
+	"golang.org/x/net/idna"
 )
 
 func update(inst *instance.Instance) error {
@@ -130,6 +131,10 @@ const illegalChars = " /,;&?#@|='\"\t\r\n\x00"
 const illegalFirstChars = "0123456789."
 
 func validateDomain(domain string) (string, error) {
+	var err error
+	if domain, err = idna.ToUnicode(domain); err != nil {
+		return "", instance.ErrIllegalDomain
+	}
 	domain = strings.TrimSpace(domain)
 	if domain == "" || domain == ".." || domain == "." {
 		return "", instance.ErrIllegalDomain

--- a/model/session/session.go
+++ b/model/session/session.go
@@ -183,7 +183,7 @@ func (s *Session) Delete(i *instance.Instance) *http.Cookie {
 		Value:  "",
 		MaxAge: -1,
 		Path:   "/",
-		Domain: utils.StripPort("." + i.ContextualDomain()),
+		Domain: utils.CookieDomain("." + i.ContextualDomain()),
 	}
 }
 
@@ -204,7 +204,7 @@ func (s *Session) ToCookie() (*http.Cookie, error) {
 		Value:    string(encoded),
 		MaxAge:   maxAge,
 		Path:     "/",
-		Domain:   utils.StripPort("." + s.Instance.ContextualDomain()),
+		Domain:   utils.CookieDomain("." + s.Instance.ContextualDomain()),
 		Secure:   !build.IsDevRelease(),
 		HttpOnly: true,
 	}, nil
@@ -222,7 +222,7 @@ func (s *Session) ToAppCookie(domain, slug string) (*http.Cookie, error) {
 		Value:    string(encoded),
 		MaxAge:   0, // "session cookie", expiring when the browser is closed
 		Path:     "/",
-		Domain:   utils.StripPort(domain),
+		Domain:   utils.CookieDomain(domain),
 		Secure:   !build.IsDevRelease(),
 		HttpOnly: true,
 	}, nil

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 	"unicode/utf8"
+
+	"golang.org/x/net/idna"
 )
 
 func init() {
@@ -69,6 +71,16 @@ func StripPort(domain string) string {
 		return cleaned
 	}
 	return domain
+}
+
+// CookieDomain removes the port and does IDNA encoding.
+func CookieDomain(domain string) string {
+	domain = StripPort(domain)
+	ascii, err := idna.ToASCII(domain)
+	if err != nil {
+		return domain
+	}
+	return ascii
 }
 
 // SplitTrimString slices s into all substrings a s separated by sep, like

--- a/web/apps/serve.go
+++ b/web/apps/serve.go
@@ -422,7 +422,7 @@ func deleteAppCookie(c echo.Context, i *instance.Instance, slug string) error {
 		Value:  "",
 		MaxAge: -1,
 		Path:   "/",
-		Domain: utils.StripPort(i.ContextualDomain()),
+		Domain: utils.CookieDomain(i.ContextualDomain()),
 	})
 
 	redirect := *(c.Request().URL)

--- a/web/routing.go
+++ b/web/routing.go
@@ -43,6 +43,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/net/idna"
 )
 
 const (
@@ -288,7 +289,10 @@ func CreateSubdomainProxy(router *echo.Echo, appsHandler echo.HandlerFunc) (*ech
 // use the API router, serve an app, or use delegated authentication.
 func firstRouting(router *echo.Echo, appsHandler echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		host := c.Request().Host
+		host, err := idna.ToASCII(c.Request().Host)
+		if err != nil {
+			return err
+		}
 		if contextName, ok := oidc.FindLoginDomain(host); ok {
 			return oidc.LoginDomainHandler(c, contextName)
 		}


### PR DESCRIPTION
RFC 5980 defines Internationalized Domain Names for Applications. It allows to have domain names like zoé.example.net.