### PR TITLE
Update the app when calling /apps/:slug

### DIFF
--- a/web/apps/apps.go
+++ b/web/apps/apps.go
@@ -98,8 +98,11 @@ func getHandler(appType consts.AppType) echo.HandlerFunc {
 		if err := middlewares.Allow(c, permission.GET, man); err != nil {
 			return err
 		}
-		if webapp, ok := man.(*app.WebappManifest); ok {
-			webapp.Instance = instance
+		if appType == consts.WebappType {
+			registries := instance.Registries()
+			copier := app.Copier(consts.WebappType, instance)
+			man = app.DoLazyUpdate(instance, man, copier, registries)
+			man.(*app.WebappManifest).Instance = instance
 		}
 		return jsonapi.Data(c, http.StatusOK, &apiApp{man}, nil)
 	}


### PR DESCRIPTION
When someone is using only the flagship app, we still need a way to keep
the webapps up-to-date. When the flagship app opens a webapp, it makes 3
calls to the stack:

- GET /apps/:slug/open
- GET /apps/:slug
- GET /apps/:slug/download

It seems that updating the app (if a new version is available without
needing a consent from the user) on the second call, GET /apps/:slug,
is the best choice as this call in made in background.