### PR TITLE
Add a fallback parameter for the BW icons route

### DIFF
--- a/docs/bitwarden.md
+++ b/docs/bitwarden.md
@@ -1153,6 +1153,12 @@ Content-Type: application/json
 This route returns an icon for the given domain, that can be used by the
 bitwarden clients. No authorization token is required.
 
+If no favicon has been found for the domain, a fallback will be used, depending
+of the `fallback` parameter in the query-string:
+
+- `default`: a default icon is returned
+- `404`: just a 404 - Not found error.
+
 #### Request
 
 ```http

--- a/web/bitwarden/icons.go
+++ b/web/bitwarden/icons.go
@@ -26,10 +26,14 @@ func serveDefaultIcon(c echo.Context) error {
 func GetIcon(c echo.Context) error {
 	domain := c.Param("domain")
 	ico, err := bitwarden.GetIcon(domain)
-	if err != nil {
-		inst := middlewares.GetInstance(c)
-		inst.Logger().WithField("nspace", "bitwarden").Debugf("Error for icon %s: %s", domain, err)
-		return serveDefaultIcon(c)
+	if err == nil {
+		return c.Blob(http.StatusOK, ico.Mime, ico.Body)
 	}
-	return c.Blob(http.StatusOK, ico.Mime, ico.Body)
+
+	inst := middlewares.GetInstance(c)
+	inst.Logger().WithField("nspace", "bitwarden").Debugf("Error for icon %s: %s", domain, err)
+	if c.QueryParam("fallback") == "404" {
+		return echo.NewHTTPError(http.StatusNotFound, "Page not found")
+	}
+	return serveDefaultIcon(c)
 }


### PR DESCRIPTION
The pass clients show an icon for each domain that has a cipher. This
clients request the GET /bitwarden/icons/:domain/icon.png route of the
stack for this icon. This route has now a fallback parameter that allows
to return a 404 Not found error, instead of the default icon when no
favicon has been found for the domain. The clients can then use what
they want for the icon in that case.