### PR TITLE
Fix services execution with --appdir

### DIFF
--- a/model/app/webapp.go
+++ b/model/app/webapp.go
@@ -501,7 +501,14 @@ func SetupAppsDir(apps map[string]string) {
 }
 
 // FSForAppDir returns a FS for the webapp in development.
-func FSForAppDir(slug string) afero.Fs {
+func FSForAppDir(slug string) appfs.FileServer {
+	base := baseFSForAppDir(slug)
+	return appfs.NewAferoFileServer(base, func(_, _, _, file string) string {
+		return path.Join("/", file)
+	})
+}
+
+func baseFSForAppDir(slug string) afero.Fs {
 	return afero.NewBasePathFs(afero.NewOsFs(), appsdir[slug])
 }
 
@@ -511,7 +518,7 @@ func loadManifestFromDir(slug string) (*WebappManifest, error) {
 	if !ok {
 		return nil, ErrNotFound
 	}
-	fs := FSForAppDir(slug)
+	fs := baseFSForAppDir(slug)
 	manFile, err := fs.Open(WebappManifestName)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/web/apps/serve.go
+++ b/web/apps/serve.go
@@ -59,10 +59,7 @@ func Serve(c echo.Context) error {
 		}
 
 		fs := app.FSForAppDir(slug)
-		f := appfs.NewAferoFileServer(fs, func(_, _, _, file string) string {
-			return path.Join("/", file)
-		})
-		return ServeAppFile(c, i, f, webapp)
+		return ServeAppFile(c, i, fs, webapp)
 	}
 
 	if file == "" || file == route.Index {

--- a/worker/exec/service.go
+++ b/worker/exec/service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cozy/cozy-stack/model/app"
 	"github.com/cozy/cozy-stack/model/instance"
 	"github.com/cozy/cozy-stack/model/job"
+	"github.com/cozy/cozy-stack/pkg/appfs"
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
@@ -119,7 +120,12 @@ func (w *serviceWorker) PrepareWorkDir(ctx *job.WorkerContext, i *instance.Insta
 	}
 	workFS := afero.NewBasePathFs(osFS, workDir)
 
-	fs := app.AppsFileServer(i)
+	var fs appfs.FileServer
+	if man.FromAppsDir {
+		fs = app.FSForAppDir(man.Slug())
+	} else {
+		fs = app.AppsFileServer(i)
+	}
 	src, err := fs.Open(man.Slug(), man.Version(), man.Checksum(), path.Join("/", service.File))
 	if err != nil {
 		return


### PR DESCRIPTION
When a stack is started with the --appdir option, it should take the .js
file for a service from the given appdir, not from where the application
is normally installed.