### PR TITLE
Fix orphan triggers on app updates

### DIFF
--- a/model/app/webapp.go
+++ b/model/app/webapp.go
@@ -264,6 +264,12 @@ func (m *WebappManifest) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 	doc.M["permissions"] = json.RawMessage(perms)
+	doc.M["terms"] = m.val.Terms
+	doc.M["intents"] = m.val.Intents
+	doc.M["routes"] = m.val.Routes
+	doc.M["services"] = m.val.Services
+	doc.M["locales"] = m.val.Locales
+	doc.M["notifications"] = m.val.Notifications
 	return json.Marshal(doc)
 }
 


### PR DESCRIPTION
When a webapp is updated, and its manifest contains services, it can happen that a new trigger is created but the old one is not removed. It was the case, for example, when the type of the trigger is changed (@every -> @monthly).