### PR TITLE
Opt-out of FLoC

### DIFF
--- a/web/middlewares/secure.go
+++ b/web/middlewares/secure.go
@@ -154,6 +154,7 @@ func Secure(conf *SecureConfig) echo.MiddlewareFunc {
 				h.Set(echo.HeaderContentSecurityPolicy, cspHeader)
 			}
 			h.Set(echo.HeaderXContentTypeOptions, "nosniff")
+			h.Set("Permissions-Policy", "interest-cohort=()")
 			return next(c)
 		}
 	}


### PR DESCRIPTION
Google’s Federated Learning of Cohorts is a new initiative to track
internet users without their consent. This feature is already enabled by
default for a small percentage of Google Chrome users, and is intended
to be enabled for all users at the end of the experiment. We don't want
of it, so let's add an HTTP header to disable it on Cozy.

See https://plausible.io/blog/google-floc#how-to-opt-out-of-floc-as-a-web-developer-set-a-permissions-policy