### PR TITLE
Fix the OAuth workflow for konnectors

### DIFF
--- a/model/account/type.go
+++ b/model/account/type.go
@@ -110,6 +110,12 @@ func (at *AccountType) Clone() couchdb.Doc {
 // ensure AccountType implements couchdb.Doc
 var _ couchdb.Doc = (*AccountType)(nil)
 
+// ServiceID is the ID, without the (optional) context prefix
+func (at *AccountType) ServiceID() string {
+	parts := strings.SplitN(at.DocID, "/", 2)
+	return parts[len(parts)-1]
+}
+
 // HasSecretGrant tells if the account type has non-OAuth secrets.
 func (at *AccountType) HasSecretGrant() bool {
 	return at.GrantMode == SecretGrant || at.GrantMode == BIWebauthAndSecret

--- a/web/accounts/oauth.go
+++ b/web/accounts/oauth.go
@@ -38,7 +38,7 @@ func start(c echo.Context) error {
 
 	state, err := getStorage().Add(&stateHolder{
 		InstanceDomain: instance.Domain,
-		AccountType:    accountType.ID(),
+		AccountType:    accountType.ServiceID(),
 		ClientState:    c.QueryParam("state"),
 		Nonce:          c.QueryParam("nonce"),
 		Slug:           c.QueryParam("slug"),


### PR DESCRIPTION
When an account type is configured for a service on a context (and not
for the whole stack), we need to remove the context prefix when checking
the service name after the redirection on the OAuth flow.