### PR TITLE
Allow to open a note from the sharing preview

### DIFF
--- a/web/notes/notes.go
+++ b/web/notes/notes.go
@@ -262,8 +262,9 @@ func OpenNoteURL(c echo.Context) error {
 	}
 
 	// If a directory is shared by link and contains a note, the note can be
-	// opened with the same sharecode as the directory.
-	if pdoc.Type == permission.TypeShareByLink {
+	// opened with the same sharecode as the directory. The sharecode is also
+	// used to identify the member that previews a sharing.
+	if pdoc.Type == permission.TypeShareByLink || pdoc.Type == permission.TypeSharePreview {
 		code := middlewares.GetRequestToken(c)
 		open.AddShareByLinkCode(code)
 	}


### PR DESCRIPTION
When a directory is shared (Cozy to Cozy) with a note inside it, a user that previews this sharing can open the note. And if the sharing allows edition, the user will be able to edit the note. The preview sharecode will only have read permissions, but the stack will generate a share-interact token so that the user can write on the note.