### PR TITLE
Allow to confirm an invited member

### DIFF
--- a/web/bitwarden/organization.go
+++ b/web/bitwarden/organization.go
@@ -3,6 +3,7 @@ package bitwarden
 import (
 	"encoding/json"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/cozy/cozy-stack/model/bitwarden"
@@ -471,6 +472,9 @@ func ConfirmUser(c echo.Context) error {
 			return c.JSON(http.StatusInternalServerError, echo.Map{
 				"error": "Unknown Cozy URL for this user",
 			})
+		}
+		if u, err := url.Parse(domain); err == nil {
+			domain = u.Host
 		}
 		org.Members[domain] = bitwarden.OrgMember{
 			UserID:   bwContact.UserID,

--- a/web/bitwarden/organization.go
+++ b/web/bitwarden/organization.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cozy/cozy-stack/model/bitwarden"
 	"github.com/cozy/cozy-stack/model/bitwarden/settings"
+	"github.com/cozy/cozy-stack/model/contact"
 	"github.com/cozy/cozy-stack/model/instance"
 	"github.com/cozy/cozy-stack/model/instance/lifecycle"
 	"github.com/cozy/cozy-stack/model/permission"
@@ -430,6 +431,18 @@ func ConfirmUser(c echo.Context) error {
 	}
 
 	userID := c.Param("user-id")
+	var bwContact bitwarden.Contact
+	if err := couchdb.GetDoc(inst, consts.BitwardenContacts, userID, &bwContact); err != nil {
+		if couchdb.IsNotFoundError(err) {
+			return c.JSON(http.StatusNotFound, echo.Map{
+				"error": "not found",
+			})
+		}
+		return c.JSON(http.StatusInternalServerError, echo.Map{
+			"error": err.Error(),
+		})
+	}
+
 	found := false
 	for domain, member := range org.Members {
 		if member.UserID != userID {
@@ -447,26 +460,33 @@ func ConfirmUser(c echo.Context) error {
 		org.Members[domain] = member
 	}
 	if !found {
-		return c.JSON(http.StatusNotFound, echo.Map{
-			"error": "The specified user isn't a member of the organization",
-		})
-	}
-
-	var contact bitwarden.Contact
-	if err := couchdb.GetDoc(inst, consts.BitwardenContacts, userID, &contact); err != nil {
-		if couchdb.IsNotFoundError(err) {
-			return c.JSON(http.StatusNotFound, echo.Map{
-				"error": "not found",
+		card, err := contact.FindByEmail(inst, bwContact.Email)
+		if err != nil {
+			return c.JSON(http.StatusInternalServerError, echo.Map{
+				"error": err.Error(),
 			})
 		}
-		return c.JSON(http.StatusInternalServerError, echo.Map{
-			"error": err.Error(),
-		})
+		domain := card.PrimaryCozyURL()
+		if domain == "" {
+			return c.JSON(http.StatusInternalServerError, echo.Map{
+				"error": "Unknown Cozy URL for this user",
+			})
+		}
+		org.Members[domain] = bitwarden.OrgMember{
+			UserID:   bwContact.UserID,
+			Email:    bwContact.Email,
+			Name:     card.PrimaryName(),
+			OrgKey:   confirm.Key,
+			Status:   bitwarden.OrgMemberInvited,
+			Owner:    false,
+			ReadOnly: true, // it will be overwritten when the user accepts the sharing
+		}
 	}
-	if !contact.Confirmed {
-		contact.Confirmed = true
-		contact.Metadata.UpdatedAt = time.Now()
-		if err := couchdb.UpdateDoc(inst, &contact); err != nil {
+
+	if !bwContact.Confirmed {
+		bwContact.Confirmed = true
+		bwContact.Metadata.UpdatedAt = time.Now()
+		if err := couchdb.UpdateDoc(inst, &bwContact); err != nil {
 			return c.JSON(http.StatusInternalServerError, echo.Map{
 				"error": err.Error(),
 			})


### PR DESCRIPTION
When several sharings are made between Alice and Bob, Bob can have
accepted one but not the others. In that case, if Alice confirms
the Bob's identity for the sharing of a bitwarden organization,
cozy-pass-web will also send a confirmation for the other sharings
of bitwarden organizations. For those sharings, Bob can still be
in the invited status, and this commit allow the confirmation to
work in that case.