### PR TITLE
Add tinycode support

### DIFF
--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -283,6 +283,9 @@ some of them later. A `ttl` parameter can also be given to make the codes
 expires after a delay ([bigduration
 format](https://github.com/justincampbell/bigduration/blob/master/README.md)).
 
+If the `ttl` does not exceed 1 hour, it is possible to add a `tinycode=true`
+parameter to the query-string to have a shortcode of 6 digits.
+
 **Note**: it is only possible to create a strict subset of the permissions
 associated to the sent token.
 

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -73,6 +73,9 @@ const MaxItemsPerPageForMango = 1000
 // ShortCodeLen is the number of chars for the shortcode
 const ShortCodeLen = 12
 
+// TinyCodeLen is the number of digits for the tinycode
+const TinyCodeLen = 6
+
 // KnownFlatDomains is a list of top-domains that can hosts cozy instances with
 // flat sub-domains.
 var KnownFlatDomains = []string{

--- a/pkg/crypto/utils.go
+++ b/pkg/crypto/utils.go
@@ -3,7 +3,9 @@ package crypto
 import (
 	"crypto/rand"
 	"encoding/base64"
+	"fmt"
 	"io"
+	math "math/rand"
 	"time"
 )
 
@@ -50,4 +52,10 @@ func GenerateRandomString(n int) string {
 	}
 
 	return string(bytes)
+}
+
+// GenerateRandomSixDigits returns a random string made of 6 digits
+func GenerateRandomSixDigits() string {
+	n := math.Intn(999999)
+	return fmt.Sprintf("%06d", n+1)
 }

--- a/web/middlewares/permissions.go
+++ b/web/middlewares/permissions.go
@@ -114,12 +114,14 @@ func GetForOauth(instance *instance.Instance, claims *permission.Claims, c inter
 	return pdoc, nil
 }
 
+var shortCodeRegexp = regexp.MustCompile(`^(\d{6}|(\w|\d){12})\.?$`)
+
 // ParseJWT parses a JSON Web Token, and returns the associated permissions.
 func ParseJWT(c echo.Context, instance *instance.Instance, token string) (*permission.Permission, error) {
 	var claims permission.Claims
 	var err error
 
-	if isShortCode, _ := regexp.MatchString("^(\\w|\\d){12}\\.?$", token); isShortCode { // token is a shortcode
+	if shortCodeRegexp.MatchString(token) { // token is a shortcode
 		// XXX in theory, the shortcode is exactly 12 characters. But
 		// somethimes, when people shares a public link with this token, they
 		// can put a "." just after the link to finish their sentence, and this

--- a/web/permissions/permissions.go
+++ b/web/permissions/permissions.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -105,6 +106,7 @@ func createPermission(c echo.Context) error {
 	instance := middlewares.GetInstance(c)
 	names := strings.Split(c.QueryParam("codes"), ",")
 	ttl := c.QueryParam("ttl")
+	tiny, _ := strconv.ParseBool(c.QueryParam("tiny"))
 
 	parent, err := middlewares.GetPermission(c)
 	if err != nil {
@@ -128,6 +130,17 @@ func createPermission(c echo.Context) error {
 		return err
 	}
 
+	var expiresAt *time.Time
+	if ttl != "" {
+		if d, errd := bigduration.ParseDuration(ttl); errd == nil {
+			ex := time.Now().Add(d)
+			expiresAt = &ex
+			if d.Hours() > 1.0 {
+				tiny = false
+			}
+		}
+	}
+
 	var codes map[string]string
 	var shortcodes map[string]string
 
@@ -136,7 +149,7 @@ func createPermission(c echo.Context) error {
 		shortcodes = make(map[string]string, len(names))
 		for _, name := range names {
 			longcode, err := instance.CreateShareCode(name)
-			shortcode := crypto.GenerateRandomString(consts.ShortCodeLen)
+			shortcode := createShortCode(tiny)
 
 			codes[name] = longcode
 			shortcodes[name] = shortcode
@@ -148,14 +161,6 @@ func createPermission(c echo.Context) error {
 
 	if parent == nil {
 		return echo.NewHTTPError(http.StatusUnauthorized, "no parent")
-	}
-
-	var expiresAt *time.Time
-	if ttl != "" {
-		if d, errd := bigduration.ParseDuration(ttl); errd == nil {
-			ex := time.Now().Add(d)
-			expiresAt = &ex
-		}
 	}
 
 	// Getting the slug from the token if it has not been retrieved before
@@ -184,6 +189,13 @@ func createPermission(c echo.Context) error {
 	}
 
 	return jsonapi.Data(c, http.StatusOK, &APIPermission{pdoc, nil}, nil)
+}
+
+func createShortCode(tiny bool) string {
+	if tiny {
+		return crypto.GenerateRandomSixDigits()
+	}
+	return crypto.GenerateRandomString(consts.ShortCodeLen)
 }
 
 const (

--- a/web/permissions/permissions.go
+++ b/web/permissions/permissions.go
@@ -135,7 +135,8 @@ func createPermission(c echo.Context) error {
 		if d, errd := bigduration.ParseDuration(ttl); errd == nil {
 			ex := time.Now().Add(d)
 			expiresAt = &ex
-			if d.Hours() > 1.0 {
+			if d.Hours() > 1.0 && tiny {
+				instance.Logger().Info("Tiny can not be set to true since duration > 1h")
 				tiny = false
 			}
 		}


### PR DESCRIPTION
When creating a permission for a sharing by link, it is now possible to
create a tinycode made of 6 digits by using the `tiny=true` parameter in
the query-string when the sharing has a TTL that doesn't exceed 1 hour.