### PR TITLE
Fix changes feed with selective synchronization

### DIFF
--- a/model/vfs/directory.go
+++ b/model/vfs/directory.go
@@ -347,8 +347,8 @@ func FilterNotSynchronizedDocs(fs VFS, clientID string, changes *couchdb.Changes
 			docID := changes.Results[i].DocID
 			changes.Results[i].Doc = couchdb.JSONDoc{
 				M: map[string]interface{}{
-					"id":       docID,
-					"rev":      rev,
+					"_id":      docID,
+					"_rev":     rev,
 					"_deleted": true,
 				},
 				Type: consts.Files,

--- a/tests/integration/lib/stack.rb
+++ b/tests/integration/lib/stack.rb
@@ -168,7 +168,6 @@ class Stack
 
   def pending_clients(inst)
     clients = Helpers.couch.all_docs inst.domain, "io.cozy.oauth.clients"
-    ap clients
     clients.select { |c| c["pending"] }
   end
 

--- a/tests/integration/tests/selective_sync.rb
+++ b/tests/integration/tests/selective_sync.rb
@@ -44,10 +44,12 @@ describe "An OAuth client" do
     assert_equal changes["results"].length, 2
     assert_equal changes.dig("results", 0, "id"), folder1.couch_id
     assert changes.dig("results", 0, "deleted")
-    assert_equal changes.dig("results", 0, "doc").keys, %w[_deleted id rev]
+    assert_equal changes.dig("results", 0, "doc").keys, %w[_deleted _id _rev]
+    assert_equal changes.dig("results", 0, "doc", "_id"), folder1.couch_id
+    assert_equal changes.dig("results", 0, "doc", "_deleted"), true
     assert_equal changes.dig("results", 1, "id"), folder2.couch_id
     assert changes.dig("results", 1, "deleted")
-    assert_equal changes.dig("results", 1, "doc").keys, %w[_deleted id rev]
+    assert_equal changes.dig("results", 1, "doc").keys, %w[_deleted _id _rev]
 
     # Make some operations
     child1.rename inst, Faker::Internet.slug


### PR DESCRIPTION
The format of the changes feed is a bit weird. The results are an array
of object which can have `deleted`, `id`, and `changes` with `rev` inside. It
can also have a `doc` object, but the `doc` object have `_deleted`, `_id`, and
`_rev` (prefixed with an underscore). We have added the missing underscore
for `_id` and `_rev` inside `doc`.