### PR TITLE
feat: Add client-side konnector tokens build route

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1036,6 +1036,50 @@ authentication cookie.
 The passcode can be sent to the instance's owner via email — more transport
 shall be added later.
 
+### POST /auth/tokens/konnectors/:slug
+
+This endpoint can be used by the flagship application in order to create a
+token for the konnector with the given slug. This token can then be used by the
+client-side konnector to make requests to cozy-stack.
+The flagship app will need to use its own access token to request the konnector 
+token.
+
+#### Request
+
+```http
+POST /auth/tokens/konnectors/impots HTTP/1.1
+Host: cozy.example.org
+Accept: application/json
+Authorization: Bearer eyJpc3Mi...
+```
+
+#### Response
+
+```http
+HTTP/1.1 201 Created
+Content-Type: application/json
+```
+
+```json
+"OWY0MjNjMGEtOTNmNi0xMWVjLWIyZGItN2I5YjgwNmRjYzBiCg"
+```
+
+### FAQ
+
+> What format is used for tokens?
+
+The access tokens are formatted as [JSON Web Tokens (JWT)](https://jwt.io/),
+like this:
+
+| Claim   | Fullname  | What it identifies                                                      |
+| ------- | --------- | ----------------------------------------------------------------------- |
+| `aud`   | Audience  | Identify the recipient where the token can be used (i.e. `konn`)        |
+| `iss`   | Issuer    | Identify the Cozy instance (its domain in fact)                         |
+| `iat`   | Issued At | Identify when the token was issued (Unix timestamp)                     |
+| `sub`   | Subject   | Identify the client that can use the token (i.e. the konnector slug)    |
+| `scope` | Scope     | Konnector tokens don't have any scope                                   |
+
+
 ## Client-side apps
 
 **Important**: OAuth2 is not used here! The steps looks similar (like obtaining

--- a/docs/flagship.md
+++ b/docs/flagship.md
@@ -85,6 +85,7 @@ will have to do a few more steps to have access to the Cozy:
 Some routes of the stack are dedicated to the flagship app, like:
 
 - creating a session code with `POST /auth/session_code`
+- getting a konnector token with `POST /auth/tokens/konnectors/:slug`
 - getting the parameters to open a webapp with `GET /apps/:slug/open`
 
 And some routes accept a `session_code` to open a session in a webview or

--- a/tests/testutils/test_utils.go
+++ b/tests/testutils/test_utils.go
@@ -1,6 +1,7 @@
 package testutils
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -10,13 +11,18 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"path"
 	"testing"
 	"time"
 
+	"github.com/andybalholm/brotli"
+	apps "github.com/cozy/cozy-stack/model/app"
 	"github.com/cozy/cozy-stack/model/instance"
 	"github.com/cozy/cozy-stack/model/instance/lifecycle"
 	"github.com/cozy/cozy-stack/model/oauth"
+	"github.com/cozy/cozy-stack/model/permission"
 	"github.com/cozy/cozy-stack/model/stack"
+	"github.com/cozy/cozy-stack/model/vfs"
 	"github.com/cozy/cozy-stack/pkg/assets/dynamic"
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
@@ -296,4 +302,69 @@ func (c *TestSetup) GetCookieJar() *CookieJar {
 		Jar: j,
 		URL: instanceURL,
 	}
+}
+
+func (c *TestSetup) InstallMiniKonnector() (string, error) {
+	slug := "mini"
+	instance := c.GetTestInstance()
+	c.AddCleanup(func() error { return permission.DestroyKonnector(instance, slug) })
+
+	permissions := permission.Set{
+		permission.Rule{
+			Type:  "io.cozy.apps.logs",
+			Verbs: permission.Verbs(permission.POST),
+		},
+	}
+	version := "1.0.0"
+	manifest := &couchdb.JSONDoc{
+		Type: consts.Konnectors,
+		M: map[string]interface{}{
+			"_id":         consts.Konnectors + "/" + slug,
+			"name":        "Mini",
+			"icon":        "icon.svg",
+			"slug":        slug,
+			"source":      "git://github.com/cozy/mini.git",
+			"state":       apps.Ready,
+			"permissions": permissions,
+			"version":     version,
+		},
+	}
+
+	err := couchdb.CreateNamedDoc(instance, manifest)
+	if err != nil {
+		return "", err
+	}
+
+	_, err = permission.CreateKonnectorSet(instance, slug, permissions, version)
+	if err != nil {
+		return "", err
+	}
+
+	konnDir := path.Join(vfs.KonnectorsDirName, slug, version)
+	_, err = vfs.MkdirAll(instance.VFS(), konnDir)
+	if err != nil {
+		return "", err
+	}
+
+	err = createFile(instance, konnDir, "icon.svg", "<svg>...</svg>")
+	return slug, err
+}
+
+func createFile(instance *instance.Instance, dir, filename, content string) error {
+	abs := path.Join(dir, filename+".br")
+	file, err := vfs.Create(instance.VFS(), abs)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	_, err = file.Write(compress(content))
+	return err
+}
+
+func compress(content string) []byte {
+	buf := &bytes.Buffer{}
+	bw := brotli.NewWriter(buf)
+	_, _ = bw.Write([]byte(content))
+	_ = bw.Close()
+	return buf.Bytes()
 }

--- a/web/auth/auth.go
+++ b/web/auth/auth.go
@@ -614,6 +614,7 @@ func Routes(router *echo.Group) {
 
 	// Flagship app
 	router.POST("/session_code", CreateSessionCode)
+	router.POST("/tokens/konnectors/:slug", buildKonnectorToken)
 
 	// 2FA
 	router.GET("/twofactor", twoFactorForm)

--- a/web/auth/oauth.go
+++ b/web/auth/oauth.go
@@ -914,6 +914,24 @@ func accessToken(c echo.Context) error {
 	return c.JSON(http.StatusOK, out)
 }
 
+func buildKonnectorToken(c echo.Context) error {
+	inst := middlewares.GetInstance(c)
+	slug := c.Param("slug")
+
+	if err := middlewares.AllowMaximal(c); err != nil {
+		return c.JSON(http.StatusForbidden, err)
+	}
+
+	_, err := app.GetBySlug(inst, slug, consts.KonnectorType)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, err)
+	}
+
+	token := inst.BuildKonnectorToken(slug)
+
+	return c.JSON(http.StatusCreated, token)
+}
+
 // Used to trade a secret for OAuth client informations
 func secretExchange(c echo.Context) error {
 	type exchange struct {


### PR DESCRIPTION
The flagship app should be able to retrieve tokens for client-side
konnectors so it can run them with their own token instead of the
flagship token.

Using specific konnector tokens means separate permission sets and an
accurate client name for konnector requests to cozy-stack.