### PR TITLE
fix: Do not return err if m.Notifications is nil

### DIFF
--- a/model/notification/center/notification_center.go
+++ b/model/notification/center/notification_center.go
@@ -109,7 +109,7 @@ func Push(inst *instance.Instance, perm *permission.Permission, n *notification.
 	case permission.TypeWebapp:
 		slug := strings.TrimPrefix(perm.SourceID, consts.Apps+"/")
 		m, err := app.GetWebappBySlug(inst, slug)
-		if err != nil || m.Notifications == nil {
+		if err != nil {
 			return err
 		}
 		var ok bool
@@ -122,7 +122,7 @@ func Push(inst *instance.Instance, perm *permission.Permission, n *notification.
 	case permission.TypeKonnector:
 		slug := strings.TrimPrefix(perm.SourceID, consts.Apps+"/")
 		m, err := app.GetKonnectorBySlug(inst, slug)
-		if err != nil || m.Notifications == nil {
+		if err != nil {
 			return err
 		}
 		var ok bool

--- a/model/notification/center/notification_center.go
+++ b/model/notification/center/notification_center.go
@@ -112,6 +112,9 @@ func Push(inst *instance.Instance, perm *permission.Permission, n *notification.
 		if err != nil {
 			return err
 		}
+		if m.Notifications == nil {
+			return ErrUnauthorized
+		}
 		var ok bool
 		p, ok = m.Notifications[n.Category]
 		if !ok {
@@ -124,6 +127,9 @@ func Push(inst *instance.Instance, perm *permission.Permission, n *notification.
 		m, err := app.GetKonnectorBySlug(inst, slug)
 		if err != nil {
 			return err
+		}
+		if m.Notifications == nil {
+			return ErrUnauthorized
 		}
 		var ok bool
 		p, ok = m.Notifications[n.Category]


### PR DESCRIPTION
Since err can be nil when m.Notifications is nil, we're not sending
any error at the end in that case. We returned a 201 OK whereas we're
not creating anything.

Later in the code, we check if m.Notifications[p.category] exists. If
not we are returning an error. Let's use this error.

I had this case when the app manifest was not well build for the notifications part (having the notifications object part of the permissions object, not a new one) 