### PR TITLE
Send Kdf and kdfIterations on bitwarden login

### DIFF
--- a/web/bitwarden/bitwarden.go
+++ b/web/bitwarden/bitwarden.go
@@ -218,13 +218,15 @@ func GetToken(c echo.Context) error {
 // AccessTokenReponse is the stuct used for serializing to JSON the response
 // for an access token.
 type AccessTokenReponse struct {
-	ClientID  string `json:"client_id,omitempty"`
-	RegToken  string `json:"registration_access_token,omitempty"`
-	Type      string `json:"token_type"`
-	ExpiresIn int    `json:"expires_in"`
-	Access    string `json:"access_token"`
-	Refresh   string `json:"refresh_token"`
-	Key       string `json:"Key"`
+	ClientID   string `json:"client_id,omitempty"`
+	RegToken   string `json:"registration_access_token,omitempty"`
+	Type       string `json:"token_type"`
+	ExpiresIn  int    `json:"expires_in"`
+	Access     string `json:"access_token"`
+	Refresh    string `json:"refresh_token"`
+	Key        string `json:"Key"`
+	Kdf        int    `json:"Kdf"`
+	Iterations int    `json:"KdfIterations"`
 }
 
 func getInitialCredentials(c echo.Context) error {
@@ -312,13 +314,15 @@ func getInitialCredentials(c echo.Context) error {
 
 	// Send the response
 	out := AccessTokenReponse{
-		ClientID:  client.ClientID,
-		RegToken:  client.RegistrationToken,
-		Type:      "Bearer",
-		ExpiresIn: int(consts.AccessTokenValidityDuration.Seconds()),
-		Access:    access,
-		Refresh:   refresh,
-		Key:       key,
+		ClientID:   client.ClientID,
+		RegToken:   client.RegistrationToken,
+		Type:       "Bearer",
+		ExpiresIn:  int(consts.AccessTokenValidityDuration.Seconds()),
+		Access:     access,
+		Refresh:    refresh,
+		Key:        key,
+		Kdf:        setting.PassphraseKdf,
+		Iterations: setting.PassphraseKdfIterations,
 	}
 	return c.JSON(http.StatusOK, out)
 }
@@ -416,11 +420,13 @@ func refreshToken(c echo.Context) error {
 
 	// Send the response
 	out := AccessTokenReponse{
-		Type:      "Bearer",
-		ExpiresIn: int(consts.AccessTokenValidityDuration.Seconds()),
-		Access:    access,
-		Refresh:   refresh,
-		Key:       key,
+		Type:       "Bearer",
+		ExpiresIn:  int(consts.AccessTokenValidityDuration.Seconds()),
+		Access:     access,
+		Refresh:    refresh,
+		Key:        key,
+		Kdf:        setting.PassphraseKdf,
+		Iterations: setting.PassphraseKdfIterations,
 	}
 	return c.JSON(http.StatusOK, out)
 }

--- a/web/bitwarden/bitwarden_test.go
+++ b/web/bitwarden/bitwarden_test.go
@@ -80,6 +80,8 @@ func TestConnect(t *testing.T) {
 	assert.NotEmpty(t, result["Key"])
 	assert.NotEmpty(t, result["client_id"])
 	assert.NotEmpty(t, result["registration_access_token"])
+	assert.NotNil(t, result["Kdf"])
+	assert.NotNil(t, result["KdfIterations"])
 
 	assert.NotZero(t, len(testLogger.Entries))
 	assert.Equal(t, "Organization key does not exist", testLogger.Entries[0].Message)


### PR DESCRIPTION
The bitwarden clients are now expecting the kdf type and iterations on
the login response. This change was made for supporting SSO. The stack
doesn't support that, but we still need to send those fields as the
client logic for deconnection/reconnection is now based on that even
without SSO support.

See https://github.com/bitwarden/jslib/pull/127