### PR TITLE
Fix cleaning OAuth clients with delegated auth

### DIFF
--- a/web/oidc/oidc.go
+++ b/web/oidc/oidc.go
@@ -214,6 +214,14 @@ func AccessToken(c echo.Context) error {
 		})
 	}
 
+	// Remove the pending flag on the OAuth client (if needed)
+	if client.Pending {
+		client.Pending = false
+		client.ClientID = ""
+		_ = couchdb.UpdateDoc(inst, client)
+		client.ClientID = client.CouchID
+	}
+
 	// Generate the access/refresh tokens
 	accessToken, err := client.CreateJWT(inst, consts.AccessTokenAudience, out.Scope)
 	if err != nil {


### PR DESCRIPTION
When an OAuth client is created and not used in the next hour, it is
deleted in CouchDB by the clean-clients worker. When using delegated
authentication, it was possible to create and use an OAuth client, but
the pending flag was not removed, and the client was removed even if it
had been used. We are removing the flag when giving an access token via
delegated auth.