### PR TITLE
Rework opening shared notes

### DIFF
--- a/model/note/open.go
+++ b/model/note/open.go
@@ -140,8 +140,11 @@ func (o *Opener) shouldOpenLocally() bool {
 	if o.sharing == nil {
 		return true
 	}
-	domain := o.file.CozyMetadata.CreatedOn
-	return o.inst.HasDomain(domain)
+	u, err := url.Parse(o.file.CozyMetadata.CreatedOn)
+	if err != nil {
+		return true
+	}
+	return o.inst.HasDomain(u.Host)
 }
 
 func (o *Opener) openLocalNote(memberIndex int, readOnly bool) (*apiNoteURL, error) {
@@ -180,7 +183,7 @@ func (o *Opener) openSharedNote() (*apiNoteURL, error) {
 			if i == 0 {
 				continue // Skip the owner
 			}
-			if m.Instance == domain {
+			if m.Instance == domain || m.Instance+"/" == domain {
 				creds = &s.Credentials[i-1]
 				creator = &s.Members[i]
 			}
@@ -245,7 +248,7 @@ func (o *Opener) openSharedNote() (*apiNoteURL, error) {
 
 func (o *Opener) getSharecode(memberIndex int, readOnly bool) (string, error) {
 	s := o.sharing
-	if s == nil {
+	if s == nil || o.clientID == "" {
 		return o.code, nil
 	}
 

--- a/model/note/open.go
+++ b/model/note/open.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cozy/cozy-stack/client/request"
 	"github.com/cozy/cozy-stack/model/instance"
+	"github.com/cozy/cozy-stack/model/permission"
 	"github.com/cozy/cozy-stack/model/sharing"
 	"github.com/cozy/cozy-stack/model/vfs"
 	build "github.com/cozy/cozy-stack/pkg/config"
@@ -36,36 +37,35 @@ func (n *apiNoteURL) Included() []jsonapi.Object             { return nil }
 func (n *apiNoteURL) Links() *jsonapi.LinksList              { return nil }
 func (n *apiNoteURL) Fetch(field string) []string            { return nil }
 
-// Open returns the parameters to create the URL where the note can be opened.
-func Open(inst *instance.Instance, file *vfs.FileDoc, code string) (*apiNoteURL, error) {
+// Opener can be used to find the parameters for creating the URL where the
+// note can be opened.
+type Opener struct {
+	inst     *instance.Instance
+	file     *vfs.FileDoc
+	sharing  *sharing.Sharing // can be nil
+	clientID string
+	code     string
+}
+
+// Open will return an Opener for the given file.
+func Open(inst *instance.Instance, fileID string) (*Opener, error) {
+	file, err := inst.VFS().FileByID(fileID)
+	if err != nil {
+		return nil, err
+	}
+
 	// Check that the file is a note
 	if _, err := fromMetadata(file); err != nil {
 		return nil, err
 	}
 
 	// Looks if the note is shared
-	fileID := file.ID()
 	sharing, err := getSharing(inst, fileID)
 	if err != nil {
 		return nil, err
 	}
 
-	var doc *apiNoteURL
-	if sharing == nil || sharing.Owner {
-		doc = openLocalNote(inst, fileID, code)
-	} else {
-		doc, err = openSharedNote(inst, sharing, fileID)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// Enforce DocID and PublicName with local values
-	doc.DocID = fileID
-	if name, err := inst.PublicName(); err == nil {
-		doc.PublicName = name
-	}
-	return doc, nil
+	return &Opener{inst: inst, file: file, sharing: sharing}, nil
 }
 
 func getSharing(inst *instance.Instance, fileID string) (*sharing.Sharing, error) {
@@ -93,43 +93,64 @@ func getSharing(inst *instance.Instance, fileID string) (*sharing.Sharing, error
 	return nil, nil
 }
 
-func openSharedNote(inst *instance.Instance, s *sharing.Sharing, fileID string) (*apiNoteURL, error) {
-	xoredID := sharing.XorID(fileID, s.Credentials[0].XorKey)
-	u, err := url.Parse(s.Members[0].Instance)
-	if err != nil {
-		return nil, err
-	}
-	c := &s.Credentials[0]
-	opts := &request.Options{
-		Method:  http.MethodGet,
-		Scheme:  u.Scheme,
-		Domain:  u.Host,
-		Path:    "/notes/" + xoredID + "/open",
-		Queries: url.Values{"SharingID": {s.ID()}},
-		Headers: request.Headers{
-			"Accept":        "application/vnd.api+json",
-			"Authorization": "Bearer " + c.AccessToken.AccessToken,
-		},
-	}
-	res, err := request.Req(opts)
-	if res != nil && res.StatusCode/100 == 4 {
-		res, err = sharing.RefreshToken(inst, s, &s.Members[0], c, opts, nil)
-	}
-	if err != nil {
-		return nil, sharing.ErrInternalServerError
-	}
-	defer res.Body.Close()
-	var doc apiNoteURL
-	if _, err := jsonapi.Bind(res.Body, &doc); err != nil {
-		return nil, err
-	}
-	return &doc, nil
+// AddShareByLinkCode can be used to give a sharecode that can be used to open
+// the note, when the note is in a directory shared by link.
+func (o *Opener) AddShareByLinkCode(code string) {
+	o.code = code
 }
 
-func openLocalNote(inst *instance.Instance, fileID, code string) *apiNoteURL {
+// CheckPermission takes the permission doc, and checks that the user has the
+// right to open the note.
+func (o *Opener) CheckPermission(pdoc *permission.Permission, sharingID string) error {
+	// If a note is opened via a token for cozy-to-cozy sharing, then the note
+	// must be in this sharing, or the stack should refuse to open the note.
+	if sharingID != "" && o.sharing != nil && o.sharing.ID() == sharingID {
+		o.clientID = pdoc.SourceID
+		return nil
+	}
+
+	fs := o.inst.VFS()
+	return vfs.Allows(fs, pdoc.Permissions, permission.GET, o.file)
+}
+
+// GetResult looks if the note can be opened locally or not, which code can be
+// used in case of a shared note, and other parameters.. and returns the information.
+func (o *Opener) GetResult(memberIndex int, readOnly bool) (jsonapi.Object, error) {
+	var result *apiNoteURL
+	var err error
+	if o.shouldOpenLocally() {
+		result, err = o.openLocalNote(memberIndex, readOnly)
+	} else {
+		result, err = o.openSharedNote()
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// Enforce DocID and PublicName with local values
+	result.DocID = o.file.ID()
+	if name, err := o.inst.PublicName(); err == nil {
+		result.PublicName = name
+	}
+	return result, nil
+}
+
+func (o *Opener) shouldOpenLocally() bool {
+	if o.sharing == nil {
+		return true
+	}
+	domain := o.file.CozyMetadata.CreatedOn
+	return o.inst.HasDomain(domain)
+}
+
+func (o *Opener) openLocalNote(memberIndex int, readOnly bool) (*apiNoteURL, error) {
+	code, err := o.getSharecode(memberIndex, readOnly)
+	if err != nil {
+		return nil, err
+	}
 	doc := &apiNoteURL{
-		NoteID:    fileID,
-		Instance:  inst.ContextualDomain(),
+		NoteID:    o.file.ID(),
+		Instance:  o.inst.ContextualDomain(),
 		Sharecode: code,
 	}
 	switch config.GetConfig().Subdomains {
@@ -142,5 +163,151 @@ func openLocalNote(inst *instance.Instance, fileID, code string) *apiNoteURL {
 	if build.IsDevRelease() {
 		doc.Protocol = "http"
 	}
-	return doc
+	return doc, nil
+}
+
+func (o *Opener) openSharedNote() (*apiNoteURL, error) {
+	s := o.sharing
+	var creds *sharing.Credentials
+	var creator *sharing.Member
+	if s.Owner {
+		domain := o.file.CozyMetadata.CreatedOn
+		for i, m := range s.Members {
+			if i == 0 {
+				continue // Skip the owner
+			}
+			if m.Instance == domain {
+				creds = &s.Credentials[i-1]
+				creator = &s.Members[i]
+			}
+		}
+	} else {
+		creds = &s.Credentials[0]
+		creator = &s.Members[0]
+	}
+
+	if creator == nil || creator.Status == sharing.MemberStatusRevoked {
+		return nil, ErrInvalidFile
+	}
+
+	xoredID := sharing.XorID(o.file.ID(), creds.XorKey)
+	u, err := url.Parse(creator.Instance)
+	if err != nil {
+		return nil, err
+	}
+	opts := &request.Options{
+		Method:  http.MethodGet,
+		Scheme:  u.Scheme,
+		Domain:  u.Host,
+		Path:    "/notes/" + xoredID + "/open",
+		Queries: url.Values{"SharingID": {s.ID()}},
+		Headers: request.Headers{
+			"Accept":        "application/vnd.api+json",
+			"Authorization": "Bearer " + creds.AccessToken.AccessToken,
+		},
+	}
+	res, err := request.Req(opts)
+	if res != nil && res.StatusCode/100 == 4 {
+		res, err = sharing.RefreshToken(o.inst, s, creator, creds, opts, nil)
+	}
+	if err != nil {
+		return nil, sharing.ErrInternalServerError
+	}
+	defer res.Body.Close()
+	var doc apiNoteURL
+	if _, err := jsonapi.Bind(res.Body, &doc); err != nil {
+		return nil, err
+	}
+	return &doc, nil
+}
+
+func (o *Opener) getSharecode(memberIndex int, readOnly bool) (string, error) {
+	s := o.sharing
+	if s == nil {
+		return o.code, nil
+	}
+
+	var member *sharing.Member
+	var err error
+	if s.Owner {
+		member, err = s.FindMemberByInboundClientID(o.clientID)
+		if err != nil {
+			return "", err
+		}
+		if member.ReadOnly {
+			readOnly = true
+		} else {
+			readOnly = s.ReadOnlyRules()
+		}
+	} else {
+		// Trust the owner
+		if memberIndex < 0 && memberIndex >= len(s.Members) {
+			return "", sharing.ErrMemberNotFound
+		}
+		member = &s.Members[memberIndex]
+	}
+
+	if readOnly {
+		return o.getPreviewCode(member)
+	}
+	return o.getInteractCode(member)
+}
+
+// getPreviewCode returns a sharecode that can be used for reading the note. It
+// uses a share-preview token.
+func (o *Opener) getPreviewCode(member *sharing.Member) (string, error) {
+	var codes map[string]string
+	preview, err := permission.GetForSharePreview(o.inst, o.sharing.ID())
+	if err != nil {
+		if couchdb.IsNotFoundError(err) {
+			codes, err = o.sharing.CreatePreviewPermissions(o.inst)
+		}
+		if err != nil {
+			return "", err
+		}
+	} else {
+		codes = preview.Codes
+	}
+
+	for key, code := range codes {
+		if key == member.Instance || key == member.Email {
+			return code, nil
+		}
+	}
+
+	return "", ErrInvalidFile
+}
+
+// getInteractCode returns a sharecode that can be use for reading and writing
+// the note. It uses a share-interact token.
+func (o *Opener) getInteractCode(member *sharing.Member) (string, error) {
+	interact, err := permission.GetForShareInteract(o.inst, o.sharing.ID())
+	if err != nil {
+		if couchdb.IsNotFoundError(err) {
+			return o.sharing.CreateInteractPermissions(o.inst, member)
+		}
+		return "", err
+	}
+
+	// If we already have a code for this member, let's use it
+	for key, code := range interact.Codes {
+		if key == member.Instance || key == member.Email {
+			return code, nil
+		}
+	}
+
+	// Else, create a code and add it to the permission doc
+	key := member.Email
+	if key == "" {
+		key = member.Instance
+	}
+	code, err := o.inst.CreateShareCode(key)
+	if err != nil {
+		return "", err
+	}
+	interact.Codes[key] = code
+	if err := couchdb.UpdateDoc(o.inst, interact); err != nil {
+		return "", err
+	}
+	return code, nil
 }

--- a/model/permission/permissions.go
+++ b/model/permission/permissions.go
@@ -58,6 +58,10 @@ const (
 	// TypeSharePreview is the value of Permission.Type to preview a
 	// cozy-to-cozy sharing
 	TypeSharePreview = "share-preview"
+
+	// TypeShareInteract is the value of Permission.Type for reading and
+	// writing a note in a shared folder.
+	TypeShareInteract = "share-interact"
 )
 
 // ID implements jsonapi.Doc
@@ -208,6 +212,12 @@ func GetForKonnector(db prefixer.Prefixer, slug string) (*Permission, error) {
 // GetForSharePreview retrieves the Permission doc for a given sharing preview
 func GetForSharePreview(db prefixer.Prefixer, sharingID string) (*Permission, error) {
 	return getFromSource(db, TypeSharePreview, consts.Sharings, sharingID)
+}
+
+// GetForShareInteract retrieves the Permission doc for a given sharing to
+// read/write a note
+func GetForShareInteract(db prefixer.Prefixer, sharingID string) (*Permission, error) {
+	return getFromSource(db, TypeShareInteract, consts.Sharings, sharingID)
 }
 
 func getFromSource(db prefixer.Prefixer, permType, docType, slug string) (*Permission, error) {
@@ -489,6 +499,23 @@ func CreateShareSet(db prefixer.Prefixer, parent *Permission, sourceID string, c
 func CreateSharePreviewSet(db prefixer.Prefixer, sharingID string, codes map[string]string, subdoc Permission) (*Permission, error) {
 	doc := &Permission{
 		Type:        TypeSharePreview,
+		Permissions: subdoc.Permissions,
+		Codes:       codes,
+		SourceID:    consts.Sharings + "/" + sharingID,
+		Metadata:    subdoc.Metadata,
+	}
+	err := couchdb.CreateDoc(db, doc)
+	if err != nil {
+		return nil, err
+	}
+	return doc, nil
+}
+
+// CreateShareInteractSet creates a Permission doc for reading/writing a note
+// inside a sharing
+func CreateShareInteractSet(db prefixer.Prefixer, sharingID string, codes map[string]string, subdoc Permission) (*Permission, error) {
+	doc := &Permission{
+		Type:        TypeShareInteract,
 		Permissions: subdoc.Permissions,
 		Codes:       codes,
 		SourceID:    consts.Sharings + "/" + sharingID,

--- a/tests/integration/tests/sharing_sync.rb
+++ b/tests/integration/tests/sharing_sync.rb
@@ -150,6 +150,7 @@ describe "A folder" do
     child1_recipient.move_to inst_recipient, child3_recipient.couch_id
     file_recipient.rename inst_recipient, "#{Faker::Internet.slug}.txt"
     file_recipient.overwrite inst_recipient, content: "New content from recipient"
+    note_recipient = Note.create inst_recipient, dir_id: child3_recipient.couch_id
 
     sleep 12
     child1 = Folder.find inst, child1.couch_id
@@ -162,6 +163,16 @@ describe "A folder" do
     assert_equal file_recipient.name, file.name
     assert_equal file_recipient.md5sum, file.md5sum
     assert_equal file_recipient.couch_rev, file.couch_rev
+
+    note_path = CGI.escape "/#{folder.name}/#{child3.name}/#{note_recipient.file.name}"
+    note = CozyFile.find_by_path inst, note_path
+    parameters = Note.open inst, note.couch_id
+    assert_equal note_recipient.file.couch_id, parameters["note_id"]
+    assert %w[flat nested].include? parameters["subdomain"]
+    assert %w[http https].include? parameters["protocol"]
+    assert_equal inst_recipient.domain, parameters["instance"]
+    refute_nil parameters["sharecode"]
+    assert_equal "Alice", parameters["public_name"]
 
     # Check that the files are the same on disk
     da = File.join Helpers.current_dir, inst.domain, folder.name

--- a/web/middlewares/permissions.go
+++ b/web/middlewares/permissions.go
@@ -206,7 +206,7 @@ func ParseJWT(c echo.Context, instance *instance.Instance, token string) (*permi
 		}
 
 		// A share token is only valid if the user has not been revoked
-		if pdoc.Type == permission.TypeSharePreview {
+		if pdoc.Type == permission.TypeSharePreview || pdoc.Type == permission.TypeShareInteract {
 			sharingID := strings.Split(pdoc.SourceID, "/")
 			sharingDoc, err := sharing.FindSharing(instance, sharingID[1])
 			if err != nil {


### PR DESCRIPTION
A note can be opened on the same Cozy instance as it has been created by the owner of its instance (easy). Or, the note can be inside a directory shared by link, and the visitor can also open the note with the same sharecode.

And there are the notes inside a Cozy-to-Cozy sharing. The note should be opened on the instance where it has been created. The sharecode must gives read-only permission if the person that tries to open the note is marked as read-only in the sharing, or if the sharing rules forbid writing the note. Else, it must be read-write.

Note that we have to take into account the star model used for sharing. Two recipients instances can't talk directly as they have no common authentication proof, the requests must be proxified by the sharer instance.