### PR TITLE
Return an absolute URL for the webhook link

### DIFF
--- a/docs/konnectors-workflow.md
+++ b/docs/konnectors-workflow.md
@@ -712,7 +712,7 @@ Content-Type: application/vnd.api+json
     },
     "links": {
       "self": "/jobs/triggers/0915b6b0-0c97-0139-5af7-543d7eb8149c",
-      "webhook": "/jobs/webhooks/0915b6b0-0c97-0139-5af7-543d7eb8149c"
+      "webhook": "https://jane.cozy.example/jobs/webhooks/0915b6b0-0c97-0139-5af7-543d7eb8149c"
     }
   }
 }

--- a/tests/integration/lib/job.rb
+++ b/tests/integration/lib/job.rb
@@ -25,22 +25,4 @@ class Job
     j = JSON.parse(res.body)
     j.dig("data", "attributes", "state")
   end
-
-  module Webhook
-    def self.create(inst, message)
-      opts = {
-        :"content-type" => 'application/json',
-        authorization: "Bearer #{inst.token_for 'io.cozy.triggers'}"
-      }
-      attrs = {
-        type: "@webhook",
-        worker: "konnector",
-        message: message
-      }
-      body = JSON.generate data: { attributes: attrs }
-      res = inst.client["/jobs/triggers"].post body, opts
-      j = JSON.parse(res)
-      j.dig "data", "links", "webhook"
-    end
-  end
 end

--- a/tests/integration/lib/trigger.rb
+++ b/tests/integration/lib/trigger.rb
@@ -1,7 +1,7 @@
 class Trigger
   include Model
 
-  attr_reader :attributes
+  attr_reader :attributes, :links
 
   def self.doctype
     "io.cozy.triggers"
@@ -20,6 +20,7 @@ class Trigger
     res = inst.client["/jobs/triggers"].post to_json, opts
     j = JSON.parse(res.body)
     @couch_id = j["data"]["id"]
+    @links = j["data"]["links"]
   end
 
   def as_json
@@ -28,5 +29,17 @@ class Trigger
 
   def self.from_json(j)
     Trigger.new j
+  end
+
+  module Webhook
+    def self.create(inst, message)
+      attrs = {
+        type: "@webhook",
+        worker: "konnector",
+        message: message
+      }
+      t = Trigger.create inst, attrs
+      t.links["webhook"]
+    end
   end
 end

--- a/tests/integration/tests/trigger_webhook.rb
+++ b/tests/integration/tests/trigger_webhook.rb
@@ -13,11 +13,11 @@ describe "A webhook trigger" do
     inst.install_konnector konnector_name, source_url
     account = Account.create inst, type: konnector_name, name: Faker::DrWho.character
     args = { "konnector" => konnector_name, "account" => account.couch_id, "foo" => "bar" }
-    webhook_url = Job::Webhook.create inst, args
+    webhook_url = Trigger::Webhook.create inst, args
 
     opts = { :"content-type" => 'application/json' }
     body = { "quote" => Faker::DrWho.quote }
-    inst.client[webhook_url].post JSON.generate(body), opts
+    RestClient.post webhook_url, JSON.generate(body), opts
 
     done = false
     10.times do

--- a/web/jobs/jobs_test.go
+++ b/web/jobs/jobs_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cozy/cozy-stack/model/job"
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/jsonapi"
 	"github.com/cozy/cozy-stack/tests/testutils"
 	"github.com/cozy/cozy-stack/web/errors"
 	"github.com/cozy/cozy-stack/web/middlewares"
@@ -285,7 +286,7 @@ func TestAddTriggerWithMetadata(t *testing.T) {
 	body, _ := json.Marshal(&jsonapiReq{
 		Data: &jsonapiData{
 			Attributes: map[string]interface{}{
-				"type":      "@at",
+				"type":      "@webhook",
 				"arguments": at,
 				"worker":    "print",
 				"message":   "foo",
@@ -308,6 +309,7 @@ func TestAddTriggerWithMetadata(t *testing.T) {
 			ID         string            `json:"id"`
 			Type       string            `json:"type"`
 			Attributes *job.TriggerInfos `json:"attributes"`
+			Links      jsonapi.LinksList `json:"links"`
 		}
 	}
 
@@ -320,7 +322,8 @@ func TestAddTriggerWithMetadata(t *testing.T) {
 	}
 	triggerID := v.Data.ID
 	assert.Equal(t, consts.Triggers, v.Data.Type)
-	assert.Equal(t, "@at", v.Data.Attributes.Type)
+	assert.Equal(t, "@webhook", v.Data.Attributes.Type)
+	assert.Equal(t, "https://"+testInstance.Domain+"/jobs/webhooks/"+triggerID, v.Data.Links.Webhook)
 	assert.Equal(t, at, v.Data.Attributes.Arguments)
 	assert.Equal(t, "print", v.Data.Attributes.WorkerType)
 


### PR DESCRIPTION
As a webhook is meant to be used from a third party service, it is
simpler to return an absolute URL for the webhook link.