### PR TITLE
Fix filename for new notes

### DIFF
--- a/model/note/note.go
+++ b/model/note/note.go
@@ -152,9 +152,9 @@ func (d *Document) asFile(inst *instance.Instance, old *vfs.FileDoc) *vfs.FileDo
 
 	// If the file was renamed manually before, we will keep its name. Else, we
 	// can rename with the new title.
-	newTitle := titleToFilename(inst, d.Title, now)
+	newTitle := titleToFilename(inst, d.Title, old.CreatedAt)
 	oldTitle, _ := old.Metadata["title"].(string)
-	rename := d.Title != "" && titleToFilename(inst, oldTitle, old.UpdatedAt) == old.DocName
+	rename := d.Title != "" && titleToFilename(inst, oldTitle, old.CreatedAt) == old.DocName
 	if old.DocName == "" {
 		rename = true
 	}


### PR DESCRIPTION
When creating a new note, a call is now made to put the schema. It
updates the updated_at attribute of the file. And this attribute was
used for checking if the file should be renamed when its title has
changed. Now, we are using the created_at to fix notes not renamed
according to their titles.