### PR TITLE
Fix the BI reconnect flow

### DIFF
--- a/web/accounts/oauth.go
+++ b/web/accounts/oauth.go
@@ -200,15 +200,15 @@ func refresh(c echo.Context) error {
 
 // reconnect can used to reconnect a user from BI
 func reconnect(c echo.Context) error {
+	if !middlewares.IsLoggedIn(c) {
+		return echo.NewHTTPError(http.StatusForbidden)
+	}
+
 	instance := middlewares.GetInstance(c)
 	accountid := c.Param("accountid")
 
 	var acc account.Account
 	if err := couchdb.GetDoc(instance, consts.Accounts, accountid, &acc); err != nil {
-		return err
-	}
-
-	if err := middlewares.Allow(c, permission.GET, &acc); err != nil {
 		return err
 	}
 
@@ -242,6 +242,6 @@ func reconnect(c echo.Context) error {
 func Routes(router *echo.Group) {
 	router.GET("/:accountType/start", start, middlewares.NeedInstance, middlewares.LoadSession)
 	router.GET("/:accountType/redirect", redirect)
-	router.POST("/:accountType/:accountid/refresh", refresh, middlewares.NeedInstance)
+	router.POST("/:accountType/:accountid/refresh", refresh, middlewares.NeedInstance, middlewares.LoadSession)
 	router.GET("/:accountType/:accountid/reconnect", reconnect, middlewares.NeedInstance)
 }

--- a/web/accounts/oauth.go
+++ b/web/accounts/oauth.go
@@ -242,6 +242,6 @@ func reconnect(c echo.Context) error {
 func Routes(router *echo.Group) {
 	router.GET("/:accountType/start", start, middlewares.NeedInstance, middlewares.LoadSession)
 	router.GET("/:accountType/redirect", redirect)
-	router.POST("/:accountType/:accountid/refresh", refresh, middlewares.NeedInstance, middlewares.LoadSession)
-	router.GET("/:accountType/:accountid/reconnect", reconnect, middlewares.NeedInstance)
+	router.POST("/:accountType/:accountid/refresh", refresh, middlewares.NeedInstance)
+	router.GET("/:accountType/:accountid/reconnect", reconnect, middlewares.NeedInstance, middlewares.LoadSession)
 }


### PR DESCRIPTION
The BI reconnect flow is similar to the OAuth flow for konnectors: it is
meant to be triggered via a browser opening a tab, not via a fetch/xhr
request. As such, there is no token for checking permissions, but we can
rely on the session to ensure the security.