### PR TITLE
Fix redirection after cancel Google OAuth

### DIFF
--- a/web/accounts/oauth.go
+++ b/web/accounts/oauth.go
@@ -115,6 +115,13 @@ func redirect(c echo.Context) error {
 			}
 		}
 
+		// https://developers.google.com/identity/protocols/oauth2/web-server?hl=en#handlingresponse
+		if c.QueryParam("error") == "access_denied" {
+			u := i.SubDomain(consts.StoreSlug)
+			u.Fragment = "/discover/" + accountTypeID
+			return c.Redirect(http.StatusSeeOther, u.String())
+		}
+
 		accountType, err := account.TypeInfo(accountTypeID, i.ContextName)
 		if err != nil {
 			return err


### PR DESCRIPTION
When configuring the Google konnector, an OAuth danse is made, and if
the user clicks on Cancel, it will be redirected to the stack. Then, a
JSON message was shown to them to explain the failure, but it is better
to redirect to the store in that case.