### PR TITLE
Restrict OAuth clients

### DIFF
--- a/model/oauth/client.go
+++ b/model/oauth/client.go
@@ -302,6 +302,13 @@ func (c *Client) checkMandatoryFields(i *instance.Instance) *ClientRegistrationE
 func (c *Client) CheckSoftwareID(instance *instance.Instance) *ClientRegistrationError {
 	if strings.HasPrefix(c.SoftwareID, "registry://") {
 		appSlug := strings.TrimPrefix(c.SoftwareID, "registry://")
+		if appSlug == consts.StoreSlug || appSlug == consts.SettingsSlug {
+			return &ClientRegistrationError{
+				Code:        http.StatusBadRequest,
+				Error:       "unapproved_software_id",
+				Description: "Link with store/settings is forbidden",
+			}
+		}
 		_, err := registry.GetApplication(appSlug, instance.Registries())
 		if err != nil {
 			return &ClientRegistrationError{
@@ -491,6 +498,11 @@ func (c *Client) Update(i *instance.Instance, old *Client) *ClientRegistrationEr
 	c.RegistrationToken = ""
 	c.GrantTypes = []string{"authorization_code", "refresh_token"}
 	c.ResponseTypes = []string{"code"}
+	c.AllowLoginScope = old.AllowLoginScope
+	c.OnboardingSecret = ""
+	c.OnboardingApp = ""
+	c.OnboardingPermissions = ""
+	c.OnboardingState = ""
 	if c.NotificationPlatform == "" {
 		c.NotificationPlatform = old.NotificationPlatform
 	}

--- a/web/auth/register.go
+++ b/web/auth/register.go
@@ -29,10 +29,7 @@ func registerClient(c echo.Context) error {
 	// ("login" scope), except via the CLI.
 	if client.AllowLoginScope {
 		perm, err := middlewares.GetPermission(c)
-		if err != nil {
-			return err
-		}
-		if perm.Type != permission.TypeCLI {
+		if err != nil || perm.Type != permission.TypeCLI {
 			return echo.NewHTTPError(http.StatusUnauthorized,
 				"Not authorized to create client with given parameters")
 		}


### PR DESCRIPTION
In order to improve security, we don't want to allow OAuth clients to
link with store and settings. They are apps with special privileges, and
we don't want untrusted code to use those permissions.