### PR TITLE
docs: Add konnectors to the /registry/maintenance route

### DIFF
--- a/docs/registry.md
+++ b/docs/registry.md
@@ -568,7 +568,7 @@ Content-Type: application/json
 
 ### GET /registry/maintenance
 
-Get the list of applications with maintenance mode activated.
+Get the list of applications (and konnectors) with maintenance mode activated.
 
 #### Request
 


### PR DESCRIPTION
It was not clear when reading the line that konnectors are also concerned by this route. I understand that from the point of view of the registry apps and konnectors are the same, but this is not the case when querying from the stack (io.cozy.apps vs io.cozy.konnectors) 