### PR TITLE
Fix serving apps with devtools

### DIFF
--- a/pkg/appfs/server.go
+++ b/pkg/appfs/server.go
@@ -291,6 +291,10 @@ func (s *aferoServer) serveFileContent(w http.ResponseWriter, req *http.Request,
 		if err != nil {
 			return err
 		}
+		_, err = f.Seek(0, io.SeekStart)
+		if err != nil {
+			return err
+		}
 		content = f
 	}
 


### PR DESCRIPTION
When the browser devtools are used to disable cache, and the stack is
using afero for apps (not swift), there was a bug where brotli
compressed assets where not served correctly.