### PR TITLE
Add _design docs routes

### DIFF
--- a/docs/data-system.md
+++ b/docs/data-system.md
@@ -538,6 +538,7 @@ Content-Type: application/json
 ## Access a design document
 
 A design document is a special CouchDB document that represents a view or Mango index definition.
+
 ### Request
 
 ```http

--- a/docs/data-system.md
+++ b/docs/data-system.md
@@ -533,3 +533,141 @@ Content-Type: application/json
 -   The creation and usage of [Mango indexes](mango.md) is possible.
 -   CouchDB behaviors are not always straight forward: see
     [some quirks](couchdb-quirks.md) for more details.
+
+
+## Access a design document
+
+A design document is a special CouchDB document that represents a view or Mango index definition.
+### Request
+
+```http
+GET /data/:type/_design/:ddoc HTTP/1.1
+```
+
+```http
+GET /data/io.cozy.events/_design/c4a8fa4a4660b8eed43137881500265c HTTP/1.1
+```
+
+### Response OK
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+```
+
+```json
+{
+  "_id": "_design/c4a8fa4a4660b8eed43137881500265c",
+  "_rev": "1-56cf55098fc69450f84a22a632ffafb9",
+  "language": "query",
+  "views": {
+    "by-startdate-and-enddate": {
+      "map": {
+        "fields": {
+          "startdate": "asc",
+          "enddate": "asc",
+        },
+        "partial_filter_selector": {}
+      },
+      "reduce": "_count",
+      "options": {
+        "def": {
+          "fields": [
+            "startdate",
+            "enddate",
+            "metadata.datetime"
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+## Access all design documents for a doctype
+
+### Request
+
+```http
+GET /data/:type/_design_docs HTTP/1.1
+```
+
+```http
+GET /data/io.cozy.events/_design_docs HTTP/1.1
+```
+
+### Response OK
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+```
+
+```json
+{
+  "total_rows": 123,
+  "offset": 57,
+  "rows": [
+      ...
+  ]
+}
+```
+
+## Delete a design document
+
+### Request
+
+```http
+DELETE /data/:type/_design/:ddoc HTTP/1.1
+```
+
+```http
+DELETE /data/io.cozy.events/_design/c4a8fa4a4660b8eed43137881500265c?rev=1-1aa097a2eef904db9b1842342e6c6f50 HTTP/1.1
+```
+
+### Response OK
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+```
+
+```json
+{
+  "ok": true,
+  "id": "_design/c4a8fa4a4660b8eed43137881500265c",
+  "rev": "1-56cf55098fc69450f84a22a632ffafb9"
+}
+```
+
+## Copy a design document
+
+This is useful to duplicate a view or Mango index definition, without having to recompute the whole B-Tree. The original and the copy will both use the same index on disk. 
+
+
+### Request
+
+```http
+POST /data/:type/_design/:ddoc/copy HTTP/1.1
+
+```
+
+```http
+DELETE /data/io.cozy.events/_design/c4a8fa4a4660b8eed43137881500265c/copy?rev=1-1aa097a2eef904db9b1842342e6c6f50 HTTP/1.1
+Destination: _design/d7349ab71c0859c408a725ebbfd453b18aa94ec7
+```
+
+### Response OK
+
+```http
+HTTP/1.1 201 CREATED
+Content-Type: application/json
+```
+
+```json
+{
+  "ok": true,
+  "id": "_design/d7349ab71c0859c408a725ebbfd453b18aa94ec7",
+  "rev": "1-1aa097a2eef904db9b1842342e6c6f50"
+}
+```

--- a/docs/data-system.md
+++ b/docs/data-system.md
@@ -637,7 +637,7 @@ Content-Type: application/json
 {
   "ok": true,
   "id": "_design/c4a8fa4a4660b8eed43137881500265c",
-  "rev": "1-56cf55098fc69450f84a22a632ffafb9"
+  "rev": "2-2ad11c9dc32df12a4b24f994807408ba"
 }
 ```
 
@@ -654,14 +654,14 @@ POST /data/:type/_design/:ddoc/copy HTTP/1.1
 ```
 
 ```http
-DELETE /data/io.cozy.events/_design/c4a8fa4a4660b8eed43137881500265c/copy?rev=1-1aa097a2eef904db9b1842342e6c6f50 HTTP/1.1
+POST /data/io.cozy.events/_design/c4a8fa4a4660b8eed43137881500265c/copy?rev=1-1aa097a2eef904db9b1842342e6c6f50 HTTP/1.1
 Destination: _design/d7349ab71c0859c408a725ebbfd453b18aa94ec7
 ```
 
 ### Response OK
 
 ```http
