### PR TITLE
Fix the folder path for recreating a konnector folder

### DIFF
--- a/worker/exec/konnector.go
+++ b/worker/exec/konnector.go
@@ -337,7 +337,7 @@ func (w *konnectorWorker) ensureFolderToSave(ctx *job.WorkerContext, inst *insta
 		folderPath = acc.FolderPath
 	}
 	if folderPath == "" {
-		folderPath = computeFolderPath(inst, w.slug, acc)
+		folderPath = computeFolderPath(inst, w.man.Name(), acc)
 	}
 
 	// 5. Try to recreate the folder


### PR DESCRIPTION
When a konnector is executed, the stack ensure it has a folder where it
can be put its files if needed. The path for this folder is taken from
the account, but if it is missing, a fallback will use the konnector and
account data. It was using the slug of the konnector, and it will now be
using the konnector name instead.