### PR TITLE
Fix event-stream extra linefeed

### DIFF
--- a/web/apps/apps.go
+++ b/web/apps/apps.go
@@ -12,6 +12,7 @@ import (
 	"path"
 	"runtime"
 	"strconv"
+	"strings"
 
 	"github.com/cozy/cozy-stack/model/account"
 	"github.com/cozy/cozy-stack/model/app"
@@ -373,7 +374,7 @@ func pollInstaller(c echo.Context, instance *instance.Instance, isEventStream bo
 		}
 		buf := new(bytes.Buffer)
 		if err := jsonapi.WriteData(buf, &apiApp{man}, nil); err == nil {
-			writeStream(w, "state", buf.String())
+			writeStream(w, "state", strings.TrimSuffix(buf.String(), "\n"))
 		}
 		if done {
 			break


### PR DESCRIPTION
When requesting the stack as `text/event-stream` to install or update app/konnector, the event-stream response contain an extra linefeed (`\n`) after each event.

![image](https://user-images.githubusercontent.com/2768193/77461289-a2e30b80-6e02-11ea-8ba2-49f23a75932d.png)

This PR removes the extra linefeed.