### PR TITLE
Add connectivity check route

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -77,6 +77,7 @@ designing new services.
     -   [Apps registry](registry.md)
     -   [Konnectors](konnectors.md)
 -   `/bitwarden` - [Bitwarden](bitwarden.md)
+-   `/connection_check` - [Connection check](connection-check.md)
 -   `/contacts` - [Contacts](contacts.md)
 -   `/data` - [Data System](data-system.md)
     -   [Mango](mango.md)

--- a/docs/connection-check.md
+++ b/docs/connection-check.md
@@ -1,0 +1,23 @@
+[Table of contents](README.md#table-of-contents)
+
+# Connection check URI
+
+## Connection-check
+
+This endpoint respond with HTTP 204 No Content and can be used
+to test connectivity to cozy instance. It is primarily used by the
+flagship mobile application.
+
+### Request
+
+```http
+GET /connection_check HTTP/1.1
+Host: alice.cozy.example.net
+```
+
+### Response
+
+```http
+HTTP/1.1 204
+
+```

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -25,6 +25,7 @@
   - "/apps - Applications Management": ./apps.md
   - " /apps - Apps registry": ./registry.md
   - "/bitwarden - Bitwarden": ./bitwarden.md
+  - "/connection_check - Connection check": ./connection-check.md
   - "/contacts - Contacts": ./contacts.md
   - "/data - Data System": ./data-system.md
   - " /data - Mango": ./mango.md

--- a/web/conncheck/conncheck.go
+++ b/web/conncheck/conncheck.go
@@ -1,0 +1,19 @@
+// Package conncheck returns HTTP 204 No Content for connectivity check
+package conncheck
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+// NoContent responds with HTTP 204 No Content
+func NoContent(c echo.Context) error {
+	return c.NoContent(http.StatusNoContent)
+}
+
+// Routes sets the routing for the conncheck service
+func Routes(router *echo.Group) {
+	router.GET("", NoContent)
+	router.HEAD("", NoContent)
+}

--- a/web/routing.go
+++ b/web/routing.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cozy/cozy-stack/web/auth"
 	"github.com/cozy/cozy-stack/web/bitwarden"
 	"github.com/cozy/cozy-stack/web/compat"
+	"github.com/cozy/cozy-stack/web/conncheck"
 	"github.com/cozy/cozy-stack/web/contacts"
 	"github.com/cozy/cozy-stack/web/data"
 	"github.com/cozy/cozy-stack/web/errors"
@@ -247,6 +248,7 @@ func SetupRoutes(router *echo.Echo) error {
 
 	// other non-authentified routes
 	{
+		conncheck.Routes(router.Group("/connection_check"))
 		status.Routes(router.Group("/status"))
 		version.Routes(router.Group("/version"))
 	}


### PR DESCRIPTION
This PR adds a public unauthenticated connectivity check route `/connection_check` that respond with HTTP 204 No Content for the flagship application to check for connectivity