### PR TITLE
Fix sharing an empty directory in read-only

### DIFF
--- a/model/sharing/setup.go
+++ b/model/sharing/setup.go
@@ -27,23 +27,24 @@ func (s *Sharing) SetupReceiver(inst *instance.Instance) error {
 	if err := s.AddTrackTriggers(inst); err != nil {
 		return err
 	}
+	withFiles := s.FirstFilesRule() != nil
 	if !s.ReadOnly() {
 		if err := s.AddReplicateTrigger(inst); err != nil {
 			return err
 		}
-		if s.FirstFilesRule() != nil {
+		if withFiles {
 			if err := s.AddUploadTrigger(inst); err != nil {
 				return err
 			}
-			// The sharing directory is created when the stack receives the
-			// first file (it allows to not create it if it's just a file that
-			// is shared, not a directory or an album). But, for an empty
-			// directory, no files are sent, so we need to create it now.
-			if s.NbFiles == 0 {
-				if _, err := s.GetSharingDir(inst); err != nil {
-					return err
-				}
-			}
+		}
+	}
+	// The sharing directory is created when the stack receives the
+	// first file (it allows to not create it if it's just a file that
+	// is shared, not a directory or an album). But, for an empty
+	// directory, no files are sent, so we need to create it now.
+	if withFiles && s.NbFiles == 0 {
+		if _, err := s.GetSharingDir(inst); err != nil {
+			return err
 		}
 	}
 	return nil


### PR DESCRIPTION
When an empty directory is shared to a recipient in read-only, and the
recipient accepts the sharing, the directory wasn't created until a file
was added to this directory by the sharer. It is now fixed.