### PR TITLE
fix: Save konnector folder path into account

### DIFF
--- a/model/account/accounts.go
+++ b/model/account/accounts.go
@@ -18,20 +18,26 @@ import (
 
 // Account holds configuration information for an account
 type Account struct {
-	DocID             string                 `json:"_id,omitempty"`
-	DocRev            string                 `json:"_rev,omitempty"`
-	Name              string                 `json:"name"`
-	AccountType       string                 `json:"account_type"`
-	DefaultFolderPath string                 `json:"defaultFolderPath,omitempty"`
-	FolderPath        string                 `json:"folderPath,omitempty"` // Legacy
-	Token             string                 `json:"token,omitempty"`      // Used by bi-aggregator
-	UserID            string                 `json:"user_id,omitempty"`    // Used by bi-aggregator-user
-	Basic             *BasicInfo             `json:"auth,omitempty"`
-	Oauth             *OauthInfo             `json:"oauth,omitempty"`
-	Extras            map[string]interface{} `json:"oauth_callback_results,omitempty"`
-	Relationships     map[string]interface{} `json:"relationships,omitempty"`
-	Data              map[string]interface{} `json:"data,omitempty"`
-	Metadata          *metadata.CozyMetadata `json:"cozyMetadata,omitempty"`
+	DocID         string                 `json:"_id,omitempty"`
+	DocRev        string                 `json:"_rev,omitempty"`
+	Relationships map[string]interface{} `json:"relationships,omitempty"`
+	Metadata      *metadata.CozyMetadata `json:"cozyMetadata,omitempty"`
+
+	AccountType       string                   `json:"account_type"`
+	Name              string                   `json:"name"`                        // Filled during creation request
+	FolderPath        string                   `json:"folderPath,omitempty"`        // Legacy. Replaced by DefaultFolderPath
+	DefaultFolderPath string                   `json:"defaultFolderPath,omitempty"` // Computed from other attributes if not provided
+	Identifier        string                   `json:"identifier,omitempty"`        // Name of the Basic attribute used as identifier
+	Basic             *BasicInfo               `json:"auth,omitempty"`
+	Oauth             *OauthInfo               `json:"oauth,omitempty"`
+	Extras            map[string]interface{}   `json:"oauth_callback_results,omitempty"`
+	Data              map[string]interface{}   `json:"data,omitempty"`
+	State             string                   `json:"state,omitempty"`
+	TwoFACode         string                   `json:"twoFACode,omitempty"`
+	MutedErrors       []map[string]interface{} `json:"mutedErrors,omitempty"`
+	Token             string                   `json:"token,omitempty"`   // Used by bi-aggregator
+	UserID            string                   `json:"user_id,omitempty"` // Used by bi-aggregator-user
+
 	// When an account is deleted, the stack cleans the triggers and calls its
 	// konnector to clean the account remotely (when available). It is done via
 	// a hook on deletion, but when the konnector is removed, this cleaning is
@@ -55,9 +61,13 @@ type OauthInfo struct {
 // BasicInfo holds configuration information for an user/pass account
 type BasicInfo struct {
 	Login                string `json:"login,omitempty"`
-	Email                string `json:"email,omitempty"`    // used in some accounts instead of login
-	Password             string `json:"password,omitempty"` // used when no encryption
+	Email                string `json:"email,omitempty"`          // Legacy, used in some accounts instead of login
+	Identifier           string `json:"identifier,omitempty"`     // Legacy, used in some accounts instead of login
+	NewIdentifier        string `json:"new_identifier,omitempty"` // Legacy, used in some accounts instead of login
+	AccountName          string `json:"accountName,omitempty"`    // Used when konnector has no credentials
+	Password             string `json:"password,omitempty"`       // Legacy, used when no encryption
 	EncryptedCredentials string `json:"credentials_encrypted,omitempty"`
+	Token                string `json:"token,omitempty"` // Used by legacy OAuth konnectors
 }
 
 // ID is used to implement the couchdb.Doc interface

--- a/model/account/accounts.go
+++ b/model/account/accounts.go
@@ -249,6 +249,30 @@ func PushAccountDeletedJob(jobsSystem job.JobSystem, db prefixer.Prefixer, accou
 	})
 }
 
+// ComputeName tries to use the value of the `auth` attribute pointed by the
+// value of the `identifier` attribute as the Account name and set it in the
+// JSON document.
+//
+// See https://github.com/cozy/cozy-doctypes/blob/master/docs/io.cozy.accounts.md#about-the-name-of-the-account
+func ComputeName(doc couchdb.JSONDoc) {
+	auth, ok := doc.M["auth"].(map[string]interface{})
+	if !ok || auth == nil {
+		return
+	}
+
+	identifier, ok := doc.M["identifier"].(string)
+	if !ok || identifier == "" {
+		if login, ok := auth["login"].(string); ok {
+			doc.M["name"] = login
+		}
+		return
+	}
+
+	if name, ok := auth[identifier].(string); ok {
+		doc.M["name"] = name
+	}
+}
+
 func init() {
 	couchdb.AddHook(consts.Accounts, couchdb.EventDelete,
 		func(db prefixer.Prefixer, doc couchdb.Doc, old couchdb.Doc) error {

--- a/model/bi/webhook.go
+++ b/model/bi/webhook.go
@@ -364,6 +364,7 @@ func (c *WebhookCall) createAccountAndTrigger(konn *app.KonnManifest, connection
 		"relationships": rels,
 	}
 	account.Encrypt(acc)
+	account.ComputeName(acc)
 	if err := couchdb.CreateDoc(c.Instance, &acc); err != nil {
 		return nil, nil, err
 	}

--- a/web/data/accounts.go
+++ b/web/data/accounts.go
@@ -153,6 +153,7 @@ func createAccount(c echo.Context) error {
 	}
 
 	account.Encrypt(doc)
+	account.ComputeName(doc)
 
 	if err := couchdb.CreateDoc(instance, &doc); err != nil {
 		return err

--- a/worker/exec/konnector.go
+++ b/worker/exec/konnector.go
@@ -327,10 +327,10 @@ func (w *konnectorWorker) ensureFolderToSave(ctx *job.WorkerContext, inst *insta
 		return nil
 	}
 
-	// 4. Find a name for the folder
+	// 4. Find a path for the folder
 	folderPath := acc.DefaultFolderPath
 	if folderPath == "" {
-		folderPath = acc.FolderPath
+		folderPath = acc.FolderPath // For legacy purposes
 	}
 	if folderPath == "" {
 		folderPath = computeFolderPath(inst, w.man.Name(), acc)

--- a/worker/exec/konnector.go
+++ b/worker/exec/konnector.go
@@ -367,6 +367,13 @@ func (w *konnectorWorker) ensureFolderToSave(ctx *job.WorkerContext, inst *insta
 		dir.CozyMetadata.SourceAccount = acc.ID()
 		_ = couchdb.UpdateDoc(inst, dir)
 	}
+
+	// 6. Ensure that the account knows the folder path
+	if acc.DefaultFolderPath == "" {
+		acc.DefaultFolderPath = folderPath
+		_ = couchdb.UpdateDoc(inst, acc)
+	}
+
 	return nil
 }
 
@@ -376,7 +383,12 @@ func computeFolderPath(inst *instance.Instance, slug string, acc *account.Accoun
 		",", "_", "+", "_", "(", "_", ")", "_", "$", "_", "@", "_", "~",
 		"_", "%", "_", ".", "_", "'", "_", "\"", "_", ":", "_", "*", "_",
 		"?", "_", "<", "_", ">", "_", "{", "_", "}", "_")
+
 	accountName := r.Replace(acc.Name)
+	if accountName == "" {
+		accountName = acc.ID()
+	}
+
 	title := cases.Title(language.Make(inst.Locale)).String(slug)
 	return fmt.Sprintf("/%s/%s/%s", admin, title, accountName)
 }


### PR DESCRIPTION
When running a konnector for the first time, we compute the path of
the folder that will be used to save the files fetched by the
konnector if necessary and create it if it's missing.

We should also save that path as the associated Account's default folder
path so it's reused later.