### PR TITLE
Improve the bitwarden prelogin route

### DIFF
--- a/docs/bitwarden.md
+++ b/docs/bitwarden.md
@@ -31,7 +31,9 @@ to `https://<instance>/bitwarden`.
 ### POST /bitwarden/api/accounts/prelogin
 
 It allows the client to know the number of KDF iterations to apply when hashing
-the master password.
+the master password. It can also tell if the login via OIDC is mandatory, and
+if the vault is empty (when both conditions are true, the onboarding process is
+a bit different).
 
 #### Request
 
@@ -57,7 +59,9 @@ Content-Type: application/json
 ```json
 {
   "Kdf": 0,
-  "KdfIterations": 10000
+  "KdfIterations": 10000,
+  "OIDC": false,
+  "HasCiphers": true
 }
 ```
 

--- a/web/bitwarden/bitwarden.go
+++ b/web/bitwarden/bitwarden.go
@@ -45,9 +45,16 @@ func Prelogin(c echo.Context) error {
 	if err != nil {
 		return err
 	}
+	passwordAuth := inst.IsPasswordAuthenticationEnabled()
+	hasCiphers := true
+	if resp, err := couchdb.NormalDocs(inst, consts.BitwardenCiphers, 0, 1, "", false); err == nil {
+		hasCiphers = resp.Total > 0
+	}
 	return c.JSON(http.StatusOK, echo.Map{
 		"Kdf":           setting.PassphraseKdf,
 		"KdfIterations": setting.PassphraseKdfIterations,
+		"OIDC":          !passwordAuth,
+		"HasCiphers":    hasCiphers,
 	})
 }
 

--- a/web/bitwarden/bitwarden_test.go
+++ b/web/bitwarden/bitwarden_test.go
@@ -39,11 +39,13 @@ func TestPrelogin(t *testing.T) {
 	res, err := http.DefaultClient.Do(req)
 	assert.NoError(t, err)
 	assert.Equal(t, 200, res.StatusCode)
-	var result map[string]int
+	var result map[string]interface{}
 	err = json.NewDecoder(res.Body).Decode(&result)
 	assert.NoError(t, err)
-	assert.Equal(t, 0, result["Kdf"])
-	assert.Equal(t, crypto.DefaultPBKDF2Iterations, result["KdfIterations"])
+	assert.EqualValues(t, 0, result["Kdf"])
+	assert.EqualValues(t, crypto.DefaultPBKDF2Iterations, result["KdfIterations"])
+	assert.Equal(t, false, result["OIDC"])
+	assert.Equal(t, false, result["HasCiphers"])
 }
 
 func TestConnect(t *testing.T) {


### PR DESCRIPTION
This route can now tell if the login via OIDC is mandatory and when the vault is empty. When both conditions are true, the onboarding process for the mobile apps and browser extensions is a bit different.