### PR TITLE
Fix a race condition when installing app with services

### DIFF
--- a/model/app/webapp.go
+++ b/model/app/webapp.go
@@ -289,13 +289,14 @@ func (m *WebappManifest) ReadManifest(r io.Reader, slug, sourceURL string) (Mani
 
 // Create is part of the Manifest interface
 func (m *WebappManifest) Create(db prefixer.Prefixer) error {
-	if err := diffServices(db, m.Slug(), nil, m.Services); err != nil {
-		return err
-	}
 	m.DocID = consts.Apps + "/" + m.DocSlug
 	m.CreatedAt = time.Now()
 	m.UpdatedAt = time.Now()
 	if err := couchdb.CreateNamedDocWithDB(db, m); err != nil {
+		return err
+	}
+
+	if err := diffServices(db, m.Slug(), nil, m.Services); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
When the stack receive several requests to install the same application
at the same time, a race condition happens and the triggers for this app
may be created several times. The fix is to create the triggers only
after creating the CouchDB document for the application, as it will
return a conflict in that case.