### PR TITLE
Allow to configure firebase per app

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -18,7 +18,7 @@ key used to connect to firebase is set in the configuration file, via the
 firebase accounts when there are several applications developed by several
 organizations. In that case, it is possible to tell the stack to use a particular
 key for a given app by creating a CouchDB document inside the
-`secrets/account_types` database, like this:
+`secrets/io-cozy-account_types` database, like this:
 
 ```json
 {

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -10,6 +10,35 @@ These notifications are part of a "Notification Center" where the user can
 configure the behavior of these notifications and the channel in which they are
 sent.
 
+## Firebase configuration
+
+The push notifications can be sent via Firebase to smartphones. By default, the
+key used to connect to firebase is set in the configuration file, via the
+`notifications.android_api_key` parameter. But it can be useful to have several
+firebase accounts when there are several applications developed by several
+organizations. In that case, it is possible to tell the stack to use a particular
+key for a given app by creating a CouchDB document inside the
+`secrets/account_types` database, like this:
+
+```json
+{
+    "_id": "myapp",
+    "slug": "myapp",
+    "android_api_key": "th3_f1r3b4s3_k3y"
+}
+```
+
+And we can go further to restrict this to a context, by prefixing the `_id`
+with the context name and `/`:
+
+```json
+{
+    "_id": "mycontext/myapp",
+    "slug": "myapp",
+    "android_api_key": "th3_0th3r_f1r3b4s3_k3y"
+}
+```
+
 ## Declare application's notifications
 
 Each application have to declare in its manifest the notifications it needs to

--- a/model/account/type.go
+++ b/model/account/type.go
@@ -53,8 +53,11 @@ var ErrUnrefreshable = errors.New("this account can not be refreshed")
 
 // AccountType holds configuration information for
 type AccountType struct {
-	DocID                 string            `json:"_id,omitempty"`
-	DocRev                string            `json:"_rev,omitempty"`
+	DocID  string `json:"_id,omitempty"`
+	DocRev string `json:"_rev,omitempty"`
+	Slug   string `json:"slug,omitempty"`
+
+	// OAuth parameters
 	GrantMode             string            `json:"grant_mode,omitempty"`
 	ClientID              string            `json:"client_id,omitempty"`
 	ClientSecret          string            `json:"client_secret,omitempty"`
@@ -63,10 +66,14 @@ type AccountType struct {
 	TokenAuthMode         string            `json:"token_mode,omitempty"`
 	RegisteredRedirectURI string            `json:"redirect_uri,omitempty"`
 	ExtraAuthQuery        map[string]string `json:"extras,omitempty"`
-	Slug                  string            `json:"slug,omitempty"`
-	Secret                interface{}       `json:"secret,omitempty"`
 	SkipRedirectURI       bool              `json:"skip_redirect_uri_on_authorize,omitempty"`
 	SkipState             bool              `json:"skip_state_on_token,omitempty"`
+
+	// Other secrets that can be used by the konnectors
+	Secret interface{} `json:"secret,omitempty"`
+
+	// For sending notifications via Firebase Cloud Messaging
+	AndroidAPIKey string `json:"android_api_key"`
 }
 
 // ID is used to implement the couchdb.Doc interface

--- a/model/notification/center/push_message.go
+++ b/model/notification/center/push_message.go
@@ -1,6 +1,10 @@
 package center
 
-import "github.com/cozy/cozy-stack/pkg/mail"
+import (
+	"strings"
+
+	"github.com/cozy/cozy-stack/pkg/mail"
+)
 
 // PushMessage contains a push notification request.
 type PushMessage struct {
@@ -15,4 +19,13 @@ type PushMessage struct {
 	Data map[string]interface{} `json:"data,omitempty"`
 
 	MailFallback *mail.Options `json:"mail_fallback,omitempty"`
+}
+
+// Slug returns the slug of the app that wants to send this push message.
+func (pm *PushMessage) Slug() string {
+	parts := strings.Split(pm.Source, "/")
+	if len(parts) < 3 {
+		return ""
+	}
+	return parts[2]
 }

--- a/worker/push/push_test.go
+++ b/worker/push/push_test.go
@@ -1,0 +1,46 @@
+package push
+
+import (
+	"testing"
+
+	"github.com/cozy/cozy-stack/model/account"
+	"github.com/cozy/cozy-stack/pkg/config/config"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/tests/testutils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetFirebaseClient(t *testing.T) {
+	contextName := "foo"
+	slug := "bar"
+
+	// Ensure that the global fcmClient is nil for this test, and restore its
+	// old value after the test
+	oldFcmClient := fcmClient
+	fcmClient = nil
+	defer func() {
+		fcmClient = oldFcmClient
+	}()
+
+	// Create an account type for the test
+	typ := account.AccountType{
+		DocID:         contextName + "/" + slug,
+		Slug:          slug,
+		AndroidAPIKey: "th3_f1r3b4s3_k3y",
+	}
+	err := couchdb.CreateNamedDoc(couchdb.GlobalSecretsDB, &typ)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer func() {
+		_ = couchdb.DeleteDoc(couchdb.GlobalSecretsDB, &typ)
+	}()
+
+	client := getFirebaseClient(slug, contextName)
+	assert.NotNil(t, client)
+}
+
+func TestMain(m *testing.M) {
+	config.UseTestFile()
+	testutils.NeedCouchdb()
+}


### PR DESCRIPTION
The push notifications can be sent via Firebase to mobile. When we have
several apps developed by several organizations, it can be useful to use
several Firebase accounts. It is now possible. The keys are stored in
the global/io.cozy.account_types database, with a document per app (and
it can be also restricted to a context).