### PR TITLE
Fix trigger creation for konnectors (folder_to_save)

### DIFF
--- a/model/app/konnector.go
+++ b/model/app/konnector.go
@@ -345,7 +345,11 @@ func (m *KonnManifest) triggerCrontab() string {
 	return spec.ToRandomCrontab(m.Slug())
 }
 
+// Cf https://github.com/cozy/cozy-libs/blob/55b5f23f0adbc308c3b70fa287c3938ee1b0a4cc/packages/cozy-harvest-lib/src/helpers/konnectors.js#L213-L225
 func (m *KonnManifest) hasFolderPath() bool {
+	if _, ok := m.doc.M["folders"].(map[string]interface{}); ok {
+		return true
+	}
 	fields, ok := m.doc.M["fields"].(map[string]interface{})
 	if !ok {
 		return false


### PR DESCRIPTION
When a trigger is created for a konnectors via the stack endpoint POST /jobs/:slug/trigger, the stack tries to mimick the behavior of harvest. In particular, it needs to to fill if the folder_to_save field of the trigger if the konnector manipulates files. Harvest looks at the manifest of the konnector for the fields.advanced_fields.folderPath (and the stack was doing it too) and folders (which wasn't done by the stack before this commit).