### PR TITLE
Improvements

### DIFF
--- a/cmd/apps.go
+++ b/cmd/apps.go
@@ -376,7 +376,9 @@ func updateApp(cmd *cobra.Command, args []string, appType string) error {
 	}
 	msg := "%s is already up-to-date at %s\n"
 	if manifest.Attrs.Version < newManifest.Attrs.Version {
-		msg = "%s has been updated to %s\n"
+		msg = "%s has been upgraded to %s\n"
+	} else if manifest.Attrs.Version > newManifest.Attrs.Version {
+		msg = "%s has been downgraded to %s\n"
 	}
 	fmt.Printf(msg, args[0], newManifest.Attrs.Version)
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -145,7 +145,7 @@ as `package oauth_test`.
 ## External assets
 
 The cozy-stack serve some assets for the client application. In particular,
-cozy-client-js and cozy-bar assets are listed in `assets/external`. To update
+cozy-client-js and cozy-bar assets are listed in `assets/.externals`. To update
 them, you can open a pull request for this file. When a maintainer will accept
 this pull request, he will also run `scripts/build.sh assets` to transform them
 in go code (to make the repository go gettable).

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -192,7 +192,7 @@ download_debug_asset() {
 		if [ "${3}" != "${dgst}" ]; then
 			echo "failed"
 			echo_err "Checksum SHA256 does not match for asset ${1} downloaded on ${2}:"
-			echo_err "  expecting \"${dgst}\", got \"${3}\"."
+			echo_err "  expecting \"${3}\", got \"${dgst}\"."
 			exit 1
 		fi
 	fi


### PR DESCRIPTION
Small fixes that were waiting on my computer...

- Fixes on external assets
- Fix installation message: it would report "app already up-to-date"
in case of a downgrade

```shell
$ cozy-stack apps install banks2 registry://banks/dev
banks2 has been installed (1.20.1-dev.c5cae281599037051902)
$ cozy-stack apps update banks2 registry://banks/dev
banks2 is already up-to-date at 1.20.1-dev.c5cae281599037051902
$ cozy-stack apps update banks2 registry://banks/stable
banks2 has been downgraded to 1.20.0
$ cozy-stack apps update banks2 registry://banks/dev
banks2 has been upgraded to 1.20.1-dev.c5cae281599037051902
```