### PR TITLE
Make the shortcut parser more tolerant

### DIFF
--- a/pkg/shortcut/shortcut_test.go
+++ b/pkg/shortcut/shortcut_test.go
@@ -14,3 +14,12 @@ func TestShortcut(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, link, res.URL)
 }
+
+func TestShortcutUnixFileFormat(t *testing.T) {
+	link := "https://alice-drive.cozy.example/"
+	buf := Generate(link)
+	buf = bytes.ReplaceAll(buf, []byte{'\r'}, []byte{})
+	res, err := Parse(bytes.NewReader(buf))
+	assert.NoError(t, err)
+	assert.Equal(t, link, res.URL)
+}


### PR DESCRIPTION
Before, only .url files with CR LF where accepted (DOS file format). Now, it also accepts .url files with LF (UNIX file format).