### PR TITLE
Remove explicit mapping for app manifests

### DIFF
--- a/client/apps.go
+++ b/client/apps.go
@@ -45,6 +45,7 @@ type AppManifest struct {
 		Messages     *json.RawMessage `json:"messages,omitempty"`
 		OAuth        *json.RawMessage `json:"oauth,omitempty"`
 		TimeInterval *json.RawMessage `json:"time_interval,omitempty"`
+		ClientSide   bool             `json:"clientSide,omitempty"`
 
 		Slug        string `json:"slug"`
 		State       string `json:"state"`

--- a/model/app/apps.go
+++ b/model/app/apps.go
@@ -81,6 +81,7 @@ type Manifest interface {
 	SetError(err error)
 	Error() error
 
+	SetSlug(slug string)
 	SetSource(src *url.URL)
 	SetState(state State)
 	SetVersion(version string)

--- a/model/app/apps.go
+++ b/model/app/apps.go
@@ -78,6 +78,10 @@ type Manifest interface {
 	LastUpdate() time.Time
 	Terms() Terms
 
+	Name() string
+	Icon() string
+	Notifications() Notifications
+
 	SetError(err error)
 	Error() error
 

--- a/model/app/apps_test.go
+++ b/model/app/apps_test.go
@@ -8,13 +8,13 @@ import (
 
 func TestFindRoute(t *testing.T) {
 	manifest := &WebappManifest{}
-	manifest.Routes = make(Routes)
-	manifest.Routes["/foo"] = Route{Folder: "/foo", Index: "index.html"}
-	manifest.Routes["/foo/bar"] = Route{Folder: "/bar", Index: "index.html"}
-	manifest.Routes["/foo/qux"] = Route{Folder: "/qux", Index: "index.html"}
-	manifest.Routes["/public"] = Route{Folder: "/public", Index: "public.html", Public: true}
-	manifest.Routes["/admin"] = Route{Folder: "/admin", Index: "admin.html"}
-	manifest.Routes["/admin/special"] = Route{Folder: "/special", Index: "admin.html"}
+	manifest.val.Routes = make(Routes)
+	manifest.val.Routes["/foo"] = Route{Folder: "/foo", Index: "index.html"}
+	manifest.val.Routes["/foo/bar"] = Route{Folder: "/bar", Index: "index.html"}
+	manifest.val.Routes["/foo/qux"] = Route{Folder: "/qux", Index: "index.html"}
+	manifest.val.Routes["/public"] = Route{Folder: "/public", Index: "public.html", Public: true}
+	manifest.val.Routes["/admin"] = Route{Folder: "/admin", Index: "admin.html"}
+	manifest.val.Routes["/admin/special"] = Route{Folder: "/special", Index: "admin.html"}
 
 	ctx, rest := manifest.FindRoute("/admin")
 	assert.Equal(t, "/admin", ctx.Folder)
@@ -62,8 +62,8 @@ func TestFindRoute(t *testing.T) {
 
 func TestNoRegression217(t *testing.T) {
 	var man WebappManifest
-	man.Routes = make(Routes)
-	man.Routes["/"] = Route{
+	man.val.Routes = make(Routes)
+	man.val.Routes["/"] = Route{
 		Folder: "/",
 		Index:  "index.html",
 		Public: false,
@@ -79,7 +79,7 @@ func TestFindIntent(t *testing.T) {
 	found := man.FindIntent("PICK", "io.cozy.files")
 	assert.Nil(t, found)
 
-	man.Intents = []Intent{
+	man.val.Intents = []Intent{
 		{
 			Action: "PICK",
 			Types:  []string{"io.cozy.contacts", "io.cozy.calendars"},
@@ -117,7 +117,7 @@ func TestFindIntent(t *testing.T) {
 	assert.NotNil(t, found)
 	assert.Equal(t, "EDIT", found.Action)
 
-	man.Intents = []Intent{
+	man.val.Intents = []Intent{
 		{
 			Action: "PICK",
 			Href:   "/pick",

--- a/model/app/installer.go
+++ b/model/app/installer.go
@@ -47,7 +47,7 @@ type Installer struct {
 	db       prefixer.Prefixer
 	endState State
 
-	overridenParameters *json.RawMessage
+	overridenParameters map[string]interface{}
 	permissionsAcked    bool
 
 	man     Manifest
@@ -74,7 +74,7 @@ type InstallerOptions struct {
 	// Used to override the "Parameters" field of konnectors during installation.
 	// This modification is useful to allow the parameterization of a konnector
 	// at its installation as we do not have yet a registry up and running.
-	OverridenParameters *json.RawMessage
+	OverridenParameters map[string]interface{}
 }
 
 // Fetcher interface should be implemented by the underlying transport
@@ -520,9 +520,7 @@ func (i *Installer) ReadManifest(state State) (Manifest, error) {
 		i.src.Scheme != "registry")
 	if shouldOverrideParameters {
 		if m, ok := newManifest.(*KonnManifest); ok {
-			// TODO Parameters
-			m.val.Parameters["TODO"] = true
-			// m.Parameters = i.overridenParameters
+			m.val.Parameters = i.overridenParameters
 		}
 	}
 

--- a/model/app/installer.go
+++ b/model/app/installer.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/appfs"
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/hooks"
 	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/cozy/cozy-stack/pkg/prefixer"
@@ -208,9 +209,14 @@ func initManifest(db prefixer.Prefixer, opts *InstallerOptions) (man Manifest, e
 			}
 		case consts.KonnectorType:
 			man = &KonnManifest{
-				DocID:   consts.Konnectors + "/" + slug,
-				DocSlug: slug,
+				doc: &couchdb.JSONDoc{
+					Type: consts.Konnectors,
+					M: map[string]interface{}{
+						"_id": consts.Konnectors + "/" + slug,
+					},
+				},
 			}
+			man.SetSlug(slug)
 		}
 	} else {
 		man, err = GetBySlug(db, slug, opts.Type)
@@ -510,7 +516,9 @@ func (i *Installer) ReadManifest(state State) (Manifest, error) {
 		i.src.Scheme != "registry")
 	if shouldOverrideParameters {
 		if m, ok := newManifest.(*KonnManifest); ok {
-			m.Parameters = i.overridenParameters
+			// TODO Parameters
+			m.val.Parameters["TODO"] = true
+			// m.Parameters = i.overridenParameters
 		}
 	}
 

--- a/model/app/installer.go
+++ b/model/app/installer.go
@@ -204,8 +204,12 @@ func initManifest(db prefixer.Prefixer, opts *InstallerOptions) (man Manifest, e
 		switch opts.Type {
 		case consts.WebappType:
 			man = &WebappManifest{
-				DocID:   consts.Apps + "/" + slug,
-				DocSlug: slug,
+				doc: &couchdb.JSONDoc{
+					Type: consts.Apps,
+					M: map[string]interface{}{
+						"_id": consts.Apps + "/" + slug,
+					},
+				},
 			}
 		case consts.KonnectorType:
 			man = &KonnManifest{
@@ -216,8 +220,8 @@ func initManifest(db prefixer.Prefixer, opts *InstallerOptions) (man Manifest, e
 					},
 				},
 			}
-			man.SetSlug(slug)
 		}
+		man.SetSlug(slug)
 	} else {
 		man, err = GetBySlug(db, slug, opts.Type)
 		if err != nil {
@@ -442,7 +446,7 @@ func (i *Installer) update() error {
 		i.man.SetState(i.endState)
 	} else {
 		if i.man.AppType() == consts.WebappType {
-			i.man.(*WebappManifest).oldServices = i.man.(*WebappManifest).Services
+			i.man.(*WebappManifest).oldServices = i.man.(*WebappManifest).val.Services
 		}
 		i.man.SetSource(i.src)
 		if availableVersion != "" {

--- a/model/app/installer_webapp_test.go
+++ b/model/app/installer_webapp_test.go
@@ -306,8 +306,8 @@ func TestWebappInstallWithUpgrade(t *testing.T) {
 	version1 := man.Version()
 
 	manWebapp := man.(*app.WebappManifest)
-	if assert.NotNil(t, manWebapp.Services["service1"]) {
-		service1 := manWebapp.Services["service1"]
+	if assert.NotNil(t, manWebapp.Services()["service1"]) {
+		service1 := manWebapp.Services()["service1"]
 		assert.Equal(t, "/services/service1.js", service1.File)
 		assert.Equal(t, "@cron 0 0 0 * * *", service1.TriggerOptions)
 		assert.Equal(t, "node", service1.Type)
@@ -364,7 +364,7 @@ func TestWebappInstallWithUpgrade(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, ok, "The manifest has the right version")
 	manWebapp = man.(*app.WebappManifest)
-	assert.Nil(t, manWebapp.Services["service1"])
+	assert.Nil(t, manWebapp.Services()["service1"])
 }
 
 func TestWebappInstallAndUpgradeWithBranch(t *testing.T) {

--- a/model/app/konnector.go
+++ b/model/app/konnector.go
@@ -181,6 +181,7 @@ func (m *KonnManifest) MarshalJSON() ([]byte, error) {
 	} else {
 		m.doc.M["available_version"] = m.val.AvailableVersion
 	}
+	m.doc.M["checksum"] = m.val.Checksum
 	if m.val.Parameters == nil {
 		delete(m.doc.M, "parameters")
 	} else {
@@ -193,6 +194,8 @@ func (m *KonnManifest) MarshalJSON() ([]byte, error) {
 	} else {
 		m.doc.M["error"] = m.val.Err
 	}
+	// XXX: keep the weird UnmarshalJSON of permission.Set
+	m.doc.M["permissions"] = m.val.Permissions
 	return json.Marshal(m.doc)
 }
 

--- a/model/app/webapp.go
+++ b/model/app/webapp.go
@@ -69,6 +69,11 @@ type Terms struct {
 	Version string `json:"version"`
 }
 
+// Locales is used for the translations of the application name.
+type Locales map[string]struct {
+	Name string `json:"name"`
+}
+
 // WebappManifest contains all the informations associated with an installed web
 // application.
 type WebappManifest struct {
@@ -99,6 +104,7 @@ type WebappManifest struct {
 		Intents       []Intent       `json:"intents"`
 		Routes        Routes         `json:"routes"`
 		Services      Services       `json:"services"`
+		Locales       Locales        `json:"locales"`
 		Notifications Notifications  `json:"notifications"`
 	}
 
@@ -222,17 +228,11 @@ func (m *WebappManifest) Fetch(field string) []string {
 
 // NameLocalized returns the name of the app in the given locale
 func (m *WebappManifest) NameLocalized(locale string) string {
-	// TODO localized name
-	// if m.Locales != nil && locale != "" {
-	// 	var locales map[string]struct {
-	// 		Name string `json:"name"`
-	// 	}
-	// 	if err := json.Unmarshal(*m.Locales, &locales); err == nil {
-	// 		if v, ok := locales[locale]; ok && v.Name != "" {
-	// 			return v.Name
-	// 		}
-	// 	}
-	// }
+	if m.val.Locales != nil && locale != "" {
+		if v, ok := m.val.Locales[locale]; ok && v.Name != "" {
+			return v.Name
+		}
+	}
 	return m.val.Name
 }
 
@@ -247,6 +247,7 @@ func (m *WebappManifest) MarshalJSON() ([]byte, error) {
 	} else {
 		m.doc.M["available_version"] = m.val.AvailableVersion
 	}
+	m.doc.M["checksum"] = m.val.Checksum
 	m.doc.M["created_at"] = m.val.CreatedAt
 	m.doc.M["updated_at"] = m.val.UpdatedAt
 	if m.val.Err == "" {
@@ -254,6 +255,8 @@ func (m *WebappManifest) MarshalJSON() ([]byte, error) {
 	} else {
 		m.doc.M["error"] = m.val.Err
 	}
+	// XXX: keep the weird UnmarshalJSON of permission.Set
+	m.doc.M["permissions"] = m.val.Permissions
 	return json.Marshal(m.doc)
 }
 

--- a/model/app/webapp.go
+++ b/model/app/webapp.go
@@ -202,6 +202,9 @@ func (m *WebappManifest) State() State { return m.DocState }
 // LastUpdate is part of the Manifest interface
 func (m *WebappManifest) LastUpdate() time.Time { return m.UpdatedAt }
 
+// SetSlug is part of the Manifest interface
+func (m *WebappManifest) SetSlug(slug string) { m.DocSlug = slug }
+
 // SetState is part of the Manifest interface
 func (m *WebappManifest) SetState(state State) { m.DocState = state }
 

--- a/model/instance/instance_test.go
+++ b/model/instance/instance_test.go
@@ -4,10 +4,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cozy/cozy-stack/model/app"
 	"github.com/cozy/cozy-stack/model/instance"
 	"github.com/cozy/cozy-stack/pkg/config/config"
-	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/crypto"
 	"github.com/stretchr/testify/assert"
 	jwt "gopkg.in/dgrijalva/jwt-go.v3"
@@ -31,16 +29,12 @@ func TestSubdomain(t *testing.T) {
 }
 
 func TestBuildAppToken(t *testing.T) {
-	manifest := &app.WebappManifest{
-		DocID:   consts.Apps + "/my-app",
-		DocSlug: "my-app",
-	}
 	inst := &instance.Instance{
 		Domain:     "test-ctx-token.example.com",
 		SessSecret: crypto.GenerateRandomBytes(64),
 	}
 
-	tokenString := inst.BuildAppToken(manifest.Slug(), "sessionid")
+	tokenString := inst.BuildAppToken("my-app", "sessionid")
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
 		_, ok := token.Method.(*jwt.SigningMethodHMAC)
 		assert.True(t, ok, "The signing method should be HMAC")

--- a/model/instance/lifecycle/destroy.go
+++ b/model/instance/lifecycle/destroy.go
@@ -112,7 +112,7 @@ func deleteAccounts(inst *instance.Instance) error {
 		entry := account.CleanEntry{
 			Account:          acc,
 			Triggers:         nil, // We don't care, the triggers will all be deleted a bit later
-			ManifestOnDelete: man.OnDeleteAccount != "",
+			ManifestOnDelete: man.OnDeleteAccount() != "",
 			Slug:             slug,
 		}
 		toClean = append(toClean, entry)

--- a/model/intent/intents.go
+++ b/model/intent/intents.go
@@ -218,7 +218,7 @@ func (in *Intent) FillAvailableWebapps(inst *instance.Instance) error {
 	for _, manif := range lastVersions {
 		if intent := manif.FindIntent(in.Action, in.Type); intent != nil {
 			availableApp := AvailableApp{
-				Name: manif.Name,
+				Name: manif.Name(),
 				Slug: manif.Slug(),
 			}
 			in.AvailableApps = append(in.AvailableApps, availableApp)

--- a/model/intent/intents_test.go
+++ b/model/intent/intents_test.go
@@ -28,32 +28,38 @@ func TestGenerateHref(t *testing.T) {
 }
 
 func TestFillServices(t *testing.T) {
-	files := &app.WebappManifest{
-		DocID:   consts.Apps + "/files",
-		DocSlug: "files",
-		Intents: []app.Intent{
-			{
-				Action: "PICK",
-				Types:  []string{"io.cozy.files", "image/gif"},
-				Href:   "/pick",
+	files := &couchdb.JSONDoc{
+		Type: consts.Apps,
+		M: map[string]interface{}{
+			"_id":  consts.Apps + "/files",
+			"slug": "files",
+			"intents": []app.Intent{
+				{
+					Action: "PICK",
+					Types:  []string{"io.cozy.files", "image/gif"},
+					Href:   "/pick",
+				},
 			},
 		},
 	}
 	err := couchdb.CreateNamedDoc(ins, files)
 	assert.NoError(t, err)
-	photos := &app.WebappManifest{
-		DocID:   consts.Apps + "/photos",
-		DocSlug: "photos",
-		Intents: []app.Intent{
-			{
-				Action: "PICK",
-				Types:  []string{"image/*"},
-				Href:   "/picker",
-			},
-			{
-				Action: "VIEW",
-				Types:  []string{"io.cozy.files"},
-				Href:   "/viewer",
+	photos := &couchdb.JSONDoc{
+		Type: consts.Apps,
+		M: map[string]interface{}{
+			"_id":  consts.Apps + "/photos",
+			"slug": "photos",
+			"intents": []app.Intent{
+				{
+					Action: "PICK",
+					Types:  []string{"image/*"},
+					Href:   "/picker",
+				},
+				{
+					Action: "VIEW",
+					Types:  []string{"io.cozy.files"},
+					Href:   "/viewer",
+				},
 			},
 		},
 	}

--- a/model/move/importer.go
+++ b/model/move/importer.go
@@ -269,7 +269,7 @@ func (im *importer) importAccount(zf *zip.File) error {
 		im.installApp(consts.Konnectors + "/" + slug)
 		man, err = app.GetKonnectorBySlug(im.inst, slug)
 	}
-	if err != nil || man.OnDeleteAccount != "" {
+	if err != nil || man.OnDeleteAccount() != "" {
 		im.servicesInError[slug] = true
 		return nil
 	}

--- a/model/notification/center/notification_center.go
+++ b/model/notification/center/notification_center.go
@@ -131,11 +131,12 @@ func Push(inst *instance.Instance, perm *permission.Permission, n *notification.
 		if err != nil {
 			return err
 		}
-		if m.Notifications == nil {
+		notifications := m.Notifications()
+		if notifications == nil {
 			return ErrNoCategory
 		}
 		var ok bool
-		p, ok = m.Notifications[n.Category]
+		p, ok = notifications[n.Category]
 		if !ok {
 			return ErrCategoryNotFound
 		}

--- a/model/notification/center/notification_center.go
+++ b/model/notification/center/notification_center.go
@@ -98,10 +98,11 @@ func Push(inst *instance.Instance, perm *permission.Permission, n *notification.
 			if err != nil {
 				return err
 			}
-			if m.Notifications == nil {
+			notifications := m.Notifications()
+			if notifications == nil {
 				return ErrNoCategory
 			}
-			p, ok = m.Notifications[n.Category]
+			p, ok = notifications[n.Category]
 		} else if c.Notifications != nil {
 			p, ok = c.Notifications[n.Category]
 		}
@@ -115,11 +116,12 @@ func Push(inst *instance.Instance, perm *permission.Permission, n *notification.
 		if err != nil {
 			return err
 		}
-		if m.Notifications == nil {
+		notifications := m.Notifications()
+		if notifications == nil {
 			return ErrNoCategory
 		}
 		var ok bool
-		p, ok = m.Notifications[n.Category]
+		p, ok = notifications[n.Category]
 		if !ok {
 			return ErrCategoryNotFound
 		}

--- a/web/apps/apps.go
+++ b/web/apps/apps.go
@@ -59,7 +59,7 @@ func (man *apiApp) Links() *jsonapi.LinksList {
 		}
 	case (*app.KonnManifest):
 		route = "/konnectors/"
-		if a.Icon != "" {
+		if a.Icon() != "" {
 			links.Icon = "/konnectors/" + a.Slug() + "/icon/" + a.Version()
 		}
 		links.Perms = "/permissions/konnectors/" + a.Slug()
@@ -333,7 +333,7 @@ func deleteKonnectorWithAccounts(instance *instance.Instance, man *app.KonnManif
 
 		slug := man.Slug()
 		for i := range toDelete {
-			toDelete[i].ManifestOnDelete = man.OnDeleteAccount != ""
+			toDelete[i].ManifestOnDelete = man.OnDeleteAccount() != ""
 			toDelete[i].Slug = slug
 		}
 
@@ -531,7 +531,7 @@ func iconHandler(appType consts.AppType) echo.HandlerFunc {
 			filepath = path.Join("/", a.(*app.WebappManifest).Icon)
 			fs = app.AppsFileServer(instance)
 		case consts.KonnectorType:
-			filepath = path.Join("/", a.(*app.KonnManifest).Icon)
+			filepath = path.Join("/", a.(*app.KonnManifest).Icon())
 			fs = app.KonnectorsFileServer(instance)
 		}
 

--- a/web/apps/apps.go
+++ b/web/apps/apps.go
@@ -50,7 +50,7 @@ func (man *apiApp) Links() *jsonapi.LinksList {
 	switch a := man.Manifest.(type) {
 	case (*app.WebappManifest):
 		route = "/apps/"
-		if a.Icon != "" {
+		if a.Icon() != "" {
 			links.Icon = "/apps/" + a.Slug() + "/icon/" + a.Version()
 		}
 		if (a.State() == app.Ready || a.State() == app.Installed) &&
@@ -528,7 +528,7 @@ func iconHandler(appType consts.AppType) echo.HandlerFunc {
 		var filepath string
 		switch appType {
 		case consts.WebappType:
-			filepath = path.Join("/", a.(*app.WebappManifest).Icon)
+			filepath = path.Join("/", a.(*app.WebappManifest).Icon())
 			fs = app.AppsFileServer(instance)
 		case consts.KonnectorType:
 			filepath = path.Join("/", a.(*app.KonnManifest).Icon())

--- a/web/apps/apps.go
+++ b/web/apps/apps.go
@@ -115,13 +115,11 @@ func installHandler(installerType consts.AppType) echo.HandlerFunc {
 			return err
 		}
 
-		var overridenParameters *json.RawMessage
+		var overridenParameters map[string]interface{}
 		if p := c.QueryParam("Parameters"); p != "" {
-			var v json.RawMessage
-			if err := json.Unmarshal([]byte(p), &v); err != nil {
+			if err := json.Unmarshal([]byte(p), &overridenParameters); err != nil {
 				return echo.NewHTTPError(http.StatusBadRequest)
 			}
-			overridenParameters = &v
 		}
 
 		var w http.ResponseWriter
@@ -170,13 +168,11 @@ func updateHandler(installerType consts.AppType) echo.HandlerFunc {
 			return err
 		}
 
-		var overridenParameters *json.RawMessage
+		var overridenParameters map[string]interface{}
 		if p := c.QueryParam("Parameters"); p != "" {
-			var v json.RawMessage
-			if err := json.Unmarshal([]byte(p), &v); err != nil {
+			if err := json.Unmarshal([]byte(p), &overridenParameters); err != nil {
 				return echo.NewHTTPError(http.StatusBadRequest)
 			}
-			overridenParameters = &v
 		}
 
 		var w http.ResponseWriter

--- a/web/apps/apps_test.go
+++ b/web/apps/apps_test.go
@@ -46,7 +46,6 @@ const slug = "mini"
 var ts *httptest.Server
 var testInstance *instance.Instance
 var token string
-var manifest *apps.WebappManifest
 
 var jar http.CookieJar
 var client *http.Client
@@ -71,35 +70,38 @@ func createFile(dir, filename, content string) error {
 }
 
 func installMiniApp() error {
-	manifest = &apps.WebappManifest{
-		DocID:     consts.Apps + "/" + slug,
-		Name:      "Mini",
-		Icon:      "icon.svg",
-		DocSlug:   slug,
-		DocSource: "git://github.com/cozy/mini.git",
-		DocState:  apps.Ready,
-		Intents: []apps.Intent{
-			{
-				Action: "PICK",
-				Types:  []string{"io.cozy.foos"},
-				Href:   "/foo",
+	manifest := &couchdb.JSONDoc{
+		Type: consts.Apps,
+		M: map[string]interface{}{
+			"_id":    consts.Apps + "/" + slug,
+			"name":   "Mini",
+			"icon":   "icon.svg",
+			"slug":   slug,
+			"source": "git://github.com/cozy/mini.git",
+			"state":  apps.Ready,
+			"intents": []apps.Intent{
+				{
+					Action: "PICK",
+					Types:  []string{"io.cozy.foos"},
+					Href:   "/foo",
+				},
 			},
-		},
-		Routes: apps.Routes{
-			"/foo": apps.Route{
-				Folder: "/",
-				Index:  "index.html",
-				Public: false,
-			},
-			"/bar": apps.Route{
-				Folder: "/bar",
-				Index:  "index.html",
-				Public: false,
-			},
-			"/public": apps.Route{
-				Folder: "/public",
-				Index:  "index.html",
-				Public: true,
+			"routes": apps.Routes{
+				"/foo": apps.Route{
+					Folder: "/",
+					Index:  "index.html",
+					Public: false,
+				},
+				"/bar": apps.Route{
+					Folder: "/bar",
+					Index:  "index.html",
+					Public: false,
+				},
+				"/public": apps.Route{
+					Folder: "/public",
+					Index:  "index.html",
+					Public: true,
+				},
 			},
 		},
 	}

--- a/web/apps/serve.go
+++ b/web/apps/serve.go
@@ -394,15 +394,15 @@ func (s serveParams) AppName() string {
 }
 
 func (s serveParams) AppEditor() string {
-	return s.webapp.Editor
+	return s.webapp.Editor()
 }
 
 func (s serveParams) AppNamePrefix() string {
-	return s.webapp.NamePrefix
+	return s.webapp.NamePrefix()
 }
 
 func (s serveParams) IconPath() string {
-	return s.webapp.Icon
+	return s.webapp.Icon()
 }
 
 func (s serveParams) Capabilities() (string, error) {

--- a/web/auth/auth_test.go
+++ b/web/auth/auth_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cozy/cozy-stack/model/app"
 	"github.com/cozy/cozy-stack/model/instance"
 	"github.com/cozy/cozy-stack/model/instance/lifecycle"
 	"github.com/cozy/cozy-stack/model/oauth"
@@ -1269,12 +1268,8 @@ func TestLogoutNoToken(t *testing.T) {
 }
 
 func TestLogoutSuccess(t *testing.T) {
-	a := app.WebappManifest{
-		DocID:   consts.Apps + "/home",
-		DocSlug: "home",
-	}
-	token := testInstance.BuildAppToken(a.Slug(), getSessionID(jar.Cookies(nil)))
-	_, err := permission.CreateWebappSet(testInstance, a.Slug(), permission.Set{}, "1.0.0")
+	token := testInstance.BuildAppToken("home", getSessionID(jar.Cookies(nil)))
+	_, err := permission.CreateWebappSet(testInstance, "home", permission.Set{}, "1.0.0")
 	assert.NoError(t, err)
 	req, _ := http.NewRequest("DELETE", ts.URL+"/auth/login", nil)
 	req.Host = domain
@@ -1333,12 +1328,8 @@ func TestLogoutOthers(t *testing.T) {
 	cookies2 := res2.Cookies()
 	assert.Len(t, cookies2, 2)
 
-	a := app.WebappManifest{
-		DocID:   consts.Apps + "/home",
-		DocSlug: "home",
-	}
-	token := testInstance.BuildAppToken(a.Slug(), getSessionID(cookies1))
-	_, err = permission.CreateWebappSet(testInstance, a.Slug(), permission.Set{}, "1.0.0")
+	token := testInstance.BuildAppToken("home", getSessionID(cookies1))
+	_, err = permission.CreateWebappSet(testInstance, "home", permission.Set{}, "1.0.0")
 	assert.NoError(t, err)
 
 	reqLogout1, _ := http.NewRequest("DELETE", ts.URL+"/auth/login/others", nil)

--- a/web/instances/fixers.go
+++ b/web/instances/fixers.go
@@ -217,7 +217,7 @@ func orphanAccountFixer(c echo.Context) error {
 		return err
 	}
 
-	var konnectors []*app.KonnManifest
+	var konnectors []*couchdb.JSONDoc
 	err = couchdb.GetAllDocs(inst, consts.Konnectors, nil, &konnectors)
 	if err != nil {
 		return err
@@ -230,7 +230,7 @@ func orphanAccountFixer(c echo.Context) error {
 		}
 		found := false
 		for _, konn := range konnectors {
-			if konn.Slug() == acc.AccountType {
+			if konn.M["slug"] == acc.AccountType {
 				found = true
 				break
 			}

--- a/web/instances/instances.go
+++ b/web/instances/instances.go
@@ -407,12 +407,11 @@ func appVersion(c echo.Context) error {
 	version := c.Param("version")
 
 	var instancesAppVersion []string
-	var doc app.WebappManifest
 
 	for _, instance := range instances {
-		err := couchdb.GetDoc(instance, consts.Apps, consts.Apps+"/"+appSlug, &doc)
+		app, err := app.GetBySlug(instance, appSlug, consts.WebappType)
 		if err == nil {
-			if doc.Version() == version {
+			if app.Version() == version {
 				instancesAppVersion = append(instancesAppVersion, instance.Domain)
 			}
 		}

--- a/web/intents/intents_test.go
+++ b/web/intents/intents_test.go
@@ -124,31 +124,35 @@ func TestMain(m *testing.M) {
 	})
 	_, token = setup.GetTestClient(consts.Settings)
 
-	webapp := &app.WebappManifest{
-		DocID:          consts.Apps + "/app",
-		DocSlug:        "app",
-		DocPermissions: permission.Set{},
+	webapp := &couchdb.JSONDoc{
+		Type: consts.Apps,
+		M: map[string]interface{}{
+			"_id":  consts.Apps + "/app",
+			"slug": "app",
+		},
 	}
 	err := couchdb.CreateNamedDoc(ins, webapp)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	appPerms, err = permission.CreateWebappSet(ins, webapp.Slug(), webapp.Permissions(), "1.0.0")
+	appPerms, err = permission.CreateWebappSet(ins, "app", permission.Set{}, "1.0.0")
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	appToken = ins.BuildAppToken(webapp.Slug(), "")
-	files := &app.WebappManifest{
-		DocID:          consts.Apps + "/files",
-		DocSlug:        "files",
-		DocPermissions: permission.Set{},
-		Intents: []app.Intent{
-			{
-				Action: "PICK",
-				Types:  []string{"io.cozy.files", "image/gif"},
-				Href:   "/pick",
+	appToken = ins.BuildAppToken("app", "")
+	files := &couchdb.JSONDoc{
+		Type: consts.Apps,
+		M: map[string]interface{}{
+			"_id":  consts.Apps + "/files",
+			"slug": "files",
+			"intents": []app.Intent{
+				{
+					Action: "PICK",
+					Types:  []string{"io.cozy.files", "image/gif"},
+					Href:   "/pick",
+				},
 			},
 		},
 	}
@@ -156,11 +160,11 @@ func TestMain(m *testing.M) {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	if _, err := permission.CreateWebappSet(ins, files.Slug(), files.Permissions(), "1.0.0"); err != nil {
+	if _, err := permission.CreateWebappSet(ins, "files", permission.Set{}, "1.0.0"); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	filesToken = ins.BuildAppToken(files.Slug(), "")
+	filesToken = ins.BuildAppToken("files", "")
 
 	ts = setup.GetTestServer("/intents", Routes)
 	ts.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cozy/cozy-stack/model/app"
 	"github.com/cozy/cozy-stack/model/contact"
 	"github.com/cozy/cozy-stack/model/instance"
 	"github.com/cozy/cozy-stack/model/instance/lifecycle"
@@ -1262,16 +1261,19 @@ func generateAppToken(inst *instance.Instance, slug, doctype string) string {
 	if err != nil {
 		return ""
 	}
-	manifest := &app.WebappManifest{
-		DocID:          consts.Apps + "/" + slug,
-		DocSlug:        slug,
-		DocPermissions: rules,
+	manifest := &couchdb.JSONDoc{
+		Type: consts.Apps,
+		M: map[string]interface{}{
+			"_id":         consts.Apps + "/" + slug,
+			"slug":        slug,
+			"permissions": rules,
+		},
 	}
 	err = couchdb.CreateNamedDocWithDB(inst, manifest)
 	if err != nil {
 		return ""
 	}
-	return inst.BuildAppToken(manifest.Slug(), "")
+	return inst.BuildAppToken(slug, "")
 }
 
 func noRedirect(*http.Request, []*http.Request) error {

--- a/worker/exec/service.go
+++ b/worker/exec/service.go
@@ -71,10 +71,11 @@ func (w *serviceWorker) PrepareWorkDir(ctx *job.WorkerContext, i *instance.Insta
 
 	var service *app.Service
 	var ok bool
+	services := man.Services()
 	if name != "" {
-		service, ok = man.Services[name]
+		service, ok = services[name]
 	} else {
-		for _, s := range man.Services {
+		for _, s := range services {
 			if s.File == opts.File {
 				service, ok = s, true
 				break

--- a/worker/migrations/migrate-accounts-to-organisation.go
+++ b/worker/migrations/migrate-accounts-to-organisation.go
@@ -1,7 +1,6 @@
 package migrations
 
 import (
-	"encoding/json"
 	"strings"
 
 	"github.com/cozy/cozy-stack/model/app"
@@ -61,7 +60,7 @@ func buildCipher(orgKey []byte, manifest *app.KonnManifest, account couchdb.JSON
 	uris := []bitwarden.LoginURI{u}
 
 	ivName := crypto.GenerateRandomBytes(16)
-	encName, err := crypto.EncryptWithAES256HMAC(key, hmac, []byte(manifest.Name), ivName)
+	encName, err := crypto.EncryptWithAES256HMAC(key, hmac, []byte(manifest.Name()), ivName)
 	if err != nil {
 		return nil, err
 	}
@@ -130,12 +129,9 @@ func buildCipher(orgKey []byte, manifest *app.KonnManifest, account couchdb.JSON
 }
 
 func getCipherLinkFromManifest(manifest *app.KonnManifest) (string, error) {
-	var link string
-	if manifest.VendorLink == nil {
+	link, ok := manifest.VendorLink().(string)
+	if !ok {
 		return "", nil
-	}
-	if err := json.Unmarshal(*manifest.VendorLink, &link); err != nil {
-		return "", err
 	}
 	link = strings.Trim(link, "'")
 	return link, nil


### PR DESCRIPTION
The apps registry allow developers to add custom fields to the manifest of applications. But, it worked only if the fields were defined in the stack: the stack was doing unserialize to a Go struct + reserialize to JSON, and unmapped fields were lost in the process. This PR fixes this issue but unserializing twice the JSON: one time to a Go struct, and one time to a `map`. The Go struct is used for simple manipulation in Go code. The `map` is used for serialization to JSON (and is updated with the changes from the Go struct).

Fix #3103