### PR TITLE
Use 401 Unauthorized for bad bearer tokens

### DIFF
--- a/docs/important-changes.md
+++ b/docs/important-changes.md
@@ -4,15 +4,21 @@
 
 This section will list important changes to the stack or its usage, and migration procedures if any is needed.
 
+## October 2021: 401 for invalid bearer tokens
+
+We used to send 400 Bad Request when a bearer token was sent in the request but is not valid (the token has expired, its signature is incorrect, its audience isn't the expected one, etc.).
+
+We will now send a 401 Unauthorized for this case, following [RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750).
+
 ## December 2020: Jobs permissions
 
 We used to have a specific permission logic for jobs, in order to allow apps to direclty manage konnectors. More specifically, an app had the right to access a trigger state or remove it, if there was a doctype in common between the app permissions and the konnector manifest.
 
-This does not seem useful anymore as the konnectors are handled directly through harvest.  
+This does not seem useful anymore as the konnectors are handled directly through harvest.
 
 ## October 2019: Authentication
 
-We are about to change our authentification logic. 
+We are about to change our authentification logic.
 
 This change will be transparent for end-users. End-users don't need to change anything.
 
@@ -53,6 +59,3 @@ Users will migrate transparently to the new authentification logic on their firs
 ### Why this change
 
 Some content will support end-to-end encryption in the future. To ease the use for most users, we'll use the same passphrase for to login in their cozy instance and to encrypt their data. As we do not want the server to be able to read this encrypted data, we do not want to know your real passphrase anymore.
-
-
-

--- a/model/permission/errors.go
+++ b/model/permission/errors.go
@@ -9,16 +9,16 @@ import (
 var (
 	// ErrInvalidToken is used when the token is invalid (the signature is not
 	// correct, the domain is not the good one, etc.)
-	ErrInvalidToken = echo.NewHTTPError(http.StatusBadRequest,
+	ErrInvalidToken = echo.NewHTTPError(http.StatusUnauthorized,
 		"Invalid JWT token")
 
 	// ErrInvalidAudience is used when the audience is not expected
-	ErrInvalidAudience = echo.NewHTTPError(http.StatusBadRequest,
+	ErrInvalidAudience = echo.NewHTTPError(http.StatusUnauthorized,
 		"Invalid audience for JWT token")
 
 	// ErrExpiredToken is used when the token has expired and the client should
 	// refresh it
-	ErrExpiredToken = echo.NewHTTPError(http.StatusBadRequest,
+	ErrExpiredToken = echo.NewHTTPError(http.StatusUnauthorized,
 		"Expired token")
 
 	// ErrBadScope is used when the given scope is malformed

--- a/web/permissions/permissions_test.go
+++ b/web/permissions/permissions_test.go
@@ -269,7 +269,7 @@ func TestGetPermissionsForRevokedClient(t *testing.T) {
 	req.Header.Add("Authorization", "Bearer "+tok)
 	res, err := http.DefaultClient.Do(req)
 	assert.NoError(t, err)
-	assert.Equal(t, 400, res.StatusCode)
+	assert.Equal(t, 401, res.StatusCode)
 	body, err := ioutil.ReadAll(res.Body)
 	assert.NoError(t, err)
 	assert.Equal(t, `Invalid JWT token`, string(body))
@@ -284,7 +284,7 @@ func TestGetPermissionsForExpiredToken(t *testing.T) {
 	req.Header.Add("Authorization", "Bearer "+tok)
 	res, err := http.DefaultClient.Do(req)
 	assert.NoError(t, err)
-	assert.Equal(t, 400, res.StatusCode)
+	assert.Equal(t, 401, res.StatusCode)
 	body, err := ioutil.ReadAll(res.Body)
 	assert.NoError(t, err)
 	assert.Equal(t, `Expired token`, string(body))
@@ -298,7 +298,7 @@ func TestBadPermissionsBearer(t *testing.T) {
 		return
 	}
 	defer res.Body.Close()
-	assert.Equal(t, res.StatusCode, http.StatusBadRequest)
+	assert.Equal(t, 401, res.StatusCode)
 }
 
 func TestCreateSubPermission(t *testing.T) {
@@ -663,7 +663,7 @@ func TestGetPermissionsWithBadShortCode(t *testing.T) {
 	req1, _ := http.NewRequest("GET", ts.URL+"/permissions/self", nil)
 	req1.Header.Add("Authorization", "Bearer "+"foobar")
 	res1, _ := http.DefaultClient.Do(req1)
-	assert.Equal(t, res1.StatusCode, http.StatusBadRequest)
+	assert.Equal(t, 401, res1.StatusCode)
 }
 
 func TestGetTokenFromShortCode(t *testing.T) {

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -768,7 +768,7 @@ func TestRevokedSharingWithPreview(t *testing.T) {
 	badRequestContent, err := ioutil.ReadAll(res2.Body)
 	assert.NoError(t, err)
 	defer res2.Body.Close()
-	assert.Equal(t, http.StatusBadRequest, res2.StatusCode)
+	assert.Equal(t, http.StatusUnauthorized, res2.StatusCode)
 	assert.Contains(t, string(badRequestContent), "Invalid JWT")
 }
 


### PR DESCRIPTION
**This is breaking change!** We will now use 401 instead of 400 as the HTTP
code for the response when a bearer token in the request is invalid
(expired for example). See RFC 6750.

This is a draft pull request, not to be merged yet, as we want to give time to clients to test it and update their code if needed.