### PR TITLE
Allow wildcard permission for sharing

### DIFF
--- a/model/permission/set.go
+++ b/model/permission/set.go
@@ -149,7 +149,7 @@ func (s Set) Some(predicate func(Rule) bool) bool {
 // is allowed by the set.
 func (s *Set) RuleInSubset(r2 Rule) bool {
 	for _, r := range *s {
-		if r.Type != r2.Type {
+		if !matchType(r, r2.Type) {
 			continue
 		}
 


### PR DESCRIPTION
It was not possible for an app to have a wildcard permission on a doctype and use the sharing on a doctype included in this wildcard