### PR TITLE
Fix uploading files in a sharing

### DIFF
--- a/model/vfs/vfsswift/impl_v1.go
+++ b/model/vfs/vfsswift/impl_v1.go
@@ -86,6 +86,7 @@ func (sfs *swiftVFS) UseSharingIndexer(index vfs.Indexer) vfs.VFS {
 		container:       sfs.container,
 		version:         sfs.version,
 		mu:              sfs.mu,
+		ctx:             context.Background(),
 		log:             sfs.log,
 	}
 }

--- a/model/vfs/vfsswift/impl_v2.go
+++ b/model/vfs/vfsswift/impl_v2.go
@@ -104,6 +104,7 @@ func (sfs *swiftVFSV2) UseSharingIndexer(index vfs.Indexer) vfs.VFS {
 		version:         sfs.version,
 		dataContainer:   sfs.dataContainer,
 		mu:              sfs.mu,
+		ctx:             context.Background(),
 		log:             sfs.log,
 	}
 }

--- a/model/vfs/vfsswift/impl_v3.go
+++ b/model/vfs/vfsswift/impl_v3.go
@@ -110,6 +110,7 @@ func (sfs *swiftVFSV3) UseSharingIndexer(index vfs.Indexer) vfs.VFS {
 		prefix:          sfs.prefix,
 		container:       sfs.container,
 		mu:              sfs.mu,
+		ctx:             context.Background(),
 		log:             sfs.log,
 	}
 }


### PR DESCRIPTION
After we have upgraded the github.com/ncw/swift library to v2, we need
to use a context in each call to swift. For sharing uploads, there was a
path where this context was nil, making the http requests to fail. This
is now fixed.