### PR TITLE
Fix multiple conflicts on the same file

### DIFF
--- a/model/sharing/files.go
+++ b/model/sharing/files.go
@@ -696,7 +696,14 @@ func (s *Sharing) resolveConflictSamePath(inst *instance.Instance, visitorID, pt
 	if err != nil {
 		return "", err
 	}
-	name := conflictName(path.Base(pth), f != nil)
+	indexer := vfs.NewCouchdbIndexer(inst)
+	var dirID string
+	if d != nil {
+		dirID = d.DirID
+	} else {
+		dirID = f.DirID
+	}
+	name := conflictName(indexer, dirID, path.Base(pth), f != nil)
 	if s.Owner {
 		return name, nil
 	}

--- a/model/sharing/revisions_test.go
+++ b/model/sharing/revisions_test.go
@@ -347,17 +347,6 @@ func TestIndexerCreateBogusPrevRev(t *testing.T) {
 	assert.Equal(t, indexer.bulkRevs.Rev, rev)
 }
 
-func TestConflictName(t *testing.T) {
-	assert.Equal(t, "foo (2)", conflictName("foo", false))
-	assert.Equal(t, "foo (3)", conflictName("foo (2)", false))
-	assert.Equal(t, "foo (1000)", conflictName("foo (999)", false))
-	assert.Equal(t, "foo () (2)", conflictName("foo ()", false))
-
-	assert.Equal(t, "bar (2)", conflictName("bar", true))
-	assert.Equal(t, "bar (2).txt", conflictName("bar.txt", true))
-	assert.Equal(t, "bar (3).txt", conflictName("bar (2).txt", true))
-}
-
 func TestConflictID(t *testing.T) {
 	id := "d9dfd293577eea9f6d29d140259fa71d"
 	rev := "3-bf26bb2d42b0abf6a715ccf949d8e5f4"

--- a/model/sharing/upload.go
+++ b/model/sharing/upload.go
@@ -732,7 +732,7 @@ func (s *Sharing) uploadLostConflict(inst *instance.Instance, target *FileDocWit
 		body.Close()
 		return nil
 	}
-	newdoc.DocName = conflictName(newdoc.DocName, true)
+	newdoc.DocName = conflictName(indexer, newdoc.DirID, newdoc.DocName, true)
 	newdoc.DocRev = ""
 	newdoc.ResetFullpath()
 	file, err := fs.CreateFile(newdoc, nil)
@@ -758,7 +758,7 @@ func (s *Sharing) uploadWonConflict(inst *instance.Instance, src *vfs.FileDoc) e
 	if _, err := fs.FileByID(dst.DocID); err != os.ErrNotExist {
 		return err
 	}
-	dst.DocName = conflictName(dst.DocName, true)
+	dst.DocName = conflictName(indexer, dst.DirID, dst.DocName, true)
 	dst.ResetFullpath()
 	content, err := fs.OpenFile(src)
 	if err != nil {

--- a/tests/integration/tests/sharing_conflicts.rb
+++ b/tests/integration/tests/sharing_conflicts.rb
@@ -280,7 +280,7 @@ describe 'A sharing' do
     file1.overwrite inst_a, content: Faker::SiliconValley.quote
     file2.overwrite inst_a, content: Faker::SiliconValley.quote
 
-    sleep 80
+    sleep 60
 
     # Check that the files have been synchronized
     da = File.join Helpers.current_dir, inst_a.domain, folder.name


### PR DESCRIPTION
When a shared file is updated often by several members of the sharing,
it will lead to conflicts. And if several conflicts happen on the same
file, the stack can try to use a new name for the old content that was
already used. It fails and it aborts the upload of the new content. With
this commit, the stack will try harder to avoid already used names for
conflicts.