### PR TITLE
Allow to filter fields for mango queries on files

### DIFF
--- a/model/vfs/directory.go
+++ b/model/vfs/directory.go
@@ -23,14 +23,14 @@ type DirDoc struct {
 	// Directory revision
 	DocRev string `json:"_rev,omitempty"`
 	// Directory name
-	DocName string `json:"name"`
+	DocName string `json:"name,omitempty"`
 	// Parent directory identifier
-	DirID       string `json:"dir_id"`
+	DirID       string `json:"dir_id,omitempty"`
 	RestorePath string `json:"restore_path,omitempty"`
 
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
-	Tags      []string  `json:"tags"`
+	Tags      []string  `json:"tags,omitempty"`
 
 	// Directory path on VFS.
 	// Fullpath should always be present. It is marked "omitempty" because

--- a/model/vfs/file.go
+++ b/model/vfs/file.go
@@ -24,7 +24,7 @@ type FileDoc struct {
 	// File revision
 	DocRev string `json:"_rev,omitempty"`
 	// File name
-	DocName string `json:"name"`
+	DocName string `json:"name,omitempty"`
 	// Parent directory identifier
 	DirID       string `json:"dir_id,omitempty"`
 	RestorePath string `json:"restore_path,omitempty"`
@@ -33,12 +33,12 @@ type FileDoc struct {
 	UpdatedAt time.Time `json:"updated_at"`
 
 	ByteSize   int64    `json:"size,string"` // Serialized in JSON as a string, because JS has some issues with big numbers
-	MD5Sum     []byte   `json:"md5sum"`
-	Mime       string   `json:"mime"`
-	Class      string   `json:"class"`
+	MD5Sum     []byte   `json:"md5sum,omitempty"`
+	Mime       string   `json:"mime,omitempty"`
+	Class      string   `json:"class,omitempty"`
 	Executable bool     `json:"executable"`
 	Trashed    bool     `json:"trashed"`
-	Tags       []string `json:"tags"`
+	Tags       []string `json:"tags,omitempty"`
 
 	Metadata     Metadata               `json:"metadata,omitempty"`
 	ReferencedBy []couchdb.DocReference `json:"referenced_by,omitempty"`


### PR DESCRIPTION
I was not very pleased by #3149, as it makes changes on a lot of files, and looks like it can easily introduce a regression. Here, I'm making another proposition, with changes more focused in `web/files`.