### PR TITLE
Forbid the deletion of stack indexes/views

### DIFF
--- a/pkg/couchdb/index.go
+++ b/pkg/couchdb/index.go
@@ -334,3 +334,19 @@ func InitGlobalDB() error {
 	DefineViews(g, GlobalDB, globalViews)
 	return g.Wait()
 }
+
+// CheckDesignDocCanBeDeleted will return false for an index or view used by
+// the stack.
+func CheckDesignDocCanBeDeleted(doctype, name string) bool {
+	for _, index := range Indexes {
+		if doctype == index.Doctype && name == index.Request.DDoc {
+			return false
+		}
+	}
+	for _, view := range Views {
+		if doctype == view.Doctype && name == view.Name {
+			return false
+		}
+	}
+	return true
+}

--- a/web/data/data.go
+++ b/web/data/data.go
@@ -456,6 +456,11 @@ func deleteDesignDoc(c echo.Context) error {
 			"error": "You must pass a rev param",
 		})
 	}
+	if !couchdb.CheckDesignDocCanBeDeleted(doctype, ddoc) {
+		return c.JSON(http.StatusForbidden, echo.Map{
+			"error": "This design doc cannot be deleted",
+		})
+	}
 	return proxy(c, "_design/"+ddoc)
 }
 


### PR DESCRIPTION
The stack needs a few CouchDB design docs for its own indexes and views.
The front applications will no longer be able to delete them with the
DELETE /data/:doctype/_design/:ddoc route.