### PR TITLE
Add a way to automatically clean old trashed files and directories

### DIFF
--- a/cozy.example.yaml
+++ b/cozy.example.yaml
@@ -127,6 +127,7 @@ jobs:
   #   - "share-track":       idem
   #   - "share-upload":      idem
   #   - "thumbnail":         creatings and deleting thumbnails for images
+  #   - "thumbnailck":       generate missing thumbnails for all images
   #   - "trash-files":       async deletion of files in the trash
   #   - "clean-old-trashed": deletion of old files and directories after some time
   #   - "unzip":             unzipping tarball

--- a/cozy.example.yaml
+++ b/cozy.example.yaml
@@ -71,8 +71,8 @@ fs:
   # default_layout: 2 # 1 for layout v2 and 2 for layout v3
 
   # auto_clean_trashed_after:
-  #   context_a: 30d
-  #   context_b: 3m
+  #   context_a: 30D
+  #   context_b: 3M
 
   # versioning:
   #   max_number_of_versions_to_keep: 20

--- a/cozy.example.yaml
+++ b/cozy.example.yaml
@@ -70,6 +70,10 @@ fs:
   # can_query_info: true
   # default_layout: 2 # 1 for layout v2 and 2 for layout v3
 
+  # auto_clean_trashed_after:
+  #   context_a: 30d
+  #   context_b: 3m
+
   # versioning:
   #   max_number_of_versions_to_keep: 20
   #   min_delay_between_two_versions: 15m
@@ -109,23 +113,25 @@ jobs:
   #
   # List of available workers:
   #
-  #   - "clean-clients":   delete unused OAuth clients
-  #   - "export":          exporting data from a cozy instance
-  #   - "import":          importing data into a cozy instance
-  #   - "konnector":       launching konnectors
-  #   - "migrations":      transforming a VFS with Swift to layout v3
-  #   - "notes-persist":   saving notes to the VFS
-  #   - "push":            sending push notifications
-  #   - "sms":             sending SMS notifications
-  #   - "sendmail":        sending mails
-  #   - "service":         launching services
-  #   - "share-replicate": for cozy to cozy sharing
-  #   - "share-track":     idem
-  #   - "share-upload":    idem
-  #   - "thumbnail":       creatings and deleting thumbnails for images
-  #   - "unzip":           unzipping tarball
-  #   - "updates":         run updates for installed applications (deprecated)
-  #   - "zip":             creating a zip tarball
+  #   - "clean-clients":     delete unused OAuth clients
+  #   - "export":            exporting data from a cozy instance
+  #   - "import":            importing data into a cozy instance
+  #   - "konnector":         launching konnectors
+  #   - "service":           launching services
+  #   - "migrations":        transforming a VFS with Swift to layout v3
+  #   - "notes-save":        saving notes to the VFS
+  #   - "push":              sending push notifications
+  #   - "sms":               sending SMS notifications
+  #   - "sendmail":          sending mails
+  #   - "share-replicate":   for cozy to cozy sharing
+  #   - "share-track":       idem
+  #   - "share-upload":      idem
+  #   - "thumbnail":         creatings and deleting thumbnails for images
+  #   - "trash-files":       async deletion of files in the trash
+  #   - "clean-old-trashed": deletion of old files and directories after some time
+  #   - "unzip":             unzipping tarball
+  #   - "updates":           run updates for installed applications (deprecated)
+  #   - "zip":               creating a zip tarball
   #
   # When no configuration is given for a worker, a default configuration is
   # used. When a false boolean value is given, the worker is deactivated.

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -301,6 +301,12 @@ asynchronously. The behavior is not the same for all the VFS:
   the file versions are deleted in CouchDB via the job, and the files and their
   versions are deleted in Swift via the job.
 
+## clean-old-trashed worker
+
+This worker is used to automatically delete files and directories that are in
+the trash for too long. The threshold for deletion is configurable per context
+in the config file, via the `fs.auto_clean_trashed_after` parameter.
+
 ## share workers
 
 The stack have 3 workers to power the sharings (internal usage only):

--- a/model/job/scheduler.go
+++ b/model/job/scheduler.go
@@ -51,7 +51,7 @@ type (
 		UpdateCron(db prefixer.Prefixer, trigger Trigger, arguments string) error
 		DeleteTrigger(db prefixer.Prefixer, id string) error
 		GetAllTriggers(db prefixer.Prefixer) ([]Trigger, error)
-		HasEventTrigger(trigger Trigger) bool
+		HasTrigger(db prefixer.Prefixer, infos TriggerInfos) bool
 		CleanRedis() error
 		RebuildRedis(db prefixer.Prefixer) error
 	}

