### PR TITLE
Preserve the redirect parameter on OIDC

### DIFF
--- a/web/auth/auth.go
+++ b/web/auth/auth.go
@@ -105,7 +105,11 @@ func isTrustedDevice(c echo.Context, inst *instance.Instance) bool {
 
 func renderLoginForm(c echo.Context, i *instance.Instance, code int, credsErrors string, redirect *url.URL) error {
 	if !i.IsPasswordAuthenticationEnabled() {
-		return c.Redirect(http.StatusSeeOther, i.PageURL("/oidc/start", nil))
+		var q url.Values
+		if redirect := c.QueryParam("redirect"); redirect != "" {
+			q = url.Values{"redirect": {redirect}}
+		}
+		return c.Redirect(http.StatusSeeOther, i.PageURL("/oidc/start", q))
 	}
 
 	publicName, err := i.PublicName()

--- a/web/oidc/statestore.go
+++ b/web/oidc/statestore.go
@@ -18,15 +18,17 @@ type stateHolder struct {
 	id        string
 	expiresAt int64
 	Instance  string
+	Redirect  string
 	Nonce     string
 }
 
-func newStateHolder(domain string) *stateHolder {
+func newStateHolder(domain, redirect string) *stateHolder {
 	id := hex.EncodeToString(crypto.GenerateRandomBytes(16))
 	nonce := hex.EncodeToString(crypto.GenerateRandomBytes(16))
 	return &stateHolder{
 		id:       id,
 		Instance: domain,
+		Redirect: redirect,
 		Nonce:    nonce,
 	}
 }


### PR DESCRIPTION
When a user tries to connect a mobile app and their instance is on a
context where the login with OIDC is required, it wasn't working because
the OAuth danse was lost during the OIDC authentication. The stack will
now preserve the redirect, which should enable to restart the OAuth
danse after the user has been authenticated.