### PR TITLE
Fix opening shared note

### DIFF
--- a/model/sharing/member.go
+++ b/model/sharing/member.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/url"
 	"runtime"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/cozy/cozy-stack/client/auth"
@@ -503,6 +505,12 @@ func (s *Sharing) FindMemberByCode(perms *permission.Permission, sharecode strin
 	}
 	for i, m := range s.Members {
 		if m.Instance == emailOrInstance {
+			return &s.Members[i], nil
+		}
+	}
+	if strings.HasPrefix(emailOrInstance, "index:") {
+		i, err := strconv.Atoi(strings.TrimPrefix(emailOrInstance, "index:"))
+		if err == nil && i > 0 && i < len(s.Members) {
 			return &s.Members[i], nil
 		}
 	}
@@ -1026,6 +1034,9 @@ func (s *Sharing) NotifyRecipients(inst *instance.Instance, except *Member) {
 			perms, err := permission.GetForSharePreview(inst, s.SID)
 			if err == nil {
 				token = perms.Codes[m.Email]
+			}
+			if token == "" {
+				continue
 			}
 		}
 		opts := &request.Options{

--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -3,6 +3,7 @@ package sharing
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -194,6 +195,9 @@ func (s *Sharing) CreatePreviewPermissions(inst *instance.Instance) (*permission
 		if key == "" {
 			key = m.Instance
 		}
+		if key == "" {
+			key = keyFromMemberIndex(i)
+		}
 
 		// Checks that we don't already have a sharing code
 		if doc != nil {
@@ -250,6 +254,10 @@ func (s *Sharing) CreatePreviewPermissions(inst *instance.Instance) (*permission
 		return nil, err
 	}
 	return doc, nil
+}
+
+func keyFromMemberIndex(index int) string {
+	return fmt.Sprintf("index:%d", index)
 }
 
 // CreateInteractPermissions creates the permissions doc for reading and


### PR DESCRIPTION
When Alice shares a directory with Bob, and only the instance URL of Bob
is known (not his email address), a note inside this directory could
not be opened by Bob.