### PR TITLE
feat: Still continue to to run acount with USER_ACTION_NEEDED.CGU_FORM message

### DIFF
--- a/worker/exec/konnector.go
+++ b/worker/exec/konnector.go
@@ -30,8 +30,9 @@ import (
 )
 
 const (
-	konnErrorLoginFailed      = "LOGIN_FAILED"
-	konnErrorUserActionNeeded = "USER_ACTION_NEEDED"
+	konnErrorLoginFailed         = "LOGIN_FAILED"
+	konnErrorUserActionNeeded    = "USER_ACTION_NEEDED"
+	konnErrorUserActionNeededCgu = "USER_ACTION_NEEDED.CGU_FORM"
 )
 
 type konnectorWorker struct {
@@ -105,7 +106,8 @@ func jobHookErrorCheckerKonnector(err error) bool {
 
 	lastError := err.Error()
 	if strings.HasPrefix(lastError, konnErrorLoginFailed) ||
-		strings.HasPrefix(lastError, konnErrorUserActionNeeded) {
+		strings.HasPrefix(lastError, konnErrorUserActionNeeded) &&
+			lastError != konnErrorUserActionNeededCgu {
 		return false
 	}
 	return true


### PR DESCRIPTION
I am not sure of my go syntax but here is what I want :
Accounts with USER_ACTION_NEEDED.CGU_FORM need an action from the user on the website but
it is possible that the user will do this action without knowing this is needed for the connector
and there are some cases the ameli connector where the connector sees the CGU from but not the
user because this form is displayed only when the user connects to his ameli accout, and the
ameli session can be long.

At the moment, I run all the USER_ACTION_NEEDED.CGU_FORM accounts progressively and manually.
I would be nice if the stack would do it automatically and this is the goal of this PR