### PR TITLE
Allow to force setting password for Cozy Pass

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -163,6 +163,11 @@ The user can change its passphrase with this route.
 For users with two-factor authentication activated, a second step on the same
 route is necessary to actually update the passphrase. See below.
 
+A `"force": true` parameter can be added in the JSON to force a passphrase on a
+Cozy where authentication by password is disabled and the vault is empty. It
+allows to use Cozy Pass when the authentication on the Cozy is delegated via
+OIDC.
+
 #### Request
 
 ```http

--- a/model/instance/lifecycle/passphrase.go
+++ b/model/instance/lifecycle/passphrase.go
@@ -244,13 +244,15 @@ func UpdatePassphrase(
 }
 
 // ForceUpdatePassphrase replace the passphrase without checking the current one
-func ForceUpdatePassphrase(inst *instance.Instance, newPassword []byte) error {
+func ForceUpdatePassphrase(inst *instance.Instance, newPassword []byte, iterations int) error {
 	if len(newPassword) == 0 {
 		return instance.ErrMissingPassphrase
 	}
-	params := PassParameters{Pass: newPassword}
-	if err := setDefaultParameters(inst, &params); err != nil {
-		return err
+	params := PassParameters{Pass: newPassword, Iterations: iterations}
+	if iterations == 0 {
+		if err := setDefaultParameters(inst, &params); err != nil {
+			return err
+		}
 	}
 	settings, err := settings.Get(inst)
 	if err != nil {

--- a/web/apps/apps_test.go
+++ b/web/apps/apps_test.go
@@ -493,7 +493,7 @@ func TestMain(m *testing.M) {
 
 	pass := "aephe2Ei"
 	testInstance = setup.GetTestInstance(&lifecycle.Options{Domain: domain})
-	_ = lifecycle.ForceUpdatePassphrase(testInstance, []byte(pass))
+	_ = lifecycle.ForceUpdatePassphrase(testInstance, []byte(pass), 0)
 	testInstance.RegisterToken = nil
 	testInstance.OnboardingFinished = true
 	_ = couchdb.UpdateDoc(couchdb.GlobalDB, testInstance)


### PR DESCRIPTION
On instances with authentication via OIDC, it is now possible to force a
password to allow the setup of Cozy Pass.