### PR TITLE
Use email account if login is empty

### DIFF
--- a/model/account/accounts.go
+++ b/model/account/accounts.go
@@ -51,6 +51,7 @@ type OauthInfo struct {
 // BasicInfo holds configuration information for an user/pass account
 type BasicInfo struct {
 	Login                string `json:"login,omitempty"`
+	Email                string `json:"email,omitempty"`    // used in some accounts instead of login
 	Password             string `json:"password,omitempty"` // used when no encryption
 	EncryptedCredentials string `json:"credentials_encrypted,omitempty"`
 }

--- a/worker/migrations/migrations.go
+++ b/worker/migrations/migrations.go
@@ -208,6 +208,10 @@ func migrateAccountsToOrganization(domain string) error {
 			}
 			continue
 		}
+		// Special case if the email field is used instead of login
+		if login == "" && acc.Basic.Email != "" {
+			login = acc.Basic.Email
+		}
 		cipher, err := buildCipher(orgKey, msg.Slug, login, password, link)
 		if err != nil {
 			errm = multierror.Append(errm, err)


### PR DESCRIPTION
In some connectors, e.g. EDF, the account have a `auth.email` instead of `auth.login`. In which case, the `auth.credentials_encrypted` [only contains the password](https://github.com/cozy/cozy-stack/blob/10cca451b61365aa3d1cc39dc24336070672bc7b/web/data/accounts.go#L155-L163) ; then, the account migration worker was missing the `email` field.
