### PR TITLE
fix: Send 200 when importing ciphers

### DIFF
--- a/web/bitwarden/bitwarden_test.go
+++ b/web/bitwarden/bitwarden_test.go
@@ -689,7 +689,7 @@ func TestImportCiphers(t *testing.T) {
 	req.Header.Add("Authorization", "Bearer "+token)
 	res, err := http.DefaultClient.Do(req)
 	assert.NoError(t, err)
-	assert.Equal(t, 204, res.StatusCode)
+	assert.Equal(t, 200, res.StatusCode)
 	nb, err := couchdb.CountAllDocs(inst, consts.BitwardenCiphers)
 	assert.NoError(t, err)
 	assert.Equal(t, nbCiphers+2, nb)

--- a/web/bitwarden/ciphers.go
+++ b/web/bitwarden/ciphers.go
@@ -687,5 +687,5 @@ func ImportCiphers(c echo.Context) error {
 	}
 	_ = settings.UpdateRevisionDate(inst, setting)
 
-	return c.NoContent(http.StatusNoContent)
+	return c.NoContent(http.StatusOK)
 }


### PR DESCRIPTION
Unfortunately, bitwarden's jslib expects a 200
See https://github.com/bitwarden/jslib/blob/44b86f5dd028271059b70a00d7878fbb1a06023f/src/services/api.service.ts#L1001