### PR TITLE
Add command aliases for user-friendliness

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -326,6 +326,7 @@ Deprecated: please use the command cozy-stack assets ls.
 
 var listContextsCmd = &cobra.Command{
 	Use:     "ls-contexts",
+	Aliases: []string{"list-contexts"},
 	Short:   "List contexts",
 	Long:    "List contexts currently used by the stack",
 	Example: "$ cozy-stack config ls-contexts",

--- a/cmd/instances.go
+++ b/cmd/instances.go
@@ -136,8 +136,9 @@ given domain. The prefix is used for databases and VFS prefixing.
 }
 
 var addInstanceCmd = &cobra.Command{
-	Use:   "add <domain>",
-	Short: "Manage instances of a stack",
+	Use:     "add <domain>",
+	Aliases: []string{"create"},
+	Short:   "Manage instances of a stack",
 	Long: `
 cozy-stack instances add allows to create an instance on the cozy for a
 given domain.
@@ -412,8 +413,9 @@ specific domain.
 }
 
 var lsInstanceCmd = &cobra.Command{
-	Use:   "ls",
-	Short: "List instances",
+	Use:     "ls",
+	Aliases: []string{"list"},
+	Short:   "List instances",
 	Long: `
 cozy-stack instances ls allows to list all the instances that can be served
 by this server.
@@ -569,7 +571,7 @@ var destroyInstanceCmd = &cobra.Command{
 cozy-stack instances destroy allows to remove an instance
 and all its data.
 `,
-	Aliases: []string{"rm"},
+	Aliases: []string{"rm", "delete", "remove"},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if reason := os.Getenv("COZY_DISABLE_INSTANCES_ADD_RM"); reason != "" {
 			return fmt.Errorf("Sorry, instances add is disabled: %s", reason)

--- a/cmd/swift.go
+++ b/cmd/swift.go
@@ -57,7 +57,8 @@ var lsLayoutsCmd = &cobra.Command{
 }
 
 var swiftGetCmd = &cobra.Command{
-	Use: "get <domain> <object-name>",
+	Use:     "get <domain> <object-name>",
+	Aliases: []string{"download"},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 2 {
 			return cmd.Usage()
@@ -82,7 +83,8 @@ var swiftGetCmd = &cobra.Command{
 }
 
 var swiftPutCmd = &cobra.Command{
-	Use: "put <domain> <object-name>",
+	Use:     "put <domain> <object-name>",
+	Aliases: []string{"upload"},
 	Long: `cozy-stack swift put can be used to create or update an object in
 the swift container associated to the given domain. The content of the file is
 expected on the standard input.`,
@@ -138,7 +140,8 @@ var swiftDeleteCmd = &cobra.Command{
 }
 
 var swiftLsCmd = &cobra.Command{
-	Use: "ls <domain>",
+	Use:     "ls <domain>",
+	Aliases: []string{"list"},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return cmd.Usage()


### PR DESCRIPTION
Add command aliases for user-friendliness.
Also ensure all commands are coherents and match with de-facto standard (`create`, `list`, `show`, `delete`)