### PR TITLE
Fix index_bad_fullpath on shared directories

### DIFF
--- a/model/vfs/couchdb_indexer.go
+++ b/model/vfs/couchdb_indexer.go
@@ -205,7 +205,7 @@ func (c *couchdbIndexer) UpdateDirDoc(olddoc, newdoc *DirDoc) error {
 	}
 
 	if newdoc.Fullpath != olddoc.Fullpath {
-		if err := c.moveDir(olddoc.Fullpath, newdoc.Fullpath); err != nil {
+		if err := c.MoveDir(olddoc.Fullpath, newdoc.Fullpath); err != nil {
 			return err
 		}
 	}
@@ -259,7 +259,7 @@ func (c *couchdbIndexer) BatchDelete(docs []couchdb.Doc) error {
 	return couchdb.BulkDeleteDocs(c.db, consts.Files, docs)
 }
 
-func (c *couchdbIndexer) moveDir(oldpath, newpath string) error {
+func (c *couchdbIndexer) MoveDir(oldpath, newpath string) error {
 	limit := 256
 	var children []*DirDoc
 	docs := make([]interface{}, 0, limit)

--- a/model/vfs/vfs.go
+++ b/model/vfs/vfs.go
@@ -169,6 +169,11 @@ type Indexer interface {
 	// were removed.
 	DeleteDirDocAndContent(doc *DirDoc, onlyContent bool) ([]*FileDoc, int64, error)
 
+	// MoveDir is an internal call to update the fullpath of the subdirectories
+	// of a renamed/moved directory. It is exported to allow the sharing
+	// indexer to call this method on the couchdb indexer of the VFS.
+	MoveDir(oldpath, newpath string) error
+
 	// DirByID returns the directory document information associated with the
 	// specified identifier.
 	DirByID(fileID string) (*DirDoc, error)

--- a/tests/integration/tests/sharing_rename_dir.rb
+++ b/tests/integration/tests/sharing_rename_dir.rb
@@ -1,0 +1,72 @@
+require_relative '../boot'
+require 'minitest/autorun'
+require 'pry-rescue/minitest' unless ENV['CI']
+
+describe "A directory in a sharing" do
+  it "can be renamed" do
+    Helpers.scenario "rename_dir"
+    Helpers.start_mailhog
+
+    recipient_name = "Bob"
+
+    # Create the instance
+    inst = Instance.create name: "Alice"
+    inst_recipient = Instance.create name: recipient_name
+
+    # Create hierarchy
+    folder = Folder.create inst
+    folder.couch_id.wont_be_empty
+    subdir = Folder.create inst, dir_id: folder.couch_id
+    child1 = Folder.create inst, dir_id: subdir.couch_id
+    child2 = Folder.create inst, dir_id: subdir.couch_id
+    child3 = Folder.create inst, dir_id: subdir.couch_id
+
+    # Create the sharing
+    contact = Contact.create inst, given_name: recipient_name
+    sharing = Sharing.new
+    sharing.rules << Rule.sync(folder)
+    sharing.members << inst << contact
+    inst.register sharing
+
+    # Accept the sharing
+    sleep 1
+    inst_recipient.accept sharing
+    sleep 12
+
+    # Check that the files have been synchronized
+    da = File.join Helpers.current_dir, inst.domain, folder.name
+    db = File.join Helpers.current_dir, inst_recipient.domain,
+                   Helpers::SHARED_WITH_ME, folder.name
+    diff = Helpers.fsdiff da, db
+    diff.must_be_empty
+
+    # Rename the directory
+    subdir.rename inst, "9.1_#{subdir.name}"
+    child3.move_to inst, child2.couch_id
+    sleep 12
+
+    # Check that no children have been lost
+    path = CGI.escape "/#{Helpers::SHARED_WITH_ME}/#{folder.name}/#{subdir.name}"
+    subdir_recipient = Folder.find_by_path inst_recipient, path
+    refute subdir_recipient.trashed
+    path = CGI.escape "/#{Helpers::SHARED_WITH_ME}/#{folder.name}/#{subdir.name}/#{child1.name}"
+    child1_recipient = Folder.find_by_path inst_recipient, path
+    refute child1_recipient.trashed
+    path = CGI.escape "/#{Helpers::SHARED_WITH_ME}/#{folder.name}/#{subdir.name}/#{child2.name}"
+    child2_recipient = Folder.find_by_path inst_recipient, path
+    refute child2_recipient.trashed
+    path = CGI.escape "/#{child2_recipient.path}/#{child3.name}"
+    child3_recipient = Folder.find_by_path inst_recipient, path
+    refute child3_recipient.trashed
+
+    # Check that we have no surprise
+    diff = Helpers.fsdiff da, db
+    diff.must_be_empty
+
+    assert_equal inst.fsck, ""
+    assert_equal inst_recipient.fsck, ""
+
+    inst.remove
+    inst_recipient.remove
+  end
+end


### PR DESCRIPTION
When a directory is shared from Cozy to Cozy, the stack uses a protocol inspired by the replication protocol of CouchDB. It means that the new documents are sent in bulk, and several changes to the same document are regrouped.

For a tree of directories, the stack has to update the fullpaths of the descendants when a directory is renamed or moved. This is often done in the sharing by recomputing the fullpath when the new revision of the given document is synchronized. But if this happens for a child before the parent has been renamed/moved on the recipient's instance, it was failing (index_bad_fullpath was reported by FSCK).

Now, when the parent directory is updated, the stack also recomputes the fullpaths of the descendants (like the normal indexer of the VFS).