### PR TITLE
Add a context parameter to the ls-maintenances command

### DIFF
--- a/client/apps.go
+++ b/client/apps.go
@@ -203,10 +203,15 @@ func (c *Client) UninstallApp(opts *AppOptions) (*AppManifest, error) {
 }
 
 // ListMaintenances returns a list of konnectors in maintenance
-func (c *Client) ListMaintenances() ([]interface{}, error) {
+func (c *Client) ListMaintenances(context string) ([]interface{}, error) {
+	queries := url.Values{}
+	if context != "" {
+		queries.Add("Context", context)
+	}
 	res, err := c.Req(&request.Options{
-		Method: "GET",
-		Path:   "/konnectors/maintenance",
+		Method:  "GET",
+		Path:    "/konnectors/maintenance",
+		Queries: queries,
 	})
 	if err != nil {
 		return nil, err

--- a/cmd/apps.go
+++ b/cmd/apps.go
@@ -21,6 +21,7 @@ var flagSafeUpdate bool
 var flagKonnectorAccountID string
 var flagKonnectorsParameters string
 
+var flagKonnectorContext string
 var flagKonnectorsShortMaintenance bool
 var flagKonnectorsDisallowManualExec bool
 
@@ -273,7 +274,7 @@ var listMaintenancesCmd = &cobra.Command{
 	Short: `List the konnectors in maintenance`,
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		c := newAdminClient()
-		list, err := c.ListMaintenances()
+		list, err := c.ListMaintenances(flagKonnectorContext)
 		if err != nil {
 			return err
 		}
@@ -658,6 +659,7 @@ func init() {
 
 	runKonnectorsCmd.PersistentFlags().StringVar(&flagKonnectorAccountID, "account-id", "", "specify the account ID to use for running the konnector")
 
+	listMaintenancesCmd.PersistentFlags().StringVar(&flagKonnectorContext, "context", "", "include konnectors in maintenance for apps registry of this context")
 	activateMaintenanceKonnectorsCmd.PersistentFlags().BoolVar(&flagKonnectorsShortMaintenance, "short", false, "specify a short maintenance")
 	activateMaintenanceKonnectorsCmd.PersistentFlags().BoolVar(&flagKonnectorsDisallowManualExec, "no-manual-exec", false, "specify a maintenance disallowing manual execution")
 

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -459,6 +459,9 @@ Content-Type: application/json
 GET /konnectors/maintenance HTTP/1.1
 ```
 
+A parameter `Context` can be given on the query string to also includes the
+konnectors that are in maintenance on the apps registry.
+
 #### Response
 
 ```http
@@ -475,6 +478,7 @@ Content-Type: application/json
     {
       "type": "io.cozy.konnectors.maintenance",
       "attributes": {
+        "level": "stack",
         "maintenance_activated": true,
         "maintenance_options": {
           "flag_disallow_manual_exec": false,
@@ -494,6 +498,8 @@ Content-Type: application/json
   ]
 }
 ```
+
+**Note:** `level` can be `stack` or `registry`.
 
 ### PUT /konnectors/maintenance/:slug
 

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -161,7 +161,7 @@ func Proxy(req *http.Request, registries []*url.URL, cache CacheControl) (*http.
 
 // ProxyMaintenance will proxy the given request to the registries to fetch all
 // the apps in maintenance.
-func ProxyMaintenance(req *http.Request, registries []*url.URL) ([]json.RawMessage, error) {
+func ProxyMaintenance(registries []*url.URL) ([]json.RawMessage, error) {
 	apps := make([]json.RawMessage, 0)
 	for _, r := range registries {
 		ref := &url.URL{Path: "/registry/maintenance"}

--- a/web/registry/registry.go
+++ b/web/registry/registry.go
@@ -135,8 +135,7 @@ func proxyMaintenanceReq(c echo.Context) error {
 	if pdoc.Type != permission.TypeWebapp && pdoc.Type != permission.TypeOauth {
 		return echo.NewHTTPError(http.StatusForbidden)
 	}
-	req := c.Request()
-	apps, err := registry.ProxyMaintenance(req, i.Registries())
+	apps, err := registry.ProxyMaintenance(i.Registries())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
With this parameter, the stack will also list the konnectors in maintenance on
the apps registry for the given context.