### PR TITLE
Improve the previews for PDFs

### DIFF
--- a/model/vfs/preview.go
+++ b/model/vfs/preview.go
@@ -64,10 +64,13 @@ func generatePreview(fs VFS, doc *FileDoc) (*bytes.Buffer, error) {
 	args := []string{
 		"-limit", "Memory", "2GB",
 		"-limit", "Map", "3GB",
+		"-density", "300", // We want a high resolution for PDFs
 		"-[0]",           // Takes the input from stdin
 		"-quality", "82", // A good compromise between file size and quality
 		"-interlace", "none", // Don't use progressive JPEGs, they are heavier
 		"-thumbnail", "1080x1920>", // Makes a thumbnail that fits inside the given format
+		"-background", "white", // Use white for the background
+		"-alpha", "remove", // JPEGs don't have an alpha channel
 		"-colorspace", "sRGB", // Use the colorspace recommended for web, sRGB
 		"jpg:-", // Send the output on stdout, in JPEG format
 	}


### PR DESCRIPTION
1. Fix the black background when PDFs have transparency
2. Use a high density when reading the image with Image Magick, and
   only resizes it to the target size at the end to make the text less
   blurry.