### PR TITLE
Allow to use big payload for webhook triggers

### DIFF
--- a/docs/konnectors-workflow.md
+++ b/docs/konnectors-workflow.md
@@ -793,6 +793,13 @@ HTTP/1.1 204 No Content
 - `COZY_PAYLOAD={"param_from_http_body": "bar"}`
 - etc.
 
+**Note:** the environnement variables have a limit for their size defined by
+the linux kernel. If the payload is too big to fit inside the env variable,
+the stack will put the payload in a temporary file, and will set the
+`COZY_PAYLOAD` variable to `@` + the filename of this file, like:
+
+`COZY_PAYLOAD=@cozy_payload.json`
+
 7. The konnector will fetch the documents from the external service and save
    them in the Cozy.
 

--- a/tests/integration/konnector/index.js
+++ b/tests/integration/konnector/index.js
@@ -1,13 +1,20 @@
 let fs = require('fs')
+let path = require('path')
 let http = require('http')
 
 let fields = JSON.parse(process.env['COZY_FIELDS'])
 let credentials = process.env['COZY_CREDENTIALS']
 let instance = process.env['COZY_URL']
 
+let cozyPayload = process.env['COZY_PAYLOAD']
 let payload
 try {
-  payload = JSON.parse(process.env['COZY_PAYLOAD'])
+  if (cozyPayload[0] == '@') {
+    let filepath = path.resolve(__dirname, cozyPayload.slice(1))
+    payload = { fromFile: JSON.parse(fs.readFileSync(filepath)) }
+  } else {
+    payload = JSON.parse(cozyPayload)
+  }
 } catch (e) {
   payload = { error: e }
 }


### PR DESCRIPTION
The payload from webhooks was read from the COZY_PAYLOAD env variable by
the konnector or service. But, env variables have a size limit (defined
by the linux kernel), which makes impossible to use large payload. Now,
when the stack sees a big payload, it will write it to a temporary file
and will just put @ + the filename of this file in COZY_PAYLOAD.