### PR TITLE
Require GET permission for index copy

### DIFF
--- a/web/data/data.go
+++ b/web/data/data.go
@@ -430,7 +430,7 @@ func copyDesignDoc(c echo.Context) error {
 	if err := permission.CheckReadable(doctype); err != nil {
 		return err
 	}
-	if err := middlewares.AllowWholeType(c, permission.POST, doctype); err != nil {
+	if err := middlewares.AllowWholeType(c, permission.GET, doctype); err != nil {
 		return err
 	}
 	path := "_design/" + ddoc


### PR DESCRIPTION
While some index-related requests  are expressed as `POST`, we only ask for a `GET` 
permission as the application objective is to actually read data.