### PR TITLE
Fix a panic on addMissingRevsToChain

### DIFF
--- a/model/sharing/revisions.go
+++ b/model/sharing/revisions.go
@@ -316,6 +316,9 @@ func addMissingRevsToChain(db couchdb.Database, ref *SharedRef, chain []string) 
 		return chain, err
 	}
 	revisions := revsMapToStruct(doc.M["_revisions"])
+	if len(revisions.IDs) < chainLowestGen-1 {
+		return nil, fmt.Errorf("Cannot add the missing revs to io.cozy.shared %s", docRef.ID)
+	}
 	var oldRevs []string
 	for i := refHighestGen + 1; i < chainLowestGen; i++ {
 		revID := revisions.IDs[len(revisions.IDs)-i]


### PR DESCRIPTION
When there are multiple changes on a shared document, both on the local
instance and on other instances of the sharing, it was possible to have
a race condition that leads to a panic on the addMissingRevsToChain
function.