### PR TITLE
Fix removing the deleting flag

### DIFF
--- a/model/instance/lifecycle/create.go
+++ b/model/instance/lifecycle/create.go
@@ -47,7 +47,6 @@ type Options struct {
 	Apps               []string
 	AutoUpdate         *bool
 	Debug              *bool
-	Deleting           *bool
 	Traced             *bool
 	OnboardingFinished *bool
 	Blocked            *bool

--- a/model/instance/lifecycle/patch.go
+++ b/model/instance/lifecycle/patch.go
@@ -56,11 +56,6 @@ func Patch(i *instance.Instance, opts *Options) error {
 			needUpdate = true
 		}
 
-		if opts.Deleting != nil && *opts.Deleting != i.Deleting {
-			i.Deleting = *opts.Deleting
-			needUpdate = true
-		}
-
 		if opts.BlockingReason != "" && opts.BlockingReason != i.BlockingReason {
 			i.BlockingReason = opts.BlockingReason
 			needUpdate = true


### PR DESCRIPTION
When an instance deletion has failed, and the instance has no longer its
database for io.cozy.settings, the command to remove the deleting
flag(1) was failing:

	$ cozy-stack instances modify --deleting=false <domain>
	Failed to modify instance for domain <domain>
	Error: not_found: Database does not exist.