### PR TITLE
Fix certificate digest for Android flagship certification

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -190,7 +190,7 @@ func init() {
 	flags.StringSlice("flagship-apk-package-names", []string{"io.cozy.drive.mobile", "io.cozy.flagship.mobile"}, "Package name for the flagship app on android")
 	checkNoErr(viper.BindPFlag("flagship.apk_package_names", flags.Lookup("flagship-apk-package-names")))
 
-	flags.StringSlice("flagship-apk-certificate-digests", []string{"xNnH7T1BSDh6erMzNysfakBVLLacbSbOMxVk8jEPgdU="}, "SHA-256 hash (base64 encoded) of the flagship app's signing certificate on android")
+	flags.StringSlice("flagship-apk-certificate-digests", []string{"u2eUUnfB4Y7k7eqQL7u2jiYDJeVBwZoSV3PZSs8pttc="}, "SHA-256 hash (base64 encoded) of the flagship app's signing certificate on android")
 	checkNoErr(viper.BindPFlag("flagship.apk_certificate_digests", flags.Lookup("flagship-apk-certificate-digests")))
 
 	flags.StringSlice("flagship-apple-app-ids", []string{"3AKXFMV43J.io.cozy.drive.mobile", "3AKXFMV43J.io.cozy.flagship.mobile"}, "App ID of the flagship app on iOS")


### PR DESCRIPTION
Previous used digest was from CozyPass app

Now the Flagship app has its own new certificate