### PR TITLE
feat: Use semantic color for link in error.html

### DIFF
--- a/assets/templates/error.html
+++ b/assets/templates/error.html
@@ -30,7 +30,11 @@
           </div>
           {{if .Button}}
           <footer class="wizard-footer u-pb-half">
-            <a class="c-btn c-btn--full wizard-button" href="{{.ButtonLink}}"><span>{{t .Button}}</span></a>
+            <!--
+              TODO remove u-primaryColor when wizard-button uses var(--primaryColor) instead of var(--dodgerBlue)
+              To remove when https://github.com/cozy/cozy-ui/pull/1741 is merged and when the stack has updated cozy-ui
+             -->
+            <a class="c-btn c-btn--full wizard-button u-primaryColor" href="{{.ButtonLink}}"><span>{{t .Button}}</span></a>
           </footer>
           {{end}}
         </section>


### PR DESCRIPTION
Otherwise the link stays blue even in a context where the primary color changes.