### PR TITLE
Allow setting UpdatedAt during file update

### DIFF
--- a/docs/files.md
+++ b/docs/files.md
@@ -428,6 +428,7 @@ The `created_at` field will be the first valid value in this list:
 
 The `updated_at` field will be the first value in this list:
 
+- the datetime extracted from the EXIF for a photo if it is greater than the other values
 - the `UpdatedAt` parameter from the query-string
 - the `Date` HTTP header
 - the current time from the server.
@@ -730,12 +731,21 @@ Get a thumbnail of a file (for an image only). `:format` can be `small`
 
 Overwrite a file
 
+The `updated_at` field will be the first value in this list:
+
+- the datetime extracted from the EXIF for a photo if it is greater than the other values
+- the `UpdatedAt` parameter from the query-string
+- the `Date` HTTP header
+- the current time from the server.
+
 #### Query-String
 
-| Parameter  | Description                         |
-| ---------- | ----------------------------------- |
-| Tags       | an array of tags                    |
-| MetadataID | the identifier of a metadata object |
+| Parameter  | Description                                        |
+| ---------- | -------------------------------------------------- |
+| Tags       | an array of tags                                   |
+| Executable | `true` if the file is executable (UNIX permission) |
+| MetadataID | the identifier of a metadata object                |
+| UpdatedAt  | the modification date of the file                  |
 
 #### HTTP headers
 

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -208,6 +208,12 @@ func OverwriteFileContentHandler(c echo.Context) (err error) {
 		return WrapVfsError(err)
 	}
 
+	if updated := c.QueryParam("UpdatedAt"); updated != "" {
+		if at, err2 := time.Parse(time.RFC3339, updated); err2 == nil {
+			newdoc.UpdatedAt = at
+		}
+	}
+
 	newdoc.ReferencedBy = olddoc.ReferencedBy
 
 	if err = CheckIfMatch(c, olddoc.Rev()); err != nil {


### PR DESCRIPTION
The `UpdatedAt` parameter was used during a file creation but not
during a file update.
Updating the `CreatedAt` field is not allowed so we don't try to fetch
and parse this parameter.