### PR TITLE
Support SoftDelete and Restore routes for bitwarden

### DIFF
--- a/docs/bitwarden.md
+++ b/docs/bitwarden.md
@@ -878,6 +878,43 @@ Host: alice.example.com
 HTTP/1.1 204 No Content
 ```
 
+### PUT /bitwarden/api/ciphers/:id/delete
+
+This route is used to soft delete a cipher, by adding a `deletedDate`
+attribute on it.
+
+#### Request
+
+```http
+PUT /bitwarden/api/ciphers/4c2869dd-0e1c-499f-b116-a824016df251/delete HTTP/1.1
+Host: alice.example.com
+```
+
+#### Response
+
+```http
+HTTP/1.1 204 No Content
+```
+
+### PUT /bitwarden/api/ciphers/:id/restore
+
+This route is used to restore a soft-deleted cipher, by removing the
+`deletedDate` attribute.
+
+#### Request
+
+```http
+PUT /bitwarden/api/ciphers/4c2869dd-0e1c-499f-b116-a824016df251/restore HTTP/1.1
+Host: alice.example.com
+```
+
+#### Response
+
+```http
+HTTP/1.1 204 No Content
+```
+
+
 ### POST /bitwarden/api/ciphers/import
 
 This route can be used to import several ciphers and folders in bulk.

--- a/model/bitwarden/cipher.go
+++ b/model/bitwarden/cipher.go
@@ -2,6 +2,7 @@ package bitwarden
 
 import (
 	"encoding/json"
+	"time"
 
 	"github.com/cozy/cozy-stack/model/instance"
 	"github.com/cozy/cozy-stack/pkg/consts"
@@ -76,6 +77,7 @@ type Cipher struct {
 	Data           *MapData               `json:"data,omitempty"`
 	Fields         []Field                `json:"fields"`
 	Metadata       *metadata.CozyMetadata `json:"cozyMetadata,omitempty"`
+	DeletedDate    *time.Time             `json:"deletedDate,omitempty"`
 }
 
 // ID returns the cipher qualified identifier

--- a/web/bitwarden/bitwarden.go
+++ b/web/bitwarden/bitwarden.go
@@ -488,6 +488,8 @@ func Routes(router *echo.Group) {
 	ciphers.PUT("/:id", UpdateCipher)
 	ciphers.DELETE("/:id", DeleteCipher)
 	ciphers.POST("/:id/delete", DeleteCipher)
+	ciphers.PUT("/:id/delete", SoftDeleteCipher)
+	ciphers.PUT("/:id/restore", RestoreCipher)
 	ciphers.POST("/:id/share", ShareCipher)
 	ciphers.PUT("/:id/share", ShareCipher)
 	ciphers.POST("/import", ImportCiphers)

--- a/web/bitwarden/bitwarden_test.go
+++ b/web/bitwarden/bitwarden_test.go
@@ -467,6 +467,98 @@ func TestDeleteCipher(t *testing.T) {
 	assert.Equal(t, 200, res.StatusCode)
 }
 
+func TestSoftDeleteCipher(t *testing.T) {
+	body := `
+{
+	"type": 1,
+	"favorite": false,
+	"name": "2.d7MttWzJTSSKx1qXjHUxlQ==|01Ath5UqFZHk7csk5DVtkQ==|EMLoLREgCUP5Cu4HqIhcLqhiZHn+NsUDp8dAg1Xu0Io=",
+	"notes": null,
+	"folderId": null,
+	"organizationId": null,
+	"login": {
+		"uri": "2.T57BwAuV8ubIn/sZPbQC+A==|EhUSSpJWSzSYOdJ/AQzfXuUXxwzcs/6C4tOXqhWAqcM=|OWV2VIqLfoWPs9DiouXGUOtTEkVeklbtJQHkQFIXkC8=",
+		"username": "2.JbFkAEZPnuMm70cdP44wtA==|fsN6nbT+udGmOWv8K4otgw==|JbtwmNQa7/48KszT2hAdxpmJ6DRPZst0EDEZx5GzesI=",
+		"password": "2.e83hIsk6IRevSr/H1lvZhg==|48KNkSCoTacopXRmIZsbWg==|CIcWgNbaIN2ix2Fx1Gar6rWQeVeboehp4bioAwngr0o=",
+		"totp": null
+	}
+}`
+	req, _ := http.NewRequest("POST", ts.URL+"/bitwarden/api/ciphers", bytes.NewBufferString(body))
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Authorization", "Bearer "+token)
+	res, err := http.DefaultClient.Do(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, res.StatusCode)
+	var result map[string]interface{}
+	err = json.NewDecoder(res.Body).Decode(&result)
+	assert.NoError(t, err)
+	id := result["Id"].(string)
+
+	req, _ = http.NewRequest("PUT", ts.URL+"/bitwarden/api/ciphers/"+id+"/delete", nil)
+	req.Header.Add("Authorization", "Bearer "+token)
+	res, err = http.DefaultClient.Do(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, res.StatusCode)
+
+	req, _ = http.NewRequest("GET", ts.URL+"/bitwarden/api/ciphers/"+id, nil)
+	req.Header.Add("Authorization", "Bearer "+token)
+	res, err = http.DefaultClient.Do(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, res.StatusCode)
+	err = json.NewDecoder(res.Body).Decode(&result)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, result["DeletedDate"])
+}
+
+func TestRestoreCipher(t *testing.T) {
+	body := `
+{
+	"type": 1,
+	"favorite": false,
+	"name": "2.d7MttWzJTSSKx1qXjHUxlQ==|01Ath5UqFZHk7csk5DVtkQ==|EMLoLREgCUP5Cu4HqIhcLqhiZHn+NsUDp8dAg1Xu0Io=",
+	"notes": null,
+	"folderId": null,
+	"organizationId": null,
+	"login": {
+		"uri": "2.T57BwAuV8ubIn/sZPbQC+A==|EhUSSpJWSzSYOdJ/AQzfXuUXxwzcs/6C4tOXqhWAqcM=|OWV2VIqLfoWPs9DiouXGUOtTEkVeklbtJQHkQFIXkC8=",
+		"username": "2.JbFkAEZPnuMm70cdP44wtA==|fsN6nbT+udGmOWv8K4otgw==|JbtwmNQa7/48KszT2hAdxpmJ6DRPZst0EDEZx5GzesI=",
+		"password": "2.e83hIsk6IRevSr/H1lvZhg==|48KNkSCoTacopXRmIZsbWg==|CIcWgNbaIN2ix2Fx1Gar6rWQeVeboehp4bioAwngr0o=",
+		"totp": null
+	}
+}`
+	req, _ := http.NewRequest("POST", ts.URL+"/bitwarden/api/ciphers", bytes.NewBufferString(body))
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Authorization", "Bearer "+token)
+	res, err := http.DefaultClient.Do(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, res.StatusCode)
+	var result map[string]interface{}
+	err = json.NewDecoder(res.Body).Decode(&result)
+	assert.NoError(t, err)
+	id := result["Id"].(string)
+
+	req, _ = http.NewRequest("PUT", ts.URL+"/bitwarden/api/ciphers/"+id+"/delete", nil)
+	req.Header.Add("Authorization", "Bearer "+token)
+	res, err = http.DefaultClient.Do(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, res.StatusCode)
+
+	req, _ = http.NewRequest("PUT", ts.URL+"/bitwarden/api/ciphers/"+id+"/restore", nil)
+	req.Header.Add("Authorization", "Bearer "+token)
+	res, err = http.DefaultClient.Do(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, res.StatusCode)
+
+	req, _ = http.NewRequest("GET", ts.URL+"/bitwarden/api/ciphers/"+id, nil)
+	req.Header.Add("Authorization", "Bearer "+token)
+	res, err = http.DefaultClient.Do(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, res.StatusCode)
+	err = json.NewDecoder(res.Body).Decode(&result)
+	assert.NoError(t, err)
+	assert.Empty(t, result["DeletedDate"])
+}
+
 func TestSync(t *testing.T) {
 	req, _ := http.NewRequest("GET", ts.URL+"/bitwarden/api/sync", nil)
 	req.Header.Add("Authorization", "Bearer "+token)
@@ -493,7 +585,7 @@ func TestSync(t *testing.T) {
 	assert.Equal(t, "profile", profile["Object"])
 
 	ciphers := result["Ciphers"].([]interface{})
-	assert.Len(t, ciphers, 1)
+	assert.Len(t, ciphers, 3)
 	c := ciphers[0].(map[string]interface{})
 	assertUpdatedCipherResponse(t, c)
 

--- a/web/bitwarden/ciphers.go
+++ b/web/bitwarden/ciphers.go
@@ -563,6 +563,14 @@ func SoftDeleteCipher(c echo.Context) error {
 			"error": err.Error(),
 		})
 	}
+
+	setting, err := settings.Get(inst)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, echo.Map{
+			"error": err.Error(),
+		})
+	}
+
 	cipher.Metadata.ChangeUpdatedAt()
 	cipher.DeletedDate = &cipher.Metadata.UpdatedAt
 	if err := couchdb.UpdateDoc(inst, cipher); err != nil {
@@ -570,6 +578,8 @@ func SoftDeleteCipher(c echo.Context) error {
 			"error": err.Error(),
 		})
 	}
+	_ = settings.UpdateRevisionDate(inst, setting)
+
 	return c.NoContent(http.StatusOK)
 }
 
@@ -601,6 +611,14 @@ func RestoreCipher(c echo.Context) error {
 			"error": err.Error(),
 		})
 	}
+
+	setting, err := settings.Get(inst)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, echo.Map{
+			"error": err.Error(),
+		})
+	}
+
 	cipher.DeletedDate = nil
 	cipher.Metadata.ChangeUpdatedAt()
 	if err := couchdb.UpdateDoc(inst, cipher); err != nil {
@@ -608,6 +626,7 @@ func RestoreCipher(c echo.Context) error {
 			"error": err.Error(),
 		})
 	}
+	_ = settings.UpdateRevisionDate(inst, setting)
 	return c.NoContent(http.StatusOK)
 }
 


### PR DESCRIPTION
Bitwarden now [supports](https://github.com/bitwarden/server/pull/684) a trash system, where (soft) deleted ciphers are actually updated with a `deletedDate` attribute. Then, the client filters the ciphers having this attribute to display them in a Trash.
The restore simply consists of removing this attribute.

This PR adds the soft delete and restore routes.