### PR TITLE
Fix security issues with CSP

### DIFF
--- a/web/routing.go
+++ b/web/routing.go
@@ -168,9 +168,10 @@ func SetupRoutes(router *echo.Echo) error {
 	if !config.GetConfig().CSPDisabled {
 		secure := middlewares.Secure(&middlewares.SecureConfig{
 			HSTSMaxAge:        hstsMaxAge,
-			CSPDefaultSrc:     []middlewares.CSPSource{middlewares.CSPSrcSelf},
-			CSPImgSrc:         []middlewares.CSPSource{middlewares.CSPSrcData, middlewares.CSPSrcBlob},
+			CSPDefaultSrc:     []middlewares.CSPSource{middlewares.CSPSrcNone},
+			CSPFrameSrc:       []middlewares.CSPSource{middlewares.CSPSrcNone},
 			CSPFrameAncestors: []middlewares.CSPSource{middlewares.CSPSrcNone},
+			CSPBaseURI:        []middlewares.CSPSource{middlewares.CSPSrcNone},
 		})
 		router.Use(secure)
 	}

--- a/web/statik/handler.go
+++ b/web/statik/handler.go
@@ -198,6 +198,11 @@ func (r *renderer) Render(w io.Writer, name string, data interface{}, c echo.Con
 			return err
 		}
 	}
+
+	// Add some CSP for rendered web pages
+	middlewares.AppendCSPRule(c, "default-src", "'self'")
+	middlewares.AppendCSPRule(c, "img-src", "'self' data:")
+
 	return t.Funcs(funcMap).ExecuteTemplate(w, name, data)
 }
 


### PR DESCRIPTION
API endpoints like /files/download must have a strict Content Security
Policy to avoid using them as an HTML page or JS script. Their origin
is the main domain of a Cozy, and as such, they can read responses to
xhr/fetch to /auth/ endpoints.