### PR TITLE
Add routes for bulk handling of bitwarden ciphers

### DIFF
--- a/docs/bitwarden.md
+++ b/docs/bitwarden.md
@@ -875,7 +875,7 @@ Host: alice.example.com
 #### Response
 
 ```http
-HTTP/1.1 204 No Content
+HTTP/1.1 200 OK
 ```
 
 ### DELETE /bitwarden/api/ciphers
@@ -903,7 +903,7 @@ Content-Type: application/json
 #### Response
 
 ```http
-HTTP/1.1 204 No Content
+HTTP/1.1 200 OK
 ```
 
 ### PUT /bitwarden/api/ciphers/delete
@@ -930,7 +930,7 @@ Content-Type: application/json
 #### Response
 
 ```http
-HTTP/1.1 204 No Content
+HTTP/1.1 200 OK
 ```
 
 ### PUT /bitwarden/api/ciphers/:id/delete

--- a/docs/bitwarden.md
+++ b/docs/bitwarden.md
@@ -906,6 +906,33 @@ Content-Type: application/json
 HTTP/1.1 204 No Content
 ```
 
+### PUT /bitwarden/api/ciphers/delete
+
+This route is used to soft delete ciphers in bulk.
+
+#### Request
+
+```http
+PUT /bitwarden/api/ciphers/delete HTTP/1.1
+Host: alice.example.com
+Content-Type: application/json
+```
+
+```json
+{
+  "ids": [
+    "4c2869dd-0e1c-499f-b116-a824016df251",
+    "205c22f0-8642-0139-c874-543d7eb8149c"
+  ]
+}
+```
+
+#### Response
+
+```http
+HTTP/1.1 204 No Content
+```
+
 ### PUT /bitwarden/api/ciphers/:id/delete
 
 This route is used to soft delete a cipher, by adding a `deletedDate`

--- a/docs/bitwarden.md
+++ b/docs/bitwarden.md
@@ -878,6 +878,34 @@ Host: alice.example.com
 HTTP/1.1 204 No Content
 ```
 
+### DELETE /bitwarden/api/ciphers
+
+This route is used to delete ciphers in bulk. It can also be called via
+`POST /bitwarden/api/ciphers/delete`.
+
+#### Request
+
+```http
+DELETE /bitwarden/api/ciphers HTTP/1.1
+Host: alice.example.com
+Content-Type: application/json
+```
+
+```json
+{
+  "ids": [
+    "4c2869dd-0e1c-499f-b116-a824016df251",
+    "205c22f0-8642-0139-c874-543d7eb8149c"
+  ]
+}
+```
+
+#### Response
+
+```http
+HTTP/1.1 204 No Content
+```
+
 ### PUT /bitwarden/api/ciphers/:id/delete
 
 This route is used to soft delete a cipher, by adding a `deletedDate`

--- a/docs/bitwarden.md
+++ b/docs/bitwarden.md
@@ -906,6 +906,24 @@ Content-Type: application/json
 HTTP/1.1 200 OK
 ```
 
+### PUT /bitwarden/api/ciphers/:id/delete
+
+This route is used to soft delete a cipher, by adding a `deletedDate`
+attribute on it.
+
+#### Request
+
+```http
+PUT /bitwarden/api/ciphers/4c2869dd-0e1c-499f-b116-a824016df251/delete HTTP/1.1
+Host: alice.example.com
+```
+
+#### Response
+
+```http
+HTTP/1.1 204 No Content
+```
+
 ### PUT /bitwarden/api/ciphers/delete
 
 This route is used to soft delete ciphers in bulk.
@@ -933,24 +951,6 @@ Content-Type: application/json
 HTTP/1.1 200 OK
 ```
 
-### PUT /bitwarden/api/ciphers/:id/delete
-
-This route is used to soft delete a cipher, by adding a `deletedDate`
-attribute on it.
-
-#### Request
-
-```http
-PUT /bitwarden/api/ciphers/4c2869dd-0e1c-499f-b116-a824016df251/delete HTTP/1.1
-Host: alice.example.com
-```
-
-#### Response
-
-```http
-HTTP/1.1 204 No Content
-```
-
 ### PUT /bitwarden/api/ciphers/:id/restore
 
 This route is used to restore a soft-deleted cipher, by removing the
