### PR TITLE
Forbid to create a too depth directory

### DIFF
--- a/model/vfs/directory.go
+++ b/model/vfs/directory.go
@@ -130,10 +130,6 @@ func (d *DirDoc) RemoveReferencedBy(ri ...couchdb.DocReference) {
 
 // NewDirDoc is the DirDoc constructor. The given name is validated.
 func NewDirDoc(index Indexer, name, dirID string, tags []string) (*DirDoc, error) {
-	if err := checkFileName(name); err != nil {
-		return nil, err
-	}
-
 	if dirID == "" {
 		dirID = consts.RootDirID
 	}
@@ -155,21 +151,7 @@ func NewDirDoc(index Indexer, name, dirID string, tags []string) (*DirDoc, error
 // NewDirDocWithParent returns an instance of DirDoc from a parent document.
 // The given name is validated.
 func NewDirDocWithParent(name string, parent *DirDoc, tags []string) (*DirDoc, error) {
-	if err := checkFileName(name); err != nil {
-		return nil, err
-	}
-
-	createDate := time.Now()
-	return &DirDoc{
-		Type:    consts.DirType,
-		DocName: name,
-		DirID:   parent.DocID,
-
-		CreatedAt: createDate,
-		UpdatedAt: createDate,
-		Tags:      uniqueTags(tags),
-		Fullpath:  path.Join(parent.Fullpath, name),
-	}, nil
+	return NewDirDocWithPath(name, parent.DocID, parent.Fullpath, tags)
 }
 
 // NewDirDocWithPath returns an instance of DirDoc its directory ID and path.
@@ -179,10 +161,15 @@ func NewDirDocWithPath(name, dirID, dirPath string, tags []string) (*DirDoc, err
 		return nil, err
 	}
 
-	createDate := time.Now()
 	if dirPath == "" || dirPath == "." {
 		dirPath = "/"
 	}
+	fullpath := path.Join(dirPath, name)
+	if err := checkDepth(fullpath); err != nil {
+		return nil, err
+	}
+
+	createDate := time.Now()
 	return &DirDoc{
 		Type:    consts.DirType,
 		DocName: name,
@@ -191,7 +178,7 @@ func NewDirDocWithPath(name, dirID, dirPath string, tags []string) (*DirDoc, err
 		CreatedAt: createDate,
 		UpdatedAt: createDate,
 		Tags:      uniqueTags(tags),
-		Fullpath:  path.Join(dirPath, name),
+		Fullpath:  fullpath,
 	}, nil
 }
 

--- a/model/vfs/errors.go
+++ b/model/vfs/errors.go
@@ -11,6 +11,8 @@ var (
 	ErrForbiddenDocMove = errors.New("Forbidden document move")
 	// ErrIllegalFilename is used when the given filename is not allowed
 	ErrIllegalFilename = errors.New("Invalid filename: empty or contains an illegal character")
+	// ErrIllegalPath is used when the path has too many levels
+	ErrIllegalPath = errors.New("Invalid path: too many levels")
 	// ErrIllegalTime is used when a time given (creation or
 	// modification) is not allowed
 	ErrIllegalTime = errors.New("Invalid time given")

--- a/model/vfs/vfs.go
+++ b/model/vfs/vfs.go
@@ -46,9 +46,9 @@ const (
 	conflictFormat = "%s (__cozy__: %s)"
 )
 
-// maxWalkRecursive is the maximum amount of recursion allowed for the
-// recursive walk process.
-const maxWalkRecursive = 512
+// MaxDepth is the maximum amount of recursion allowed for the recursive walk
+// process.
+const MaxDepth = 512
 
 // ErrSkipDir is used in WalkFn as an error to skip the current
 // directory. It is not returned by any function of the package.
@@ -573,7 +573,7 @@ func WalkAlreadyLocked(fs Indexer, dir *DirDoc, walkFn WalkFn) error {
 }
 
 func walk(fs Indexer, name string, dir *DirDoc, file *FileDoc, walkFn WalkFn, count int) error {
-	if count >= maxWalkRecursive {
+	if count >= MaxDepth {
 		return ErrWalkOverflow
 	}
 	err := walkFn(name, dir, file, nil)
@@ -785,6 +785,14 @@ func normalizeDocPatch(data, patch *DocPatch, cdate time.Time) (*DocPatch, error
 func checkFileName(str string) error {
 	if str == "" || strings.ContainsAny(str, ForbiddenFilenameChars) {
 		return ErrIllegalFilename
+	}
+	return nil
+}
+
+func checkDepth(fullpath string) error {
+	depth := strings.Count(fullpath, "/")
+	if depth >= MaxDepth {
+		return ErrIllegalPath
 	}
 	return nil
 }

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -1402,6 +1402,8 @@ func wrapVfsError(err error) *jsonapi.Error {
 		return jsonapi.PreconditionFailed("dir-id", err)
 	case vfs.ErrIllegalFilename:
 		return jsonapi.InvalidParameter("name", err)
+	case vfs.ErrIllegalPath:
+		return jsonapi.InvalidParameter("path", err)
 	case vfs.ErrIllegalTime:
 		return jsonapi.InvalidParameter("UpdatedAt", err)
 	case vfs.ErrInvalidHash:


### PR DESCRIPTION
When a path has more than 512 levels, the walk function of the VFS
reaches a limit and fails. To avoid this issue, we don't allow to create
directories with a too depth path.