### PR TITLE
Do not retry upload on Internal Server Error

### DIFF
--- a/model/sharing/upload.go
+++ b/model/sharing/upload.go
@@ -143,6 +143,13 @@ func (s *Sharing) UploadTo(inst *instance.Instance, m *Member, lastTry bool) (bo
 	inst.Logger().WithNamespace("upload").Debugf("lastSeq = %s", lastSeq)
 
 	file, ruleIndex, seq, err := s.findNextFileToUpload(inst, lastSeq)
+	if err == ErrInternalServerError {
+		// Retrying is useless in this case, let's skip this file
+		if seq != lastSeq {
+			_ = s.UpdateLastSequenceNumber(inst, m, "upload", seq)
+		}
+		return false, nil
+	}
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
When uploading a file for a sharing, it may happen that the io.cozy.shared document is corrupted (bad chain of revisions), and the upload fails with an Internal Server Error. In that case, it is useless to retry, as it will fail again, but it is better to skip this file to allow uploading the next files sooner.