### PR TITLE
Increase the number of iterations for PBKDF2

### DIFF
--- a/docs/important-changes.md
+++ b/docs/important-changes.md
@@ -4,6 +4,10 @@
 
 This section will list important changes to the stack or its usage, and migration procedures if any is needed.
 
+## December 2023: Iterations for PBKDF2 increased
+
+We have increased the number of PBKDF2 iterations for new users to 650_000, and removed the exception for Edge as it now supports PBKDF2 via the subtle crypto API.
+
 ## December 2020: Jobs permissions
 
 We used to have a specific permission logic for jobs, in order to allow apps to direclty manage konnectors. More specifically, an app had the right to access a trigger state or remove it, if there was a doctype in common between the app permissions and the konnector manifest.

--- a/pkg/crypto/pbkdf2.go
+++ b/pkg/crypto/pbkdf2.go
@@ -9,22 +9,15 @@ import (
 
 // DefaultPBKDF2Iterations is the number of iterations used to hash the
 // passphrase on the client-side with the PBKDF2 algorithm.
-const DefaultPBKDF2Iterations = 100000
-
-// EdgePBKDF2Iterations is the number of iterations used to hash the passphrase
-// on the client-side with the PBKDF2 algorithm when the browser is Edge. As
-// Edge doesn't support PBKDF2 in its window.crypto, we have to rely on a
-// slower JS alternative, and to reduce the number of PBKDF2 iterations to
-// avoid freezing the browser.
-const EdgePBKDF2Iterations = 10000
+const DefaultPBKDF2Iterations = 650000
 
 // MinPBKDF2Iterations is the recommended minimum number of iterations for
 // hashing with PBKDF2.
-const MinPBKDF2Iterations = 5000
+const MinPBKDF2Iterations = 50000
 
 // MaxPBKDF2Iterations is the recommended maximal number of iterations for
 // hashing with PBKDF2.
-const MaxPBKDF2Iterations = 1000000
+const MaxPBKDF2Iterations = 5000000
 
 // hashedPassLen is the length of the hashed password (in bytes).
 const hashedPassLen = 32

--- a/tests/system/lib/bitwarden/organization.rb
+++ b/tests/system/lib/bitwarden/organization.rb
@@ -72,7 +72,7 @@ class Bitwarden
       master_key = PBKDF2.new do |p|
         p.password = inst.passphrase
         p.salt = "me@" + inst.domain.split(':').first
-        p.iterations = 100_000 # See pkg/crypto/pbkdf2.go
+        p.iterations = 650_000 # See pkg/crypto/pbkdf2.go
         p.hash_function = OpenSSL::Digest::SHA256
         p.key_length = 256 / 8
       end.bin_string

--- a/tests/system/lib/instance.rb
+++ b/tests/system/lib/instance.rb
@@ -142,7 +142,7 @@ class Instance
     key = PBKDF2.new do |p|
       p.password = passphrase
       p.salt = "me@" + domain.split(':').first
-      p.iterations = 100_000 # See pkg/crypto/pbkdf2.go
+      p.iterations = 650_000 # See pkg/crypto/pbkdf2.go
       p.hash_function = OpenSSL::Digest::SHA256
       p.key_length = 256 / 8
     end.bin_string

--- a/tests/system/lib/oauth/client.rb
+++ b/tests/system/lib/oauth/client.rb
@@ -32,7 +32,7 @@ module OAuth
         client_secret: @client_secret,
         register_token: inst.register_token,
         passphrase: inst.hashed_passphrase,
-        iterations: 100_000,
+        iterations: 650_000,
         hint: "a hint to help me remember my passphrase",
         key: "dont_care_key",
         public_key: "dont_care_public_key",

--- a/web/auth/auth.go
+++ b/web/auth/auth.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cozy/cozy-stack/pkg/limits"
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/labstack/echo/v4"
-	"github.com/mssola/user_agent"
 )
 
 const (
@@ -345,12 +344,7 @@ func login(c echo.Context) error {
 	if ok { // The user was already logged-in
 		sessionID = sess.ID()
 	} else if instance.CheckPassphrase(inst, passphrase) == nil {
-		ua := user_agent.New(c.Request().UserAgent())
-		browser, _ := ua.Browser()
 		iterations := crypto.DefaultPBKDF2Iterations
-		if browser == "Edge" {
-			iterations = crypto.EdgePBKDF2Iterations
-		}
 		settings, err := settings.Get(inst)
 		// If the passphrase was not yet hashed on the client side, migrate it
 		if err == nil && settings.PassphraseKdfIterations == 0 {

--- a/web/auth/passphrase.go
+++ b/web/auth/passphrase.go
@@ -88,7 +88,7 @@ func passphraseForm(c echo.Context) error {
 	cryptoPolyfill := middlewares.CryptoPolyfill(c)
 	iterations := crypto.DefaultPBKDF2Iterations
 	if cryptoPolyfill {
-		iterations = crypto.EdgePBKDF2Iterations
+		iterations = crypto.MinPBKDF2Iterations
 	}
 
 	return c.Render(http.StatusOK, "passphrase_choose.html", echo.Map{
@@ -193,7 +193,7 @@ func passphraseRenewForm(c echo.Context) error {
 	cryptoPolyfill := middlewares.CryptoPolyfill(c)
 	iterations := crypto.DefaultPBKDF2Iterations
 	if cryptoPolyfill {
-		iterations = crypto.EdgePBKDF2Iterations
+		iterations = crypto.MinPBKDF2Iterations
 	}
 
 	return c.Render(http.StatusOK, "passphrase_choose.html", echo.Map{

--- a/web/middlewares/user_agent.go
+++ b/web/middlewares/user_agent.go
@@ -69,12 +69,12 @@ var rules = []browserRule{
 		iPhone:     iPhoneOrNotIPhone,
 		minVersion: maxInt,
 	},
-	// We don't support Edge before version 79, because we need support for
-	// unicode property escape of regexps.
+	// We don't support Edge before version 80, because we need support for
+	// unicode property escape of regexps, and PBKDF2 in subtle crypto.
 	{
 		name:       Edge,
 		iPhone:     iPhoneOrNotIPhone,
-		minVersion: 79,
+		minVersion: 80,
 	},
 	// Idem for Chrome and Chromium before version 64.
 	{
@@ -151,16 +151,10 @@ func GetMajorVersion(rawVersion string) (int, bool) {
 }
 
 // CryptoPolyfill returns true if the browser can't use its window.crypto API
-// to hash the password with PBKDF2. It is the case for Edge, but also for most
-// browsers in development mode, because this API is only available in secure
-// more (HTTPS or localhost).
+// to hash the password with PBKDF2. It is the case in development mode,
+// because this API is only available in secure more (HTTPS or localhost).
 func CryptoPolyfill(c echo.Context) bool {
 	req := c.Request()
-	ua := user_agent.New(req.UserAgent())
-	browser, _ := ua.Browser()
-	if browser == Edge {
-		return true
-	}
 	return build.IsDevRelease() && !strings.Contains(req.Host, "localhost")
 }
 

--- a/web/settings/settings_test.go
+++ b/web/settings/settings_test.go
@@ -257,7 +257,7 @@ func TestSettings(t *testing.T) {
 			WithHeader("Content-Type", "application/json").
 			WithBytes([]byte(`{
         "passphrase":     "MyFirstPassphrase",
-        "iterations":     5000,
+        "iterations":     50000,
         "register_token": "BADBEEF",
       }`)).
 			Expect().Status(400)
@@ -267,7 +267,7 @@ func TestSettings(t *testing.T) {
 			WithHeader("Content-Type", "application/json").
 			WithBytes([]byte(`{
         "passphrase":     "MyFirstPassphrase",
-        "iterations":     5000,
+        "iterations":     50000,
         "register_token": "XYZ",
       }`)).
 			Expect().Status(400)
@@ -280,7 +280,7 @@ func TestSettings(t *testing.T) {
 			WithCookie(sessCookie, "connected").
 			WithJSON(map[string]interface{}{
 				"passphrase":     "MyFirstPassphrase",
-				"iterations":     5000,
+				"iterations":     50000,
 				"register_token": hex.EncodeToString(testInstance.RegisterToken),
 				"key":            "xxx",
 			}).
@@ -300,7 +300,7 @@ func TestSettings(t *testing.T) {
 			WithBytes([]byte(`{
         "new_passphrase":     "MyPassphrase",
         "current_passphrase": "BADBEEF",
-        "iterations":         5000
+        "iterations":         50000
       }`)).
 			Expect().Status(400)
 	})
@@ -315,7 +315,7 @@ func TestSettings(t *testing.T) {
 			WithBytes([]byte(`{
         "new_passphrase":     "MyUpdatedPassphrase",
         "current_passphrase": "MyFirstPassphrase",
-        "iterations":         5000
+        "iterations":         50000
       }`)).
 			Expect().Status(204)
 
@@ -332,7 +332,7 @@ func TestSettings(t *testing.T) {
 			WithHeader("Content-Type", "application/json").
 			WithBytes([]byte(`{
         "new_passphrase": "MyPassphrase",
-        "iterations":     5000,
+        "iterations":     50000,
         "force":          true
       }`)).
 			Expect().Status(400)
@@ -347,7 +347,7 @@ func TestSettings(t *testing.T) {
 			WithHeader("Content-Type", "application/json").
 			WithBytes([]byte(`{
         "new_passphrase": "MyPassphrase",
-        "iterations":     5000,
+        "iterations":     50000,
         "force":          true
       }`)).
 			Expect().Status(204)
@@ -441,7 +441,7 @@ func TestSettings(t *testing.T) {
 		attrs := data.Value("attributes").Object()
 		attrs.ValueEqual("salt", "me@"+testInstance.Domain)
 		attrs.ValueEqual("kdf", 0.0)
-		attrs.ValueEqual("iterations", 5000.0)
+		attrs.ValueEqual("iterations", 50000)
 	})
 
 	t.Run("GetCapabilities", func(t *testing.T) {
@@ -1134,7 +1134,7 @@ func TestRegisterPassphraseForFlagshipApp(t *testing.T) {
 	obj := e.POST("/settings/passphrase/flagship").
 		WithJSON(map[string]interface{}{
 			"passphrase":     "MyFirstPassphrase",
-			"iterations":     5000,
+			"iterations":     50000,
 			"register_token": hex.EncodeToString(testInstance.RegisterToken),
 			"key":            "xxx-key-xxx",
 			"public_key":     "xxx-public-key-xxx",


### PR DESCRIPTION
The OWASP recommends at least 310,000 iterations for PBKDF2. Cf https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html

We also remove the exception for lower iterations when the instance was created from Edge, as this browser now supports PBKDF2 via the subtle crypto API (the polyfill is no longer needed in production).