### PR TITLE
feat: Add warning about Cozy Pass data loss on password reset email

### DIFF
--- a/assets/locales/en.po
+++ b/assets/locales/en.po
@@ -677,6 +677,11 @@ msgstr ""
 "You asked to change your password for Cozy Pass. "
 "If you didn't initiate this request, please contact us by replying directly to this email."
 
+msgid "Mail Reset Passphrase Warning Cozy Pass"
+msgstr ""
+"Warning! Your current password is the only way to decode the passwords kept in your app Cozy Pass. "
+"If you reset it, you will lose that data. The rest of your data will remain accessible."
+
 msgid "Mail Reset Passphrase Button instruction"
 msgstr "Click on the this button to safely change it."
 

--- a/assets/locales/fr.po
+++ b/assets/locales/fr.po
@@ -751,6 +751,11 @@ msgstr ""
 "Vous avez demandé à changer votre mot de passe Coyz Pass. Si ce n'est pas le"
 " cas, contactez-nous en réponse à ce mail."
 
+msgid "Mail Reset Passphrase Warning Cozy Pass"
+msgstr ""
+"Attention ! Votre mot de passe actuel est l'unique moyen pour accéder aux mots de passe gardés par votre application Cozy Pass. "
+"Si vous le réinitialisez, vous perdrez ces données. Le reste de vos données resteront accessibles."
+
 msgid "Mail Reset Passphrase Button instruction"
 msgstr "Cliquez sur ce bouton pour le changer en toute sécurité."
 

--- a/assets/mails/passphrase_reset.mjml
+++ b/assets/mails/passphrase_reset.mjml
@@ -14,6 +14,9 @@
 <mj-text mj-class="content-medium">
 	{{t "Mail Reset Passphrase Button instruction"}}
 </mj-text>
+<mj-text mj-class="content-medium">
+	{{t "Mail Reset Passphrase Warning Cozy Pass"}}
+</mj-text>
 <mj-button href="{{.PassphraseResetLink}}" align="left" mj-class="primary-button content-medium">
 	{{t "Mail Reset Passphrase Button text"}}
 </mj-button>

--- a/assets/mails/passphrase_reset.text
+++ b/assets/mails/passphrase_reset.text
@@ -5,6 +5,8 @@
 {{t "Mail Reset Passphrase Intro 2"}}
 {{end}}
 
+{{t "Mail Reset Passphrase Warning Cozy Pass"}}
+
 {{t "Mail Reset Passphrase Button instruction"}}
 {{.PassphraseResetLink}}
 


### PR DESCRIPTION
As reseting user's password makes its Cozy Pass vault impossible to be
decrypted, then we should alert the user on password reset instructions
email