### PR TITLE
Add more checks for the consistency of instances

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -1,0 +1,94 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"net/url"
+	"os"
+	"strconv"
+
+	"github.com/cozy/cozy-stack/client/request"
+	"github.com/spf13/cobra"
+)
+
+var flagCheckFSIndexIntegrity bool
+var flagCheckFSFilesConsistensy bool
+var flagCheckFSFailFast bool
+
+var checkCmdGroup = &cobra.Command{
+	Use:   "check <command>",
+	Short: "A set of tools to check that instances are in the expected state.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmd.Usage()
+	},
+}
+
+var checkFSCmd = &cobra.Command{
+	Use:   "fs <domain>",
+	Short: "Check a vfs",
+	Long: `
+This command checks that the files in the VFS are not desynchronized, ie a file
+present in CouchDB but not swift/localfs, or present in swift/localfs but not
+couchdb.
+
+There are 2 steps:
+
+- index integrity checks that there are nothing wrong in the index (CouchDB),
+  like a file present in a directory that has been deleted
+- files consistency checks that the files are the same in the index (CouchDB)
+  and the storage (Swift or localfs).
+
+By default, both operations are done, but you can choose one or the other via
+the flags.
+`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 0 {
+			return cmd.Usage()
+		}
+		return fsck(args[0])
+	},
+}
+
+func fsck(domain string) error {
+	if flagCheckFSFilesConsistensy && flagCheckFSIndexIntegrity {
+		flagCheckFSIndexIntegrity = false
+		flagCheckFSFilesConsistensy = false
+	}
+
+	c := newAdminClient()
+	res, err := c.Req(&request.Options{
+		Method: "GET",
+		Path:   "/instances/" + url.PathEscape(domain) + "/fsck",
+		Queries: url.Values{
+			"IndexIntegrity":   {strconv.FormatBool(flagCheckFSIndexIntegrity)},
+			"FilesConsistency": {strconv.FormatBool(flagCheckFSFilesConsistensy)},
+			"FailFast":         {strconv.FormatBool(flagCheckFSFailFast)},
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	hasLogs := false
+	scanner := bufio.NewScanner(res.Body)
+	for scanner.Scan() {
+		hasLogs = true
+		fmt.Println(string(scanner.Bytes()))
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	if hasLogs {
+		os.Exit(1)
+	}
+	return nil
+}
+
+func init() {
+	checkCmdGroup.AddCommand(checkFSCmd)
+	checkFSCmd.Flags().BoolVar(&flagCheckFSIndexIntegrity, "index-integrity", false, "Check the index integrity only")
+	checkFSCmd.Flags().BoolVar(&flagCheckFSFilesConsistensy, "files-consistency", false, "Check the files consistency only (between CouchDB and Swift)")
+	checkFSCmd.Flags().BoolVar(&flagCheckFSFailFast, "fail-fast", false, "Stop the FSCK on the first error")
+
+	RootCmd.AddCommand(checkCmdGroup)
+}

--- a/cmd/fix.go
+++ b/cmd/fix.go
@@ -27,8 +27,9 @@ var withMetadataFlag bool
 var noDryRunFlag bool
 
 var fixerCmdGroup = &cobra.Command{
-	Use:   "fixer <command>",
-	Short: "A set of tools to fix issues or migrate content for retro-compatibility.",
+	Use:     "fix <command>",
+	Aliases: []string{"fixer"},
+	Short:   "A set of tools to fix issues or migrate content.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return cmd.Usage()
 	},

--- a/model/sharing/revisions.go
+++ b/model/sharing/revisions.go
@@ -86,6 +86,9 @@ func (rt *RevsTree) Find(rev string) (*RevsTree, int) {
 
 // Add inserts the given revision in the main branch
 func (rt *RevsTree) Add(rev string) *RevsTree {
+	if rev == rt.Rev {
+		return rt
+	}
 	// TODO check generations (conflicts)
 	if len(rt.Branches) > 0 {
 		// XXX This condition shouldn't be true, but it can help to limit

--- a/model/vfs/errors.go
+++ b/model/vfs/errors.go
@@ -40,8 +40,8 @@ var (
 	ErrWrongCouchdbState = errors.New("Wrong couchdb reduce value")
 	// ErrFileTooBig is used when there is no more space left on the filesystem
 	ErrFileTooBig = errors.New("The file is too big and exceeds the disk quota")
-	// ErrFsckFailFail is used when the FSCK is stopped by the fail-fast option
-	ErrFsckFailFail = errors.New("FSCK has been stopped on first failure")
+	// ErrFsckFailFast is used when the FSCK is stopped by the fail-fast option
+	ErrFsckFailFast = errors.New("FSCK has been stopped on first failure")
 	// ErrWrongToken is used when a key is not found on the store
 	ErrWrongToken = errors.New("Wrong download token")
 )

--- a/model/vfs/fsck.go
+++ b/model/vfs/fsck.go
@@ -38,6 +38,12 @@ const (
 	// IndexDuplicateName is used when two files or directories have the same
 	// name inside the same folder (ie they have the same path).
 	IndexDuplicateName = "index_duplicate_name"
+	// TrashedNotInTrash is used when a file has trashed: true but its parent
+	// directory is not the trash, not is in the trash.
+	TrashedNotInTrash = "trashed_not_in_trash"
+	// NotTrashedInTrash is used when a file has trashed: false but its parent
+	// directory is the trash or a directory in the trash.
+	NotTrashedInTrash = "not_trashed_in_trash"
 )
 
 // FsckLog is a struct for an inconsistency in the VFS

--- a/model/vfs/fsck.go
+++ b/model/vfs/fsck.go
@@ -44,6 +44,9 @@ const (
 	// NotTrashedInTrash is used when a file has trashed: false but its parent
 	// directory is the trash or a directory in the trash.
 	NotTrashedInTrash = "not_trashed_in_trash"
+	// ConflictInIndex is used when there is a conflict in CouchDB with 2
+	// branches of revisions.
+	ConflictInIndex = "conflict_in_index"
 )
 
 // FsckLog is a struct for an inconsistency in the VFS

--- a/model/vfs/vfsafero/fsck.go
+++ b/model/vfs/vfsafero/fsck.go
@@ -29,7 +29,7 @@ func (afs *aferoVFS) Fsck(accumulate func(log *vfs.FsckLog), failFast bool) erro
 		return err
 	}
 	if err = afs.CheckTreeIntegrity(tree, accumulate, failFast); err != nil {
-		if err == vfs.ErrFsckFailFail {
+		if err == vfs.ErrFsckFailFast {
 			return nil
 		}
 		return err

--- a/model/vfs/vfsswift/fsck_v1.go
+++ b/model/vfs/vfsswift/fsck_v1.go
@@ -22,7 +22,7 @@ func (sfs *swiftVFS) Fsck(accumulate func(log *vfs.FsckLog), failFast bool) erro
 		return err
 	}
 	if err = sfs.CheckTreeIntegrity(tree, accumulate, failFast); err != nil {
-		if err == vfs.ErrFsckFailFail {
+		if err == vfs.ErrFsckFailFast {
 			return nil
 		}
 		return err

--- a/model/vfs/vfsswift/fsck_v2.go
+++ b/model/vfs/vfsswift/fsck_v2.go
@@ -21,7 +21,7 @@ func (sfs *swiftVFSV2) Fsck(accumulate func(log *vfs.FsckLog), failFast bool) er
 		return err
 	}
 	if err = sfs.CheckTreeIntegrity(tree, accumulate, failFast); err != nil {
-		if err == vfs.ErrFsckFailFail {
+		if err == vfs.ErrFsckFailFast {
 			return nil
 		}
 		return err

--- a/model/vfs/vfsswift/fsck_v3.go
+++ b/model/vfs/vfsswift/fsck_v3.go
@@ -24,7 +24,7 @@ func (sfs *swiftVFSV3) Fsck(accumulate func(log *vfs.FsckLog), failFast bool) er
 		return err
 	}
 	if err = sfs.CheckTreeIntegrity(tree, accumulate, failFast); err != nil {
-		if err == vfs.ErrFsckFailFail {
+		if err == vfs.ErrFsckFailFast {
 			return nil
 		}
 		return err

--- a/pkg/couchdb/index.go
+++ b/pkg/couchdb/index.go
@@ -7,7 +7,7 @@ import (
 
 // IndexViewsVersion is the version of current definition of views & indexes.
 // This number should be incremented when this file changes.
-const IndexViewsVersion int = 27
+const IndexViewsVersion int = 28
 
 // Indexes is the index list required by an instance to run properly.
 var Indexes = []*mango.Index{
@@ -20,6 +20,8 @@ var Indexes = []*mango.Index{
 	mango.IndexOnFields(consts.Files, "dir-by-path", []string{"path"}),
 	// Used to find notes
 	mango.IndexOnFields(consts.Files, "by-mime-updated-at", []string{"mime", "trashed", "updated_at"}),
+	// Used by the FSCK to detect conflicts
+	mango.IndexOnFields(consts.Files, "with-conflicts", []string{"_conflicts"}),
 
 	// Used to lookup a queued and running jobs
 	mango.IndexOnFields(consts.Jobs, "by-worker-and-state", []string{"worker", "state"}),

--- a/tests/integration/lib/instance.rb
+++ b/tests/integration/lib/instance.rb
@@ -93,6 +93,10 @@ class Instance
     @stack.fsck self
   end
 
+  def check
+    @stack.check self
+  end
+
   # See https://github.com/jcs/rubywarden/blob/master/API.md#example
   def hashed_passphrase
     key = PBKDF2.new do |p|

--- a/tests/integration/lib/stack.rb
+++ b/tests/integration/lib/stack.rb
@@ -134,6 +134,17 @@ class Stack
     cmd = ["cozy-stack", "check", "fs", inst.domain,
            "--admin-port", @admin]
     puts cmd.join(" ").green
-    `#{cmd.join(" ")}`.chomp
+    `#{cmd.join(" ")}`.chomp.lines
+  end
+
+  def check_shared(inst)
+    cmd = ["cozy-stack", "check", "shared", inst.domain,
+           "--admin-port", @admin]
+    puts cmd.join(" ").green
+    `#{cmd.join(" ")}`.chomp.lines
+  end
+
+  def check(inst)
+    [fsck(inst), check_shared(inst)].flatten
   end
 end

--- a/tests/integration/lib/stack.rb
+++ b/tests/integration/lib/stack.rb
@@ -131,7 +131,7 @@ class Stack
   end
 
   def fsck(inst)
-    cmd = ["cozy-stack", "instances", "fsck", inst.domain,
+    cmd = ["cozy-stack", "check", "fs", inst.domain,
            "--admin-port", @admin]
     puts cmd.join(" ").green
     `#{cmd.join(" ")}`.chomp

--- a/tests/integration/tests/avoid_name_conflict.rb
+++ b/tests/integration/tests/avoid_name_conflict.rb
@@ -47,8 +47,8 @@ describe "A file or folder" do
     assert_equal "foobar", one_bob.name
     assert_equal "foo", two_bob.name
 
-    assert_equal inst_alice.fsck, ""
-    assert_equal inst_bob.fsck, ""
+    assert_equal inst_alice.fsck, []
+    assert_equal inst_bob.fsck, []
 
     inst_alice.remove
     inst_bob.remove

--- a/tests/integration/tests/loop_shared_file.rb
+++ b/tests/integration/tests/loop_shared_file.rb
@@ -47,6 +47,9 @@ describe "A sharing" do
     assert_equal file.name, file_bob.name
     assert_equal file.md5sum, file_bob.md5sum
 
+    assert_equal inst_alice.check, []
+    assert_equal inst_bob.check, []
+
     inst_alice.remove
     inst_bob.remove
   end

--- a/tests/integration/tests/multiple_sharings.rb
+++ b/tests/integration/tests/multiple_sharings.rb
@@ -106,6 +106,10 @@ describe "A folder" do
     diff = Helpers.fsdiff da, dc
     diff.must_be_empty
 
+    assert_equal inst_alice.check, []
+    assert_equal inst_bob.check, []
+    assert_equal inst_charlie.check, []
+
     inst_alice.remove
     inst_bob.remove
     inst_charlie.remove

--- a/tests/integration/tests/revoke_sharing.rb
+++ b/tests/integration/tests/revoke_sharing.rb
@@ -340,7 +340,7 @@ describe "A sharing" do
     instances = [inst_alice, inst_bob, inst_charlie, inst_dave]
     instances.each do |inst|
       Folder.clear_trash inst
-      inst.fsck
+      assert_equal inst.check, []
     end
     instances.each(&:remove)
   end

--- a/tests/integration/tests/sharing_conflicts.rb
+++ b/tests/integration/tests/sharing_conflicts.rb
@@ -182,8 +182,8 @@ describe "A sharing" do
       diff.must_be_empty
     end
 
-    assert_equal inst.fsck, ""
-    assert_equal inst_recipient.fsck, ""
+    assert_equal inst.check, []
+    assert_equal inst_recipient.check, []
 
     inst.remove
     inst_recipient.remove

--- a/tests/integration/tests/sharing_moves_n_delete.rb
+++ b/tests/integration/tests/sharing_moves_n_delete.rb
@@ -87,8 +87,8 @@ describe "A shared directory" do
     diff = Helpers.fsdiff da, db
     diff.must_be_empty
 
-    assert_equal inst.fsck, ""
-    assert_equal inst_recipient.fsck, ""
+    assert_equal inst.check, []
+    assert_equal inst_recipient.check, []
 
     inst.remove
     inst_recipient.remove

--- a/tests/integration/tests/sharing_push_folder.rb
+++ b/tests/integration/tests/sharing_push_folder.rb
@@ -150,8 +150,8 @@ describe "A folder" do
       diff.must_be_empty
     end
 
-    assert_equal inst.fsck, ""
-    assert_equal inst_recipient.fsck, ""
+    assert_equal inst.check, []
+    assert_equal inst_recipient.check, []
 
     inst.remove
     inst_recipient.remove

--- a/tests/integration/tests/sharing_read_only.rb
+++ b/tests/integration/tests/sharing_read_only.rb
@@ -100,6 +100,10 @@ describe "A file or folder" do
     refute_nil parameters["sharecode"]
     assert_equal bob, parameters["public_name"]
 
+    assert_equal inst_alice.check, []
+    assert_equal inst_bob.check, []
+    assert_equal inst_charlie.check, []
+
     inst_alice.remove
     inst_bob.remove
     inst_charlie.remove

--- a/tests/integration/tests/sharing_referenced_by.rb
+++ b/tests/integration/tests/sharing_referenced_by.rb
@@ -116,6 +116,9 @@ describe "A photo" do
     refute file_has_album_reference(file, album.couch_id)
     refute file.trashed
 
+    assert_equal inst.check, []
+    assert_equal inst_recipient.check, []
+
     inst.remove
     inst_recipient.remove
   end

--- a/tests/integration/tests/sharing_remove_folder.rb
+++ b/tests/integration/tests/sharing_remove_folder.rb
@@ -88,6 +88,9 @@ describe "A shared folder" do
     f3_sharer = CozyFile.find inst, f3.couch_id
     refute f3_sharer.trashed
 
+    assert_equal inst.check, []
+    assert_equal inst_recipient.check, []
+
     inst.remove
     inst_recipient.remove
   end

--- a/tests/integration/tests/sharing_rename_dir.rb
+++ b/tests/integration/tests/sharing_rename_dir.rb
@@ -63,8 +63,8 @@ describe "A directory in a sharing" do
     diff = Helpers.fsdiff da, db
     diff.must_be_empty
 
-    assert_equal inst.fsck, ""
-    assert_equal inst_recipient.fsck, ""
+    assert_equal inst.check, []
+    assert_equal inst_recipient.check, []
 
     inst.remove
     inst_recipient.remove

--- a/tests/integration/tests/sharing_sync.rb
+++ b/tests/integration/tests/sharing_sync.rb
@@ -187,11 +187,12 @@ describe "A folder" do
 
     # Create a folder on the recipient side, with a fixed id being the
     # xor_id of the child2 folder
+    name = Faker::Internet.slug
     doc = {
       type: "directory",
       name: name,
       dir_id: Folder::ROOT_DIR,
-      path: "/#{Faker::Internet.slug}",
+      path: "/#{name}",
       created_at: "2018-05-11T12:18:37.558389182+02:00",
       updated_at: "2018-05-11T12:18:37.558389182+02:00"
     }
@@ -252,6 +253,9 @@ describe "A folder" do
     assert_equal file.name, file_recipient.name
     assert_equal file.md5sum, file_recipient.md5sum
     assert_equal file.couch_rev, file_recipient.couch_rev
+
+    assert_equal inst.check, []
+    # XXX we don't check the FS of inst_recipient as we have played directly with CouchDB on it
 
     inst.remove
     inst_recipient.remove

--- a/web/instances/checks.go
+++ b/web/instances/checks.go
@@ -1,0 +1,87 @@
+package instances
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/cozy/cozy-stack/model/instance/lifecycle"
+	"github.com/cozy/cozy-stack/model/sharing"
+	"github.com/cozy/cozy-stack/model/vfs"
+	"github.com/labstack/echo/v4"
+)
+
+func fsckHandler(c echo.Context) (err error) {
+	domain := c.Param("domain")
+	i, err := lifecycle.GetInstance(domain)
+	if err != nil {
+		return wrapError(err)
+	}
+
+	indexIntegrityCheck, _ := strconv.ParseBool(c.QueryParam("IndexIntegrity"))
+	filesConsistencyCheck, _ := strconv.ParseBool(c.QueryParam("FilesConsistency"))
+	failFast, _ := strconv.ParseBool(c.QueryParam("FailFast"))
+
+	logCh := make(chan *vfs.FsckLog)
+	go func() {
+		fs := i.VFS()
+		if indexIntegrityCheck {
+			err = fs.CheckIndexIntegrity(func(log *vfs.FsckLog) { logCh <- log }, failFast)
+		} else if filesConsistencyCheck {
+			err = fs.CheckFilesConsistency(func(log *vfs.FsckLog) { logCh <- log }, failFast)
+		} else {
+			err = fs.Fsck(func(log *vfs.FsckLog) { logCh <- log }, failFast)
+		}
+		close(logCh)
+	}()
+
+	w := c.Response().Writer
+	w.WriteHeader(200)
+	encoder := json.NewEncoder(w)
+	for log := range logCh {
+		// XXX do not serialize to JSON the children and the cozyMetadata, as
+		// it can take more than 64ko and scanner will ignore such lines.
+		if log.FileDoc != nil {
+			log.FileDoc.DirsChildren = nil  // It can be filled on type mismatch
+			log.FileDoc.FilesChildren = nil // Idem
+			log.FileDoc.Metadata = nil
+		}
+		if log.DirDoc != nil {
+			log.DirDoc.DirsChildren = nil
+			log.DirDoc.FilesChildren = nil
+			log.DirDoc.Metadata = nil
+		}
+		if errenc := encoder.Encode(log); errenc != nil {
+			i.Logger().WithField("nspace", "fsck").
+				Warnf("Cannot encode to JSON: %s (%v)", err, log)
+		}
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}
+	if err != nil {
+		log := map[string]string{"error": err.Error()}
+		if errenc := encoder.Encode(log); errenc != nil {
+			i.Logger().WithField("nspace", "fsck").
+				Warnf("Cannot encode to JSON: %s (%v)", err, log)
+		}
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}
+	return nil
+}
+
+func checkShared(c echo.Context) error {
+	domain := c.Param("domain")
+	i, err := lifecycle.GetInstance(domain)
+	if err != nil {
+		return wrapError(err)
+	}
+
+	results, err := sharing.CheckShared(i)
+	if err != nil {
+		return wrapError(err)
+	}
+	return c.JSON(http.StatusOK, results)
+}


### PR DESCRIPTION
- The `cozy-stack instances fsck` command is renamed `cozy-stack check fs`
- this command will now also check that the `trashed` attribute of files is consistent with the fullpath of its parent
- a new `cozy-stack check shared` command has been added to check io.cozy.shared documents.