### PR TITLE
feat: allow connectors to be run in cozy-app-dev image

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -65,6 +65,11 @@ RUN set -eux; apt-get update \
   && mv ./rel/couchdb /usr/local \
   && cd / \
   && rm -rf /usr/src/couchdb \
+  && curl -fsSL --compressed https://nodejs.org/dist/v12.9.1/node-v12.9.1-linux-x64.tar.xz \
+  && tar -xJf "node-v12.9.1-linux-x64.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+  && rm "node-v12.9.1-linux-x64.tar.xz" \
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+  && node --version \
   # Cleanup
   && apt-get purge -y \
     build-essential \
@@ -82,6 +87,7 @@ COPY --from=build \
   /app/cozy-stack \
   /app/scripts/docker-entrypoint.sh \
   /app/scripts/cozy-app-dev.sh \
+  /app/scripts/konnector-node-run.sh \
   /app/MailHog \
   /usr/bin/
 

--- a/scripts/cozy-app-dev.sh
+++ b/scripts/cozy-app-dev.sh
@@ -8,6 +8,7 @@ set -m
 [ -z "${COZY_STACK_PASS}" ] && COZY_STACK_PASS="cozy"
 [ -z "${COZY_STACK_ADMIN_PORT}" ] && COZY_STACK_ADMIN_PORT="6060"
 [ -z "${COUCHDB_URL}" ] && COUCHDB_URL="http://localhost:5984/"
+[ -n "${COZY_KONNECTORS_CMD}" ] && COZY_KONNECTORS_CMD_OPTION="--konnectors-cmd $COZY_KONNECTORS_CMD"
 
 if [ -d "${COZY_STACK_PATH}" ] && [ -f "${COZY_STACK_PATH}/cozy-stack" ]; then
 	COZY_STACK_PATH="${COZY_STACK_PATH}/cozy-stack"
@@ -109,6 +110,7 @@ do_start() {
 		--admin-port "${COZY_STACK_ADMIN_PORT}" \
 		--couchdb-url "${COUCHDB_URL}" \
 		--mailhog \
+		${COZY_KONNECTORS_CMD_OPTION} \
 		--fs-url "file://localhost${vfsdir}" &
 
 	wait_for "${COZY_STACK_HOST}:${COZY_STACK_PORT}/version/" "cozy-stack"

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -26,6 +26,6 @@ else
 	fi
 fi
 
-/usr/bin/cozy-app-dev.sh \
+COZY_KONNECTORS_CMD="/usr/bin/konnector-node-run.sh" /usr/bin/cozy-app-dev.sh \
 	-d "${appdir}" \
 	-f /data/cozy-storage


### PR DESCRIPTION
This way, connectors can be run in the cozy-app-dev image without any special setup, but this add
75Mo to the cozy-app-dev image.
Another solution would be to create another docker image specific for this goal.