### PR TITLE
small documentation modifications

### DIFF
--- a/docs/cli/cozy-stack_instances_add.md
+++ b/docs/cli/cozy-stack_instances_add.md
@@ -19,8 +19,16 @@ cozy-stack instances add <domain> [flags]
 
 ### Examples
 
+A simple exemple creating an instance with the domain `instance01.localhost:8080`
+
+```sh
+$ cozy-stack instances add instance01.localhost:8080 --passphrase cozy --apps drive,photos,settings,home,store
 ```
-$ cozy-stack instances add --passphrase cozy --apps drive,photos,settings,home,store cozy.localhost:8080
+
+A more complexe exemple, with pre-installed apps, a context, the user email, public name and local and a context.
+
+```sh
+$ cozy-stack instances add instance02.localhost:8080 --passphrase cozy --apps home,store,drive,photos,settings,contacts,notes,passwords --email claude@cozy.localhost --locale fr --public-name Claude --context-name dev
 ```
 
 ### Options


### PR DESCRIPTION
1. respect the order `<domain>` and then `[flags]` in the exemples.
2. rename the created instances with a less ambiguous name than "cozy" wich make difficult to understand what is what.

note : if somewhere in the documentation there are explanations about the notion of "domain" and "slug", a link to this documentation could be added in this page.