### PR TITLE
Add home and store in instance creation example

### DIFF
--- a/cmd/instances.go
+++ b/cmd/instances.go
@@ -145,7 +145,7 @@ If the COZY_DISABLE_INSTANCES_ADD_RM env variable is set, creating and
 destroying instances will be desactivated and the content of this variable will
 be used as the error message.
 `,
-	Example: "$ cozy-stack instances add --passphrase cozy --apps drive,photos,settings cozy.localhost:8080",
+	Example: "$ cozy-stack instances add --passphrase cozy --apps drive,photos,settings,home,store cozy.localhost:8080",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if reason := os.Getenv("COZY_DISABLE_INSTANCES_ADD_RM"); reason != "" {
 			return fmt.Errorf("Sorry, instances add is disabled: %s", reason)


### PR DESCRIPTION
The example given to create an instance did not include the home and store apps. 
The default redirection is `home.cozy.localhost:8080` so it particularly makes
sense to include it.