### PR TITLE
Make the all_docs endpoint with Fields faster

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/mssola/user_agent v0.5.3
 	github.com/ncw/swift/v2 v2.0.1
 	github.com/nightlyone/lockfile v1.0.0
+	github.com/ohler55/ojg v1.14.5 // indirect
 	github.com/oschwald/maxminddb-golang v1.10.0
 	github.com/pquerna/otp v1.3.0
 	github.com/prometheus/client_golang v1.12.2

--- a/go.sum
+++ b/go.sum
@@ -402,6 +402,10 @@ github.com/nightlyone/lockfile v1.0.0/go.mod h1:rywoIealpdNse2r832aiD9jRk8ErCatR
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
+github.com/ohler55/ojg v1.14.4 h1:L2ds8AlB5t/QbqSfhRwvagJzQ7pgmdrefMIypQs0Xik=
+github.com/ohler55/ojg v1.14.4/go.mod h1:7Ghirupn8NC8hSSDpI0gcjorPxj+vSVIONDWfliHR1k=
+github.com/ohler55/ojg v1.14.5 h1:xCX2oyh/ZaoesbLH6fwVHStSJpk4o4eJs8ttXutzdg0=
+github.com/ohler55/ojg v1.14.5/go.mod h1:7Ghirupn8NC8hSSDpI0gcjorPxj+vSVIONDWfliHR1k=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=

--- a/pkg/couchdb/stream/all_docs.go
+++ b/pkg/couchdb/stream/all_docs.go
@@ -63,7 +63,7 @@ func (f *allDocsFilter) Stream(r io.Reader, w io.Writer) error {
 }
 
 func (f *allDocsFilter) isKeptField() bool {
-	// Decision has already been at an higher level
+	// Decision has already been made at an higher level
 	if f.matchedAt >= 0 {
 		return true
 	}

--- a/pkg/couchdb/stream/all_docs.go
+++ b/pkg/couchdb/stream/all_docs.go
@@ -208,8 +208,9 @@ func (f *allDocsFilter) objectStartInDoc() error {
 		return f.row.Object()
 	}
 
-	// We need to keep cozyMetadata.uploadedBy if fields include cozyMetadata,
-	// and we keep everything if fields is empty.
+	// We keep every attribute of an included field and we keep everything if
+	// fields is empty.
+	// e.g. we keep `cozyMetadata.uploadedBy` if fields include `cozyMetadata`,
 	if f.matchedAt >= 0 || len(f.fields) == 0 {
 		return f.row.Object(key)
 	}

--- a/pkg/couchdb/stream/all_docs.go
+++ b/pkg/couchdb/stream/all_docs.go
@@ -223,7 +223,8 @@ func (f *allDocsFilter) objectStartInDoc() error {
 		}
 	}
 
