### PR TITLE
Limit the number of duplicates for check triggers

### DIFF
--- a/web/instances/checks.go
+++ b/web/instances/checks.go
@@ -143,6 +143,7 @@ func checkTriggers(c echo.Context) error {
 				"debounce":  lInfos.Debounce,
 				"message":   fmt.Sprintf("%s", lInfos.Message),
 			})
+			break
 		}
 	}
 


### PR DESCRIPTION
The cozy-stack check triggers command returns a list of duplicate
triggers. When we have 3 triggers (or more) that are seen as duplicate,
we can return (1,2) and (2,3), but skip (1,3).