### PR TITLE
Revoke a sharing when its root is trashed

### DIFF
--- a/model/sharing/revoke_trashed.go
+++ b/model/sharing/revoke_trashed.go
@@ -1,0 +1,42 @@
+package sharing
+
+import (
+	"github.com/cozy/cozy-stack/model/instance"
+	"github.com/cozy/cozy-stack/model/vfs"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
+)
+
+func init() {
+	vfs.RevokeSharingFunc = revokeTrashed
+}
+
+const (
+	SharingDirAlreadyTrashed = true
+	SharingDirNotTrashed     = false
+)
+
+func revokeTrashed(db prefixer.Prefixer, sharingID string) {
+	s, err := FindSharing(db, sharingID)
+	if err != nil {
+		return
+	}
+
+	// XXX: we simulate an instance from the information of the prefixer. It is
+	// an hack, but I don't see a better way to do that for the moment. Maybe
+	// it is something we can improve later. I hope it should have all the
+	// fields that are used for revoking the sharing.
+	inst := &instance.Instance{
+		Prefix: db.DBPrefix(),
+		Domain: db.DomainName(),
+	}
+
+	if s.Owner {
+		err = s.Revoke(inst)
+	} else {
+		err = s.RevokeRecipientBySelf(inst, SharingDirAlreadyTrashed)
+	}
+	if err != nil {
+		inst.Logger().WithField("nspace", "sharing").
+			Errorf("revokeTrashed failed for sharing %s: %s", sharingID, err)
+	}
+}

--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -393,7 +393,7 @@ func (s *Sharing) RevokeRecipient(inst *instance.Instance, index int) error {
 }
 
 // RevokeRecipientBySelf revoke the sharing on the recipient side
-func (s *Sharing) RevokeRecipientBySelf(inst *instance.Instance) error {
+func (s *Sharing) RevokeRecipientBySelf(inst *instance.Instance, sharingDirTrashed bool) error {
 	if s.Owner {
 		return ErrInvalidSharing
 	}
@@ -409,7 +409,7 @@ func (s *Sharing) RevokeRecipientBySelf(inst *instance.Instance) error {
 	if err := RemoveSharedRefs(inst, s.SID); err != nil {
 		return err
 	}
-	if s.FirstFilesRule() != nil {
+	if !sharingDirTrashed && s.FirstFilesRule() != nil {
 		if err := s.RemoveSharingDir(inst); err != nil {
 			return err
 		}

--- a/web/sharings/revoke.go
+++ b/web/sharings/revoke.go
@@ -102,7 +102,7 @@ func RevokeRecipientBySelf(c echo.Context) error {
 	if err != nil {
 		return echo.NewHTTPError(http.StatusForbidden)
 	}
-	if err = s.RevokeRecipientBySelf(inst); err != nil {
+	if err = s.RevokeRecipientBySelf(inst, sharing.SharingDirNotTrashed); err != nil {
 		return wrapErrors(err)
 	}
 	return c.NoContent(http.StatusNoContent)


### PR DESCRIPTION
When a sharing is made for a file or folder, and this file or folder is
put to the trash, the sharing should be revoked. Before this commit, it
wasn't the case, and everything inside the shared folder was also put in
the trash, and the synchronisation of the sharing makes the content in
this folder not available for all the members of the sharing. Not good!

Now, the sharing is revoked before the synchronisation can happen, and
the other members of the sharing will keep the content available (ie not
in the trash).