### PR TITLE
Fix shared integrity

### DIFF
--- a/model/sharing/shared.go
+++ b/model/sharing/shared.go
@@ -263,14 +263,15 @@ func updateRemovedForFiles(inst *instance.Instance, sharingID, dirID string, rul
 // UpdateShared updates the io.cozy.shared database when a document is
 // created/update/removed
 func UpdateShared(inst *instance.Instance, msg TrackMessage, evt TrackEvent) error {
-	mu := lock.ReadWrite(inst, "shared")
+	evt.Doc.Type = msg.DocType
+	sid := evt.Doc.Type + "/" + evt.Doc.ID()
+
+	mu := lock.ReadWrite(inst, "shared/"+sid)
 	if err := mu.Lock(); err != nil {
 		return err
 	}
 	defer mu.Unlock()
 
-	evt.Doc.Type = msg.DocType
-	sid := evt.Doc.Type + "/" + evt.Doc.ID()
 	var ref SharedRef
 	if err := couchdb.GetDoc(inst, consts.Shared, sid, &ref); err != nil {
 		if !couchdb.IsNotFoundError(err) {

--- a/pkg/couchdb/couchdb.go
+++ b/pkg/couchdb/couchdb.go
@@ -415,6 +415,22 @@ func GetDocRev(db Database, doctype, id, rev string, out Doc) error {
 	return makeRequest(db, doctype, http.MethodGet, url, nil, out)
 }
 
+// GetDocWithRevs fetches a document by its docType and ID.
+// out is filled with the document by json.Unmarshal-ing and contains the list
+// of all revisions
+func GetDocWithRevs(db Database, doctype, id string, out Doc) error {
+	var err error
+	id, err = validateDocID(id)
+	if err != nil {
+		return err
+	}
+	if id == "" {
+		return fmt.Errorf("Missing ID for GetDoc")
+	}
+	url := url.PathEscape(id) + "?revs=true"
+	return makeRequest(db, doctype, http.MethodGet, url, nil, out)
+}
+
 // EnsureDBExist creates the database for the doctype if it doesn't exist
 func EnsureDBExist(db Database, doctype string) error {
 	if _, err := DBStatus(db, doctype); IsNoDatabaseError(err) {

--- a/pkg/couchdb/couchdb_test.go
+++ b/pkg/couchdb/couchdb_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -138,6 +139,29 @@ func TestGetAllDocs(t *testing.T) {
 		assert.Equal(t, results[0].Test, "all_1")
 		assert.Equal(t, results[1].Test, "all_2")
 	}
+}
+
+func TestGetDocRevs(t *testing.T) {
+	doc := &testDoc{Test: "1"}
+	assert.NoError(t, CreateDoc(TestPrefix, doc))
+	rev1 := doc.TestRev
+	doc.Test = "2"
+	assert.NoError(t, UpdateDoc(TestPrefix, doc))
+	rev2 := doc.TestRev
+
+	res := &JSONDoc{}
+	err := GetDocWithRevs(TestPrefix, TestDoctype, doc.TestID, res)
+	revisions := res.M["_revisions"].(map[string]interface{})
+	ids := revisions["ids"].([]interface{})
+	assert.NoError(t, err)
+	assert.Len(t, ids, 2)
+	sliceRev1 := strings.SplitN(rev1, "-", 2)
+	assert.Len(t, sliceRev1, 2)
+	sliceRev2 := strings.SplitN(rev2, "-", 2)
+	assert.Len(t, sliceRev2, 2)
+
+	assert.Equal(t, ids[0].(string), sliceRev2[1])
+	assert.Equal(t, ids[1].(string), sliceRev1[1])
 }
 
 func TestBulkUpdateDocs(t *testing.T) {

--- a/tests/integration/tests/sharing_conflicts.rb
+++ b/tests/integration/tests/sharing_conflicts.rb
@@ -193,7 +193,7 @@ describe 'A sharing' do
     child1 = Folder.create inst_a, dir_id: folder.couch_id
     child2 = Folder.create inst_a, dir_id: folder.couch_id
     child1_1 = Folder.create inst_a, dir_id: child1.couch_id
-    Folder.create inst_a, dir_id: child1.couch_id
+    child1_2 = Folder.create inst_a, dir_id: child1.couch_id
     child1_1_1 = Folder.create inst_a, dir_id: child1_1.couch_id
     Folder.create inst_a, dir_id: child1_1.couch_id
     Folder.create inst_a, dir_id: child1_1.couch_id
@@ -264,9 +264,14 @@ describe 'A sharing' do
     file1.rename inst_a, Faker::Internet.slug
     file1.rename inst_a, Faker::Internet.slug
     file2.rename inst_a, Faker::Internet.slug
+
     child1_1_1c.move_to inst_c, child1_c.couch_id
     child1_1_1c.rename inst_c, Faker::Internet.slug
     child1_1_1b.move_to inst_b, child2_b.couch_id
+
+    child1_1_1.move_to inst_a, child1_2.couch_id
+    child1_1_1.rename inst_a, Faker::Internet.slug
+
     file2_b.overwrite inst_b, content: Faker::Friends.quote
     file2_c.rename inst_c, Faker::Internet.slug
     file2_c.overwrite inst_c, content: Faker::GameOfThrones.quote
@@ -275,7 +280,7 @@ describe 'A sharing' do
     file1.overwrite inst_a, content: Faker::SiliconValley.quote
     file2.overwrite inst_a, content: Faker::SiliconValley.quote
 
-    sleep 180 # TODO can we decrease this timeout?
+    sleep 80
 
     # Check that the files have been synchronized
     da = File.join Helpers.current_dir, inst_a.domain, folder.name


### PR DESCRIPTION
When a shared document has updates both from local and remote instances,
the remote revisions might be saved before the local ones in the
revisions tree. If there are several updates, this could cause integrity
issues in the tree. Here is an illustrative scenario:

1. A shared doc has the revision 1-a.
2. The doc is updated twice locally, producing the revisions 2-a and 3-a.
3. The doc is also updated twice on a remote instance, producing the revisions 4-b and 5-b.
4. The revision tree has still the 1-a revision and the following chain is saved: `[3-a, 4-b, 5-b]`. It corresponds to the last local revision (3-a) and the incoming remote revisions (4-b, 5-b).
5. The 2-a revision will be later saved in the tree, in a new branch starting from 1-a.

To solve this, at the step 4, we retrieve the revision history of the
doc, compare the incoming ones and save this revision chain:
`[2-a, 3-a, 4-b, 5-b]`