### PR TITLE
Purge the steps of a note in a goroutine

### DIFF
--- a/model/note/step.go
+++ b/model/note/step.go
@@ -250,7 +250,7 @@ func purgeOldSteps(inst *instance.Instance, fileID string) {
 
 func purgeAllSteps(inst *instance.Instance, fileID string) {
 	var docs []couchdb.Doc
-	err := couchdb.ForeachDocs(inst, consts.NotesSteps, func(_ string, raw json.RawMessage) error {
+	err := couchdb.ForeachDocsWithCustomPagination(inst, consts.NotesSteps, 1000, func(_ string, raw json.RawMessage) error {
 		var doc Step
 		if err := json.Unmarshal(raw, &doc); err != nil {
 			return err

--- a/web/notes/notes_test.go
+++ b/web/notes/notes_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/cozy/cozy-stack/model/instance"
 	"github.com/cozy/cozy-stack/model/note"
@@ -487,6 +488,7 @@ func TestPutSchema(t *testing.T) {
 	panel, _ := nodes[1].([]interface{})
 	assert.EqualValues(t, "panel", panel[0])
 
+	time.Sleep(1 * time.Second)
 	path2 := fmt.Sprintf("/notes/%s/steps?Version=%d", noteID, version)
 	req2, _ := http.NewRequest("GET", ts.URL+path2, nil)
 	req2.Header.Add("Authorization", "Bearer "+token)


### PR DESCRIPTION
When a note has its schema updated, the stack deletes all the steps for
it to force other clients that would be opened to reload the note. But
it can take a few seconds, so it is better to do that in a goroutine.