### PR TITLE
Use interact token for preview URL of sharing

### DIFF
--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -261,7 +261,7 @@ func keyFromMemberIndex(index int) string {
 	return fmt.Sprintf("index:%d", index)
 }
 
-// GetInteractCode returns a sharecode that can be use for reading and writing
+// GetInteractCode returns a sharecode that can be used for reading and writing
 // the file. It uses a share-interact token.
 func (s *Sharing) GetInteractCode(inst *instance.Instance, member *Member, memberIndex int) (string, error) {
 	interact, err := permission.GetForShareInteract(inst, s.ID())

--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -261,6 +261,61 @@ func keyFromMemberIndex(index int) string {
 	return fmt.Sprintf("index:%d", index)
 }
 
+// GetInteractCode returns a sharecode that can be use for reading and writing
+// the file. It uses a share-interact token.
+func (s *Sharing) GetInteractCode(inst *instance.Instance, member *Member, memberIndex int) (string, error) {
+	interact, err := permission.GetForShareInteract(inst, s.ID())
+	if err != nil {
+		if couchdb.IsNotFoundError(err) {
+			return s.CreateInteractPermissions(inst, member)
+		}
+		return "", err
+	}
+
+	// Check if the sharing has not been revoked and accepted again, in which
+	// case, we need to update the permission set.
+	needUpdate := false
+	set := s.CreateInteractSet()
+	if !set.HasSameRules(interact.Permissions) {
+		interact.Permissions = set
+		needUpdate = true
+	}
+
+	// If we already have a code for this member, let's use it
+	indexKey := keyFromMemberIndex(memberIndex)
+	for key, code := range interact.Codes {
+		if key == "" {
+			continue
+		}
+		if key == member.Instance || key == member.Email || key == indexKey {
+			if needUpdate {
+				if err := couchdb.UpdateDoc(inst, interact); err != nil {
+					return "", err
+				}
+			}
+			return code, nil
+		}
+	}
+
+	// Else, create a code and add it to the permission doc
+	key := member.Email
+	if key == "" {
+		key = member.Instance
+	}
+	if key == "" {
+		key = indexKey
+	}
+	code, err := inst.CreateShareCode(key)
+	if err != nil {
+		return "", err
+	}
+	interact.Codes[key] = code
+	if err := couchdb.UpdateDoc(inst, interact); err != nil {
+		return "", err
+	}
+	return code, nil
+}
+
 // CreateInteractPermissions creates the permissions doc for reading and
 // writing a note inside this sharing.
 func (s *Sharing) CreateInteractPermissions(inst *instance.Instance, m *Member) (string, error) {


### PR DESCRIPTION
When a user goes to the preview URL for a Cozy to Cozy sharing, and if their Cozy URL is known (ie they have accepted a sharing), then we should allow this user to interact with the sharing. For a note, it means that they will be allowed to edit it. For a folder, they can upload new files.

Note: we also need to update the webapps to use the interact token.