### PR TITLE
Fix cleaning on uninstall konnectors

### DIFF
--- a/model/account/accounts.go
+++ b/model/account/accounts.go
@@ -131,7 +131,7 @@ func GetTriggers(jobsSystem job.JobSystem, db prefixer.Prefixer, accountID strin
 // CleanEntry is a struct with an account and its associated trigger.
 type CleanEntry struct {
 	Account          *Account
-	Trigger          job.Trigger
+	Triggers         []job.Trigger
 	ManifestOnDelete bool // the manifest of the konnector has a field "on_delete_account"
 	Slug             string
 }
@@ -180,8 +180,8 @@ func cleanAndWaitSingle(inst *instance.Instance, entry CleanEntry) error {
 			return err
 		}
 	}
-	if entry.Trigger != nil {
-		err := jobsSystem.DeleteTrigger(inst, entry.Trigger.ID())
+	for _, t := range entry.Triggers {
+		err := jobsSystem.DeleteTrigger(inst, t.ID())
 		if err != nil {
 			inst.Logger().WithField("nspace", "accounts").
 				Errorf("Cannot delete the trigger: %v", err)

--- a/model/instance/lifecycle/destroy.go
+++ b/model/instance/lifecycle/destroy.go
@@ -111,7 +111,7 @@ func deleteAccounts(inst *instance.Instance) error {
 		}
 		entry := account.CleanEntry{
 			Account:          acc,
-			Trigger:          nil, // We don't care, the triggers will all be deleted a bit later
+			Triggers:         nil, // We don't care, the triggers will all be deleted a bit later
 			ManifestOnDelete: man.OnDeleteAccount != "",
 			Slug:             slug,
 		}


### PR DESCRIPTION
When a konnector is uninstalled, the stack cleans the accounts. To do
that, it looks at the triggers, and when we had several triggers for the
same accounts (e.g. cron + webhook), it was trying to delete the
accounts several times, which failed. Now, the cleaning entries will
regroup the triggers with the same account to avoid this issue.