### PR TITLE
Fix adding again a "ready" contact to a sharing

### DIFF
--- a/model/sharing/member.go
+++ b/model/sharing/member.go
@@ -139,13 +139,17 @@ func (s *Sharing) AddContact(inst *instance.Instance, contactID string, readOnly
 		} else {
 			found = m.Email == member.Email
 		}
-		if found && member.Status != MemberStatusReady {
-			idx = i
-			s.Members[i].Status = m.Status
-			s.Members[i].Name = m.Name
-			s.Members[i].Instance = m.Instance
-			s.Members[i].ReadOnly = m.ReadOnly
+		if !found {
+			continue
 		}
+		if member.Status != MemberStatusReady {
+			return nil
+		}
+		idx = i
+		s.Members[i].Status = m.Status
+		s.Members[i].Name = m.Name
+		s.Members[i].Instance = m.Instance
+		s.Members[i].ReadOnly = m.ReadOnly
 	}
 	if idx < 1 {
 		if len(s.Members) >= maximalNumberOfMembers {
@@ -289,14 +293,12 @@ func (s *Sharing) DelegateAddContacts(inst *instance.Instance, contactIDs map[st
 			if i == 0 {
 				continue // skip the owner
 			}
-			var same bool
 			if m.Email == "" {
-				same = m.Instance == member.Instance
+				found = m.Instance == member.Instance
 			} else {
-				same = m.Email == member.Email
+				found = m.Email == member.Email
 			}
-			if same && member.Status != MemberStatusReady {
-				found = true
+			if found && member.Status != MemberStatusReady {
 				s.Members[i].Status = m.Status
 				s.Members[i].Name = m.Name
 				s.Members[i].Instance = m.Instance


### PR DESCRIPTION
When a member of a sharing is in the ready state, and if they are added
again to the sharing, they were added twice to the sharing. But two
members with the same email address confuse the sharing package (the
wrong credentials may be used), so it is better to avoid this
duplication. The owner can still revoke the member from the sharing if
they really want to add it again.