### PR TITLE
Always respond with a 200 for /settings/context

### DIFF
--- a/web/settings/context.go
+++ b/web/settings/context.go
@@ -2,7 +2,6 @@ package settings
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -102,18 +101,17 @@ func finishOnboarding(c echo.Context, acceptHTML bool) error {
 }
 
 func context(c echo.Context) error {
-	i := middlewares.GetInstance(c)
-	ctx, ok := i.SettingsContext()
-	if !ok {
-		return jsonapi.NotFound(errors.New("No context defined in config"))
-	}
-
-	doc := &apiContext{normalize(ctx)}
 	// Any request with a token can ask for the context (no permissions are required)
 	if _, err := middlewares.GetPermission(c); err != nil {
 		return echo.NewHTTPError(http.StatusForbidden)
 	}
 
+	i := middlewares.GetInstance(c)
+	ctx, ok := i.SettingsContext()
+	if !ok {
+		ctx = map[string]interface{}{}
+	}
+	doc := &apiContext{normalize(ctx)}
 	return jsonapi.Data(c, http.StatusOK, doc, nil)
 }
 

--- a/web/settings/settings_test.go
+++ b/web/settings/settings_test.go
@@ -36,6 +36,15 @@ var instanceRev string
 var token string
 var oauthClientID string
 
+func TestGetContext(t *testing.T) {
+	req, _ := http.NewRequest("GET", ts.URL+"/settings/context", nil)
+	req.Header.Add("Accept", "application/vnd.api+json")
+	req.Header.Add("Authorization", "Bearer "+token)
+	res, err := http.DefaultClient.Do(req)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+}
+
 func TestPatchWithGoodRev(t *testing.T) {
 	// We are going to patch an instance with newer values, and give the good rev
 	body := `{


### PR DESCRIPTION
When the context was not configured in the config file, the response to GET /settings/context was a 404. We will change it to a 200 with an empty object to make it easier for developers to use this endpoint.

Fix #2410 