### PR TITLE
Allow to put in maintenance a konnector on an environment

### DIFF
--- a/client/apps.go
+++ b/client/apps.go
@@ -201,6 +201,32 @@ func (c *Client) UninstallApp(opts *AppOptions) (*AppManifest, error) {
 	return readAppManifest(res)
 }
 
+// ActivateMaintenance is used to activate the maintenance for a konnector
+func (c *Client) ActivateMaintenance(slug string, opts map[string]interface{}) error {
+	data := map[string]interface{}{"attributes": opts}
+	body, err := writeJSONAPI(data)
+	if err != nil {
+		return err
+	}
+	_, err = c.Req(&request.Options{
+		Method:     "PUT",
+		Path:       "/konnectors/maintenance/" + slug,
+		Body:       body,
+		NoResponse: true,
+	})
+	return err
+}
+
+// DeactivateMaintenance is used to deactivate the maintenance for a konnector
+func (c *Client) DeactivateMaintenance(slug string) error {
+	_, err := c.Req(&request.Options{
+		Method:     "DELETE",
+		Path:       "/konnectors/maintenance/" + slug,
+		NoResponse: true,
+	})
+	return err
+}
+
 func makeAppsPath(appType, path string) string {
 	switch appType {
 	case consts.Apps:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/cozy/cozy-stack/client"
@@ -184,4 +186,15 @@ func cozyDomain() string {
 		domain = defaultDevDomain
 	}
 	return domain
+}
+
+func prompt(text string) string {
+	fmt.Fprintf(os.Stderr, "%s ", text)
+	r := bufio.NewReader(os.Stdin)
+	s, err := r.ReadString('\n')
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		os.Exit(1)
+	}
+	return strings.TrimSuffix(s, "\n")
 }

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -401,6 +401,61 @@ Content-Type: application/json
 ```
 
 
+## Konnectors
+
+### PUT /konnectors/maintenance/:slug
+
+#### Request
+
+```http
+PUT /konnectors/maintenance/ameli HTTP/1.1
+Content-Type: application/vnd.api+json
+```
+
+```json
+{
+  "data": {
+    "attributes": {
+      "flag_short_maintenance": true,
+      "flag_disallow_manual_exec": false,
+      "messages": {
+        "fr": {
+          "long_message": "Bla bla bla",
+          "short_message": "Bla"
+        },
+        "en": {
+          "long_message": "Yadi yadi yada",
+          "short_message": "Yada"
+        }
+      }
+    }
+  }
+}
+```
+
+**Note:** the `flag_infra_maintenance` will always be set to true with this
+endpoint.
+
+#### Response
+
+```http
+HTTP/1.1 204 No Content
+```
+
+### DELETE /konnectors/maintenance/:slug
+
+#### Request
+
+```http
+DELETE /konnectors/maintenance/ameli HTTP/1.1
+```
+
+#### Response
+
+```http
+HTTP/1.1 204 No Content
+```
+
 ## Swift
 
 ### GET /swift/layouts

--- a/model/app/maintenance.go
+++ b/model/app/maintenance.go
@@ -45,6 +45,22 @@ func loadMaintenance(slug string) (couchdb.JSONDoc, error) {
 	return doc, nil
 }
 
+// GetMaintenanceOptions will return the maintenance options for the given
+// konnector if it is in maintenance on this stack.
+func GetMaintenanceOptions(slug string) (map[string]interface{}, error) {
+	var doc couchdb.JSONDoc
+	err := couchdb.GetDoc(couchdb.GlobalDB, consts.KonnectorsMaintenance, slug, &doc)
+	if couchdb.IsNotFoundError(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	delete(doc.M, "_id")
+	delete(doc.M, "_rev")
+	return doc.M, nil
+}
+
 // ListMaintenance returns the list of konnectors in maintenance for the stack
 // (not from apps registry).
 func ListMaintenance() ([]interface{}, error) {

--- a/model/app/maintenance.go
+++ b/model/app/maintenance.go
@@ -1,0 +1,44 @@
+package app
+
+import (
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+)
+
+// ActivateMaintenance activates maintenance for the given konnector.
+func ActivateMaintenance(slug string, opts map[string]interface{}) error {
+	doc, err := loadMaintenance(slug)
+	if err != nil {
+		return err
+	}
+	doc.M = opts
+	if doc.M == nil {
+		doc.M = map[string]interface{}{}
+	}
+	doc.M["flag_infra_maintenance"] = true
+	doc.SetID(slug)
+	return couchdb.Upsert(couchdb.GlobalDB, &doc)
+}
+
+// DeactivateMaintenance disables maintenance for the given konnector.
+func DeactivateMaintenance(slug string) error {
+	doc, err := loadMaintenance(slug)
+	if err != nil {
+		return err
+	}
+	if doc.M == nil {
+		doc.M = map[string]interface{}{}
+	}
+	doc.SetID(slug)
+	return couchdb.DeleteDoc(couchdb.GlobalDB, &doc)
+}
+
+func loadMaintenance(slug string) (couchdb.JSONDoc, error) {
+	var doc couchdb.JSONDoc
+	err := couchdb.GetDoc(couchdb.GlobalDB, consts.KonnectorsMaintenance, slug, &doc)
+	if err != nil && !couchdb.IsNotFoundError(err) {
+		return doc, err
+	}
+	doc.Type = consts.KonnectorsMaintenance
+	return doc, nil
+}

--- a/pkg/consts/doctype.go
+++ b/pkg/consts/doctype.go
@@ -17,6 +17,8 @@ const (
 	Versions = "io.cozy.registry.versions"
 	// KonnectorLogs doc type for konnector last execution logs.
 	KonnectorLogs = "io.cozy.konnectors.logs"
+	// KonnectorsMaintenance doc type for maintenance of konnectors.
+	KonnectorsMaintenance = "io.cozy.konnectors.maintenance"
 	// Archives doc type for zip archives with files and directories
 	Archives = "io.cozy.files.archives"
 	// Exports doc type for global exports archives

--- a/web/apps/maintenance.go
+++ b/web/apps/maintenance.go
@@ -1,0 +1,37 @@
+package apps
+
+import (
+	"net/http"
+
+	"github.com/cozy/cozy-stack/model/app"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/jsonapi"
+	"github.com/labstack/echo/v4"
+)
+
+func activateMaintenance(c echo.Context) error {
+	slug := c.Param("slug")
+	var doc couchdb.JSONDoc
+	if _, err := jsonapi.Bind(c.Request().Body, &doc); err != nil {
+		return err
+	}
+	if err := app.ActivateMaintenance(slug, doc.M); err != nil {
+		return err
+	}
+	return c.NoContent(http.StatusNoContent)
+}
+
+func deactivateMaintenance(c echo.Context) error {
+	slug := c.Param("slug")
+	if err := app.DeactivateMaintenance(slug); err != nil {
+		return err
+	}
+	return c.NoContent(http.StatusNoContent)
+}
+
+// AdminRoutes sets the routing for the admin interface to configure
+// maintenance for the konnectors.
+func AdminRoutes(router *echo.Group) {
+	router.PUT("/maintenance/:slug", activateMaintenance)
+	router.DELETE("/maintenance/:slug", deactivateMaintenance)
+}

--- a/web/registry/registry.go
+++ b/web/registry/registry.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"net/http"
 
+	"github.com/cozy/cozy-stack/model/app"
 	"github.com/cozy/cozy-stack/model/permission"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/registry"
@@ -94,7 +95,14 @@ func proxyMaintenanceReq(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	return c.JSON(http.StatusOK, list)
+	maintenance, err := app.ListMaintenance()
+	if err != nil {
+		return err
+	}
+	for _, item := range list {
+		maintenance = append(maintenance, item)
+	}
+	return c.JSON(http.StatusOK, maintenance)
 }
 
 // Routes sets the routing for the registry

--- a/web/registry/registry.go
+++ b/web/registry/registry.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"encoding/json"
 	"net/http"
 
 	"github.com/cozy/cozy-stack/model/app"
@@ -38,10 +39,11 @@ func proxyReq(auth authType, clientCache clientCacheControl, proxyCacheControl r
 				}
 			}
 		case perms:
-			// pdoc, err := middlewares.GetPermission(c)
-			// if err != nil || pdoc.Type != permission.TypeWebapp {
-			_, err := middlewares.GetPermission(c)
+			pdoc, err := middlewares.GetPermission(c)
 			if err != nil {
+				return echo.NewHTTPError(http.StatusForbidden)
+			}
+			if pdoc.Type != permission.TypeWebapp && pdoc.Type != permission.TypeOauth {
 				return echo.NewHTTPError(http.StatusForbidden)
 			}
 		default:
@@ -81,6 +83,37 @@ func proxyListReq(c echo.Context) error {
 	return c.JSON(http.StatusOK, list)
 }
 
+func proxyAppReq(c echo.Context) error {
+	// router.GET("/:app", proxyReq(perms, noClientCache, registry.WithCache))
+	i := middlewares.GetInstance(c)
+	pdoc, err := middlewares.GetPermission(c)
+	if err != nil {
+		return err
+	}
+	if pdoc.Type != permission.TypeWebapp && pdoc.Type != permission.TypeOauth {
+		return echo.NewHTTPError(http.StatusForbidden)
+	}
+	req := c.Request()
+	proxyResp, err := registry.Proxy(req, i.Registries(), registry.WithCache)
+	if err != nil {
+		return err
+	}
+	defer proxyResp.Body.Close()
+	var doc map[string]interface{}
+	if err := json.NewDecoder(proxyResp.Body).Decode(&doc); err != nil {
+		return err
+	}
+	opts, err := app.GetMaintenanceOptions(c.Param("app"))
+	if err != nil {
+		return err
+	}
+	if opts != nil {
+		doc["maintenance_activated"] = true
+		doc["maintenance_options"] = opts
+	}
+	return c.JSON(http.StatusOK, doc)
+}
+
 func proxyMaintenanceReq(c echo.Context) error {
 	i := middlewares.GetInstance(c)
 	pdoc, err := middlewares.GetPermission(c)
@@ -111,7 +144,7 @@ func Routes(router *echo.Group) {
 	router.GET("", proxyListReq, gzip)
 	router.GET("/", proxyListReq, gzip)
 	router.GET("/maintenance", proxyMaintenanceReq, gzip)
-	router.GET("/:app", proxyReq(perms, noClientCache, registry.WithCache))
+	router.GET("/:app", proxyAppReq, gzip)
 	router.GET("/:app/icon", proxyReq(authed, shortClientCache, registry.NoCache))
 	router.GET("/:app/partnership_icon", proxyReq(authed, shortClientCache, registry.NoCache))
 	router.GET("/:app/screenshots/*", proxyReq(authed, shortClientCache, registry.NoCache))

--- a/web/routing.go
+++ b/web/routing.go
@@ -275,6 +275,7 @@ func SetupAdminRoutes(router *echo.Echo) error {
 	}
 
 	instances.Routes(router.Group("/instances", mws...))
+	apps.AdminRoutes(router.Group("/konnectors", mws...))
 	version.Routes(router.Group("/version", mws...))
 	metrics.Routes(router.Group("/metrics", mws...))
 	realtime.Routes(router.Group("/realtime", mws...))


### PR DESCRIPTION
With this PR, it will now be possible to put a konnector for only one environment (aka a stack). Before, it was only possible to do that by updating the konnector on the apps registry, which impacts all the environments.

We have 2 CLI commands to manipulate this: `cozy-stack konnectors maintenance` and `cozy-stack konnectors deactivate-maintenance`. And we have modified two routes to use this information: `GET /registry/maintenance` and `GET /registry/:app`.