### PR TITLE
Refine app install message on cli

### DIFF
--- a/cmd/apps.go
+++ b/cmd/apps.go
@@ -316,7 +316,7 @@ func installApp(cmd *cobra.Command, args []string, appType string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("%s has been installed (%s)\n", slug, manifest.Attrs.Version)
+	fmt.Printf("%s (%s) has been installed on %s\n", slug, manifest.Attrs.Version, flagDomain)
 
 	return nil
 }


### PR DESCRIPTION
Refine cli message on app installation to include domain

Before:

`store has been installed (1.9.2)`

After:

`store (1.9.2) has been installed on cozy.domain.name`