### PR TITLE
Forbid . and .. as names of files/directories

### DIFF
--- a/model/vfs/vfs.go
+++ b/model/vfs/vfs.go
@@ -816,7 +816,7 @@ func normalizeDocPatch(data, patch *DocPatch, cdate time.Time) (*DocPatch, error
 }
 
 func checkFileName(str string) error {
-	if str == "" || strings.ContainsAny(str, ForbiddenFilenameChars) {
+	if str == "" || str == "." || str == ".." || strings.ContainsAny(str, ForbiddenFilenameChars) {
 		return ErrIllegalFilename
 	}
 	return nil


### PR DESCRIPTION
. and .. are reserved names the current directory and the parent
directory on file systems, and it can cause trouble when someone creates
a file or directory with such a name.