### PR TITLE
Send a 404 for icon of a not installed app

### DIFF
--- a/web/apps/apps.go
+++ b/web/apps/apps.go
@@ -506,6 +506,9 @@ func iconHandler(appType consts.AppType) echo.HandlerFunc {
 		version := c.Param("version")
 		a, err := app.GetBySlug(instance, slug, appType)
 		if err != nil {
+			if err == app.ErrNotFound {
+				return jsonapi.NotFound(err)
+			}
 			return err
 		}
 


### PR DESCRIPTION
When a client asks for the icon of an app that is not installed via the
GET /apps/:slug/icon route, we were sending a 500 Internal Server Error.
This is fixed by sending the expected 404 Not Found.