### PR TITLE
Fix instance creation with OIDC

### DIFF
--- a/model/instance/lifecycle/reset.go
+++ b/model/instance/lifecycle/reset.go
@@ -44,9 +44,12 @@ func Reset(inst *instance.Instance) error {
 	g.Go(func() error { return couchdb.CreateDB(inst, consts.Konnectors) })
 	g.Go(func() error { return couchdb.CreateDB(inst, consts.OAuthClients) })
 	g.Go(func() error { return couchdb.CreateDB(inst, consts.Jobs) })
+	g.Go(func() error { return couchdb.CreateDB(inst, consts.Triggers) })
 	g.Go(func() error { return couchdb.CreateDB(inst, consts.Permissions) })
 	g.Go(func() error { return couchdb.CreateDB(inst, consts.Sharings) })
 	g.Go(func() error { return couchdb.CreateDB(inst, consts.BitwardenCiphers) })
+	g.Go(func() error { return couchdb.CreateDB(inst, consts.SessionsLogins) })
+	g.Go(func() error { return couchdb.CreateDB(inst, consts.Notifications) })
 	g.Go(func() error { return couchdb.CreateDB(inst, consts.Contacts) })
 	g.Go(func() error {
 		if err := couchdb.CreateDB(inst, consts.Settings); err != nil {

--- a/tests/integration/tests/accounts-to-ciphers.rb
+++ b/tests/integration/tests/accounts-to-ciphers.rb
@@ -73,7 +73,7 @@ describe "Copying accounts to bitwarden ciphers" do
     # Check that the cipher has been linked
     assert_equal account["relationships"]["vaultCipher"]["data"]["_id"], cipher[:id]
 
-    # Check that the account auth fields have not been removed 
+    # Check that the account auth fields have not been removed
     assert_equal account["auth"]["login"], "Isabelle"
     assert_equal account["auth"]["zipcode"], "64000"
   end


### PR DESCRIPTION
The stack should create the CouchDB databases for a new instance before
registering a fake password for OIDC instance, as registering the
password also try to create a settings document for bitwarden.