-	// We need to keep metadata if fields include metadata.datetime
+	// We keep parent attributes of included fields.
+	// e.g. we keep `metadata` if fields include `metadata.datetime`.
 	for _, field := range f.fields {
 		if strings.HasPrefix(field, f.path+".") {
 			return f.row.Object(key)

--- a/pkg/couchdb/stream/all_docs.go
+++ b/pkg/couchdb/stream/all_docs.go
@@ -30,7 +30,7 @@ type allDocsFilter struct {
 	err        error
 }
 
-// NewAllDocsFilter creates an object that can be use to remove some fields
+// NewAllDocsFilter creates an object that can be used to remove some fields
 // from a response to the all_docs endpoint of CouchDB.
 func NewAllDocsFilter(fields []string) *allDocsFilter {
 	for k, v := range fields {

--- a/pkg/couchdb/stream/all_docs.go
+++ b/pkg/couchdb/stream/all_docs.go
@@ -25,7 +25,7 @@ type allDocsFilter struct {
 	path       string     // The JSON object keys leading to the current position, joined with `.` (inside a row)
 	depth      int        // The number of `{` and `[` minus the number of `}` and `]`
 	matchedAt  int        // The depth of an exact match on a field, or -1
-	rejectedAt int        // The depth were no fields can match (partial or exact), or -1
+	rejectedAt int        // The depth where no fields can match (partial or exact), or -1
 	total      int        // The number of rows kept
 	err        error
 }

--- a/pkg/couchdb/stream/all_docs.go
+++ b/pkg/couchdb/stream/all_docs.go
@@ -22,7 +22,7 @@ type allDocsFilter struct {
 	w          io.Writer
 	row        oj.Builder // The current row without the filtered fields
 	rowIsDDoc  bool       // The current row is a design doc
-	path       string     // The JSON object keys of the current position, joined with `.` (inside a row)
+	path       string     // The JSON object keys leading to the current position, joined with `.` (inside a row)
 	depth      int        // The number of `{` and `[` minus the number of `}` and `]`
 	matchedAt  int        // The depth of an exact match on a field, or -1
 	rejectedAt int        // The depth were no fields can match (partial or exact), or -1

--- a/pkg/couchdb/stream/all_docs.go
+++ b/pkg/couchdb/stream/all_docs.go
@@ -1,0 +1,350 @@
+// The stream package can be used for streaming CouchDB responses in JSON
+// format from the CouchDB cluster to a client, with the stack doing stuff like
+// filtering some fields. It is way faster that doing a full parsing of the
+// JSON response, doing stuff, and then reserialize to JSON for large payloads.
+package stream
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/ohler55/ojg/oj"
+)
+
+type allDocsFilter struct {
+	// config
+	fields   []string
+	skipDDoc bool
+
+	// state
+	w          io.Writer
+	row        oj.Builder // The current row without the filtered fields
+	rowIsDDoc  bool       // The current row is a design doc
+	path       string     // The JSON object keys of the current position, joined with `.` (inside a row)
+	depth      int        // The number of `{` and `[` minus the number of `}` and `]`
+	matchedAt  int        // The depth of an exact match on a field, or -1
+	rejectedAt int        // The depth were no fields can match (partial or exact), or -1
+	total      int        // The number of rows kept
+	err        error
+}
+
+// NewAllDocsFilter creates an object that can be use to remove some fields
+// from a response to the all_docs endpoint of CouchDB.
+func NewAllDocsFilter(fields []string) *allDocsFilter {
+	for k, v := range fields {
+		fields[k] = "doc." + v
+	}
+	return &allDocsFilter{fields: fields}
+}
+
+// SkipDesignDocs must be called to configure the filter to also remove the
+// design docs.
+func (f *allDocsFilter) SkipDesignDocs() {
+	f.skipDDoc = true
+}
+
+// Stream will read the JSON response from CouchDB as the r reader, and will
+// write the filtered JSON to the w writer to be sent to the client.
+func (f *allDocsFilter) Stream(r io.Reader, w io.Writer) error {
+	f.w = w
+	f.path = ""
+	f.depth = 0
+	f.matchedAt = -1
+	f.rejectedAt = -1
+	f.total = 0
+	f.err = nil
+
+	if err := oj.TokenizeLoad(r, f); err != nil {
+		return err
+	}
+	return f.err
+}
+
+func (f *allDocsFilter) isKeptField() bool {
+	// Decision has already been at an higher level
+	if f.matchedAt >= 0 {
+		return true
+	}
+	if f.rejectedAt >= 0 {
+		return false
+	}
+
+	// Special cases
+	if len(f.fields) == 0 {
+		return true
+	}
+	if f.depth <= 3 {
+		// offset, rows, and total_rows
+		// id, key, value, and doc
+		// -> we can remove key (same as id) to gain a few kbs in the response
+		return f.path != "key"
+	}
+
+	// Looks at fields to decide
+	for _, field := range f.fields {
+		if field == f.path {
+			return true
+		}
+	}
+	return false
+}
+
+// currentKey returns the last object key we have seen.
+func (f *allDocsFilter) currentKey() string {
+	idx := strings.LastIndex(f.path, ".")
+	if idx == -1 {
+		return f.path
+	}
+	return f.path[idx+1:]
+}
+
+// popKey removes the given key from the path after we have finished processing
+// its value.
+func (f *allDocsFilter) popKey(key string) {
+	pos := len(f.path) - len(key) - 1
+	if pos > 0 {
+		f.path = f.path[:pos]
+	} else {
+		f.path = ""
+	}
+}
+
+// value is used for basic values in JSON: nulls, booleans, numbers and strings.
+func (f *allDocsFilter) value(value interface{}) {
+	var err error
+	key := f.currentKey()
+	if key == "[]" {
+		if f.rejectedAt < 0 {
+			err = f.row.Value(value)
+		}
+	} else {
+		if f.isKeptField() {
+			err = f.row.Value(value, key)
+		}
+		f.popKey(key)
+	}
+	if err != nil && f.err == nil {
+		f.err = err
+	}
+}
+
+func (f *allDocsFilter) Null() {
+	f.value(nil)
+}
+
+func (f *allDocsFilter) Bool(b bool) {
+	f.value(b)
+}
+
+func (f *allDocsFilter) Int(i int64) {
+	if f.depth > 2 { // total_rows and offset are not kept from the reader
+		f.value(i)
+	}
+}
+
+func (f *allDocsFilter) Float(x float64) {
+	f.value(x)
+}
+
+func (f *allDocsFilter) Number(n string) {
+	if f.err == nil {
+		f.err = fmt.Errorf("number %q is not supported", n)
+	}
+}
+
+func (f *allDocsFilter) String(s string) {
+	if f.skipDDoc && f.depth == 3 && f.path == "id" && strings.HasPrefix(s, "_design") {
+		// skip design docs
+		f.rowIsDDoc = true
+		f.path = ""
+	} else {
+		f.value(s)
+	}
+}
+
+func (f *allDocsFilter) Key(s string) {
+	if f.path == "" {
+		f.path = s
+	} else {
+		f.path += "." + s
+	}
+}
+
+func (f *allDocsFilter) ObjectStart() {
+	var err error
+	switch f.depth {
+	case 0: // global
+		// nothing
+	case 1: // rows array
+		err = errors.New("unexpected case")
+	case 2: // a row
+		f.rowIsDDoc = false
+		f.path = ""
+		err = f.row.Object()
+	case 3: // doc or value
+		if len(f.fields) == 0 || f.path != "value" {
+			err = f.row.Object(f.path)
+		}
+	default: // inside doc
+		err = f.objectStartInDoc()
+	}
+	if err != nil && f.err == nil {
+		f.err = err
+	}
+	f.depth++
+}
+
+func (f *allDocsFilter) objectStartInDoc() error {
+	// We are inside an object that won't be copied to the response
+	if f.rejectedAt >= 0 {
+		return nil
+	}
+
+	// Objects inside an array are always kept
+	key := f.currentKey()
+	if key == "[]" {
+		return f.row.Object()
+	}
+
+	// We need to keep cozyMetadata.uploadedBy if fields include cozyMetadata,
+	// and we keep everything if fields is empty.
+	if f.matchedAt >= 0 || len(f.fields) == 0 {
+		return f.row.Object(key)
+	}
+
+	// Exact match
+	for _, field := range f.fields {
+		if field == f.path {
+			f.matchedAt = f.depth
+			return f.row.Object(key)
+		}
+	}
+
+	// We need to keep metadata if fields include metadata.datetime
+	for _, field := range f.fields {
+		if strings.HasPrefix(field, f.path+".") {
+			return f.row.Object(key)
+		}
+	}
+
+	// We can remove this object from the response
+	f.rejectedAt = f.depth
+	return nil
+}
+
+func (f *allDocsFilter) ObjectEnd() {
+	f.depth--
+
+	switch f.depth {
+	case 0: // global
+		// nothing
+	case 1: // rows array
+		if f.err == nil {
+			f.err = errors.New("unexpected case")
+		}
+	case 2: // a row
+		if f.rowIsDDoc {
+			f.row.Reset()
+		} else {
+			f.flushRow()
+		}
+	case 3: // doc or value
+		if len(f.fields) == 0 || f.path != "value" {
+			f.row.Pop()
+		}
+		f.path = ""
+	default: // inside doc
+		f.objectEndInDoc()
+	}
+}
+
+func (f *allDocsFilter) objectEndInDoc() {
+	if key := f.currentKey(); key != "[]" {
+		f.popKey(key)
+	}
+
+	if f.rejectedAt >= 0 {
+		if f.rejectedAt == f.depth {
+			f.rejectedAt = -1
+		}
+		return
+	}
+	if f.matchedAt == f.depth {
+		f.matchedAt = -1
+	}
+
+	f.row.Pop()
+}
+
+func (f *allDocsFilter) flushRow() {
+	prefix := ""
+	if f.total != 0 {
+		prefix = ","
+	}
+	row := prefix + oj.JSON(f.row.Result()) + "\n"
+	f.row.Reset()
+	if _, err := f.w.Write([]byte(row)); err != nil && f.err != nil {
+		f.err = err
+	}
+	f.total++
+}
+
+func (f *allDocsFilter) ArrayStart() {
+	f.depth++
+
+	if f.depth <= 2 {
+		// Special case for the rows array
+		if _, err := f.w.Write([]byte(`{"rows":[`)); err != nil && f.err == nil {
+			f.err = err
+		}
+		return
+	}
+
+	key := f.currentKey()
+	f.path += ".[]"
+
+	if f.rejectedAt >= 0 {
+		return
+	}
+
+	var err error
+	if key == "[]" {
+		err = f.row.Array()
+	} else if f.isKeptField() {
+		err = f.row.Array(key)
+	} else {
+		f.rejectedAt = f.depth - 1
+	}
+	if err != nil && f.err == nil {
+		f.err = err
+	}
+}
+
+func (f *allDocsFilter) ArrayEnd() {
+	f.depth--
+
+	if f.depth <= 2 {
+		// Special case for the rows array
+		buf := fmt.Sprintf(`],"offset":0,"total_rows":%d}`, f.total)
+		if _, err := f.w.Write([]byte(buf)); err != nil && f.err == nil {
+			f.err = err
+		}
+		return
+	}
+
+	f.popKey("[]")
+	if key := f.currentKey(); key != "[]" {
+		f.popKey(key)
+	}
+
+	if f.rejectedAt >= 0 {
+		if f.rejectedAt == f.depth {
+			f.rejectedAt = -1
+		}
+		return
+	}
+
+	f.row.Pop()
+}

--- a/pkg/couchdb/stream/all_docs_test.go
+++ b/pkg/couchdb/stream/all_docs_test.go
@@ -1,0 +1,290 @@
+package stream
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const input = `
+{
+  "total_rows": 6,
+  "offset": 0,
+  "rows": [
+    {
+      "id": "1bbde1890ad23cb023e0b2ee1d0cc1aa",
+      "key": "1bbde1890ad23cb023e0b2ee1d0cc1aa",
+      "value": {
+        "rev": "1-14532ac999e880c2b731f0bd6ed5aef5"
+      },
+      "doc": {
+        "_id": "1bbde1890ad23cb023e0b2ee1d0cc1aa",
+        "_rev": "1-14532ac999e880c2b731f0bd6ed5aef5",
+        "type": "file",
+        "name": "happycloud.png",
+        "dir_id": "ecbc071979a81554709a0394310c5291",
+        "created_at": "2022-01-03T16:07:37.886Z",
+        "updated_at": "2022-01-03T16:07:37.886Z",
+        "size": "5167",
+        "md5sum": "+ifa4cMPFbvDY8hERyfyGw==",
+        "mime": "image/png",
+        "class": "image",
+        "executable": false,
+        "trashed": false,
+        "encrypted": false,
+        "metadata": {
+          "arrays": [[
+            [{ "foo": "bar", "more": [] }],
+            [{ "foo": "baz", "more": [] }]
+          ]],
+          "datetime": "2022-01-03T16:07:37.886Z",
+          "extractor_version": 2,
+          "height": 84,
+          "width": 110
+        },
+        "cozyMetadata": {
+          "doctypeVersion": "1",
+          "metadataVersion": 1,
+          "createdAt": "2022-10-24T17:32:27.187580797+02:00",
+          "createdByApp": "drive",
+          "updatedAt": "2022-10-24T17:32:27.187580797+02:00",
+          "updatedByApps": [
+            {
+              "slug": "drive",
+              "date": "2022-10-24T17:32:27.187580797+02:00",
+              "instance": "http://joe.localhost:8080/"
+            }
+          ],
+          "createdOn": "http://joe.localhost:8080/",
+          "uploadedAt": "2022-10-24T17:32:27.187580797+02:00",
+          "uploadedBy": {
+            "slug": "drive"
+          },
+          "uploadedOn": "http://joe.localhost:8080/"
+        }
+      }
+    },
+    {
+      "id": "_design/disk-usage",
+      "key": "_design/disk-usage",
+      "value": {
+        "rev": "1-aa2ea41ec37738d50438e5b87fa5f544"
+      },
+      "doc": {
+        "_id": "_design/disk-usage",
+        "_rev": "1-aa2ea41ec37738d50438e5b87fa5f544",
+        "language": "javascript",
+        "views": {
+          "disk-usage": {
+            "map": "function(doc) { if (doc.type === 'file') { emit(doc.dir_id, +doc.size); } }",
+            "reduce": "_sum"
+          }
+        }
+      }
+    },
+    {
+      "id": "_design/by-dir-id-updated-at",
+      "key": "_design/by-dir-id-updated-at",
+      "value": {
+        "rev": "1-afade1d0263e3fb50ab52b61445aa4b9"
+      },
+      "doc": {
+        "_id": "_design/by-dir-id-updated-at",
+        "_rev": "1-afade1d0263e3fb50ab52b61445aa4b9",
+        "language": "query",
+        "views": {
+          "5a9b035bcbceb460f09d8ae4f4ebf60ffa37125e": {
+            "map": {
+              "fields": {
+                "dir_id": "asc",
+                "updated_at": "asc"
+              },
+              "partial_filter_selector": {}
+            },
+            "reduce": "_count",
+            "options": {
+              "def": {
+                "fields": [
+                  "dir_id",
+                  "updated_at"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "ecbc071979a81554709a0394310c5291",
+      "key": "ecbc071979a81554709a0394310c5291",
+      "value": {
+        "rev": "1-b894889f9135ca4ba915d6e7e96fba08"
+      },
+      "doc": {
+        "_id": "ecbc071979a81554709a0394310c5291",
+        "_rev": "1-b894889f9135ca4ba915d6e7e96fba08",
+        "type": "directory",
+        "name": "Photos",
+        "dir_id": "io.cozy.files.root-dir",
+        "created_at": "2022-09-19T13:45:54.565507012+02:00",
+        "updated_at": "2022-09-19T13:45:54.565507012+02:00",
+        "path": "/Photos",
+        "cozyMetadata": {
+          "doctypeVersion": "1",
+          "metadataVersion": 1,
+          "createdAt": "2022-09-19T13:45:54.565507834+02:00",
+          "updatedAt": "2022-09-19T13:45:54.565507834+02:00",
+          "createdOn": "http://joe.localhost:8080/"
+        }
+      }
+    },
+    {
+      "id": "io.cozy.files.root-dir",
+      "key": "io.cozy.files.root-dir",
+      "value": {
+        "rev": "1-1e0b279e7a36ccc415c1843f0355840f"
+      },
+      "doc": {
+        "_id": "io.cozy.files.root-dir",
+        "_rev": "1-1e0b279e7a36ccc415c1843f0355840f",
+        "type": "directory",
+        "created_at": "2022-09-19T13:45:54.54955097+02:00",
+        "updated_at": "2022-09-19T13:45:54.54955097+02:00",
+        "path": "/"
+      }
+    },
+    {
+      "id": "io.cozy.files.trash-dir",
+      "key": "io.cozy.files.trash-dir",
+      "value": {
+        "rev": "1-11f72bef9b00c46cf8fe3c35c20bd86e"
+      },
+      "doc": {
+        "_id": "io.cozy.files.trash-dir",
+        "_rev": "1-11f72bef9b00c46cf8fe3c35c20bd86e",
+        "type": "directory",
+        "name": ".cozy_trash",
+        "dir_id": "io.cozy.files.root-dir",
+        "created_at": "2022-09-19T13:45:54.54955097+02:00",
+        "updated_at": "2022-09-19T13:45:54.54955097+02:00",
+        "path": "/.cozy_trash"
+      }
+    }
+  ]
+}`
+
+func TestSkipDesingDocs(t *testing.T) {
+	filter := NewAllDocsFilter(nil)
+	filter.SkipDesignDocs()
+	var w bytes.Buffer
+	require.NoError(t, filter.Stream(strings.NewReader(input), &w))
+	var data map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Bytes(), &data))
+	assert.EqualValues(t, 0, data["offset"])
+	assert.EqualValues(t, 4, data["total_rows"])
+	rows, ok := data["rows"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, rows, 4)
+	for i := range rows {
+		row, ok := rows[i].(map[string]interface{})
+		require.True(t, ok)
+		id, ok := row["id"].(string)
+		require.True(t, ok)
+		assert.False(t, strings.HasPrefix(id, "_design/"))
+		key, ok := row["key"].(string)
+		require.True(t, ok)
+		assert.Equal(t, id, key)
+		value, ok := row["value"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Contains(t, value["rev"], "1-")
+	}
+}
+
+func TestFilterBasicFields(t *testing.T) {
+	filter := NewAllDocsFilter([]string{"_id", "type", "path"})
+	var w bytes.Buffer
+	require.NoError(t, filter.Stream(strings.NewReader(input), &w))
+	var data map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Bytes(), &data))
+	assert.EqualValues(t, 0, data["offset"])
+	assert.EqualValues(t, 6, data["total_rows"])
+	rows, ok := data["rows"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, rows, 6)
+
+	row, ok := rows[4].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "io.cozy.files.root-dir", row["id"])
+	assert.NotContains(t, row, "key")
+	assert.NotContains(t, row, "value")
+	doc, ok := row["doc"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "io.cozy.files.root-dir", doc["_id"])
+	assert.Equal(t, "directory", doc["type"])
+	assert.Equal(t, "/", doc["path"])
+	assert.NotContains(t, doc, "_rev")
+	assert.NotContains(t, doc, "name")
+	assert.NotContains(t, doc, "dir_id")
+	assert.NotContains(t, doc, "created_at")
+	assert.NotContains(t, doc, "updated_at")
+
+	row, ok = rows[5].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "io.cozy.files.trash-dir", row["id"])
+	assert.NotContains(t, row, "key")
+	assert.NotContains(t, row, "value")
+	doc, ok = row["doc"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "io.cozy.files.trash-dir", doc["_id"])
+	assert.Equal(t, "directory", doc["type"])
+	assert.Equal(t, "/.cozy_trash", doc["path"])
+	assert.NotContains(t, doc, "_rev")
+	assert.NotContains(t, doc, "name")
+	assert.NotContains(t, doc, "dir_id")
+	assert.NotContains(t, doc, "created_at")
+	assert.NotContains(t, doc, "updated_at")
+}
+
+func TestFilterDottedFields(t *testing.T) {
+	filter := NewAllDocsFilter([]string{"metadata.datetime", "cozyMetadata.uploadedBy"})
+	var w bytes.Buffer
+	require.NoError(t, filter.Stream(strings.NewReader(input), &w))
+	var data map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Bytes(), &data))
+	assert.EqualValues(t, 0, data["offset"])
+	assert.EqualValues(t, 6, data["total_rows"])
+	rows, ok := data["rows"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, rows, 6)
+
+	row, ok := rows[0].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "1bbde1890ad23cb023e0b2ee1d0cc1aa", row["id"])
+	doc, ok := row["doc"].(map[string]interface{})
+	require.True(t, ok)
+	assert.NotContains(t, doc, "_id")
+	assert.NotContains(t, doc, "_rev")
+	assert.NotContains(t, doc, "name")
+	assert.NotContains(t, doc, "dir_id")
+	assert.NotContains(t, doc, "created_at")
+	assert.NotContains(t, doc, "updated_at")
+	metadata, ok := doc["metadata"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "2022-01-03T16:07:37.886Z", metadata["datetime"])
+	assert.NotContains(t, metadata, "extractor_version")
+	assert.NotContains(t, metadata, "height")
+	assert.NotContains(t, metadata, "width")
+	cozyMetadata, ok := doc["cozyMetadata"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "2022-01-03T16:07:37.886Z", metadata["datetime"])
+	assert.NotContains(t, cozyMetadata, "doctypeVersion")
+	assert.NotContains(t, cozyMetadata, "uploadedAt")
+	assert.NotContains(t, cozyMetadata, "uploadedOn")
+	uploadedBy, ok := cozyMetadata["uploadedBy"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "drive", uploadedBy["slug"])
+}

