### PR TITLE
Fix share-track jobs when they are not in expected order

### DIFF
--- a/model/sharing/revisions.go
+++ b/model/sharing/revisions.go
@@ -122,6 +122,13 @@ func (rt *RevsTree) Add(rev string) *RevsTree {
 		if rt.Branches[0].Rev == rev {
 			return &rt.Branches[0]
 		}
+		if RevGeneration(rev) < RevGeneration(rt.Branches[0].Rev) {
+			rt.Branches = []RevsTree{
+				{Rev: rt.Rev, Branches: rt.Branches},
+			}
+			rt.Rev = rev
+			return rt
+		}
 		return rt.Branches[0].Add(rev)
 	}
 	rt.Branches = []RevsTree{

--- a/model/sharing/revisions_test.go
+++ b/model/sharing/revisions_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRevsTreeGeneration(t *testing.T) {
@@ -75,6 +76,20 @@ func TestRevsTreeAdd(t *testing.T) {
 	sub = sub.Branches[0]
 	assert.Equal(t, sub.Rev, "3-ccc")
 	assert.Len(t, sub.Branches, 0)
+
+	tree = &RevsTree{Rev: "2-bbb"}
+	ret = tree.Add("3-ccc")
+	assert.Equal(t, "3-ccc", ret.Rev)
+	ret = tree.Add("1-aaa")
+	assert.Equal(t, "1-aaa", ret.Rev)
+	assert.Equal(t, "1-aaa", tree.Rev)
+	require.Len(t, tree.Branches, 1)
+	sub = tree.Branches[0]
+	assert.Equal(t, "2-bbb", sub.Rev)
+	require.Len(t, sub.Branches, 1)
+	sub = sub.Branches[0]
+	assert.Equal(t, "3-ccc", sub.Rev)
+	require.Len(t, sub.Branches, 0)
 }
 
 func TestRevsTreeInsertAfter(t *testing.T) {


### PR DESCRIPTION
When an io.cozy.file is created and modified just after, it may happen that the share-track job for the update is processed before the job for the creation. When this happens, the revs tree for the io.cozy.shared wasn't correct: the revision 2 was coming before the revision 1. This commit adds a check to put the revisions in the good order for this case.