### PR TITLE
Fix cleaning thumbnails while dissociating files

### DIFF
--- a/model/vfs/vfsswift/impl_v3.go
+++ b/model/vfs/vfsswift/impl_v3.go
@@ -298,7 +298,11 @@ func (sfs *swiftVFSV3) DissociateFile(src, dst *vfs.FileDoc) error {
 	}
 
 	// Remove the source
-	thumbsFS := &thumbsV2{c: sfs.c, container: sfs.container}
+	thumbsFS := &thumbsV2{
+		c:         sfs.c,
+		container: sfs.container,
+		ctx:       context.Background(),
+	}
 	if err := thumbsFS.RemoveThumbs(src, vfs.ThumbnailFormatNames); err != nil {
 		sfs.log.Infof("Cleaning thumbnails in DissociateFile %s has failed: %s", src.ID(), err)
 	}


### PR DESCRIPTION
When files with thumbnails are shared, and someone move them outside of the shared  folder, a copy of those files is put in the trash for the other members of the sharing. This operation is called dissociating files, but it didn't removed the thumbnails of the old files because of an error "nil Context". This is now fixed by setting the context on the thumbsV2 object.