### PR TITLE
Allow services to have no triggers

### DIFF
--- a/docs/apps.md
+++ b/docs/apps.md
@@ -139,7 +139,12 @@ The `trigger` field should follow the available triggers described in the
 [jobs documentation](./jobs.md). The `file` field should specify the service
 code run and the `type` field describe the code type (only `"node"` for now).
 
-If you need to know more about how to develop a service, please check the [how-to documentation here](https://github.com/cozy/cozy.github.io/blob/dev/src/howTos/dev/services.md).
+If you need to know more about how to develop a service, please check the
+[how-to documentation here](https://github.com/cozy/cozy.github.io/blob/dev/src/howTos/dev/services.md).
+
+**Note:** it is possible to declare a service with no trigger. For example,
+this can be used when the service is programmatically called from another
+service.
 
 ### Available fields to the service
 During the service execution, the stack will give some environment variables to the service if you need to use them, available with `process.env[FIELD]`. Once again, it's the **stack** that gives those variables. So if you're developing a service and using a script to execute/test your service, you won't get those variables.

--- a/web/apps/apps_test.go
+++ b/web/apps/apps_test.go
@@ -457,6 +457,11 @@ func TestUninstallAppWithoutLinkedClient(t *testing.T) {
 	assert.Nil(t, errc)
 }
 
+func TestRemoveFakeTriggersFromBanksManifest(t *testing.T) {
+	testutils.TODO(t, "2020-11-01",
+		"Remove the triggers from the bank manifest for services called programmatically")
+}
+
 func TestMain(m *testing.M) {
 	config.UseTestFile()
 	config.GetConfig().Assets = "../../assets"


### PR DESCRIPTION
Some services can be called programmatically and the stack should allow
those services to have no triggers.