@@ -967,6 +967,81 @@ Host: alice.example.com
 
 ```http
 HTTP/1.1 204 No Content
+```
+
+### PUT /bitwarden/api/ciphers/restore
+
+This route is used to restore ciphers in bulk.
+
+#### Request
+
+```http
+PUT /bitwarden/api/ciphers/restore HTTP/1.1
+Host: alice.example.com
+Content-Type: application/json
+```
+
+```json
+{
+  "ids": [
+    "4c2869dd-0e1c-499f-b116-a824016df251",
+    "205c22f0-8642-0139-c874-543d7eb8149c"
+  ]
+}
+```
+
+#### Response
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+```
+
+```json
+{
+  "Data": [
+    {
+      "Object": "cipher",
+      "Id": "4c2869dd-0e1c-499f-b116-a824016df251",
+      "Type": 1,
+      "Favorite": false,
+      "Name": "2.d7MttWzJTSSKx1qXjHUxlQ==|01Ath5UqFZHk7csk5DVtkQ==|EMLoLREgCUP5Cu4HqIhcLqhiZHn+NsUDp8dAg1Xu0Io=",
+      "FolderId": null,
+      "OrganizationId": null,
+      "Notes": null,
+      "Login": {
+        "Uris": [
+          {
+            "Uri": "2.T57BwAuV8ubIn/sZPbQC+A==|EhUSSpJWSzSYOdJ/AQzfXuUXxwzcs/6C4tOXqhWAqcM=|OWV2VIqLfoWPs9DiouXGUOtTEkVeklbtJQHkQFIXkC8=",
+            "Match": null
+          }
+        ]
+      },
+      "Username": "2.JbFkAEZPnuMm70cdP44wtA==|fsN6nbT+udGmOWv8K4otgw==|JbtwmNQa7/48KszT2hAdxpmJ6DRPZst0EDEZx5GzesI=",
+      "Password": "2.e83hIsk6IRevSr/H1lvZhg==|48KNkSCoTacopXRmIZsbWg==|CIcWgNbaIN2ix2Fx1Gar6rWQeVeboehp4bioAwngr0o=",
+      "Totp": null,
+      "Fields": null,
+      "Attachments": null,
+      "RevisionDate": "2021-04-23T12:58:01Z",
+      "Edit": true,
+      "OrganizationUseTotp": false
+    },
+    {
+      "Object": "cipher",
+      "Id": "205c22f0-8642-0139-c874-543d7eb8149c",
+      "Type": 2,
+      "Favorite": true,
+      "Name": "2.G38TIU3t1pGOfkzjCQE7OQ==|Xa1RupttU7zrWdzIT6oK+w==|J3C6qU1xDrfTgyJD+OrDri1GjgGhU2nmRK75FbZHXoI=",
+      "FolderId": null,
+      "OrganizationId": null,
+      "Notes": "2.rSw0uVQEFgUCEmOQx0JnDg==|MKqHLD25aqaXYHeYJPH/mor7l3EeSQKsI7A/R+0bFTI=|ODcUScISzKaZWHlUe4MRGuTT2S7jpyDmbOHl7d+6HiM=",
+      "RevisionDate": "2021-04-23T12:58:01Z",
+      "Edit": true,
+      "OrganizationUseTotp": false
+    }
+  ],
+  "Object": "list"
+}
 ```
 
 

--- a/pkg/assets/dynamic/dynamic.go
+++ b/pkg/assets/dynamic/dynamic.go
@@ -44,6 +44,11 @@ func ListAssets() (map[string][]*model.Asset, error) {
 
 // GetAsset retrieves a raw asset from the dynamic FS and builds a fs.Asset
 func GetAsset(context, name string) (*model.Asset, error) {
+	// In unit tests, the assetFS is often not initialized
+	if assetFS == nil {
+		return nil, ErrDynAssetNotFound
+	}
+
 	// Re-constructing the asset struct from the dyn FS content
 	content, err := assetFS.Get(context, name)
 	if err != nil {

--- a/web/bitwarden/bitwarden.go
+++ b/web/bitwarden/bitwarden.go
@@ -500,6 +500,7 @@ func Routes(router *echo.Group) {
 	ciphers.PUT("/:id/restore", RestoreCipher)
 	ciphers.DELETE("", BulkDeleteCiphers)
 	ciphers.POST("/delete", BulkDeleteCiphers)
+	ciphers.PUT("/delete", BulkSoftDeleteCiphers)
 
 	ciphers.POST("/:id/share", ShareCipher)
 	ciphers.PUT("/:id/share", ShareCipher)

--- a/web/bitwarden/bitwarden.go
+++ b/web/bitwarden/bitwarden.go
@@ -501,6 +501,7 @@ func Routes(router *echo.Group) {
 	ciphers.DELETE("", BulkDeleteCiphers)
 	ciphers.POST("/delete", BulkDeleteCiphers)
 	ciphers.PUT("/delete", BulkSoftDeleteCiphers)
+	ciphers.PUT("/restore", BulkRestoreCiphers)
 
 	ciphers.POST("/:id/share", ShareCipher)
 	ciphers.PUT("/:id/share", ShareCipher)

--- a/web/bitwarden/bitwarden.go
+++ b/web/bitwarden/bitwarden.go
@@ -492,13 +492,17 @@ func Routes(router *echo.Group) {
 	ciphers.GET("/:id", GetCipher)
 	ciphers.POST("/:id", UpdateCipher)
 	ciphers.PUT("/:id", UpdateCipher)
+	ciphers.POST("/import", ImportCiphers)
+
 	ciphers.DELETE("/:id", DeleteCipher)
 	ciphers.POST("/:id/delete", DeleteCipher)
 	ciphers.PUT("/:id/delete", SoftDeleteCipher)
 	ciphers.PUT("/:id/restore", RestoreCipher)
+	ciphers.DELETE("", BulkDeleteCiphers)
+	ciphers.POST("/delete", BulkDeleteCiphers)
+
 	ciphers.POST("/:id/share", ShareCipher)
 	ciphers.PUT("/:id/share", ShareCipher)
-	ciphers.POST("/import", ImportCiphers)
 
 	folders := api.Group("/folders")
 	folders.GET("", ListFolders)

--- a/web/bitwarden/bitwarden_test.go
+++ b/web/bitwarden/bitwarden_test.go
@@ -651,10 +651,30 @@ func TestBulkDeleteCiphers(t *testing.T) {
 		"ids": ids,
 	})
 	buf := bytes.NewBuffer(body)
-	req, _ := http.NewRequest("POST", ts.URL+"/bitwarden/api/ciphers/delete", buf)
+	req, _ := http.NewRequest("PUT", ts.URL+"/bitwarden/api/ciphers/delete", buf)
 	req.Header.Add("Authorization", "Bearer "+token)
 	req.Header.Add("Content-Type", "application/json")
 	res, err := http.DefaultClient.Do(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, res.StatusCode)
+
+	for _, id := range ids {
+		req, _ = http.NewRequest("GET", ts.URL+"/bitwarden/api/ciphers/"+id, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, result["DeletedDate"])
+	}
+
+	buf = bytes.NewBuffer(body)
+	req, _ = http.NewRequest("DELETE", ts.URL+"/bitwarden/api/ciphers", buf)
+	req.Header.Add("Authorization", "Bearer "+token)
+	req.Header.Add("Content-Type", "application/json")
+	res, err = http.DefaultClient.Do(req)
 	assert.NoError(t, err)
 	assert.Equal(t, 200, res.StatusCode)
 

--- a/web/bitwarden/bitwarden_test.go
+++ b/web/bitwarden/bitwarden_test.go
@@ -609,6 +609,60 @@ func TestSync(t *testing.T) {
 	assert.Equal(t, "domains", domains["Object"])
 }
 
+func TestBulkDeleteCiphers(t *testing.T) {
+	nbCiphersToDelete := 5
+	nbCiphers, err := couchdb.CountAllDocs(inst, consts.BitwardenCiphers)
+	assert.NoError(t, err)
+
+	var ids []string
+	for i := 0; i < nbCiphersToDelete; i++ {
+		body := `
+{
+	"type": 1,
+	"favorite": false,
+	"name": "2.d7MttWzJTSSKx1qXjHUxlQ==|01Ath5UqFZHk7csk5DVtkQ==|EMLoLREgCUP5Cu4HqIhcLqhiZHn+NsUDp8dAg1Xu0Io=",
+	"notes": null,
+	"folderId": null,
+	"organizationId": null,
+	"login": {
+		"uri": "2.T57BwAuV8ubIn/sZPbQC+A==|EhUSSpJWSzSYOdJ/AQzfXuUXxwzcs/6C4tOXqhWAqcM=|OWV2VIqLfoWPs9DiouXGUOtTEkVeklbtJQHkQFIXkC8=",
+		"username": "2.JbFkAEZPnuMm70cdP44wtA==|fsN6nbT+udGmOWv8K4otgw==|JbtwmNQa7/48KszT2hAdxpmJ6DRPZst0EDEZx5GzesI=",
+		"password": "2.e83hIsk6IRevSr/H1lvZhg==|48KNkSCoTacopXRmIZsbWg==|CIcWgNbaIN2ix2Fx1Gar6rWQeVeboehp4bioAwngr0o=",
+		"totp": null
+	}
+}`
+		req, _ := http.NewRequest("POST", ts.URL+"/bitwarden/api/ciphers", bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		ids = append(ids, result["Id"].(string))
+	}
+
+	nb, err := couchdb.CountAllDocs(inst, consts.BitwardenCiphers)
+	assert.NoError(t, err)
+	assert.Equal(t, nbCiphers+nbCiphersToDelete, nb)
+
+	body, _ := json.Marshal(map[string][]string{
+		"ids": ids,
+	})
+	buf := bytes.NewBuffer(body)
+	req, _ := http.NewRequest("POST", ts.URL+"/bitwarden/api/ciphers/delete", buf)
+	req.Header.Add("Authorization", "Bearer "+token)
+	req.Header.Add("Content-Type", "application/json")
+	res, err := http.DefaultClient.Do(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, res.StatusCode)
+
+	nb, err = couchdb.CountAllDocs(inst, consts.BitwardenCiphers)
+	assert.NoError(t, err)
+	assert.Equal(t, nbCiphers, nb)
+}
+
 func TestSharedCipher(t *testing.T) {
 	body := `
 {


### PR DESCRIPTION
This PR adds 3 routes to handle bitwarden ciphers in bulk:

1. for soft-deletion
2. for restoration
3. for permanent deletion.