### PR TITLE
Mitigate bugs when updating an io.cozy.shared

### DIFF
--- a/model/sharing/shared.go
+++ b/model/sharing/shared.go
@@ -400,7 +400,9 @@ func UpdateShared(inst *instance.Instance, msg TrackMessage, evt TrackEvent) err
 		if evt.OldDoc == nil {
 			inst.Logger().WithNamespace("sharing").
 				Warnf("Updating an io.cozy.shared with no previous revision: %v %v", evt, ref)
-			ref.Revisions.Add(rev)
+			if subtree, _ := ref.Revisions.Find(rev); subtree == nil {
+				ref.Revisions.Add(rev)
+			}
 		} else {
 			chain, err := addMissingRevsToChain(inst, &ref, []string{rev})
 			if err != nil {


### PR DESCRIPTION
When updating an io.cozy.shared from an event with no previous revision, we should check if the current revision exists in the io.cozy.shared document to avoid putting it twice.