### PR TITLE
Require GET permission for index deletion

### DIFF
--- a/web/data/data.go
+++ b/web/data/data.go
@@ -448,7 +448,7 @@ func deleteDesignDoc(c echo.Context) error {
 	if err := permission.CheckReadable(doctype); err != nil {
 		return err
 	}
-	if err := middlewares.AllowWholeType(c, permission.DELETE, doctype); err != nil {
+	if err := middlewares.AllowWholeType(c, permission.GET, doctype); err != nil {
 		return err
 	}
 	if c.QueryParam("rev") == "" {


### PR DESCRIPTION
Just like https://github.com/cozy/cozy-stack/pull/2939, an app might automatically delete indexes when [querying data](https://github.com/cozy/cozy-client/pull/907)