### PR TITLE
Fix instance deletion with a stale account

### DIFF
--- a/model/instance/lifecycle/destroy.go
+++ b/model/instance/lifecycle/destroy.go
@@ -106,6 +106,24 @@ func deleteAccounts(inst *instance.Instance) error {
 			continue
 		}
 		man, err := app.GetKonnectorBySlug(inst, slug)
+		if err == app.ErrNotFound {
+			copier := app.Copier(consts.KonnectorType, inst)
+			installer, erri := app.NewInstaller(inst, copier,
+				&app.InstallerOptions{
+					Operation:  app.Install,
+					Type:       consts.KonnectorType,
+					SourceURL:  "registry://" + slug + "/stable",
+					Slug:       slug,
+					Registries: inst.Registries(),
+				},
+			)
+			if erri == nil {
+				if appManifest, erri := installer.RunSync(); erri == nil {
+					man = appManifest.(*app.KonnManifest)
+					err = nil
+				}
+			}
+		}
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
When an account still exists but its konnector is missing, the instance
deletion fails (because we can't look at the on_delete field when the
konnector is not installed). We are now trying to reinstall the
konnector in that case, which should help to limit the number of
problematic cases.