### PR TITLE
Fix opening an office document from a link

### DIFF
--- a/web/notes/notes.go
+++ b/web/notes/notes.go
@@ -295,7 +295,6 @@ func OpenNoteURL(c echo.Context) error {
 	if pdoc.Type == permission.TypeShareByLink || pdoc.Type == permission.TypeSharePreview {
 		code := middlewares.GetRequestToken(c)
 		open.AddShareByLinkCode(code)
-		readOnly = true
 	}
 
 	sharingID := c.QueryParam("SharingID") // Cozy to Cozy sharing

--- a/web/office/office.go
+++ b/web/office/office.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cozy/cozy-stack/model/permission"
 	"github.com/cozy/cozy-stack/model/sharing"
 	"github.com/cozy/cozy-stack/model/vfs"
+	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/jsonapi"
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/labstack/echo/v4"
@@ -36,7 +37,14 @@ func Open(c echo.Context) error {
 	if pdoc.Type == permission.TypeShareByLink || pdoc.Type == permission.TypeSharePreview {
 		code := middlewares.GetRequestToken(c)
 		open.AddShareByLinkCode(code)
-		readOnly = true
+		if !readOnly {
+			readOnly = true
+			for _, perm := range pdoc.Permissions {
+				if perm.Type == consts.Files && !perm.Verbs.ReadOnly() {
+					readOnly = false
+				}
+			}
+		}
 	}
 
 	sharingID := c.QueryParam("SharingID") // Cozy to Cozy sharing


### PR DESCRIPTION
When a directory is shared with a link in read+write mode, and an office
document is opened from this link, the stack must use the edit mode of
OnlyOffice. It was forced to view (read-only) before this commit for all
documents opened from a sharing link.