### PR TITLE
Add lock on sharing reception

### DIFF
--- a/model/sharing/replicator.go
+++ b/model/sharing/replicator.go
@@ -578,6 +578,12 @@ func (s *Sharing) sendBulkDocs(inst *instance.Instance, m *Member, creds *Creden
 
 // ApplyBulkDocs is a multi-doctypes version of the POST _bulk_docs endpoint of CouchDB
 func (s *Sharing) ApplyBulkDocs(inst *instance.Instance, payload DocsByDoctype) error {
+	mu := lock.ReadWrite(inst, "sharings/"+s.SID+"/_bulk_docs")
+	if err := mu.Lock(); err != nil {
+		return err
+	}
+	defer mu.Unlock()
+
 	var refs []*SharedRef
 
 	for doctype, docs := range payload {

--- a/tests/integration/tests/sharing_conflicts.rb
+++ b/tests/integration/tests/sharing_conflicts.rb
@@ -283,7 +283,7 @@ describe 'A sharing' do
     file1.overwrite inst_a, content: Faker::SiliconValley.quote
     file2.overwrite inst_a, content: Faker::SiliconValley.quote
 
-    sleep 75
+    sleep 85
 
     # Check that the files have been synchronized
     da = File.join Helpers.current_dir, inst_a.domain, folder.name

--- a/tests/integration/tests/sharing_conflicts.rb
+++ b/tests/integration/tests/sharing_conflicts.rb
@@ -283,7 +283,7 @@ describe 'A sharing' do
     file1.overwrite inst_a, content: Faker::SiliconValley.quote
     file2.overwrite inst_a, content: Faker::SiliconValley.quote
 
-    sleep 85
+    sleep 120
 
     # Check that the files have been synchronized
     da = File.join Helpers.current_dir, inst_a.domain, folder.name


### PR DESCRIPTION
We used to have a lock when sending shared documents but not on their
reception. This could cause CouchDB conflicts when an instance receives
at the same time changes on the same document from different instances.

To illustrate a possible scenario of such conflict, let's assume a shared directory with the revisions list `{1-aa, 2-aa}` between the instances A, B and C.

At the same time, instance A receives changes from B and C, respectively with the revisions lists `{1-aa, 2-bb}` and `{1-aa, 2-cc, 3-cc}`.

Changes from B are applied: the revision `2-bb` conflicts with the local `2-aa`, and is solved by generating a new local update, producing the revisions list `{1-aa, 2-aa, 3-aa}`.

Simultaneously, the changes from C are applied: the last local revision is still seen as `2-aa` and the following revision list is forced: `{1-aa, 2-aa, 3-cc}`. Then, a CouchDB conflict is produced between `3-aa` and `3-cc`.