### PR TITLE
Add a new type of trigger and jobs worker: client

### DIFF
--- a/model/job/broker.go
+++ b/model/job/broker.go
@@ -224,11 +224,11 @@ func (j *Job) Ack() error {
 
 // Nack sets the job infos state to Errored, set the specified error has the
 // error field and sends the new job infos on the channel.
-func (j *Job) Nack(err error) error {
+func (j *Job) Nack(errorMessage string) error {
 	j.Logger().Debugf("nack %s", j.ID())
 	j.FinishedAt = time.Now()
 	j.State = Errored
-	j.Error = err.Error()
+	j.Error = errorMessage
 	j.Event = nil
 	j.Payload = nil
 	return j.Update()

--- a/model/job/rate_limiting.go
+++ b/model/job/rate_limiting.go
@@ -28,7 +28,9 @@ func GetCounterTypeFromWorkerType(workerType string) (limits.CounterType, error)
 	case "push":
 		return limits.JobNotificationType, nil
 	case "notes-persist":
-		return limits.JobNotificationType, nil
+		return limits.JobNotesPersistType, nil
+	case "client":
+		return limits.JobClientType, nil
 	default:
 		return -1, errors.New("CounterType was not found")
 	}

--- a/model/job/redis_scheduler.go
+++ b/model/job/redis_scheduler.go
@@ -310,7 +310,7 @@ func (s *redisScheduler) addToRedis(t Trigger, prev time.Time) error {
 		if timestamp.Before(now) {
 			timestamp = t.NextExecution(now)
 		}
-	case *WebhookTrigger:
+	case *WebhookTrigger, *ClientTrigger:
 		return nil
 	default:
 		return errors.New("Not implemented yet")

--- a/model/job/scheduler.go
+++ b/model/job/scheduler.go
@@ -133,6 +133,8 @@ func fromTriggerInfos(infos *TriggerInfos) (Trigger, error) {
 		return NewEventTrigger(infos)
 	case "@webhook":
 		return NewWebhookTrigger(infos)
+	case "@client":
+		return NewClientTrigger(infos)
 	default:
 		return nil, ErrUnknownTrigger
 	}

--- a/model/job/trigger_client.go
+++ b/model/job/trigger_client.go
@@ -1,0 +1,31 @@
+package job
+
+// ClientTrigger implements the @webhook triggers. It schedules a job when an
+// HTTP request is made at this webhook.
+type ClientTrigger struct {
+	*TriggerInfos
+}
+
+// NewClientTrigger returns a new instance of ClientTrigger.
+func NewClientTrigger(infos *TriggerInfos) (*ClientTrigger, error) {
+	infos.WorkerType = "client" // Force the worker type
+	return &ClientTrigger{infos}, nil
+}
+
+// Type implements the Type method of the Trigger interface.
+func (c *ClientTrigger) Type() string {
+	return c.TriggerInfos.Type
+}
+
+// Schedule implements the Schedule method of the Trigger interface.
+func (c *ClientTrigger) Schedule() <-chan *JobRequest {
+	return nil
+}
+
+// Unschedule implements the Unschedule method of the Trigger interface.
+func (c *ClientTrigger) Unschedule() {}
+
+// Infos implements the Infos method of the Trigger interface.
+func (c *ClientTrigger) Infos() *TriggerInfos {
+	return c.TriggerInfos
+}

--- a/model/job/worker.go
+++ b/model/job/worker.go
@@ -317,7 +317,7 @@ func (w *Worker) work(workerID string, closed chan<- struct{}) {
 			parentCtx.Logger().Errorf("error while performing job: %s",
 				errRun.Error())
 			runResultLabel = metrics.WorkerExecResultErrored
-			errAck = job.Nack(errRun)
+			errAck = job.Nack(errRun.Error())
 		} else {
 			runResultLabel = metrics.WorkerExecResultSuccess
 			errAck = job.Ack()

--- a/pkg/limits/rate_limiting.go
+++ b/pkg/limits/rate_limiting.go
@@ -64,6 +64,8 @@ const (
 	SendHintByMail
 	// JobNotesPersistType is used for saving notes to the VFS
 	JobNotesPersistType
+	// JobClientType is used for the jobs associated to a @client trigger
+	JobClientType
 	// ExportType is used for creating an export of the data
 	ExportType
 	// WebhookTriggerType is used for calling a webhook trigger
@@ -176,6 +178,12 @@ var configs = []counterConfig{
 	// JobNotesPersistType
 	{
 		Prefix: "job-notes-persist",
+		Limit:  100,
+		Period: 1 * time.Hour,
+	},
+	// JobClientType
+	{
+		Prefix: "job-client",
 		Limit:  100,
 		Period: 1 * time.Hour,
 	},

--- a/web/jobs/jobs.go
+++ b/web/jobs/jobs.go
@@ -528,13 +528,18 @@ func patchJob(c echo.Context) error {
 		return middlewares.ErrForbidden
 	}
 
-	req := apiJob{}
+	req := job.Job{}
 	if _, err := jsonapi.Bind(c.Request().Body, &req); err != nil {
 		return wrapJobsError(err)
 	}
-	switch req.j.State {
+	switch req.State {
 	case job.Errored:
-		err = j.Nack(req.j.Error)
+		err = j.Nack(req.Error)
+		inst.Logger().
+			WithField("job_id", j.ID()).
+			WithField("worker_id", "client").
+			WithField("nspace", "jobs").
+			Errorf("error while performing job: %s", req.Error)
 	case job.Done:
 		err = j.Ack()
 	default:


### PR DESCRIPTION
For running konnectors on mobile client, we want to keep a trace of the executions via the triggers and jobs. So, we are adding a new type of trigger, `@client`, and a new worker type for jobs, `client`.