### PR TITLE
Fix check endpoints when a database is missing

### DIFF
--- a/web/instances/checks.go
+++ b/web/instances/checks.go
@@ -70,6 +70,9 @@ func fsckHandler(c echo.Context) (err error) {
 	}
 	if err != nil {
 		log := map[string]string{"error": err.Error()}
+		if couchdb.IsNotFoundError(err) {
+			log = map[string]string{"type": "no_database", "error": err.Error()}
+		}
 		if errenc := encoder.Encode(log); errenc != nil {
 			i.Logger().WithField("nspace", "fsck").
 				Warnf("Cannot encode to JSON: %s (%v)", errenc, log)
@@ -108,7 +111,7 @@ func checkTriggers(c echo.Context) error {
 	if err != nil {
 		if couchdb.IsNotFoundError(err) {
 			return c.JSON(http.StatusOK, []map[string]interface{}{
-				{"error": err.Error()},
+				{"type": "no_database", "error": err.Error()},
 			})
 		}
 		return wrapError(err)
@@ -175,7 +178,7 @@ func checkShared(c echo.Context) error {
 	if err != nil {
 		if couchdb.IsNotFoundError(err) {
 			return c.JSON(http.StatusOK, []map[string]interface{}{
-				{"error": err.Error()},
+				{"type": "no_database", "error": err.Error()},
 			})
 		}
 		return wrapError(err)
@@ -194,7 +197,7 @@ func checkSharings(c echo.Context) error {
 	if err != nil {
 		if couchdb.IsNotFoundError(err) {
 			return c.JSON(http.StatusOK, []map[string]interface{}{
-				{"error": err.Error()},
+				{"type": "no_database", "error": err.Error()},
 			})
 		}
 		return wrapError(err)


### PR DESCRIPTION
The format of the response was an array of JSON objects with a single
key called `error`. This key was renamed to `type` to be more consistent
with the other errors returned by those endpoints.