### PR TITLE
Remove the exception for mapbox in the CSP

### DIFF
--- a/web/routing.go
+++ b/web/routing.go
@@ -56,9 +56,7 @@ const (
 
 	// cspImgSrcAllowList is an allowlist of images domains that are allowed in
 	// CSP.
-	cspImgSrcAllowList = "https://matomo.cozycloud.cc " +
-		"https://*.tile.openstreetmap.org https://*.tile.osm.org " +
-		"https://*.tiles.mapbox.com https://api.mapbox.com"
+	cspImgSrcAllowList = "https://matomo.cozycloud.cc https://*.tile.openstreetmap.org https://*.tile.osm.org"
 
 	// cspFrameSrcAllowList is an allowlist of custom protocols that are allowed
 	// in the CSP. We are using iframes on these custom protocols to open


### PR DESCRIPTION
Loading images from mapbox was authorized in the CSP, but this is not
used, and I don't like having exceptions in the CSP. So, let's remove
it.