### PR TITLE
Improve permissions checking for notes and shortcuts

### DIFF
--- a/model/note/note.go
+++ b/model/note/note.go
@@ -129,7 +129,8 @@ func (d *Document) Markdown() ([]byte, error) {
 	return d.markdown, nil
 }
 
-func (d *Document) getDirID(inst *instance.Instance) (string, error) {
+// GetDirID returns the ID of the directory where the note will be created.
+func (d *Document) GetDirID(inst *instance.Instance) (string, error) {
 	if d.DirID != "" {
 		return d.DirID, nil
 	}
@@ -219,7 +220,7 @@ func initialContent(inst *instance.Instance, doc *Document) (*model.Node, error)
 }
 
 func newFileDoc(inst *instance.Instance, doc *Document) (*vfs.FileDoc, error) {
-	dirID, err := doc.getDirID(inst)
+	dirID, err := doc.GetDirID(inst)
 	if err != nil {
 		return nil, err
 	}

--- a/web/notes/notes.go
+++ b/web/notes/notes.go
@@ -41,7 +41,7 @@ func CreateNote(c echo.Context) error {
 			return err
 		}
 		fileDoc, errf := vfs.NewFileDoc(
-			doc.Title,
+			"tmp.cozy-note", // We don't care, but it can't be empty
 			dirID,
 			0,   // We don't care
 			nil, // Let the VFS compute the md5sum

--- a/web/notes/notes.go
+++ b/web/notes/notes.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/cozy/cozy-stack/model/note"
 	"github.com/cozy/cozy-stack/model/permission"
@@ -23,17 +24,42 @@ import (
 // CreateNote is the API handler for POST /notes. It creates a note, aka a file
 // with a set of metadata to enable collaborative edition.
 func CreateNote(c echo.Context) error {
-	if err := middlewares.AllowWholeType(c, permission.POST, consts.Files); err != nil {
-		return err
-	}
-
+	inst := middlewares.GetInstance(c)
 	doc := &note.Document{}
 	if _, err := jsonapi.Bind(c.Request().Body, doc); err != nil {
 		return err
 	}
 	doc.CreatedBy = getCreatedBy(c)
 
-	inst := middlewares.GetInstance(c)
+	// We first look if we have a permission on the whole doctype, as it is
+	// cheap. If not, we look on more finer permissions, which is a bit more
+	// complicated and costly, but is needed for creating a note in a shared by
+	// link folder for example.
+	if err := middlewares.AllowWholeType(c, permission.POST, consts.Files); err != nil {
+		dirID, errd := doc.GetDirID(inst)
+		if errd != nil {
+			return err
+		}
+		fileDoc, errf := vfs.NewFileDoc(
+			doc.Title,
+			dirID,
+			0,   // We don't care
+			nil, // Let the VFS compute the md5sum
+			consts.NoteMimeType,
+			"text",
+			time.Now(),
+			false, // Not executable
+			false, // Not trashed
+			nil,   // No tags
+		)
+		if errf != nil {
+			return err
+		}
+		if err := middlewares.AllowVFS(c, permission.POST, fileDoc); err != nil {
+			return err
+		}
+	}
+
 	file, err := note.Create(inst, doc)
 	if err != nil {
 		return wrapError(err)

--- a/web/shortcuts/shortcuts.go
+++ b/web/shortcuts/shortcuts.go
@@ -67,10 +67,6 @@ func (s *Shortcut) Links() *jsonapi.LinksList { return nil }
 // Create is the API handler for POST /shortcuts. It can be used to create a
 // shortcut from a JSON description.
 func Create(c echo.Context) error {
-	if err := middlewares.AllowWholeType(c, permission.POST, consts.Files); err != nil {
-		return err
-	}
-
 	doc := &Shortcut{}
 	if _, err := jsonapi.Bind(c.Request().Body, doc); err != nil {
 		return err
@@ -107,6 +103,10 @@ func Create(c echo.Context) error {
 	}
 	fileDoc.Metadata = doc.Metadata
 	fileDoc.CozyMetadata = cm
+
+	if err := middlewares.AllowVFS(c, permission.POST, fileDoc); err != nil {
+		return err
+	}
 
 	inst := middlewares.GetInstance(c)
 	file, err := inst.VFS().CreateFile(fileDoc, nil)


### PR DESCRIPTION
When a note or a shortcut is created via their special API, the stack
checks the permission to write on the VFS. Before this commit, only a
permission on the whole io.cozy.files doctype was authorized. Now, we
also accept a permission on the directory where the note or shortcut
will be created. It is useful when a directory is shared by link for
example.