### PR TITLE
Fix trashing a directory with many files

### DIFF
--- a/model/vfs/couchdb_indexer.go
+++ b/model/vfs/couchdb_indexer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
+	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/cozy/cozy-stack/pkg/prefixer"
 )
 
@@ -585,7 +586,9 @@ func (c *couchdbIndexer) setTrashedForFilesInsideDir(doc *DirDoc, trashed bool) 
 			cloned := file.Clone().(*FileDoc)
 			parentPath, ok := dirs[file.DirID]
 			if !ok {
-				return ErrParentDoesNotExist
+				logger.WithDomain(c.db.DomainName()).WithField("nspace", "vfs").
+					Infof("setTrashedForFilesInsideDir: parent not found for %s", file.DocID)
+				return nil
 			}
 			fullpath := path.Join(parentPath, file.DocName)
 			fullpath = strings.TrimPrefix(fullpath, TrashDirName)


### PR DESCRIPTION
If we have a VFS inconsistency on a file, we may get an error when
trying to trash its parent, and the other files inside this directory
won't have their trashed attribute updated. I don't really see how it
can triggered, but it sounds safer to do that.