### PR TITLE
docs: Add information about user already logged

### DIFF
--- a/docs/bitwarden.md
+++ b/docs/bitwarden.md
@@ -84,9 +84,10 @@ clientName=Cozy&
 devicePushToken=
 ```
 
-If authentication with two factors is enabled on the instance, this request
-will fail with a 400 status, but it will send an email with the code. The
-request can be retried with an additional paramter: `twoFactorToken`.
+If authentication with two factors is enabled on the instance and the 
+user not logged through a web session, this request will fail with a 
+400 status, but it will send an email with the code. The request can 
+be retried with an additional paramter: `twoFactorToken`.
 
 **Note:** the `clientName` parameter is optional, and is not sent by the
 official bitwarden clients (a default value is used).


### PR DESCRIPTION
If the user is already "web logged", then the route 
/bitwarden/identity/connect/token will not send a 
2FA code. It returns directly the access_token. 

Comment from the code: 
It's OK from a security point of view as we 
still have 2 factors: the password
and a valid session cookie.