### PR TITLE
Change the ownership of the share-by-link permissions

### DIFF
--- a/model/permission/permissions.go
+++ b/model/permission/permissions.go
@@ -152,11 +152,16 @@ func (p *Permission) Revoke(db prefixer.Prefixer) error {
 	return couchdb.DeleteDoc(db, p)
 }
 
-// ParentOf check if child has been created by p
-func (p *Permission) ParentOf(child *Permission) bool {
-	canBeParent := p.Type == TypeWebapp || p.Type == TypeOauth
-	return child.Type == TypeShareByLink && canBeParent &&
-		child.SourceID == p.SourceID
+// CanUpdateShareByLink check if the child permissions can be updated by p
+// (p can be the parent or it has a superset of the permissions).
+func (p *Permission) CanUpdateShareByLink(child *Permission) bool {
+	if child.Type != TypeShareByLink {
+		return false
+	}
+	if p.Type != TypeWebapp && p.Type != TypeOauth {
+		return false
+	}
+	return child.SourceID == p.SourceID || child.Permissions.IsSubSetOf(p.Permissions)
 }
 
 // GetByID fetch a permission by its ID

--- a/web/permissions/permissions.go
+++ b/web/permissions/permissions.go
@@ -280,7 +280,7 @@ func patchPermission(getPerms getPermsFunc, paramName string) echo.HandlerFunc {
 		}
 
 		if patchCodes {
-			if !current.ParentOf(toPatch) {
+			if !current.CanUpdateShareByLink(toPatch) {
 				return permission.ErrNotParent
 			}
 			toPatch.PatchCodes(patch.Codes)
@@ -336,18 +336,7 @@ func revokePermission(c echo.Context) error {
 		return err
 	}
 
-	// Check if the permission is linked to an OAuth Client
-	if current.Client != nil {
-		oauthClient := current.Client.(*oauth.Client)
-
-		if slug := oauth.GetLinkedAppSlug(oauthClient.SoftwareID); slug != "" {
-			// Changing the sourceID from the OAuth clientID to the classic
-			// io.cozy.apps/slug one
-			current.SourceID = consts.Apps + "/" + slug
-		}
-	}
-
-	if !current.ParentOf(toRevoke) {
+	if !current.CanUpdateShareByLink(toRevoke) {
 		return permission.ErrNotParent
 	}
 


### PR DESCRIPTION
When a permission document is created for a share by link use case, the
stack keeps in the source field the slug of the app that has created the
permission. Later, if the permission is updated or revoked, the stack
was only authorizing the same application to do that. Now, it can also
be another app that has a superset of the given permissions. For
example, if a note is shared from the notes application, it is now
possible to revoke this sharing from Drive.