### PR TITLE
Add a sharing_domain config entry

### DIFF
--- a/assets/templates/sharing_discovery.html
+++ b/assets/templates/sharing_discovery.html
@@ -39,7 +39,7 @@
                   <span>https://</span>
                 </div>
                 <input type="text" class="field" name="slug" id="slug" value="{{.RecipientSlug}}" placeholder="claude" autofocus="true" />
-                <input type="text" class="domain" name="domain" id="domain" value="{{.RecipientDomain}}" placeholder="mycozy.cloud" />
+                <input type="text" class="domain" name="domain" id="domain" value="{{.RecipientDomain}}" placeholder="{{.PlaceholderDomain}}" />
               </div>
             </div>
           </div>

--- a/cozy.example.yaml
+++ b/cozy.example.yaml
@@ -294,6 +294,9 @@ contexts:
     onboarded_redirection: collect/#/discovery/?intro
     # Redirect to the photos application after login
     default_redirection: drive/#/files
+    # This domain will be used as a suggestion for the members of a sharing
+    # when they are asked for the URL of their Cozy instance
+    sharing_domain: mycozy.cloud
     # Allow to customize the cozy-bar link to the help
     help_link: https://forum.cozy.io/
     # claudy actions list

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -347,29 +347,36 @@ func renderAlreadyAccepted(c echo.Context, inst *instance.Instance, cozyURL stri
 func renderDiscoveryForm(c echo.Context, inst *instance.Instance, code int, sharingID, state, sharecode string, m *sharing.Member) error {
 	publicName, _ := inst.PublicName()
 	fqdn := strings.TrimPrefix(m.Instance, "https://")
-	slug, domain := "", consts.KnownFlatDomains[0]
+	slug, placeholder := "", consts.KnownFlatDomains[0]
+	if context, ok := inst.SettingsContext(); ok {
+		if domain, ok := context["sharing_domain"].(string); ok {
+			placeholder = domain
+		}
+	}
+	domain := placeholder
 	if strings.HasPrefix(m.Instance, "http://") {
 		slug, domain = m.Instance, ""
 	} else if parts := strings.SplitN(fqdn, ".", 2); len(parts) == 2 {
 		slug, domain = parts[0], parts[1]
 	}
 	return c.Render(code, "sharing_discovery.html", echo.Map{
-		"Title":           inst.TemplateTitle(),
-		"CozyUI":          middlewares.CozyUI(inst),
-		"ThemeCSS":        middlewares.ThemeCSS(inst),
-		"Domain":          inst.ContextualDomain(),
-		"ContextName":     inst.ContextName,
-		"Locale":          inst.Locale,
-		"PublicName":      publicName,
-		"RecipientSlug":   slug,
-		"RecipientDomain": domain,
-		"RecipientName":   m.Name,
-		"SharingID":       sharingID,
-		"State":           state,
-		"ShareCode":       sharecode,
-		"URLError":        code == http.StatusBadRequest,
-		"NotEmailError":   code == http.StatusPreconditionFailed,
-		"Favicon":         middlewares.Favicon(inst),
+		"Title":             inst.TemplateTitle(),
+		"CozyUI":            middlewares.CozyUI(inst),
+		"ThemeCSS":          middlewares.ThemeCSS(inst),
+		"Domain":            inst.ContextualDomain(),
+		"ContextName":       inst.ContextName,
+		"Locale":            inst.Locale,
+		"PublicName":        publicName,
+		"RecipientName":     m.Name,
+		"RecipientSlug":     slug,
+		"RecipientDomain":   domain,
+		"PlaceholderDomain": placeholder,
+		"SharingID":         sharingID,
+		"State":             state,
+		"ShareCode":         sharecode,
+		"URLError":          code == http.StatusBadRequest,
+		"NotEmailError":     code == http.StatusPreconditionFailed,
+		"Favicon":           middlewares.Favicon(inst),
 	})
 }
 


### PR DESCRIPTION
When a member of a sharing is asked for the URL of their cozy instance, the input widget offers a suggestion on the domain. This suggestion can now be customized per context (the default is "mycozy.cloud").