### PR TITLE
Fix trace in BasicAuth middleware

### DIFF
--- a/web/middlewares/basic_auth.go
+++ b/web/middlewares/basic_auth.go
@@ -20,49 +20,57 @@ import (
 // The format of the secret is the same as our hashed passwords in database: a
 // scrypt hash with a salt contained in the value.
 func BasicAuth(secretFileName string) echo.MiddlewareFunc {
-	return func(next echo.HandlerFunc) echo.HandlerFunc {
-		return func(c echo.Context) error {
-			if c.QueryParam("Trace") == "true" {
-				t := time.Now()
-				defer func() {
-					elapsed := time.Since(t)
-					logger.
-						WithDomain("admin").
-						WithField("nspace", "trace").
-						Printf("Check basic auth: %v", elapsed)
-				}()
-			}
-
-			_, passphrase, ok := c.Request().BasicAuth()
-			if !ok {
-				return echo.NewHTTPError(http.StatusUnauthorized, "missing basic auth")
-			}
-
-			shadowFile, err := config.FindConfigFile(secretFileName)
-			if err != nil {
-				return echo.NewHTTPError(http.StatusInternalServerError, err)
-			}
-
-			f, err := os.Open(shadowFile)
-			if err != nil {
-				return echo.NewHTTPError(http.StatusInternalServerError, err)
-			}
-			defer f.Close()
-
-			b, err := ioutil.ReadAll(f)
-			if err != nil {
-				return echo.NewHTTPError(http.StatusInternalServerError, err)
-			}
-			b = bytes.TrimSpace(b)
-
-			needUpdate, err := crypto.CompareHashAndPassphrase(b, []byte(passphrase))
-			if err != nil {
-				return echo.NewHTTPError(http.StatusForbidden, "bad passphrase")
-			}
-			if needUpdate {
+	check := func(next echo.HandlerFunc, c echo.Context) error {
+		if c.QueryParam("Trace") == "true" {
+			t := time.Now()
+			defer func() {
+				elapsed := time.Since(t)
 				logger.
 					WithDomain("admin").
-					Warnf("Passphrase hash from %q needs update and should be regenerated", secretFileName)
+					WithField("nspace", "trace").
+					Printf("Check basic auth: %v", elapsed)
+			}()
+		}
+
+		_, passphrase, ok := c.Request().BasicAuth()
+		if !ok {
+			return echo.NewHTTPError(http.StatusUnauthorized, "missing basic auth")
+		}
+
+		shadowFile, err := config.FindConfigFile(secretFileName)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, err)
+		}
+
+		f, err := os.Open(shadowFile)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, err)
+		}
+		defer f.Close()
+
+		b, err := ioutil.ReadAll(f)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, err)
+		}
+		b = bytes.TrimSpace(b)
+
+		needUpdate, err := crypto.CompareHashAndPassphrase(b, []byte(passphrase))
+		if err != nil {
+			return echo.NewHTTPError(http.StatusForbidden, "bad passphrase")
+		}
+		if needUpdate {
+			logger.
+				WithDomain("admin").
+				Warnf("Passphrase hash from %q needs update and should be regenerated", secretFileName)
+		}
+
+		return nil
+	}
+
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			if err := check(next, c); err != nil {
+				return err
 			}
 
 			return next(c)


### PR DESCRIPTION
The traced time was taking the time to compute the next handler, and not
just to check the basic authentication.