### PR TITLE
feat: Add UpdatedAt param to file upload

### DIFF
--- a/docs/files.md
+++ b/docs/files.md
@@ -428,8 +428,12 @@ The `created_at` field will be the first valid value in this list:
 
 The `updated_at` field will be the first value in this list:
 
+- the `UpdatedAt` parameter from the query-string
 - the `Date` HTTP header
 - the current time from the server.
+
+/!\ If the `updated_at` filed is older than the `created_at` one, 
+then the `updated_at` will be set with the value of the `created_at`.
 
 #### Query-String
 
@@ -441,7 +445,8 @@ The `updated_at` field will be the first value in this list:
 | Executable              | `true` if the file is executable (UNIX permission)             |
 | Metadata                | a JSON with metadata on this file (_deprecated_)               |
 | MetadataID              | the identifier of a metadata object                            |
-| CreatedAt               | the creation date of the file                                  |
+| CreatedAt               | the creation date of the file  
+| UpdatedAt               | the modification date of the file
 | SourceAccount           | the id of the source account used by a konnector               |
 | SourceAccountIdentifier | the unique identifier of the account targeted by the connector |
 

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -94,6 +94,11 @@ func createFileHandler(c echo.Context, fs vfs.VFS) (f *file, err error) {
 			doc.CreatedAt = at
 		}
 	}
+	if updated := c.QueryParam("UpdatedAt"); updated != "" {
+		if at, err3 := time.Parse(time.RFC3339, updated); err3 == nil {
+			doc.UpdatedAt = at
+		}
+	}
 	doc.CozyMetadata, _ = CozyMetadataFromClaims(c, true)
 
 	err = checkPerm(c, "POST", nil, doc)
@@ -159,6 +164,12 @@ func createDirHandler(c echo.Context, fs vfs.VFS) (*dir, error) {
 	if created := c.QueryParam("CreatedAt"); created != "" {
 		if at, err2 := time.Parse(time.RFC3339, created); err2 == nil {
 			doc.CreatedAt = at
+		}
+	}
+
+	if updated := c.QueryParam("UpdatedAt"); updated != "" {
+		if at, err3 := time.Parse(time.RFC3339, updated); err3 == nil {
+			doc.UpdatedAt = at
 		}
 	}
 


### PR DESCRIPTION
Chromium based browser do not allow the use of the `Date` header
when using XHR. We now introduce a new UpdatedAt param we can use
when uploading a file or a folder to set the modification date of
the file.

(see https://github.com/cozy/cozy-client/issues/690) 