### PR TITLE
Properly handle event-stream comments in client.

### DIFF
--- a/client/request/request.go
+++ b/client/request/request.go
@@ -235,6 +235,11 @@ func ReadSSE(r io.ReadCloser, ch chan *SSEEvent) {
 			ev = nil
 			continue
 		}
+		if bytes.HasPrefix(bs, []byte(":")) {
+			// A colon as the first character of a line is in essence a comment,
+			// and is ignored.
+			continue
+		}
 		spl := bytes.SplitN(bs, []byte(": "), 2)
 		if len(spl) != 2 {
 			err = ErrSSEParse


### PR DESCRIPTION
cozy-stack send comments in event-stream responses for keepalive purposes as advised in https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format and https://html.spec.whatwg.org/multipage/server-sent-events.html#authoring-notes

However, our sse parser do not handle comments
This PR add comment handling when parsing event-stream
