### PR TITLE
Ask reuploading files after disk quota increase

### DIFF
--- a/docs/sharing.md
+++ b/docs/sharing.md
@@ -1303,6 +1303,26 @@ Authorization: Bearer ...
 HTTP/1.1 204 No Content
 ```
 
+### POST /sharings/:sharing-id/reupload
+
+This is an internal route for the stack. It is called when the disk quota of an
+instance is increased to ask for the others instances on this sharing to try to
+reupload files without waiting for the normal retry period.
+
+#### Request
+
+```http
+POST /sharings/ce8835a061d0ef68947afe69a0046722/reupload HTTP/1.1
+Host: bob.example.net
+Authorization: Bearer ...
+```
+
+#### Response
+
+```http
+HTTP/1.1 204 No Content
+```
+
 ### DELETE /sharings/:sharing-id/initial
 
 This internal route is used by the sharer to inform a recipient's cozy that the

--- a/model/sharing/reupload.go
+++ b/model/sharing/reupload.go
@@ -1,0 +1,94 @@
+package sharing
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/cozy/cozy-stack/client/request"
+	"github.com/cozy/cozy-stack/model/instance"
+	"github.com/cozy/cozy-stack/model/instance/lifecycle"
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	multierror "github.com/hashicorp/go-multierror"
+)
+
+func init() {
+	lifecycle.AskReupload = AskReupload
+}
+
+// AskReupload is used when the disk quota of an instance is increased to tell
+// to the other instances that have a sharing with it that they can retry to
+// upload files.
+func AskReupload(inst *instance.Instance) error {
+	// XXX If there are more than 100 sharings, it is probably better to rely
+	// on the existing retry mechanism than asking for all of the sharings, as
+	// it may slow down the sharings.
+	req := &couchdb.AllDocsRequest{
+		Limit: 100,
+	}
+	var sharings []*Sharing
+	err := couchdb.GetAllDocs(inst, consts.Sharings, req, &sharings)
+	if err != nil {
+		return err
+	}
+	var errm error
+	for _, s := range sharings {
+		if !s.Active || s.FirstFilesRule() == nil {
+			continue
+		}
+		if s.Owner {
+			for i, m := range s.Members {
+				if i == 0 {
+					continue // skip the owner
+				}
+				if m.Status != MemberStatusReady {
+					continue
+				}
+				if err := askReuploadTo(inst, s, &s.Members[i], &s.Credentials[i-1]); err != nil {
+					errm = multierror.Append(errm, err)
+				}
+			}
+		} else {
+			if err := askReuploadTo(inst, s, &s.Members[0], &s.Credentials[0]); err != nil {
+				errm = multierror.Append(errm, err)
+			}
+		}
+	}
+	return errm
+}
+
+func askReuploadTo(inst *instance.Instance, s *Sharing, m *Member, c *Credentials) error {
+	if c == nil || c.AccessToken == nil {
+		return nil
+	}
+	u, err := url.Parse(m.Instance)
+	if err != nil {
+		return err
+	}
+	opts := &request.Options{
+		Method: http.MethodPost,
+		Scheme: u.Scheme,
+		Domain: u.Host,
+		Path:   "/sharings/" + s.SID + "/reupload",
+		Headers: request.Headers{
+			"Authorization": "Bearer " + c.AccessToken.AccessToken,
+		},
+	}
+	res, err := request.Req(opts)
+	if res != nil && res.StatusCode/100 == 4 {
+		res, err = RefreshToken(inst, s, m, c, opts, nil)
+	}
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	return nil
+}
+
+// PushUploadJob pushs a job for the share-upload worker, to try again to
+// reupload files.
+func PushUploadJob(s *Sharing, inst *instance.Instance) {
+	if s.Active && s.FirstFilesRule() != nil {
+		s.pushJob(inst, "share-upload")
+	}
+}

--- a/web/sharings/replicator.go
+++ b/web/sharings/replicator.go
@@ -132,6 +132,18 @@ func FileHandler(c echo.Context) error {
 	return c.NoContent(http.StatusNoContent)
 }
 
+// ReuploadHandler is used to try sending again files
+func ReuploadHandler(c echo.Context) error {
+	inst := middlewares.GetInstance(c)
+	sharingID := c.Param("sharing-id")
+	s, err := sharing.FindSharing(inst, sharingID)
+	if err != nil {
+		return wrapErrors(err)
+	}
+	sharing.PushUploadJob(s, inst)
+	return c.NoContent(http.StatusNoContent)
+}
+
 // EndInitial is used for ending the initial sync phase of a sharing
 func EndInitial(c echo.Context) error {
 	inst := middlewares.GetInstance(c)
@@ -154,6 +166,7 @@ func replicatorRoutes(router *echo.Group) {
 	group.GET("/:sharing-id/io.cozy.files/:id", GetFolder, checkSharingReadPermissions)
 	group.PUT("/:sharing-id/io.cozy.files/:id/metadata", SyncFile, checkSharingWritePermissions)
 	group.PUT("/:sharing-id/io.cozy.files/:id", FileHandler, checkSharingWritePermissions)
+	group.POST("/:sharing-id/reupload", ReuploadHandler, checkSharingReadPermissions)
 	group.DELETE("/:sharing-id/initial", EndInitial, checkSharingWritePermissions)
 }
 


### PR DESCRIPTION
When the disk quota for an instance has increased, we look at the
sharing and ask the other instances to reupload the files. It is a
better user experience, as someone who just paid for premium to get
space will expect that the sharing will synchronize shortly after that.