### PR TITLE
feat: Allow hiding back button on passphrase reset

### DIFF
--- a/assets/templates/passphrase_reset.html
+++ b/assets/templates/passphrase_reset.html
@@ -14,10 +14,12 @@
   <body class="theme-inverted">
     <main class="wrapper">
       <header class="wrapper-top d-flex flex-row align-items-center">
+        {{if .ShowBackButton}}
         <a href="/auth/login" class="btn btn-icon" aria-label="{{t "Back icon label"}}">
           <span class="icon icon-back"></span>
         </a>
         <div class="vertical-separator d-sm-none" role="separator"></div>
+        {{end}}
         <a href="https://cozy.io/" class="btn p-2 d-sm-none">
           <img src="{{asset .Domain "/images/logo-dark.svg"}}" alt="Cozy Cloud" class="logo" />
         </a>

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -282,8 +282,14 @@ Display a form for the user to reset its password, in case he has forgotten it
 for example. If the user is connected, he won't be shown this form and he will
 be directly redirected to his cozy.
 
+This endpoint accepts a `hideBackButton` parameter. If this parameter is present
+and set to `true` then the passphrase reset page won't display any button to go
+back to the login page.
+This is useful when this page is opened in a different context from the one in 
+which the login page was opened (e.g. a browser vs a mobile native application).
+
 ```http
-GET /auth/passphrase_reset HTTP/1.1
+GET /auth/passphrase_reset?hideBackButton=true HTTP/1.1
 Host: cozy.example.org
 Content-Type: text/html
 Cookie: ...

--- a/web/auth/passphrase.go
+++ b/web/auth/passphrase.go
@@ -29,18 +29,23 @@ func passphraseResetForm(c echo.Context) error {
 	if resp, err := couchdb.NormalDocs(instance, consts.BitwardenCiphers, 0, 1, "", false); err == nil {
 		hasCiphers = resp.Total > 0
 	}
+	showBackButton := true
+	if c.QueryParam("hideBackButton") == "true" {
+		showBackButton = false
+	}
 	passwordAuth := instance.IsPasswordAuthenticationEnabled()
 	return c.Render(http.StatusOK, "passphrase_reset.html", echo.Map{
-		"Domain":      instance.ContextualDomain(),
-		"ContextName": instance.ContextName,
-		"Locale":      instance.Locale,
-		"Title":       instance.TemplateTitle(),
-		"Favicon":     middlewares.Favicon(instance),
-		"CSRF":        c.Get("csrf"),
-		"Redirect":    c.QueryParam("redirect"),
-		"HasHint":     hasHint,
-		"HasCiphers":  hasCiphers,
-		"CozyPass":    !passwordAuth,
+		"Domain":         instance.ContextualDomain(),
+		"ContextName":    instance.ContextName,
+		"Locale":         instance.Locale,
+		"Title":          instance.TemplateTitle(),
+		"Favicon":        middlewares.Favicon(instance),
+		"CSRF":           c.Get("csrf"),
+		"Redirect":       c.QueryParam("redirect"),
+		"HasHint":        hasHint,
+		"HasCiphers":     hasCiphers,
+		"CozyPass":       !passwordAuth,
+		"ShowBackButton": showBackButton,
 	})
 }
 


### PR DESCRIPTION
When the passphrase reset page is opened from a mobile native
application into the phone's browser, we don't want users to click on
the provided back button as it would not redirect them to the native
application but the login page inside the browser and this would be
confusing.

We add a `hideBackButton` query-string parameter that native
applications can set to `true` so we know not to display the back
button on the passphrase reset page.