### PR TITLE
Update the wording for the banner

### DIFF
--- a/assets/locales/en.po
+++ b/assets/locales/en.po
@@ -49,7 +49,7 @@ msgid "Login Password best practice"
 msgstr "Best practice:"
 
 msgid "Login Password tip"
-msgstr "fill your password only if the address in your browser matches the one of your Cozy and comes with a padlock."
+msgstr "never fill your password without checking if the address in your browser matches the one of your Cozy."
 
 msgid "Login Password help"
 msgstr "Enter your password to access your Cozy"

--- a/assets/locales/fr.po
+++ b/assets/locales/fr.po
@@ -66,8 +66,8 @@ msgstr "Bonne pratique :"
 
 msgid "Login Password tip"
 msgstr ""
-"n’entrez votre mot de passe que si l’adresse ci-dessus correspond bien à "
-"celle de votre Cozy et qu’un cadenas l’accompagne."
+"n’entrez jamais votre mot de passe sans vérifier que l’adresse ci-dessus "
+"correspond bien à celle de votre Cozy."
 
 msgid "Login Password help"
 msgstr "Saisissez votre mot de passe pour accéder à votre Cozy"


### PR DESCRIPTION
The message was abput checking the URL and the padlock before filling
the password. We remove the part about the padlock because there are
some contexts where the user is expected to give their password even if
the padlock is not here (webviews on android for example). And the
sentence was modified to emphasize it is a general tip for every time
the password must be given, not only for this time.