### PR TITLE
Fix a panic when uploading with a base MetadataID

### DIFF
--- a/model/vfs/errors.go
+++ b/model/vfs/errors.go
@@ -42,4 +42,6 @@ var (
 	ErrFileTooBig = errors.New("The file is too big and exceeds the disk quota")
 	// ErrFsckFailFail is used when the FSCK is stopped by the fail-fast option
 	ErrFsckFailFail = errors.New("FSCK has been stopped on first failure")
+	// ErrWrongToken is used when a key is not found on the store
+	ErrWrongToken = errors.New("Wrong download token")
 )

--- a/model/vfs/store.go
+++ b/model/vfs/store.go
@@ -141,15 +141,15 @@ func (s *memStore) GetFile(db prefixer.Prefixer, key string) (string, error) {
 	key = db.DBPrefix() + ":" + key
 	ref, ok := s.vals[key]
 	if !ok {
-		return "", nil
+		return "", ErrWrongToken
 	}
 	if time.Now().After(ref.exp) {
 		delete(s.vals, key)
-		return "", nil
+		return "", ErrWrongToken
 	}
 	f, ok := ref.val.(string)
 	if !ok {
-		return "", nil
+		return "", ErrWrongToken
 	}
 	return f, nil
 }
@@ -160,15 +160,15 @@ func (s *memStore) GetThumb(db prefixer.Prefixer, key string) (string, error) {
 	key = db.DBPrefix() + ":" + key
 	ref, ok := s.vals[key]
 	if !ok {
-		return "", nil
+		return "", ErrWrongToken
 	}
 	if time.Now().After(ref.exp) {
 		delete(s.vals, key)
-		return "", nil
+		return "", ErrWrongToken
 	}
 	f, ok := ref.val.(string)
 	if !ok {
-		return "", nil
+		return "", ErrWrongToken
 	}
 	return f, nil
 }
@@ -179,15 +179,15 @@ func (s *memStore) GetVersion(db prefixer.Prefixer, key string) (string, error) 
 	key = db.DBPrefix() + ":" + key
 	ref, ok := s.vals[key]
 	if !ok {
-		return "", nil
+		return "", ErrWrongToken
 	}
 	if time.Now().After(ref.exp) {
 		delete(s.vals, key)
-		return "", nil
+		return "", ErrWrongToken
 	}
 	f, ok := ref.val.(string)
 	if !ok {
-		return "", nil
+		return "", ErrWrongToken
 	}
 	return f, nil
 }
@@ -198,15 +198,15 @@ func (s *memStore) GetArchive(db prefixer.Prefixer, key string) (*Archive, error
 	key = db.DBPrefix() + ":" + key
 	ref, ok := s.vals[key]
 	if !ok {
-		return nil, nil
+		return nil, ErrWrongToken
 	}
 	if time.Now().After(ref.exp) {
 		delete(s.vals, key)
-		return nil, nil
+		return nil, ErrWrongToken
 	}
 	a, ok := ref.val.(*Archive)
 	if !ok {
-		return nil, nil
+		return nil, ErrWrongToken
 	}
 	return a, nil
 }
@@ -217,15 +217,15 @@ func (s *memStore) GetMetadata(db prefixer.Prefixer, key string) (*Metadata, err
 	key = db.DBPrefix() + ":" + key
 	ref, ok := s.vals[key]
 	if !ok {
-		return nil, nil
+		return nil, ErrWrongToken
 	}
 	if time.Now().After(ref.exp) {
 		delete(s.vals, key)
-		return nil, nil
+		return nil, ErrWrongToken
 	}
 	m, ok := ref.val.(*Metadata)
 	if !ok {
-		return nil, nil
+		return nil, ErrWrongToken
 	}
 	return m, nil
 }
