### PR TITLE
Add a route to delete database

### DIFF
--- a/docs/data-system.md
+++ b/docs/data-system.md
@@ -672,3 +672,29 @@ Content-Type: application/json
   "rev": "1-1aa097a2eef904db9b1842342e6c6f50"
 }
 ```
+
+## Delete a database
+
+### Request
+
+```http
+DELETE /data/:type/ HTTP/1.1
+```
+
+```http
+DELETE /data/io.cozy.events/ HTTP/1.1
+```
+
+### Response OK
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+```
+
+```json
+{
+  "ok": true,
+  "deleted": true
+}
+```

--- a/web/data/data.go
+++ b/web/data/data.go
@@ -286,6 +286,26 @@ func DeleteDoc(c echo.Context) error {
 	})
 }
 
+// DeleteDatabase deletes the doctype's database.
+func DeleteDatabase(c echo.Context) error {
+	instance := middlewares.GetInstance(c)
+	doctype := c.Get("doctype").(string)
+
+	if err := permission.CheckWritable(doctype); err != nil {
+		return err
+	}
+	if err := middlewares.AllowWholeType(c, permission.DELETE, doctype); err != nil {
+		return err
+	}
+	if err := couchdb.DeleteDB(instance, doctype); err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, echo.Map{
+		"ok":      true,
+		"deleted": true,
+	})
+}
+
 func defineIndex(c echo.Context) error {
 	instance := middlewares.GetInstance(c)
 	doctype := c.Get("doctype").(string)
@@ -525,4 +545,6 @@ func Routes(router *echo.Group) {
 	group.GET("/_design_docs", getDesignDocs)
 	group.POST("/_design/:designdocid/copy", copyDesignDoc)
 	group.DELETE("/_design/:designdocid", deleteDesignDoc)
+
+	group.DELETE("/", DeleteDatabase)
 }

--- a/web/data/data_test.go
+++ b/web/data/data_test.go
@@ -1135,3 +1135,25 @@ func TestCopyDesignDoc(t *testing.T) {
 	assert.Equal(t, targetID, out["id"].(string))
 	assert.Equal(t, rev, out["rev"].(string))
 }
+
+func TestDeleteDatabase(t *testing.T) {
+	url := ts.URL + "/data/" + Type + "/"
+	req, _ := http.NewRequest("DELETE", url, nil)
+	req.Header.Add("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	out, res, err := doRequest(req, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "200 OK", res.Status)
+	assert.Equal(t, true, out["deleted"].(bool))
+}
+
+func TestDeleteDatabaseNoPermission(t *testing.T) {
+	doctype := "io.cozy.forbidden"
+	url := ts.URL + "/data/" + doctype + "/"
+	req, _ := http.NewRequest("DELETE", url, nil)
+	req.Header.Add("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	_, res, err := doRequest(req, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "403 Forbidden", res.Status)
+}


### PR DESCRIPTION
This might be useful to quickly destroy all database documents,
typically for running tests or performances measures.