### PR TITLE
Fix deprecated GitHub Actions commands

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -20,7 +20,11 @@ jobs:
           echo ::add-path::$(go env GOPATH)/bin
           go install
       - name: Build
-        run: make assets
+        comment: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
+        run: |
+          echo "::stop-commands::`echo -n ${{ github.token }} | sha256sum | head -c 64`"
+          make assets
+          echo "::`echo -n ${{ github.token }} | sha256sum | head -c 64`::"
       - uses: stefanzweifel/git-auto-commit-action@v2.1.0
         with:
           commit_message: Build assets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,13 @@ jobs:
           go install
       - name: Lint
         if: matrix.go-version == '1.15.x'
-        run: make lint jslint
+        comment: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
+        run: |
+          echo "::stop-commands::`echo -n ${{ github.token }} | sha256sum | head -c 64`"
+          make lint jslint
+          echo "::`echo -n ${{ github.token }} | sha256sum | head -c 64`::"
       - name: Unit tests
-        run: make unit-tests
+        run: |
+          echo "::stop-commands::`echo -n ${{ github.token }} | sha256sum | head -c 64`"
+          make unit-tests
+          echo "::`echo -n ${{ github.token }} | sha256sum | head -c 64`::"

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -20,7 +20,11 @@ jobs:
           echo ::add-path::$(go env GOPATH)/bin
           go install
       - name: Build
-        run: make cli
+        comment: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
+        run: |
+          echo "::stop-commands::`echo -n ${{ github.token }} | sha256sum | head -c 64`"
+          make cli
+          echo "::`echo -n ${{ github.token }} | sha256sum | head -c 64`::"
       - uses: stefanzweifel/git-auto-commit-action@v2.1.0
         with:
           commit_message: Build CLI docs and shell completions

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -50,4 +50,8 @@ jobs:
           echo ::add-path::$(go env GOPATH)/bin
           go install
       - name: Test
-        run: make integration-tests
+        comment: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
+        run: |
+          echo "::stop-commands::`echo -n ${{ github.token }} | sha256sum | head -c 64`"
+          make integration-tests
+          echo "::`echo -n ${{ github.token }} | sha256sum | head -c 64`::"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,13 @@ jobs:
       - name: Check code
         uses: actions/checkout@v2
       - name: Build the binaries
+        comment: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
         run: |
+          echo "::stop-commands::`echo -n ${{ github.token }} | sha256sum | head -c 64`"
           GOOS=linux   GOARCH=amd64 ./scripts/build.sh release
           GOOS=linux   GOARCH=arm   ./scripts/build.sh release
           GOOS=freebsd GOARCH=amd64 ./scripts/build.sh release
+          echo "::`echo -n ${{ github.token }} | sha256sum | head -c 64`::"
       - name: Create the release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,4 +11,9 @@ jobs:
         with:
           fetch-depth: 1
       - name: Build
-        run: go run . --help
+        comment: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
+        run: |
+          echo "::stop-commands::`echo -n ${{ github.token }} | sha256sum | head -c 64`"
+          make assets
+          go run . --help
+          echo "::`echo -n ${{ github.token }} | sha256sum | head -c 64`::"


### PR DESCRIPTION
See https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/