### PR TITLE
Forbid patching md5sum by clients

### DIFF
--- a/client/files.go
+++ b/client/files.go
@@ -79,7 +79,6 @@ type FilePatchAttrs struct {
 	Tags       []string  `json:"tags,omitempty"`
 	UpdatedAt  time.Time `json:"updated_at,omitempty"`
 	Executable bool      `json:"executable,omitempty"`
-	MD5Sum     []byte    `json:"md5sum,omitempty"`
 	Class      string    `json:"class,omitempty"`
 }
 

--- a/model/vfs/file.go
+++ b/model/vfs/file.go
@@ -316,10 +316,6 @@ func ModifyFileMetadata(fs VFS, olddoc *FileDoc, patch *DocPatch) (*FileDoc, err
 	newdoc.CozyMetadata = olddoc.CozyMetadata
 	newdoc.InternalID = olddoc.InternalID
 
-	if patch.MD5Sum != nil {
-		newdoc.MD5Sum = *patch.MD5Sum
-	}
-
 	if err = fs.UpdateFileDoc(olddoc, newdoc); err != nil {
 		return nil, err
 	}

--- a/model/vfs/vfs.go
+++ b/model/vfs/vfs.go
@@ -322,7 +322,6 @@ type DocPatch struct {
 	UpdatedAt   *time.Time `json:"updated_at,omitempty"`
 	Executable  *bool      `json:"executable,omitempty"`
 	Encrypted   *bool      `json:"encrypted,omitempty"`
-	MD5Sum      *[]byte    `json:"md5sum,omitempty"`
 	Class       *string    `json:"class,omitempty"`
 }
 


### PR DESCRIPTION
The PATCH method for io.cozy.files allowed to update the md5sum. It was
introduced for fixing missing md5sums. It looks like this endpoint has
been misused by some clients and can create FS errors (content
mismatch). So, let's remove this possibility and the fix command that is
no longer used.