### PR TITLE
fix: Return the real error for /capabilities/settings

### DIFF
--- a/web/settings/capabilities.go
+++ b/web/settings/capabilities.go
@@ -61,7 +61,7 @@ func getCapabilities(c echo.Context) error {
 	// Any request with a token can ask for the capabilities (no permissions
 	// are required)
 	if _, err := middlewares.GetPermission(c); err != nil {
-		return echo.NewHTTPError(http.StatusForbidden)
+		return err
 	}
 	inst := middlewares.GetInstance(c)
 	doc := NewCapabilities(inst)


### PR DESCRIPTION
We were returning the same error message for all
the possible errors.

Now we return the specific error.

We find out this issue when requesting this route
with an expired OAuth Token. And since the only
message we had was "Forbidden", the refresh process
was not launched.

Thought, we had the right message in the WWW-Authenticate
header.