### PR TITLE
Allow the bitwarden mobile app to ask the hint

### DIFF
--- a/assets/locales/en.po
+++ b/assets/locales/en.po
@@ -481,7 +481,7 @@ msgid "Mail Cozy Team"
 msgstr "The Cozy Cloud Team"
 
 msgid "Mail Hint Subject"
-msgstr "Forgoten password: your hint"
+msgstr "Forgotten password: your hint"
 
 msgid "Mail Hint Intro 1"
 msgstr "Hello %s,"

--- a/docs/bitwarden.md
+++ b/docs/bitwarden.md
@@ -141,6 +141,28 @@ Content-Type: application/json
 }
 ```
 
+### POST /bitwarden/api/accounts/password-hint
+
+#### Request
+
+```http
+POST /bitwarden/api/accounts/password-hint HTTP/1.1
+Host: alice.example.com
+Content-Type: application/json
+```
+
+```json
+{
+  "email": "me@alice.example.com"
+}
+```
+
+#### Response
+
+```http
+HTTP/1.1 200 OK
+```
+
 ### GET /bitwarden/api/accounts/profile
 
 #### Request

--- a/web/bitwarden/bitwarden.go
+++ b/web/bitwarden/bitwarden.go
@@ -51,6 +51,13 @@ func Prelogin(c echo.Context) error {
 	})
 }
 
+// SendHint is the handler for sending the hint when the user has forgot their
+// password.
+func SendHint(c echo.Context) error {
+	i := middlewares.GetInstance(c)
+	return lifecycle.SendHint(i)
+}
+
 // GetProfile is the handler for the route to get profile information.
 func GetProfile(c echo.Context) error {
 	inst := middlewares.GetInstance(c)
@@ -459,6 +466,7 @@ func Routes(router *echo.Group) {
 
 	accounts := api.Group("/accounts")
 	accounts.POST("/prelogin", Prelogin)
+	accounts.POST("/password-hint", SendHint)
 	accounts.GET("/profile", GetProfile)
 	accounts.POST("/profile", UpdateProfile)
 	accounts.PUT("/profile", UpdateProfile)

--- a/web/bitwarden/bitwarden_test.go
+++ b/web/bitwarden/bitwarden_test.go
@@ -718,6 +718,15 @@ func TestChangeSecurityStamp(t *testing.T) {
 	assert.Equal(t, 401, res.StatusCode)
 }
 
+func TestSendHint(t *testing.T) {
+	body := `{ "email": "me@bitwarden.example.net" }`
+	req, _ := http.NewRequest("POST", ts.URL+"/bitwarden/api/accounts/password-hint", bytes.NewBufferString(body))
+	req.Header.Add("Content-Type", "application/json")
+	res, err := http.DefaultClient.Do(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, res.StatusCode)
+}
+
 func TestMain(m *testing.M) {
 	config.UseTestFile()
 	testutils.NeedCouchdb()
@@ -726,6 +735,7 @@ func TestMain(m *testing.M) {
 		Domain:     "bitwarden.example.net",
 		Passphrase: "cozy",
 		PublicName: "Pierre",
+		Email:      "pierre@cozy.tools",
 	})
 
 	ts = setup.GetTestServer("/bitwarden", Routes)


### PR DESCRIPTION
The mobile app for passwords can ask the stack to send by mail the hint for the password via a new route, compatible with the bitwarden implementation.