### PR TITLE
Handle a special case for BI webhooks

### DIFF
--- a/worker/exec/konnector.go
+++ b/worker/exec/konnector.go
@@ -147,6 +147,10 @@ func beforeHookKonnector(j *job.Job) (bool, error) {
 			j.Logger().Infof("konnector %q has not been triggered because of its maintenance status", msg.Konnector)
 			return false, nil
 		}
+
+		if msg.BIWebhook {
+			return true, nil
+		}
 	}
 
 	if j.Manual || j.TriggerID == "" {


### PR DESCRIPTION
When the stack receives a webhook from BI, and the state of the
konnector is LOGIN_FAILED or USER_ACTION_NEEDED, we allow the creation
of the job, as we can hope that the connection has been fixed somewhere.