### PR TITLE
Fix lost of cozyMetadata for some shared directories

### DIFF
--- a/model/sharing/files.go
+++ b/model/sharing/files.go
@@ -797,7 +797,6 @@ func (s *Sharing) recreateParent(inst *instance.Instance, dirID string) (*vfs.Di
 	}
 	doc.DirID = parent.DocID
 	doc.Fullpath = path.Join(parent.Fullpath, doc.DocName)
-	doc.CozyMetadata = vfs.NewCozyMetadata(inst.PageURL("/", nil))
 	doc.SetRev("")
 	err = fs.CreateDir(doc)
 	if err != nil {


### PR DESCRIPTION
When a directory is created inside a shared directory, it will be
synchronized in bulk. It can happen that this directory will be
synchronized after one of its children. On this case, the stack will
create via a specific method, and inside the code of this method, we
were forcing the cozyMetadata like if the folder has been created on the
recipient instance. The culprit line has been removed, which should fix
the bug.