### PR TITLE
Use cozy.localhost instead of cozy.tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ run:
 
 ## instance: create an instance for local development
 instance:
-	@cozy-stack instances add cozy.tools:8080 --passphrase cozy --apps home,store,drive,photos,settings,contacts,notes --email claude@cozy.tools --locale fr --public-name Claude --context-name dev
+	@cozy-stack instances add cozy.localhost:8080 --passphrase cozy --apps home,store,drive,photos,settings,contacts,notes --email claude@cozy.localhost --locale fr --public-name Claude --context-name dev
 
 ## lint: enforce a consistent code style and detect code smells
 lint: scripts/golangci-lint

--- a/cmd/apps.go
+++ b/cmd/apps.go
@@ -56,7 +56,7 @@ var installWebappCmd = &cobra.Command{
 	Short: `Install an application with the specified slug name
 from the given source URL.`,
 	Example: `
-$ cozy-stack apps install --domain cozy.tools:8080 drive registry://drive/stable
+$ cozy-stack apps install --domain cozy.localhost:8080 drive registry://drive/stable
 $ cozy-stack apps install banks 'git://github.com/cozy/cozy-banks.git#build'
 $ cozy-stack apps install myapp 'git+ssh://git@gitlab.example.net/team/myapp.git#build'
 `,
@@ -148,10 +148,10 @@ Default channel is stable.
 Default version is latest.
 `,
 	Example: `
-$ cozy-stack konnectors install --domain cozy.tools:8080 trainline registry://trainline/stable/1.0.1
-$ cozy-stack konnectors install --domain cozy.tools:8080 trainline registry://trainline/stable
-$ cozy-stack konnectors install --domain cozy.tools:8080 trainline registry://trainline/1.2.0
-$ cozy-stack konnectors install --domain cozy.tools:8080 trainline registry://trainline
+$ cozy-stack konnectors install --domain cozy.localhost:8080 trainline registry://trainline/stable/1.0.1
+$ cozy-stack konnectors install --domain cozy.localhost:8080 trainline registry://trainline/stable
+$ cozy-stack konnectors install --domain cozy.localhost:8080 trainline registry://trainline/1.2.0
+$ cozy-stack konnectors install --domain cozy.localhost:8080 trainline registry://trainline
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return installApp(cmd, args, consts.Konnectors)
@@ -546,7 +546,7 @@ func showWebAppTriggers(cmd *cobra.Command, args []string, appType string) error
 var listTriggerCmd = &cobra.Command{
 	Use:     "ls",
 	Short:   `List triggers`,
-	Example: "$ cozy-stack triggers ls --domain cozy.tools:8080",
+	Example: "$ cozy-stack triggers ls --domain cozy.localhost:8080",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if flagDomain == "" {
 			errPrintfln("%s", errMissingDomain)
@@ -574,7 +574,7 @@ var listTriggerCmd = &cobra.Command{
 var launchTriggerCmd = &cobra.Command{
 	Use:     "launch [triggerId]",
 	Short:   `Creates a job from a specific trigger`,
-	Example: "$ cozy-stack triggers launch --domain cozy.tools:8080 748f42b65aca8c99ec2492eb660d1891",
+	Example: "$ cozy-stack triggers launch --domain cozy.localhost:8080 748f42b65aca8c99ec2492eb660d1891",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return launchTrigger(cmd, args)
 	},

--- a/cmd/feature.go
+++ b/cmd/feature.go
@@ -26,7 +26,7 @@ var featureShowCmd = &cobra.Command{
 	Long: `
 cozy-stack feature show displays the feature flags that are shown by apps.
 `,
-	Example: `$ cozy-stack feature show --domain cozy.tools:8080`,
+	Example: `$ cozy-stack feature show --domain cozy.localhost:8080`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if flagDomain == "" {
 			errPrintfln("%s", errMissingDomain)
@@ -84,7 +84,7 @@ It can also take a list of flags to update.
 
 If you give a null value, the flag will be removed.
 `,
-	Example: `$ cozy-stack feature flags --domain cozy.tools:8080 '{"add_this_flag": true, "remove_this_flag": null}'`,
+	Example: `$ cozy-stack feature flags --domain cozy.localhost:8080 '{"add_this_flag": true, "remove_this_flag": null}'`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if flagDomain == "" {
 			errPrintfln("%s", errMissingDomain)
@@ -126,7 +126,7 @@ list (no merge).
 
 All the sets can be removed by setting an empty list ('').
 `,
-	Example: `$ cozy-stack feature sets --domain cozy.tools:8080 'set1 set2'`,
+	Example: `$ cozy-stack feature sets --domain cozy.localhost:8080 'set1 set2'`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if flagDomain == "" {
 			errPrintfln("%s", errMissingDomain)

--- a/cmd/instances.go
+++ b/cmd/instances.go
@@ -86,7 +86,7 @@ var showInstanceCmd = &cobra.Command{
 cozy-stack instances show allows to show the instance on the cozy for a
 given domain.
 `,
-	Example: "$ cozy-stack instances show cozy.tools:8080",
+	Example: "$ cozy-stack instances show cozy.localhost:8080",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			return cmd.Usage()
@@ -113,7 +113,7 @@ var showDBPrefixInstanceCmd = &cobra.Command{
 cozy-stack instances show allows to show the instance prefix on the cozy for a
 given domain. The prefix is used for databases and VFS prefixing.
 `,
-	Example: "$ cozy-stack instances show-db-prefix cozy.tools:8080",
+	Example: "$ cozy-stack instances show-db-prefix cozy.localhost:8080",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			return cmd.Usage()
@@ -145,7 +145,7 @@ If the COZY_DISABLE_INSTANCES_ADD_RM env variable is set, creating and
 destroying instances will be desactivated and the content of this variable will
 be used as the error message.
 `,
-	Example: "$ cozy-stack instances add --passphrase cozy --apps drive,photos,settings cozy.tools:8080",
+	Example: "$ cozy-stack instances add --passphrase cozy --apps drive,photos,settings cozy.localhost:8080",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if reason := os.Getenv("COZY_DISABLE_INSTANCES_ADD_RM"); reason != "" {
 			return fmt.Errorf("Sorry, instances add is disabled: %s", reason)
@@ -283,7 +283,7 @@ settings for a specified domain.
 var updateInstancePassphraseCmd = &cobra.Command{
 	Use:     "set-passphrase <domain> <new-passphrase>",
 	Short:   "Change the passphrase of the instance",
-	Example: "$ cozy-stack instances set-passphrase cozy.tools:8080 myN3wP4ssowrd!",
+	Example: "$ cozy-stack instances set-passphrase cozy.localhost:8080 myN3wP4ssowrd!",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 2 {
 			return cmd.Usage()
@@ -334,7 +334,7 @@ var quotaInstanceCmd = &cobra.Command{
 cozy-stack instances set-disk-quota allows to change the disk-quota of the
 instance of the given domain. Set the quota to 0 to remove the quota.
 `,
-	Example: "$ cozy-stack instances set-disk-quota cozy.tools:8080 3GB",
+	Example: "$ cozy-stack instances set-disk-quota cozy.localhost:8080 3GB",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 2 {
 			return cmd.Usage()
@@ -364,7 +364,7 @@ var debugInstanceCmd = &cobra.Command{
 cozy-stack instances debug allows to activate or deactivate the debugging of a
 specific domain.
 `,
-	Example: "$ cozy-stack instances debug --domain cozy.tools:8080 true",
+	Example: "$ cozy-stack instances debug --domain cozy.localhost:8080 true",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		action := "enable"
 		domain := flagDomain
@@ -723,7 +723,7 @@ var cliTokenInstanceCmd = &cobra.Command{
 var oauthTokenInstanceCmd = &cobra.Command{
 	Use:     "token-oauth <domain> <clientid> <scopes>",
 	Short:   "Generate a new OAuth access token",
-	Example: "$ cozy-stack instances token-oauth cozy.tools:8080 727e677187a51d14ccd59cc0bd000a1d io.cozy.files io.cozy.jobs:POST:sendmail:worker",
+	Example: "$ cozy-stack instances token-oauth cozy.localhost:8080 727e677187a51d14ccd59cc0bd000a1d io.cozy.files io.cozy.jobs:POST:sendmail:worker",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 3 {
 			return cmd.Usage()
@@ -753,7 +753,7 @@ var oauthTokenInstanceCmd = &cobra.Command{
 var oauthRefreshTokenInstanceCmd = &cobra.Command{
 	Use:     "refresh-token-oauth <domain> <clientid> <scopes>",
 	Short:   "Generate a new OAuth refresh token",
-	Example: "$ cozy-stack instances refresh-token-oauth cozy.tools:8080 727e677187a51d14ccd59cc0bd000a1d io.cozy.files io.cozy.jobs:POST:sendmail:worker",
+	Example: "$ cozy-stack instances refresh-token-oauth cozy.localhost:8080 727e677187a51d14ccd59cc0bd000a1d io.cozy.files io.cozy.jobs:POST:sendmail:worker",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 3 {
 			return cmd.Usage()
@@ -925,7 +925,7 @@ var importCmd = &cobra.Command{
 var showSwiftPrefixInstanceCmd = &cobra.Command{
 	Use:     "show-swift-prefix <domain>",
 	Short:   "Show the instance swift prefix of the specified domain",
-	Example: "$ cozy-stack instances show-swift-prefix cozy.tools:8080",
+	Example: "$ cozy-stack instances show-swift-prefix cozy.localhost:8080",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var v map[string]string
 
@@ -1000,7 +1000,7 @@ var instanceAppVersionCmd = &cobra.Command{
 var setAuthModeCmd = &cobra.Command{
 	Use:     "auth-mode [domain] [auth-mode]",
 	Short:   `Set instance auth-mode`,
-	Example: "$ cozy-stack instances auth-mode cozy.tools:8080 two_factor_mail",
+	Example: "$ cozy-stack instances auth-mode cozy.localhost:8080 two_factor_mail",
 	Long: `Change the authentication mode for an instance. Two options are allowed:
 - two_factor_mail
 - basic

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,7 +23,7 @@ import (
 // is stored relatively to the cozy-stack binary.
 const DefaultStorageDir = "storage"
 
-const defaultDevDomain = "cozy.tools:8080"
+const defaultDevDomain = "cozy.localhost:8080"
 
 var flagDomain string
 

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -24,7 +24,7 @@ It can also take a list of settings to update.
 
 If you give a blank value, the setting will be removed.
 `,
-	Example: "$ cozy-stack settings --domain cozy.tools:8080 context:beta,public_name:John,to_remove:",
+	Example: "$ cozy-stack settings --domain cozy.localhost:8080 context:beta,public_name:John,to_remove:",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if flagDomain == "" {
 			errPrintfln("%s", errMissingDomain)

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -71,20 +71,20 @@ And then create an instance for development:
 make instance
 ```
 
-The cozy-stack server listens on http://cozy.tools:8080/ by default. See
+The cozy-stack server listens on http://cozy.localhost:8080/ by default. See
 `cozy-stack --help` for more informations.
 
-The above command will create an instance on http://cozy.tools:8080/ with the
-passphrase `cozy`. By default this will create a `storage/` entry in your current directory, containing all your instances by their URL. An instance "cozy.tools:8080" will have its stored files in `storage/cozy.tools:8080/`. Installed apps will be found in the `.cozy_apps/` directory of each instance.
+The above command will create an instance on http://cozy.localhost:8080/ with the
+passphrase `cozy`. By default this will create a `storage/` entry in your current directory, containing all your instances by their URL. An instance "cozy.localhost:8080" will have its stored files in `storage/cozy.localhost:8080/`. Installed apps will be found in the `.cozy_apps/` directory of each instance.
 
 Make sure the full stack is up with:
 
 ```bash
-curl -H 'Accept: application/json' 'http://cozy.tools:8080/status/'
+curl -H 'Accept: application/json' 'http://cozy.localhost:8080/status/'
 ```
 
 You can then remove your test instance:
 
 ```bash
-cozy-stack instances rm cozy.tools:8080
+cozy-stack instances rm cozy.localhost:8080
 ```

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -44,7 +44,7 @@ Content-Type: application/vnd.api+json
             "type": "instances",
             "id": "3af6ed68a6d9146b3529d2584a001d98",
             "attributes": {
-                "domain": "alice.cozy.tools:8080",
+                "domain": "alice.cozy.localhost:8080",
                 "prefix": "cozy7d3d5947e7f3b0c674d1b8644646348e",
                 "locale": "fr",
                 "context": "dev",
@@ -62,7 +62,7 @@ Content-Type: application/vnd.api+json
             "type": "instances",
             "id": "3af6ed68a6d9146b3529d2584a01d557",
             "attributes": {
-                "domain": "bob.cozy.tools:8080",
+                "domain": "bob.cozy.localhost:8080",
                 "prefix": "cozybf682065ca3c7d64f2dafc6cc12fe702",
                 "locale": "fr",
                 "context": "dev",
@@ -104,9 +104,9 @@ Content-Type: application/json
 ```json
 {
     "instances": [
-        "alice.cozy.tools",
-        "bob.cozy.tools",
-        "zoe.cozy.tools"
+        "alice.cozy.localhost",
+        "bob.cozy.localhost",
+        "zoe.cozy.localhost"
     ]
 }
 ```
@@ -118,7 +118,7 @@ Fixes the 64k (or multiple) content mismatch files of an instance
 #### Request
 
 ```http
-POST /instances/alice.cozy.tools/fixers/content-mismatch HTTP/1.1
+POST /instances/alice.cozy.localhost/fixers/content-mismatch HTTP/1.1
 Content-Type: application/json
 ```
 
@@ -157,7 +157,7 @@ Content-Type: application/json
       "updated_at": "2019-07-30 14:32:29.862882247 +0200 CEST"
     }
   ],
-  "domain": "alice.cozy.tools"
+  "domain": "alice.cozy.localhost"
 }
 ```
 
@@ -168,7 +168,7 @@ Delete the accounts which are not linked to a konnector
 #### Request
 
 ```http
-POST /instances/alice.cozy.tools/fixers/orphan-account HTTP/1.1
+POST /instances/alice.cozy.localhost/fixers/orphan-account HTTP/1.1
 ```
 
 
@@ -215,7 +215,7 @@ HTTP/1.1 200 OK
       "help_link": "https://forum.cozy.io/",
       "noreply_address": "noreply@cozy.beta",
       "noreply_name": "My Cozy Beta",
-      "sharing_domain": "cozy.tools"
+      "sharing_domain": "cozy.localhost"
     },
     "context": "dev",
     "registries": [
@@ -270,7 +270,7 @@ HTTP/1.1 200 OK
     "help_link": "https://forum.cozy.io/",
     "noreply_address": "noreply@cozy.beta",
     "noreply_name": "My Cozy Beta",
-    "sharing_domain": "cozy.tools"
+    "sharing_domain": "cozy.localhost"
   },
   "context": "dev",
   "registries": [
@@ -305,7 +305,7 @@ and each JSON represents an error.
 #### Request
 
 ```http
-GET /instances/alice.cozy.tools/fsck HTTP/1.1
+GET /instances/alice.cozy.localhost/fsck HTTP/1.1
 ```
 
 #### Response
@@ -315,7 +315,7 @@ HTTP/1.1 200 OK
 ```
 
 ```json
-{"type":"index_orphan_tree","dir_doc":{"type":"directory","_id":"34a61c6ceb38075fe971cc6a3263659f","_rev":"2-94ca3acfebf927cb231d125c57f85bd7","name":"Photos","dir_id":"45496c5c442dabecae87de3d73008ec4","created_at":"2020-12-15T18:23:21.498323965+01:00","updated_at":"2020-12-15T18:23:21.498323965+01:00","tags":[],"path":"/Photos","cozyMetadata":{"doctypeVersion":"1","metadataVersion":1,"createdAt":"2020-12-15T18:23:21.498327603+01:00","updatedAt":"2020-12-15T18:23:21.498327603+01:00","createdOn":"http://alice.cozy.tools:8080/"},"size":"0","is_dir":true,"is_orphan":true,"has_cycle":false},"is_file":false,"is_version":false}
+{"type":"index_orphan_tree","dir_doc":{"type":"directory","_id":"34a61c6ceb38075fe971cc6a3263659f","_rev":"2-94ca3acfebf927cb231d125c57f85bd7","name":"Photos","dir_id":"45496c5c442dabecae87de3d73008ec4","created_at":"2020-12-15T18:23:21.498323965+01:00","updated_at":"2020-12-15T18:23:21.498323965+01:00","tags":[],"path":"/Photos","cozyMetadata":{"doctypeVersion":"1","metadataVersion":1,"createdAt":"2020-12-15T18:23:21.498327603+01:00","updatedAt":"2020-12-15T18:23:21.498327603+01:00","createdOn":"http://alice.cozy.localhost:8080/"},"size":"0","is_dir":true,"is_orphan":true,"has_cycle":false},"is_file":false,"is_version":false}
 {"type":"index_missing","file_doc":{"type":"file","name":"Photos","dir_id":"","created_at":"2020-12-15T18:23:21.527308795+01:00","updated_at":"2020-12-15T18:23:21.527308795+01:00","tags":null,"path":"/Photos","size":"4096","mime":"application/octet-stream","class":"files","executable":true,"is_dir":false,"is_orphan":false,"has_cycle":false},"is_file":true,"is_version":false}
 ```
 
@@ -326,7 +326,7 @@ This endpoint will check if no trigger has been installed twice (or more).
 #### Request
 
 ```http
-POST /instances/alice.cozy.tools/checks/triggers HTTP/1.1
+POST /instances/alice.cozy.localhost/checks/triggers HTTP/1.1
 ```
 
 #### Response
@@ -358,7 +358,7 @@ revision tree (no generation smaller for a children than its parent).
 #### Request
 
 ```http
-POST /instances/alice.cozy.tools/checks/shared HTTP/1.1
+POST /instances/alice.cozy.localhost/checks/shared HTTP/1.1
 ```
 
 #### Response
@@ -380,7 +380,7 @@ Content-Type: application/json
 #### Request
 
 ```http
-POST /instances/alice.cozy.tools/checks/sharings HTTP/1.1
+POST /instances/alice.cozy.localhost/checks/sharings HTTP/1.1
 ```
 
 #### Response
@@ -568,7 +568,7 @@ Content-Type: application/json
   "v1": {
     "counter": 1,
     "domains": [
-      "bob.cozy.tools:8081"
+      "bob.cozy.localhost:8081"
     ]
   },
   "v2a": {
@@ -580,17 +580,17 @@ Content-Type: application/json
   "v3a": {
     "counter": 2,
     "domains": [
-      "alice.cozy.tools:8081",
-      "ru.cozy.tools:8081"
+      "alice.cozy.localhost:8081",
+      "ru.cozy.localhost:8081"
     ]
   },
   "v3b": {
     "counter": 4,
     "domains": [
-      "foo.cozy.tools:8081",
-      "bar.cozy.tools:8081",
-      "baz.cozy.tools:8081",
-      "foobar.cozy.tools:8081"
+      "foo.cozy.localhost:8081",
+      "bar.cozy.localhost:8081",
+      "baz.cozy.localhost:8081",
+      "foobar.cozy.localhost:8081"
     ]
   }
 }
@@ -604,7 +604,7 @@ Retrieves a Swift object
 
 ```http
 GET /swift/vfs/67a88b22520680b1fae840%2F9a8a0%2F18d02%2FiYbkfuCDEMaVoIXg HTTP/1.1
-Host: alice.cozy.tools
+Host: alice.cozy.localhost
 ```
 
 #### Response
@@ -626,7 +626,7 @@ Put an object in Swift
 
 ```http
 PUT /swift/vfs/67a88b22520680b1fae840%2F9a8a0%2F18d02%2FiYbkfuCDEMaVoIXg HTTP/1.1
-Host: alice.cozy.tools
+Host: alice.cozy.localhost
 Content-Type: text/plain
 ```
 
@@ -642,7 +642,7 @@ Removes an object from Swift
 
 ```http
 DELETE /swift/vfs/67a88b22520680b1fae840%2F9a8a0%2F18d02%2FiYbkfuCDEMaVoIXg HTTP/1.1
-Host: alice.cozy.tools
+Host: alice.cozy.localhost
 ```
 
 ### GET /swift/vfs
@@ -653,7 +653,7 @@ List Swift objects of an instance
 
 ```http
 GET /swift/vfs HTTP/1.1
-Host: alice.cozy.tools
+Host: alice.cozy.localhost
 ```
 
 #### Response

--- a/docs/assets.md
+++ b/docs/assets.md
@@ -37,8 +37,8 @@ In development mode, a `/dev` route is available to render a template or a mail
 with given parameter. For example:
 
 ```
-http://cozy.tools:8080/dev/templates/error.html?Error=oops
-http://cozy.tools:8080/dev/mails/two_factor?TwoFactorPasscode=123456
+http://cozy.localhost:8080/dev/templates/error.html?Error=oops
+http://cozy.localhost:8080/dev/mails/two_factor?TwoFactorPasscode=123456
 ```
 
 ## In production

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -304,7 +304,7 @@ Two parameters in the query string can be sent:
 - `redirect` (optional), where the user will be redirected after the confirmation.
 
 ```http
-GET /auth/confirm?state=51814f30-5818-0139-9348-543d7eb8149c&redirect=http://banks.cozy.tools:8080/ HTTP/1.1
+GET /auth/confirm?state=51814f30-5818-0139-9348-543d7eb8149c&redirect=http://banks.cozy.localhost:8080/ HTTP/1.1
 ```
 
 The application can know the user has confirmed their identity by subscribing
@@ -320,7 +320,7 @@ Send the hashed password for confirming the authentication.
 
 ```http
 HTTP/1.1 302 Moved Temporarily
-Location: http://banks.cozy.tools:8080/?state=51814f30-5818-0139-9348-543d7eb8149c&code=543d7eb8149c
+Location: http://banks.cozy.localhost:8080/?state=51814f30-5818-0139-9348-543d7eb8149c&code=543d7eb8149c
 ```
 
 #### Real-time via websockets

--- a/docs/bitwarden.md
+++ b/docs/bitwarden.md
@@ -446,7 +446,7 @@ Content-Type: application/json
       "Id": "38ac39d0-d48d-11e9-91bf-f37e45d48c79",
       "Name": "Cozy",
       "Key": "4.HUzVDQVAFc4JOpW3/j/QwZeET0mXOiDW5s/HdpxLZ2GFnGcxOm1FE4XD2p7XTSwORXO/Lo8y0A87UhXKEXzfHZmpJR04pbpUPr4NJbjRKv/cSkNFlvm0rIUw/m0Jkft/gew9v3QfkVSGdSZk5XIimwkTQ5WM+WCStxbQJIKAH+AoEA5q6t9mpNNlTAQvMgqs8u7CJwSjeZ7qbabfEUVX1HIPgxC3BtVUkySRSws/gUNeMwY23kAJJQYT+uuMooZUr7umU6YkEHG2RQZwCCjVHX4czxZRWsVo/xQOYoNr7DjgCf92D7OrJlFmDtQjzSy2BjotN6vn+1SwtHbeDILWaQ==",
-      "BillingEmail": "me@cozy.tools",
+      "BillingEmail": "me@cozy.localhost",
       "Plan": "TeamsAnnually",
       "PlanType": 5,
       "Seats": 2,

--- a/docs/cli/cozy-stack_apps.md
+++ b/docs/cli/cozy-stack_apps.md
@@ -19,7 +19,7 @@ cozy-stack apps <command> [flags]
 
 ```
       --all-domains     work on all domains iteratively
-      --domain string   specify the domain name of the instance (default "cozy.tools:8080")
+      --domain string   specify the domain name of the instance (default "cozy.localhost:8080")
   -h, --help            help for apps
 ```
 

--- a/docs/cli/cozy-stack_apps_install.md
+++ b/docs/cli/cozy-stack_apps_install.md
@@ -15,7 +15,7 @@ cozy-stack apps install <slug> [sourceurl] [flags]
 
 ```
 
-$ cozy-stack apps install --domain cozy.tools:8080 drive registry://drive/stable
+$ cozy-stack apps install --domain cozy.localhost:8080 drive registry://drive/stable
 $ cozy-stack apps install banks 'git://github.com/cozy/cozy-banks.git#build'
 $ cozy-stack apps install myapp 'git+ssh://git@gitlab.example.net/team/myapp.git#build'
 
@@ -35,7 +35,7 @@ $ cozy-stack apps install myapp 'git+ssh://git@gitlab.example.net/team/myapp.git
       --admin-port int      administration server port (default 6060)
       --all-domains         work on all domains iteratively
   -c, --config string       configuration file (default "$HOME/.cozy.yaml")
-      --domain string       specify the domain name of the instance (default "cozy.tools:8080")
+      --domain string       specify the domain name of the instance (default "cozy.localhost:8080")
       --host string         server host (default "localhost")
   -p, --port int            server port (default 8080)
 ```

--- a/docs/cli/cozy-stack_apps_ls.md
+++ b/docs/cli/cozy-stack_apps_ls.md
@@ -19,7 +19,7 @@ cozy-stack apps ls [flags]
       --admin-port int      administration server port (default 6060)
       --all-domains         work on all domains iteratively
   -c, --config string       configuration file (default "$HOME/.cozy.yaml")
-      --domain string       specify the domain name of the instance (default "cozy.tools:8080")
+      --domain string       specify the domain name of the instance (default "cozy.localhost:8080")
       --host string         server host (default "localhost")
   -p, --port int            server port (default 8080)
 ```

--- a/docs/cli/cozy-stack_apps_show.md
+++ b/docs/cli/cozy-stack_apps_show.md
@@ -19,7 +19,7 @@ cozy-stack apps show <slug> [flags]
       --admin-port int      administration server port (default 6060)
       --all-domains         work on all domains iteratively
   -c, --config string       configuration file (default "$HOME/.cozy.yaml")
-      --domain string       specify the domain name of the instance (default "cozy.tools:8080")
+      --domain string       specify the domain name of the instance (default "cozy.localhost:8080")
       --host string         server host (default "localhost")
   -p, --port int            server port (default 8080)
 ```

--- a/docs/cli/cozy-stack_apps_uninstall.md
+++ b/docs/cli/cozy-stack_apps_uninstall.md
@@ -19,7 +19,7 @@ cozy-stack apps uninstall <slug> [flags]
       --admin-port int      administration server port (default 6060)
       --all-domains         work on all domains iteratively
   -c, --config string       configuration file (default "$HOME/.cozy.yaml")
-      --domain string       specify the domain name of the instance (default "cozy.tools:8080")
+      --domain string       specify the domain name of the instance (default "cozy.localhost:8080")
       --host string         server host (default "localhost")
   -p, --port int            server port (default 8080)
 ```

--- a/docs/cli/cozy-stack_apps_update.md
+++ b/docs/cli/cozy-stack_apps_update.md
@@ -20,7 +20,7 @@ cozy-stack apps update <slug> [sourceurl] [flags]
       --admin-port int      administration server port (default 6060)
       --all-domains         work on all domains iteratively
   -c, --config string       configuration file (default "$HOME/.cozy.yaml")
-      --domain string       specify the domain name of the instance (default "cozy.tools:8080")
+      --domain string       specify the domain name of the instance (default "cozy.localhost:8080")
       --host string         server host (default "localhost")
   -p, --port int            server port (default 8080)
 ```

--- a/docs/cli/cozy-stack_features_flags.md
+++ b/docs/cli/cozy-stack_features_flags.md
@@ -19,7 +19,7 @@ cozy-stack features flags [flags]
 ### Examples
 
 ```
-$ cozy-stack feature flags --domain cozy.tools:8080 '{"add_this_flag": true, "remove_this_flag": null}'
+$ cozy-stack feature flags --domain cozy.localhost:8080 '{"add_this_flag": true, "remove_this_flag": null}'
 ```
 
 ### Options

--- a/docs/cli/cozy-stack_features_sets.md
+++ b/docs/cli/cozy-stack_features_sets.md
@@ -20,7 +20,7 @@ cozy-stack features sets [flags]
 ### Examples
 
 ```
-$ cozy-stack feature sets --domain cozy.tools:8080 'set1 set2'
+$ cozy-stack feature sets --domain cozy.localhost:8080 'set1 set2'
 ```
 
 ### Options

--- a/docs/cli/cozy-stack_features_show.md
+++ b/docs/cli/cozy-stack_features_show.md
@@ -15,7 +15,7 @@ cozy-stack features show [flags]
 ### Examples
 
 ```
-$ cozy-stack feature show --domain cozy.tools:8080
+$ cozy-stack feature show --domain cozy.localhost:8080
 ```
 
 ### Options

--- a/docs/cli/cozy-stack_files.md
+++ b/docs/cli/cozy-stack_files.md
@@ -20,7 +20,7 @@ cozy-stack files <command> [flags]
 ### Options
 
 ```
-      --domain string   specify the domain name of the instance (default "cozy.tools:8080")
+      --domain string   specify the domain name of the instance (default "cozy.localhost:8080")
   -h, --help            help for files
 ```
 

--- a/docs/cli/cozy-stack_files_exec.md
+++ b/docs/cli/cozy-stack_files_exec.md
@@ -35,7 +35,7 @@ cozy-stack files exec [--domain domain] <command> [flags]
       --admin-host string   administration server host (default "localhost")
       --admin-port int      administration server port (default 6060)
   -c, --config string       configuration file (default "$HOME/.cozy.yaml")
-      --domain string       specify the domain name of the instance (default "cozy.tools:8080")
+      --domain string       specify the domain name of the instance (default "cozy.localhost:8080")
       --host string         server host (default "localhost")
   -p, --port int            server port (default 8080)
 ```

--- a/docs/cli/cozy-stack_files_import.md
+++ b/docs/cli/cozy-stack_files_import.md
@@ -22,7 +22,7 @@ cozy-stack files import [--domain domain] [--match pattern] --from <name> --to <
       --admin-host string   administration server host (default "localhost")
       --admin-port int      administration server port (default 6060)
   -c, --config string       configuration file (default "$HOME/.cozy.yaml")
-      --domain string       specify the domain name of the instance (default "cozy.tools:8080")
+      --domain string       specify the domain name of the instance (default "cozy.localhost:8080")
       --host string         server host (default "localhost")
   -p, --port int            server port (default 8080)
 ```

--- a/docs/cli/cozy-stack_files_usage.md
+++ b/docs/cli/cozy-stack_files_usage.md
@@ -19,7 +19,7 @@ cozy-stack files usage [--domain domain] [--trash] [flags]
       --admin-host string   administration server host (default "localhost")
       --admin-port int      administration server port (default 6060)
   -c, --config string       configuration file (default "$HOME/.cozy.yaml")
-      --domain string       specify the domain name of the instance (default "cozy.tools:8080")
+      --domain string       specify the domain name of the instance (default "cozy.localhost:8080")
       --host string         server host (default "localhost")
   -p, --port int            server port (default 8080)
 ```

--- a/docs/cli/cozy-stack_instances_add.md
+++ b/docs/cli/cozy-stack_instances_add.md
@@ -20,7 +20,7 @@ cozy-stack instances add <domain> [flags]
 ### Examples
 
 ```
-$ cozy-stack instances add --passphrase cozy --apps drive,photos,settings cozy.tools:8080
+$ cozy-stack instances add --passphrase cozy --apps drive,photos,settings cozy.localhost:8080
 ```
 
 ### Options

--- a/docs/cli/cozy-stack_instances_auth-mode.md
+++ b/docs/cli/cozy-stack_instances_auth-mode.md
@@ -16,7 +16,7 @@ cozy-stack instances auth-mode [domain] [auth-mode] [flags]
 ### Examples
 
 ```
-$ cozy-stack instances auth-mode cozy.tools:8080 two_factor_mail
+$ cozy-stack instances auth-mode cozy.localhost:8080 two_factor_mail
 ```
 
 ### Options

--- a/docs/cli/cozy-stack_instances_debug.md
+++ b/docs/cli/cozy-stack_instances_debug.md
@@ -16,13 +16,13 @@ cozy-stack instances debug <true/false> [flags]
 ### Examples
 
 ```
-$ cozy-stack instances debug --domain cozy.tools:8080 true
+$ cozy-stack instances debug --domain cozy.localhost:8080 true
 ```
 
 ### Options
 
 ```
-      --domain string   Specify the domain name of the instance (default "cozy.tools:8080")
+      --domain string   Specify the domain name of the instance (default "cozy.localhost:8080")
   -h, --help            help for debug
       --ttl duration    Specify how long the debug mode will last (default 24h0m0s)
 ```

--- a/docs/cli/cozy-stack_instances_refresh-token-oauth.md
+++ b/docs/cli/cozy-stack_instances_refresh-token-oauth.md
@@ -9,7 +9,7 @@ cozy-stack instances refresh-token-oauth <domain> <clientid> <scopes> [flags]
 ### Examples
 
 ```
-$ cozy-stack instances refresh-token-oauth cozy.tools:8080 727e677187a51d14ccd59cc0bd000a1d io.cozy.files io.cozy.jobs:POST:sendmail:worker
+$ cozy-stack instances refresh-token-oauth cozy.localhost:8080 727e677187a51d14ccd59cc0bd000a1d io.cozy.files io.cozy.jobs:POST:sendmail:worker
 ```
 
 ### Options

--- a/docs/cli/cozy-stack_instances_set-disk-quota.md
+++ b/docs/cli/cozy-stack_instances_set-disk-quota.md
@@ -16,7 +16,7 @@ cozy-stack instances set-disk-quota <domain> <disk-quota> [flags]
 ### Examples
 
 ```
-$ cozy-stack instances set-disk-quota cozy.tools:8080 3GB
+$ cozy-stack instances set-disk-quota cozy.localhost:8080 3GB
 ```
 
 ### Options

--- a/docs/cli/cozy-stack_instances_set-passphrase.md
+++ b/docs/cli/cozy-stack_instances_set-passphrase.md
@@ -9,7 +9,7 @@ cozy-stack instances set-passphrase <domain> <new-passphrase> [flags]
 ### Examples
 
 ```
-$ cozy-stack instances set-passphrase cozy.tools:8080 myN3wP4ssowrd!
+$ cozy-stack instances set-passphrase cozy.localhost:8080 myN3wP4ssowrd!
 ```
 
 ### Options

--- a/docs/cli/cozy-stack_instances_show-db-prefix.md
+++ b/docs/cli/cozy-stack_instances_show-db-prefix.md
@@ -16,7 +16,7 @@ cozy-stack instances show-db-prefix <domain> [flags]
 ### Examples
 
 ```
-$ cozy-stack instances show-db-prefix cozy.tools:8080
+$ cozy-stack instances show-db-prefix cozy.localhost:8080
 ```
 
 ### Options

--- a/docs/cli/cozy-stack_instances_show-swift-prefix.md
+++ b/docs/cli/cozy-stack_instances_show-swift-prefix.md
@@ -9,7 +9,7 @@ cozy-stack instances show-swift-prefix <domain> [flags]
 ### Examples
 
 ```
-$ cozy-stack instances show-swift-prefix cozy.tools:8080
+$ cozy-stack instances show-swift-prefix cozy.localhost:8080
 ```
 
 ### Options

--- a/docs/cli/cozy-stack_instances_show.md
+++ b/docs/cli/cozy-stack_instances_show.md
@@ -16,7 +16,7 @@ cozy-stack instances show <domain> [flags]
 ### Examples
 
 ```
-$ cozy-stack instances show cozy.tools:8080
+$ cozy-stack instances show cozy.localhost:8080
 ```
 
 ### Options

--- a/docs/cli/cozy-stack_instances_token-oauth.md
+++ b/docs/cli/cozy-stack_instances_token-oauth.md
@@ -9,7 +9,7 @@ cozy-stack instances token-oauth <domain> <clientid> <scopes> [flags]
 ### Examples
 
 ```
-$ cozy-stack instances token-oauth cozy.tools:8080 727e677187a51d14ccd59cc0bd000a1d io.cozy.files io.cozy.jobs:POST:sendmail:worker
+$ cozy-stack instances token-oauth cozy.localhost:8080 727e677187a51d14ccd59cc0bd000a1d io.cozy.files io.cozy.jobs:POST:sendmail:worker
 ```
 
 ### Options

--- a/docs/cli/cozy-stack_jobs.md
+++ b/docs/cli/cozy-stack_jobs.md
@@ -5,7 +5,7 @@ Launch and manage jobs and workers
 ### Options
 
 ```
-      --domain string   specify the domain name of the instance (default "cozy.tools:8080")
+      --domain string   specify the domain name of the instance (default "cozy.localhost:8080")
   -h, --help            help for jobs
 ```
 

--- a/docs/cli/cozy-stack_jobs_purge-old-jobs.md
+++ b/docs/cli/cozy-stack_jobs_purge-old-jobs.md
@@ -26,7 +26,7 @@ $ cozy-stack jobs purge-old-jobs example.mycozy.cloud
       --admin-host string   administration server host (default "localhost")
       --admin-port int      administration server port (default 6060)
   -c, --config string       configuration file (default "$HOME/.cozy.yaml")
-      --domain string       specify the domain name of the instance (default "cozy.tools:8080")
+      --domain string       specify the domain name of the instance (default "cozy.localhost:8080")
       --host string         server host (default "localhost")
   -p, --port int            server port (default 8080)
 ```

--- a/docs/cli/cozy-stack_jobs_run.md
+++ b/docs/cli/cozy-stack_jobs_run.md
@@ -27,7 +27,7 @@ $ cozy-stack jobs run service --domain example.mycozy.cloud --json '{"slug": "ba
       --admin-host string   administration server host (default "localhost")
       --admin-port int      administration server port (default 6060)
   -c, --config string       configuration file (default "$HOME/.cozy.yaml")
-      --domain string       specify the domain name of the instance (default "cozy.tools:8080")
+      --domain string       specify the domain name of the instance (default "cozy.localhost:8080")
       --host string         server host (default "localhost")
   -p, --port int            server port (default 8080)
 ```

--- a/docs/cli/cozy-stack_konnectors.md
+++ b/docs/cli/cozy-stack_konnectors.md
@@ -19,7 +19,7 @@ cozy-stack konnectors <command> [flags]
 
 ```
       --all-domains         work on all domains iteratively
-      --domain string       specify the domain name of the instance (default "cozy.tools:8080")
+      --domain string       specify the domain name of the instance (default "cozy.localhost:8080")
   -h, --help                help for konnectors
       --parameters string   override the parameters of the installed konnector
 ```

--- a/docs/cli/cozy-stack_konnectors_deactivate-maintenance.md
+++ b/docs/cli/cozy-stack_konnectors_deactivate-maintenance.md
@@ -19,7 +19,7 @@ cozy-stack konnectors deactivate-maintenance [slug] [flags]
       --admin-port int      administration server port (default 6060)
       --all-domains         work on all domains iteratively
   -c, --config string       configuration file (default "$HOME/.cozy.yaml")
-      --domain string       specify the domain name of the instance (default "cozy.tools:8080")
+      --domain string       specify the domain name of the instance (default "cozy.localhost:8080")
       --host string         server host (default "localhost")
       --parameters string   override the parameters of the installed konnector
   -p, --port int            server port (default 8080)

--- a/docs/cli/cozy-stack_konnectors_install.md
+++ b/docs/cli/cozy-stack_konnectors_install.md
@@ -27,10 +27,10 @@ cozy-stack konnectors install <slug> [sourceurl] [flags]
 
 ```
 
-$ cozy-stack konnectors install --domain cozy.tools:8080 trainline registry://trainline/stable/1.0.1
-$ cozy-stack konnectors install --domain cozy.tools:8080 trainline registry://trainline/stable
-$ cozy-stack konnectors install --domain cozy.tools:8080 trainline registry://trainline/1.2.0
-$ cozy-stack konnectors install --domain cozy.tools:8080 trainline registry://trainline
+$ cozy-stack konnectors install --domain cozy.localhost:8080 trainline registry://trainline/stable/1.0.1
+$ cozy-stack konnectors install --domain cozy.localhost:8080 trainline registry://trainline/stable
+$ cozy-stack konnectors install --domain cozy.localhost:8080 trainline registry://trainline/1.2.0
+$ cozy-stack konnectors install --domain cozy.localhost:8080 trainline registry://trainline
 
 ```
 
@@ -47,7 +47,7 @@ $ cozy-stack konnectors install --domain cozy.tools:8080 trainline registry://tr
       --admin-port int      administration server port (default 6060)
       --all-domains         work on all domains iteratively
   -c, --config string       configuration file (default "$HOME/.cozy.yaml")
-      --domain string       specify the domain name of the instance (default "cozy.tools:8080")
+      --domain string       specify the domain name of the instance (default "cozy.localhost:8080")
       --host string         server host (default "localhost")
       --parameters string   override the parameters of the installed konnector
   -p, --port int            server port (default 8080)

--- a/docs/cli/cozy-stack_konnectors_ls-maintenances.md
+++ b/docs/cli/cozy-stack_konnectors_ls-maintenances.md
@@ -19,7 +19,7 @@ cozy-stack konnectors ls-maintenances [flags]
       --admin-port int      administration server port (default 6060)
       --all-domains         work on all domains iteratively
   -c, --config string       configuration file (default "$HOME/.cozy.yaml")
-      --domain string       specify the domain name of the instance (default "cozy.tools:8080")
+      --domain string       specify the domain name of the instance (default "cozy.localhost:8080")
       --host string         server host (default "localhost")
       --parameters string   override the parameters of the installed konnector
   -p, --port int            server port (default 8080)

--- a/docs/cli/cozy-stack_konnectors_ls.md
+++ b/docs/cli/cozy-stack_konnectors_ls.md
@@ -19,7 +19,7 @@ cozy-stack konnectors ls [flags]
       --admin-port int      administration server port (default 6060)
       --all-domains         work on all domains iteratively
   -c, --config string       configuration file (default "$HOME/.cozy.yaml")
-      --domain string       specify the domain name of the instance (default "cozy.tools:8080")
+      --domain string       specify the domain name of the instance (default "cozy.localhost:8080")
       --host string         server host (default "localhost")
       --parameters string   override the parameters of the installed konnector
   -p, --port int            server port (default 8080)

--- a/docs/cli/cozy-stack_konnectors_maintenance.md
+++ b/docs/cli/cozy-stack_konnectors_maintenance.md
@@ -21,7 +21,7 @@ cozy-stack konnectors maintenance [slug] [flags]
       --admin-port int      administration server port (default 6060)
       --all-domains         work on all domains iteratively
   -c, --config string       configuration file (default "$HOME/.cozy.yaml")
-      --domain string       specify the domain name of the instance (default "cozy.tools:8080")
+      --domain string       specify the domain name of the instance (default "cozy.localhost:8080")
       --host string         server host (default "localhost")
       --parameters string   override the parameters of the installed konnector
   -p, --port int            server port (default 8080)

--- a/docs/cli/cozy-stack_konnectors_run.md
+++ b/docs/cli/cozy-stack_konnectors_run.md
@@ -24,7 +24,7 @@ cozy-stack konnectors run <slug> [flags]
       --admin-port int      administration server port (default 6060)
       --all-domains         work on all domains iteratively
   -c, --config string       configuration file (default "$HOME/.cozy.yaml")
-      --domain string       specify the domain name of the instance (default "cozy.tools:8080")
+      --domain string       specify the domain name of the instance (default "cozy.localhost:8080")
       --host string         server host (default "localhost")
       --parameters string   override the parameters of the installed konnector
   -p, --port int            server port (default 8080)

--- a/docs/cli/cozy-stack_konnectors_show.md
+++ b/docs/cli/cozy-stack_konnectors_show.md
@@ -19,7 +19,7 @@ cozy-stack konnectors show <slug> [flags]
       --admin-port int      administration server port (default 6060)
       --all-domains         work on all domains iteratively
   -c, --config string       configuration file (default "$HOME/.cozy.yaml")
-      --domain string       specify the domain name of the instance (default "cozy.tools:8080")
+      --domain string       specify the domain name of the instance (default "cozy.localhost:8080")
       --host string         server host (default "localhost")
       --parameters string   override the parameters of the installed konnector
   -p, --port int            server port (default 8080)

--- a/docs/cli/cozy-stack_konnectors_uninstall.md
+++ b/docs/cli/cozy-stack_konnectors_uninstall.md
@@ -19,7 +19,7 @@ cozy-stack konnectors uninstall <slug> [flags]
       --admin-port int      administration server port (default 6060)
       --all-domains         work on all domains iteratively
   -c, --config string       configuration file (default "$HOME/.cozy.yaml")
-      --domain string       specify the domain name of the instance (default "cozy.tools:8080")
+      --domain string       specify the domain name of the instance (default "cozy.localhost:8080")
       --host string         server host (default "localhost")
       --parameters string   override the parameters of the installed konnector
   -p, --port int            server port (default 8080)

--- a/docs/cli/cozy-stack_konnectors_update.md
+++ b/docs/cli/cozy-stack_konnectors_update.md
@@ -20,7 +20,7 @@ cozy-stack konnectors update <slug> [sourceurl] [flags]
       --admin-port int      administration server port (default 6060)
       --all-domains         work on all domains iteratively
   -c, --config string       configuration file (default "$HOME/.cozy.yaml")
-      --domain string       specify the domain name of the instance (default "cozy.tools:8080")
+      --domain string       specify the domain name of the instance (default "cozy.localhost:8080")
       --host string         server host (default "localhost")
       --parameters string   override the parameters of the installed konnector
   -p, --port int            server port (default 8080)

--- a/docs/cli/cozy-stack_settings.md
+++ b/docs/cli/cozy-stack_settings.md
@@ -19,13 +19,13 @@ cozy-stack settings [settings] [flags]
 ### Examples
 
 ```
-$ cozy-stack settings --domain cozy.tools:8080 context:beta,public_name:John,to_remove:
+$ cozy-stack settings --domain cozy.localhost:8080 context:beta,public_name:John,to_remove:
 ```
 
 ### Options
 
 ```
-      --domain string   specify the domain name of the instance (default "cozy.tools:8080")
+      --domain string   specify the domain name of the instance (default "cozy.localhost:8080")
   -h, --help            help for settings
 ```
 

--- a/docs/cli/cozy-stack_triggers.md
+++ b/docs/cli/cozy-stack_triggers.md
@@ -17,7 +17,7 @@ cozy-stack triggers <command> [flags]
 ### Options
 
 ```
-      --domain string   specify the domain name of the instance (default "cozy.tools:8080")
+      --domain string   specify the domain name of the instance (default "cozy.localhost:8080")
   -h, --help            help for triggers
 ```
 

--- a/docs/cli/cozy-stack_triggers_launch.md
+++ b/docs/cli/cozy-stack_triggers_launch.md
@@ -9,7 +9,7 @@ cozy-stack triggers launch [triggerId] [flags]
 ### Examples
 
 ```
-$ cozy-stack triggers launch --domain cozy.tools:8080 748f42b65aca8c99ec2492eb660d1891
+$ cozy-stack triggers launch --domain cozy.localhost:8080 748f42b65aca8c99ec2492eb660d1891
 ```
 
 ### Options
@@ -24,7 +24,7 @@ $ cozy-stack triggers launch --domain cozy.tools:8080 748f42b65aca8c99ec2492eb66
       --admin-host string   administration server host (default "localhost")
       --admin-port int      administration server port (default 6060)
   -c, --config string       configuration file (default "$HOME/.cozy.yaml")
-      --domain string       specify the domain name of the instance (default "cozy.tools:8080")
+      --domain string       specify the domain name of the instance (default "cozy.localhost:8080")
       --host string         server host (default "localhost")
   -p, --port int            server port (default 8080)
 ```

--- a/docs/cli/cozy-stack_triggers_ls.md
+++ b/docs/cli/cozy-stack_triggers_ls.md
@@ -9,7 +9,7 @@ cozy-stack triggers ls [flags]
 ### Examples
 
 ```
-$ cozy-stack triggers ls --domain cozy.tools:8080
+$ cozy-stack triggers ls --domain cozy.localhost:8080
 ```
 
 ### Options
@@ -24,7 +24,7 @@ $ cozy-stack triggers ls --domain cozy.tools:8080
       --admin-host string   administration server host (default "localhost")
       --admin-port int      administration server port (default 6060)
   -c, --config string       configuration file (default "$HOME/.cozy.yaml")
-      --domain string       specify the domain name of the instance (default "cozy.tools:8080")
+      --domain string       specify the domain name of the instance (default "cozy.localhost:8080")
       --host string         server host (default "localhost")
   -p, --port int            server port (default 8080)
 ```

--- a/docs/cli/cozy-stack_triggers_show-from-app.md
+++ b/docs/cli/cozy-stack_triggers_show-from-app.md
@@ -18,7 +18,7 @@ cozy-stack triggers show-from-app <slug> [flags]
       --admin-host string   administration server host (default "localhost")
       --admin-port int      administration server port (default 6060)
   -c, --config string       configuration file (default "$HOME/.cozy.yaml")
-      --domain string       specify the domain name of the instance (default "cozy.tools:8080")
+      --domain string       specify the domain name of the instance (default "cozy.localhost:8080")
       --host string         server host (default "localhost")
   -p, --port int            server port (default 8080)
 ```

--- a/docs/client-app-dev.md
+++ b/docs/client-app-dev.md
@@ -12,8 +12,8 @@ have to install part of the dependencies yourself or _via_ a Docker image in
 which all dependencies are packed.
 
 This environment will provide a running instance a http server serving both a
-specified directory of your application on `app.cozy.tools:8080` and the
-`cozy-stack` on `cozy.tools:8080` (you can change the hostname and port if you
+specified directory of your application on `app.cozy.localhost:8080` and the
+`cozy-stack` on `cozy.localhost:8080` (you can change the hostname and port if you
 want, see below).
 
 The default passphrase will be "cozy"
@@ -61,7 +61,7 @@ docker pull cozy/cozy-app-dev
 
 If you work behind a corporate proxy, and Docker is configured to inject proxy
 configuration into the containers, you need to ensure that both `localhost` and
-`cozy.tools` are configured not to use the proxy. Following is the minimal
+`cozy.localhost` are configured not to use the proxy. Following is the minimal
 `~/.docker/config.json` configuration that has been shown to work:
 
 ```json
@@ -70,7 +70,7 @@ configuration into the containers, you need to ensure that both `localhost` and
         "default": {
             "httpProxy": "MY_CORPORATE_PROXY",
             "httpsProxy": "MY_CORPORATE_PROXY",
-            "noProxy": "localhost,cozy.tools"
+            "noProxy": "localhost,cozy.localhost"
         }
     }
 }
@@ -113,7 +113,7 @@ $ docker run --rm -it \
 
 A [MailHog](https://github.com/mailhog/MailHog) is running inside docker to
 catch emails. You can view the emails sent by the stack in a web interface on
-http://cozy.tools:8025/
+http://cozy.localhost:8025/
 
 You can also expose the couchdb port (listening in the container on 5984) in
 order to access its admin page. For instance add `-p 1234:5984` to access to the

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -53,7 +53,7 @@ A precision for the app name:
 docker run --rm -it -p 8080:8080 -v "$(pwd)/build":/data/cozy-app/***my-app*** cozy/cozy-app-dev
 ```
 
-***my-app*** will be the first part of: ***my-app***.cozy.tools:8080
+***my-app*** will be the first part of: ***my-app***.cozy.localhost:8080
 
 ## Only-Office document server
 

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -219,7 +219,7 @@ Example and description of the attributes of a `io.cozy.jobs`:
 
 ```js
 {
-  "domain": "me.cozy.tools",
+  "domain": "me.cozy.localhost",
   "worker": "sendmail",    // worker type name
   "options": {
     "priority": 3,         // priority from 1 to 100, higher number is higher priority
@@ -230,7 +230,7 @@ Example and description of the attributes of a `io.cozy.jobs`:
     "mode": "noreply",
     "template_name": "new_registration",
     "template_values": {
-      "DevicesLink": "http://me.cozy.tools/#/connectedDevices",
+      "DevicesLink": "http://me.cozy.localhost/#/connectedDevices",
     }
   },
   "state": "running",      // queued, running, done, errored
@@ -270,7 +270,7 @@ Accept: application/vnd.api+json
     "type": "io.cozy.jobs",
     "id": "123123",
     "attributes": {
-      "domain": "me.cozy.tools",
+      "domain": "me.cozy.localhost",
       "worker": "sendmail",
       "options": {
         "priority": 3,
@@ -328,7 +328,7 @@ Accept: application/vnd.api+json
     "type": "io.cozy.jobs",
     "id": "123123",
     "attributes": {
-      "domain": "me.cozy.tools",
+      "domain": "me.cozy.localhost",
       "worker": "sendmail",
       "options": {
         "timeout": 60,
@@ -420,7 +420,7 @@ Accept: application/vnd.api+json
   "data": [
     {
       "attributes": {
-        "domain": "cozy.tools:8080",
+        "domain": "cozy.localhost:8080",
         "options": null,
         "queued_at": "2017-09-29T15:32:31.953878568+02:00",
         "started_at": "0001-01-01T00:00:00Z",
@@ -501,7 +501,7 @@ Content-Type: application/vnd.api+json
     "type": "io.cozy.jobs",
     "id": "022368c07dc701396403543d7eb8149c",
     "attributes": {
-      "domain": "me.cozy.tools",
+      "domain": "me.cozy.localhost",
       "worker": "sendmail",
       "options": {},
       "state": "errored",
@@ -762,7 +762,7 @@ Accept: application/vnd.api+json
     "type": "io.cozy.jobs",
     "id": "123123",
     "attributes": {
-      "domain": "me.cozy.tools",
+      "domain": "me.cozy.localhost",
       "worker": "sendmail",
       "options": {},
       "state": "running",

--- a/docs/move.md
+++ b/docs/move.md
@@ -31,7 +31,7 @@ Exports options fields are:
 
 ```http
 POST /move/exports HTTP/1.1
-Host: source.cozy.tools
+Host: source.cozy.localhost
 Authorization: Bearer ...
 Content-Type: application/vnd.api+json
 ```
@@ -71,7 +71,7 @@ Exports fields are:
 
 ```http
 GET /move/exports/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX HTTP/1.1
-Host: source.cozy.tools
+Host: source.cozy.localhost
 Authorization: Bearer ...
 Content-Type: application/vnd.api+json
 ```
@@ -121,7 +121,7 @@ URL, before doing the real import.
 
 ```http
 POST /move/imports/precheck HTTP/1.1
-Host: destination.cozy.tools
+Host: destination.cozy.localhost
 Authorization: Bearer ...
 Content-Type: application/vnd.api+json
 ```
@@ -130,7 +130,7 @@ Content-Type: application/vnd.api+json
 {
     "data": {
         "attributes": {
-            "url": "https://settings.source.cozy.tools/#/exports/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+            "url": "https://settings.source.cozy.localhost/#/exports/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
         }
     }
 }
@@ -150,7 +150,7 @@ This endpoint can be used to really start an import.
 
 ```http
 POST /move/imports HTTP/1.1
-Host: destination.cozy.tools
+Host: destination.cozy.localhost
 Authorization: Bearer ...
 Content-Type: application/vnd.api+json
 ```
@@ -159,7 +159,7 @@ Content-Type: application/vnd.api+json
 {
     "data": {
         "attributes": {
-            "url": "https://settings.source.cozy.tools/#/exports/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+            "url": "https://settings.source.cozy.localhost/#/exports/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
         }
     }
 }
@@ -169,7 +169,7 @@ Content-Type: application/vnd.api+json
 
 ```http
 HTTP/1.1 303 See Other
-Location: https://destination.cozy.tools/move/importing
+Location: https://destination.cozy.localhost/move/importing
 ```
 
 ### POST /move/importing
@@ -188,7 +188,7 @@ This is a websocket endpoint that can be used to wait for the end of the
 import. The server will send an event when it is done (or errored):
 
 ```
-server> {"redirect": "http://cozy.tools:8080/auth/login"}
+server> {"redirect": "http://cozy.localhost:8080/auth/login"}
 ```
 
 ### GET /move/authorize
@@ -201,7 +201,7 @@ still need a confirmation by mail to start moving the Cozy.
 
 ```http
 GET /move/authorize?state=8d560d60&redirect_uri=https://move.cozycloud.cc/callback/source HTTP/1.1
-Server: source.cozy.tools
+Server: source.cozy.localhost
 ```
 
 #### Response
@@ -219,14 +219,14 @@ This endpoint is used by the settings application to open the move wizard.
 
 ```http
 POST /move/initialize HTTP/1.1
-Host: source.cozy.tools
+Host: source.cozy.localhost
 ```
 
 #### Response
 
 ```http
 HTTP/1.1 307 Temporary Redirect
-Location: https://move.cozycloud.cc/initialize?code=834d7eb8149c&cozy_url=https://source.cozy.tools&used=123456&quota=5000000&client_id=09136b00-1778-0139-f0a7-543d7eb8149c&client_secret=NDkyZTEzMDA&vault=false
+Location: https://move.cozycloud.cc/initialize?code=834d7eb8149c&cozy_url=https://source.cozy.localhost&used=123456&quota=5000000&client_id=09136b00-1778-0139-f0a7-543d7eb8149c&client_secret=NDkyZTEzMDA&vault=false
 ```
 
 ### POST /move/request
@@ -241,7 +241,7 @@ POST /move/request HTTP/1.1
 Content-Type: application/x-www-form-urlencoded
 
 code=834d7eb8149c
-&target_url=https://target.cozy.tools/
+&target_url=https://target.cozy.localhost/
 &target_token=M2EwYjlhZjAtMTc3OC0wMTM5LWYwYWMtNTQzZDdlYjgxNDlj
 &target_client_id=09136b00-1778-0139-f0a7-543d7eb8149c
 &target_client_secret=NDkyZTEzMDA
@@ -267,14 +267,14 @@ its-self during the move and pushs a job for the export.
 
 ```http
 GET /move/go?secret=tNTQzZDdlYjgxNDlj HTTP/1.1
-Host: source.cozy.tools
+Host: source.cozy.localhost
 ```
 
 #### Reponse
 
 ```http
 HTTP/1.1 303 See Other
-Location: https://target.cozy.tools/move/importing
+Location: https://target.cozy.localhost/move/importing
 ```
 
 ### POST /move/finalize
@@ -286,7 +286,7 @@ the source Cozy so that it can stop the konnectors and unblock the instance.
 
 ```http
 POST /move/finalize?subdomain=flat HTTP/1.1
-Host: source.cozy.tools
+Host: source.cozy.localhost
 ```
 #### Reponse
 
@@ -303,7 +303,7 @@ endpoint for the other instance to unblock it.
 
 ```http
 POST /move/abort HTTP/1.1
-Host: source.cozy.tools
+Host: source.cozy.localhost
 ```
 #### Reponse
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -125,7 +125,7 @@ of the message cannot be longer than 160 characters.
 
 ```http
 POST /notifications HTTP/1.1
-Host: alice.cozy.tools
+Host: alice.cozy.localhost
 Authorization: Bearer ...
 Content-Type: application/vnd.api+json
 ```

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -264,7 +264,7 @@ included in the response, like this:
 			"attributes": {
 				"status": "seen",
 				"name": "Bob",
-				"email": "bob@cozy.tools"
+				"email": "bob@cozy.localhost"
 			}
 		}
 	]

--- a/docs/remote.md
+++ b/docs/remote.md
@@ -124,7 +124,7 @@ Example:
 
 ```http
 GET /remote/org.wikidata.search?q=Douglas+Adams HTTP/1.1
-Host: alice.cozy.tools
+Host: alice.cozy.localhost
 ```
 
 It is possible to send some extra informations, to make it easier to understand
@@ -135,7 +135,7 @@ Example:
 
 ```http
 POST /remote/org.example HTTP/1.1
-Host: alice.cozy.tools
+Host: alice.cozy.localhost
 Content-Type: application/json
 ```
 
@@ -160,7 +160,7 @@ Example:
 
 ```http
 GET /remote/assets/bank HTTP/1.1
-Host: alice.cozy.tools
+Host: alice.cozy.localhost
 ```
 
 ## Logs

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -419,7 +419,7 @@ this modal again the next time they will open the Home again).
 
 ```http
 DELETE /settings/instance/moved_from HTTP/1.1
-Host: target.cozy.tools
+Host: target.cozy.localhost
 Cookie: sessionid=xxxxx
 ```
 

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -263,7 +263,7 @@ Its options are:
 
 ```json
 {
-  "manifest_url": "http://cozy.tools:8080/move/exports/QUFBQUFGLVg5b3c0WTJNNU9HRmpPR0V4WlRnd01XVTJZMlU0T0RjeE5UaGpNVEF3TWpKbVplblFfRWZWUVAtRGJXU0lnV2tIZ3NsVHN5dUR6V0ZIdVdSeERLb196X3A0"
+  "manifest_url": "http://cozy.localhost:8080/move/exports/QUFBQUFGLVg5b3c0WTJNNU9HRmpPR0V4WlRnd01XVTJZMlU0T0RjeE5UaGpNVEF3TWpKbVplblFfRWZWUVAtRGJXU0lnV2tIZ3NsVHN5dUR6V0ZIdVdSeERLb196X3A0"
 }
 ```
 

--- a/model/job/mem_broker_test.go
+++ b/model/job/mem_broker_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestProperSerial(t *testing.T) {
-	job := jobs.NewJob(prefixer.NewPrefixer("cozy.tools:8080", "cozy.tools:8080"),
+	job := jobs.NewJob(prefixer.NewPrefixer("cozy.localhost:8080", "cozy.localhost:8080"),
 		&jobs.JobRequest{
 			WorkerType: "",
 		})

--- a/model/vfs/cozy_metadata_test.go
+++ b/model/vfs/cozy_metadata_test.go
@@ -9,65 +9,65 @@ import (
 )
 
 func TestUpdatedByApp(t *testing.T) {
-	fcm := NewCozyMetadata("alice.cozy.tools")
+	fcm := NewCozyMetadata("alice.cozy.localhost")
 	entry := &metadata.UpdatedByAppEntry{
 		Slug:     "drive",
 		Date:     time.Now(),
-		Instance: "alice.cozy.tools",
+		Instance: "alice.cozy.localhost",
 	}
 	fcm.UpdatedByApp(entry)
 	assert.Len(t, fcm.UpdatedByApps, 1)
 	assert.Equal(t, "drive", fcm.UpdatedByApps[0].Slug)
-	assert.Equal(t, "alice.cozy.tools", fcm.UpdatedByApps[0].Instance)
+	assert.Equal(t, "alice.cozy.localhost", fcm.UpdatedByApps[0].Instance)
 
 	entry = &metadata.UpdatedByAppEntry{
 		Slug:     "photo",
 		Date:     time.Now(),
-		Instance: "alice.cozy.tools",
+		Instance: "alice.cozy.localhost",
 	}
 	fcm.UpdatedByApp(entry)
 	assert.Len(t, fcm.UpdatedByApps, 2)
 	assert.Equal(t, "photo", fcm.UpdatedByApps[1].Slug)
-	assert.Equal(t, "alice.cozy.tools", fcm.UpdatedByApps[1].Instance)
+	assert.Equal(t, "alice.cozy.localhost", fcm.UpdatedByApps[1].Instance)
 
 	entry = &metadata.UpdatedByAppEntry{
 		Slug:     "drive",
 		Date:     time.Now(),
-		Instance: "bob.cozy.tools",
+		Instance: "bob.cozy.localhost",
 	}
 	fcm.UpdatedByApp(entry)
 	assert.Len(t, fcm.UpdatedByApps, 3)
 	assert.Equal(t, "drive", fcm.UpdatedByApps[2].Slug)
-	assert.Equal(t, "bob.cozy.tools", fcm.UpdatedByApps[2].Instance)
+	assert.Equal(t, "bob.cozy.localhost", fcm.UpdatedByApps[2].Instance)
 
 	entry = &metadata.UpdatedByAppEntry{
 		Slug:     "drive",
 		Date:     time.Now(),
-		Instance: "alice.cozy.tools",
+		Instance: "alice.cozy.localhost",
 	}
 	fcm.UpdatedByApp(entry)
 	assert.Len(t, fcm.UpdatedByApps, 3)
 	assert.Equal(t, "photo", fcm.UpdatedByApps[0].Slug)
-	assert.Equal(t, "alice.cozy.tools", fcm.UpdatedByApps[0].Instance)
+	assert.Equal(t, "alice.cozy.localhost", fcm.UpdatedByApps[0].Instance)
 	assert.Equal(t, "drive", fcm.UpdatedByApps[1].Slug)
-	assert.Equal(t, "bob.cozy.tools", fcm.UpdatedByApps[1].Instance)
+	assert.Equal(t, "bob.cozy.localhost", fcm.UpdatedByApps[1].Instance)
 	assert.Equal(t, "drive", fcm.UpdatedByApps[2].Slug)
-	assert.Equal(t, "alice.cozy.tools", fcm.UpdatedByApps[2].Instance)
+	assert.Equal(t, "alice.cozy.localhost", fcm.UpdatedByApps[2].Instance)
 	assert.Equal(t, entry.Date, fcm.UpdatedByApps[2].Date)
 
 	entry = &metadata.UpdatedByAppEntry{
 		Slug:     "drive",
 		Date:     time.Now(),
-		Instance: "alice.cozy.tools",
+		Instance: "alice.cozy.localhost",
 	}
 	fcm.UpdatedByApp(entry)
 	assert.Len(t, fcm.UpdatedByApps, 3)
 	assert.Equal(t, "photo", fcm.UpdatedByApps[0].Slug)
-	assert.Equal(t, "alice.cozy.tools", fcm.UpdatedByApps[0].Instance)
+	assert.Equal(t, "alice.cozy.localhost", fcm.UpdatedByApps[0].Instance)
 	assert.Equal(t, "drive", fcm.UpdatedByApps[1].Slug)
-	assert.Equal(t, "bob.cozy.tools", fcm.UpdatedByApps[1].Instance)
+	assert.Equal(t, "bob.cozy.localhost", fcm.UpdatedByApps[1].Instance)
 	assert.Equal(t, "drive", fcm.UpdatedByApps[2].Slug)
-	assert.Equal(t, "alice.cozy.tools", fcm.UpdatedByApps[2].Instance)
+	assert.Equal(t, "alice.cozy.localhost", fcm.UpdatedByApps[2].Instance)
 	assert.Equal(t, entry.Date, fcm.UpdatedByApps[2].Date)
 
 	one := *entry
@@ -77,15 +77,15 @@ func TestUpdatedByApp(t *testing.T) {
 	entry = &metadata.UpdatedByAppEntry{
 		Slug:     "photo",
 		Date:     time.Now(),
-		Instance: "alice.cozy.tools",
+		Instance: "alice.cozy.localhost",
 	}
 	fcm.UpdatedByApp(entry)
 	assert.Len(t, fcm.UpdatedByApps, 3)
 	assert.Equal(t, "drive", fcm.UpdatedByApps[0].Slug)
-	assert.Equal(t, "bob.cozy.tools", fcm.UpdatedByApps[0].Instance)
+	assert.Equal(t, "bob.cozy.localhost", fcm.UpdatedByApps[0].Instance)
 	assert.Equal(t, "drive", fcm.UpdatedByApps[1].Slug)
-	assert.Equal(t, "alice.cozy.tools", fcm.UpdatedByApps[1].Instance)
+	assert.Equal(t, "alice.cozy.localhost", fcm.UpdatedByApps[1].Instance)
 	assert.Equal(t, "photo", fcm.UpdatedByApps[2].Slug)
-	assert.Equal(t, "alice.cozy.tools", fcm.UpdatedByApps[2].Instance)
+	assert.Equal(t, "alice.cozy.localhost", fcm.UpdatedByApps[2].Instance)
 	assert.Equal(t, entry.Date, fcm.UpdatedByApps[2].Date)
 }

--- a/model/vfs/metadata_test.go
+++ b/model/vfs/metadata_test.go
@@ -65,7 +65,7 @@ func TestShortcutMetadataExtractor(t *testing.T) {
 	doc := &FileDoc{
 		Mime: consts.ShortcutMimeType,
 		CozyMetadata: &FilesCozyMetadata{
-			CreatedOn: "http://cozy.tools:8080/",
+			CreatedOn: "http://cozy.localhost:8080/",
 		},
 	}
 	extractor := NewMetaExtractor(doc)
@@ -86,7 +86,7 @@ func TestShortcutMetadataExtractor(t *testing.T) {
 	assert.True(t, ok, "target.cozyMetadata is present")
 	cozy, ok := cm["instance"].(string)
 	assert.True(t, ok, "target.cozyMetadata.instance is present")
-	assert.Equal(t, "cozy.tools:8080", cozy)
+	assert.Equal(t, "cozy.localhost:8080", cozy)
 	app, ok := target["app"]
 	assert.True(t, ok, "target.app is present")
 	assert.Equal(t, "drive", app)

--- a/pkg/config/config/split_host.go
+++ b/pkg/config/config/split_host.go
@@ -8,9 +8,6 @@ func SplitCozyHost(host string) (instanceHost, appSlug, siblings string) {
 	parts := strings.SplitN(host, ".", 2)
 	if len(parts) == 2 {
 		if GetConfig().Subdomains == NestedSubdomains {
-			if host == "cozy.tools:8080" {
-				return host, "", ""
-			}
 			return parts[1], parts[0], "*." + parts[1]
 		}
 		subs := strings.SplitN(parts[0], "-", 2)

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -29,7 +29,7 @@ RUN ./scripts/build.sh dev
 FROM debian:stretch-slim
 
 # cozy-stack
-ENV COZY_STACK_HOST=cozy.tools \
+ENV COZY_STACK_HOST=cozy.localhost \
 	COZY_STACK_PORT=8080 \
 	COZY_STACK_PATH=cozy-stack \
 	COUCHDB_SRC_URL=https://dist.apache.org/repos/dist/release/couchdb/source/2.3.1/apache-couchdb-2.3.1.tar.gz \

--- a/scripts/cozy-app-dev.sh
+++ b/scripts/cozy-app-dev.sh
@@ -3,7 +3,7 @@
 set -e
 set -m
 
-[ -z "${COZY_STACK_HOST}" ] && COZY_STACK_HOST="cozy.tools"
+[ -z "${COZY_STACK_HOST}" ] && COZY_STACK_HOST="cozy.localhost"
 [ -z "${COZY_STACK_PORT}" ] && COZY_STACK_PORT="8080"
 [ -z "${COZY_STACK_PASS}" ] && COZY_STACK_PASS="cozy"
 [ -z "${COZY_STACK_ADMIN_PORT}" ] && COZY_STACK_ADMIN_PORT="6060"
@@ -35,7 +35,7 @@ usage() {
 	echo -e "    itself. default: \"\$GOPATH/bin\"."
 	echo -e "\n  COZY_STACK_HOST"
 	echo -e "    specify the hostname on which the cozy-stack is launched."
-	echo -e "    default: cozy.tools."
+	echo -e "    default: cozy.localhost."
 	echo -e "\n  COZY_STACK_PORT"
 	echo -e "    specify the port on which the cozy-stack is listening."
 	echo -e "    default: 8080."

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -14,7 +14,7 @@ sudo npm install -g @bitwarden/cli
 # force the resolution via the /etc/hosts to 127.0.0.1.
 #
 # See https://github.com/eventmachine/eventmachine/blob/v1.2.7/lib/em/resolver.rb
-echo "127.0.0.1 alice.test.cozy.tools bob.test.cozy.tools" | sudo tee -a /etc/hosts
+echo "127.0.0.1 alice.test.localhost bob.test.localhost" | sudo tee -a /etc/hosts
 
 bundle install --jobs=3 --retry=3
 # bundle exec ruby -e 'Dir.glob("tests/*.rb") { |f| load f }'

--- a/scripts/lnav_cozy_log.json
+++ b/scripts/lnav_cozy_log.json
@@ -21,7 +21,7 @@
       },
       {
         "line":
-          "time=\"2018-04-18T14:26:23+02:00\" level=debug msg=\"request: GET alice-test-cozy-tools-8081%2Fio-cozy-shared/_local/sharing-be7813ea5927dc06a5b044ca47010ffe-1 \" domain=\"alice.test.cozy.tools:8081\""
+          "time=\"2018-04-18T14:26:23+02:00\" level=debug msg=\"request: GET alice-test-cozy.localhost-8081%2Fio-cozy-shared/_local/sharing-be7813ea5927dc06a5b044ca47010ffe-1 \" domain=\"alice.test.cozy.localhost:8081\""
       }
     ],
     "value": {

--- a/tests/fixtures/shortcut.url
+++ b/tests/fixtures/shortcut.url
@@ -1,2 +1,2 @@
 [InternetShortcut]
-URL=http://drive.cozy.tools:8080/
+URL=http://drive.cozy.localhost:8080/

--- a/tests/integration/lib/instance.rb
+++ b/tests/integration/lib/instance.rb
@@ -12,9 +12,9 @@ class Instance
   def initialize(stack, opts = {})
     @stack = stack
     @name = opts[:name] || Faker::Internet.domain_word
-    @domain = opts[:domain] || "#{@name.downcase}.test.cozy.tools:#{stack.port}"
+    @domain = opts[:domain] || "#{@name.downcase}.test.localhost:#{stack.port}"
     @passphrase = opts[:passphrase] || "cozy"
-    @email = opts[:email] || "#{@name.downcase}+test@cozy.tools"
+    @email = opts[:email] || "#{@name.downcase}+test@localhost"
     @locale = opts[:locale] || "fr"
   end
 

--- a/tests/integration/scalability/trash.rb
+++ b/tests/integration/scalability/trash.rb
@@ -1,8 +1,8 @@
 require_relative '../boot'
 
 stack_port = 8080
-domain = 'trash.test.cozy.tools:8080'
-email = 'me@cozy.tools'
+domain = 'trash.test.localhost:8080'
+email = 'me@localhost'
 
 stack = Stack.get stack_port
 inst = Instance.new stack, domain: domain, email: email

--- a/tests/integration/tests/revoke_sharing.rb
+++ b/tests/integration/tests/revoke_sharing.rb
@@ -84,7 +84,7 @@ describe "A sharing" do
     contact_charlie = Contact.create inst_alice, given_name: charlie
     Contact.create inst_bob, given_name: "Alice",
                              family_name: lastname,
-                             email: "alice+test@cozy.tools"
+                             email: "alice+test@localhost"
     Contact.create inst_bob, given_name: "Charlie",
                              family_name: lastname,
                              email: contact_charlie.primary_email
@@ -111,7 +111,7 @@ describe "A sharing" do
     owner = doc["members"].first
     assert_equal "owner", owner["status"]
     assert_equal "Alice", owner["public_name"]
-    assert_equal "alice+test@cozy.tools", owner["email"]
+    assert_equal "alice+test@localhost", owner["email"]
     assert_equal inst_alice.url, owner["instance"]
     recpt1 = doc["members"][1]
     assert_equal "pending", recpt1["status"]
@@ -218,7 +218,7 @@ describe "A sharing" do
     assert_equal "owner", owner["status"]
     assert_equal "Alice", owner["public_name"]
     assert_equal "Alice #{lastname}", owner["name"]
-    assert_equal "alice+test@cozy.tools", owner["email"]
+    assert_equal "alice+test@localhost", owner["email"]
     assert_equal inst_alice.url, owner["instance"]
     recpt1 = doc["members"][1]
     assert_equal "ready", recpt1["status"]
@@ -273,7 +273,7 @@ describe "A sharing" do
     owner = doc["members"].first
     assert_equal "owner", owner["status"]
     assert_equal "Alice", owner["public_name"]
-    assert_equal "alice+test@cozy.tools", owner["email"]
+    assert_equal "alice+test@localhost", owner["email"]
     assert_equal inst_alice.url, owner["instance"]
     assert_nil owner["name"]
     recpt1 = doc["members"][1]

--- a/web/accounts/oauth_test.go
+++ b/web/accounts/oauth_test.go
@@ -151,7 +151,7 @@ func TestRedirectURLOauthFlow(t *testing.T) {
 }
 
 func TestFixedRedirectURIOauthFlow(t *testing.T) {
-	redirectURI := "http://_oauth_callback.cozy.tools/accounts/test-service3/redirect"
+	redirectURI := "http://_oauth_callback.cozy.localhost/accounts/test-service3/redirect"
 	service := makeTestACService(redirectURI)
 	defer service.Close()
 
@@ -238,7 +238,7 @@ func TestMain(m *testing.M) {
 	setup = testutils.NewSetup(m, "oauth-konnectors")
 	ts = setup.GetTestServer("/accounts", Routes)
 	testInstance = setup.GetTestInstance(&lifecycle.Options{
-		Domain: strings.Replace(ts.URL, "http://127.0.0.1", "cozy.tools", 1),
+		Domain: strings.Replace(ts.URL, "http://127.0.0.1", "cozy.localhost", 1),
 	})
 	_ = couchdb.ResetDB(couchdb.GlobalSecretsDB, consts.AccountTypes)
 	setup.AddCleanup(func() error {

--- a/web/bitwarden/bitwarden_test.go
+++ b/web/bitwarden/bitwarden_test.go
@@ -927,7 +927,7 @@ func TestMain(m *testing.M) {
 		Domain:     "bitwarden.example.net",
 		Passphrase: "cozy",
 		PublicName: "Pierre",
-		Email:      "pierre@cozy.tools",
+		Email:      "pierre@cozy.localhost",
 	})
 
 	ts = setup.GetTestServer("/bitwarden", Routes)

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -475,7 +475,7 @@ func TestUploadShortcut(t *testing.T) {
 	req, err := http.NewRequest("POST", ts.URL+"/files/?Type=file&Name=shortcut.url", f)
 	assert.NoError(t, err)
 	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	res, obj := doUploadOrMod(t, req, "application/octet-stream", "Zmko77UB8tJqERoef4MMlg==")
+	res, obj := doUploadOrMod(t, req, "application/octet-stream", "+tHtr9V8+4gcCDxTFAqt3w==")
 	assert.Equal(t, 201, res.StatusCode)
 	data := obj["data"].(map[string]interface{})
 	attrs := data["attributes"].(map[string]interface{})

--- a/web/oidc/oidc.go
+++ b/web/oidc/oidc.go
@@ -43,7 +43,7 @@ func Start(c echo.Context) error {
 
 // Redirect is the route after the Identity Provider has redirected the user to
 // the stack. The redirection is made to a generic domain, like
-// oauthcallback.cozy.tools and the association with an instance is made via a
+// oauthcallback.cozy.localhost and the association with an instance is made via a
 // call to the UserInfo endpoint. It redirects to the cozy instance to login
 // the user.
 func Redirect(c echo.Context) error {

--- a/web/settings/context.go
+++ b/web/settings/context.go
@@ -85,7 +85,7 @@ func finishOnboarding(c echo.Context, redirection string, acceptHTML bool) error
 		// Create and adding a fallbackURI in case of no-supporting custom
 		// protocol cozy<app>://
 		// Basically, it parses the app slug and computes the web app url
-		// Example: cozydrive:// => http://drive.alice.cozy.tools:8080/
+		// Example: cozydrive:// => http://drive.alice.cozy.localhost:8080/
 		r, err := url.Parse(redirectURI)
 		if err != nil {
 			return err


### PR DESCRIPTION
By using http://cozy.localhost:8080/ as the default instance for
developement, we don't need JS polyfill for window.crypto.