### PR TITLE
Fix the isNoLongerShared function

### DIFF
--- a/model/sharing/shared.go
+++ b/model/sharing/shared.go
@@ -185,8 +185,7 @@ func isFileNoLongerShared(inst *instance.Instance, msg TrackMessage, evt TrackEv
 	} else {
 		// For a directory, we have to check the path, as it can be a subfolder
 		// of a folder moved from inside the sharing to outside, and we will
-		// have an event for that (path is updated by the VFS, and we will have
-		// an event for that (path is updated by the VFS).
+		// have an event for that (path is updated by the VFS).
 		if evt.OldDoc.Get("path") == evt.Doc.Get("path") {
 			olds := extractReferencedBy(evt.OldDoc)
 			news := extractReferencedBy(&evt.Doc)
@@ -209,6 +208,14 @@ func isFileNoLongerShared(inst *instance.Instance, msg TrackMessage, evt TrackEv
 			}
 		}
 		return true, nil
+	}
+	if rule.Selector == "" || rule.Selector == "id" {
+		docID := evt.Doc.ID()
+		for _, id := range rule.Values {
+			if id == docID {
+				return false, nil
+			}
+		}
 	}
 
 	var docPath string

--- a/tests/integration/tests/sharing_conflicts.rb
+++ b/tests/integration/tests/sharing_conflicts.rb
@@ -11,11 +11,11 @@ def assert_conflict_children(inst_a, inst_b, parent_id_a, parent_id_b, filename)
   basename = File.basename filename, File.extname(filename)
 
   _, children_a = children_by_parent_id inst_a, parent_id_a
-  assert 2, children_a.length
+  assert_equal 2, children_a.length
   children_a.each { |child| assert child.name.include? basename }
 
   _, children_b = children_by_parent_id inst_b, parent_id_b
-  assert 2, children_b.length
+  assert_equal 2, children_b.length
   children_b.each { |child| assert child.name.include? basename }
 
   assert_equal children_a[0].name, children_b[0].name


### PR DESCRIPTION
When a single file is shared, if this file is moved to a new directory, the share-track worker was failing because of the isNoLongerShared function. We were trying to load the file as a directory, which triggered a "file not found" error.