### PR TITLE
Fix echo on restore file deleted from a shared dir

### DIFF
--- a/model/sharing/upload.go
+++ b/model/sharing/upload.go
@@ -367,7 +367,7 @@ func (s *Sharing) SyncFile(inst *instance.Instance, target *FileDocWithRevisions
 		}
 		return nil, err
 	}
-	if _, ok := ref.Infos[s.SID]; !ok {
+	if infos, ok := ref.Infos[s.SID]; !ok || infos.Removed {
 		return nil, ErrSafety
 	}
 	if sub, _ := ref.Revisions.Find(target.DocRev); sub != nil {


### PR DESCRIPTION
When a file was in a shared directory, was trashed, and is now restored,
the stack should be able to make the file available for all the members
of the sharing. It is not the case today, and this commit is not enough
to do so. But, at least, the file isn't moved again to the trash by the
sharing for the user who restored the file.