### PR TITLE
Fix JSON serialization of app manifests

### DIFF
--- a/model/app/konnector.go
+++ b/model/app/konnector.go
@@ -173,36 +173,37 @@ func (m *KonnManifest) VendorLink() interface{} {
 }
 
 func (m *KonnManifest) MarshalJSON() ([]byte, error) {
-	m.doc.Type = consts.Konnectors
-	m.doc.M["slug"] = m.val.Slug
-	m.doc.M["source"] = m.val.Source
-	m.doc.M["state"] = m.val.State
-	m.doc.M["version"] = m.val.Version
+	doc := m.doc.Clone().(*couchdb.JSONDoc)
+	doc.Type = consts.Konnectors
+	doc.M["slug"] = m.val.Slug
+	doc.M["source"] = m.val.Source
+	doc.M["state"] = m.val.State
+	doc.M["version"] = m.val.Version
 	if m.val.AvailableVersion == "" {
-		delete(m.doc.M, "available_version")
+		delete(doc.M, "available_version")
 	} else {
-		m.doc.M["available_version"] = m.val.AvailableVersion
+		doc.M["available_version"] = m.val.AvailableVersion
 	}
-	m.doc.M["checksum"] = m.val.Checksum
+	doc.M["checksum"] = m.val.Checksum
 	if m.val.Parameters == nil {
-		delete(m.doc.M, "parameters")
+		delete(doc.M, "parameters")
 	} else {
-		m.doc.M["parameters"] = m.val.Parameters
+		doc.M["parameters"] = m.val.Parameters
 	}
-	m.doc.M["created_at"] = m.val.CreatedAt
-	m.doc.M["updated_at"] = m.val.UpdatedAt
+	doc.M["created_at"] = m.val.CreatedAt
+	doc.M["updated_at"] = m.val.UpdatedAt
 	if m.val.Err == "" {
-		delete(m.doc.M, "error")
+		delete(doc.M, "error")
 	} else {
-		m.doc.M["error"] = m.val.Err
+		doc.M["error"] = m.val.Err
 	}
 	// XXX: keep the weird UnmarshalJSON of permission.Set
 	perms, err := m.val.Permissions.MarshalJSON()
 	if err != nil {
 		return nil, err
 	}
-	m.doc.M["permissions"] = json.RawMessage(perms)
-	return json.Marshal(m.doc)
+	doc.M["permissions"] = json.RawMessage(perms)
+	return json.Marshal(doc)
 }
 
 func (m *KonnManifest) UnmarshalJSON(j []byte) error {

--- a/model/app/webapp.go
+++ b/model/app/webapp.go
@@ -239,31 +239,32 @@ func (m *WebappManifest) NameLocalized(locale string) string {
 }
 
 func (m *WebappManifest) MarshalJSON() ([]byte, error) {
-	m.doc.Type = consts.Apps
-	m.doc.M["slug"] = m.val.Slug
-	m.doc.M["source"] = m.val.Source
-	m.doc.M["state"] = m.val.State
-	m.doc.M["version"] = m.val.Version
+	doc := m.doc.Clone().(*couchdb.JSONDoc)
+	doc.Type = consts.Apps
+	doc.M["slug"] = m.val.Slug
+	doc.M["source"] = m.val.Source
+	doc.M["state"] = m.val.State
+	doc.M["version"] = m.val.Version
 	if m.val.AvailableVersion == "" {
-		delete(m.doc.M, "available_version")
+		delete(doc.M, "available_version")
 	} else {
-		m.doc.M["available_version"] = m.val.AvailableVersion
+		doc.M["available_version"] = m.val.AvailableVersion
 	}
-	m.doc.M["checksum"] = m.val.Checksum
-	m.doc.M["created_at"] = m.val.CreatedAt
-	m.doc.M["updated_at"] = m.val.UpdatedAt
+	doc.M["checksum"] = m.val.Checksum
+	doc.M["created_at"] = m.val.CreatedAt
+	doc.M["updated_at"] = m.val.UpdatedAt
 	if m.val.Err == "" {
-		delete(m.doc.M, "error")
+		delete(doc.M, "error")
 	} else {
-		m.doc.M["error"] = m.val.Err
+		doc.M["error"] = m.val.Err
 	}
 	// XXX: keep the weird UnmarshalJSON of permission.Set
 	perms, err := m.val.Permissions.MarshalJSON()
 	if err != nil {
 		return nil, err
 	}
-	m.doc.M["permissions"] = json.RawMessage(perms)
-	return json.Marshal(m.doc)
+	doc.M["permissions"] = json.RawMessage(perms)
+	return json.Marshal(doc)
 }
 
 func (m *WebappManifest) UnmarshalJSON(j []byte) error {


### PR DESCRIPTION
When a webapp or konnector is installed/updated/removed, and we have
several websockets listening to changes for io.cozy.webapps or
io.cozy.konnectors, the stack try to serialize to JSON the same manifest
several times concurrently. Golang doesn't like that a map is read and
written concurrently and can crash. The fix is to clone the map to have
one map per serialization.