### PR TITLE
Fix deleting old versions on emptying trash

### DIFF
--- a/model/vfs/couchdb_indexer.go
+++ b/model/vfs/couchdb_indexer.go
@@ -659,9 +659,9 @@ func (c *couchdbIndexer) BatchDeleteVersions(versions []*Version) error {
 		}
 		toDelete := remaining[:n]
 		remaining = remaining[n:]
-		if err := couchdb.BulkDeleteDocs(c.db, consts.Files, toDelete); err != nil {
+		if err := couchdb.BulkDeleteDocs(c.db, consts.FilesVersions, toDelete); err != nil {
 			// If it fails once, try again
-			if err := couchdb.BulkDeleteDocs(c.db, consts.Files, toDelete); err != nil {
+			if err := couchdb.BulkDeleteDocs(c.db, consts.FilesVersions, toDelete); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
When the user asks for emptying the trash, the stack puts a job for the
trash worker that will do the real work in background. In particular, it
cleans the old versions. There was a bug that made the bulk requests for
deleting old versions in CouchDB on the wrong database. Let's fix that!
And improve our logs, even if the logs couldn't have given us a clue,
because the CouchDB call on the wrong database is still a success:
deleting documents that don't exist is OK for CouchDB.