### PR TITLE
Fix ForeachDocs with 100+ design docs

### DIFF
--- a/pkg/couchdb/bulk.go
+++ b/pkg/couchdb/bulk.go
@@ -138,18 +138,16 @@ func ForeachDocsWithCustomPagination(db Database, doctype string, limit int, fn 
 			return err
 		}
 
-		var count int
 		startKey = ""
 		for _, row := range res.Rows {
 			if !strings.HasPrefix(row.ID, "_design") {
 				if err = fn(row.ID, row.Doc); err != nil {
 					return err
 				}
-				startKey = row.ID
-				count++
 			}
+			startKey = row.ID
 		}
-		if count == 0 || len(res.Rows) < limit {
+		if len(res.Rows) < limit {
 			break
 		}
 	}


### PR DESCRIPTION
When the ForeachDocs function is called on a database with more than 100
design documents, the pagination can have a page with just design docs.
The function stopped here, even if there were other documents further.
This fix will avoid stopping the ForeachDocs too soon.