### PR TITLE
Add trashed files size to files usage cmd

### DIFF
--- a/client/instances.go
+++ b/client/instances.go
@@ -458,10 +458,18 @@ func (c *Client) RebuildRedis() error {
 }
 
 // DiskUsage returns the information about disk usage and quota
-func (c *Client) DiskUsage(domain string) (map[string]interface{}, error) {
+func (c *Client) DiskUsage(domain string, includeTrash bool) (map[string]interface{}, error) {
+	var q map[string][]string
+	if includeTrash {
+		q = url.Values{
+			"include": {"trash"},
+		}
+	}
+
 	res, err := c.Req(&request.Options{
-		Method: "GET",
-		Path:   "/instances/" + domain + "/disk-usage",
+		Method:  "GET",
+		Path:    "/instances/" + url.PathEscape(domain) + "/disk-usage",
+		Queries: q,
 	})
 	if err != nil {
 		return nil, err

--- a/cmd/files.go
+++ b/cmd/files.go
@@ -41,6 +41,7 @@ var flagImportFrom string
 var flagImportTo string
 var flagImportDryRun bool
 var flagImportMatch string
+var flagIncludeTrash bool
 
 // filesCmdGroup represents the instances command
 var filesCmdGroup = &cobra.Command{
@@ -108,7 +109,7 @@ var importFilesCmd = &cobra.Command{
 }
 
 var usageFilesCmd = &cobra.Command{
-	Use:   "usage [--domain domain]",
+	Use:   "usage [--domain domain] [--trash]",
 	Short: "Show the usage and quota for the files of this instance",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if flagDomain == "" {
@@ -116,7 +117,7 @@ var usageFilesCmd = &cobra.Command{
 			return cmd.Usage()
 		}
 		c := newAdminClient()
-		info, err := c.DiskUsage(flagDomain)
+		info, err := c.DiskUsage(flagDomain, flagIncludeTrash)
 		if err != nil {
 			return err
 		}
@@ -127,6 +128,12 @@ var usageFilesCmd = &cobra.Command{
 		}
 		if versions, ok := info["versions"]; ok {
 			fmt.Printf("  Including older versions of files: %v\n", versions)
+		}
+
+		if flagIncludeTrash {
+			if trashed, ok := info["trashed"]; ok {
+				fmt.Printf("  Including trashed files: %v\n", trashed)
+			}
 		}
 
 		if quota, ok := info["quota"]; ok {
@@ -511,6 +518,8 @@ func init() {
 	_ = importFilesCmd.MarkFlagRequired("to")
 	importFilesCmd.Flags().BoolVar(&flagImportDryRun, "dry-run", false, "do not actually import the files")
 	importFilesCmd.Flags().StringVar(&flagImportMatch, "match", "", "pattern that the imported files must match")
+
+	usageFilesCmd.Flags().BoolVar(&flagIncludeTrash, "trash", false, "Include trashed files total size")
 
 	filesCmdGroup.AddCommand(execFilesCmd)
 	filesCmdGroup.AddCommand(importFilesCmd)

--- a/web/instances/instances.go
+++ b/web/instances/instances.go
@@ -270,6 +270,7 @@ type diskUsageResult struct {
 	Files         int64 `json:"files,string,omitempty"`
 	Versions      int64 `json:"versions,string,omitempty"`
 	VersionsCount int   `json:"versions_count,string,omitempty"`
+	Trashed       int64 `json:"trashed,string,omitempty"`
 }
 
 func diskUsage(c echo.Context) error {
@@ -294,6 +295,15 @@ func diskUsage(c echo.Context) error {
 	result.Used = files + versions
 	result.Files = files
 	result.Versions = versions
+
+	if c.QueryParam("include") == "trash" {
+		trashed, err := fs.TrashUsage()
+		if err != nil {
+			return err
+		}
+		result.Trashed = trashed
+	}
+
 	result.Quota = fs.DiskQuota()
 	if stats, err := couchdb.DBStatus(instance, consts.Files); err == nil {
 		result.Count = stats.DocCount


### PR DESCRIPTION
We sometimes need to know the size of the trash for an instance.

This PR adds a `--trash` flag to `cozy-stack files usage` command and a corresponding `include=trash` query param to the `disk-usage` admin API (similar to the `include=trash` query param of the `settings/disk-usage` endpoint that return the total size of files inside the trash.

This functionnality is hidden behind a flag for two main reasons:
- keep exact compatibility with existing command
- Walking through all files in the trash can be particularly time consuming and not always needed