### PR TITLE
Allow auto-update for carbon copy permission added

### DIFF
--- a/model/permission/set.go
+++ b/model/permission/set.go
@@ -228,10 +228,10 @@ func (s Set) HasSameRules(other Set) bool {
 //
 // We are ignoring removed values/verbs between rule 1 and rule 2.
 // - At the moment, it onlys show the added values, verbs and rules
-func Diff(set1, set2 Set) (Set, error) {
+func Diff(set1, set2 Set) Set {
 	// If sets are the same, do not compute
 	if set1.HasSameRules(set2) {
-		return set1, nil
+		return set1
 	}
 
 	newSet := Set{}
@@ -284,7 +284,7 @@ func Diff(set1, set2 Set) (Set, error) {
 			}
 		}
 	}
-	return newSet, nil
+	return newSet
 }
 
 // IsMaximal returns true if the permission is valid for everything. Only the

--- a/model/permission/set_test.go
+++ b/model/permission/set_test.go
@@ -25,8 +25,7 @@ func TestDiffSameSets(t *testing.T) {
 		},
 	}
 
-	d, err := Diff(set1, set2)
-	assert.NoError(t, err)
+	d := Diff(set1, set2)
 	assert.True(t, set1.HasSameRules(d))
 }
 
@@ -49,8 +48,7 @@ func TestDiffNotSameSets(t *testing.T) {
 		},
 	}
 
-	d, err := Diff(set1, set2)
-	assert.NoError(t, err)
+	d := Diff(set1, set2)
 	assert.False(t, set1.HasSameRules(d))
 
 	expectedSet := Set{
@@ -96,8 +94,7 @@ func TestDiffMultipleRules(t *testing.T) {
 		},
 	}
 
-	d, err := Diff(set1, set2)
-	assert.NoError(t, err)
+	d := Diff(set1, set2)
 	assert.False(t, set1.HasSameRules(d))
 
 	expectedSet := Set{
@@ -141,8 +138,7 @@ func TestDiffNotSameSetsNewRule(t *testing.T) {
 		},
 	}
 
-	d, err := Diff(set1, set2)
-	assert.NoError(t, err)
+	d := Diff(set1, set2)
 	assert.False(t, set1.HasSameRules(d))
 
 	expectedSet := Set{


### PR DESCRIPTION
The stack can auto-update konnectors if only a permission of carbon copy
or electronic safe is added, without asking permission from the user.