--- a/model/note/note.go
+++ b/model/note/note.go
@@ -324,18 +324,20 @@ type DebounceMessage struct {
 
 func setupTrigger(inst *instance.Instance, fileID string) error {
 	sched := job.System()
-	msg := &DebounceMessage{NoteID: fileID}
-	t, err := job.NewTrigger(inst, job.TriggerInfos{
+	infos := job.TriggerInfos{
 		Type:       "@event",
 		WorkerType: "notes-save",
 		Arguments:  fmt.Sprintf("%s:UPDATED:%s", consts.NotesEvents, fileID),
 		Debounce:   persistenceDebouce,
-	}, msg)
+	}
+	if sched.HasTrigger(inst, infos) {
+		return nil
+	}
+
+	msg := &DebounceMessage{NoteID: fileID}
+	t, err := job.NewTrigger(inst, infos, msg)
 	if err != nil {
 		return err
-	}
-	if sched.HasEventTrigger(t) {
-		return nil
 	}
 	return sched.AddTrigger(t)
 }

--- a/pkg/config/config/config.go
+++ b/pkg/config/config/config.go
@@ -746,7 +746,7 @@ func UseViper(v *viper.Viper) error {
 			Transport:             fsClient.Transport,
 			DefaultLayout:         defaultLayout,
 			CanQueryInfo:          v.GetBool("fs.can_query_info"),
-			AutoCleanTrashedAfter: v.GetStringMapString("auto_clean_trashed_after"),
+			AutoCleanTrashedAfter: v.GetStringMapString("fs.auto_clean_trashed_after"),
 			Versioning: FsVersioning{
 				MaxNumberToKeep:            v.GetInt("fs.versioning.max_number_of_versions_to_keep"),
 				MinDelayBetweenTwoVersions: v.GetDuration("fs.versioning.min_delay_between_two_versions"),

--- a/pkg/config/config/config.go
+++ b/pkg/config/config/config.go
@@ -167,12 +167,13 @@ func (v *Vault) CredentialsDecryptorKey() *keymgmt.NACLKey {
 
 // Fs contains the configuration values of the file-system
 type Fs struct {
-	Auth          *url.Userinfo
-	URL           *url.URL
-	Transport     http.RoundTripper
-	DefaultLayout int
-	CanQueryInfo  bool
-	Versioning    FsVersioning
+	Auth                  *url.Userinfo
+	URL                   *url.URL
+	Transport             http.RoundTripper
+	DefaultLayout         int
+	CanQueryInfo          bool
+	AutoCleanTrashedAfter map[string]string
+	Versioning            FsVersioning
 }
 
 // FsVersioning contains the configuration for the versioning of files
@@ -741,10 +742,11 @@ func UseViper(v *viper.Viper) error {
 		CredentialsDecryptorKey: v.GetString("vault.credentials_decryptor_key"),
 
 		Fs: Fs{
-			URL:           fsURL,
-			Transport:     fsClient.Transport,
-			DefaultLayout: defaultLayout,
-			CanQueryInfo:  v.GetBool("fs.can_query_info"),
+			URL:                   fsURL,
+			Transport:             fsClient.Transport,
+			DefaultLayout:         defaultLayout,
+			CanQueryInfo:          v.GetBool("fs.can_query_info"),
+			AutoCleanTrashedAfter: v.GetStringMapString("auto_clean_trashed_after"),
 			Versioning: FsVersioning{
 				MaxNumberToKeep:            v.GetInt("fs.versioning.max_number_of_versions_to_keep"),
 				MinDelayBetweenTwoVersions: v.GetDuration("fs.versioning.min_delay_between_two_versions"),

--- a/pkg/couchdb/index.go
+++ b/pkg/couchdb/index.go
@@ -10,7 +10,7 @@ import (
 
 // IndexViewsVersion is the version of current definition of views & indexes.
 // This number should be incremented when this file changes.
-const IndexViewsVersion int = 31
+const IndexViewsVersion int = 32
 
 // Indexes is the index list required by an instance to run properly.
 var Indexes = []*mango.Index{
@@ -27,6 +27,8 @@ var Indexes = []*mango.Index{
 	mango.IndexOnFields(consts.Files, "with-conflicts", []string{"_conflicts"}),
 	// Used to count the shortuts to a sharing that have not been seen
 	mango.IndexOnFields(consts.Files, "by-sharing-status", []string{"metadata.sharing.status"}),
+	// Used to find old files and directories in the trashed that should be deleted
+	mango.IndexOnFields(consts.Files, "by-dir-id-updated-at", []string{"dir_id", "updated_at"}),
 
 	// Used to lookup a queued and running jobs
 	mango.IndexOnFields(consts.Jobs, "by-worker-and-state", []string{"worker", "state"}),

--- a/pkg/couchdb/index.go
+++ b/pkg/couchdb/index.go
@@ -35,6 +35,9 @@ var Indexes = []*mango.Index{
 	mango.IndexOnFields(consts.Jobs, "by-trigger-id", []string{"trigger_id", "queued_at"}),
 	mango.IndexOnFields(consts.Jobs, "by-queued-at", []string{"queued_at"}),
 
+	// Used to lookup a trigger to see if it exists or must be created
+	mango.IndexOnFields(consts.Triggers, "by-worker-and-type", []string{"worker", "type"}),
+
 	// Used to lookup oauth clients by name
 	mango.IndexOnFields(consts.OAuthClients, "by-client-name", []string{"client_name"}),
 	mango.IndexOnFields(consts.OAuthClients, "by-notification-platform", []string{"notification_platform"}),

--- a/worker/trash/trash.go
+++ b/worker/trash/trash.go
@@ -59,7 +59,7 @@ func WorkerTrashFiles(ctx *job.WorkerContext) error {
 func WorkerCleanOldTrashed(ctx *job.WorkerContext) error {
 	cfg := config.GetConfig().Fs.AutoCleanTrashedAfter
 	after, ok := cfg[ctx.Instance.ContextName]
-	if !ok {
+	if !ok || after == "" {
 		return nil
 	}
 	delay, err := bigduration.ParseDuration(after)

--- a/worker/trash/trash.go
+++ b/worker/trash/trash.go
@@ -1,11 +1,18 @@
 package trash
 
 import (
+	"fmt"
 	"runtime"
 	"time"
 
 	"github.com/cozy/cozy-stack/model/job"
 	"github.com/cozy/cozy-stack/model/vfs"
+	"github.com/cozy/cozy-stack/pkg/config/config"
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
+	"github.com/hashicorp/go-multierror"
+	"github.com/justincampbell/bigduration"
 )
 
 func init() {
@@ -16,6 +23,15 @@ func init() {
 		Reserved:     true,
 		Timeout:      2 * time.Hour,
 		WorkerFunc:   WorkerTrashFiles,
+	})
+
+	job.AddWorker(&job.WorkerConfig{
+		WorkerType:   "clean-old-trashed",
+		Concurrency:  runtime.NumCPU() * 4,
+		MaxExecCount: 2,
+		Reserved:     true,
+		Timeout:      2 * time.Hour,
+		WorkerFunc:   WorkerCleanOldTrashed,
 	})
 }
 
@@ -34,4 +50,61 @@ func WorkerTrashFiles(ctx *job.WorkerContext) error {
 		return err
 	}
 	return nil
+}
+
+// WorkerCleanOldTrashed is a worker used to automatically delete files and
+// directories that are in the trash for too long. The threshold for deletion
+// is configurable per context in the config file, via the
+// fs.auto_clean_trashed_after parameter.
+func WorkerCleanOldTrashed(ctx *job.WorkerContext) error {
+	cfg := config.GetConfig().Fs.AutoCleanTrashedAfter
+	after, ok := cfg[ctx.Instance.ContextName]
+	if !ok {
+		return nil
+	}
+	delay, err := bigduration.ParseDuration(after)
+	if err != nil {
+		ctx.Logger().WithField("critical", "true").
+			Errorf("Invalid config for auto_clean_trashed_after: %s", err)
+		return err
+	}
+	before := time.Now().Add(-delay)
+
+	var list []*vfs.DirOrFileDoc
+	sel := mango.And(
+		mango.Equal("dir_id", consts.TrashDirID),
+		mango.Lt("updated_at", before),
+	)
+	req := &couchdb.FindRequest{
+		UseIndex: "by-dir-id-updated-at",
+		Selector: sel,
+		Limit:    1000,
+	}
+	if _, err := couchdb.FindDocsRaw(ctx.Instance, consts.Files, req, &list); err != nil {
+		return err
+	}
+
+	var errm error
+	fs := ctx.Instance.VFS()
+	push := pushTrashJob(fs)
+	for _, item := range list {
+		d, f := item.Refine()
+		if f != nil {
+			err = fs.DestroyFile(f)
+		} else if d != nil {
+			err = fs.DestroyDirAndContent(d, push)
+		} else {
+			err = fmt.Errorf("Invalid type for %v", item)
+		}
+		if err != nil {
+			errm = multierror.Append(errm, err)
+		}
+	}
+	return errm
+}
+
+func pushTrashJob(fs vfs.VFS) func(vfs.TrashJournal) error {
+	return func(journal vfs.TrashJournal) error {
+		return fs.EnsureErased(journal)
+	}
 }


### PR DESCRIPTION
A new worker has been added to delete files and directories that have been trashed after a configurable delay. It is called via a `@cron` trigger that is created by the stack when a file or directory is put in the trash and the configurable delay has been configured for this instance context.