### PR TITLE
Add reference to the sharing directory

### DIFF
--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -318,6 +318,12 @@ func (s *Sharing) Create(inst *instance.Instance) (*permission.Permission, error
 	if err := couchdb.CreateDoc(inst, s); err != nil {
 		return nil, err
 	}
+	if rule := s.FirstFilesRule(); rule != nil && rule.Selector != couchdb.SelectorReferencedBy {
+		if err := s.AddReferenceForSharingDir(inst, rule); err != nil {
+			inst.Logger().WithNamespace("sharing").
+				Warnf("Error on referenced_by for the sharing dir (%s): %s", s.SID, err)
+		}
+	}
 
 	if s.Owner && s.PreviewPath != "" {
 		return s.CreatePreviewPermissions(inst)


### PR DESCRIPTION
When a sharing is created for a directory, the stack should add a reference to the new sharing on the directory. It was done when a recipient accepts the sharing, but it could be too late if the directory was trashed before that: the sharing should have been revoked.