### PR TITLE
Fix running already installed konnectors (afero)

### DIFF
--- a/pkg/appfs/server.go
+++ b/pkg/appfs/server.go
@@ -350,6 +350,7 @@ func (s *aferoServer) FilesList(slug, version, shasum string) ([]string, error) 
 		}
 		if !infos.IsDir() {
 			name := strings.TrimPrefix(path, rootPath)
+			name = strings.TrimSuffix(name, ".gz")
 			name = strings.TrimSuffix(name, ".br")
 			names = append(names, name)
 		}


### PR DESCRIPTION
When a konnector was installed before we start using brotli for
apps&konnectors assets on a stack with afero FS (not swift), the files
were saved with a .gz extension. They are now saved with a .br
extension.

When running a konnector, we list the files, decompress them and rewrite
them in the temporary directory that will be used to execute them. We
have forgotten to remove the .gz extension for konnectors that were
already installed and nodejs didn't like that as it was expecting a .js
file.