### PR TITLE
Make app installer start log more meaningful

### DIFF
--- a/model/app/installer.go
+++ b/model/app/installer.go
@@ -268,7 +268,7 @@ func (i *Installer) run() (err error) {
 			i.log.Infof("Successful installer process: %s", i.man.Version())
 		}
 	}()
-	i.log.Info("Start")
+	i.log.Infof("Start installer process: %s", i.man.Version())
 	switch i.op {
 	case Install:
 		return i.install()


### PR DESCRIPTION
Update installer start log message to make is more understandable when debugging