### PR TITLE
Fix a case of conflicts in a sharing

### DIFF
--- a/model/sharing/files.go
+++ b/model/sharing/files.go
@@ -493,7 +493,7 @@ func (s *Sharing) ApplyBulkFiles(inst *instance.Instance, docs DocsList) error {
 		inst.Logger().WithField("nspace", "replicator").
 			Warnf("Error on apply bulk files: %s", errm)
 	}
-	return nil
+	return errm
 }
 
 func removeReferencesFromRule(file *vfs.FileDoc, rule *Rule) {
@@ -912,9 +912,9 @@ func (s *Sharing) UpdateDir(inst *instance.Instance, target map[string]interface
 
 	err = fs.UpdateDirDoc(oldDoc, dir)
 	if err == os.ErrExist {
-		name, errr := s.resolveConflictSamePath(inst, dir.DocID, dir.Fullpath)
-		if errr != nil {
-			return errr
+		name, errb := s.resolveConflictSamePath(inst, dir.DocID, dir.Fullpath)
+		if errb != nil {
+			return errb
 		}
 		if name != "" {
 			indexer.IncrementRevision()

--- a/model/sharing/files.go
+++ b/model/sharing/files.go
@@ -424,7 +424,14 @@ func (s *Sharing) GetFolder(inst *instance.Instance, m *Member, xoredID string) 
 // ApplyBulkFiles takes a list of documents for the io.cozy.files doctype and
 // will apply changes to the VFS according to those documents.
 func (s *Sharing) ApplyBulkFiles(inst *instance.Instance, docs DocsList) error {
+	type retryOp struct {
+		target map[string]interface{}
+		dir    *vfs.DirDoc
+		ref    *SharedRef
+	}
+
 	var errm error
+	var retries []retryOp
 	fs := inst.VFS()
 
 	for _, target := range docs {
@@ -472,19 +479,51 @@ func (s *Sharing) ApplyBulkFiles(inst *instance.Instance, docs DocsList) error {
 				err = s.TrashFile(inst, file, &s.Rules[infos.Rule])
 			}
 		} else if file != nil {
-			err = multierror.Append(errm, ErrSafety)
+			err = ErrSafety
 		} else if ref != nil && infos.Removed {
 			continue
 		} else if dir == nil {
-			err = s.CreateDir(inst, target)
+			err = s.CreateDir(inst, target, delayResolution)
+			if err == os.ErrExist {
+				retries = append(retries, retryOp{
+					target: target,
+				})
+				err = nil
+			}
 		} else if ref == nil {
-			err = multierror.Append(errm, ErrSafety)
+			err = ErrSafety
 		} else {
-			err = s.UpdateDir(inst, target, dir, ref)
+			// XXX we have to clone the dir document as it is modified by the
+			// UpdateDir function and retrying the operation won't work with
+			// the modified doc
+			cloned := dir.Clone().(*vfs.DirDoc)
+			err = s.UpdateDir(inst, target, dir, ref, delayResolution)
+			if err == os.ErrExist {
+				retries = append(retries, retryOp{
+					target: target,
+					dir:    cloned,
+					ref:    ref,
+				})
+				err = nil
+			}
 		}
 		if err != nil {
 			inst.Logger().WithField("nspace", "replicator").
 				Debugf("Error on apply bulk file: %s (%#v - %#v)", err, target, ref)
+			errm = multierror.Append(errm, err)
+		}
+	}
+
+	for _, op := range retries {
+		var err error
+		if op.dir == nil {
+			err = s.CreateDir(inst, op.target, resolveResolution)
+		} else {
+			err = s.UpdateDir(inst, op.target, op.dir, op.ref, resolveResolution)
+		}
+		if err != nil {
+			inst.Logger().WithField("nspace", "replicator").
+				Debugf("Error on apply bulk file: %s (%#v - %#v)", err, op.target, op.ref)
 			errm = multierror.Append(errm, err)
 		}
 	}
@@ -781,9 +820,16 @@ func extractNameAndIndexer(inst *instance.Instance, target map[string]interface{
 	return name, indexer, nil
 }
 
+type nameConflictResolution int
+
+const (
+	delayResolution nameConflictResolution = iota
+	resolveResolution
+)
+
 // CreateDir creates a directory on this cozy to reflect a change on another
 // cozy instance of this sharing.
-func (s *Sharing) CreateDir(inst *instance.Instance, target map[string]interface{}) error {
+func (s *Sharing) CreateDir(inst *instance.Instance, target map[string]interface{}, resolution nameConflictResolution) error {
 	inst.Logger().WithField("nspace", "replicator").
 		Debugf("CreateDir %v (%#v)", target["_id"], target)
 	ref := SharedRef{
@@ -828,7 +874,7 @@ func (s *Sharing) CreateDir(inst *instance.Instance, target map[string]interface
 	}
 	ref.Infos[s.SID] = SharedInfo{Rule: ruleIndex}
 	err = fs.CreateDir(dir)
-	if err == os.ErrExist {
+	if err == os.ErrExist && resolution == resolveResolution {
 		name, errr := s.resolveConflictSamePath(inst, dir.DocID, dir.Fullpath)
 		if errr != nil {
 			return errr
@@ -877,7 +923,13 @@ func (s *Sharing) prepareDirWithAncestors(inst *instance.Instance, dir *vfs.DirD
 
 // UpdateDir updates a directory on this cozy to reflect a change on another
 // cozy instance of this sharing.
-func (s *Sharing) UpdateDir(inst *instance.Instance, target map[string]interface{}, dir *vfs.DirDoc, ref *SharedRef) error {
+func (s *Sharing) UpdateDir(
+	inst *instance.Instance,
+	target map[string]interface{},
+	dir *vfs.DirDoc,
+	ref *SharedRef,
+	resolution nameConflictResolution,
+) error {
 	inst.Logger().WithField("nspace", "replicator").
 		Debugf("UpdateDir %v (%#v)", target["_id"], target)
 	if strings.HasPrefix(dir.Fullpath+"/", vfs.TrashDirName+"/") {
@@ -911,7 +963,7 @@ func (s *Sharing) UpdateDir(inst *instance.Instance, target map[string]interface
 	copySafeFieldsToDir(target, dir)
 
 	err = fs.UpdateDirDoc(oldDoc, dir)
-	if err == os.ErrExist {
+	if err == os.ErrExist && resolution == resolveResolution {
 		name, errb := s.resolveConflictSamePath(inst, dir.DocID, dir.Fullpath)
 		if errb != nil {
 			return errb

--- a/model/sharing/files_test.go
+++ b/model/sharing/files_test.go
@@ -122,7 +122,7 @@ func TestCreateDir(t *testing.T) {
 		},
 		"name": "Foo",
 	}
-	assert.NoError(t, s.CreateDir(inst, target))
+	assert.NoError(t, s.CreateDir(inst, target, resolveResolution))
 	dir, err := inst.VFS().DirByID(idFoo)
 	assert.NoError(t, err)
 	if assert.NotNil(t, dir) {
@@ -149,7 +149,7 @@ func TestCreateDir(t *testing.T) {
 		"updated_at": "2018-04-13T15:08:32.581420274+01:00",
 		"tags":       []interface{}{"qux", "courge"},
 	}
-	assert.NoError(t, s.CreateDir(inst, target))
+	assert.NoError(t, s.CreateDir(inst, target, resolveResolution))
 	dir, err = inst.VFS().DirByID(idBar)
 	assert.NoError(t, err)
 	if assert.NotNil(t, dir) {
@@ -190,7 +190,7 @@ func TestUpdateDir(t *testing.T) {
 		"updated_at": "2018-04-13T15:08:32.581420274+01:00",
 		"tags":       []interface{}{"qux", "courge"},
 	}
-	assert.NoError(t, s.CreateDir(inst, target))
+	assert.NoError(t, s.CreateDir(inst, target, resolveResolution))
 	dir, err := inst.VFS().DirByID(idFoo)
 	assert.NoError(t, err)
 	if assert.NotNil(t, dir) {
@@ -218,7 +218,7 @@ func TestUpdateDir(t *testing.T) {
 	var ref SharedRef
 	err = couchdb.GetDoc(inst, consts.Shared, consts.Files+"/"+idFoo, &ref)
 	assert.NoError(t, err)
-	assert.NoError(t, s.UpdateDir(inst, target, dir, &ref))
+	assert.NoError(t, s.UpdateDir(inst, target, dir, &ref, resolveResolution))
 	dir, err = inst.VFS().DirByID(idFoo)
 	assert.NoError(t, err)
 	if assert.NotNil(t, dir) {

--- a/tests/integration/tests/avoid_name_conflict.rb
+++ b/tests/integration/tests/avoid_name_conflict.rb
@@ -39,13 +39,13 @@ describe "A file or folder" do
     assert_equal two.name, two_bob.name
 
     # Rename the directories and check that we have no conflict
-    two.rename inst_alice, "baz"
-    one.rename inst_alice, "bar"
+    one.rename inst_alice, "foobar"
+    two.rename inst_alice, "foo"
     sleep 12
     one_bob = Folder.find inst_bob, one_bob.couch_id
     two_bob = Folder.find inst_bob, two_bob.couch_id
-    assert_equal "bar", one_bob.name
-    assert_equal "baz", two_bob.name
+    assert_equal "foobar", one_bob.name
+    assert_equal "foo", two_bob.name
 
     assert_equal inst_alice.fsck, ""
     assert_equal inst_bob.fsck, ""

--- a/tests/integration/tests/avoid_name_conflict.rb
+++ b/tests/integration/tests/avoid_name_conflict.rb
@@ -1,0 +1,56 @@
+require_relative '../boot'
+require 'minitest/autorun'
+require 'pry-rescue/minitest' unless ENV['CI']
+
+describe "A file or folder" do
+  it "can be shared in read-only mode" do
+    Helpers.scenario "read_only"
+    Helpers.start_mailhog
+
+    # Create the instances
+    inst_alice = Instance.create name: "Alice"
+    inst_bob = Instance.create name: "Bob"
+    contact_bob = Contact.create inst_alice, given_name: "Bob"
+
+    # Create the folder
+    folder = Folder.create inst_alice
+    folder.couch_id.wont_be_empty
+
+    # Create the sharing
+    sharing = Sharing.new
+    sharing.rules << Rule.sync(folder)
+    sharing.members << inst_alice << contact_bob
+    inst_alice.register sharing
+
+    # Accept the sharing
+    sleep 1
+    inst_bob.accept sharing
+    sleep 1
+
+    # Create two directories and check they are synchronized
+    one = Folder.create inst_alice, name: "foo", dir_id: folder.couch_id
+    two = Folder.create inst_alice, name: "bar", dir_id: folder.couch_id
+    sleep 12
+    one_path = CGI.escape "/#{Helpers::SHARED_WITH_ME}/#{folder.name}/#{one.name}"
+    one_bob = Folder.find_by_path inst_bob, one_path
+    two_path = CGI.escape "/#{Helpers::SHARED_WITH_ME}/#{folder.name}/#{two.name}"
+    two_bob = Folder.find_by_path inst_bob, two_path
+    assert_equal one.name, one_bob.name
+    assert_equal two.name, two_bob.name
+
+    # Rename the directories and check that we have no conflict
+    two.rename inst_alice, "baz"
+    one.rename inst_alice, "bar"
+    sleep 12
+    one_bob = Folder.find inst_bob, one_bob.couch_id
+    two_bob = Folder.find inst_bob, two_bob.couch_id
+    assert_equal "bar", one_bob.name
+    assert_equal "baz", two_bob.name
+
+    assert_equal inst_alice.fsck, ""
+    assert_equal inst_bob.fsck, ""
+
+    inst_alice.remove
+    inst_bob.remove
+  end
+end

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/limits"
 	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/cozy/cozy-stack/web/middlewares"
+	"github.com/hashicorp/go-multierror"
 	"github.com/labstack/echo/v4"
 )
 
@@ -619,6 +620,9 @@ func checkGetPermissions(c echo.Context, s *sharing.Sharing) error {
 
 // wrapErrors returns a formatted error
 func wrapErrors(err error) error {
+	if merr, ok := err.(*multierror.Error); ok {
+		err = merr.WrappedErrors()[0]
+	}
 	switch err {
 	case contact.ErrNoMailAddress:
 		return jsonapi.InvalidAttribute("recipients", err)


### PR DESCRIPTION
When a folder is shared, and several renaming happens in a short lapse of time, the sharing synchronisation can encouter temporary conflicts of name. Those errors were silently ignored, and it is no longer the case. It should improve the sharing resiliency.