### PR TITLE
Fix redirect when cancelling OAuth for a konnector

### DIFF
--- a/web/accounts/oauth.go
+++ b/web/accounts/oauth.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 
 	"github.com/cozy/cozy-stack/model/account"
+	"github.com/cozy/cozy-stack/model/instance"
 	"github.com/cozy/cozy-stack/model/instance/lifecycle"
 	"github.com/cozy/cozy-stack/model/permission"
 	"github.com/cozy/cozy-stack/model/session"
@@ -61,12 +62,11 @@ func start(c echo.Context) error {
 	return c.Redirect(http.StatusSeeOther, url)
 }
 
-func redirectToApp(c echo.Context, acc *account.Account, clientState, slug string) error {
-	instance := middlewares.GetInstance(c)
+func redirectToApp(c echo.Context, inst *instance.Instance, acc *account.Account, clientState, slug string) error {
 	if slug == "" {
 		slug = consts.HomeSlug
 	}
-	u := instance.SubDomain(slug)
+	u := inst.SubDomain(slug)
 	vv := &url.Values{}
 	if acc != nil {
 		vv.Add("account", acc.ID())
@@ -121,11 +121,12 @@ func redirect(c echo.Context) error {
 			}
 		}
 
+		clientState = state.ClientState
+		slug = state.Slug
+
 		// https://developers.google.com/identity/protocols/oauth2/web-server?hl=en#handlingresponse
 		if c.QueryParam("error") == "access_denied" {
-			u := i.SubDomain(consts.StoreSlug)
-			u.Fragment = "/discover/" + accountTypeID
-			return c.Redirect(http.StatusSeeOther, u.String())
+			return redirectToApp(c, i, nil, clientState, slug)
 		}
 
 		accountType, err := account.TypeInfo(accountTypeID, i.ContextName)
@@ -133,11 +134,8 @@ func redirect(c echo.Context) error {
 			return err
 		}
 
-		clientState = state.ClientState
-		slug = state.Slug
-
 		if state.ReconnectFlow {
-			return redirectToApp(c, nil, clientState, slug)
+			return redirectToApp(c, i, nil, clientState, slug)
 		}
 
 		if accountType.TokenEndpoint == "" {
@@ -164,7 +162,7 @@ func redirect(c echo.Context) error {
 	}
 
 	c.Set("instance", i.WithContextualDomain(c.Request().Host))
-	return redirectToApp(c, acc, clientState, slug)
+	return redirectToApp(c, i, acc, clientState, slug)
 }
 
 // refresh is an internal route used by konnectors to refresh accounts


### PR DESCRIPTION
For Google and BI webviews, an OAuth danse is made, and if the user
clicks to cancel it, they are redirected to the stack. We want to go
back to the app where they started the OAuth danse, not to an hard-coded
slug (store), because the store app may be not available and it makes
harder to have a coherent User Experience.