### PR TITLE
Add a suffix to revoked sharing directories

### DIFF
--- a/assets/locales/en.po
+++ b/assets/locales/en.po
@@ -24,6 +24,9 @@ msgstr "Inbox of sharings"
 msgid "Tree No longer shared"
 msgstr "No longer shared"
 
+msgid "Tree Revoked sharing suffix"
+msgstr "cancelled sharing"
+
 msgid "Notes New note"
 msgstr "New note"
 

--- a/assets/locales/fr.po
+++ b/assets/locales/fr.po
@@ -36,6 +36,9 @@ msgstr "Partages reçus"
 msgid "Tree No longer shared"
 msgstr "Retirés des partages"
 
+msgid "Tree Revoked sharing suffix"
+msgstr "partage annulé"
+
 msgid "Notes New note"
 msgstr "Nouvelle note"
 

--- a/tests/integration/lib/folder.rb
+++ b/tests/integration/lib/folder.rb
@@ -3,6 +3,7 @@ class Folder
   TRASH_DIR = "io.cozy.files.trash-dir".freeze
   TRASH_PATH = "/.cozy_trash/".freeze
   NO_LONGER_SHARED_DIR = "io.cozy.files.no-longer-shared-dir".freeze
+  CANCELLED_SUFFIX = "(partage annulé)".freeze
 
   include Model::Files
 

--- a/tests/integration/tests/revoke_sharing.rb
+++ b/tests/integration/tests/revoke_sharing.rb
@@ -153,7 +153,9 @@ describe "A sharing" do
     old_name = file.name
     file.rename inst_alice, Faker::Internet.slug
     sleep 3
-    file_path = CGI.escape "/#{Helpers::SHARED_WITH_ME}/#{folder.name}/#{old_name}"
+    # XXX: the folder name was changed after the sharing was revoked
+    folder_path = "/#{Helpers::SHARED_WITH_ME}/#{folder.name} #{Folder::CANCELLED_SUFFIX}"
+    file_path = CGI.escape "#{folder_path}/#{old_name}"
     file_recipient = Folder.find_by_path inst_bob, file_path
     refute_equal file_recipient.name, file.name
 
@@ -300,7 +302,9 @@ describe "A sharing" do
     old_name = file.name
     file.rename inst_alice, Faker::Internet.slug
     sleep 3
-    file_path = CGI.escape "/#{Helpers::SHARED_WITH_ME}/#{folder.name}/#{old_name}"
+    # XXX: the folder name was changed after the sharing was revoked
+    folder_path = "/#{Helpers::SHARED_WITH_ME}/#{folder.name} #{Folder::CANCELLED_SUFFIX}"
+    file_path = CGI.escape "#{folder_path}/#{old_name}"
     file_bob = Folder.find_by_path inst_bob, file_path
     file_charlie = Folder.find_by_path inst_charlie, file_path
     refute_equal file_bob.name, file.name


### PR DESCRIPTION
When a sharing is revoked, the directory is kept on the recipients'
instances. If a new sharing is made for the same directory, the
recipients that accept it will have a conflict between the directories
for the old sharing and the new one. It can be confusing. To avoid that,
the directory is renammed when the sharing is revoked (with a suffix).
It will also help people understand that a sharing has been revoked.