--- a/web/data/data.go
+++ b/web/data/data.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cozy/cozy-stack/model/permission"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/couchdb/stream"
 	"github.com/cozy/cozy-stack/pkg/jsonapi"
 	"github.com/cozy/cozy-stack/web/files"
 	"github.com/cozy/cozy-stack/web/middlewares"
@@ -405,77 +406,24 @@ func allDocs(c echo.Context) error {
 		StartKey:   c.QueryParam("startkey"),
 		EndKey:     c.QueryParam("endkey"),
 	}
-	var docs []*couchdb.JSONDoc
-	if err := couchdb.GetAllDocs(inst, doctype, req, &docs); err != nil {
+	body, err := couchdb.MakeAllDocsRequest(inst, doctype, req)
+	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": err})
 	}
+	defer body.Close()
 
-	skipDDoc := c.QueryParam("DesignDocs") == "false"
-	var fields [][]string
-	for _, f := range strings.Split(c.QueryParam("Fields"), ",") {
-		fields = append(fields, strings.Split(f, "."))
+	fields := strings.Split(c.QueryParam("Fields"), ",")
+	filter := stream.NewAllDocsFilter(fields)
+	if c.QueryParam("DesignDocs") == "false" {
+		filter.SkipDesignDocs()
 	}
-	res := couchdb.AllDocsResponse{
-		Offset:    req.Skip,
-		TotalRows: len(docs),
+	c.Response().Header().Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	c.Response().WriteHeader(http.StatusOK)
+	if err := filter.Stream(body, c.Response()); err != nil {
+		inst.Logger().WithNamespace("couchdb").Warnf("error on all_docs: %s", err)
+		return err
 	}
-	for _, doc := range docs {
-		if skipDDoc && strings.HasPrefix(doc.ID(), "_design") {
-			continue
-		}
-		m := filterFields(doc, fields)
-		raw, err := json.Marshal(m)
-		if err != nil {
-			return c.JSON(http.StatusInternalServerError, echo.Map{"error": err})
-		}
-		row := couchdb.AllDocsRow{
-			ID:  doc.ID(),
-			Doc: raw,
-		}
-		res.Rows = append(res.Rows, row)
-	}
-	return c.JSON(http.StatusOK, res)
-}
-
-func filterFields(doc *couchdb.JSONDoc, fields [][]string) map[string]interface{} {
-	m := make(map[string]interface{})
-	for _, field := range fields {
-		if val, ok := extractField(doc, field); ok {
-			assignField(m, field, val)
-		}
-	}
-	return m
-}
-
-func extractField(doc *couchdb.JSONDoc, field []string) (interface{}, bool) {
-	var value interface{} = doc.M
-	for _, part := range field {
-		val, ok := value.(map[string]interface{})
-		if !ok {
-			return nil, false
-		}
-		value, ok = val[part]
-		if !ok {
-			return nil, false
-		}
-	}
-	return value, true
-}
-
-func assignField(m map[string]interface{}, field []string, val interface{}) {
-	for i, part := range field {
-		if i == len(field)-1 {
-			m[part] = val
-		} else {
-			if v, ok := m[part].(map[string]interface{}); ok {
-				m = v
-			} else {
-				nested := make(map[string]interface{})
-				m[part] = nested
-				m = nested
-			}
-		}
-	}
+	return nil
 }
 
 func normalDocs(c echo.Context) error {

--- a/web/data/data_test.go
+++ b/web/data/data_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/tests/testutils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -833,92 +834,13 @@ func TestGetAllDocs(t *testing.T) {
 	assert.Equal(t, "quux", qux)
 }
 
-func TestFilterFields(t *testing.T) {
-	m := map[string]interface{}{
-		"hello": "world",
-		"foo": map[string]interface{}{
-			"bar": map[string]interface{}{
-				"baz": "baz",
-			},
-			"courge": map[string]interface{}{
-				"qux":  "qux",
-				"quux": "quux",
-			},
-		},
-		"123": "456",
-	}
-	doc := &couchdb.JSONDoc{M: m}
-	fields := [][]string{
-		{"hello"},
-		{"foo", "courge", "qux"},
-	}
-	filtered := filterFields(doc, fields)
-	expected := map[string]interface{}{
-		"hello": "world",
-		"foo": map[string]interface{}{
-			"courge": map[string]interface{}{
-				"qux": "qux",
-			},
-		},
-	}
-	assert.EqualValues(t, expected, filtered)
-}
-
-func TestExtractField(t *testing.T) {
-	m := map[string]interface{}{
-		"hello": "world",
-		"foo": map[string]interface{}{
-			"bar": map[string]interface{}{
-				"baz": "baz",
-			},
-			"courge": map[string]interface{}{
-				"qux":  "qux",
-				"quux": "quux",
-			},
-		},
-	}
-	doc := &couchdb.JSONDoc{M: m}
-	_, ok := extractField(doc, []string{"nosuchfield"})
-	assert.False(t, ok)
-	val, ok := extractField(doc, []string{"hello"})
-	assert.True(t, ok)
-	assert.Equal(t, "world", val)
-	val, ok = extractField(doc, []string{"foo", "bar"})
-	assert.True(t, ok)
-	assert.EqualValues(t, map[string]interface{}{"baz": "baz"}, val)
-	val, ok = extractField(doc, []string{"foo", "bar", "baz"})
-	assert.True(t, ok)
-	assert.Equal(t, "baz", val)
-}
-
-func TestAssignField(t *testing.T) {
-	m := make(map[string]interface{})
-	assignField(m, []string{"hello"}, "world")
-	assignField(m, []string{"foo", "bar", "baz"}, "baz")
-	assignField(m, []string{"foo", "courge", "qux"}, "qux")
-	assignField(m, []string{"foo", "courge", "quux"}, "quux")
-	expected := map[string]interface{}{
-		"hello": "world",
-		"foo": map[string]interface{}{
-			"bar": map[string]interface{}{
-				"baz": "baz",
-			},
-			"courge": map[string]interface{}{
-				"qux":  "qux",
-				"quux": "quux",
-			},
-		},
-	}
-	assert.EqualValues(t, expected, m)
-}
-
 func TestGetAllDocsWithFields(t *testing.T) {
 	url := ts.URL + "/data/" + Type + "/_all_docs?include_docs=true&Fields=test,nosuchfield,foo.qux"
 	req, _ := http.NewRequest("GET", url, nil)
 	req.Header.Add("Authorization", "Bearer "+token)
 	out, res, err := doRequest(req, nil)
 	assert.Equal(t, "200 OK", res.Status, "should get a 200")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	totalRows := out["total_rows"].(float64)
 	assert.Equal(t, float64(3), totalRows)
 	offset := out["offset"].(float64)


### PR DESCRIPTION
When requesting all_docs for a lot of io.cozy.files with Fields, the response can be quite slow (a few seconds). Part of that is CouchDB and transfering the bytes, and we can't do anything about that, but there is also another part that is deserializing JSON, keeping only the required fields, and reserializing to JSON. And it looks like this part is taking way much longer that we would have expected.

In this commit, we are trying to make things faster by replacing the full JSON parser by just a tokenizer (and doing some low-level stuff). I have added unit tests, but the code is tricky, so I'm less confident than usual on the risk of a regression. And we need to deploy on servers to really see the performance boost (or lack of).