### PR TITLE
feat: Add ReadOnly property to organization.GetCollections()'s return

### DIFF
--- a/web/bitwarden/bitwarden_test.go
+++ b/web/bitwarden/bitwarden_test.go
@@ -953,6 +953,7 @@ func TestListCollections(t *testing.T) {
 	assert.Equal(t, "2.rrpSDDODsWZqL7EhLVsu/Q==|OSuh+MmmR89ppdb/A7KxBg==|kofpAocL2G4a3P1C2R1U+i9hWbhfKfsPKM6kfoyCg/M=", coll["Name"])
 	assert.Equal(t, "collection", coll["Object"])
 	assert.Equal(t, orgaID, coll["OrganizationId"])
+	assert.Equal(t, false, coll["ReadOnly"])
 }
 
 func TestSyncOrganizationAndCollection(t *testing.T) {

--- a/web/bitwarden/sync.go
+++ b/web/bitwarden/sync.go
@@ -70,28 +70,12 @@ func newProfileResponse(inst *instance.Instance, setting *settings.Settings) (*p
 
 // https://github.com/bitwarden/jslib/blob/master/common/src/models/response/syncResponse.ts
 type syncResponse struct {
-	Profile     *profileResponse             `json:"Profile"`
-	Folders     []*folderResponse            `json:"Folders"`
-	Ciphers     []*cipherResponse            `json:"Ciphers"`
-	Collections []*collectionDetailsResponse `json:"Collections"`
-	Domains     *domainsResponse             `json:"Domains"`
-	Object      string                       `json:"Object"`
-}
-
-// https://github.com/bitwarden/jslib/blob/master/common/src/models/response/collectionResponse.ts
-type collectionDetailsResponse struct {
-	*collectionResponse
-	ReadOnly bool `json:"ReadOnly"`
-}
-
-func newCollectionDetailsResponse(
-	inst *instance.Instance,
-	org *bitwarden.Organization,
-	coll *bitwarden.Collection,
-) *collectionDetailsResponse {
-	readOnly := org.Members[inst.Domain].ReadOnly
-	collectionResponse := newCollectionResponse(coll, org.ID())
-	return &collectionDetailsResponse{collectionResponse, readOnly}
+	Profile     *profileResponse      `json:"Profile"`
+	Folders     []*folderResponse     `json:"Folders"`
+	Ciphers     []*cipherResponse     `json:"Ciphers"`
+	Collections []*collectionResponse `json:"Collections"`
+	Domains     *domainsResponse      `json:"Domains"`
+	Object      string                `json:"Object"`
 }
 
 func newSyncResponse(
@@ -111,9 +95,9 @@ func newSyncResponse(
 	for i, c := range ciphers {
 		ciphersResponse[i] = newCipherResponse(c, setting)
 	}
-	collectionsResponse := make([]*collectionDetailsResponse, len(organizations))
+	collectionsResponse := make([]*collectionResponse, len(organizations))
 	for i, o := range organizations {
-		collectionsResponse[i] = newCollectionDetailsResponse(inst, o, &o.Collection)
+		collectionsResponse[i] = newCollectionResponse(inst, o, &o.Collection)
 	}
 	return &syncResponse{
 		Profile:     profile,


### PR DESCRIPTION
Bitwarden's protocol return the ReadOnly property only when in a
FullSync context

They don't need it on `GetCollections` because it is used only by
Export methods

As we use this method for realtime sync, we need to have the ReadOnly
property

____

This is WIP because I wan't to discuss about those edits first.

Those changes imply that `CollectionResponse` and `CollectionDetailsResponse` now have the same content. So maybe there is no need to keep `CollectionDetailsResponse` ? (although it fit the class name used on Bitwarden's protocol)

Also this may impact the Export method. I think it ignores the ReadOnly property but I should test it to confirm that

Finally I did not edit tests nor run them. Current tests seems to cover only a local organization not a shared one. Should we edit tests to cover the ReadOnly field? 