### PR TITLE
Force trashing file

### DIFF
--- a/model/vfs/file.go
+++ b/model/vfs/file.go
@@ -323,7 +323,10 @@ func TrashFile(fs VFS, olddoc *FileDoc) (*FileDoc, error) {
 		return nil, err
 	}
 
-	if strings.HasPrefix(oldpath, TrashDirName) {
+	// If there is only the trashed attribute or the parent in trash, but not
+	// both, we can try again to move the file to the trash to fix the
+	// inconsistency.
+	if olddoc.Trashed && strings.HasPrefix(oldpath, TrashDirName) {
 		return nil, ErrFileInTrash
 	}
 


### PR DESCRIPTION
When a file is requested to be put in the trash, the stack looks if it
is not already in the trash. It was done via checking if its path
doesn't start by the trash name. But there is also a trashed attribute,
and we can check both. If only one of those is true, we have an
inconsistency and we can hope that moving the file again to the trash
will help fixing it.