### PR TITLE
Improve the onboarding page

### DIFF
--- a/assets/locales/en.po
+++ b/assets/locales/en.po
@@ -156,6 +156,9 @@ msgstr "Use at least eight characters with letters, digits and symbols."
 msgid "Passphrase Hint Error"
 msgstr "Your hint must be different from your password!"
 
+msgid "Passphrase Onboarding Show hint form"
+msgstr "Leave a hint"
+
 msgid "Passphrase Onboarding Hint Field"
 msgstr "Leave a hint (optional)"
 

--- a/assets/locales/fr.po
+++ b/assets/locales/fr.po
@@ -192,6 +192,9 @@ msgstr ""
 msgid "Passphrase Hint Error"
 msgstr "Votre indice doit être différent de votre mot de passe !"
 
+msgid "Passphrase Onboarding Show hint form"
+msgstr "Laisser un indice"
+
 msgid "Passphrase Onboarding Hint Field"
 msgstr "Laisser un indice (facultatif)"
 

--- a/assets/scripts/onboarding.js
+++ b/assets/scripts/onboarding.js
@@ -107,4 +107,13 @@
   })
 
   submitButton.removeAttribute('disabled')
+
+  let showHintButton = d.getElementById('show-password-hint')
+  let hintForm = d.getElementById('password-hint')
+
+  showHintButton.addEventListener('click', function (event) {
+    event.preventDefault()
+    hintForm.classList.remove('u-hide')
+    showHintButton.classList.add('u-hide')
+  })
 })(window, document)

--- a/assets/styles/stack.css
+++ b/assets/styles/stack.css
@@ -228,8 +228,7 @@ h1 {
 li[class^="com.bitwarden.ciphers"]:before,
 li[class^="com.bitwarden.folders"]:before,
 li[class^="com.bitwarden.organizations"]:before,
-li[class^="com.bitwarden.profiles"]:before
- {
+li[class^="com.bitwarden.profiles"]:before {
   background-image: url("../images/icon-permissions.svg");
 }
 li[class^="io.cozy.settings"]:before,

--- a/assets/templates/passphrase_onboarding.html
+++ b/assets/templates/passphrase_onboarding.html
@@ -67,11 +67,12 @@
               <input id="password" class="wizard-password c-input-text" name="passphrase" type="password" autofocus autocomplete="current-password" />
               <progress id="password-strength" max="100" value="0" class="pw-indicator u-m-0"></progress>
             </div>
-            <p id="password-tip" class="u-coolGrey u-m-1">{{t "Passphrase Onboarding Help"}}</p>
-            <div class="o-field password-form u-m-0">
-              <label for="hint" class="c-label c-label--block u-mt-1">{{t "Passphrase Onboarding Hint Field"}}</label>
+            <p id="password-tip" class="u-text u-coolGrey u-mv-1 u-fs-italic">{{t "Passphrase Onboarding Help"}}</p>
+            <a href="#password-hint" id="show-password-hint" class="u-text u-link u-uppercase u-fw-bold u-mv-half">+ {{t "Passphrase Onboarding Show hint form"}}</a>
+            <div id="password-hint" class="u-hide o-field password-form u-m-0">
+              <label for="hint" class="c-label c-label--block">{{t "Passphrase Onboarding Hint Field"}}</label>
               <input id="hint" class="c-input-text" name="hint" type="text" />
-              <p class="wizard-notice u-mb-2 u-mt-1-half-s" id="login-password-tip">{{t "Passphrase Onboarding Hint Help"}}</p>
+              <p class="u-text u-coolGrey u-mv-1 u-fs-italic" id="login-password-tip">{{t "Passphrase Onboarding Hint Help"}}</p>
             </div>
           </div>
           <footer class="wizard-footer u-pb-2">


### PR DESCRIPTION
When the stack asks for the passphrase during the onboarding, the hint
field is now masked to avoid confusion with a a passphrase confirmation.
It can be shown by clicking on the "Leave a hint" link.