### PR TITLE
Group session audit messages in a dedicated nspace

### DIFF
--- a/model/session/login_history.go
+++ b/model/session/login_history.go
@@ -132,7 +132,7 @@ func StoreNewLoginEntry(i *instance.Instance, sessionID, clientID string,
 	os := ua.OS()
 
 	createdAt := time.Now()
-	i.Logger().WithField("nspace", "sessions").
+	i.Logger().WithField("nspace", "loginaudit").
 		Infof("New connection from %s at %s (%s)", ip, createdAt, logMessage)
 	if timezone != "" {
 		if loc, err := time.LoadLocation(timezone); err == nil {

--- a/model/session/session.go
+++ b/model/session/session.go
@@ -107,8 +107,11 @@ func Get(i *instance.Instance, sessionID string) (*Session, error) {
 	if s.OlderThan(SessionMaxAge) {
 		err := couchdb.DeleteDoc(i, s)
 		if err != nil {
-			i.Logger().WithField("nspace", "sessions").
+			i.Logger().WithField("nspace", "loginaudit").
 				Warnf("Failed to delete expired session: %s", err)
+		} else {
+			i.Logger().WithField("nspace", "loginaudit").
+				Infof("Expired session deleted: %s", s.DocID)
 		}
 		return nil, ErrExpired
 	}
@@ -185,8 +188,11 @@ func GetAll(inst *instance.Instance) ([]*Session, error) {
 func (s *Session) Delete(i *instance.Instance) *http.Cookie {
 	err := couchdb.DeleteDoc(i, s)
 	if err != nil {
-		i.Logger().WithField("nspace", "sessions").
+		i.Logger().WithField("nspace", "loginaudit").
 			Errorf("Failed to delete session: %s", err)
+	} else {
+		i.Logger().WithField("nspace", "loginaudit").
+			Infof("Session deleted: %s", s.DocID)
 	}
 	return &http.Cookie{
 		Name:   CookieName(i),

--- a/web/auth/oauth.go
+++ b/web/auth/oauth.go
@@ -277,7 +277,7 @@ func authorize(c echo.Context) error {
 	if ip == "" {
 		ip = strings.Split(c.Request().RemoteAddr, ":")[0]
 	}
-	instance.Logger().WithField("nspace", "oauth").
+	instance.Logger().WithField("nspace", "loginaudit").
 		Infof("Access code created from %s at %s with scope %s", ip, time.Now(), access.Scope)
 
 	// We should be sending "code" only, but for compatibility reason, we keep

--- a/web/bitwarden/bitwarden.go
+++ b/web/bitwarden/bitwarden.go
@@ -320,7 +320,7 @@ func getInitialCredentials(c echo.Context) error {
 	if ip == "" {
 		ip = strings.Split(c.Request().RemoteAddr, ":")[0]
 	}
-	inst.Logger().WithField("nspace", "bitwarden").
+	inst.Logger().WithField("nspace", "loginaudit").
 		Infof("New bitwarden client from %s at %s", ip, time.Now())
 
 	// Send the response

--- a/web/instances/client.go
+++ b/web/instances/client.go
@@ -67,7 +67,7 @@ func createToken(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	logger.WithDomain(domain).WithField("nspace", "admin").
+	logger.WithDomain(domain).WithField("nspace", "loginaudit").
 		Infof("%s token created from admin API at %s", audience, issuedAt)
 	return c.String(http.StatusOK, token)
 }


### PR DESCRIPTION
#3105 Added audit traces for sessions. 

This PR:
- group them in a new dedicated `loginaudit` nspace
- add log messages for successful session deletion and expiration