### PR TITLE
Make the sharing revocation more robust

### DIFF
--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -434,7 +434,8 @@ func (s *Sharing) RevokeRecipientBySelf(inst *instance.Instance, sharingDirTrash
 	}
 	if !sharingDirTrashed && s.FirstFilesRule() != nil {
 		if err := s.RemoveSharingDir(inst); err != nil {
-			return err
+			inst.Logger().WithField("nspace", "sharing").
+				Warnf("RevokeRecipientBySelf failed to delete dir %s: %s", s.ID(), err)
 		}
 	}
 	s.Active = false
@@ -466,8 +467,8 @@ func (s *Sharing) RemoveTriggers(inst *instance.Instance) error {
 
 func removeSharingTrigger(inst *instance.Instance, triggerID string) error {
 	if triggerID != "" {
-		sched := job.System()
-		if err := sched.DeleteTrigger(inst, triggerID); err != nil {
+		err := job.System().DeleteTrigger(inst, triggerID)
+		if err != nil && err != job.ErrNotFoundTrigger {
 			return err
 		}
 	}


### PR DESCRIPTION
When a user puts a shared directory to the trash, the sharing is
revoked. We have seen a case where the revocation failed, which is bad,
and it blocks the user from accepting the sharing again, which is worse.
So, let's make the revocation process more robust, by trying harder to
manage errors and adds a retry loop for removing the shared references.