### PR TITLE
Allow to redirect to an app from login

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -119,7 +119,9 @@ made to this endpoint.
 
 The `redirect` parameter is passed inside the body. If it is missing, the
 redirection will be made against the default target: the home application of
-this cozy instance.
+this cozy instance. The redirect can be a full URL (like
+`http://cozy-drive.example.org/#/folder`), or just a slug+path+hash (like
+`drive/#/folder`).
 
 ```http
 POST /auth/login HTTP/1.1

--- a/web/auth/auth_test.go
+++ b/web/auth/auth_test.go
@@ -1256,6 +1256,18 @@ func TestRefreshTokenSuccess(t *testing.T) {
 	assertValidToken(t, response["access_token"], "access", clientID, "files:read")
 }
 
+func TestAppRedirectionOnLogin(t *testing.T) {
+	req, _ := http.NewRequest("GET", ts.URL+"/auth/login?redirect=drive/%23/foobar", nil)
+	req.Host = domain
+	res, err := client.Do(req)
+	assert.NoError(t, err)
+	defer res.Body.Close()
+	if assert.Equal(t, "303 See Other", res.Status) {
+		assert.Equal(t, "https://drive.cozy.example.net#/foobar",
+			res.Header.Get("Location"))
+	}
+}
+
 func TestLogoutNoToken(t *testing.T) {
 	req, _ := http.NewRequest("DELETE", ts.URL+"/auth/login", nil)
 	req.Host = domain

--- a/web/settings/context.go
+++ b/web/settings/context.go
@@ -6,13 +6,13 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/cozy/cozy-stack/model/app"
 	"github.com/cozy/cozy-stack/model/instance/lifecycle"
 	"github.com/cozy/cozy-stack/model/oauth"
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/jsonapi"
+	"github.com/cozy/cozy-stack/web/auth"
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/labstack/echo/v4"
 )
@@ -57,16 +57,7 @@ func finishOnboarding(c echo.Context, redirection string, acceptHTML bool) error
 	}
 	redirect := i.OnboardedRedirection().String()
 	if redirection != "" {
-		splits := strings.SplitN(redirection, "#", 2)
-		parts := strings.SplitN(splits[0], "/", 2)
-		if _, err := app.GetWebappBySlug(i, parts[0]); err == nil {
-			u := i.SubDomain(parts[0])
-			if len(parts) == 2 {
-				u.Path = parts[1]
-			}
-			if len(splits) == 2 {
-				u.Fragment = splits[1]
-			}
+		if u, err := auth.AppRedirection(i, redirection); err == nil {
 			redirect = u.String()
 		}
 	}


### PR DESCRIPTION
When using the redirect parameter of the /auth/login route, a full URL
was expected. But it can be complicated to know if the stack is in flat
or nested subdomains. It is now possible to use a short version of the
redirect parameter (like store/#/discover) to let the stack build the
correct host.