### PR TITLE
Fix cleaning app slug in Cozy URL for sharings

### DIFF
--- a/model/sharing/oauth.go
+++ b/model/sharing/oauth.go
@@ -112,24 +112,6 @@ func (m *Member) CreateSharingRequest(inst *instance.Instance, s *Sharing, c *Cr
 	return nil
 }
 
-func clearAppInHost(host string) string {
-	knownDomain := false
-	for _, domain := range consts.KnownFlatDomains {
-		if strings.HasSuffix(host, domain) {
-			knownDomain = true
-			break
-		}
-	}
-	if !knownDomain {
-		return host
-	}
-	parts := strings.SplitN(host, ".", 2)
-	sub := parts[0]
-	domain := parts[1]
-	parts = strings.SplitN(sub, "-", 2)
-	return parts[0] + "." + domain
-}
-
 // countFiles returns the number of files that should be uploaded on the
 // initial synchronisation.
 func (s *Sharing) countFiles(inst *instance.Instance) int {
@@ -184,7 +166,6 @@ func (s *Sharing) RegisterCozyURL(inst *instance.Instance, m *Member, cozyURL st
 	if err != nil || u.Host == "" {
 		return ErrInvalidURL
 	}
-	u.Host = clearAppInHost(u.Host)
 	u.Path = ""
 	u.RawPath = ""
 	u.RawQuery = ""

--- a/model/sharing/rule_test.go
+++ b/model/sharing/rule_test.go
@@ -192,12 +192,3 @@ func TestTriggersArgs(t *testing.T) {
 	r.Local = true
 	assert.Equal(t, "", r.TriggerArgs())
 }
-
-func TestClearAppInHost(t *testing.T) {
-	host := clearAppInHost("example.mycozy.cloud")
-	assert.Equal(t, "example.mycozy.cloud", host)
-	host = clearAppInHost("example-drive.mycozy.cloud")
-	assert.Equal(t, "example.mycozy.cloud", host)
-	host = clearAppInHost("my-cozy.example.net")
-	assert.Equal(t, "my-cozy.example.net", host)
-}

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -1103,6 +1103,15 @@ func TestRevocationFromRecipient(t *testing.T) {
 	assertLastRecipientIsRevoked(t, s, sharedRefs)
 }
 
+func TestClearAppInURL(t *testing.T) {
+	host := sharings.ClearAppInURL("https://example.mycozy.cloud/")
+	assert.Equal(t, "https://example.mycozy.cloud/", host)
+	host = sharings.ClearAppInURL("https://example-drive.mycozy.cloud/")
+	assert.Equal(t, "https://example.mycozy.cloud/", host)
+	host = sharings.ClearAppInURL("https://my-cozy.example.net/")
+	assert.Equal(t, "https://my-cozy.example.net/", host)
+}
+
 func TestMain(m *testing.M) {
 	config.UseTestFile()
 	config.GetConfig().Assets = "../../assets"


### PR DESCRIPTION
When a user wants to accept a sharing, they must give the URL of their
Cozy. There are a few mistakes that can happen easily on this step, and
we want to fix them for the user. For example, the URL can have been
copied-pasted from address bar of the browser, and it contains the app
slug in that case (https://john-drive.mycozy.cloud/ instead of
https://john.mycozy.cloud/). This mistake was already identified and the
stack was fixing the URL for creating the OAuth client, but the fix was
in too low-level code, and the incorrect URL was used later for the
redirection. This commit moves this code to a better place and fix the
issue on redirection.