### PR TITLE
Make passwords sharing possible with delegated auth

### DIFF
--- a/docs/sharing.md
+++ b/docs/sharing.md
@@ -710,6 +710,41 @@ Content-Type: application/vnd.api+json
 }
 ```
 
+### POST /sharings/:sharing-id/public-key
+
+This route can be used by a sharing member to send their new public key after
+they have chosen their password for the first time (delegated authentication).
+
+#### Request
+
+```http
+POST /sharings/ce8835a061d0ef68947afe69a0046722/public-key HTTP/1.1
+Host: alice.example.net
+Content-Type: application/vnd.api+json
+Authorization: Bearer ...
+```
+
+```json
+{
+  "data": {
+    "type": "io.cozy.sharings.answer",
+    "id": "ce8835a061d0ef68947afe69a0046722",
+    "attributes": {
+      "bitwarden": {
+        "user_id": "0dc76ad9b1cf3a979b916b3155001830",
+        "public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1wboB9QutvRKGswphAre6xi4boYxSw4IjXqXDTV297Cq/MB2cBklj+sMmRQNTkU266HFSTGp3jDVcegAsHMpVVlTKZnWW+gSP2+vSyGs9NUvG8JfLday1iuOntHJQkfYiZ7+BfBYFtx6iWRnbnegickyoS7PWibLP5lmEzZnFtrGcRT8urSfN61qlOVD1u+eqtif5tabdU6eyNWUMLCQYgtaGb1nNht/xDgbpBc3b2XbEF0tBJRFR5571EH1h//Ae7IT+pYuBZB9BoPAHj4fhQm3++oNjemUJbaVi0dM4KNfQ89z1lBBCh5lxAGPlpOjapN0qGPgSov8B9U+qXlmzQIDAQAB"
+      }
+    }
+  }
+}
+```
+
+#### Response
+
+```http
+HTTP/1.1 204 No Content
+```
+
 ### POST /sharings/:sharing-id/recipients
 
 This route allows the sharer to add new recipients to a sharing. It can also be

--- a/tests/integration/tests/bitwarden_cli.rb
+++ b/tests/integration/tests/bitwarden_cli.rb
@@ -251,5 +251,6 @@ describe "The bitwarden API of the stack" do
     assert_equal bw2.logout, "You have logged out."
 
     inst.remove
+    inst_recipient.remove
   end
 end

--- a/web/settings/passphrase.go
+++ b/web/settings/passphrase.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cozy/cozy-stack/model/instance/lifecycle"
 	"github.com/cozy/cozy-stack/model/permission"
 	"github.com/cozy/cozy-stack/model/session"
+	"github.com/cozy/cozy-stack/model/sharing"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/crypto"
@@ -191,6 +192,9 @@ func updatePassphrase(c echo.Context) error {
 		if err != nil {
 			return err
 		}
+		go func() {
+			_ = sharing.SendPublicKey(inst, params.PublicKey)
+		}()
 		if hasSession {
 			_, _ = auth.SetCookieForNewSession(c, session.LongRun)
 		}


### PR DESCRIPTION
When an instance is in a context with delegated authentication, its owner may have no password when they accept the sharing. In that case, the password will be created a bit later in cozy pass web. And when it's done, the stack is now sending the public key to the sharing owner instance to make it work.