### PR TITLE
Fix view requests to CouchDB with keys

### DIFF
--- a/pkg/couchdb/couchdb.go
+++ b/pkg/couchdb/couchdb.go
@@ -809,7 +809,7 @@ func ExecView(db Database, view *View, req *ViewRequest, results interface{}) er
 	err = makeRequest(db, view.Doctype, http.MethodGet, viewurl, nil, &results)
 	if IsInternalServerError(err) {
 		time.Sleep(1 * time.Second)
-		// Retry the error on 500, sa it may be just that CouchDB is slow to build the view
+		// Retry the error on 500, as it may be just that CouchDB is slow to build the view
 		err = makeRequest(db, view.Doctype, http.MethodGet, viewurl, nil, &results)
 		if IsInternalServerError(err) {
 			logger.

--- a/pkg/couchdb/encoding.go
+++ b/pkg/couchdb/encoding.go
@@ -34,11 +34,6 @@ func (vr *ViewRequest) Values() (url.Values, error) {
 	if err := maybeSet(v, "key", vr.Key); err != nil {
 		return nil, err
 	}
-	if len(vr.Keys) > 0 {
-		if err := maybeSet(v, "keys", vr.Keys); err != nil {
-			return nil, err
-		}
-	}
 	if err := maybeSet(v, "start_key", vr.StartKey); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When the stack send a request to CouchDB for a view with the keys
parameter, it is sent as a POST with the keys in the body. So, we should
not put the keys in the query-string, as it defeats the purpose of using
a POST in the first place (avoiding too long URLs).