### PR TITLE
Fix session timeout on OAuth for banks

### DIFF
--- a/web/accounts/oauth.go
+++ b/web/accounts/oauth.go
@@ -272,8 +272,15 @@ func reconnect(c echo.Context) error {
 func checkLogin(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		inst := middlewares.GetInstance(c)
-		isLoggedIn := middlewares.IsLoggedIn(c)
+		sess, isLoggedIn := middlewares.GetSession(c)
 		wasLoggedIn := isLoggedIn
+
+		if sess != nil && sess.ShortRun {
+			// XXX it's better to create a new session in that case, as the
+			// existing short session can easily timeout between now and when
+			// the user will come back.
+			wasLoggedIn = false
+		}
 
 		if code := c.QueryParam("session_code"); code != "" {
 			// XXX we should always clear the session code to avoid it being


### PR DESCRIPTION
When a short session is created on the OAuth flow for banks, it can be reused if the user makes a second flow. But, as it is a short session, it can easily timeout between the beginning and the end of the flow. This fix consists of creating a new short session in that case.