### PR TITLE
Fix swift previewfs

### DIFF
--- a/pkg/previewfs/cache.go
+++ b/pkg/previewfs/cache.go
@@ -83,7 +83,7 @@ func (s swiftCache) Set(md5sum []byte, buffer *bytes.Buffer) error {
 	headers := objectMeta.ObjectHeaders()
 	headers["X-Delete-After"] = strconv.FormatInt(int64(ttl.Seconds()), 10)
 	f, err := s.c.ObjectCreate(containerName, objectName, true, "", "image/jpg", headers)
-	if err == swift.ContainerNotFound {
+	if err == swift.ObjectNotFound {
 		_ = s.c.ContainerCreate(containerName, nil)
 		f, err = s.c.ObjectCreate(containerName, objectName, true, "", "image/jpg", headers)
 	}


### PR DESCRIPTION
previewfs stores PDF preview files to avoid regenerating it each time.
Previews are stored in afero fs or in swift.
When using swift, if previewfs container doesn't exist, the stack should [create it](https://github.com/cozy/cozy-stack/blob/master/pkg/previewfs/cache.go#L86-L87).

Unfortunately, this doesn't work currently because we test for error `swift.ContainerNotFound` but `ObjectCreate()` errors are mapped against `objectErrorMap`  (see [here](https://github.com/ncw/swift/blob/master/swift.go#L1496)) and 404 status code is then interpreted as `ObjectNotFound`

So previewfs container is never created.

This PR fixes that behaviour by comparing error to `ObjectNotFound` instead of `ContainerNotFound`