### PR TITLE
Fix opening shared office documents

### DIFF
--- a/model/sharing/open_file.go
+++ b/model/sharing/open_file.go
@@ -303,6 +303,12 @@ func (o *FileOpener) PrepareRequestForSharedFile() (*PreparedRequest, error) {
 			if i == 0 {
 				continue // Skip the owner
 			}
+			// XXX Skip the not-ready members, as an instance can be listed
+			// several times in members;w ith different email addresses and
+			// status.
+			if m.Status != MemberStatusReady {
+				continue
+			}
 			if m.Instance == domain || m.Instance+"/" == domain {
 				prepared.Creds = &s.Credentials[i-1]
 				prepared.Creator = &s.Members[i]

--- a/model/sharing/open_file.go
+++ b/model/sharing/open_file.go
@@ -304,7 +304,7 @@ func (o *FileOpener) PrepareRequestForSharedFile() (*PreparedRequest, error) {
 				continue // Skip the owner
 			}
 			// XXX Skip the not-ready members, as an instance can be listed
-			// several times in members;w ith different email addresses and
+			// several times in members; with different email addresses and
 			// status.
 			if m.Status != MemberStatusReady {
 				continue


### PR DESCRIPTION
When a sharing member has been invited with several email addresses, and
has accepted and revoked the sharing from one email addresse, and later
accepted the sharing from another email address, their instance will be
listed twice in the sharing (with the status revoked and ready). If this
member creates an office document, and someone else in the sharing tries
to open it, it may fail as the sharing status may have been seen as
revoked (it depends of the order of sharing members). We are now
ignoring the not-ready members to avoid this issue.