### PR TITLE
Make the CI simpler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,22 +10,22 @@ on:
       - 'docs/**'
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     services:
       redis:
         image: redis
         ports:
           - 6379:6379
     strategy:
+      fail-fast: false
       matrix:
-        go-version: [1.13.x, 1.14.x, 1.15.x, 1.16.x]
-        couchdb-version: [2.3.1, 3.0.0]
-        exclude:
+        include:
+          # Recommended version
+          - go-version: 1.16.x
+            couchdb-version: 2.3.1
+            lint: true
+          # More exotic version
           - go-version: 1.13.x
-            couchdb-version: 3.0.0
-          - go-version: 1.14.x
-            couchdb-version: 3.0.0
-          - go-version: 1.15.x
             couchdb-version: 3.0.0
     steps:
       - name: Install CouchDB
@@ -58,7 +58,7 @@ jobs:
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
           go install
       - name: Lint
-        if: matrix.go-version == '1.16.x'
+        if: ${{ matrix.lint }}
         run: |
           make lint jslint
       - name: Unit tests

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,7 +10,7 @@ on:
       - 'docs/**'
 jobs:
   integration:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     services:
       mailhog:
         image: mailhog/mailhog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     - '*.*.*' # Matching a version number like 1.4.19
 jobs:
   publish_on_release:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Install Go
         uses: actions/setup-go@v1


### PR DESCRIPTION
- Use ubuntu-latest for all the workflows
- Run only two builds for the unit tests, one with the recommended Go
  and CouchDB versions, and the other with an old version of Go (to
  check that we are still compatible with it) and a more exotic version
  of CouchDB