### PR TITLE
Disable instance creation using swift layout v1

### DIFF
--- a/model/instance/lifecycle/create.go
+++ b/model/instance/lifecycle/create.go
@@ -3,6 +3,7 @@ package lifecycle
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"strconv"
 	"strings"
 
@@ -105,9 +106,13 @@ func CreateWithoutHooks(opts *Options) (*instance.Instance, error) {
 	i.OAuthSecret = crypto.GenerateRandomBytes(instance.OauthSecretLen)
 	i.CLISecret = crypto.GenerateRandomBytes(instance.OauthSecretLen)
 
-	if 0 <= opts.SwiftLayout && opts.SwiftLayout <= 2 {
+	switch opts.SwiftLayout {
+	case 0:
+		err = errors.New("Swift layout v1 disabled for instance creation")
+		return nil, err
+	case 1, 2:
 		i.SwiftLayout = opts.SwiftLayout
-	} else {
+	default:
 		i.SwiftLayout = config.GetConfig().Fs.DefaultLayout
 	}
 

--- a/model/instance/lifecycle/create.go
+++ b/model/instance/lifecycle/create.go
@@ -106,14 +106,16 @@ func CreateWithoutHooks(opts *Options) (*instance.Instance, error) {
 	i.OAuthSecret = crypto.GenerateRandomBytes(instance.OauthSecretLen)
 	i.CLISecret = crypto.GenerateRandomBytes(instance.OauthSecretLen)
 
-	switch opts.SwiftLayout {
-	case 0:
-		err = errors.New("Swift layout v1 disabled for instance creation")
-		return nil, err
-	case 1, 2:
-		i.SwiftLayout = opts.SwiftLayout
-	default:
-		i.SwiftLayout = config.GetConfig().Fs.DefaultLayout
+	switch config.FsURL().Scheme {
+	case config.SchemeSwift, config.SchemeSwiftSecure:
+		switch opts.SwiftLayout {
+		case 0:
+			return nil, errors.New("Swift layout v1 disabled for instance creation")
+		case 1, 2:
+			i.SwiftLayout = opts.SwiftLayout
+		default:
+			i.SwiftLayout = config.GetConfig().Fs.DefaultLayout
+		}
 	}
 
 	if opts.AuthMode != "" {

--- a/model/instance/lifecycle/lifecycle_test.go
+++ b/model/instance/lifecycle/lifecycle_test.go
@@ -42,13 +42,12 @@ func TestCreateInstance(t *testing.T) {
 
 func TestCreateInstanceWithFewSettings(t *testing.T) {
 	inst, err := lifecycle.Create(&lifecycle.Options{
-		Domain:      "test2.cozycloud.cc",
-		Timezone:    "Europe/Berlin",
-		Email:       "alice@example.com",
-		PublicName:  "Alice",
-		Passphrase:  "password",
-		SwiftLayout: 1,
-		Settings:    "offer:freemium,context:my_context,auth_mode:two_factor_mail,uuid:XXX,locale:en,tos:20151111,oidc_id:oidc_42",
+		Domain:     "test2.cozycloud.cc",
+		Timezone:   "Europe/Berlin",
+		Email:      "alice@example.com",
+		PublicName: "Alice",
+		Passphrase: "password",
+		Settings:   "offer:freemium,context:my_context,auth_mode:two_factor_mail,uuid:XXX,locale:en,tos:20151111,oidc_id:oidc_42",
 	})
 
 	assert.NoError(t, err)
@@ -66,7 +65,6 @@ func TestCreateInstanceWithFewSettings(t *testing.T) {
 	assert.Equal(t, inst.TOSSigned, "1.0.0-20151111")
 	assert.Equal(t, inst.ContextName, "my_context")
 	assert.Equal(t, inst.AuthMode, instance.TwoFactorMail)
-	assert.Equal(t, inst.SwiftLayout, 1)
 }
 
 func TestCreateInstanceWithMoreSettings(t *testing.T) {
@@ -83,7 +81,6 @@ func TestCreateInstanceWithMoreSettings(t *testing.T) {
 		PublicName:  "Alice",
 		AuthMode:    "two_factor_mail",
 		Passphrase:  "password",
-		SwiftLayout: 2,
 		Settings:    "offer:freemium",
 	})
 
@@ -102,7 +99,6 @@ func TestCreateInstanceWithMoreSettings(t *testing.T) {
 	assert.Equal(t, inst.TOSSigned, "1.0.0-20151111")
 	assert.Equal(t, inst.ContextName, "my_context")
 	assert.Equal(t, inst.AuthMode, instance.TwoFactorMail)
-	assert.Equal(t, inst.SwiftLayout, 2)
 }
 
 func TestCreateInstanceBadDomain(t *testing.T) {


### PR DESCRIPTION
Instance creation using swift layout v1 is known to be bugguy since the introduction of instance prefix somewhere during life of swift layout v2, leaving an instance with unexpected swift containers using prefix for file and version container but using domain for data (thumbnails) container.
We still neeed to keep swift layout v1 compatibility for old instances but don't need to create new instances in that layout that would obviously be bugguy.
This PR disables creation of instances using swift layout v1.
This PR also ensure most of the unit tests (otherwise explicitely chosen) use the default swift layout instead of the old v1 layout.