### PR TITLE
Explicitely use stable registry channel when installing app without source

### DIFF
--- a/web/apps/apps.go
+++ b/web/apps/apps.go
@@ -107,7 +107,7 @@ func installHandler(installerType consts.AppType) echo.HandlerFunc {
 		slug := c.Param("slug")
 		source := c.QueryParam("Source")
 		if source == "" {
-			source = "registry://" + slug
+			source = "registry://" + slug + "/stable"
 		}
 		if err := middlewares.AllowInstallApp(c, installerType, source, permission.POST); err != nil {
 			return err

--- a/web/instances/fixers.go
+++ b/web/instances/fixers.go
@@ -262,7 +262,7 @@ func orphanAccountFixer(c echo.Context) error {
 		opts := &app.InstallerOptions{
 			Operation:  app.Install,
 			Type:       consts.KonnectorType,
-			SourceURL:  "registry://" + slug,
+			SourceURL:  "registry://" + slug + "/stable",
 			Slug:       slug,
 			Registries: inst.Registries(),
 		}


### PR DESCRIPTION
Fix incoherent source for app install when no source is explicitely given between [cli default](https://github.com/cozy/cozy-stack/blob/a6462057decfa27acebbada072cac263f2bd82ae/cmd/apps.go#L273) and [admin api default](https://github.com/cozy/cozy-stack/blob/master/web/apps/apps.go#L110) by explictely using registry stable channel.

Also explicitely use registry stable channel when re-installing konnectors to remove account inside orphan accounts fixer.