### PR TITLE
Fix couchdb conflicts on directories

### DIFF
--- a/model/sharing/indexer.go
+++ b/model/sharing/indexer.go
@@ -293,20 +293,17 @@ func (s *sharingIndexer) UpdateDirDoc(olddoc, doc *vfs.DirDoc) error {
 	}
 	doc.SetRev(s.bulkRevs.Rev)
 	docs[0]["_rev"] = s.bulkRevs.Rev
+	newRevs := s.bulkRevs.Revisions
 	if olddoc != nil {
-		/*
-			XXX We cannot directly apply the revision chain as received by the remote
-			instance because it might create a CouchDB conflict if a rev does not
-			exist on the local instance. Therefore, we start from the last local rev
-			and apply all the higher revs received from the remote.
-		*/
-		chain := revsStructToChain(s.bulkRevs.Revisions)
+		// XXX We cannot directly apply the revision chain as received by the remote
+		// instance because it might create a CouchDB conflict if a rev does not
+		// exist on the local instance. Therefore, we start from the last local rev
+		// and apply all the higher revs received from the remote.
+		chain := revsStructToChain(newRevs)
 		newChain := MixupChainToResolveConflict(olddoc.DocRev, chain)
-		newRevs := revsChainToStruct(newChain)
-		docs[0]["_revisions"] = newRevs
-	} else {
-		docs[0]["_revisions"] = s.bulkRevs.Revisions
+		newRevs = revsChainToStruct(newChain)
 	}
+	docs[0]["_revisions"] = newRevs
 
 	if err := couchdb.BulkForceUpdateDocs(s.db, consts.Files, docs); err != nil {
 		return err


### PR DESCRIPTION
In some cases, unexpected CouchDB conflicts were produced on shared directories, leading to unexpected behaviors. For instance, after a delete on a conflicted directory, the winning revision branch was removed, but the lost one was still there, causing the directory to re-appear from the last conflicted revision.

These conflicts were caused because we force the revision list on shared documents in the [bulk_docs](https://docs.couchdb.org/en/stable/replication/protocol.html#upload-batch-of-changed-documents) replication route, as specified in the CouchDB documentation. In particular, the `new_edits` field, when set to false, avoids to generate a new revision, but can produce conflicts when a specified revision differ from a local one with the same number, e.g. `2-aa` vs `2-bb`.

See the [commit](https://github.com/cozy/cozy-stack/commit/252c0b74682ae93d6bcc01e348882bc666f7a568) description for more details about the problematic and its resolution.