### PR TITLE
Avoid unnecessary storage backend access when preparing konnector run

### DIFF
--- a/worker/exec/konnector.go
+++ b/worker/exec/konnector.go
@@ -242,15 +242,7 @@ func (w *konnectorWorker) PrepareWorkDir(ctx *job.WorkerContext, i *instance.Ins
 	workFS := afero.NewBasePathFs(osFS, workDir)
 
 	fileServer := app.KonnectorsFileServer(i)
-	tarFile, err := fileServer.Open(slug, man.Version(), man.Checksum(), app.KonnectorArchiveName)
-	if err == nil {
-		err = extractTar(workFS, tarFile)
-		if errc := tarFile.Close(); err == nil {
-			err = errc
-		}
-	} else if os.IsNotExist(err) {
-		err = copyFiles(workFS, fileServer, slug, man.Version(), man.Checksum())
-	}
+	err = copyFiles(workFS, fileServer, slug, man.Version(), man.Checksum())
 	if err != nil {
 		return "", cleanDir, err
 	}
@@ -432,6 +424,21 @@ func copyFiles(workFS afero.Fs, fileServer appfs.FileServer, slug, version, shas
 			"package.json",
 			".travis.yml",
 			"LICENSE":
+			continue
+		// Backward compatibility with older konnector storage pattern
+		// in unique tar file which has ben removed in #1332
+		case app.KonnectorArchiveName:
+			tarFile, err := fileServer.Open(slug, version, shasum, file)
+			if err != nil {
+				return err
+			}
+			err = extractTar(workFS, tarFile)
+			if errc := tarFile.Close(); err == nil {
+				err = errc
+			}
+			if err != nil {
+				return err
+			}
 			continue
 		}
 		var src io.ReadCloser

--- a/worker/exec/konnector.go
+++ b/worker/exec/konnector.go
@@ -424,6 +424,16 @@ func copyFiles(workFS afero.Fs, fileServer appfs.FileServer, slug, version, shas
 		return err
 	}
 	for _, file := range files {
+		switch file {
+		// The following files are completely useless for running a konnector, so we skip them
+		// in order to lower pressure on underlying file storage backend during high konnector execution rate
+		case
+			"README.md",
+			"package.json",
+			".travis.yml",
+			"LICENSE":
+			continue
+		}
 		var src io.ReadCloser
 		var dst io.WriteCloser
 		src, err = fileServer.Open(slug, version, shasum, file)


### PR DESCRIPTION
When preparing workdir for konnector run, avoid downloading useless files to lower pressure on underlying storage backend during high konnector execution rate.

Also avoid looking for older konnector storage `app.tar` because these are non-existent in the vast majority of cases. Simply assume there is no `app.tar`, start copying all files, and extract `app.tar` on-the-fly if we encounter one. Side effect is we now copy other files that reside alongside `app.tar` which should not be a problem because the only case where this can happen is in a specially crafted konnector with an `app.tar` file alongside other files and AFAIK there is currently no such konnector.