### PR TITLE
Forbid to move files in the trash

### DIFF
--- a/model/vfs/directory.go
+++ b/model/vfs/directory.go
@@ -219,6 +219,9 @@ func ModifyDirMetadata(fs VFS, olddoc *DirDoc, patch *DocPatch) (*DirDoc, error)
 
 	var newdoc *DirDoc
 	if *patch.DirID != olddoc.DirID {
+		if strings.HasPrefix(olddoc.Fullpath, TrashDirName) {
+			return nil, ErrFileInTrash
+		}
 		newdoc, err = NewDirDoc(fs, *patch.Name, *patch.DirID, *patch.Tags)
 	} else {
 		newdoc, err = NewDirDocWithPath(*patch.Name, olddoc.DirID, path.Dir(olddoc.Fullpath), *patch.Tags)

--- a/model/vfs/file.go
+++ b/model/vfs/file.go
@@ -279,6 +279,10 @@ func ModifyFileMetadata(fs VFS, olddoc *FileDoc, patch *DocPatch) (*FileDoc, err
 		mime, class = olddoc.Mime, olddoc.Class
 	}
 
+	if trashed && olddoc.DirID != *patch.DirID {
+		return nil, ErrFileInTrash
+	}
+
 	newdoc, err := NewFileDoc(
 		newname,
 		*patch.DirID,

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -1858,6 +1858,26 @@ func TestFileTrash(t *testing.T) {
 	}
 }
 
+func TestForbidMovingTrashedFile(t *testing.T) {
+	body := "foo,bar"
+	res1, data1 := upload(t, "/files/?Type=file&Name=forbidmovingtrashedfile", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
+	if !assert.Equal(t, 201, res1.StatusCode) {
+		return
+	}
+
+	fileID, _ := extractDirData(t, data1)
+	res2, _ := trash(t, "/files/"+fileID)
+	if !assert.Equal(t, 200, res2.StatusCode) {
+		return
+	}
+
+	attrs := map[string]interface{}{
+		"dir_id": consts.RootDirID,
+	}
+	res3, _ := patchFile(t, "/files/"+fileID, "file", fileID, attrs, nil)
+	assert.Equal(t, 400, res3.StatusCode)
+}
+
 func TestFileRestore(t *testing.T) {
 	body := "foo,bar"
 	res1, data1 := upload(t, "/files/?Type=file&Name=torestorefile", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")


### PR DESCRIPTION
Moving a file in the trashed to another directory can lead to an
inconsistency on the trashed attribute. More generally, it looks safer
to forbid moving trashed files and directories.