### PR TITLE
Refactor the pkg/cache tests and handle the `--short` flag

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1,55 +1,72 @@
 package cache
 
 import (
+	"context"
 	"sort"
 	"testing"
 	"time"
 
 	"github.com/go-redis/redis/v8"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestCacheInMemory(t *testing.T) {
-	key := "foo"
-	val := []byte("bar")
-	c := New(nil)
-	c.Set(key, val, 10*time.Millisecond)
-	actual, ok := c.Get(key)
-	assert.True(t, ok)
-	assert.Equal(t, val, actual)
-	time.Sleep(11 * time.Millisecond)
-	_, ok = c.Get(key)
-	assert.False(t, ok)
-}
+func TestCacheImplementations(t *testing.T) {
+	t.Run("in memory", func(t *testing.T) {
+		// In-memory is setup when New is called with nil.
+		c := New(nil)
 
-func TestMultiGet(t *testing.T) {
-	redisURL := "redis://localhost:6379/0"
-	opts, _ := redis.ParseURL(redisURL)
-	client := redis.NewClient(opts)
-	c := New(client)
-	c.Set("one", []byte("1"), 10*time.Millisecond)
-	c.Set("two", []byte("2"), 10*time.Millisecond)
-	bufs := c.MultiGet([]string{"one", "two", "three"})
-	assert.Len(t, bufs, 3)
-	assert.Equal(t, []byte("1"), bufs[0])
-	assert.Equal(t, []byte("2"), bufs[1])
-	assert.Nil(t, bufs[2])
-}
+		runTests(t, c)
+	})
 
-func TestKeys(t *testing.T) {
-	test := func(client redis.UniversalClient) {
+	t.Run("redis", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("a redis is required for this test: test skipped due to the use of --short flag")
+		}
+
+		opts, err := redis.ParseURL("redis://localhost:6379/0")
+		require.NoError(t, err)
+
+		client := redis.NewClient(opts)
+
+		res := client.Ping(context.Background())
+		require.NoError(t, res.Err())
+
 		c := New(client)
+
+		runTests(t, c)
+	})
+}
+
+func runTests(t *testing.T, c Cache) {
+	t.Run("Get", func(t *testing.T) {
+		key := "foo"
+		val := []byte("bar")
+		c.Set(key, val, 10*time.Millisecond)
+		actual, ok := c.Get(key)
+		assert.True(t, ok)
+		assert.Equal(t, val, actual)
+		time.Sleep(11 * time.Millisecond)
+		_, ok = c.Get(key)
+		assert.False(t, ok)
+	})
+
+	t.Run("keys", func(t *testing.T) {
 		c.Set("foo:one", []byte("1"), 10*time.Millisecond)
 		c.Set("foo:two", []byte("2"), 10*time.Millisecond)
 		c.Set("bar:baz", []byte("3"), 10*time.Millisecond)
 		keys := c.Keys("foo:")
 		sort.Strings(keys)
 		assert.Equal(t, []string{"foo:one", "foo:two"}, keys)
-	}
+	})
 
-	redisURL := "redis://localhost:6379/0"
-	opts, _ := redis.ParseURL(redisURL)
-	client := redis.NewClient(opts)
-	test(client)
-	test(nil) // In-memory
+	t.Run("multi get", func(t *testing.T) {
+		c.Set("one", []byte("1"), 10*time.Millisecond)
+		c.Set("two", []byte("2"), 10*time.Millisecond)
+		bufs := c.MultiGet([]string{"one", "two", "three"})
+		assert.Len(t, bufs, 3)
+		assert.Equal(t, []byte("1"), bufs[0])
+		assert.Equal(t, []byte("2"), bufs[1])
+		assert.Nil(t, bufs[2])
+	})
 }


### PR DESCRIPTION
This refactoring goals are:

- Use the same test for all the implementations: this allow to ensure that all implementations have the same behavior.
- Taking into account the --short flag and skip the tests with dependencies
- Handling the errors with require.NoError in order to have more detailed errors messages
- Replacing the use of MainTest by the use of subtests. This task have several advantages: \
  - It allow to have different init in the same packages. 
  - It allow to skip several test at once if necessary. 
  - It allow the use of t.Cleanup which ensure the tests cleanup even in case of panic. 
  - It avoid the use of globals which can be source of dataraces. 
  - It make more explicit the depedances between the subtests inside the logs.