### PR TITLE
Add context features from config to admin endpoint and cli

### DIFF
--- a/docs/cli/cozy-stack_features.md
+++ b/docs/cli/cozy-stack_features.md
@@ -25,6 +25,7 @@ Manage the feature flags
 ### SEE ALSO
 
 * [cozy-stack](cozy-stack.md)	 - cozy-stack is the main command
+* [cozy-stack features config](cozy-stack_features_config.md)	 - Display the feature flags from configuration for a context
 * [cozy-stack features defaults](cozy-stack_features_defaults.md)	 - Display and update the default values for feature flags
 * [cozy-stack features flags](cozy-stack_features_flags.md)	 - Display and update the feature flags for an instance
 * [cozy-stack features ratio](cozy-stack_features_ratio.md)	 - Display and update the feature flags for a context

--- a/docs/cli/cozy-stack_features_config.md
+++ b/docs/cli/cozy-stack_features_config.md
@@ -1,0 +1,43 @@
+## cozy-stack features config
+
+Display the feature flags from configuration for a context
+
+### Synopsis
+
+
+cozy-stack feature config displays the feature flags from configuration for a context.
+
+These flags are read only and can only be updated by changing configuration and restarting the stack.
+
+
+```
+cozy-stack features config <context-name> [flags]
+```
+
+### Examples
+
+```
+$ cozy-stack feature config --context beta
+```
+
+### Options
+
+```
+      --context string   The context for the feature flags
+  -h, --help             help for config
+```
+
+### Options inherited from parent commands
+
+```
+      --admin-host string   administration server host (default "localhost")
+      --admin-port int      administration server port (default 6060)
+  -c, --config string       configuration file (default "$HOME/.cozy.yaml")
+      --host string         server host (default "localhost")
+  -p, --port int            server port (default 8080)
+```
+
+### SEE ALSO
+
+* [cozy-stack features](cozy-stack_features.md)	 - Manage the feature flags
+

--- a/scripts/completion/cozy-stack.bash
+++ b/scripts/completion/cozy-stack.bash
@@ -1194,6 +1194,41 @@ _cozy-stack_doc()
     noun_aliases=()
 }
 
+_cozy-stack_features_config()
+{
+    last_command="cozy-stack_features_config"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--context=")
+    two_word_flags+=("--context")
+    local_nonpersistent_flags+=("--context=")
+    flags+=("--admin-host=")
+    two_word_flags+=("--admin-host")
+    flags+=("--admin-port=")
+    two_word_flags+=("--admin-port")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    two_word_flags+=("-c")
+    flags+=("--host=")
+    two_word_flags+=("--host")
+    flags+=("--port=")
+    two_word_flags+=("--port")
+    two_word_flags+=("-p")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _cozy-stack_features_defaults()
 {
     last_command="cozy-stack_features_defaults"
@@ -1375,6 +1410,7 @@ _cozy-stack_features()
     command_aliases=()
 
     commands=()
+    commands+=("config")
     commands+=("defaults")
     commands+=("flags")
     if [[ -z "${BASH_VERSION}" || "${BASH_VERSINFO[0]}" -gt 3 ]]; then

--- a/scripts/completion/cozy-stack.zsh
+++ b/scripts/completion/cozy-stack.zsh
@@ -520,6 +520,7 @@ function _cozy-stack_features {
   case $state in
   cmnds)
     commands=(
+      "config:Display the feature flags from configuration for a context"
       "defaults:Display and update the default values for feature flags"
       "flags:Display and update the feature flags for an instance"
       "ratio:Display and update the feature flags for a context"
@@ -531,6 +532,9 @@ function _cozy-stack_features {
   esac
 
   case "$words[1]" in
+  config)
+    _cozy-stack_features_config
+    ;;
   defaults)
     _cozy-stack_features_defaults
     ;;
@@ -547,6 +551,16 @@ function _cozy-stack_features {
     _cozy-stack_features_show
     ;;
   esac
+}
+
+function _cozy-stack_features_config {
+  _arguments \
+    '--context[The context for the feature flags]:' \
+    '--admin-host[administration server host]:' \
+    '--admin-port[administration server port]:' \
+    '(-c --config)'{-c,--config}'[configuration file (default "$HOME/.cozy.yaml")]:' \
+    '--host[server host]:' \
+    '(-p --port)'{-p,--port}'[server port]:'
 }
 
 function _cozy-stack_features_defaults {

--- a/web/instances/instances.go
+++ b/web/instances/instances.go
@@ -462,6 +462,7 @@ func Routes(router *echo.Group) {
 	router.PATCH("/:domain/feature/flags", patchFeatureFlags)
 	router.GET("/:domain/feature/sets", getFeatureSets)
 	router.PUT("/:domain/feature/sets", putFeatureSets)
+	router.GET("/feature/config/:context", getFeatureConfig)
 	router.GET("/feature/contexts/:context", getFeatureContext)
 	router.PATCH("/feature/contexts/:context", patchFeatureContext)
 	router.GET("/feature/defaults", getFeatureDefaults)


### PR DESCRIPTION
Allow to query stack for feature flags configured in configuration file, inside a specific context