### PR TITLE
Add a protection when revoking a sharing

### DIFF
--- a/model/vfs/couchdb_indexer.go
+++ b/model/vfs/couchdb_indexer.go
@@ -780,6 +780,14 @@ func (c *couchdbIndexer) checkTrashedDirIsShared(doc *DirDoc) {
 // the main file of a sharing. If it is the case, the sharing is revoked and
 // the reference to the sharing is removed.
 func (c *couchdbIndexer) checkTrashedFileIsShared(doc *FileDoc) {
+	// A shortcut is created for a sharing not yet accepted if the owner of the
+	// sharing knows the Cozy URL of a recipient. Normally, this shortcut is
+	// removed when the sharing is accepted, but it is safer to avoid revoking
+	// the sharing is such a shortcut is deleted later.
+	if doc.Class == "shortcut" {
+		return
+	}
+
 	refs := doc.ReferencedBy[:0]
 	for _, ref := range doc.ReferencedBy {
 		if ref.Type == consts.Sharings {


### PR DESCRIPTION
Removing a shortcut for a sharing should never revoke the sharing, so let's add a protection against that. We have seen a case in production where this protection would have been useful.