### PR TITLE
Drop the Host header when proxy request to CouchDB

### DIFF
--- a/pkg/couchdb/proxy.go
+++ b/pkg/couchdb/proxy.go
@@ -26,6 +26,7 @@ func Proxy(db prefixer.Prefixer, doctype, path string) *httputil.ReverseProxy {
 		req.URL.Host = couch.URL.Host
 		req.Header.Del(echo.HeaderAuthorization) // drop stack auth
 		req.Header.Del(echo.HeaderCookie)
+		req.Header.Del("Host")
 		req.URL.RawPath = "/" + makeDBName(db, doctype) + "/" + path
 		req.URL.Path, _ = url.PathUnescape(req.URL.RawPath)
 		if auth := couch.Auth; auth != nil {


### PR DESCRIPTION
The /data API allows to make requests to CouchDB, and the stack only proxify the request and check the permission. In thoses cases, it is better to drop the Host header.