@@ -289,7 +289,7 @@ func (s *redisStore) AddMetadata(db prefixer.Prefixer, metadata *Metadata) (stri
 func (s *redisStore) GetFile(db prefixer.Prefixer, key string) (string, error) {
 	f, err := s.c.Get(db.DBPrefix() + ":" + key).Result()
 	if err == redis.Nil {
-		return "", nil
+		return "", ErrWrongToken
 	}
 	if err != nil {
 		return "", err
@@ -300,7 +300,7 @@ func (s *redisStore) GetFile(db prefixer.Prefixer, key string) (string, error) {
 func (s *redisStore) GetThumb(db prefixer.Prefixer, key string) (string, error) {
 	f, err := s.c.Get(db.DBPrefix() + ":" + key).Result()
 	if err == redis.Nil {
-		return "", nil
+		return "", ErrWrongToken
 	}
 	if err != nil {
 		return "", err
@@ -311,7 +311,7 @@ func (s *redisStore) GetThumb(db prefixer.Prefixer, key string) (string, error) 
 func (s *redisStore) GetVersion(db prefixer.Prefixer, key string) (string, error) {
 	f, err := s.c.Get(db.DBPrefix() + ":" + key).Result()
 	if err == redis.Nil {
-		return "", nil
+		return "", ErrWrongToken
 	}
 	if err != nil {
 		return "", err
@@ -322,7 +322,7 @@ func (s *redisStore) GetVersion(db prefixer.Prefixer, key string) (string, error
 func (s *redisStore) GetArchive(db prefixer.Prefixer, key string) (*Archive, error) {
 	b, err := s.c.Get(db.DBPrefix() + ":" + key).Bytes()
 	if err == redis.Nil {
-		return nil, nil
+		return nil, ErrWrongToken
 	}
 	if err != nil {
 		return nil, err
@@ -337,7 +337,7 @@ func (s *redisStore) GetArchive(db prefixer.Prefixer, key string) (*Archive, err
 func (s *redisStore) GetMetadata(db prefixer.Prefixer, key string) (*Metadata, error) {
 	b, err := s.c.Get(db.DBPrefix() + ":" + key).Bytes()
 	if err == redis.Nil {
-		return nil, nil
+		return nil, ErrWrongToken
 	}
 	if err != nil {
 		return nil, err

--- a/model/vfs/store_test.go
+++ b/model/vfs/store_test.go
@@ -23,7 +23,7 @@ func TestStoreInMemory(t *testing.T) {
 	assert.NoError(t, err)
 
 	path2, err := store.GetFile(dbB, key1)
-	assert.NoError(t, err)
+	assert.Equal(t, ErrWrongToken, err)
 	assert.Zero(t, path2, "Inter-instances store leaking")
 
 	path3, err := store.GetFile(dbA, key1)
@@ -33,7 +33,7 @@ func TestStoreInMemory(t *testing.T) {
 	time.Sleep(2 * storeTTL)
 
 	path4, err := store.GetFile(dbA, key1)
-	assert.NoError(t, err)
+	assert.Equal(t, ErrWrongToken, err)
 	assert.Zero(t, path4, "no expiration")
 
 	a := &Archive{
@@ -53,7 +53,7 @@ func TestStoreInMemory(t *testing.T) {
 	time.Sleep(2 * storeTTL)
 
 	a3, err := store.GetArchive(dbA, key2)
-	assert.NoError(t, err)
+	assert.Equal(t, ErrWrongToken, err)
 	assert.Nil(t, a3, "no expiration")
 
 	m := &Metadata{"foo": "bar"}
@@ -67,7 +67,7 @@ func TestStoreInMemory(t *testing.T) {
 	time.Sleep(2 * storeTTL)
 
 	m3, err := store.GetArchive(dbA, key3)
-	assert.NoError(t, err)
+	assert.Equal(t, ErrWrongToken, err)
 	assert.Nil(t, m3, "no expiration")
 }
 
@@ -88,7 +88,7 @@ func TestStoreInRedis(t *testing.T) {
 	assert.NoError(t, err)
 
 	path2, err := store.GetFile(dbB, key1)
-	assert.NoError(t, err)
+	assert.Equal(t, ErrWrongToken, err)
 	assert.Zero(t, path2, "Inter-instances store leaking")
 
 	path3, err := store.GetFile(dbA, key1)
@@ -98,7 +98,7 @@ func TestStoreInRedis(t *testing.T) {
 	time.Sleep(2 * storeTTL)
 
 	path4, err := store.GetFile(dbA, key1)
-	assert.NoError(t, err)
+	assert.Equal(t, ErrWrongToken, err)
 	assert.Zero(t, path4, "no expiration")
 
 	a := &Archive{
@@ -118,7 +118,7 @@ func TestStoreInRedis(t *testing.T) {
 	time.Sleep(2 * storeTTL)
 
 	a3, err := store.GetArchive(dbA, key2)
-	assert.NoError(t, err)
+	assert.Equal(t, ErrWrongToken, err)
 	assert.Nil(t, a3, "no expiration")
 
 	m := &Metadata{"foo": "bar"}
@@ -132,6 +132,6 @@ func TestStoreInRedis(t *testing.T) {
 	time.Sleep(2 * storeTTL)
 
 	m3, err := store.GetArchive(dbA, key3)
-	assert.NoError(t, err)
+	assert.Equal(t, ErrWrongToken, err)
 	assert.Nil(t, m3, "no expiration")
 }

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -795,7 +795,7 @@ func ThumbnailHandler(c echo.Context) error {
 	if err != nil {
 		return WrapVfsError(err)
 	}
-	if fileID == "" || c.Param("file-id") != fileID {
+	if c.Param("file-id") != fileID {
 		return jsonapi.NewError(http.StatusBadRequest, "Wrong download token")
 	}
 
@@ -986,9 +986,6 @@ func ArchiveDownloadHandler(c echo.Context) error {
 	if err != nil {
 		return WrapVfsError(err)
 	}
-	if archive == nil {
-		return jsonapi.NewError(http.StatusBadRequest, "Wrong download token")
-	}
 	if err := archive.Serve(instance.VFS(), c.Response()); err != nil {
 		return WrapVfsError(err)
 	}
@@ -1007,9 +1004,6 @@ func FileDownloadHandler(c echo.Context) error {
 	if err != nil {
 		return WrapVfsError(err)
 	}
-	if path == "" {
-		return jsonapi.NewError(http.StatusBadRequest, "Wrong download token")
-	}
 	return sendFileFromPath(c, path, false)
 }
 
@@ -1018,9 +1012,6 @@ func versionDownloadHandler(c echo.Context, secret string) error {
 	versionID, err := vfs.GetStore().GetVersion(instance, secret)
 	if err != nil {
 		return WrapVfsError(err)
-	}
-	if versionID == "" {
-		return jsonapi.NewError(http.StatusBadRequest, "Wrong download token")
 	}
 
 	fileID := strings.Split(versionID, "/")[0]
@@ -1401,6 +1392,8 @@ func wrapVfsError(err error) *jsonapi.Error {
 		return jsonapi.BadRequest(err)
 	case vfs.ErrFileTooBig:
 		return jsonapi.Errorf(http.StatusRequestEntityTooLarge, "%s", err)
+	case vfs.ErrWrongToken:
+		return jsonapi.BadRequest(err)
 	}
 	if _, ok := err.(*jsonapi.Error); !ok {
 		logger.WithNamespace("files").Warnf("Not wrapped error: %s", err)


### PR DESCRIPTION
Using return nil, nil with one nil for the result and one nil for the error is an anti-pattern, and it was the cause of a panic where we try to derefence a nil value. This commit removes this anti-pattern on the
VFS store, and thus fix the panic.