### PR TITLE
Fix creation of previewfs swift container

### DIFF
--- a/pkg/previewfs/cache.go
+++ b/pkg/previewfs/cache.go
@@ -83,14 +83,18 @@ func (s swiftCache) Set(md5sum []byte, buffer *bytes.Buffer) error {
 	headers := objectMeta.ObjectHeaders()
 	headers["X-Delete-After"] = strconv.FormatInt(int64(ttl.Seconds()), 10)
 	f, err := s.c.ObjectCreate(containerName, objectName, true, "", "image/jpg", headers)
-	if err == swift.ObjectNotFound {
-		_ = s.c.ContainerCreate(containerName, nil)
-		f, err = s.c.ObjectCreate(containerName, objectName, true, "", "image/jpg", headers)
-	}
 	if err != nil {
 		return err
 	}
-	return writeClose(f, buffer)
+	err = writeClose(f, buffer)
+	if err == swift.ContainerNotFound || err == swift.ObjectNotFound {
+		_ = s.c.ContainerCreate(containerName, nil)
+		f, err = s.c.ObjectCreate(containerName, objectName, true, "", "image/jpg", headers)
+		if err == nil {
+			err = writeClose(f, buffer)
+		}
+	}
+	return err
 }
 
 func filename(md5sum []byte) string {


### PR DESCRIPTION
When the swift container for previewfs is missing, the error happens on
the write operation, not on ObjectCreate. So, the stack was checking too
soon if saving a file to previewfs was failing because the container was
missing.