### PR TITLE
Add a referenced_by on a single shared file

### DIFF
--- a/tests/integration/tests/sharing_read_only.rb
+++ b/tests/integration/tests/sharing_read_only.rb
@@ -92,6 +92,9 @@ describe "A file or folder" do
     sleep 12
     note_path = "/#{Helpers::SHARED_WITH_ME}/#{note.file.name}"
     note_bob = CozyFile.find_by_path inst_bob, note_path
+    assert_equal note_bob.referenced_by.length, 1
+    assert_equal note_bob.referenced_by[0]["type"], Sharing.doctype
+    assert_equal note_bob.referenced_by[0]["id"], sharing.couch_id
     parameters = Note.open inst_bob, note_bob.couch_id
     assert_equal note.file.couch_id, parameters["note_id"]
     assert %w[flat nested].include? parameters["subdomain"]


### PR DESCRIPTION
When a single file is shared via a Cozy to Cozy mode, this file will
have a referenced_by to the sharing on the recipients instances.