### PR TITLE
Fix trigger deletion on konnector uninstall

### DIFF
--- a/web/apps/apps.go
+++ b/web/apps/apps.go
@@ -287,9 +287,9 @@ func findAccountsToDelete(instance *instance.Instance, slug string) ([]account.C
 		if err == nil && msg.Slug == slug && msg.Account != "" {
 			// XXX we can have several triggers for the same account (e.g. cron + webhook)
 			hasEntry := false
-			for _, entry := range toDelete {
+			for i, entry := range toDelete {
 				if entry.Account.ID() == msg.Account {
-					entry.Triggers = append(entry.Triggers, t)
+					toDelete[i].Triggers = append(entry.Triggers, t)
 					hasEntry = true
 					break
 				}


### PR DESCRIPTION
When a konnector is uninstalled, the stack looks at the accounts used by
this konnector, deletes them if the konnector has a on_delete property
in its manifest, and deletes the associated triggers. When there are
several triggers for the same account, only the last one was deleted
because of a bug where the assigned value was lost. This commit fixes
this issue (and I'm surprized that the linter didn't noticed that).