### PR TITLE
Fix the response for check shared on JSON errors

### DIFF
--- a/model/sharing/shared.go
+++ b/model/sharing/shared.go
@@ -475,10 +475,11 @@ func extractDocReferenceFromID(id string) *couchdb.DocReference {
 // revision tree for inconsistencies.
 func CheckShared(inst *instance.Instance) ([]*CheckSharedError, error) {
 	checks := []*CheckSharedError{}
-	err := couchdb.ForeachDocs(inst, consts.Shared, func(_ string, data json.RawMessage) error {
+	err := couchdb.ForeachDocs(inst, consts.Shared, func(id string, data json.RawMessage) error {
 		s := &SharedRef{}
 		if err := json.Unmarshal(data, s); err != nil {
-			return err
+			checks = append(checks, &CheckSharedError{Type: "invalid_json", ID: id})
+			return nil
 		}
 		if check := s.Revisions.check(); check != nil {
 			check.ID = s.SID

--- a/web/instances/checks.go
+++ b/web/instances/checks.go
@@ -216,6 +216,11 @@ func checkShared(c echo.Context) error {
 				{"type": "no_database", "error": err.Error()},
 			})
 		}
+		if _, ok := err.(*json.SyntaxError); ok {
+			return c.JSON(http.StatusOK, []map[string]interface{}{
+				{"type": "invalid_json", "error": err.Error()},
+			})
+		}
 		return wrapError(err)
 	}
 	return c.JSON(http.StatusOK, results)


### PR DESCRIPTION
Some old io.cozy.shared documents have a JSON with more than 10000
levels of nesting. With go 1.15+, these documents cannot be parsed as
JSON. This commit makes the check shared to return a correct response.