### PR TITLE
Fix resharing ciphers with the same member

### DIFF
--- a/docs/sharing-design.md
+++ b/docs/sharing-design.md
@@ -236,6 +236,28 @@ able to prevent CouchDB conflicts for `io.cozy.files` documents and enforce
 [reconciliation](#conflict-resolution) when possible. We also detail what is
 done when [no reconciliation](#conflict-with-no-reconciliation) can be made.
 
+### Id transformations
+
+Initially, we were using the CouchDB protocol revision as described above, but
+we have introduced a transformation of the identifiers for io.cozy.files, and
+later, we have generalized this transformation for all doctypes. It means that
+Alice and Bob have the same shared documents, but not with the same
+identifiers. The identifiers are transformed with a XOR, using a key exchanged
+when the recipient accepts the sharing.
+
+In practice, it is useful when someone is revoked from a sharing, and accepts
+later the sharing again. It allows to avoid reusing the same identifiers for
+documents exchanged on the first sharing and on the second sharing, which can
+create some weird situations. For example, a cipher is shared between Alice and
+Bob when its revision is 3-aaa. Later, when the sharing is revoked, the
+document will be deleted on Bob's instance (the ciphers are deleted on
+recipients when a sharing is revoked), which creates a revision 4-bbb. If Alice
+invites Bob again, and Bob accepts, the replication will sent the document from
+Alice's instance to Bob's instance with revision 3-aaa. CouchDB will say OK,
+but the revision 4-bbb will still be seen as a successor of 3-aaa, and for
+CouchDB, the document will still be deleted. Using different IDs for the first
+and second sharing fixes this issue.
+
 ## Files and folders
 
 ### Why are they special?

--- a/model/sharing/files.go
+++ b/model/sharing/files.go
@@ -108,6 +108,7 @@ func (s *Sharing) SortFilesToSent(files []map[string]interface{}) {
 // to another cozy instance:
 // - its identifier is XORed
 // - its dir_id is XORed or removed
+// - the referenced_by are XORed or removed
 // - the path is removed (directory only)
 //
 // ruleIndexes is a map of "doctype-docid" -> rule index
@@ -133,7 +134,8 @@ func (s *Sharing) TransformFileToSent(doc map[string]interface{}, xorKey []byte,
 					v := r["type"].(string) + "/" + r["id"].(string)
 					for _, val := range rule.Values {
 						if val == v {
-							kept = append(kept, ref)
+							r["id"] = XorID(r["id"].(string), xorKey)
+							kept = append(kept, r)
 							break
 						}
 					}

--- a/model/sharing/shared.go
+++ b/model/sharing/shared.go
@@ -315,8 +315,9 @@ func UpdateShared(inst *instance.Instance, msg TrackMessage, evt TrackEvent) err
 	}
 
 	if evt.Verb == "DELETED" || isTrashed(evt.Doc) {
-		// Ignore the first revision for new file (trashed=true)
-		if evt.Doc.Type == consts.Files && ref.Rev() == "" {
+		// Do not create a shared doc for a deleted document: it's useless and
+		// it can have some side effects!
+		if ref.Rev() == "" {
 			return nil
 		}
 		ref.Infos[msg.SharingID] = SharedInfo{

--- a/tests/integration/lib/sharing.rb
+++ b/tests/integration/lib/sharing.rb
@@ -2,6 +2,38 @@ class Sharing
   attr_accessor :couch_id, :couch_rev, :rules, :members
   attr_reader :description, :app_slug
 
+  def self.make_xor_key
+    random = Random.new.bytes(8)
+    res = []
+    random.each_byte do |c|
+      res << (c & 0xf)
+      res << (c >> 4)
+    end
+    res
+  end
+
+  def self.xor_id(id, key)
+    l = key.length
+    buf = id.bytes.to_a
+    buf.each_with_index do |c, i|
+      if 48 <= c && c <= 57
+        c = (c - 48) ^ key[i%l].ord
+      elsif 97 <= c && c <= 102
+        c = (c -  87) ^ key[i%l].ord
+      elsif 65 <= c && c <= 70
+        c = (c - 55) ^ key[i%l].ord
+      else
+        next
+      end
+      if c < 10
+        buf[i] = c + 48
+      else
+        buf[i] = (c - 10) + 97
+      end
+    end
+    buf.pack('c*')
+  end
+
   def self.get_sharing_info(inst, sharing_id, doctype)
     opts = {
       accept: "application/vnd.api+json",

--- a/tests/integration/tests/bitwarden_cli.rb
+++ b/tests/integration/tests/bitwarden_cli.rb
@@ -226,10 +226,10 @@ describe "The bitwarden API of the stack" do
     items = bw3.items
     assert_equal items.length, 1
     assert_equal items.first[:name], "Family card"
-    item_id = items.first[:id]
 
     # Update an item
     shared_item[:name] = "Updated card"
+    item_id = bw.items.find { |i| i[:name] == "Family card" }[:id]
     bw.edit_item item_id, shared_item
 
     # Check that the item is updated on Bob's instance

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -103,7 +103,7 @@ func assertSharingIsCorrectOnSharer(t *testing.T, body io.Reader) {
 	rule := rules[0].(map[string]interface{})
 	assert.Equal(t, rule["title"], "test one")
 	assert.Equal(t, rule["doctype"], iocozytests)
-	assert.Equal(t, rule["values"], []interface{}{"foobar"})
+	assert.Equal(t, rule["values"], []interface{}{"000000"})
 }
 
 func assertInvitationMailWasSent(t *testing.T) string {
@@ -153,7 +153,7 @@ func TestCreateSharingSuccess(t *testing.T) {
 					echo.Map{
 						"title":   "test one",
 						"doctype": iocozytests,
-						"values":  []string{"foobar"},
+						"values":  []string{"000000"},
 						"add":     "sync",
 					},
 				},
@@ -241,7 +241,7 @@ func assertSharingRequestHasBeenCreated(t *testing.T) {
 	rule := s.Rules[0]
 	assert.Equal(t, rule.Title, "test one")
 	assert.Equal(t, rule.DocType, iocozytests)
-	assert.Equal(t, rule.Values, []string{"foobar"})
+	assert.NotEmpty(t, rule.Values)
 }
 
 func assertSharingInfoRequestIsCorrect(t *testing.T, body io.Reader, s1, s2 string) {
@@ -785,13 +785,13 @@ func TestCheckPermissions(t *testing.T) {
 					echo.Map{
 						"title":   "test one",
 						"doctype": iocozytests,
-						"values":  []string{"foobar"},
+						"values":  []string{"000000"},
 						"add":     "sync",
 					},
 					echo.Map{
 						"title":   "test two",
 						"doctype": consts.Contacts,
-						"values":  []string{"foobar"},
+						"values":  []string{"000000"},
 						"add":     "sync",
 					},
 				},


### PR DESCRIPTION
1. Alice has shared a bitwarden organization + ciphers to Bob
2. Bob has accepted this sharing
3. later, Alice has revoked Bob from the sharing
4. later later, Alice shares again this organization with Bob
5. and Bob accepts

With this scenario, the ciphers in the organization weren't synchronized
on Bob's Cozy. It is due to how the CouchDB replication works. For
example, if a cipher was in revision 3-aaa when Alice has shared it to
Bob the first time, a document was created on Bob's instance with this
revision. Later, when the sharing was revoked, this document was
deleted, and CouchDB will do that by creating a revision 4-bbb. On the
second sharing, the same document is sent with revision 3-aaa. CouchDB
will accept the document with this revision, but the revision 4-bbb is
still seen as a successor of 3-aaa, and as such, the document is still
seen as deleted.

To fix this issue, we haven't tried to update the revision numbers
(really hard to do that in a reliable way), but we are using the same
trick as for files: we are doing a transformation of the ID (XOR), and
the key to do that is changed for each sharing member and when the same
member is accepted again.

**TODO:**

- [x] update docs