### PR TITLE
Fix saving docs with OnlyOffice

### DIFF
--- a/model/office/open.go
+++ b/model/office/open.go
@@ -168,7 +168,8 @@ func (o *Opener) openLocalDocument(memberIndex int, readOnly bool) (*apiOfficeUR
 			Infof("Cannot build download URL: %s", err)
 		return nil, ErrInternalServerError
 	}
-	key, err := GetStore().AddDoc(o.Inst, o.File.ID(), o.File.Rev())
+	detector := conflictDetector{ID: o.File.ID(), Rev: o.File.Rev(), MD5Sum: o.File.MD5Sum}
+	key, err := GetStore().AddDoc(o.Inst, detector)
 	if err != nil {
 		o.Inst.Logger().WithField("nspace", "office").
 			Infof("Cannot add doc to store: %s", err)


### PR DESCRIPTION
When an office document was renamed while edited in OnlyOffice, the
callback for saving the file was creating a conflict as the doc revision
was not the expected one due to the renaming. Now, we are also using the
md5sum to detect if we should really create a conflict in such a case.