### PR TITLE
Make the deletion of old versions more robust

### DIFF
--- a/model/vfs/vfsswift/impl_v3.go
+++ b/model/vfs/vfsswift/impl_v3.go
@@ -755,19 +755,8 @@ func (sfs *swiftVFSV3) ClearOldVersions() error {
 	if err := sfs.Indexer.BatchDeleteVersions(versions); err != nil {
 		return err
 	}
-	_, err = sfs.c.BulkDelete(sfs.container, objNames)
-	if err == swift.Forbidden {
-		sfs.log.Warnf("ClearOldVersions failed on BulkDelete: %s", err)
-		err = nil
-		for _, objName := range objNames {
-			if errd := sfs.c.ObjectDelete(sfs.container, objName); err == nil && errd != nil {
-				sfs.log.Infof("ClearOldVersions failed on ObjectDelete: %s", errd)
-				err = errd
-			}
-		}
-	}
 	vfs.DiskQuotaAfterDestroy(sfs, diskUsage, destroyed)
-	return err
+	return deleteContainerFiles(sfs.c, sfs.container, objNames)
 }
 
 type swiftFileOpenV3 struct {


### PR DESCRIPTION
When using the VFS Swift backend, the deletion of old versions can reuse
code for emptying the trash: it makes several calls to Swift, with a bit
of waiting if needed and a retry logic.