### PR TITLE
Fix skipping flagship validation via config when using default context

### DIFF
--- a/web/auth/oauth.go
+++ b/web/auth/oauth.go
@@ -83,7 +83,11 @@ func checkAuthorizeParams(c echo.Context, params *authorizeParams) (bool, error)
 	params.scope = strings.TrimSpace(params.scope)
 	if params.scope == "*" {
 		instance := middlewares.GetInstance(c)
-		cfg := config.GetConfig().Flagship.Contexts[instance.ContextName]
+		context := instance.ContextName
+		if context == "" {
+			context = config.DefaultInstanceContext
+		}
+		cfg := config.GetConfig().Flagship.Contexts[context]
 		skipCertification := false
 		if cfg, ok := cfg.(map[string]interface{}); ok {
 			skipCertification = cfg["skip_certification"] == true
@@ -184,7 +188,11 @@ func authorizeForm(c echo.Context) error {
 
 	permissions, err := permission.UnmarshalScopeString(params.scope)
 	if err != nil {
-		cfg := config.GetConfig().Flagship.Contexts[instance.ContextName]
+		context := instance.ContextName
+		if context == "" {
+			context = config.DefaultInstanceContext
+		}
+		cfg := config.GetConfig().Flagship.Contexts[context]
 		skipCertification := false
 		if cfg, ok := cfg.(map[string]interface{}); ok {
 			skipCertification = cfg["skip_certification"] == true

--- a/web/middlewares/permissions.go
+++ b/web/middlewares/permissions.go
@@ -92,7 +92,11 @@ func GetForOauth(instance *instance.Instance, claims *permission.Claims, client 
 	linkedAppScope, err := parseLinkedAppScope(claims.Scope)
 
 	if claims.Scope == "*" {
-		cfg := config.GetConfig().Flagship.Contexts[instance.ContextName]
+		context := instance.ContextName
+		if context == "" {
+			context = config.DefaultInstanceContext
+		}
+		cfg := config.GetConfig().Flagship.Contexts[context]
 		skipCertification := false
 		if cfg, ok := cfg.(map[string]interface{}); ok {
 			skipCertification = cfg["skip_certification"] == true


### PR DESCRIPTION
`Flagship.Contexts` uses `default` key to store default configuration

`instance.ContextName` returns empty string if no context is set for
the cozy instance

So when instance has no context we should force `default` key instead
of empty string when accessing `Flagship.Contexts`