### PR TITLE
Improve notes handling in shared directory

### DIFF
--- a/docs/sharing-design.md
+++ b/docs/sharing-design.md
@@ -195,9 +195,12 @@ We have several cases of conflicts:
 For 1. and 2., we will reconciliate the changes except for a file with two
 versions having a distinct binary (we rely on `size` and `checksum` to detect
 that). In such a case, we create a copy of the file with one version, while
-keeping the other version in the original file.
+keeping the other version in the original file (the higher revision wins).
 
-For 3., we rename the file or folder with the smaller `id`.
+For 3., we say that the owner instance wins: the file with the name in conflict
+on the owner instance will keep its name, and the other file with the same name
+will be renamed. This rule helps to minimize the number of exchanges between
+the cozy instances, which is a factor of stability to avoid more conflicts.
 
 For 4., we restore the trashed parent, or recreate it if it the trash was
 emptied.

--- a/model/sharing/revisions.go
+++ b/model/sharing/revisions.go
@@ -2,9 +2,9 @@ package sharing
 
 import (
 	"fmt"
+	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 )
 
 type conflictStatus int
@@ -294,11 +294,23 @@ func MixupChainToResolveConflict(rev string, chain []string) []string {
 
 // conflictName generates a new name for a file/folder in conflict with another
 // that has the same path.
-func conflictName(name, suffix string) string {
-	if suffix == "" {
-		suffix = fmt.Sprintf("%d", time.Now().Unix())
+func conflictName(name string, isFile bool) string {
+	base, ext := name, ""
+	if isFile {
+		ext = filepath.Ext(name)
+		base = strings.TrimSuffix(base, ext)
 	}
-	return fmt.Sprintf("%s - conflict - %s", name, suffix)
+	i := 2
+	if strings.HasSuffix(base, ")") {
+		if idx := strings.LastIndex(base, " ("); idx > 0 {
+			num, err := strconv.Atoi(base[idx+2 : len(base)-1])
+			if err == nil {
+				i = num + 1
+				base = base[0:idx]
+			}
+		}
+	}
+	return fmt.Sprintf("%s (%d)%s", base, i, ext)
 }
 
 // conflictID generates a new ID for a file/folder that has a conflict between

--- a/model/sharing/revisions_test.go
+++ b/model/sharing/revisions_test.go
@@ -321,6 +321,17 @@ func TestIndexerCreateBogusPrevRev(t *testing.T) {
 	assert.Equal(t, indexer.bulkRevs.Rev, rev)
 }
 
+func TestConflictName(t *testing.T) {
+	assert.Equal(t, "foo (2)", conflictName("foo", false))
+	assert.Equal(t, "foo (3)", conflictName("foo (2)", false))
+	assert.Equal(t, "foo (1000)", conflictName("foo (999)", false))
+	assert.Equal(t, "foo () (2)", conflictName("foo ()", false))
+
+	assert.Equal(t, "bar (2)", conflictName("bar", true))
+	assert.Equal(t, "bar (2).txt", conflictName("bar.txt", true))
+	assert.Equal(t, "bar (3).txt", conflictName("bar (2).txt", true))
+}
+
 func TestConflictID(t *testing.T) {
 	id := "d9dfd293577eea9f6d29d140259fa71d"
 	rev := "3-bf26bb2d42b0abf6a715ccf949d8e5f4"

--- a/model/sharing/upload.go
+++ b/model/sharing/upload.go
@@ -730,7 +730,7 @@ func (s *Sharing) uploadLostConflict(inst *instance.Instance, target *FileDocWit
 		body.Close()
 		return nil
 	}
-	newdoc.DocName = conflictName(newdoc.DocName, rev)
+	newdoc.DocName = conflictName(newdoc.DocName, true)
 	newdoc.DocRev = ""
 	newdoc.ResetFullpath()
 	file, err := fs.CreateFile(newdoc, nil)
@@ -756,7 +756,7 @@ func (s *Sharing) uploadWonConflict(inst *instance.Instance, src *vfs.FileDoc) e
 	if _, err := fs.FileByID(dst.DocID); err != os.ErrNotExist {
 		return err
 	}
-	dst.DocName = conflictName(dst.DocName, rev)
+	dst.DocName = conflictName(dst.DocName, true)
 	dst.ResetFullpath()
 	content, err := fs.OpenFile(src)
 	if err != nil {

--- a/tests/integration/tests/sharing_conflicts.rb
+++ b/tests/integration/tests/sharing_conflicts.rb
@@ -8,13 +8,15 @@ def children_by_parent_id(inst, parent_id)
 end
 
 def assert_conflict_children(inst_a, inst_b, parent_id_a, parent_id_b, filename)
+  basename = File.basename filename, File.extname(filename)
+
   _, children_a = children_by_parent_id inst_a, parent_id_a
   assert 2, children_a.length
-  children_a.each { |child| assert child.name.include? filename }
+  children_a.each { |child| assert child.name.include? basename }
 
   _, children_b = children_by_parent_id inst_b, parent_id_b
   assert 2, children_b.length
-  children_b.each { |child| assert child.name.include? filename }
+  children_b.each { |child| assert child.name.include? basename }
 
   assert_equal children_a[0].name, children_b[0].name
   assert_equal children_a[1].name, children_b[1].name
@@ -163,7 +165,7 @@ describe "A sharing" do
     sleep 30
     # Check the conflicted files
     _, files = Folder.children inst, parent_file.path
-    conflict_file = files.find { |c| c.name.include? "conflict" }
+    conflict_file = files.find { |c| c.name =~ / \(\d+\)/ }
     refute_nil conflict_file
     path = CGI.escape "#{parent_file_recipient.path}/#{conflict_file.name}"
     conflict_file_recipient = CozyFile.find_by_path inst_recipient, path


### PR DESCRIPTION
When a note is in a shared directory, the stack should avoid to modify
the content and rename the note in a single CouchDB revision. It doesn't
play nicely with the sharing, as the stack has to create a new revision
on the recipients' instances. And if there are several instances, the
new revisions can be different, leading to conflicts.

To fix that, the stack now makes a first CouchDB revision with the
renaming, and only after that, writes the new content to the VFS.