### PR TITLE
Fix lack of support of wildcard permission in several cases

### DIFF
--- a/docs/important-changes.md
+++ b/docs/important-changes.md
@@ -4,6 +4,11 @@
 
 This section will list important changes to the stack or its usage, and migration procedures if any is needed.
 
+## December 2020: Jobs permissions
+
+We used to have a specific permission logic for jobs, in order to allow apps to direclty manage konnectors. More specifically, an app had the right to access a trigger state or remove it, if there was a doctype in common between the app permissions and the konnector manifest.
+
+This does not seem useful anymore as the konnectors are handled directly through harvest.  
 
 ## October 2019: Authentication
 

--- a/model/permission/match.go
+++ b/model/permission/match.go
@@ -43,7 +43,8 @@ func matchVerb(r Rule, v Verb) bool {
 	return r.Verbs.Contains(v)
 }
 
-func matchType(r Rule, doctype string) bool {
+// MatchType returns true if the rule type matches the given doctype
+func MatchType(r Rule, doctype string) bool {
 	if r.Type == doctype {
 		return true
 	}
@@ -67,7 +68,7 @@ func matchID(r Rule, id string) bool {
 func (s Set) AllowWholeType(v Verb, doctype string) bool {
 	return s.Some(func(r Rule) bool {
 		return matchVerb(r, v) &&
-			matchType(r, doctype) &&
+			MatchType(r, doctype) &&
 			matchWholeType(r)
 	})
 }
@@ -76,7 +77,7 @@ func (s Set) AllowWholeType(v Verb, doctype string) bool {
 func (s Set) AllowID(v Verb, doctype, id string) bool {
 	return s.Some(func(r Rule) bool {
 		return matchVerb(r, v) &&
-			matchType(r, doctype) &&
+			MatchType(r, doctype) &&
 			(matchWholeType(r) || matchID(r, id))
 	})
 }
@@ -85,7 +86,7 @@ func (s Set) AllowID(v Verb, doctype, id string) bool {
 func (s Set) Allow(v Verb, o Fetcher) bool {
 	return s.Some(func(r Rule) bool {
 		return matchVerb(r, v) &&
-			matchType(r, o.DocType()) &&
+			MatchType(r, o.DocType()) &&
 			matchValues(r, o)
 	})
 }
@@ -95,7 +96,7 @@ func (s Set) Allow(v Verb, o Fetcher) bool {
 func (s Set) AllowOnFields(v Verb, o Fetcher, fields ...string) bool {
 	return s.Some(func(r Rule) bool {
 		return matchVerb(r, v) &&
-			matchType(r, o.DocType()) &&
+			MatchType(r, o.DocType()) &&
 			matchOnFields(r, o, fields...)
 	})
 }

--- a/model/permission/permissions_test.go
+++ b/model/permission/permissions_test.go
@@ -353,7 +353,6 @@ func TestSubset(t *testing.T) {
 }
 
 func TestShareSetPermissions(t *testing.T) {
-
 	setFiles := Set{Rule{Type: "io.cozy.files"}}
 	setFilesWildCard := Set{Rule{Type: "io.cozy.files.*"}}
 	setEvents := Set{Rule{Type: "io.cozy.events"}}

--- a/model/permission/permissions_test.go
+++ b/model/permission/permissions_test.go
@@ -352,6 +352,32 @@ func TestSubset(t *testing.T) {
 	assert.False(t, s5.IsSubSetOf(s6))
 }
 
+func TestShareSetPermissions(t *testing.T) {
+
+	setFiles := Set{Rule{Type: "io.cozy.files"}}
+	setFilesWildCard := Set{Rule{Type: "io.cozy.files.*"}}
+	setEvents := Set{Rule{Type: "io.cozy.events"}}
+
+	parent := &Permission{Type: TypeCLI, Permissions: setEvents}
+	err := checkSetPermissions(setFiles, parent)
+	assert.Error(t, err)
+
+	parent.Type = TypeWebapp
+	err = checkSetPermissions(setFiles, parent)
+	assert.Error(t, err)
+
+	parent.Permissions = setFiles
+	err = checkSetPermissions(setFiles, parent)
+	assert.NoError(t, err)
+
+	err = checkSetPermissions(setFilesWildCard, parent)
+	assert.Error(t, err)
+
+	parent.Permissions = setFilesWildCard
+	err = checkSetPermissions(setFilesWildCard, parent)
+	assert.NoError(t, err)
+}
+
 func TestCreateShareSetBlocklist(t *testing.T) {
 	s := Set{Rule{Type: "io.cozy.notifications"}}
 	subdoc := Permission{

--- a/model/permission/set.go
+++ b/model/permission/set.go
@@ -149,7 +149,7 @@ func (s Set) Some(predicate func(Rule) bool) bool {
 // is allowed by the set.
 func (s *Set) RuleInSubset(r2 Rule) bool {
 	for _, r := range *s {
-		if !matchType(r, r2.Type) {
+		if !MatchType(r, r2.Type) {
 			continue
 		}
 

--- a/web/middlewares/permissions.go
+++ b/web/middlewares/permissions.go
@@ -341,7 +341,7 @@ func CanWriteToAnyDirectory(c echo.Context) error {
 		return err
 	}
 	for _, rule := range pdoc.Permissions {
-		if rule.Type == consts.Files && rule.Verbs.Contains(permission.POST) {
+		if permission.MatchType(rule, consts.Files) && rule.Verbs.Contains(permission.POST) {
 			return nil
 		}
 	}

--- a/worker/exec/konnector.go
+++ b/worker/exec/konnector.go
@@ -370,7 +370,7 @@ func (w *konnectorWorker) ensurePermissions(inst *instance.Instance) error {
 	}
 	value := consts.Konnectors + "/" + w.slug
 	for _, rule := range perms.Permissions {
-		if permission.MatchType(rule, consts.Files) && rule.Selector == couchdb.SelectorReferencedBy {
+		if rule.Type == consts.Files && rule.Selector == couchdb.SelectorReferencedBy {
 			for _, val := range rule.Values {
 				if val == value {
 					return nil

--- a/worker/exec/konnector.go
+++ b/worker/exec/konnector.go
@@ -370,7 +370,7 @@ func (w *konnectorWorker) ensurePermissions(inst *instance.Instance) error {
 	}
 	value := consts.Konnectors + "/" + w.slug
 	for _, rule := range perms.Permissions {
-		if rule.Type == consts.Files && rule.Selector == couchdb.SelectorReferencedBy {
+		if permission.MatchType(rule, consts.Files) && rule.Selector == couchdb.SelectorReferencedBy {
 			for _, val := range rule.Values {
 				if val == value {
 					return nil


### PR DESCRIPTION
The permission logic is splitted in many places in the stack and it some cases we didn't handled the wildcard permission logic, in particular for files.

This also removes unused code in web/jobs, where we implemented a specific logic to handle jobs permissions for
apps to manage konnectors. This does not seem useful anymore as this is handled directly through harvest.