### PR TITLE
Add a work-around for a couchdb quirk on index

### DIFF
--- a/pkg/couchdb/couchdb.go
+++ b/pkg/couchdb/couchdb.go
@@ -840,6 +840,12 @@ func DefineIndexRaw(db Database, doctype string, index interface{}) (*IndexCreat
 		}
 		err = makeRequest(db, doctype, http.MethodPost, url, &index, &response)
 	}
+	// XXX when creating the same index twice at the same time, CouchDB respond
+	// with a 500, so let's just retry as a work-around...
+	if IsInternalServerError(err) {
+		time.Sleep(100 * time.Millisecond)
+		err = makeRequest(db, doctype, http.MethodPost, url, &index, &response)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/web/data/data.go
+++ b/web/data/data.go
@@ -304,11 +304,6 @@ func defineIndex(c echo.Context) error {
 	}
 
 	result, err := couchdb.DefineIndexRaw(instance, doctype, &definitionRequest)
-	if couchdb.IsNoDatabaseError(err) {
-		if err = couchdb.CreateDB(instance, doctype); err == nil || couchdb.IsFileExists(err) {
-			result, err = couchdb.DefineIndexRaw(instance, doctype, &definitionRequest)
-		}
-	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When asking CouchDB to create the same index twice at the same time, it
respond to one request with a 500 response. So, let's add a retry as a
work-around.