### PR TITLE
Fix files wildcard permission

### DIFF
--- a/model/permission/doctype.go
+++ b/model/permission/doctype.go
@@ -91,7 +91,7 @@ func CheckDoctypeName(doctype string, authorizeWildcard bool) error {
 		if strings.Count(doctype, ".") < 3 {
 			return err
 		}
-		doctype = trimWildcard(doctype)
+		doctype = TrimWildcard(doctype)
 	}
 
 	for _, c := range doctype {
@@ -119,6 +119,7 @@ func isWildcard(doctype string) bool {
 	return strings.HasSuffix(doctype, wildcardSuffix)
 }
 
-func trimWildcard(doctype string) string {
+// TrimWildcard returns the given doctype without the wildcard suffix
+func TrimWildcard(doctype string) string {
 	return strings.TrimSuffix(doctype, wildcardSuffix)
 }

--- a/model/permission/match.go
+++ b/model/permission/match.go
@@ -50,7 +50,7 @@ func matchType(r Rule, doctype string) bool {
 	if !isWildcard(r.Type) {
 		return false
 	}
-	typ := trimWildcard(r.Type)
+	typ := TrimWildcard(r.Type)
 	return typ == doctype || strings.HasPrefix(doctype, typ+".")
 }
 

--- a/model/vfs/permissions.go
+++ b/model/vfs/permissions.go
@@ -29,11 +29,11 @@ func Allows(fs VFS, pset permission.Set, v permission.Verb, fd Fetcher) error {
 	// First pass, we iterate over the rules, check if we have an easy match
 	// keep a short list of useful rules and allowed IDs.
 	for _, r := range pset {
-		isFileDoctype := false
-		if r.Type == consts.Files || permission.TrimWildcard(r.Type) == consts.Files {
-			isFileDoctype = true
+		typ := permission.TrimWildcard(r.Type)
+		if typ != consts.Files && !strings.HasPrefix(consts.Files, typ+".") {
+			continue
 		}
-		if !isFileDoctype || !r.Verbs.Contains(v) {
+		if !r.Verbs.Contains(v) {
 			continue
 		}
 

--- a/model/vfs/permissions.go
+++ b/model/vfs/permissions.go
@@ -29,7 +29,11 @@ func Allows(fs VFS, pset permission.Set, v permission.Verb, fd Fetcher) error {
 	// First pass, we iterate over the rules, check if we have an easy match
 	// keep a short list of useful rules and allowed IDs.
 	for _, r := range pset {
-		if r.Type != consts.Files || !r.Verbs.Contains(v) {
+		isFileDoctype := false
+		if r.Type == consts.Files || permission.TrimWildcard(r.Type) == consts.Files {
+			isFileDoctype = true
+		}
+		if !isFileDoctype || !r.Verbs.Contains(v) {
 			continue
 		}
 

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -626,19 +626,6 @@ func TestUploadWithSourceAccount(t *testing.T) {
 	assert.Equal(t, account, fcm["sourceAccount"])
 	assert.Equal(t, identifier, fcm["sourceAccountIdentifier"])
 }
-
-func TestUploadWithWildcardPermission(t *testing.T) {
-	_, wildToken := setup.GetTestClient(consts.Files + ".*")
-	f, err := os.Open("../../tests/fixtures/wet-cozy_20160910__M4Dz.jpg")
-	assert.NoError(t, err)
-	defer f.Close()
-	req, err := http.NewRequest("POST", ts.URL+"/files/?Type=file&Name=wet2.jpg", f)
-	assert.NoError(t, err)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+wildToken)
-	res, _ := doUploadOrMod(t, req, "image/jpeg", "tHWYYuXBBflJ8wXgJ2c2yg==")
-	assert.Equal(t, 201, res.StatusCode)
-}
-
 func TestModifyMetadataByPath(t *testing.T) {
 	body := "foo"
 	res1, data1 := upload(t, "/files/?Type=file&Name=file-move-me-by-path", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")

--- a/web/files/permissions_test.go
+++ b/web/files/permissions_test.go
@@ -26,6 +26,13 @@ func TestCreateDirBadType(t *testing.T) {
 	assert.Equal(t, 403, res.StatusCode)
 }
 
+func TestCreateDirWildCard(t *testing.T) {
+	wildTok, _ := testInstance.MakeJWT(consts.AccessTokenAudience, clientID, "io.cozy.files.*", "", time.Now())
+	res, err := request("POST", "/files/?Name=icantcreateyou&Type=directory", wildTok, strings.NewReader(""))
+	assert.NoError(t, err)
+	assert.Equal(t, 201, res.StatusCode)
+}
+
 func TestCreateDirLimitedScope(t *testing.T) {
 	res, data := createDir(t, "/files/?Name=permissionholder&Type=directory")
 	assert.Equal(t, 201, res.StatusCode)


### PR DESCRIPTION
The files permissions are handled differently from the other doctypes, and it wasn't possible to request `io.cozy.files` docs when using a `io.cozy.files.*` permission. This should fix this behaviour.