### PR TITLE
Make CSP configurable per context

### DIFF
--- a/cozy.example.yaml
+++ b/cozy.example.yaml
@@ -295,6 +295,10 @@ csp_allowlist:
   # style:  https://allowed.domain.com/
   # font:   https://allowed.domain.com/
 
+  contexts:
+    beta:
+      img: https://allowed2.domain.com/
+
 # It can useful to disable the CSP policy to debug and test things in local
 # disable_csp: true
 

--- a/cozy.example.yaml
+++ b/cozy.example.yaml
@@ -295,6 +295,8 @@ csp_allowlist:
   # style:  https://allowed.domain.com/
   # font:   https://allowed.domain.com/
 
+  # It is also possible to configure the CSP policy per context. The values are
+  # cumulative with the global csp allowlist.
   contexts:
     beta:
       img: https://allowed2.domain.com/

--- a/web/routing.go
+++ b/web/routing.go
@@ -97,6 +97,8 @@ func SetupAppsHandler(appsHandler echo.HandlerFunc) echo.HandlerFunc {
 			CSPStyleSrcAllowList:   config.GetConfig().CSPAllowList["style"],
 			CSPFontSrcAllowList:    config.GetConfig().CSPAllowList["font"],
 			CSPFrameSrcAllowList:   config.GetConfig().CSPAllowList["frame"] + " " + cspFrameSrcAllowList,
+
+			CSPPerContext: config.GetConfig().CSPPerContext,
 		})
 		mws = append([]echo.MiddlewareFunc{secure}, mws...)
 	}


### PR DESCRIPTION
Note: the config per context is only available via the `csp_allowlist key`
in the config file (not via the deprecated `csp_whitelist`).