### PR TITLE
Fix removing a cipher from a shared organization

### DIFF
--- a/model/sharing/rule.go
+++ b/model/sharing/rule.go
@@ -181,7 +181,7 @@ func (r Rule) TriggerArgs() string {
 	if r.Update == ActionRuleSync || r.Update == ActionRulePush {
 		verbs = append(verbs, "UPDATED")
 	}
-	if r.Remove == ActionRuleSync || r.Remove == ActionRulePush {
+	if r.Remove == ActionRuleSync || r.Remove == ActionRulePush || r.Remove == ActionRuleRevoke {
 		verbs = append(verbs, "DELETED")
 	}
 	if len(verbs) == 0 {

--- a/model/sharing/rule_test.go
+++ b/model/sharing/rule_test.go
@@ -186,7 +186,7 @@ func TestTriggersArgs(t *testing.T) {
 		Update:  "push",
 		Remove:  "revoke",
 	}
-	expected = "io.cozy.test.foos:CREATED,UPDATED:foo"
+	expected = "io.cozy.test.foos:CREATED,UPDATED,DELETED:foo"
 	assert.Equal(t, expected, r.TriggerArgs())
 
 	r.Local = true

--- a/model/sharing/shared.go
+++ b/model/sharing/shared.go
@@ -337,11 +337,13 @@ func UpdateShared(inst *instance.Instance, msg TrackMessage, evt TrackEvent) err
 	needToUpdateFiles := false
 	removed := false
 	wasRemoved := true
+	ruleIndex := msg.RuleIndex
 	if rule, ok := ref.Infos[msg.SharingID]; ok {
 		wasRemoved = rule.Removed
+		ruleIndex = ref.Infos[msg.SharingID].Rule
 	}
 	ref.Infos[msg.SharingID] = SharedInfo{
-		Rule:    ref.Infos[msg.SharingID].Rule,
+		Rule:    ruleIndex,
 		Binary:  evt.Doc.Type == consts.Files && evt.Doc.Get("type") == consts.FileType,
 		Removed: false,
 	}
@@ -353,7 +355,7 @@ func UpdateShared(inst *instance.Instance, msg TrackMessage, evt TrackEvent) err
 			return nil
 		}
 		ref.Infos[msg.SharingID] = SharedInfo{
-			Rule:    ref.Infos[msg.SharingID].Rule,
+			Rule:    ruleIndex,
 			Removed: true,
 			Binary:  false,
 		}
@@ -371,7 +373,7 @@ func UpdateShared(inst *instance.Instance, msg TrackMessage, evt TrackEvent) err
 				return nil
 			}
 			ref.Infos[msg.SharingID] = SharedInfo{
-				Rule:    ref.Infos[msg.SharingID].Rule,
+				Rule:    ruleIndex,
 				Removed: true,
 				Binary:  false,
 			}
@@ -406,8 +408,7 @@ func UpdateShared(inst *instance.Instance, msg TrackMessage, evt TrackEvent) err
 	// For a directory, we have to update the Removed flag for the files inside
 	// it, as we won't have any events for them.
 	if needToUpdateFiles {
-		ruleIdx := ref.Infos[msg.SharingID].Rule
-		err := updateRemovedForFiles(inst, msg.SharingID, evt.Doc.ID(), ruleIdx, removed)
+		err := updateRemovedForFiles(inst, msg.SharingID, evt.Doc.ID(), ruleIndex, removed)
 		if err != nil {
 			inst.Logger().WithField("nspace", "sharing").
 				Warnf("Error on updateRemovedForFiles for %v: %s", evt, err)

--- a/model/sharing/shared.go
+++ b/model/sharing/shared.go
@@ -325,7 +325,8 @@ func UpdateShared(inst *instance.Instance, msg TrackMessage, evt TrackEvent) err
 	}
 
 	rev := evt.Doc.Rev()
-	if _, ok := ref.Infos[msg.SharingID]; ok {
+	// XXX this optimization only works for files
+	if _, ok := ref.Infos[msg.SharingID]; ok && msg.DocType == consts.Files {
 		if sub, _ := ref.Revisions.Find(rev); sub != nil {
 			return nil
 		}

--- a/tests/integration/lib/bitwarden/cipher.rb
+++ b/tests/integration/lib/bitwarden/cipher.rb
@@ -3,5 +3,37 @@ class Bitwarden
     def self.doctype
       "com.bitwarden.ciphers"
     end
+
+    # Bitwarden CLI doesn't let us remove a cipher from an organization, or
+    # move a cipher from one organization to another. But, we can use the
+    # update method manually.
+    def self.update(inst, item_id, data)
+      opts = {
+        accept: "application/json",
+        content_type: "application/json",
+        authorization: "Bearer #{inst.token_for doctype}"
+      }
+      key = get_symmetric_key(inst)
+      data[:name] = Bitwarden::Organization.encrypt_name(key, data[:name])
+      data[:notes] = Bitwarden::Organization.encrypt_name(key, data[:notes] || "")
+      data[:card].each do |field, value|
+        data[:card][field] = Bitwarden::Organization.encrypt_name(key, value)
+      end if data[:card]
+      data[:organizationId] = nil
+      data[:collectionsIds] = nil
+      body = JSON.generate data
+      res = inst.client["/bitwarden/api/ciphers/#{item_id}"].put body, opts
+      JSON.parse(res.body)
+    end
+
+    def self.get_symmetric_key(inst)
+      opts = {
+        accept: "application/json",
+        authorization: "Bearer #{inst.token_for 'com.bitwarden.profiles'}"
+      }
+      res = inst.client["/bitwarden/api/accounts/profile"].get opts
+      body = JSON.parse(res.body)
+      Bitwarden::Organization.decrypt_symmetric_key(inst, body["Key"])
+    end
   end
 end

--- a/tests/integration/tests/bitwarden_cli.rb
+++ b/tests/integration/tests/bitwarden_cli.rb
@@ -239,8 +239,9 @@ describe "The bitwarden API of the stack" do
     assert_equal items.length, 1
     assert_equal items.first[:name], "Updated card"
 
-    # Delete an item
-    bw.delete_item item_id
+    # Move an item out of the organization
+    Bitwarden::Cipher.update inst, item_id, items.first
+    bw.sync
 
     # Check that the item is deleted on Bob's instance
     sleep 6
@@ -256,7 +257,7 @@ describe "The bitwarden API of the stack" do
       organizationId: org.id,
       collectionIds: [coll_id]
     }
-    bw.create_item shared_item, org.id
+    bw.create_item new_item, org.id
     sleep 6
     Bitwarden::Organization.delete inst, org.id
 


### PR DESCRIPTION
When a cipher is in a shared organization, and is moved to another
organization, the local stack sees an update, but the sharing
replication protocol must delete the cipher for the recipients. It is
done by marking the io.cozy.shared as removed in the share-track worker.
This clue is later interpreted by the worker-replicate that can send the
cipher document as deleted in the replication.