### PR TITLE
fix: Pass encrypt key when force updating passphrase

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -166,7 +166,14 @@ route is necessary to actually update the passphrase. See below.
 A `"force": true` parameter can be added in the JSON to force a passphrase on a
 Cozy where authentication by password is disabled and the vault is empty. It
 allows to use Cozy Pass when the authentication on the Cozy is delegated via
-OIDC.
+OIDC. When forcing a password reset, you need to regenerate the 
+
+* public and private keys
+* encryption key
+
+ of the vault and pass them via `key`, `publicKey` and `privateKey`.
+
+See [those password-helpers](https://github.com/cozy/cozy-stack/blob/master/assets/scripts/password-helpers.js#L165-L218) for example on how to regenerate those keys.
 
 #### Request
 

--- a/model/instance/lifecycle/passphrase.go
+++ b/model/instance/lifecycle/passphrase.go
@@ -244,11 +244,11 @@ func UpdatePassphrase(
 }
 
 // ForceUpdatePassphrase replace the passphrase without checking the current one
-func ForceUpdatePassphrase(inst *instance.Instance, newPassword []byte, iterations int) error {
+func ForceUpdatePassphrase(inst *instance.Instance, newPassword []byte, key string, iterations int) error {
 	if len(newPassword) == 0 {
 		return instance.ErrMissingPassphrase
 	}
-	params := PassParameters{Pass: newPassword, Iterations: iterations}
+	params := PassParameters{Pass: newPassword, Iterations: iterations, Key: key}
 	if iterations == 0 {
 		if err := setDefaultParameters(inst, &params); err != nil {
 			return err

--- a/model/instance/lifecycle/passphrase.go
+++ b/model/instance/lifecycle/passphrase.go
@@ -244,11 +244,11 @@ func UpdatePassphrase(
 }
 
 // ForceUpdatePassphrase replace the passphrase without checking the current one
-func ForceUpdatePassphrase(inst *instance.Instance, newPassword []byte, key string, iterations int) error {
+func ForceUpdatePassphrase(inst *instance.Instance, newPassword []byte, key string, publicKey string, privateKey string, iterations int) error {
 	if len(newPassword) == 0 {
 		return instance.ErrMissingPassphrase
 	}
-	params := PassParameters{Pass: newPassword, Iterations: iterations, Key: key}
+	params := PassParameters{Pass: newPassword, Iterations: iterations, PublicKey: publicKey, PrivateKey: privateKey, Key: key}
 	if iterations == 0 {
 		if err := setDefaultParameters(inst, &params); err != nil {
 			return err

--- a/model/instance/lifecycle/passphrase.go
+++ b/model/instance/lifecycle/passphrase.go
@@ -244,12 +244,11 @@ func UpdatePassphrase(
 }
 
 // ForceUpdatePassphrase replace the passphrase without checking the current one
-func ForceUpdatePassphrase(inst *instance.Instance, newPassword []byte, key string, publicKey string, privateKey string, iterations int) error {
+func ForceUpdatePassphrase(inst *instance.Instance, newPassword []byte, params PassParameters) error {
 	if len(newPassword) == 0 {
 		return instance.ErrMissingPassphrase
 	}
-	params := PassParameters{Pass: newPassword, Iterations: iterations, PublicKey: publicKey, PrivateKey: privateKey, Key: key}
-	if iterations == 0 {
+	if params.Iterations == 0 {
 		if err := setDefaultParameters(inst, &params); err != nil {
 			return err
 		}

--- a/web/apps/apps_test.go
+++ b/web/apps/apps_test.go
@@ -493,7 +493,7 @@ func TestMain(m *testing.M) {
 
 	pass := "aephe2Ei"
 	testInstance = setup.GetTestInstance(&lifecycle.Options{Domain: domain})
-	_ = lifecycle.ForceUpdatePassphrase(testInstance, []byte(pass), "fake-key", 0)
+	_ = lifecycle.ForceUpdatePassphrase(testInstance, []byte(pass), "fake-encrypt-key", "fake-public-key", "fake-private-key", 0)
 	testInstance.RegisterToken = nil
 	testInstance.OnboardingFinished = true
 	_ = couchdb.UpdateDoc(couchdb.GlobalDB, testInstance)

--- a/web/apps/apps_test.go
+++ b/web/apps/apps_test.go
@@ -493,7 +493,11 @@ func TestMain(m *testing.M) {
 
 	pass := "aephe2Ei"
 	testInstance = setup.GetTestInstance(&lifecycle.Options{Domain: domain})
-	_ = lifecycle.ForceUpdatePassphrase(testInstance, []byte(pass), "fake-encrypt-key", "fake-public-key", "fake-private-key", 0)
+	params := lifecycle.PassParameters{
+		Key: "fake-encrypt-key",
+		Iterations: 0,
+	}
+	_ = lifecycle.ForceUpdatePassphrase(testInstance, []byte(pass), params)
 	testInstance.RegisterToken = nil
 	testInstance.OnboardingFinished = true
 	_ = couchdb.UpdateDoc(couchdb.GlobalDB, testInstance)

--- a/web/apps/apps_test.go
+++ b/web/apps/apps_test.go
@@ -493,7 +493,7 @@ func TestMain(m *testing.M) {
 
 	pass := "aephe2Ei"
 	testInstance = setup.GetTestInstance(&lifecycle.Options{Domain: domain})
-	_ = lifecycle.ForceUpdatePassphrase(testInstance, []byte(pass), 0)
+	_ = lifecycle.ForceUpdatePassphrase(testInstance, []byte(pass), "fake-key", 0)
 	testInstance.RegisterToken = nil
 	testInstance.OnboardingFinished = true
 	_ = couchdb.UpdateDoc(couchdb.GlobalDB, testInstance)

--- a/web/apps/apps_test.go
+++ b/web/apps/apps_test.go
@@ -494,7 +494,7 @@ func TestMain(m *testing.M) {
 	pass := "aephe2Ei"
 	testInstance = setup.GetTestInstance(&lifecycle.Options{Domain: domain})
 	params := lifecycle.PassParameters{
-		Key: "fake-encrypt-key",
+		Key:        "fake-encrypt-key",
 		Iterations: 0,
 	}
 	_ = lifecycle.ForceUpdatePassphrase(testInstance, []byte(pass), params)

--- a/web/settings/passphrase.go
+++ b/web/settings/passphrase.go
@@ -181,7 +181,7 @@ func updatePassphrase(c echo.Context) error {
 			return jsonapi.BadRequest(err)
 		}
 
-		err = lifecycle.ForceUpdatePassphrase(inst, newPassphrase, args.Iterations)
+		err = lifecycle.ForceUpdatePassphrase(inst, newPassphrase, args.Key, args.Iterations)
 		if err != nil {
 			return err
 		}

--- a/web/settings/passphrase.go
+++ b/web/settings/passphrase.go
@@ -183,7 +183,14 @@ func updatePassphrase(c echo.Context) error {
 			return jsonapi.BadRequest(err)
 		}
 
-		err = lifecycle.ForceUpdatePassphrase(inst, newPassphrase, args.Key, args.PublicKey, args.PrivateKey, args.Iterations)
+		params := lifecycle.PassParameters{
+			Pass: []byte(args.Passphrase),
+			Iterations: args.Iterations,
+			PublicKey: args.PublicKey,
+			PrivateKey: args.PrivateKey,
+			Key: args.Key,
+		}
+		err = lifecycle.ForceUpdatePassphrase(inst, newPassphrase, params)
 		if err != nil {
 			return err
 		}

--- a/web/settings/passphrase.go
+++ b/web/settings/passphrase.go
@@ -170,6 +170,9 @@ func updatePassphrase(c echo.Context) error {
 			bitwarden, err := settings.Get(inst)
 			if err == nil && !bitwarden.ExtensionInstalled {
 				canForce = true
+			} else {
+				err = fmt.Errorf("Bitwarden extension has already been installed on this Cozy, cannot force update the passphrase.")
+				return jsonapi.BadRequest(err)
 			}
 		}
 

--- a/web/settings/passphrase.go
+++ b/web/settings/passphrase.go
@@ -172,27 +172,27 @@ func updatePassphrase(c echo.Context) error {
 			bitwarden, err := settings.Get(inst)
 			if err == nil && !bitwarden.ExtensionInstalled {
 				canForce = true
-			} else {
-				err = fmt.Errorf("Bitwarden extension has already been installed on this Cozy, cannot force update the passphrase.")
-				return jsonapi.BadRequest(err)
 			}
 		}
 
 		if !canForce {
-			err = fmt.Errorf("You must have a CLI audience to force change the password")
+			err = fmt.Errorf("Bitwarden extension has already been installed on this Cozy, cannot force update the passphrase.")
 			return jsonapi.BadRequest(err)
 		}
 
 		params := lifecycle.PassParameters{
-			Pass: []byte(args.Passphrase),
+			Pass:       []byte(args.Passphrase),
 			Iterations: args.Iterations,
-			PublicKey: args.PublicKey,
+			PublicKey:  args.PublicKey,
 			PrivateKey: args.PrivateKey,
-			Key: args.Key,
+			Key:        args.Key,
 		}
 		err = lifecycle.ForceUpdatePassphrase(inst, newPassphrase, params)
 		if err != nil {
 			return err
+		}
+		if hasSession {
+			_, _ = auth.SetCookieForNewSession(c, session.LongRun)
 		}
 		return c.NoContent(http.StatusNoContent)
 	}

--- a/web/settings/passphrase.go
+++ b/web/settings/passphrase.go
@@ -146,6 +146,8 @@ func updatePassphrase(c echo.Context) error {
 		TwoFactorToken    []byte `json:"two_factor_token"`
 		Force             bool   `json:"force,omitempty"`
 		Key               string `json:"key"`
+		PublicKey         string `json:"publicKey"`
+		PrivateKey        string `json:"privateKey"`
 	}{}
 	err := c.Bind(&args)
 	if err != nil {
@@ -181,7 +183,7 @@ func updatePassphrase(c echo.Context) error {
 			return jsonapi.BadRequest(err)
 		}
 
-		err = lifecycle.ForceUpdatePassphrase(inst, newPassphrase, args.Key, args.Iterations)
+		err = lifecycle.ForceUpdatePassphrase(inst, newPassphrase, args.Key, args.PublicKey, args.PrivateKey, args.Iterations)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Otherwise, key was not replaced in the bitwarden settings document and then
the vault was unusable