### PR TITLE
Check carbonCopy and electronicSafe metadata

### DIFF
--- a/docs/files.md
+++ b/docs/files.md
@@ -643,7 +643,7 @@ Send a metadata object that can be associated to a file uploaded after that,
 via the `MetadataID` query parameter.
 
 **Note:** a special permission on `io.cozy.certified.carbonCopy` is required to
-send a request with `carbonCopy` as key in the `attributes` map. Safe for
+send a request with `carbonCopy` as key in the `attributes` map. Same for
 `electronicSafe`.
 
 #### Request

--- a/docs/files.md
+++ b/docs/files.md
@@ -642,6 +642,10 @@ more informations about the references field.
 Send a metadata object that can be associated to a file uploaded after that,
 via the `MetadataID` query parameter.
 
+**Note:** a special permission on `io.cozy.certified.carbonCopy` is required to
+send a request with `carbonCopy` as key in the `attributes` map. Safe for
+`electronicSafe`.
+
 #### Request
 
 ```http

--- a/model/sharing/files.go
+++ b/model/sharing/files.go
@@ -608,7 +608,7 @@ func buildReferencedBy(target, file *vfs.FileDoc, rule *Rule) []couchdb.DocRefer
 
 func copySafeFieldsToFile(target, file *vfs.FileDoc) {
 	file.Tags = target.Tags
-	file.Metadata = target.Metadata
+	file.Metadata = target.Metadata.RemoveCertifiedMetadata()
 	file.CreatedAt = target.CreatedAt
 	file.UpdatedAt = target.UpdatedAt
 	file.Mime = target.Mime
@@ -1141,7 +1141,7 @@ func fileToJSONDoc(file *vfs.FileDoc, instanceURL string) couchdb.JSONDoc {
 		doc.M["restore_path"] = file.RestorePath
 	}
 	if len(file.Metadata) > 0 {
-		doc.M["metadata"] = file.Metadata
+		doc.M["metadata"] = file.Metadata.RemoveCertifiedMetadata()
 	}
 	fcm := file.CozyMetadata
 	if fcm == nil {

--- a/model/vfs/metadata.go
+++ b/model/vfs/metadata.go
@@ -61,6 +61,23 @@ func MergeMetadata(doc *FileDoc, meta Metadata) {
 	}
 }
 
+// RemoveCertifiedMetadata returns a metadata map where the keys that are
+// certified have been removed. It can be useful for sharing, as certified
+// metadata are only valid localy.
+func (m Metadata) RemoveCertifiedMetadata() Metadata {
+	if len(m) == 0 {
+		return Metadata{}
+	}
+	result := make(Metadata, len(m))
+	for k, v := range m {
+		if k == consts.CarbonCopyKey || k == consts.ElectronicSafeKey {
+			continue
+		}
+		result[k] = v
+	}
+	return result
+}
+
 // MetaExtractor is an interface for extracting metadata from a file
 type MetaExtractor interface {
 	io.WriteCloser

--- a/pkg/consts/doctype.go
+++ b/pkg/consts/doctype.go
@@ -36,6 +36,12 @@ const (
 	// Thumbnails is a synthetic doctype for thumbnails, used for realtime
 	// events
 	Thumbnails = "io.cozy.files.thumbnails"
+	// CertifiedCarbonCopy is a synthetic doctype, used for given permission to
+	// add the carbonCopy metadata on files
+	CertifiedCarbonCopy = "io.cozy.certified.carbonCopy"
+	// CertifiedElectronicSafe is a synthetic doctype, used for given
+	// permission to add the electronicSafe metadata on files
+	CertifiedElectronicSafe = "io.cozy.certified.electronicSafe"
 	// PhotosAlbums doc type for photos albums
 	PhotosAlbums = "io.cozy.photos.albums"
 	// Intents doc type for intents persisted in couchdb

--- a/pkg/consts/file.go
+++ b/pkg/consts/file.go
@@ -26,3 +26,10 @@ const (
 	// NoteMimeType is the mime-type for the .cozy-note files.
 	NoteMimeType = "text/vnd.cozy.note+markdown"
 )
+
+const (
+	// CarbonCopyKey is the metadata key for a carbon copy (certified)
+	CarbonCopyKey = "carbonCopy"
+	// ElectronicSafeKey is the metadata key for an electronic safe (certified)
+	ElectronicSafeKey = "electronicSafe"
+)

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -1510,6 +1510,19 @@ func FileDocFromReq(c echo.Context, name, dirID string) (*vfs.FileDoc, error) {
 		doc.Metadata = *meta
 	}
 
+	if len(doc.Metadata) > 0 {
+		if _, ok := doc.Metadata[consts.CarbonCopyKey]; ok {
+			if err := middlewares.AllowWholeType(c, permission.POST, consts.CertifiedCarbonCopy); err != nil {
+				delete(doc.Metadata, consts.CarbonCopyKey)
+			}
+		}
+		if _, ok := doc.Metadata[consts.ElectronicSafeKey]; ok {
+			if err := middlewares.AllowWholeType(c, permission.POST, consts.CertifiedElectronicSafe); err != nil {
+				delete(doc.Metadata, consts.ElectronicSafeKey)
+			}
+		}
+	}
+
 	return doc, nil
 }
 


### PR DESCRIPTION
The metadata map for io.cozy.files cannot have a carbonCopy or
electronicSafe key unless the app/konnector that adds it has a
permission on io.cozy.certified.carbonCopy /
io.cozy.certified.electronicSafe.

When a file with such metadata attribute is shared, this attribute will
be removed on the instances of the other members: this attribute is only
valid localy, we don't want to trust other instances as it is easy to
cheat for a self-hosted.