### PR TITLE
Allow to override an account type per context

### DIFF
--- a/docs/konnectors-workflow.md
+++ b/docs/konnectors-workflow.md
@@ -388,6 +388,21 @@ secrets are needed for this service.
 
 The secret is given to the konnector in the `COZY_PARAMETERS` env variable.
 
+### Overloading an account type for a given context
+
+It is possible to use a different account type for a given context, by creating
+a new document with an id prefix by the context name and `/`. For example, a
+different secret can be used in the `foobar` context by injecting this document
+in `secrets/io-cozy-account_types`:
+
+```
+{
+    "_id": "foobar/service.example",
+    "grant_mode": "secret",
+    "slug": "service",
+    "secret": "th1$_1$_n0t_th3_s4m3_s3cr3t!"
+}
+```
 
 ### Reminder OAuth flow
 

--- a/model/account/type_test.go
+++ b/model/account/type_test.go
@@ -1,0 +1,42 @@
+package account
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterByContext(t *testing.T) {
+	bar := &AccountType{
+		DocID:     "bar.example",
+		Slug:      "my-konnector",
+		GrantMode: "secret",
+		Secret:    "bar",
+	}
+	foobar := &AccountType{
+		DocID:     "foo/bar.example",
+		Slug:      "my-konnector",
+		GrantMode: "secret",
+		Secret:    "foobar",
+	}
+	qux := &AccountType{
+		DocID:     "qux.example",
+		Slug:      "my-konnector",
+		GrantMode: "secret",
+		Secret:    "qux",
+	}
+	types := []*AccountType{bar, foobar, qux}
+
+	filtered := filterByContext(types, "foo")
+	assert.Len(t, filtered, 2)
+	assert.Contains(t, filtered, foobar)
+	assert.Contains(t, filtered, qux)
+
+	filtered = filterByContext(types, "courge")
+	assert.Len(t, filtered, 2)
+	assert.Contains(t, filtered, bar)
+	assert.Contains(t, filtered, qux)
+
+	filtered = filterByContext([]*AccountType{foobar}, "courge")
+	assert.Len(t, filtered, 0)
+}

--- a/worker/exec/konnector.go
+++ b/worker/exec/konnector.go
@@ -465,7 +465,7 @@ func (w *konnectorWorker) Slug() string {
 func (w *konnectorWorker) PrepareCmdEnv(ctx *job.WorkerContext, i *instance.Instance) (cmd string, env []string, err error) {
 	var parameters interface{} = w.man.Parameters
 
-	accountTypes, err := account.FindAccountTypesBySlug(w.slug)
+	accountTypes, err := account.FindAccountTypesBySlug(w.slug, i.ContextName)
 	if err == nil && len(accountTypes) == 1 && accountTypes[0].GrantMode == "secret" {
 		secret := accountTypes[0].Secret
 		if w.man.Parameters == nil {

--- a/worker/exec/konnector_test.go
+++ b/worker/exec/konnector_test.go
@@ -229,7 +229,7 @@ echo "{\"type\": \"params\", \"message\": ${SECRET} }"
 	assert.NoError(t, err)
 	defer func() {
 		// Clean the account types
-		ats, _ := account.FindAccountTypesBySlug("my-konnector-1")
+		ats, _ := account.FindAccountTypesBySlug("my-konnector-1", "all-contexts")
 		for _, at = range ats {
 			_ = couchdb.DeleteDoc(couchdb.GlobalSecretsDB, at)
 		}


### PR DESCRIPTION
Until now, the same account type document was used for all the instances on a same server. It is now possible to override the account type of a konnector for a given context, by creating a new document with an id prefixed by the context name and /.