### PR TITLE
Fix revoke sharing by a recipient

### DIFF
--- a/model/sharing/member.go
+++ b/model/sharing/member.go
@@ -910,6 +910,7 @@ func (s *Sharing) RevokeOwner(inst *instance.Instance) error {
 	}
 	m.Status = MemberStatusRevoked
 	s.Credentials = nil
+	s.Active = false
 	return couchdb.UpdateDoc(inst, s)
 }
 

--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -454,7 +454,8 @@ func (s *Sharing) RevokeRecipientBySelf(inst *instance.Instance, sharingDirTrash
 		return err
 	}
 	if err := RemoveSharedRefs(inst, s.SID); err != nil {
-		return err
+		inst.Logger().WithNamespace("sharing").
+			Warnf("RevokeRecipientBySelf failed to remove shared refs (%s)': %s", s.ID(), err)
 	}
 	if !sharingDirTrashed && s.FirstFilesRule() != nil {
 		if err := s.RemoveSharingDir(inst); err != nil {


### PR DESCRIPTION
If a recipient revokes a sharing, and an error occur while removing the
references, the sharing was marked as active with a revoked owner, which
is a state that can cause panics in the stack. We can avoid this issue
by removing the active flag sooner on the sharing.