### PR TITLE
docs: Add docs about SMS notification

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -115,6 +115,10 @@ Notifications fields are:
 -   `at` (string): send the notification later, at this date formatted in
     ISO-8601 (optional)
 
+Note that if you send a notification by sms, only the `message` attribute 
+will be sent. Also, keep in mind that, depending on your sms provider, the length 
+of the message cannot be longer than 160 characters. 
+
 #### Request
 
 ```http

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -59,7 +59,16 @@ To use this worker from a client-side application, you should use
 ## sms worker
 
 The `sms` worker can be used to send SMS notifications to a user, via
-[the notifications API](./notifications.md).
+[the notifications API](./notifications.md). 
+
+The phone number used is the `primary phone number` registered in 
+the contact that has the flag `me: true` (see [contact doctype](https://github.com/cozy/cozy-doctypes/blob/master/docs/io.cozy.contacts.md) )
+
+Note: If an error happens during the send of the sms (for instance no phone number on the cozy or SMS provider not available), the content will be send by email as fallback.
+
+To use the sms worker, you need to configure your SMS provider:
+- first enable sms worker in your [stack configuration](https://github.com/cozy/cozy-stack/blob/master/cozy.example.yaml#L156)
+- configure the [notification configuration](https://github.com/cozy/cozy-stack/blob/master/cozy.example.yaml#L281-L285) by setting your provider's informations.
 
 ## unzip worker
 


### PR DESCRIPTION
Adding a few lines about SMS notification. I haven't used it yet, but it will help answer some questions from partners ;). But I'm not sure that ./worker#sms is the best place to do it.

I'm wondering, currently for push notification configuration, we're setting a document in the `secrets/io-cozy-account_types` database. Can we do the same for SMS provider? 