### PR TITLE
Fix swift authURL hardcoded path

### DIFF
--- a/pkg/config/config/swift.go
+++ b/pkg/config/config/swift.go
@@ -34,16 +34,16 @@ func InitSwiftConnection(fs Fs) error {
 		authURL = &url.URL{
 			Scheme: "http",
 			Host:   fsURL.Host,
-			Path:   "/identity/v3",
+			Path:   fsURL.Path,
+		}
+		if isSecure {
+			authURL.Scheme = "https"
 		}
 	} else {
 		authURL, err = url.Parse(auth)
 		if err != nil {
 			panic(fmt.Sprintf("swift: could not parse AuthURL %s", err))
 		}
-	}
-	if isSecure {
-		authURL.Scheme = "https"
 	}
 
 	var username, password string


### PR DESCRIPTION
Fix swift auth URL hardcoded path and allow to specify an http auth url as additional parameter even with a `swift+https` scheme