### PR TITLE
Fix a sharing issue with moves and delete

### DIFF
--- a/model/job/worker.go
+++ b/model/job/worker.go
@@ -444,26 +444,28 @@ func (t *task) run() (err error) {
 		t.endTime = time.Now()
 
 		// Incrementing timeouts counter
-		var slug string
-		var msg map[string]interface{}
+		if t.job.Message != nil {
+			var slug string
+			var msg map[string]interface{}
 
-		if errd := json.Unmarshal(t.job.Message, &msg); errd != nil {
-			ctx.Logger().Errorf("Cannot unmarshal job message %s", t.job.Message)
-		} else {
-			switch t.w.Type {
-			case "konnector":
-				slug, _ = msg["konnector"].(string)
-			case "service":
-				slug, _ = msg["slug"].(string)
-			default:
-				slug = ""
-			}
+			if errd := json.Unmarshal(t.job.Message, &msg); errd != nil {
+				ctx.Logger().Errorf("Cannot unmarshal job message %s", t.job.Message)
+			} else {
+				switch t.w.Type {
+				case "konnector":
+					slug, _ = msg["konnector"].(string)
+				case "service":
+					slug, _ = msg["slug"].(string)
+				default:
+					slug = ""
+				}
 
-			// Forcing the timeout counter to 0 if it has not been initialized
-			metrics.WorkerExecTimeoutsCounter.WithLabelValues(t.w.Type, slug)
+				// Forcing the timeout counter to 0 if it has not been initialized
+				metrics.WorkerExecTimeoutsCounter.WithLabelValues(t.w.Type, slug)
 
-			if err == context.DeadlineExceeded { // This is a timeout
-				metrics.WorkerExecTimeoutsCounter.WithLabelValues(t.w.Type, slug).Inc()
+				if err == context.DeadlineExceeded { // This is a timeout
+					metrics.WorkerExecTimeoutsCounter.WithLabelValues(t.w.Type, slug).Inc()
+				}
 			}
 		}
 

--- a/model/sharing/files.go
+++ b/model/sharing/files.go
@@ -430,6 +430,20 @@ func (s *Sharing) ApplyBulkFiles(inst *instance.Instance, docs DocsList) error {
 		ref    *SharedRef
 	}
 
+	// XXX: we need to make the changes for live documents before the _deleted
+	// ones to avoid deleting too much files. For example, if the A folder is
+	// deleted, and the B/A file is moved outside of B, we must make the move
+	// before deleting A and its children.
+	sort.SliceStable(docs, func(i, j int) bool {
+		if _, ok := docs[j]["_deleted"]; ok {
+			return true
+		}
+		if _, ok := docs[i]["_deleted"]; ok {
+			return false
+		}
+		return true
+	})
+
 	var errm error
 	var retries []retryOp
 	fs := inst.VFS()

--- a/model/sharing/files.go
+++ b/model/sharing/files.go
@@ -801,6 +801,11 @@ func (s *Sharing) recreateParent(inst *instance.Instance, dirID string) (*vfs.Di
 	doc.SetRev("")
 	err = fs.CreateDir(doc)
 	if err != nil {
+		// Maybe the directory has been created concurrently, so let's try
+		// again to fetch it from the database
+		if err == os.ErrExist {
+			return fs.DirByID(dirID)
+		}
 		return nil, err
 	}
 	return doc, nil

--- a/model/sharing/member.go
+++ b/model/sharing/member.go
@@ -463,9 +463,15 @@ func (s *Sharing) findMemberByCode(codes map[string]string, sharecode string) (*
 // FindMemberByInboundClientID returns the member that have used this client
 // ID to make a request on the given sharing
 func (s *Sharing) FindMemberByInboundClientID(clientID string) (*Member, error) {
-	for i, c := range s.Credentials {
-		if c.InboundClientID == clientID {
-			return &s.Members[i+1], nil
+	if s.Owner {
+		for i, c := range s.Credentials {
+			if c.InboundClientID == clientID {
+				return &s.Members[i+1], nil
+			}
+		}
+	} else {
+		if s.Credentials[0].InboundClientID == clientID {
+			return &s.Members[0], nil
 		}
 	}
 	return nil, ErrMemberNotFound

--- a/model/sharing/rule.go
+++ b/model/sharing/rule.go
@@ -256,6 +256,23 @@ func (s *Sharing) findRuleForNewFile(file *vfs.FileDoc) (*Rule, int) {
 	return nil, 0
 }
 
+func (s *Sharing) hasExplicitRuleForFile(file *vfs.FileDoc) bool {
+	for _, rule := range s.Rules {
+		if rule.Local || rule.DocType != consts.Files {
+			continue
+		}
+		if rule.Selector != "" {
+			continue
+		}
+		for _, id := range rule.Values {
+			if id == file.DocID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // HasSync returns true if the rule has a sync behaviour
 func (r *Rule) HasSync() bool {
 	return r.Add == ActionRuleSync || r.Update == ActionRuleSync ||

--- a/model/sharing/upload.go
+++ b/model/sharing/upload.go
@@ -382,6 +382,12 @@ func (s *Sharing) SyncFile(inst *instance.Instance, target *FileDocWithRevisions
 // prepareFileWithAncestors find the parent directory for file, and recreates it
 // if it is missing.
 func (s *Sharing) prepareFileWithAncestors(inst *instance.Instance, newdoc *vfs.FileDoc, dirID string) error {
+	// Case 1: there is a rule for sharing this file
+	if s.hasExplicitRuleForFile(newdoc) {
+		return nil
+	}
+
+	// Case 2: the file is in a directory that is shared
 	if dirID == "" {
 		parent, err := s.GetSharingDir(inst)
 		if err != nil {

--- a/model/sharing/upload.go
+++ b/model/sharing/upload.go
@@ -641,8 +641,9 @@ func (s *Sharing) UploadExistingFile(inst *instance.Instance, target *FileDocWit
 	newdoc.ReferencedBy = buildReferencedBy(target.FileDoc, olddoc, rule)
 	copySafeFieldsToFile(target.FileDoc, newdoc)
 	newdoc.DocName = target.DocName
-	// TODO check the error
-	_ = s.prepareFileWithAncestors(inst, newdoc, target.DirID)
+	if err := s.prepareFileWithAncestors(inst, newdoc, target.DirID); err != nil {
+		return err
+	}
 	newdoc.ResetFullpath()
 	newdoc.ByteSize = target.ByteSize
 	newdoc.MD5Sum = target.MD5Sum

--- a/tests/integration/tests/sharing_moves_n_delete.rb
+++ b/tests/integration/tests/sharing_moves_n_delete.rb
@@ -1,0 +1,89 @@
+require_relative '../boot'
+require 'minitest/autorun'
+require 'pry-rescue/minitest' unless ENV['CI']
+
+describe "A shared directory" do
+  it "can have its children moved out of it and then be deleted" do
+    Helpers.scenario "moves_n_delete"
+    Helpers.start_mailhog
+
+    recipient_name = "Bob"
+
+    # Create the instance
+    inst = Instance.create name: "Alice"
+    inst_recipient = Instance.create name: recipient_name
+
+    # Create hierarchy
+    folder = Folder.create inst
+    folder.couch_id.wont_be_empty
+    subdir = Folder.create inst, dir_id: folder.couch_id
+    child1 = Folder.create inst, dir_id: subdir.couch_id
+    child2 = Folder.create inst, dir_id: subdir.couch_id
+    child3 = Folder.create inst, dir_id: subdir.couch_id
+    filename1 = "#{Faker::Internet.slug}.txt"
+    filename2 = "#{Faker::Internet.slug}.txt"
+    filename3 = "#{Faker::Internet.slug}.txt"
+    file1 = CozyFile.create inst, name: filename1, dir_id: child1.couch_id
+    file2 = CozyFile.create inst, name: filename2, dir_id: child2.couch_id
+    file3 = CozyFile.create inst, name: filename3, dir_id: subdir.couch_id
+
+    # Create the sharing
+    contact = Contact.create inst, given_name: recipient_name
+    sharing = Sharing.new
+    sharing.rules << Rule.sync(folder)
+    sharing.members << inst << contact
+    inst.register sharing
+
+    # Accept the sharing
+    sleep 1
+    inst_recipient.accept sharing
+    sleep 12
+
+    # Check that the files have been synchronized
+    da = File.join Helpers.current_dir, inst.domain, folder.name
+    db = File.join Helpers.current_dir, inst_recipient.domain,
+                   Helpers::SHARED_WITH_ME, folder.name
+    diff = Helpers.fsdiff da, db
+    diff.must_be_empty
+
+    # Move what is in subdir out of it...
+    child1.move_to inst, folder.couch_id
+    child2.move_to inst, folder.couch_id
+    child3.move_to inst, folder.couch_id
+    file3.move_to inst, folder.couch_id
+
+    # ...and delete it
+    subdir.remove inst
+    sleep 12
+
+    # Check that no children have been lost
+    path = CGI.escape "/#{Helpers::SHARED_WITH_ME}/#{folder.name}/#{child1.name}"
+    child1_recipient = Folder.find_by_path inst_recipient, path
+    refute child1_recipient.trashed
+    path = CGI.escape "/#{Helpers::SHARED_WITH_ME}/#{folder.name}/#{child2.name}"
+    child2_recipient = Folder.find_by_path inst_recipient, path
+    refute child2_recipient.trashed
+    path = CGI.escape "/#{Helpers::SHARED_WITH_ME}/#{folder.name}/#{child3.name}"
+    child3_recipient = Folder.find_by_path inst_recipient, path
+    refute child3_recipient.trashed
+    path = CGI.escape "/#{Helpers::SHARED_WITH_ME}/#{folder.name}/#{child1.name}/#{file1.name}"
+    file1_recipient = CozyFile.find_by_path inst_recipient, path
+    refute file1_recipient.trashed
+    path = CGI.escape "/#{Helpers::SHARED_WITH_ME}/#{folder.name}/#{child2.name}/#{file2.name}"
+    file2_recipient = CozyFile.find_by_path inst_recipient, path
+    refute file2_recipient.trashed
+    path = CGI.escape "/#{Helpers::SHARED_WITH_ME}/#{folder.name}/#{file3.name}"
+    file3_recipient = CozyFile.find_by_path inst_recipient, path
+    refute file3_recipient.trashed
+
+    # Check that we have no surprise
+    diff = Helpers.fsdiff da, db
+    diff.must_be_empty
+
+    assert_equal inst.fsck, ""
+    assert_equal inst_recipient.fsck, ""
+
+    inst.remove
+    inst_recipient.remove
+  end
+end

--- a/tests/integration/tests/sharing_sync.rb
+++ b/tests/integration/tests/sharing_sync.rb
@@ -150,6 +150,7 @@ describe "A folder" do
     child1_recipient.move_to inst_recipient, child3_recipient.couch_id
     file_recipient.rename inst_recipient, "#{Faker::Internet.slug}.txt"
     file_recipient.overwrite inst_recipient, content: "New content from recipient"
+    sleep 3
     note_recipient = Note.create inst_recipient, dir_id: child3_recipient.couch_id
 
     sleep 12

--- a/web/server.go
+++ b/web/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/cozy/cozy-stack/pkg/utils"
 	"github.com/cozy/cozy-stack/web/apps"
+	"github.com/sirupsen/logrus"
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
@@ -120,8 +121,12 @@ func ListenAndServe() (*Servers, error) {
 	}
 
 	if build.IsDevRelease() {
+		timeFormat := "time_rfc3339"
+		if logrus.GetLevel() == logrus.DebugLevel {
+			timeFormat = "time_rfc3339_nano"
+		}
 		major.Use(middleware.LoggerWithConfig(middleware.LoggerConfig{
-			Format: "time=${time_rfc3339}\tstatus=${status}\tmethod=${method}\thost=${host}\turi=${uri}\tbytes_out=${bytes_out}\n",
+			Format: "time=${" + timeFormat + "}\tstatus=${status}\tmethod=${method}\thost=${host}\turi=${uri}\tbytes_out=${bytes_out}\n",
 		}))
 	}
 


### PR DESCRIPTION
Example:
1. a folder foo is shared between Alice and Bob
2. foo contains a directory bar, and inside this directory, there is a file baz (on both cozy instances)
3. Alice moves foo/bar/baz to foo/baz, and just after, deletes foo/bar
4. the sharing process must make the move before the deletion, even if bar has a lower id than baz (and comes first in the revs_diff).