### PR TITLE
Allow to send the file size via query string

### DIFF
--- a/docs/files.md
+++ b/docs/files.md
@@ -464,12 +464,13 @@ then the `updated_at` will be set with the value of the `created_at`.
 | ----------------------- | -------------------------------------------------------------- |
 | Type                    | `file`                                                         |
 | Name                    | the file name                                                  |
+| Size                    | the file size (when `Content-Length` can't be used)            |
 | Tags                    | an array of tags                                               |
 | Executable              | `true` if the file is executable (UNIX permission)             |
 | Metadata                | a JSON with metadata on this file (_deprecated_)               |
 | MetadataID              | the identifier of a metadata object                            |
-| CreatedAt               | the creation date of the file  
-| UpdatedAt               | the modification date of the file
+| CreatedAt               | the creation date of the file                                  |
+| UpdatedAt               | the modification date of the file                              |
 | SourceAccount           | the id of the source account used by a konnector               |
 | SourceAccountIdentifier | the unique identifier of the account targeted by the connector |
 


### PR DESCRIPTION
When uploading a file to the VFS, the file size can be sent by clients
via the Content-Length HTTP header. But the desktop client had some
issues with that: Electron removes this header when the body is a stream
or a chunked body, and the client doesn't want to load the whole file in
memory before sending it. So, we have added a fallback where the file
size can also be sent via a Size parameter in the query string.