### PR TITLE
Don't send a notification for the first time

### DIFF
--- a/model/session/login_history.go
+++ b/model/session/login_history.go
@@ -175,6 +175,16 @@ func StoreNewLoginEntry(i *instance.Instance, sessionID, clientID string,
 }
 
 func sendLoginNotification(i *instance.Instance, l *LoginEntry) error {
+	// Don't send a notification the first time the user logs in their Cozy, as
+	// it doesn't make sense for the user. In general, this function is not
+	// even called when this is the case, but sometimes the user can create
+	// their Cozy from the manager with an OIDC flow, with no confirmation mail
+	// no password choosing, and we need this trick for them.
+	nb, _ := couchdb.CountNormalDocs(i, consts.SessionsLogins)
+	if nb == 1 {
+		return nil
+	}
+
 	var results []*LoginEntry
 	r := &couchdb.FindRequest{
 		UseIndex: "by-os-browser-ip",


### PR DESCRIPTION
It doesn't make sense for the user to receive a mail when they are using
their Cozy for the first time. It was already the case for most users,
but we are fixing that for users with OIDC flow.