### PR TITLE
Remove the Vary: Origin HTTP header for assets

### DIFF
--- a/web/statik/handler.go
+++ b/web/statik/handler.go
@@ -300,6 +300,8 @@ func (h *Handler) ServeFile(w http.ResponseWriter, r *http.Request, f *modelAsse
 	headers := w.Header()
 	headers.Set("Content-Type", f.Mime)
 	headers.Set("Content-Length", f.Size())
+	// Remove vary: origin, as we want to mutualize caching between the apps
+	headers.Del("Vary")
 	headers.Add("Vary", "Accept-Encoding")
 
 	acceptsBrotli := strings.Contains(r.Header.Get("Accept-Encoding"), "br")


### PR DESCRIPTION
We want to mutualize the HTTP cache between the apps, and each web app
has its own HTTP origin.