### PR TITLE
fix: Revert redirection to store on google danse error

### DIFF
--- a/web/accounts/oauth.go
+++ b/web/accounts/oauth.go
@@ -121,13 +121,6 @@ func redirect(c echo.Context) error {
 			}
 		}
 
-		// https://developers.google.com/identity/protocols/oauth2/web-server?hl=en#handlingresponse
-		if c.QueryParam("error") == "access_denied" {
-			u := i.SubDomain(consts.StoreSlug)
-			u.Fragment = "/discover/" + accountTypeID
-			return c.Redirect(http.StatusSeeOther, u.String())
-		}
-
 		accountType, err := account.TypeInfo(accountTypeID, i.ContextName)
 		if err != nil {
 			return err


### PR DESCRIPTION
We have the same access_denied message when user cancels BI webview and in some cases, there is no store application available.

Then, we go back to a redirection to home/harvest which will handle 
- BI webview cancel case
- Google Oauth danse cancel case

To se in another PR

This reverts commit b8a9f46cf1405712e2b9c0f39a56c523e4bc7ec6.
