### PR TITLE
Add icon and locales for all DACC remote doctypes

### DIFF
--- a/assets/locales/en.po
+++ b/assets/locales/en.po
@@ -682,6 +682,18 @@ msgstr "Categorization model enrichment file"
 msgid "Permissions cc.cozycloud.dacc"
 msgstr "Anonymous aggregate statistics"
 
+msgid "Permissions cc.cozycloud.dacc.dev"
+msgstr "Anonymous aggregate statistics for development purpose"
+
+msgid "Permissions cc.cozycloud.dacc_v2"
+msgstr "Anonymous aggregate statistics"
+
+msgid "Permissions cc.cozycloud.dacc.dev_v2"
+msgstr "Anonymous aggregate statistics for development purpose"
+
+msgid "Permissions eu.mycozy.dacc_v2"
+msgstr "Anonymous aggregate statistics"
+
 msgid "Permissions cc.cozycloud.sentry"
 msgstr "Application logs"
 

--- a/assets/locales/fr.po
+++ b/assets/locales/fr.po
@@ -753,6 +753,18 @@ msgstr "Fichier d'enrichissement du modèle de catégorisation"
 msgid "Permissions cc.cozycloud.dacc"
 msgstr "Statistiques agrégées anonymes"
 
+msgid "Permissions cc.cozycloud.dacc.dev"
+msgstr "Statistiques agrégées anonymes pour le développement"
+
+msgid "Permissions cc.cozycloud.dacc_v2"
+msgstr "Statistiques agrégées anonymes"
+
+msgid "Permissions cc.cozycloud.dacc.dev_v2"
+msgstr "Statistiques agrégées anonymes pour le développement"
+
+msgid "Permissions eu.mycozy.dacc_v2"
+msgstr "Statistiques agrégées anonymes"
+
 msgid "Permissions cc.cozycloud.sentry"
 msgstr "Journaux de l'application"
 

--- a/assets/styles/cirrus.css
+++ b/assets/styles/cirrus.css
@@ -279,7 +279,11 @@
   -webkit-mask-image: url("../icons/doctypes/organization.svg");
   mask-image: url("../icons/doctypes/organization.svg");
 }
-.perm[class^="cc-cozycloud-dacc"] {
+.perm[class^="cc-cozycloud-dacc"],
+.perm[class^="cc-cozycloud-dacc-dev"],
+.perm[class^="cc-cozycloud-dacc_v2"],
+.perm[class^="cc-cozycloud-dacc-dev_v2"],
+.perm[class^="eu.mycozy.dacc_v2"] {
   -webkit-mask-image: url("../icons/doctypes/stats.svg");
   mask-image: url("../icons/doctypes/stats.svg");
 }


### PR DESCRIPTION
We have many remote-doctypes for the DACC (unfortunately), but only one had the correct locales and icon