### PR TITLE
Fix a case of trashed-not-in-trash with vfsswift

### DIFF
--- a/model/vfs/vfsswift/impl_v3.go
+++ b/model/vfs/vfsswift/impl_v3.go
@@ -791,6 +791,13 @@ func (f *swiftFileCreationV3) Close() (err error) {
 		}
 	}
 
+	var newpath string
+	newpath, err = f.fs.Indexer.FilePath(newdoc)
+	if err != nil {
+		return err
+	}
+	newdoc.Trashed = strings.HasPrefix(newpath, vfs.TrashDirName+"/")
+
 	var v *vfs.Version
 	if olddoc != nil {
 		v = vfs.NewVersion(olddoc)


### PR DESCRIPTION
When using vfsswift, if a file is uploaded to a directory and while the
transfer, the directory is put in the trash, the file wasn't created
with the trashed attribute.