### PR TITLE
Fix cwd for konnectors

### DIFF
--- a/worker/exec/cmd_unix.go
+++ b/worker/exec/cmd_unix.go
@@ -4,13 +4,22 @@
 package exec
 
 import (
+	"os"
 	"os/exec"
+	"path/filepath"
 	"syscall"
 )
 
 // CreateCmd creates an exec.Cmd.
 func CreateCmd(cmdStr, workDir string) *exec.Cmd {
-	c := exec.Command(cmdStr, workDir)
+	script := "."
+	cwd := workDir
+	if info, err := os.Stat(workDir); err == nil && !info.IsDir() {
+		script = filepath.Base(workDir)
+		cwd = filepath.Dir(workDir)
+	}
+	c := exec.Command(cmdStr, script)
+	c.Dir = cwd
 	c.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	return c
 }

--- a/worker/exec/konnector_test.go
+++ b/worker/exec/konnector_test.go
@@ -162,8 +162,7 @@ echo "{\"type\": \"manifest\", \"message\": \"$(ls ${1}/manifest.konnector)\" }"
 		assert.Equal(t, "manifest", doc2.M["type"])
 
 		msg2 := doc2.M["message"].(string)
-		assert.True(t, strings.HasPrefix(msg2, os.TempDir()))
-		assert.True(t, strings.HasSuffix(msg2, "/manifest.konnector"))
+		assert.Equal(t, "./manifest.konnector", msg2)
 
 		msg1 := doc1.M["message"].(string)
 		cozyURL := "COZY_URL=" + inst.PageURL("/", nil) + " "


### PR DESCRIPTION
The current working directory for a konnector should be the directory where its script is running (and not keeping the cwd of the stack). It would make easier to find the payload.json from a konnector when needed.