### PR TITLE
Add support for go 1.14

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.x'
+          go-version: '1.14.x'
       - name: Install
         run: |
           echo ::add-path::$(go env GOPATH)/bin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           - 6379:6379
     strategy:
       matrix:
-        go-version: [1.12.x, 1.13.x]
+        go-version: [1.13.x, 1.14.x]
     steps:
       - name: Install CouchDB
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           	couchdb couchdb/adminpass_again password
           	couchdb couchdb/adminpass_again seen true
           EOF
-          DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --force-yes couchdb
+          DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --force-yes couchdb=2.3.1*
       - name: Install Go
         uses: actions/setup-go@v1
         with:

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.x'
+          go-version: '1.14.x'
       - name: Install
         run: |
           echo ::add-path::$(go env GOPATH)/bin

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,7 +33,7 @@ jobs:
           	couchdb couchdb/adminpass_again password
           	couchdb couchdb/adminpass_again seen true
           EOF
-          DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --force-yes couchdb
+          DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --force-yes couchdb=2.3.1*
       - name: Install Go
         uses: actions/setup-go@v1
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.x'
+          go-version: '1.14.x'
       - name: Install Ruby
         uses: actions/setup-ruby@v1
         with:

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -37,7 +37,7 @@ executable bit (`chmod +x cozy-stack`) and put it in your `$PATH`.
 
 #### Using `go`
 
-[Install go](https://golang.org/doc/install), version >= 1.12. With `go`
+[Install go](https://golang.org/doc/install), version >= 1.13. With `go`
 installed and configured, you can run the following command:
 
 ```

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -36,7 +36,7 @@ docker run -it --rm --name cozy-stack \
     --workdir /app \
     -v $(pwd):/app \
     -v $(pwd):/go/bin \
-    golang:1.13 \
+    golang:1.14 \
     go get -v github.com/cozy/cozy-stack
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cozy/cozy-stack
 
-go 1.12
+go 1.13
 
 require (
 	github.com/Masterminds/semver v1.5.0

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -4,7 +4,7 @@
 
 
 # Multi-stage image: this step builds cozy-stack (and mailhog)
-FROM golang:1.13 as build
+FROM golang:1.14 as build
 WORKDIR /app
 
 # MailHog


### PR DESCRIPTION
The last two versions of Go are supported. This is now the version 1.13 and 1.14