### PR TITLE
Fix sort for deleted files

### DIFF
--- a/model/sharing/files.go
+++ b/model/sharing/files.go
@@ -74,7 +74,7 @@ func XorID(id string, key []byte) string {
 //   directory, we must create directory before the file)
 // - directories are sorted by increasing depth (if a sub-folder is created
 //   in a new directory, we must create the parent before the child)
-// - deleted elements must come at the end, to efficently cope with moves.
+// - deleted elements must come at the end, to efficiently cope with moves.
 //	 For example, if we have A->B->C hierarchy and C is moved elsewhere
 //	 and B deleted, we must make the move before deleting B and its children.
 func (s *Sharing) SortFilesToSent(files []map[string]interface{}) {
@@ -92,13 +92,13 @@ func (s *Sharing) SortFilesToSent(files []map[string]interface{}) {
 		if b["type"] == consts.FileType {
 			return true
 		}
-		p, ok := a["path"].(string)
-		if !ok {
-			return true
-		}
 		q, ok := b["path"].(string)
 		if !ok {
 			return false
+		}
+		p, ok := a["path"].(string)
+		if !ok {
+			return true
 		}
 		return strings.Count(p, "/") < strings.Count(q, "/")
 	})

--- a/model/sharing/files_test.go
+++ b/model/sharing/files_test.go
@@ -53,7 +53,7 @@ func TestSortFilesToSent(t *testing.T) {
 	filec := map[string]interface{}{"type": "file", "name": "filec"}
 	files := []map[string]interface{}{filea, foobar, foobarbaz, dela, delb, fileb, filec, foo}
 	s.SortFilesToSent(files)
-	expected := []map[string]interface{}{delb, dela, foo, foobar, foobarbaz, filea, fileb, filec}
+	expected := []map[string]interface{}{foo, foobar, foobarbaz, filea, fileb, filec, dela, delb}
 	assert.Equal(t, expected, files)
 }
 

--- a/model/sharing/files_test.go
+++ b/model/sharing/files_test.go
@@ -46,8 +46,8 @@ func TestSortFilesToSent(t *testing.T) {
 	foo := map[string]interface{}{"type": "directory", "name": "foo", "path": "/foo"}
 	foobar := map[string]interface{}{"type": "directory", "name": "bar", "path": "/foo/bar"}
 	foobarbaz := map[string]interface{}{"type": "directory", "name": "baz", "path": "/foo/bar/baz"}
-	dela := map[string]interface{}{"_deleted": true, "name": "dela"}
-	delb := map[string]interface{}{"_deleted": true, "name": "delb"}
+	dela := map[string]interface{}{"_deleted": true, "_id": "dela"} // No type, name, or path on deleted docs
+	delb := map[string]interface{}{"_deleted": true, "_id": "delb"}
 	filea := map[string]interface{}{"type": "file", "name": "filea"}
 	fileb := map[string]interface{}{"type": "file", "name": "fileb"}
 	filec := map[string]interface{}{"type": "file", "name": "filec"}

--- a/tests/integration/tests/sharing_moves_n_delete.rb
+++ b/tests/integration/tests/sharing_moves_n_delete.rb
@@ -47,10 +47,16 @@ describe "A shared directory" do
     diff.must_be_empty
 
     # Move what is in subdir out of it...
+    file3.move_to inst, folder.couch_id
+    # TODO remove this sleep. Files move/rename are currently managed from the
+    # worker share_upload, not with the directories in share_replicate. It is
+    # something that should be changed in the future. The triggers for the 2
+    # workers have different debounce values, which is why the sleep was added
+    # as a temporary workaround.
+    sleep 6
     child1.move_to inst, folder.couch_id
     child2.move_to inst, folder.couch_id
     child3.move_to inst, folder.couch_id
-    file3.move_to inst, folder.couch_id
 
     # ...and delete it
     subdir.remove inst


### PR DESCRIPTION
From the sharer side, we sort docs before replication in order to apply a bunch of rules, e.g. directories before files.
We also implemented a [rule](https://github.com/cozy/cozy-stack/commit/4f9a4cdc7134cb586d4461c2b4c05cf3c8a01b8a) on the recipient side in order to put the deleted files at the end, to efficiently deal with moves. However, the sort behavior was not the expected one, and it was also contradictory with the sort performed by the sharer. As it result, it was causing errors like [this one](https://github.com/cozy/cozy-stack/blob/master/model/sharing/files.go#L875) because the recipient was mistakenly trying to recursively rebuild the hierarchy.

Therefore, we remove this sort on the recipient side and implement it on the sharer side, with the other rules.