### PR TITLE
Refactor the some tests and handle the `--short` flag

### DIFF
--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -28,6 +28,10 @@ func TestDebugDomain(t *testing.T) {
 }
 
 func TestDebugDomainWithRedis(t *testing.T) {
+	if testing.Short() {
+		t.Skip("a redis is required for this test, skip due to --short flag")
+	}
+
 	opt, err := redis.ParseURL("redis://localhost:6379/0")
 	assert.NoError(t, err)
 	err = Init(Options{


### PR DESCRIPTION
This refactoring goals are:
- Taking into account the `--short` flag and skip the tests with dependencies
- Handling the errors with `require.NoError` in order to have more detailed errors messages
- Replacing the use of `MainTest` by the use of subtests. This task have several advantages: 
  - It allow to have different init in the same packages. 
  - It allow to skip several test at once if necessary. 
  - It allow the use of `t.Cleanup` which ensure the tests cleanup even in case of panic. 
  - It avoid the use of globals which can be source of dataraces. 
  - It make more explicit the depedances between the subtests inside the logs.