### PR TITLE
Avoid creating useless versions for files

### DIFF
--- a/model/vfs/vfsafero/impl.go
+++ b/model/vfs/vfsafero/impl.go
@@ -833,6 +833,9 @@ func (f *aferoFileCreation) Close() (err error) {
 
 	if v != nil {
 		actionV, toClean, _ := vfs.FindVersionsToClean(f.afs, newdoc.DocID, v)
+		if bytes.Equal(newdoc.MD5Sum, olddoc.MD5Sum) {
+			actionV = vfs.CleanCandidateVersion
+		}
 		if actionV == vfs.KeepCandidateVersion {
 			if errv := f.afs.Indexer.CreateVersion(v); errv != nil {
 				actionV = vfs.CleanCandidateVersion

--- a/model/vfs/vfsswift/impl_v3.go
+++ b/model/vfs/vfsswift/impl_v3.go
@@ -829,6 +829,9 @@ func (f *swiftFileCreationV3) Close() (err error) {
 
 	if v != nil {
 		actionV, toClean, _ := vfs.FindVersionsToClean(f.fs, newdoc.DocID, v)
+		if bytes.Equal(newdoc.MD5Sum, olddoc.MD5Sum) {
+			actionV = vfs.CleanCandidateVersion
+		}
 		if actionV == vfs.KeepCandidateVersion {
 			if errv := f.fs.Indexer.CreateVersion(v); errv != nil {
 				actionV = vfs.CleanCandidateVersion


### PR DESCRIPTION
When a new version of a file is uploaded, but the content is the same, the stack can avoid creating a new version. Some konnectors are known for importing files without checking if the file has really changed, and it creates lots of versions with the same content.