### PR TITLE
Defaults to default swift layout if parameter is absent

### DIFF
--- a/web/instances/instances.go
+++ b/web/instances/instances.go
@@ -79,6 +79,8 @@ func createHandler(c echo.Context) error {
 		if err != nil {
 			return wrapError(err)
 		}
+	} else {
+		opts.SwiftLayout = -1
 	}
 	if diskQuota := c.QueryParam("DiskQuota"); diskQuota != "" {
 		opts.DiskQuota, err = strconv.ParseInt(diskQuota, 10, 64)


### PR DESCRIPTION
When creating an instance through admin API and `SwiftLayout` parameter is ommited, it uses the default value of `0` which means swift layout v1 regardless of configured default swift layout.
This PR fixes this behaviour by using the configured default swift layout if the `SwiftLayout` parameter is ommited when calling the instance creation admin API