### PR TITLE
Revert "Add again piwik.cozycloud.cc in CSP (temporary)"

### DIFF
--- a/web/middlewares/secure.go
+++ b/web/middlewares/secure.go
@@ -104,7 +104,7 @@ func Secure(conf *SecureConfig) echo.MiddlewareFunc {
 	conf.CSPMediaSrc, conf.CSPMediaSrcAllowList =
 		validCSPList(conf.CSPMediaSrc, conf.CSPDefaultSrc, conf.CSPMediaSrcAllowList)
 	conf.CSPObjectSrc, conf.CSPObjectSrcAllowList =
-		validCSPList(conf.CSPObjectSrc, conf.CSPDefaultSrc, conf.CSPObjectSrcAllowList)
+		validCSPList(conf.CSPObjectSrc, nil, conf.CSPObjectSrcAllowList)
 	conf.CSPStyleSrc, conf.CSPStyleSrcAllowList =
 		validCSPList(conf.CSPStyleSrc, conf.CSPDefaultSrc, conf.CSPStyleSrcAllowList)
 	conf.CSPWorkerSrc, conf.CSPWorkerSrcAllowList =

--- a/web/routing.go
+++ b/web/routing.go
@@ -50,7 +50,7 @@ import (
 
 const (
 	// cspScriptSrcAllowList is an allowlist for default allowed domains in CSP.
-	cspScriptSrcAllowList = "https://piwik.cozycloud.cc https://matomo.cozycloud.cc https://sentry.cozycloud.cc https://errors.cozycloud.cc https://api.pwnedpasswords.com"
+	cspScriptSrcAllowList = "https://matomo.cozycloud.cc https://sentry.cozycloud.cc https://errors.cozycloud.cc https://api.pwnedpasswords.com"
 
 	// cspImgSrcAllowList is an allowlist of images domains that are allowed in
 	// CSP.

--- a/web/routing.go
+++ b/web/routing.go
@@ -111,6 +111,7 @@ func SetupAppsHandler(appsHandler echo.HandlerFunc) echo.HandlerFunc {
 			CSPStyleSrc:       []middlewares.CSPSource{middlewares.CSPUnsafeInline},
 			CSPFontSrc:        []middlewares.CSPSource{middlewares.CSPSrcData},
 			CSPImgSrc:         []middlewares.CSPSource{middlewares.CSPSrcData, middlewares.CSPSrcBlob},
+			CSPObjectSrc:      []middlewares.CSPSource{middlewares.CSPSrcNone},
 			CSPFrameSrc:       []middlewares.CSPSource{middlewares.CSPSrcSiblings},
 			CSPFrameAncestors: []middlewares.CSPSource{middlewares.CSPSrcSelf},
 


### PR DESCRIPTION
This reverts commit 2f03e7e12b21813185fa1395948d0ac1d2ee0b29.

Piwik.cozycloud.cc should no longer be used, but it was not yet the case
when it has been removed from the CSP. so we have added it again to give
time for clients to finish the migration. But, let's try again to remove
it!