### PR TITLE
Fix missing trigger_id for services of new apps

### DIFF
--- a/model/app/webapp.go
+++ b/model/app/webapp.go
@@ -297,8 +297,11 @@ func (m *WebappManifest) Create(db prefixer.Prefixer) error {
 		return err
 	}
 
-	if err := diffServices(db, m.Slug(), nil, m.Services); err != nil {
-		return err
+	if len(m.Services) > 0 {
+		if err := diffServices(db, m.Slug(), nil, m.Services); err != nil {
+			return err
+		}
+		_ = couchdb.UpdateDoc(db, m)
 	}
 
 	_, err := permission.CreateWebappSet(db, m.Slug(), m.Permissions(), m.Version())


### PR DESCRIPTION
When an application is installed, the CouchDB Document is created before
the triggers for its services. But, we should also update the document
after to keep track of the trigger_id.