### PR TITLE
feat: Support additional fields when copying accounts to ciphers

### DIFF
--- a/model/bitwarden/cipher.go
+++ b/model/bitwarden/cipher.go
@@ -27,6 +27,7 @@ const (
 	IdentityType   = 4
 )
 
+// Possible types for ciphers additional fields
 const (
 	FieldTypeText    = 0
 	FieldTypeHidden  = 1

--- a/model/bitwarden/cipher.go
+++ b/model/bitwarden/cipher.go
@@ -28,9 +28,9 @@ const (
 )
 
 const (
-    FieldTypeText = 0
-    FieldTypeHidden = 1
-    FieldTypeBoolean = 2
+	FieldTypeText    = 0
+	FieldTypeHidden  = 1
+	FieldTypeBoolean = 2
 )
 
 // LoginURI is a field for an URI.

--- a/model/bitwarden/cipher.go
+++ b/model/bitwarden/cipher.go
@@ -27,6 +27,12 @@ const (
 	IdentityType   = 4
 )
 
+const (
+    FieldTypeText = 0
+    FieldTypeHidden = 1
+    FieldTypeBoolean = 2
+)
+
 // LoginURI is a field for an URI.
 // See https://github.com/bitwarden/jslib/blob/master/src/models/api/loginUriApi.ts
 type LoginURI struct {

--- a/pkg/couchdb/couchdb.go
+++ b/pkg/couchdb/couchdb.go
@@ -386,8 +386,8 @@ func AllDoctypes(db Database) ([]string, error) {
 	return doctypes, nil
 }
 
-// GetDoc fetch a document by its docType and ID, out is filled with
-// the document by json.Unmarshal-ing
+// GetDoc fetches a document by its docType
+// It fills with the document by json.Unmarshal-ing
 func GetDoc(db Database, doctype, id string, out Doc) error {
 	var err error
 	id, err = validateDocID(id)

--- a/pkg/couchdb/couchdb.go
+++ b/pkg/couchdb/couchdb.go
@@ -386,8 +386,8 @@ func AllDoctypes(db Database) ([]string, error) {
 	return doctypes, nil
 }
 
-// GetDoc fetches a document by its docType
-// It fills with the document by json.Unmarshal-ing
+// GetDoc fetches a document by its docType and id
+// It fills with out by json.Unmarshal-ing
 func GetDoc(db Database, doctype, id string, out Doc) error {
 	var err error
 	id, err = validateDocID(id)

--- a/tests/integration/konnector/manifest.konnector
+++ b/tests/integration/konnector/manifest.konnector
@@ -20,5 +20,6 @@
   },
   "slug": "bankkonn",
   "type": "konnector",
-  "version": "0.1.0"
+  "version": "0.1.0",
+  "vendor_link": "http://examplebank.com"
 }

--- a/tests/integration/lib/account.rb
+++ b/tests/integration/lib/account.rb
@@ -14,6 +14,7 @@ class Account
     @aggregator = opts[:aggregator]
     @failure = opts[:failure]
     @type = opts[:type]
+    @auth = opts[:auth]
   end
 
   def as_json
@@ -21,7 +22,8 @@ class Account
       name: @name,
       log: @log,
       failure: @failure,
-      account_type: @type
+      account_type: @type,
+      auth: @auth
     }.compact
     if @aggregator
       json[:relationships] = {

--- a/tests/integration/lib/instance.rb
+++ b/tests/integration/lib/instance.rb
@@ -38,6 +38,11 @@ class Instance
     @stack.run_konnector self, slug, account_id
   end
 
+  def run_job(type, args)
+    @stack.run_job self, type, args
+  end
+
+
   def client
     @client ||= RestClient::Resource.new url
   end

--- a/tests/integration/lib/instance.rb
+++ b/tests/integration/lib/instance.rb
@@ -42,7 +42,6 @@ class Instance
     @stack.run_job self, type, args
   end
 
-
   def client
     @client ||= RestClient::Resource.new url
   end

--- a/tests/integration/lib/stack.rb
+++ b/tests/integration/lib/stack.rb
@@ -108,6 +108,16 @@ class Stack
     Job.new JSON.parse(out)
   end
 
+  def run_job(inst, type, args)
+    cmd = ["cozy-stack", "jobs", "run", type,
+           "--json", "'#{JSON.generate(args)}'",
+           "--port", @port, "--admin-port", @admin,
+           "--domain", inst.domain]
+    puts cmd.join(" ").green
+    out = `#{cmd.join(" ")}`.chomp
+    Job.new JSON.parse(out)
+  end
+
   def token_for(inst, doctypes)
     key = inst.domain + "/" + doctypes.join(" ")
     @tokens[key] ||= generate_token_for(inst, doctypes)

--- a/tests/integration/tests/account-to-ciphers.rb
+++ b/tests/integration/tests/account-to-ciphers.rb
@@ -1,0 +1,68 @@
+require_relative '../boot'
+require 'minitest/autorun'
+require 'pry-rescue/minitest' unless ENV['CI']
+
+def setup_ciphers(override_account_attrs = {})
+  puts "1"
+  inst = Instance.create name: "Alice"
+
+  bw = Bitwarden.new inst
+  bw.login
+  assert_equal bw.sync, "Syncing complete."
+
+  source_url = "file://" + File.expand_path("../konnector", __dir__)
+  inst.install_konnector "bankone", source_url
+
+  account_attrs = {
+    :type => "bankone",
+    :name => "Bank one",
+    :auth => {:login => "Isabelle", :zipcode => "64000"}
+  }
+
+  account_attrs = account_attrs.merge(override_account_attrs)
+
+  account = Account.create(inst, **account_attrs)
+
+  trigger = Trigger.create(
+    inst,
+    worker: "konnector",
+    type: "@cron",
+    arguments: "@monthly",
+    message: { konnector: "bankone", account: account.couch_id }
+  )
+
+  job = inst.run_job "migrations", {:type => "accounts-to-organization"}
+  10.times do
+    sleep 1
+    done = job.done?(inst)
+    break if done
+  end
+
+  bw.sync
+
+  return {
+    :bw => bw,
+    :account => account,
+    :inst => inst,
+    :trigger => trigger
+  }
+end
+
+
+describe "Copying accounts to bitwarden ciphers" do
+  it "copies accounts to ciphers" do
+    Helpers.scenario "account-to-ciphers"
+    Helpers.start_mailhog
+
+    res = setup_ciphers()
+    bw = res[:bw]
+
+    items = bw.items
+    assert_equal items.length, 1
+
+    cipher = items[0]
+    assert_equal cipher[:fields].length(), 1
+    assert_equal cipher[:fields][0][:name], "zipcode"
+    assert_equal cipher[:fields][0][:value], "64000"
+  end
+end

--- a/tests/integration/tests/accounts-to-ciphers.rb
+++ b/tests/integration/tests/accounts-to-ciphers.rb
@@ -3,7 +3,6 @@ require 'minitest/autorun'
 require 'pry-rescue/minitest' unless ENV['CI']
 
 def setup_ciphers(override_account_attrs = {})
-  puts "1"
   inst = Instance.create name: "Alice"
 
   bw = Bitwarden.new inst

--- a/tests/integration/tests/accounts-to-ciphers.rb
+++ b/tests/integration/tests/accounts-to-ciphers.rb
@@ -55,27 +55,19 @@ describe "Copying accounts to bitwarden ciphers" do
 
     res = setup_ciphers()
     bw = res[:bw]
+    inst = res[:inst]
+    account = res[:account]
 
     items = bw.items
     assert_equal items.length, 1
 
+    # Check cipher integrity
     cipher = items[0]
-    assert_equal cipher[:fields].length(), 1
+    assert_equal cipher[:fields].length, 1
     assert_equal cipher[:fields][0][:name], "zipcode"
     assert_equal cipher[:fields][0][:value], "64000"
-  end
 
-  it "links account to cipher and keeps auth attributes" do
-    Helpers.scenario "account-to-ciphers"
-    Helpers.start_mailhog
-
-    res = setup_ciphers()
-    account = res[:account]
-    inst = res[:inst]
-
-    bw = res[:bw]
-    cipher = bw.items[0]
-
+    # Check account integrity
     account = Helpers.couch.get_doc inst.domain, Account.doctype, account.couch_id
 
     # Check that the cipher has been linked

--- a/tests/integration/tests/accounts-to-ciphers.rb
+++ b/tests/integration/tests/accounts-to-ciphers.rb
@@ -13,9 +13,9 @@ def setup_ciphers(override_account_attrs = {})
   inst.install_konnector "bankone", source_url
 
   account_attrs = {
-    :type => "bankone",
-    :name => "Bank one",
-    :auth => {:login => "Isabelle", :zipcode => "64000"}
+    type: "bankone",
+    name: "Bank one",
+    auth: {login: "Isabelle", zipcode: "64000"}
   }
 
   account_attrs = account_attrs.merge(override_account_attrs)

--- a/tests/integration/tests/accounts-to-ciphers.rb
+++ b/tests/integration/tests/accounts-to-ciphers.rb
@@ -76,10 +76,7 @@ describe "Copying accounts to bitwarden ciphers" do
     bw = res[:bw]
     cipher = bw.items[0]
 
-    db_prefix = inst.db_prefix()
-    couch_client = RestClient::Resource.new "http://localhost:5984/"
-    res = couch_client["#{URI.escape(db_prefix)}%2Fio-cozy-accounts/#{account.couch_id}"].get()
-    account = JSON.parse(res.body)
+    account = Helpers.couch.get_doc inst.domain, Account.doctype, account.couch_id
 
     # Check that the cipher has been linked
     assert_equal account["relationships"]["vaultCipher"]["data"]["_id"], cipher[:id]

--- a/web/data/accounts.go
+++ b/web/data/accounts.go
@@ -44,7 +44,7 @@ func getAccount(c echo.Context) error {
 		return err
 	}
 
-	if encryptAccount(out) {
+	if EncryptAccount(out) {
 		if err = couchdb.UpdateDoc(instance, &out); err != nil {
 			return err
 		}
@@ -57,7 +57,7 @@ func getAccount(c echo.Context) error {
 	if perm.Type == permission.TypeKonnector ||
 		(c.QueryParam("include") == "credentials" && perm.Type == permission.TypeWebapp) {
 		// The account decryption is allowed for konnectors or for apps services
-		decryptAccount(out)
+		DecryptAccount(out)
 	}
 
 	return c.JSON(http.StatusOK, out.ToMapWithType())
@@ -109,7 +109,7 @@ func updateAccount(c echo.Context) error {
 		}
 	}
 
-	encryptAccount(doc)
+	EncryptAccount(doc)
 
 	errUpdate := couchdb.UpdateDoc(instance, &doc)
 	if errUpdate != nil {
@@ -121,7 +121,7 @@ func updateAccount(c echo.Context) error {
 		return err
 	}
 	if perm.Type == permission.TypeKonnector {
-		decryptAccount(doc)
+		DecryptAccount(doc)
 	}
 
 	return c.JSON(http.StatusOK, echo.Map{
@@ -133,14 +133,14 @@ func updateAccount(c echo.Context) error {
 	})
 }
 
-func encryptAccount(doc couchdb.JSONDoc) bool {
+func EncryptAccount(doc couchdb.JSONDoc) bool {
 	if config.GetVault().CredentialsEncryptorKey() != nil {
 		return encryptMap(doc.M)
 	}
 	return false
 }
 
-func decryptAccount(doc couchdb.JSONDoc) bool {
+func DecryptAccount(doc couchdb.JSONDoc) bool {
 	if config.GetVault().CredentialsDecryptorKey() != nil {
 		return decryptMap(doc.M)
 	}
@@ -241,7 +241,7 @@ func createAccount(c echo.Context) error {
 		return err
 	}
 
-	encryptAccount(doc)
+	EncryptAccount(doc)
 
 	if err := couchdb.CreateDoc(instance, &doc); err != nil {
 		return err

--- a/web/data/accounts.go
+++ b/web/data/accounts.go
@@ -133,6 +133,8 @@ func updateAccount(c echo.Context) error {
 	})
 }
 
+// Encrypts sensitive fields inside the account. The document
+// is modified in place.
 func EncryptAccount(doc couchdb.JSONDoc) bool {
 	if config.GetVault().CredentialsEncryptorKey() != nil {
 		return encryptMap(doc.M)
@@ -140,6 +142,8 @@ func EncryptAccount(doc couchdb.JSONDoc) bool {
 	return false
 }
 
+// Decrypts sensitive fields inside the account. The document
+// is modified in place.
 func DecryptAccount(doc couchdb.JSONDoc) bool {
 	if config.GetVault().CredentialsDecryptorKey() != nil {
 		return decryptMap(doc.M)

--- a/worker/migrations/migrate-accounts-to-organisation.go
+++ b/worker/migrations/migrate-accounts-to-organisation.go
@@ -171,8 +171,7 @@ func addCipherRelationshipToAccount(acc couchdb.JSONDoc, cipher *bitwarden.Ciphe
 		relationships = make(map[string]interface{})
 	}
 
-	rel := make(map[string][]VaultReference)
-	rel["data"] = []VaultReference{vRef}
+	rel := map[string]VaultReference{"data": vRef}
 
 	relationships[consts.BitwardenCipherRelationship] = rel
 

--- a/worker/migrations/migrate-accounts-to-organisation.go
+++ b/worker/migrations/migrate-accounts-to-organisation.go
@@ -153,11 +153,7 @@ func updateSettings(inst *instance.Instance, attempt int, logger *logrus.Entry) 
 	err = settings.UpdateRevisionDate(inst, setting)
 	if err != nil {
 		if couchdb.IsConflictError(err) && attempt < 2 {
-			err = updateSettings(inst, attempt+1, logger)
-		}
-
-		if err != nil {
-			return err
+			return updateSettings(inst, attempt+1, logger)
 		}
 	}
 	return nil
@@ -234,7 +230,6 @@ func migrateAccountsToOrganization(domain string) error {
 		}
 
 		link, err := getCipherLinkFromManifest(manifest)
-
 		if err != nil {
 			errm = multierror.Append(errm, err)
 			continue

--- a/worker/migrations/migrate-accounts-to-organisation.go
+++ b/worker/migrations/migrate-accounts-to-organisation.go
@@ -163,7 +163,7 @@ func updateSettings(inst *instance.Instance, attempt int, logger *logrus.Entry) 
 	return nil
 }
 
-func linkAccountToCipher(acc couchdb.JSONDoc, cipher *bitwarden.Cipher) {
+func addCipherRelationshipToAccount(acc couchdb.JSONDoc, cipher *bitwarden.Cipher) {
 	vRef := VaultReference{
 		ID:       cipher.ID(),
 		Type:     consts.BitwardenCiphers,
@@ -265,7 +265,7 @@ func migrateAccountsToOrganization(domain string) error {
 			errm = multierror.Append(errm, err)
 		}
 
-		linkAccountToCipher(accJson, cipher)
+		addCipherRelationshipToAccount(accJson, cipher)
 
 		data.EncryptAccount(accJson)
 

--- a/worker/migrations/migrate-accounts-to-organisation.go
+++ b/worker/migrations/migrate-accounts-to-organisation.go
@@ -19,7 +19,7 @@ import (
 	multierror "github.com/hashicorp/go-multierror"
 )
 
-type VaultReference struct {
+type vaultReference struct {
 	ID       string `json:"_id"`
 	Type     string `json:"_type"`
 	Protocol string `json:"_protocol"`
@@ -109,7 +109,6 @@ func buildCipher(orgKey []byte, manifest *app.KonnManifest, account couchdb.JSON
 			return nil, err
 		}
 
-		logger.Infof("Adding field %s = %s", name, value)
 		field := bitwarden.Field{
 			Name:  encName,
 			Value: encValue,
@@ -160,7 +159,7 @@ func updateSettings(inst *instance.Instance, attempt int, logger *logrus.Entry) 
 }
 
 func addCipherRelationshipToAccount(acc couchdb.JSONDoc, cipher *bitwarden.Cipher) {
-	vRef := VaultReference{
+	vRef := vaultReference{
 		ID:       cipher.ID(),
 		Type:     consts.BitwardenCiphers,
 		Protocol: consts.BitwardenProtocol,
@@ -171,7 +170,7 @@ func addCipherRelationshipToAccount(acc couchdb.JSONDoc, cipher *bitwarden.Ciphe
 		relationships = make(map[string]interface{})
 	}
 
-	rel := map[string]VaultReference{"data": vRef}
+	rel := map[string]vaultReference{"data": vRef}
 
 	relationships[consts.BitwardenCipherRelationship] = rel
 

--- a/worker/migrations/migrate-accounts-to-organisation.go
+++ b/worker/migrations/migrate-accounts-to-organisation.go
@@ -166,8 +166,8 @@ func addCipherRelationshipToAccount(acc couchdb.JSONDoc, cipher *bitwarden.Ciphe
 		Protocol: consts.BitwardenProtocol,
 	}
 
-	relationships := acc.M["relationships"].(map[string]interface{})
-	if relationships == nil {
+	relationships, ok := acc.M["relationships"].(map[string]interface{})
+	if !ok {
 		relationships = make(map[string]interface{})
 	}
 

--- a/worker/migrations/migrate-accounts-to-organisation.go
+++ b/worker/migrations/migrate-accounts-to-organisation.go
@@ -258,6 +258,7 @@ func migrateAccountsToOrganization(domain string) error {
 		}
 		if err := couchdb.CreateDoc(inst, cipher); err != nil {
 			errm = multierror.Append(errm, err)
+			continue
 		}
 
 		addCipherRelationshipToAccount(accJson, cipher)
@@ -267,6 +268,7 @@ func migrateAccountsToOrganization(domain string) error {
 		log.Infof("Updating doc %s", accJson)
 		if err := couchdb.UpdateDoc(inst, &accJson); err != nil {
 			errm = multierror.Append(errm, err)
+			continue
 		}
 	}
 

--- a/worker/migrations/migrate-accounts-to-organisation.go
+++ b/worker/migrations/migrate-accounts-to-organisation.go
@@ -1,0 +1,206 @@
+package migrations
+
+import (
+    "encoding/json"
+    "strings"
+
+    "github.com/cozy/cozy-stack/model/account"
+    "github.com/cozy/cozy-stack/model/app"
+    "github.com/cozy/cozy-stack/model/bitwarden"
+    "github.com/cozy/cozy-stack/model/bitwarden/settings"
+    "github.com/cozy/cozy-stack/model/instance"
+    "github.com/cozy/cozy-stack/model/job"
+    "github.com/cozy/cozy-stack/pkg/consts"
+    "github.com/cozy/cozy-stack/pkg/couchdb"
+    "github.com/cozy/cozy-stack/pkg/crypto"
+    "github.com/cozy/cozy-stack/pkg/metadata"
+
+    multierror "github.com/hashicorp/go-multierror"
+)
+
+
+type VaultReference struct {
+    ID       string `json:"_id"`
+    Type     string `json:"_type"`
+    Protocol string `json:"_protocol"`
+}
+
+func buildCipher(orgKey []byte, slug, username, password, url string) (*bitwarden.Cipher, error) {
+    key := orgKey[:32]
+    hmac := orgKey[32:]
+
+    ivURL := crypto.GenerateRandomBytes(16)
+    encURL, err := crypto.EncryptWithAES256HMAC(key, hmac, []byte(url), ivURL)
+    if err != nil {
+        return nil, err
+    }
+    u := bitwarden.LoginURI{URI: encURL, Match: nil}
+    uris := []bitwarden.LoginURI{u}
+
+    ivName := crypto.GenerateRandomBytes(16)
+    encName, err := crypto.EncryptWithAES256HMAC(key, hmac, []byte(slug), ivName)
+    if err != nil {
+        return nil, err
+    }
+
+    ivUsername := crypto.GenerateRandomBytes(16)
+    encUsername, err := crypto.EncryptWithAES256HMAC(key, hmac, []byte(username), ivUsername)
+    if err != nil {
+        return nil, err
+    }
+
+    ivPassword := crypto.GenerateRandomBytes(16)
+    encPassword, err := crypto.EncryptWithAES256HMAC(key, hmac, []byte(password), ivPassword)
+    if err != nil {
+        return nil, err
+    }
+
+    login := &bitwarden.LoginData{
+        Username: encUsername,
+        Password: encPassword,
+        URIs:     uris,
+    }
+
+    md := metadata.New()
+    md.DocTypeVersion = bitwarden.DocTypeVersion
+
+    c := bitwarden.Cipher{
+        Type:           bitwarden.LoginType,
+        Name:           encName,
+        Login:          login,
+        SharedWithCozy: true,
+        Metadata:       md,
+    }
+    return &c, nil
+}
+
+// Migrates all the encrypted accounts to Bitwarden ciphers.
+// It decrypts each account, reencrypt the fields with the organization key,
+// and save it in the ciphers database.
+func migrateAccountsToOrganization(domain string) error {
+    inst, err := instance.GetFromCouch(domain)
+    if err != nil {
+        return err
+    }
+    log := inst.Logger().WithField("nspace", "migration")
+
+    setting, err := settings.Get(inst)
+    if err != nil {
+        return err
+    }
+    // Get org key
+    if err := setting.EnsureCozyOrganization(inst); err != nil {
+        return err
+    }
+    orgKey, err := setting.OrganizationKey()
+    if err != nil {
+        return err
+    }
+
+    // Iterate over all triggers to get the konnectors with the associated account
+    jobsSystem := job.System()
+    triggers, err := jobsSystem.GetAllTriggers(inst)
+    if err != nil {
+        return err
+    }
+    var msg struct {
+        Account string `json:"account"`
+        Slug    string `json:"konnector"`
+    }
+
+    var errm error
+    for _, t := range triggers {
+        if t.Infos().WorkerType != "konnector" {
+            continue
+        }
+        err := t.Infos().Message.Unmarshal(&msg)
+        if err != nil || msg.Account == "" || msg.Slug == "" {
+            continue
+        }
+
+        manifest, err := app.GetKonnectorBySlug(inst, msg.Slug)
+        if err != nil {
+            log.Warningf("Could not get manifest for %s", msg.Slug)
+            continue
+        }
+        var link string
+        if manifest.VendorLink == nil {
+            log.Warningf("No vendor_link in manifest for %s", msg.Slug)
+            continue
+        }
+        if err := json.Unmarshal(*manifest.VendorLink, &link); err != nil {
+            errm = multierror.Append(errm, err)
+        }
+        link = strings.Trim(link, "'")
+        acc := &account.Account{}
+        if err := couchdb.GetDoc(inst, consts.Accounts, msg.Account, acc); err != nil {
+            errm = multierror.Append(errm, err)
+            continue
+        }
+        encryptedCreds := acc.Basic.EncryptedCredentials
+        login, password, err := account.DecryptCredentials(encryptedCreds)
+        if err != nil {
+            if err == account.ErrBadCredentials {
+                log.Warningf("Bad credentials for account %s - %s", acc.ID(), acc.AccountType)
+            } else {
+                errm = multierror.Append(errm, err)
+            }
+            continue
+        }
+        // Special case if the email field is used instead of login
+        if login == "" && acc.Basic.Email != "" {
+            login = acc.Basic.Email
+        }
+        cipher, err := buildCipher(orgKey, msg.Slug, login, password, link)
+        if err != nil {
+            errm = multierror.Append(errm, err)
+            continue
+        }
+        if err := couchdb.CreateDoc(inst, cipher); err != nil {
+            errm = multierror.Append(errm, err)
+        }
+        // Add vault relationship
+        vRef := VaultReference{
+            ID:       cipher.ID(),
+            Type:     consts.BitwardenCiphers,
+            Protocol: consts.BitwardenProtocol,
+        }
+        if acc.Relationships == nil {
+            acc.Relationships = make(map[string]interface{})
+        }
+        rel := make(map[string][]VaultReference)
+        rel["data"] = []VaultReference{vRef}
+        acc.Relationships[consts.BitwardenCipherRelationship] = rel
+
+        if err := couchdb.UpdateDoc(inst, acc); err != nil {
+            errm = multierror.Append(errm, err)
+        }
+    }
+    // Reload the setting in case the revision changed
+    setting, err = settings.Get(inst)
+    if err != nil {
+        errm = multierror.Append(errm, err)
+        return errm
+    }
+    // This flag is checked at the extension pre-login to run the migration or not
+    setting.ExtensionInstalled = true
+    err = settings.UpdateRevisionDate(inst, setting)
+    if err != nil {
+        if !couchdb.IsConflictError(err) {
+            errm = multierror.Append(errm, err)
+            return errm
+        }
+        // The settings have been updated elsewhere: retry
+        setting, err = settings.Get(inst)
+        if err != nil {
+            errm = multierror.Append(errm, err)
+            return errm
+        }
+        setting.ExtensionInstalled = true
+        err = settings.UpdateRevisionDate(inst, setting)
+        if err != nil {
+            errm = multierror.Append(errm, err)
+        }
+    }
+    return errm
+}

--- a/worker/migrations/migrate-accounts-to-organisation.go
+++ b/worker/migrations/migrate-accounts-to-organisation.go
@@ -1,284 +1,283 @@
 package migrations
 
 import (
-    "encoding/json"
-    "strings"
+	"encoding/json"
+	"strings"
 
-    "github.com/cozy/cozy-stack/model/app"
-    "github.com/cozy/cozy-stack/model/bitwarden"
-    "github.com/cozy/cozy-stack/model/bitwarden/settings"
-    "github.com/cozy/cozy-stack/model/instance"
-    "github.com/cozy/cozy-stack/model/job"
-    "github.com/cozy/cozy-stack/pkg/consts"
-    "github.com/cozy/cozy-stack/pkg/couchdb"
-    "github.com/cozy/cozy-stack/pkg/crypto"
-    "github.com/cozy/cozy-stack/pkg/metadata"
-    "github.com/cozy/cozy-stack/web/data"
-    "github.com/sirupsen/logrus"
+	"github.com/cozy/cozy-stack/model/app"
+	"github.com/cozy/cozy-stack/model/bitwarden"
+	"github.com/cozy/cozy-stack/model/bitwarden/settings"
+	"github.com/cozy/cozy-stack/model/instance"
+	"github.com/cozy/cozy-stack/model/job"
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/crypto"
+	"github.com/cozy/cozy-stack/pkg/metadata"
+	"github.com/cozy/cozy-stack/web/data"
+	"github.com/sirupsen/logrus"
 
-    multierror "github.com/hashicorp/go-multierror"
+	multierror "github.com/hashicorp/go-multierror"
 )
 
 type VaultReference struct {
-    ID       string `json:"_id"`
-    Type     string `json:"_type"`
-    Protocol string `json:"_protocol"`
+	ID       string `json:"_id"`
+	Type     string `json:"_type"`
+	Protocol string `json:"_protocol"`
 }
 
 func isAdditionalField(fieldName string) bool {
-    return !(
-        fieldName == "login" ||
-        fieldName == "password" ||
-        fieldName == "advancedFields")
+	return !(fieldName == "login" ||
+		fieldName == "password" ||
+		fieldName == "advancedFields")
 }
 
 // Builds a cipher from an io.cozy.account
-// 
+//
 // A raw JSONDoc is used to be able to access auth.fields
 func buildCipher(orgKey []byte, manifest *app.KonnManifest, account couchdb.JSONDoc, url string, logger *logrus.Entry) (*bitwarden.Cipher, error) {
-    logger.Infof("Building ciphers...")
+	logger.Infof("Building ciphers...")
 
-    auth, _ := account.M["auth"].(map[string]interface{})
+	auth, _ := account.M["auth"].(map[string]interface{})
 
-    username, _ := auth["login"].(string)
-    password, _ := auth["password"].(string)
-    email, _ := auth["email"].(string)
+	username, _ := auth["login"].(string)
+	password, _ := auth["password"].(string)
+	email, _ := auth["email"].(string)
 
-    // Special case if the email field is used instead of login
-    if username == "" && email != "" {
-        username = email
-    }
+	// Special case if the email field is used instead of login
+	if username == "" && email != "" {
+		username = email
+	}
 
-    key := orgKey[:32]
-    hmac := orgKey[32:]
+	key := orgKey[:32]
+	hmac := orgKey[32:]
 
-    ivURL := crypto.GenerateRandomBytes(16)
-    encURL, err := crypto.EncryptWithAES256HMAC(key, hmac, []byte(url), ivURL)
-    if err != nil {
-        return nil, err
-    }
-    u := bitwarden.LoginURI{URI: encURL, Match: nil}
-    uris := []bitwarden.LoginURI{u}
+	ivURL := crypto.GenerateRandomBytes(16)
+	encURL, err := crypto.EncryptWithAES256HMAC(key, hmac, []byte(url), ivURL)
+	if err != nil {
+		return nil, err
+	}
+	u := bitwarden.LoginURI{URI: encURL, Match: nil}
+	uris := []bitwarden.LoginURI{u}
 
-    ivName := crypto.GenerateRandomBytes(16)
-    encName, err := crypto.EncryptWithAES256HMAC(key, hmac, []byte(manifest.Name), ivName)
-    if err != nil {
-        return nil, err
-    }
+	ivName := crypto.GenerateRandomBytes(16)
+	encName, err := crypto.EncryptWithAES256HMAC(key, hmac, []byte(manifest.Name), ivName)
+	if err != nil {
+		return nil, err
+	}
 
-    ivUsername := crypto.GenerateRandomBytes(16)
-    encUsername, err := crypto.EncryptWithAES256HMAC(key, hmac, []byte(username), ivUsername)
-    if err != nil {
-        return nil, err
-    }
+	ivUsername := crypto.GenerateRandomBytes(16)
+	encUsername, err := crypto.EncryptWithAES256HMAC(key, hmac, []byte(username), ivUsername)
+	if err != nil {
+		return nil, err
+	}
 
-    ivPassword := crypto.GenerateRandomBytes(16)
-    encPassword, err := crypto.EncryptWithAES256HMAC(key, hmac, []byte(password), ivPassword)
-    if err != nil {
-        return nil, err
-    }
+	ivPassword := crypto.GenerateRandomBytes(16)
+	encPassword, err := crypto.EncryptWithAES256HMAC(key, hmac, []byte(password), ivPassword)
+	if err != nil {
+		return nil, err
+	}
 
-    login := &bitwarden.LoginData{
-        Username: encUsername,
-        Password: encPassword,
-        URIs:     uris,
-    }
+	login := &bitwarden.LoginData{
+		Username: encUsername,
+		Password: encPassword,
+		URIs:     uris,
+	}
 
-    md := metadata.New()
-    md.DocTypeVersion = bitwarden.DocTypeVersion
+	md := metadata.New()
+	md.DocTypeVersion = bitwarden.DocTypeVersion
 
-    bitwardenFields := make([]bitwarden.Field, 0)
+	bitwardenFields := make([]bitwarden.Field, 0)
 
-    for name, rawValue := range auth {
-        value, ok := rawValue.(string)
-        if (!ok) {
-            continue
-        }
-        if !isAdditionalField(name) {
-            continue
-        }
+	for name, rawValue := range auth {
+		value, ok := rawValue.(string)
+		if !ok {
+			continue
+		}
+		if !isAdditionalField(name) {
+			continue
+		}
 
-        ivName := crypto.GenerateRandomBytes(16)
-        encName, err := crypto.EncryptWithAES256HMAC(key, hmac, []byte(name), ivName)
-        if err != nil {
-            return nil, err
-        }
+		ivName := crypto.GenerateRandomBytes(16)
+		encName, err := crypto.EncryptWithAES256HMAC(key, hmac, []byte(name), ivName)
+		if err != nil {
+			return nil, err
+		}
 
-        ivValue := crypto.GenerateRandomBytes(16)
-        encValue, err := crypto.EncryptWithAES256HMAC(key, hmac, []byte(value), ivValue)
-        if err != nil {
-            return nil, err
-        }
+		ivValue := crypto.GenerateRandomBytes(16)
+		encValue, err := crypto.EncryptWithAES256HMAC(key, hmac, []byte(value), ivValue)
+		if err != nil {
+			return nil, err
+		}
 
-        logger.Infof("Adding field %s = %s", name, value)
-        field := bitwarden.Field{
-            Name: encName,
-            Value: encValue,
-            Type: bitwarden.FieldTypeText,
-        }
-        bitwardenFields = append(bitwardenFields, field)
-    }
+		logger.Infof("Adding field %s = %s", name, value)
+		field := bitwarden.Field{
+			Name:  encName,
+			Value: encValue,
+			Type:  bitwarden.FieldTypeText,
+		}
+		bitwardenFields = append(bitwardenFields, field)
+	}
 
-    c := bitwarden.Cipher{
-        Type:           bitwarden.LoginType,
-        Name:           encName,
-        Login:          login,
-        SharedWithCozy: true,
-        Metadata:       md,
-        Fields:         bitwardenFields,
-    }
-    return &c, nil
+	c := bitwarden.Cipher{
+		Type:           bitwarden.LoginType,
+		Name:           encName,
+		Login:          login,
+		SharedWithCozy: true,
+		Metadata:       md,
+		Fields:         bitwardenFields,
+	}
+	return &c, nil
 }
 
 func getCipherLinkFromManifest(manifest *app.KonnManifest) (string, error) {
-    var link string
-    if manifest.VendorLink == nil {
-        return "", nil
-    }
-    if err := json.Unmarshal(*manifest.VendorLink, &link); err != nil {
-        return "", err
-    }
-    link = strings.Trim(link, "'")
-    return link, nil
+	var link string
+	if manifest.VendorLink == nil {
+		return "", nil
+	}
+	if err := json.Unmarshal(*manifest.VendorLink, &link); err != nil {
+		return "", err
+	}
+	link = strings.Trim(link, "'")
+	return link, nil
 }
 
-func updateSettings(inst * instance.Instance, attempt int, logger *logrus.Entry) (error) {
-    logger.Infof("Updating bitwarden settings after migration...")
-    // Reload the setting in case the revision changed
-    setting, err := settings.Get(inst)
-    if err != nil {
-        return err
-    }
-    // This flag is checked at the extension pre-login to run the migration or not
-    setting.ExtensionInstalled = true
-    err = settings.UpdateRevisionDate(inst, setting)
-    if err != nil {
-        if couchdb.IsConflictError(err) && attempt < 2 {
-            err = updateSettings(inst, attempt + 1, logger)
-        }
+func updateSettings(inst *instance.Instance, attempt int, logger *logrus.Entry) error {
+	logger.Infof("Updating bitwarden settings after migration...")
+	// Reload the setting in case the revision changed
+	setting, err := settings.Get(inst)
+	if err != nil {
+		return err
+	}
+	// This flag is checked at the extension pre-login to run the migration or not
+	setting.ExtensionInstalled = true
+	err = settings.UpdateRevisionDate(inst, setting)
+	if err != nil {
+		if couchdb.IsConflictError(err) && attempt < 2 {
+			err = updateSettings(inst, attempt+1, logger)
+		}
 
-        if err != nil {
-            return err
-        }
-    }
-    return nil
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
-func linkAccountToCipher(acc couchdb.JSONDoc, cipher * bitwarden.Cipher) {
-    vRef := VaultReference{
-        ID:       cipher.ID(),
-        Type:     consts.BitwardenCiphers,
-        Protocol: consts.BitwardenProtocol,
-    }
+func linkAccountToCipher(acc couchdb.JSONDoc, cipher *bitwarden.Cipher) {
+	vRef := VaultReference{
+		ID:       cipher.ID(),
+		Type:     consts.BitwardenCiphers,
+		Protocol: consts.BitwardenProtocol,
+	}
 
-    relationships := acc.M["relationships"].(map[string]interface{})
-    if relationships == nil {
-        relationships = make(map[string]interface{})
-    }
+	relationships := acc.M["relationships"].(map[string]interface{})
+	if relationships == nil {
+		relationships = make(map[string]interface{})
+	}
 
-    rel := make(map[string][]VaultReference)
-    rel["data"] = []VaultReference{vRef}
+	rel := make(map[string][]VaultReference)
+	rel["data"] = []VaultReference{vRef}
 
-    relationships[consts.BitwardenCipherRelationship] = rel
+	relationships[consts.BitwardenCipherRelationship] = rel
 
-    acc.M["relationships"] = relationships
+	acc.M["relationships"] = relationships
 }
 
 // Migrates all the encrypted accounts to Bitwarden ciphers.
 // It decrypts each account, reencrypt the fields with the organization key,
 // and save it in the ciphers database.
 func migrateAccountsToOrganization(domain string) error {
-    inst, err := instance.GetFromCouch(domain)
-    if err != nil {
-        return err
-    }
-    log := inst.Logger().WithField("nspace", "migration")
+	inst, err := instance.GetFromCouch(domain)
+	if err != nil {
+		return err
+	}
+	log := inst.Logger().WithField("nspace", "migration")
 
-    setting, err := settings.Get(inst)
-    if err != nil {
-        return err
-    }
-    // Get org key
-    if err := setting.EnsureCozyOrganization(inst); err != nil {
-        return err
-    }
-    orgKey, err := setting.OrganizationKey()
-    if err != nil {
-        return err
-    }
+	setting, err := settings.Get(inst)
+	if err != nil {
+		return err
+	}
+	// Get org key
+	if err := setting.EnsureCozyOrganization(inst); err != nil {
+		return err
+	}
+	orgKey, err := setting.OrganizationKey()
+	if err != nil {
+		return err
+	}
 
-    // Iterate over all triggers to get the konnectors with the associated account
-    jobsSystem := job.System()
-    triggers, err := jobsSystem.GetAllTriggers(inst)
-    if err != nil {
-        return err
-    }
-    var msg struct {
-        Account string `json:"account"`
-        Slug    string `json:"konnector"`
-    }
+	// Iterate over all triggers to get the konnectors with the associated account
+	jobsSystem := job.System()
+	triggers, err := jobsSystem.GetAllTriggers(inst)
+	if err != nil {
+		return err
+	}
+	var msg struct {
+		Account string `json:"account"`
+		Slug    string `json:"konnector"`
+	}
 
-    var errm error
-    for _, t := range triggers {
-        if t.Infos().WorkerType != "konnector" {
-            continue
-        }
-        err := t.Infos().Message.Unmarshal(&msg)
-        if err != nil || msg.Account == "" || msg.Slug == "" {
-            continue
-        }
+	var errm error
+	for _, t := range triggers {
+		if t.Infos().WorkerType != "konnector" {
+			continue
+		}
+		err := t.Infos().Message.Unmarshal(&msg)
+		if err != nil || msg.Account == "" || msg.Slug == "" {
+			continue
+		}
 
-        manifest, err := app.GetKonnectorBySlug(inst, msg.Slug)
-        if err != nil {
-            log.Warningf("Could not get manifest for %s", msg.Slug)
-            continue
-        }
+		manifest, err := app.GetKonnectorBySlug(inst, msg.Slug)
+		if err != nil {
+			log.Warningf("Could not get manifest for %s", msg.Slug)
+			continue
+		}
 
-        link, err := getCipherLinkFromManifest(manifest)
+		link, err := getCipherLinkFromManifest(manifest)
 
-        if (err != nil) {
-            errm = multierror.Append(errm, err)
-            continue
-        }
+		if err != nil {
+			errm = multierror.Append(errm, err)
+			continue
+		}
 
-        if link == "" {
-            log.Warningf("No vendor_link in manifest for %s", msg.Slug)
-            continue
-        }
+		if link == "" {
+			log.Warningf("No vendor_link in manifest for %s", msg.Slug)
+			continue
+		}
 
-        var accJson couchdb.JSONDoc
+		var accJson couchdb.JSONDoc
 
-        if err := couchdb.GetDoc(inst, consts.Accounts, msg.Account, &accJson); err != nil {
-            errm = multierror.Append(errm, err)
-            continue
-        }
+		if err := couchdb.GetDoc(inst, consts.Accounts, msg.Account, &accJson); err != nil {
+			errm = multierror.Append(errm, err)
+			continue
+		}
 
-        accJson.Type = consts.Accounts
+		accJson.Type = consts.Accounts
 
-        data.DecryptAccount(accJson)
+		data.DecryptAccount(accJson)
 
-        cipher, err := buildCipher(orgKey, manifest, accJson, link, log)
-        if err != nil {
-            errm = multierror.Append(errm, err)
-            continue
-        }
-        if err := couchdb.CreateDoc(inst, cipher); err != nil {
-            errm = multierror.Append(errm, err)
-        }
+		cipher, err := buildCipher(orgKey, manifest, accJson, link, log)
+		if err != nil {
+			errm = multierror.Append(errm, err)
+			continue
+		}
+		if err := couchdb.CreateDoc(inst, cipher); err != nil {
+			errm = multierror.Append(errm, err)
+		}
 
-        linkAccountToCipher(accJson, cipher)
+		linkAccountToCipher(accJson, cipher)
 
-        data.EncryptAccount(accJson)
+		data.EncryptAccount(accJson)
 
-        log.Infof("Updating doc %s", accJson)
-        if err := couchdb.UpdateDoc(inst, &accJson); err != nil {
-            errm = multierror.Append(errm, err)
-        }
-    }
+		log.Infof("Updating doc %s", accJson)
+		if err := couchdb.UpdateDoc(inst, &accJson); err != nil {
+			errm = multierror.Append(errm, err)
+		}
+	}
 
-    err = updateSettings(inst, 0, log)
-    if (err != nil) {
-        errm = multierror.Append(errm, err)
-    }
-    return errm
+	err = updateSettings(inst, 0, log)
+	if err != nil {
+		errm = multierror.Append(errm, err)
+	}
+	return errm
 }

--- a/worker/migrations/migrations.go
+++ b/worker/migrations/migrations.go
@@ -1,17 +1,11 @@
 package migrations
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"runtime"
-	"strings"
 	"time"
 
-	"github.com/cozy/cozy-stack/model/account"
-	"github.com/cozy/cozy-stack/model/app"
-	"github.com/cozy/cozy-stack/model/bitwarden"
-	"github.com/cozy/cozy-stack/model/bitwarden/settings"
 	"github.com/cozy/cozy-stack/model/instance"
 	"github.com/cozy/cozy-stack/model/job"
 	"github.com/cozy/cozy-stack/model/note"
@@ -21,11 +15,10 @@ import (
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
-	"github.com/cozy/cozy-stack/pkg/crypto"
 	"github.com/cozy/cozy-stack/pkg/lock"
 	"github.com/cozy/cozy-stack/pkg/logger"
-	"github.com/cozy/cozy-stack/pkg/metadata"
 	"github.com/cozy/cozy-stack/pkg/utils"
+
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/ncw/swift"
 )
@@ -131,189 +124,9 @@ func migrateNotesMimeType(domain string) error {
 	return nil
 }
 
-// Migrate all the encrypted accounts to Bitwarden ciphers.
-// It decrypts each account, reencrypt the fields with the organization key,
-// and save it in the ciphers database.
-func migrateAccountsToOrganization(domain string) error {
-	inst, err := instance.GetFromCouch(domain)
-	if err != nil {
-		return err
-	}
-	log := inst.Logger().WithField("nspace", "migration")
 
-	setting, err := settings.Get(inst)
-	if err != nil {
-		return err
-	}
-	// Get org key
-	if err := setting.EnsureCozyOrganization(inst); err != nil {
-		return err
-	}
-	orgKey, err := setting.OrganizationKey()
-	if err != nil {
-		return err
-	}
 
-	// Iterate over all triggers to get the konnectors with the associated account
-	jobsSystem := job.System()
-	triggers, err := jobsSystem.GetAllTriggers(inst)
-	if err != nil {
-		return err
-	}
-	var msg struct {
-		Account string `json:"account"`
-		Slug    string `json:"konnector"`
-	}
-	type VaultReference struct {
-		ID       string `json:"_id"`
-		Type     string `json:"_type"`
-		Protocol string `json:"_protocol"`
-	}
-	var errm error
-	for _, t := range triggers {
-		if t.Infos().WorkerType != "konnector" {
-			continue
-		}
-		err := t.Infos().Message.Unmarshal(&msg)
-		if err != nil || msg.Account == "" || msg.Slug == "" {
-			continue
-		}
 
-		manifest, err := app.GetKonnectorBySlug(inst, msg.Slug)
-		if err != nil {
-			log.Warningf("Could not get manifest for %s", msg.Slug)
-			continue
-		}
-		var link string
-		if manifest.VendorLink == nil {
-			log.Warningf("No vendor_link in manifest for %s", msg.Slug)
-			continue
-		}
-		if err := json.Unmarshal(*manifest.VendorLink, &link); err != nil {
-			errm = multierror.Append(errm, err)
-		}
-		link = strings.Trim(link, "'")
-		acc := &account.Account{}
-		if err := couchdb.GetDoc(inst, consts.Accounts, msg.Account, acc); err != nil {
-			errm = multierror.Append(errm, err)
-			continue
-		}
-		encryptedCreds := acc.Basic.EncryptedCredentials
-		login, password, err := account.DecryptCredentials(encryptedCreds)
-		if err != nil {
-			if err == account.ErrBadCredentials {
-				log.Warningf("Bad credentials for account %s - %s", acc.ID(), acc.AccountType)
-			} else {
-				errm = multierror.Append(errm, err)
-			}
-			continue
-		}
-		// Special case if the email field is used instead of login
-		if login == "" && acc.Basic.Email != "" {
-			login = acc.Basic.Email
-		}
-		cipher, err := buildCipher(orgKey, msg.Slug, login, password, link)
-		if err != nil {
-			errm = multierror.Append(errm, err)
-			continue
-		}
-		if err := couchdb.CreateDoc(inst, cipher); err != nil {
-			errm = multierror.Append(errm, err)
-		}
-		// Add vault relationship
-		vRef := VaultReference{
-			ID:       cipher.ID(),
-			Type:     consts.BitwardenCiphers,
-			Protocol: consts.BitwardenProtocol,
-		}
-		if acc.Relationships == nil {
-			acc.Relationships = make(map[string]interface{})
-		}
-		rel := make(map[string][]VaultReference)
-		rel["data"] = []VaultReference{vRef}
-		acc.Relationships[consts.BitwardenCipherRelationship] = rel
-
-		if err := couchdb.UpdateDoc(inst, acc); err != nil {
-			errm = multierror.Append(errm, err)
-		}
-	}
-	// Reload the setting in case the revision changed
-	setting, err = settings.Get(inst)
-	if err != nil {
-		errm = multierror.Append(errm, err)
-		return errm
-	}
-	// This flag is checked at the extension pre-login to run the migration or not
-	setting.ExtensionInstalled = true
-	err = settings.UpdateRevisionDate(inst, setting)
-	if err != nil {
-		if !couchdb.IsConflictError(err) {
-			errm = multierror.Append(errm, err)
-			return errm
-		}
-		// The settings have been updated elsewhere: retry
-		setting, err = settings.Get(inst)
-		if err != nil {
-			errm = multierror.Append(errm, err)
-			return errm
-		}
-		setting.ExtensionInstalled = true
-		err = settings.UpdateRevisionDate(inst, setting)
-		if err != nil {
-			errm = multierror.Append(errm, err)
-		}
-	}
-	return errm
-}
-
-func buildCipher(orgKey []byte, slug, username, password, url string) (*bitwarden.Cipher, error) {
-	key := orgKey[:32]
-	hmac := orgKey[32:]
-
-	ivURL := crypto.GenerateRandomBytes(16)
-	encURL, err := crypto.EncryptWithAES256HMAC(key, hmac, []byte(url), ivURL)
-	if err != nil {
-		return nil, err
-	}
-	u := bitwarden.LoginURI{URI: encURL, Match: nil}
-	uris := []bitwarden.LoginURI{u}
-
-	ivName := crypto.GenerateRandomBytes(16)
-	encName, err := crypto.EncryptWithAES256HMAC(key, hmac, []byte(slug), ivName)
-	if err != nil {
-		return nil, err
-	}
-
-	ivUsername := crypto.GenerateRandomBytes(16)
-	encUsername, err := crypto.EncryptWithAES256HMAC(key, hmac, []byte(username), ivUsername)
-	if err != nil {
-		return nil, err
-	}
-
-	ivPassword := crypto.GenerateRandomBytes(16)
-	encPassword, err := crypto.EncryptWithAES256HMAC(key, hmac, []byte(password), ivPassword)
-	if err != nil {
-		return nil, err
-	}
-
-	login := &bitwarden.LoginData{
-		Username: encUsername,
-		Password: encPassword,
-		URIs:     uris,
-	}
-
-	md := metadata.New()
-	md.DocTypeVersion = bitwarden.DocTypeVersion
-
-	c := bitwarden.Cipher{
-		Type:           bitwarden.LoginType,
-		Name:           encName,
-		Login:          login,
-		SharedWithCozy: true,
-		Metadata:       md,
-	}
-	return &c, nil
-}
 
 func migrateToSwiftV3(domain string) error {
 	c := config.GetSwiftConnection()

--- a/worker/migrations/migrations.go
+++ b/worker/migrations/migrations.go
@@ -124,10 +124,6 @@ func migrateNotesMimeType(domain string) error {
 	return nil
 }
 
-
-
-
-
 func migrateToSwiftV3(domain string) error {
 	c := config.GetSwiftConnection()
 	inst, err := instance.GetFromCouch(domain)


### PR DESCRIPTION
Previously, only login and password were copied to bitwarden ciphers when vault was created. Since some konnectors rely on other fields (for example Pole Emploi relies on
"zipcode"), we have to copy other fields contained from the account "auth"
attribute.

The support for additional fields has been done in Harvest.

- [x] Implementation
- [x] Tests