### PR TITLE
Include the sharing member in GET /permissions/self

### DIFF
--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -221,6 +221,56 @@ Content-Type: application/vnd.api+json
 }
 ```
 
+#### Special case
+
+The token can be a sharecode when a member of a sharing is previewing a
+sharing. When it is the case, the member information from the sharing is
+included in the response, like this:
+
+```json
+{
+	"data": {
+		"type": "io.cozy.permissions",
+		"id": "bf716babb70b73b89c870fccce00233f",
+		"attributes": {
+			"type": "share-preview",
+			"source_id": "io.cozy.sharings/bf716babb70b73b89c870fccce00233a",
+			"permissions": {
+				"Essai": {
+					"type": "io.cozy.files",
+					"verbs": ["GET"],
+					"values": ["c2930bef3705096d63f5c8fb60019cc0"]
+				}
+			},
+			"cozyMetadata": {
+				"doctypeVersion": "",
+				"metadataVersion": 1,
+				"createdAt": "2020-10-19T16:12:31.440253797+02:00",
+				"createdByApp": "drive",
+				"updatedAt": "2020-10-19T16:12:31.440253797+02:00"
+			}
+		},
+		"meta": {
+			"rev": "1-18c3bc158cf5039f60fefe5fc2fcad67"
+		},
+		"links": {
+			"self": "/permissions/bf716babb70b73b89c870fccce00233f",
+			"related": "/sharings/bf716babb70b73b89c870fccce00233a"
+		}
+	},
+	"included": [
+		{
+			"type": "io.cozy.sharings.members",
+			"attributes": {
+				"status": "seen",
+				"name": "Bob",
+				"email": "bob@cozy.tools"
+			}
+		}
+	]
+}
+```
+
 ### POST /permissions
 
 Create a new set of permissions. It can also associates one or more codes to it,

--- a/model/sharing/member.go
+++ b/model/sharing/member.go
@@ -429,7 +429,7 @@ func (s *Sharing) FindMemberBySharecode(db prefixer.Prefixer, sharecode string) 
 	if err != nil {
 		return nil, err
 	}
-	return s.findMemberByCode(perms, sharecode)
+	return s.FindMemberByCode(perms, sharecode)
 }
 
 // FindMemberByInteractCode returns the member that is linked to the sharing by
@@ -439,10 +439,12 @@ func (s *Sharing) FindMemberByInteractCode(db prefixer.Prefixer, sharecode strin
 	if err != nil {
 		return nil, err
 	}
-	return s.findMemberByCode(perms, sharecode)
+	return s.FindMemberByCode(perms, sharecode)
 }
 
-func (s *Sharing) findMemberByCode(perms *permission.Permission, sharecode string) (*Member, error) {
+// FindMemberByCode returns the member that is linked to the sharing by the
+// given code.
+func (s *Sharing) FindMemberByCode(perms *permission.Permission, sharecode string) (*Member, error) {
 	var emailOrInstance string
 	for e, code := range perms.Codes {
 		if code == sharecode {

--- a/pkg/consts/doctype.go
+++ b/pkg/consts/doctype.go
@@ -64,6 +64,8 @@ const (
 	Shared = "io.cozy.shared"
 	// Sharings doc type for document and file sharing
 	Sharings = "io.cozy.sharings"
+	// SharingsMembers doc type for members of a sharing
+	SharingsMembers = "io.cozy.sharings.members"
 	// SharingsAnswer doc type for credentials exchange for sharings
 	SharingsAnswer = "io.cozy.sharings.answer"
 	// SharingsInitialSync doc type for real-time events for initial sync of a


### PR DESCRIPTION
When the GET /permissions/self route is called with a sharecode, the
stack will include the information about the linked member in the
response. In particular, if the instance field is filled, it means that
this member had a link to this sharing in their Cozy instance.