-HTTP/1.1 201 CREATED
+HTTP/1.1 201 Created
 Content-Type: application/json
 ```
 

--- a/web/data/data.go
+++ b/web/data/data.go
@@ -399,9 +399,12 @@ func normalDocs(c echo.Context) error {
 }
 
 func getDesignDoc(c echo.Context) error {
-	doctype := c.Get("doctype").(string)
+	doctype := c.Param("doctype")
 	ddoc := c.Param("designdocid")
 
+	if err := permission.CheckReadable(doctype); err != nil {
+		return err
+	}
 	if err := middlewares.AllowWholeType(c, permission.GET, doctype); err != nil {
 		return err
 	}
@@ -409,7 +412,7 @@ func getDesignDoc(c echo.Context) error {
 }
 
 func getDesignDocs(c echo.Context) error {
-	doctype := c.Get("doctype").(string)
+	doctype := c.Param("doctype")
 	if err := permission.CheckReadable(doctype); err != nil {
 		return err
 	}
@@ -430,7 +433,7 @@ func copyDesignDoc(c echo.Context) error {
 	if newDdoc == "" {
 		return c.JSON(http.StatusBadRequest, "You must set a Destination header")
 	}
-	if err := permission.CheckReadable(doctype); err != nil {
+	if err := permission.CheckWritable(doctype); err != nil {
 		return err
 	}
 	if err := middlewares.AllowWholeType(c, permission.POST, doctype); err != nil {
@@ -440,9 +443,12 @@ func copyDesignDoc(c echo.Context) error {
 }
 
 func deleteDesignDoc(c echo.Context) error {
-	ddoc := c.Param("designdocid")
 	doctype := c.Param("doctype")
+	ddoc := c.Param("designdocid")
 
+	if err := permission.CheckWritable(doctype); err != nil {
+		return err
+	}
 	if err := middlewares.AllowWholeType(c, permission.DELETE, doctype); err != nil {
 		return err
 	}

--- a/web/data/data.go
+++ b/web/data/data.go
@@ -398,6 +398,15 @@ func normalDocs(c echo.Context) error {
 	return c.JSON(http.StatusOK, res)
 }
 
+func getDesignDoc(c echo.Context) error {
+	docid := c.Param("designdocid")
+	doctype := c.Get("doctype").(string)
+
+	if err := middlewares.AllowWholeType(c, permission.GET, doctype); err != nil {
+		return err
+	}
+	return proxy(c, "_design/"+docid)
+}
 // mostly just to prevent couchdb crash on replications
 func dataAPIWelcome(c echo.Context) error {
 	return c.JSON(http.StatusOK, echo.Map{
@@ -454,4 +463,5 @@ func Routes(router *echo.Group) {
 	group.GET("/_normal_docs", normalDocs)
 	group.POST("/_index", defineIndex)
 	group.POST("/_find", findDocuments)
+	group.GET("/_design/:designdocid", getDesignDoc)
 }

--- a/web/data/data.go
+++ b/web/data/data.go
@@ -515,5 +515,4 @@ func Routes(router *echo.Group) {
 	group.GET("/_design_docs", getDesignDocs)
 	group.POST("/_design/:designdocid/copy", copyDesignDoc)
 	group.DELETE("/_design/:designdocid", deleteDesignDoc)
-
 }

--- a/web/data/data.go
+++ b/web/data/data.go
@@ -432,7 +432,7 @@ func copyDesignDoc(c echo.Context) error {
 	if destination == "" {
 		return c.JSON(http.StatusBadRequest, "You must set a Destination header")
 	}
-	if err := permission.CheckWritable(doctype); err != nil {
+	if err := permission.CheckReadable(doctype); err != nil {
 		return err
 	}
 	if err := middlewares.AllowWholeType(c, permission.POST, doctype); err != nil {
@@ -450,7 +450,7 @@ func deleteDesignDoc(c echo.Context) error {
 	doctype := c.Param("doctype")
 	ddoc := c.Param("designdocid")
 
-	if err := permission.CheckWritable(doctype); err != nil {
+	if err := permission.CheckReadable(doctype); err != nil {
 		return err
 	}
 	if err := middlewares.AllowWholeType(c, permission.DELETE, doctype); err != nil {

--- a/web/data/data_test.go
+++ b/web/data/data_test.go
@@ -1052,7 +1052,7 @@ func TestDeleteDesignDoc(t *testing.T) {
 	req, _ = http.NewRequest("DELETE", url, nil)
 	req.Header.Add("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
-	out, res, err = doRequest(req, nil)
+	_, res, err = doRequest(req, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "200 OK", res.Status)
 
@@ -1096,5 +1096,4 @@ func TestCopyDesignDoc(t *testing.T) {
 
 	assert.Equal(t, targetID, out["id"].(string))
 	assert.Equal(t, rev, out["rev"].(string))
-
 }

--- a/web/data/replication.go
+++ b/web/data/replication.go
@@ -27,23 +27,6 @@ func proxy(c echo.Context, path string) error {
 	return nil
 }
 
-func getDesignDoc(c echo.Context) error {
-	docid := c.Param("designdocid")
-	doctype := c.Get("doctype").(string)
-
-	if err := middlewares.AllowWholeType(c, permission.GET, doctype); err != nil {
-		return err
-	}
-
-	if paramIsTrue(c, "revs") {
-		return proxy(c, "_design/"+docid)
-	}
-
-	return c.JSON(http.StatusBadRequest, echo.Map{
-		"error": "_design docs are only readable for replication",
-	})
-}
-
 func getLocalDoc(c echo.Context) error {
 	doctype := c.Get("doctype").(string)
 	docid := c.Param("docid")
@@ -290,7 +273,6 @@ func replicationRoutes(group *echo.Group) {
 
 	// Routes used only for replication
 	group.GET("/", dbStatus)
-	group.GET("/_design/:designdocid", getDesignDoc)
 	group.GET("/_changes", changesFeed)
 	// POST=GET see http://docs.couchdb.org/en/stable/api/database/changes.html#post--db-_changes)
 	group.POST("/_changes", changesFeed)


### PR DESCRIPTION
This adds the following routes:
- `GET /data/:doctype/_design_docs`: access a design doc
- `DELETE /data/:doctype/_design/:ddoc`: delete a design doc
- `POST /data/:doctype/_design/:ddoci/copy`: copy a design doc

This will be useful in order to optimize the index creation from the client side: we used to create index with no name, relying on CouchDB to generate an id. We now want to create named index, by copying existing index to avoid recomputing existing ones.