### PR TITLE
Fix response code for getting a deleted doc

### DIFF
--- a/web/data/data.go
+++ b/web/data/data.go
@@ -91,11 +91,15 @@ func getDoc(c echo.Context) error {
 
 	var out couchdb.JSONDoc
 	err := couchdb.GetDoc(instance, doctype, docid, &out)
+	out.Type = doctype
 	if err != nil {
+		if couchdb.IsNotFoundError(err) {
+			if err := middlewares.Allow(c, permission.GET, &out); err != nil {
+				return err
+			}
+		}
 		return fixErrorNoDatabaseIsWrongDoctype(err)
 	}
-
-	out.Type = doctype
 
 	if err := middlewares.Allow(c, permission.GET, &out); err != nil {
 		return err

--- a/web/data/data_test.go
+++ b/web/data/data_test.go
@@ -112,6 +112,24 @@ func TestSuccessGet(t *testing.T) {
 	}
 }
 
+func TestGetForMissingDoc(t *testing.T) {
+	req, _ := http.NewRequest("GET", ts.URL+"/data/no.such.doctype/id", nil)
+	_, res, err := doRequest(req, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 401, res.StatusCode)
+
+	req, _ = http.NewRequest("GET", ts.URL+"/data/"+Type+"/no.such.id", nil)
+	_, res, err = doRequest(req, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 401, res.StatusCode)
+
+	req, _ = http.NewRequest("GET", ts.URL+"/data/"+Type+"/no-such-id", nil)
+	req.Header.Add("Authorization", "Bearer "+token)
+	_, res, err = doRequest(req, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 404, res.StatusCode)
+}
+
 func TestGetWithSlash(t *testing.T) {
 	_ = couchdb.CreateNamedDoc(testInstance, &couchdb.JSONDoc{
 		Type: Type, M: map[string]interface{}{


### PR DESCRIPTION
When a request is made to get a document with no authorization token,
and the document doesn't exist, the stack must return a status code
for the lack of permission. It should not return a 404 Not Found that
can be used to know if the document exists or not.