### PR TITLE
Flush SSE response

### DIFF
--- a/web/apps/apps.go
+++ b/web/apps/apps.go
@@ -399,6 +399,9 @@ func pollInstaller(c echo.Context, instance *instance.Instance, isEventStream bo
 		case <-ticker.C:
 			_, _ = w.Write([]byte(": still working\r\n"))
 		}
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
 	}
 }
 


### PR DESCRIPTION
The stack sends some comments in Server-Side Events response to avoid
letting the connection timeouts. But they were buffered, which defeats
the purpose. We are now flushing them to fix this issue.