### PR TITLE
Fix revoke action for a sharing rule

### DIFF
--- a/tests/integration/lib/bitwarden/organization.rb
+++ b/tests/integration/lib/bitwarden/organization.rb
@@ -33,6 +33,17 @@ class Bitwarden
       Organization.new(id: body["Id"], name: body["Name"], key: org_key)
     end
 
+    def self.delete(inst, org_id)
+      body = JSON.generate({ masterPasswordHash: inst.hashed_passphrase })
+      opts = {
+        accept: "application/json",
+        content_type: "application/json",
+        authorization: "Bearer #{inst.token_for doctype}"
+      }
+      url = "http://#{inst.domain}/bitwarden/api/organizations/#{org_id}"
+      RestClient::Request.execute method: :delete, url: url, payload: body, headers: opts
+    end
+
     def self.generate_key
       Random.bytes 64
     end

--- a/tests/integration/lib/rule.rb
+++ b/tests/integration/lib/rule.rb
@@ -65,7 +65,7 @@ class Rule
                   values: [org_id],
                   add: what,
                   update: what,
-                  remove: what
+                  remove: "revoke"
     r2 = Rule.new doctype: Bitwarden::Cipher.doctype,
                   title: "Ciphers",
                   values: [org_id],


### PR DESCRIPTION
When a sharing rule has the revoke action, and a document that matches
this rule is removed from the sharing, the stack must revoke the
sharing. It is now done by the share-replicate worker.