### PR TITLE
Fix refusing a bitwarden contact

### DIFF
--- a/web/bitwarden/contact.go
+++ b/web/bitwarden/contact.go
@@ -55,7 +55,7 @@ func RefuseContact(c echo.Context) error {
 			continue
 		}
 		for i, m := range s.Members {
-			if i != 0 && m.Email == email {
+			if i != 0 && m.Email == email && m.Status == sharing.MemberStatusReady {
 				if err := s.RevokeRecipient(inst, i); err != nil {
 					errm = multierror.Append(errm, err)
 				}


### PR DESCRIPTION
When a user has shared several bitwarden organizations with another
member, the sharings can be in different states for this member:
pending, ready, revoked, etc. For revoking a bitwarden contact, we
should revoke only the sharing with the ready state.

For revoked state, it is already revoked, so no need to do something
more. For pending, we want to let the member the possibility to accept
the sharing and use a new key (so, new fingerprint).