### PR TITLE
Improve konnector ignore logging

### DIFF
--- a/worker/exec/konnector.go
+++ b/worker/exec/konnector.go
@@ -167,7 +167,7 @@ func beforeHookKonnector(j *job.Job) (bool, error) {
 		if strings.HasPrefix(state.LastError, konnErrorLoginFailed) ||
 			strings.HasPrefix(state.LastError, konnErrorUserActionNeeded) {
 			j.Logger().
-				WithField("job_id", j.ID()).
+				WithField("account_id", msg.Account).
 				WithField("slug", slug).
 				Infof("Konnector ignore: %s", state.LastError)
 			return false, nil


### PR DESCRIPTION
- Log `account_id` on konnector ignore
- Stop logging `job_id` as this message clearly means we are not going to start a job and it is always empty