### PR TITLE
Detect thumbnails with no file

### DIFF
--- a/model/vfs/fsck.go
+++ b/model/vfs/fsck.go
@@ -47,6 +47,9 @@ const (
 	// ConflictInIndex is used when there is a conflict in CouchDB with 2
 	// branches of revisions.
 	ConflictInIndex = "conflict_in_index"
+	// ThumbnailWithNoFile is used when there is a thumbnail but not the file
+	// that was used to create it.
+	ThumbnailWithNoFile = "thumbnail_with_no_file"
 )
 
 // FsckLog is a struct for an inconsistency in the VFS


### PR DESCRIPTION
When checking the file system of an instance in Swift layout v3, the
stack will also warns for thumbnails where the file that have been used
to generate it is missing.