### PR TITLE
Send blank lines on SSE every 10 seconds

### DIFF
--- a/model/app/installer.go
+++ b/model/app/installer.go
@@ -563,6 +563,12 @@ func (i *Installer) Poll() (Manifest, bool, error) {
 	return man, done, man.Error()
 }
 
+// ManifestChannel returns the channel that can be listened to get updates
+// about the installer run.
+func (i *Installer) ManifestChannel() chan Manifest {
+	return i.manc
+}
+
 // DoLazyUpdate tries to update an application before using it
 func DoLazyUpdate(in *instance.Instance, man Manifest, copier appfs.Copier, registries []*url.URL) Manifest {
 	src, err := url.Parse(man.Source())


### PR DESCRIPTION
When installing or updating an app with Server-Sent Events, the client
can reach a timeout as nothing was sent for 1 minute or more if the code
wasn't in the cache. The stack is now sending a blank line every 10
seconds to avoid it.