### PR TITLE
[SECU] Fix error handling for getting OAuth client

### DIFF
--- a/web/auth/auth_test.go
+++ b/web/auth/auth_test.go
@@ -503,7 +503,7 @@ func TestDeleteClientNoToken(t *testing.T) {
 	req.Host = domain
 	res, err := client.Do(req)
 	assert.NoError(t, err)
-	assert.Equal(t, "400 Bad Request", res.Status)
+	assert.Equal(t, "401 Unauthorized", res.Status)
 }
 
 func TestDeleteClientSuccess(t *testing.T) {
@@ -520,10 +520,23 @@ func TestDeleteClientSuccess(t *testing.T) {
 	assert.Equal(t, "204 No Content", res2.Status)
 }
 
+func TestReadClientNoToken(t *testing.T) {
+	req, _ := http.NewRequest("GET", ts.URL+"/auth/register/"+clientID, nil)
+	req.Host = domain
+	req.Header.Add("Accept", "application/json")
+	res, err := client.Do(req)
+	assert.NoError(t, err)
+	assert.Equal(t, "401 Unauthorized", res.Status)
+	buf, _ := ioutil.ReadAll(res.Body)
+	assert.NotContains(t, string(buf), clientSecret)
+}
+
 func TestReadClientInvalidToken(t *testing.T) {
 	res, err := getJSON("/auth/register/"+clientID, altRegistrationToken)
 	assert.NoError(t, err)
 	assert.Equal(t, "401 Unauthorized", res.Status)
+	buf, _ := ioutil.ReadAll(res.Body)
+	assert.NotContains(t, string(buf), clientSecret)
 }
 
 func TestReadClientInvalidClientID(t *testing.T) {


### PR DESCRIPTION
When requesting the GET /auth/register/:client-id route with no
Authorization header, the stack was sending an error but doesn't stop
processing the request. Thus, the information about the client was also
sent in the response. Ouch!

It means that it was possible to get client_secret from a known
client_id, but this attack alone is not enough to get access to the
personal data of the users: an access_token or refresh_token is still
needed.