### PR TITLE
Fix the deletion of unused OAuth clients

### DIFF
--- a/model/move/request.go
+++ b/model/move/request.go
@@ -75,7 +75,7 @@ func CreateRequestClient(inst *instance.Instance) (*oauth.Client, error) {
 		ClientName:   "cozy-stack",
 		SoftwareID:   "github.com/cozy/cozy-stack",
 	}
-	if err := client.Create(inst); err != nil {
+	if err := client.Create(inst, oauth.NotPending); err != nil {
 		return nil, errors.New(err.Error)
 	}
 	return client, nil

--- a/model/oauth/access_code.go
+++ b/model/oauth/access_code.go
@@ -40,7 +40,9 @@ func (ac *AccessCode) SetRev(rev string) { ac.CouchRev = rev }
 func CreateAccessCode(i *instance.Instance, client *Client, scope string) (*AccessCode, error) {
 	if client.Pending {
 		client.Pending = false
+		client.ClientID = ""
 		_ = couchdb.UpdateDoc(i, client)
+		client.ClientID = client.CouchID
 	}
 
 	ac := &AccessCode{

--- a/model/sharing/oauth.go
+++ b/model/sharing/oauth.go
@@ -227,7 +227,7 @@ func CreateOAuthClient(inst *instance.Instance, m *Member) (*oauth.Client, error
 		SoftwareID:   "github.com/cozy/cozy-stack",
 		ClientURI:    m.Instance + "/",
 	}
-	if err := cli.Create(inst); err != nil {
+	if err := cli.Create(inst, oauth.NotPending); err != nil {
 		return nil, ErrInternalServerError
 	}
 	return &cli, nil

--- a/tests/testutils/test_utils.go
+++ b/tests/testutils/test_utils.go
@@ -189,7 +189,7 @@ func (c *TestSetup) GetTestClient(scopes string) (*oauth.Client, string) {
 		ClientName:   "client-" + c.host,
 		SoftwareID:   "github.com/cozy/cozy-stack/testing/" + c.name,
 	}
-	client.Create(inst)
+	client.Create(inst, oauth.NotPending)
 	token, err := c.inst.MakeJWT(consts.AccessTokenAudience,
 		client.ClientID, scopes, "", time.Now())
 	if err != nil {

--- a/web/bitwarden/bitwarden.go
+++ b/web/bitwarden/bitwarden.go
@@ -259,7 +259,7 @@ func getInitialCredentials(c echo.Context) error {
 		ClientKind:   kind,
 		SoftwareID:   softwareID,
 	}
-	if err := client.Create(inst); err != nil {
+	if err := client.Create(inst, oauth.NotPending); err != nil {
 		return c.JSON(err.Code, err)
 	}
 	client.CouchID = client.ClientID

--- a/web/instances/client.go
+++ b/web/instances/client.go
@@ -101,7 +101,7 @@ func registerClient(c echo.Context) error {
 		OnboardingPermissions: c.QueryParam("OnboardingPermissions"),
 		OnboardingState:       c.QueryParam("OnboardingState"),
 	}
-	if regErr := client.Create(in); regErr != nil {
+	if regErr := client.Create(in, oauth.NotPending); regErr != nil {
 		return c.String(http.StatusBadRequest, regErr.Description)
 	}
 	return c.JSON(http.StatusOK, client)


### PR DESCRIPTION
Some OAuth clients were used by sharings but their pending flag was not
removed, and after 1h, their clean-client trigger deletes them. Now, we
avoid setting the pending flag in first place when we know that a token
will be generated just after the client creation, which avoids this
issue.