### PR TITLE
Fix onlyoffice CSP

### DIFF
--- a/web/routing.go
+++ b/web/routing.go
@@ -4,6 +4,7 @@ package web
 
 import (
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/cozy/cozy-stack/model/instance/lifecycle"
@@ -91,6 +92,9 @@ func SetupAppsHandler(appsHandler echo.HandlerFunc) echo.HandlerFunc {
 			oo := office.OnlyOfficeURL
 			if oo == "" {
 				continue
+			}
+			if !strings.HasSuffix(oo, "/") {
+				oo += "/"
 			}
 			if ctxName == config.DefaultInstanceContext {
 				scriptSrc = oo + " " + scriptSrc


### PR DESCRIPTION
cozy-stack automatically adds configured onlyoffice URL to CSP to make it work. However if onlyoffice URL is configured without trailing slash, the lack of trailing slash in CSP make it fail requesting onlyoffice js bundle.

This PR adds missing trailing slash to onlyoffice URL in CSP.