### PR TITLE
Return updated file rev and added references

### DIFF
--- a/docs/references-docs-in-vfs.md
+++ b/docs/references-docs-in-vfs.md
@@ -113,6 +113,10 @@ Content-Type: application/vnd.api+json
 
 ```json
 {
+    "meta": {
+        "rev": "2-de8d0ba2",
+        "count": 2
+    },
     "data": [
         {
             "type": "io.cozy.playlists",
@@ -152,8 +156,23 @@ Accept: application/vnd.api+json
 #### Response
 
 ```http
-HTTP/1.1 204 No Content
+HTTP/1.1 200 OK
 Content-Type: application/vnd.api+json
+```
+
+```json
+{
+    "meta": {
+        "rev": "3-7ab812c0",
+        "count": 1
+    },
+    "data": [
+        {
+            "type": "io.cozy.playlists",
+            "id": "94375086-e2e2-11e6-81b9-5bc0b9dd4aa4"
+        }
+    ]
+}
 ```
 
 ### GET /data/:type/:doc-id/relationships/references

--- a/pkg/jsonapi/data.go
+++ b/pkg/jsonapi/data.go
@@ -19,9 +19,12 @@ type Meta struct {
 	Rev string `json:"rev,omitempty"`
 }
 
-// RelationshipMeta is a container for the total number of elements
+// RelationshipMeta is a container for the total number of elements in a
+// relationship list and optionally the couchdb revision of the owner
+// document in case we're returning an updated list outside an Object.
 type RelationshipMeta struct {
-	Count *int `json:"count,omitempty"`
+	Rev   string `json:"rev,omitempty"`
+	Count *int   `json:"count,omitempty"`
 }
 
 // LinksList is the common links used in JSON-API for the top-level or a

--- a/pkg/jsonapi/jsonapi.go
+++ b/pkg/jsonapi/jsonapi.go
@@ -102,17 +102,15 @@ func DataListWithTotal(c echo.Context, statusCode, total int, objs []Object, lin
 
 // DataRelations can be called to send a Relations page,
 // a list of ResourceIdentifier
-func DataRelations(c echo.Context, statusCode int, refs []couchdb.DocReference, total int, links *LinksList, included []Object) error {
+func DataRelations(c echo.Context, statusCode int, refs []couchdb.DocReference, meta *RelationshipMeta, links *LinksList, included []Object) error {
 	data, err := json.Marshal(refs)
 	if err != nil {
 		return InternalServerError(err)
 	}
 
 	doc := Document{
-		Data: (*json.RawMessage)(&data),
-		Meta: &RelationshipMeta{
-			Count: &total,
-		},
+		Data:  (*json.RawMessage)(&data),
+		Meta:  meta,
 		Links: links,
 	}
 

--- a/web/files/references.go
+++ b/web/files/references.go
@@ -82,6 +82,7 @@ func ListReferencesHandler(c echo.Context) error {
 			count = int(resCount.Rows[0].Value.(float64))
 		}
 	}
+	meta := &jsonapi.RelationshipMeta{Count: &count}
 
 	sort := c.QueryParam("sort")
 	descending := strings.HasPrefix(sort, "-")
@@ -147,7 +148,7 @@ func ListReferencesHandler(c echo.Context) error {
 		}
 	}
 
-	return jsonapi.DataRelations(c, http.StatusOK, refs, count, links, docs)
+	return jsonapi.DataRelations(c, http.StatusOK, refs, meta, links, docs)
 }
 
 // AddReferencesHandler add some files references to a doc


### PR DESCRIPTION
When adding new `referenced_by` objects to an io.cozy.files document,
we expect to get the updated list of references in return.
Since the document is updated to add new references, its revision has
changed and should therefore be returned as well so clients won't have
to make another request to get the updated revision and make new
changes to the document.