### PR TITLE
Fix some issues with sharing + VFS versioning

### DIFF
--- a/model/vfs/vfsafero/impl.go
+++ b/model/vfs/vfsafero/impl.go
@@ -107,6 +107,7 @@ func (afs *aferoVFS) UseSharingIndexer(index vfs.Indexer) vfs.VFS {
 		Indexer:         index,
 		DiskThresholder: afs.DiskThresholder,
 		domain:          afs.domain,
+		prefix:          afs.prefix,
 		fs:              afs.fs,
 		mu:              afs.mu,
 		pth:             afs.pth,

--- a/model/vfs/vfsswift/impl_v1.go
+++ b/model/vfs/vfsswift/impl_v1.go
@@ -79,6 +79,7 @@ func (sfs *swiftVFS) UseSharingIndexer(index vfs.Indexer) vfs.VFS {
 		DiskThresholder: sfs.DiskThresholder,
 		c:               sfs.c,
 		domain:          sfs.domain,
+		prefix:          sfs.prefix,
 		container:       sfs.container,
 		version:         sfs.version,
 		mu:              sfs.mu,

--- a/model/vfs/vfsswift/impl_v2.go
+++ b/model/vfs/vfsswift/impl_v2.go
@@ -96,6 +96,7 @@ func (sfs *swiftVFSV2) UseSharingIndexer(index vfs.Indexer) vfs.VFS {
 		DiskThresholder: sfs.DiskThresholder,
 		c:               sfs.c,
 		domain:          sfs.domain,
+		prefix:          sfs.prefix,
 		container:       sfs.container,
 		version:         sfs.version,
 		dataContainer:   sfs.dataContainer,

--- a/model/vfs/vfsswift/impl_v3.go
+++ b/model/vfs/vfsswift/impl_v3.go
@@ -104,6 +104,7 @@ func (sfs *swiftVFSV3) UseSharingIndexer(index vfs.Indexer) vfs.VFS {
 		DiskThresholder: sfs.DiskThresholder,
 		c:               sfs.c,
 		domain:          sfs.domain,
+		prefix:          sfs.prefix,
 		container:       sfs.container,
 		mu:              sfs.mu,
 		log:             sfs.log,


### PR DESCRIPTION
When files are synchronized via a sharing, the stack use a sharing
indexer to override some behaviors from the classical VFS, like forcing
the revisions to put in CouchDB. And in order to do that, we were using
the UseSharingIndexer method of the VFS that was bugged: the prefix
field was not copied. In most cases, this field wasn't used, but it made
some requests for checking old versions of a file to fail.

In practice, it means that a shared file can have several versions
written in a close time gap, ingoring the mininal delay between versions
from the configuration.