### PR TITLE
Be explicit about sameSite for cookies

### DIFF
--- a/model/session/session.go
+++ b/model/session/session.go
@@ -216,6 +216,7 @@ func (s *Session) ToCookie() (*http.Cookie, error) {
 		Domain:   CookieDomain(inst),
 		Secure:   !build.IsDevRelease(),
 		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
 	}, nil
 }
 

--- a/web/auth/auth.go
+++ b/web/auth/auth.go
@@ -516,6 +516,7 @@ func Routes(router *echo.Group) {
 		CookieMaxAge:   3600, // 1 hour
 		CookieHTTPOnly: true,
 		CookieSecure:   !build.IsDevRelease(),
+		CookieSameSite: http.SameSiteStrictMode,
 	})
 
 	// Login/logout

--- a/web/middlewares/csrf.go
+++ b/web/middlewares/csrf.go
@@ -57,6 +57,10 @@ type (
 		// Indicates if CSRF cookie is HTTP only.
 		// Optional. Default value false.
 		CookieHTTPOnly bool `yaml:"cookie_http_only"`
+
+		// Indicates the sameSite policy for the CSRF cookie.
+		// Optional. Default value is lax.
+		CookieSameSite http.SameSite `yaml:"cookie_same_site"`
 	}
 
 	// csrfTokenExtractor defines a function that takes `echo.Context` and returns
@@ -67,12 +71,13 @@ type (
 var (
 	// DefaultCSRFConfig is the default CSRF middleware config.
 	DefaultCSRFConfig = CSRFConfig{
-		Skipper:      middleware.DefaultSkipper,
-		TokenLength:  32,
-		TokenLookup:  "header:" + echo.HeaderXCSRFToken,
-		ContextKey:   "csrf",
-		CookieName:   "_csrf",
-		CookieMaxAge: 86400,
+		Skipper:        middleware.DefaultSkipper,
+		TokenLength:    32,
+		TokenLookup:    "header:" + echo.HeaderXCSRFToken,
+		ContextKey:     "csrf",
+		CookieName:     "_csrf",
+		CookieMaxAge:   86400,
+		CookieSameSite: http.SameSiteLaxMode,
 	}
 )
 
@@ -104,6 +109,9 @@ func CSRFWithConfig(config CSRFConfig) echo.MiddlewareFunc {
 	}
 	if config.CookieMaxAge == 0 {
 		config.CookieMaxAge = DefaultCSRFConfig.CookieMaxAge
+	}
+	if config.CookieSameSite == 0 {
+		config.CookieSameSite = DefaultCSRFConfig.CookieSameSite
 	}
 
 	// Initialize
@@ -160,6 +168,7 @@ func CSRFWithConfig(config CSRFConfig) echo.MiddlewareFunc {
 			cookie.MaxAge = config.CookieMaxAge
 			cookie.Secure = config.CookieSecure
 			cookie.HttpOnly = config.CookieHTTPOnly
+			cookie.SameSite = config.CookieSameSite
 			c.SetCookie(cookie)
 
 			// Store token in the context


### PR DESCRIPTION
The session cookies will have a lax policy for sameSite, and the CSRF
cookies will have a strict policy.

See https://hacks.mozilla.org/2020/08/changes-to-samesite-cookie-behavior/