### PR TITLE
Fix the available apps for intents

### DIFF
--- a/model/intent/intents.go
+++ b/model/intent/intents.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 
 	"github.com/cozy/cozy-stack/model/app"
@@ -124,7 +125,7 @@ func GetInstanceWebapps(inst *instance.Instance) ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
-		url.Path = "registry"
+		url.Path = path.Join(url.Path, "registry")
 		url.RawQuery = "filter[type]=webapp"
 
 		req, err := http.NewRequest("GET", url.String(), nil)


### PR DESCRIPTION
When no installed app can be used to answer an intent request, the stack
makes requests to the apps registry to look if other available
applications could do the job. Those requests were overwritting the path
without taking in account the different spaces of apps registy. This
commit fixes this issue by appending to the app registry path.