### PR TITLE
Fix check fs command for note images

### DIFF
--- a/model/vfs/vfsswift/fsck_v3.go
+++ b/model/vfs/vfsswift/fsck_v3.go
@@ -90,7 +90,9 @@ func (sfs *swiftVFSV3) checkFiles(
 		}
 		for _, obj := range objs {
 			if strings.HasPrefix(obj.Name, "thumbs/") {
-				objName := strings.Split(strings.TrimPrefix(obj.Name, "thumbs/"), "-")[0]
+				objName := strings.TrimPrefix(obj.Name, "thumbs/")
+				idx := strings.LastIndex(objName, "-")
+				objName = objName[0:idx] // Remove -format suffix
 				fileID := makeDocID(objName)
 				if _, ok := fileIDs[fileID]; !ok {
 					if _, ok := images[fileID]; !ok {


### PR DESCRIPTION
When using the VFS Swift, the images inside notes where seen as
thumbnail_with_no_file when the cozy-stack check fs was executed. It was
due to a bug in handling `-` in their name when removing the -format
suffix.