### PR TITLE
Add a WWW-Authenticate header for invalid token

### DIFF
--- a/web/permissions/permissions.go
+++ b/web/permissions/permissions.go
@@ -80,6 +80,7 @@ type getPermsFunc func(db prefixer.Prefixer, id string) (*permission.Permission,
 func displayPermissions(c echo.Context) error {
 	doc, err := middlewares.GetPermission(c)
 	if err != nil {
+		fmt.Printf("1. err = %s\n", err)
 		return err
 	}
 

--- a/web/permissions/permissions_test.go
+++ b/web/permissions/permissions_test.go
@@ -273,6 +273,7 @@ func TestGetPermissionsForRevokedClient(t *testing.T) {
 	body, err := ioutil.ReadAll(res.Body)
 	assert.NoError(t, err)
 	assert.Equal(t, `Invalid JWT token`, string(body))
+	assert.Equal(t, `Bearer error="invalid_token"`, res.Header.Get("WWW-Authenticate"))
 }
 
 func TestGetPermissionsForExpiredToken(t *testing.T) {
@@ -288,6 +289,7 @@ func TestGetPermissionsForExpiredToken(t *testing.T) {
 	body, err := ioutil.ReadAll(res.Body)
 	assert.NoError(t, err)
 	assert.Equal(t, `Expired token`, string(body))
+	assert.Equal(t, `Bearer error="invalid_token" error_description="The access token expired"`, res.Header.Get("WWW-Authenticate"))
 }
 
 func TestBadPermissionsBearer(t *testing.T) {


### PR DESCRIPTION
When a Bearer token is invalid (expired for example), the stack will now
send a WWW-Authenticate header in the response.

See https://datatracker.ietf.org/doc/html/rfc6750#section-3