### PR TITLE
Fix opening a note in a shared directory

### DIFF
--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -257,18 +257,7 @@ func (s *Sharing) CreateInteractPermissions(inst *instance.Instance, m *Member) 
 		return "", err
 	}
 	codes := map[string]string{key: code}
-
-	set := make(permission.Set, len(s.Rules))
-	getVerb := permission.ALL
-	for i, rule := range s.Rules {
-		set[i] = permission.Rule{
-			Type:     rule.DocType,
-			Title:    rule.Title,
-			Verbs:    getVerb,
-			Selector: rule.Selector,
-			Values:   rule.Values,
-		}
-	}
+	set := s.CreateInteractSet()
 
 	md := metadata.New()
 	md.CreatedByApp = s.AppSlug
@@ -282,6 +271,23 @@ func (s *Sharing) CreateInteractPermissions(inst *instance.Instance, m *Member) 
 		return "", err
 	}
 	return code, nil
+}
+
+// CreateInteractSet returns a set of permissions that can be used for
+// share-interact.
+func (s *Sharing) CreateInteractSet() permission.Set {
+	set := make(permission.Set, len(s.Rules))
+	getVerb := permission.ALL
+	for i, rule := range s.Rules {
+		set[i] = permission.Rule{
+			Type:     rule.DocType,
+			Title:    rule.Title,
+			Verbs:    getVerb,
+			Selector: rule.Selector,
+			Values:   rule.Values,
+		}
+	}
+	return set
 }
 
 // Create checks that the sharing is OK and it persists it in CouchDB if it is the case.

--- a/web/permissions/permissions.go
+++ b/web/permissions/permissions.go
@@ -65,7 +65,9 @@ func displayPermissions(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	doc.Codes = nil // XXX hides the codes in the response
+	// XXX hides the codes in the response
+	doc.Codes = nil
+	doc.ShortCodes = nil
 	return jsonapi.Data(c, http.StatusOK, &APIPermission{doc}, nil)
 }
 


### PR DESCRIPTION
When a sharing has been accepted by a member, and then revoked, the
stack may have kept a permission of type share-interact for this
sharing. If the same member accepts the sharing again and creates a note
inside the new shared folder, the other members would have used the
share-interact permission on the old folder, which fails. This commit
fixes this issue by checking that the permission set is correct, and by
updating it if needed.