### PR TITLE
feat: cozy-app-dev disables CSP by default

### DIFF
--- a/scripts/cozy-app-dev.sh
+++ b/scripts/cozy-app-dev.sh
@@ -105,6 +105,7 @@ do_start() {
 
 	${COZY_STACK_PATH} serve --allow-root \
 		--appdir "${appdir}" \
+		--disable-csp \
 		--host "::" \
 		--port "${COZY_STACK_PORT}" \
 		--admin-port "${COZY_STACK_ADMIN_PORT}" \


### PR DESCRIPTION
Our app in dev mode are built with HMR. The app is thus served
from a server that is not the stack. Without the --disable-csp
flag, the CSP rules forbid this.