### PR TITLE
Remove unregistred clients after error on push

### DIFF
--- a/worker/push/push.go
+++ b/worker/push/push.go
@@ -212,6 +212,9 @@ func pushToFirebase(ctx *job.WorkerContext, c *oauth.Client, msg *center.PushMes
 	}
 
 	for _, result := range res.Results {
+		if result.Unregistered() {
+			_ = c.Delete(ctx.Instance)
+		}
 		if err = result.Error; err != nil {
 			return err
 		}

--- a/worker/push/push.go
+++ b/worker/push/push.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"net/http"
 	"path/filepath"
 	"runtime"
 	"time"
@@ -291,7 +292,10 @@ func pushToAPNS(ctx *job.WorkerContext, c *oauth.Client, msg *center.PushMessage
 	if err != nil {
 		return err
 	}
-	if res.StatusCode != 200 {
+	if res.StatusCode == http.StatusGone {
+		_ = c.Delete(ctx.Instance)
+	}
+	if res.StatusCode != http.StatusOK {
 		return fmt.Errorf("failed to push apns notification: %d %s", res.StatusCode, res.Reason)
 	}
 	return nil

--- a/worker/push/push.go
+++ b/worker/push/push.go
@@ -317,7 +317,10 @@ func pushToHuawei(ctx *job.WorkerContext, c *oauth.Client, msg *center.PushMessa
 
 	notification := huawei.NewNotification(msg.Title, msg.Message, c.NotificationDeviceToken, data)
 	ctx.Logger().Infof("Huawei Push Kit send: %#v", notification)
-	err := huaweiClient.PushWithContext(ctx, notification)
+	unregistered, err := huaweiClient.PushWithContext(ctx, notification)
+	if unregistered {
+		_ = c.Delete(ctx.Instance)
+	}
 	if err != nil {
 		ctx.Logger().Warnf("Error during huawei send: %s", err)
 	}


### PR DESCRIPTION
When sending a push notification to APNS/FCM/Huawei, the error response can be interpreted to know if the mobile app has been uninstalled. If it happens, the stack will remove its associated OAuth client. The error codes are different per platform, but the logic is the same.