### PR TITLE
Avoid creating the no longer shared dir in trash

### DIFF
--- a/model/sharing/files.go
+++ b/model/sharing/files.go
@@ -395,6 +395,12 @@ func (s *Sharing) GetNoLongerSharedDir(inst *instance.Instance) (*vfs.DirDoc, er
 		if errp != nil {
 			return nil, errp
 		}
+		if strings.HasPrefix(parent.Fullpath, vfs.TrashDirName) {
+			parent, errp = fs.DirByID(consts.RootDirID)
+			if errp != nil {
+				return nil, errp
+			}
+		}
 		name := inst.Translate("Tree No longer shared")
 		dir, err = vfs.NewDirDocWithParent(name, parent, nil)
 		if err != nil {


### PR DESCRIPTION
When the folder where the sharings are received has been trashed, the
stack should not create the no longer shared directory inside it, but
should create it outside of the trash.