### PR TITLE
Return empty string when no bookmark

### DIFF
--- a/pkg/couchdb/couchdb.go
+++ b/pkg/couchdb/couchdb.go
@@ -841,6 +841,10 @@ func findDocsRaw(db Database, doctype string, req interface{}, results interface
 		// Developer should not rely on unoptimized index.
 		return nil, unoptimalError()
 	}
+	if response.Bookmark == "nil" {
+		// CouchDB surprisingly returns "nil" when there is no doc
+		response.Bookmark = ""
+	}
 	return &response, json.Unmarshal(response.Docs, results)
 }
 
@@ -896,6 +900,10 @@ func NormalDocs(db Database, doctype string, skip, limit int, bookmark string) (
 		res.Total = total - len(designRes.Rows)
 	}
 	res.Bookmark = findRes.Bookmark
+	if res.Bookmark == "nil" {
+		// CouchDB surprisingly returns "nil" when there is no doc
+		res.Bookmark = ""
+	}
 	return &res, nil
 }
 

--- a/web/data/data_test.go
+++ b/web/data/data_test.go
@@ -648,6 +648,16 @@ func TestFindDocumentsPaginatedBookmark(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, out2.Docs, 0)
 	assert.Equal(t, false, out2.Next)
+
+	var query4 = M{"selector": M{"test": "novalue"}}
+	req, _ = http.NewRequest("POST", url2, jsonReader(&query4))
+	req.Header.Add("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	_, res, err = doRequest(req, &out2)
+	assert.NoError(t, err)
+	assert.Equal(t, "200 OK", res.Status, "should get a 200")
+	assert.Len(t, out2.Docs, 0)
+	assert.Equal(t, "", out2.Bookmark)
 }
 
 func TestFindDocumentsWithoutIndex(t *testing.T) {
@@ -920,4 +930,17 @@ function(doc) {
 	assert.NotEmpty(t, id)
 	value = row["test"].(string)
 	assert.Equal(t, "fourthvalue", value)
+
+	emptyType := "io.cozy.anothertype"
+	_ = couchdb.ResetDB(testInstance, emptyType)
+	url = ts.URL + "/data/" + emptyType + "/_normal_docs"
+	req, _ = http.NewRequest("GET", url, nil)
+	req.Header.Add("Authorization", "Bearer "+token)
+	out, res, err = doRequest(req, nil)
+	assert.Equal(t, "200 OK", res.Status, "should get a 200")
+	assert.NoError(t, err)
+	totalRows = out["total_rows"].(float64)
+	assert.Equal(t, float64(0), totalRows)
+	bookmark = out["bookmark"].(string)
+	assert.Equal(t, "", bookmark)
 }

--- a/web/data/data_test.go
+++ b/web/data/data_test.go
@@ -620,7 +620,7 @@ func TestFindDocumentsPaginatedBookmark(t *testing.T) {
 		Bookmark string
 	}
 	_, res, err := doRequest(req, &out2)
-	assert.Equal(t, "200 OK", res.Status, "should get a 200")
+	assert.Equal(t, 200, res.StatusCode)
 	assert.NoError(t, err)
 	assert.Len(t, out2.Docs, 100, "should stop at 100 docs")
 	assert.Equal(t, 100, out2.Limit)
@@ -633,7 +633,7 @@ func TestFindDocumentsPaginatedBookmark(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 
 	_, res, err = doRequest(req, &out2)
-	assert.Equal(t, "200 OK", res.Status, "should get a 200")
+	assert.Equal(t, 200, res.StatusCode)
 	assert.NoError(t, err)
 	assert.Len(t, out2.Docs, 100)
 	assert.Equal(t, 100, out2.Limit)
@@ -644,7 +644,7 @@ func TestFindDocumentsPaginatedBookmark(t *testing.T) {
 	req.Header.Add("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
 	_, res, err = doRequest(req, &out2)
-	assert.Equal(t, "200 OK", res.Status, "should get a 200")
+	assert.Equal(t, 200, res.StatusCode)
 	assert.NoError(t, err)
 	assert.Len(t, out2.Docs, 0)
 	assert.Equal(t, false, out2.Next)
@@ -655,7 +655,7 @@ func TestFindDocumentsPaginatedBookmark(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	_, res, err = doRequest(req, &out2)
 	assert.NoError(t, err)
-	assert.Equal(t, "200 OK", res.Status, "should get a 200")
+	assert.Equal(t, 200, res.StatusCode)
 	assert.Len(t, out2.Docs, 0)
 	assert.Equal(t, "", out2.Bookmark)
 }


### PR DESCRIPTION
CouchDB returns `bookmark:"nil"` for queries with no docs to return. For instance, see the response of this [request](https://docs.couchdb.org/en/2.2.0/api/database/find.html#post--db-_explain) 
This can be dangerous for clients that would test a bookmark existence with something like `if (bookmark)`, so we return `bookmark:""` instead