### PR TITLE
Fix a race condition when using --appdir

### DIFF
--- a/web/apps/serve.go
+++ b/web/apps/serve.go
@@ -55,10 +55,7 @@ func Serve(c echo.Context) error {
 	if webapp.FromAppsDir {
 		// Save permissions in couchdb before loading an index page
 		if file == "" && webapp.Permissions() != nil {
-			err := permission.ForceWebapp(i, webapp.Slug(), webapp.Permissions())
-			if err != nil {
-				return err
-			}
+			_ = permission.ForceWebapp(i, webapp.Slug(), webapp.Permissions())
 		}
 
 		fs := app.FSForAppDir(slug)


### PR DESCRIPTION
When the stack is launched with the --appdir flag, it reads the
permission from the manifest and updates CouchDB when the index page of
an app if served. But, if there are two requests at the same time, it
can lead to a CouchDB conflict, and 500 error for one of those.