### PR TITLE
Fix HTTP caching of JSON-API responses

### DIFF
--- a/pkg/jsonapi/jsonapi.go
+++ b/pkg/jsonapi/jsonapi.go
@@ -111,7 +111,7 @@ func DataListWithTotal(c echo.Context, statusCode, total int, objs []Object, lin
 func compressedWriter(req *http.Request, resp *echo.Response) io.WriteCloser {
 	headers := resp.Header()
 	headers.Set("Content-Type", ContentType)
-	headers.Set("Vary", "Accept-Encoding")
+	headers.Add("Vary", "Accept-Encoding")
 	if !acceptGzipEncoding(req) {
 		return &nopCloser{resp}
 	}


### PR DESCRIPTION
The JSON-API responses are accessed from several origins (the apps)
and, as such, are bound to CORS by the browsers. A CORS preflight
(OPTIONS) is made, but the main request (GET/POST/etc.) must also
have a response with the Access-Control-Allow-Origin header set.
And the server must tell the browser to not cache this response for a
request from one origin, and reuse this cached response for a request
from another origin (or the browser will throw a CORS error). This is
done with the Vary: Origin HTTP header. In theory, it was done via the
CORS middleware, but a mistake in the Content-Encoding negociation was
reseting it.

In practice, most browsers already split their cache per origin for
privacy reasons. And the bug was only visible in the chromium family
when using the back button of the browser.