### PR TITLE
Improve the filenames for notes

### DIFF
--- a/model/note/note.go
+++ b/model/note/note.go
@@ -261,8 +261,15 @@ func titleToFilename(inst *instance.Instance, title string, updatedAt time.Time)
 		name = inst.Translate("Notes New note")
 		name += " " + updatedAt.Format(time.RFC3339)
 	}
-	name = strings.ReplaceAll(name, "/", "-")
-	name = strings.ReplaceAll(name, ":", "-")
+	// Create file with a name compatible with Windows/macOS to avoid
+	// synchronization issues with the desktop client
+	r := strings.NewReplacer("/", "-", ":", "-", "<", "-", ">", "-",
+		`"`, "-", "'", "-", "?", "-", "*", "-", "|", "-", "\\", "-")
+	name = r.Replace(name)
+	// Avoid too long filenames for the same reason
+	if len(name) > 240 {
+		name = name[:240]
+	}
 	return name + ".cozy-note"
 }
 

--- a/tests/integration/lib/cozy_file.rb
+++ b/tests/integration/lib/cozy_file.rb
@@ -92,7 +92,7 @@ class CozyFile
       authorization: "Bearer #{inst.token_for doctype}",
       :"content-type" => mime
     }
-    res = inst.client["/files/#{dir_id}?Type=file&Name=#{name}"].post @content, opts
+    res = inst.client["/files/#{dir_id}?Type=file&Name=#{CGI.escape name}"].post @content, opts
     j = JSON.parse(res.body)["data"]
     @couch_id = j["id"]
     @couch_rev = j["meta"]["rev"]


### PR DESCRIPTION
The filename of a note is generated from its title. We should avoid some
characters like ? to ensure that the filename is compatible with the
windows and macOS file systems, so that the file can be synchronized
with the desktop client safely.