### PR TITLE
Replace some multiline assert() use by a require call

### DIFF
--- a/model/account/credentials_test.go
+++ b/model/account/credentials_test.go
@@ -15,44 +15,39 @@ import (
 	"github.com/cozy/cozy-stack/pkg/crypto"
 	"github.com/cozy/cozy-stack/pkg/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEncryptDecrytCredentials(t *testing.T) {
 	encryptedCreds1, err := EncryptCredentials("me@mycozy.cloud", "fzEE6HFWsSp8jP")
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	encryptedCreds2, err := EncryptCredentials("me@mycozy.cloud", "fzEE6HFWsSp8jP")
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	encryptedCreds3, err := EncryptCredentials("", "fzEE6HFWsSp8jP")
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.NotEqual(t, encryptedCreds1, encryptedCreds2)
 
 	{
 		login, password, err := DecryptCredentials(encryptedCreds1)
-		if !assert.NoError(t, err) {
-			return
-		}
+		require.NoError(t, err)
+
 		assert.Equal(t, "me@mycozy.cloud", login)
 		assert.Equal(t, "fzEE6HFWsSp8jP", password)
 	}
 	{
 		login, password, err := DecryptCredentials(encryptedCreds2)
-		if !assert.NoError(t, err) {
-			return
-		}
+		require.NoError(t, err)
+
 		assert.Equal(t, "me@mycozy.cloud", login)
 		assert.Equal(t, "fzEE6HFWsSp8jP", password)
 	}
 	{
 		login, password, err := DecryptCredentials(encryptedCreds3)
-		if !assert.NoError(t, err) {
-			return
-		}
+		require.NoError(t, err)
+
 		assert.Equal(t, "", login)
 		assert.Equal(t, "fzEE6HFWsSp8jP", password)
 	}
@@ -65,14 +60,10 @@ func TestEncryptDecrytUTF8Credentials(t *testing.T) {
 		password := string(crypto.GenerateRandomBytes(rng.Intn(256)))
 
 		encryptedCreds, err := EncryptCredentials(login, password)
-		if !assert.NoError(t, err) {
-			return
-		}
+		require.NoError(t, err)
 
 		loginDec, passwordDec, err := DecryptCredentials(encryptedCreds)
-		if !assert.NoError(t, err) {
-			return
-		}
+		require.NoError(t, err)
 
 		assert.Equal(t, loginDec, login)
 		assert.Equal(t, passwordDec, password)
@@ -83,14 +74,10 @@ func TestEncryptDecrytUTF8Credentials(t *testing.T) {
 		password := utils.RandomString(rng.Intn(256))
 
 		encryptedCreds, err := EncryptCredentials(login, password)
-		if !assert.NoError(t, err) {
-			return
-		}
+		require.NoError(t, err)
 
 		loginDec, passwordDec, err := DecryptCredentials(encryptedCreds)
-		if !assert.NoError(t, err) {
-			return
-		}
+		require.NoError(t, err)
 
 		assert.Equal(t, loginDec, login)
 		assert.Equal(t, passwordDec, password)
@@ -116,20 +103,16 @@ func TestDecryptCredentialsRandom(t *testing.T) {
 
 func TestRandomBitFlipsCredentials(t *testing.T) {
 	original, err := EncryptCredentials("toto@titi.com", "X3hVYLJLRiUyCs")
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	originalBuffer, err := base64.StdEncoding.DecodeString(original)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	flipped := make([]byte, len(originalBuffer))
 	copy(flipped, originalBuffer)
 	login, passwd, err := DecryptCredentials(base64.StdEncoding.EncodeToString(flipped))
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, "toto@titi.com", login)
 	assert.Equal(t, "X3hVYLJLRiUyCs", passwd)
 
@@ -166,38 +149,30 @@ func TestRandomBitFlipsCredentials(t *testing.T) {
 func TestEncryptDecryptData(t *testing.T) {
 	var data interface{}
 	err := json.Unmarshal([]byte(`{"foo":"bar","baz":{"quz": "quuz"}}`), &data)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	encBuffer, err := EncryptCredentialsData(data)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	decData, err := DecryptCredentialsData(encBuffer)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.EqualValues(t, data, decData)
 }
 
 func TestRandomBitFlipsBuffer(t *testing.T) {
 	plainBuffer := make([]byte, 256)
 	_, err := io.ReadFull(cryptorand.Reader, plainBuffer)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	original, err := EncryptBufferWithKey(config.GetVault().CredentialsEncryptorKey(), plainBuffer)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	flipped := make([]byte, len(original))
 	copy(flipped, original)
 	testBuffer, err := DecryptBufferWithKey(config.GetVault().CredentialsDecryptorKey(), flipped)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.True(t, bytes.Equal(plainBuffer, testBuffer))
 
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))

--- a/model/app/installer_konnector_test.go
+++ b/model/app/installer_konnector_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func compressedFileContainsBytes(fs afero.Fs, filename string, content []byte) (ok bool, err error) {
@@ -42,9 +43,7 @@ func TestKonnectorInstallSuccessful(t *testing.T) {
 		Slug:      "local-konnector",
 		SourceURL: "git://localhost/",
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	go inst.Run()
 
@@ -54,9 +53,8 @@ func TestKonnectorInstallSuccessful(t *testing.T) {
 		var done bool
 		var err2 error
 		man, done, err2 = inst.Poll()
-		if !assert.NoError(t, err2) {
-			return
-		}
+		require.NoError(t, err2)
+
 		if state == "" {
 			if !assert.EqualValues(t, app.Installing, man.State()) {
 				return
@@ -65,9 +63,8 @@ func TestKonnectorInstallSuccessful(t *testing.T) {
 			if !assert.EqualValues(t, app.Ready, man.State()) {
 				return
 			}
-			if !assert.True(t, done) {
-				return
-			}
+			require.True(t, done)
+
 			break
 		} else {
 			t.Fatalf("invalid state")
@@ -125,9 +122,7 @@ func TestKonnectorInstallWithUpgrade(t *testing.T) {
 		Slug:      "cozy-konnector-b",
 		SourceURL: "git://localhost/",
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	go inst.Run()
 
@@ -135,9 +130,8 @@ func TestKonnectorInstallWithUpgrade(t *testing.T) {
 	for {
 		var done bool
 		man, done, err = inst.Poll()
-		if !assert.NoError(t, err) {
-			return
-		}
+		require.NoError(t, err)
+
 		if done {
 			break
 		}
@@ -157,9 +151,7 @@ func TestKonnectorInstallWithUpgrade(t *testing.T) {
 		Type:      consts.KonnectorType,
 		Slug:      "cozy-konnector-b",
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	go inst.Run()
 
@@ -167,9 +159,8 @@ func TestKonnectorInstallWithUpgrade(t *testing.T) {
 	for {
 		var done bool
 		man, done, err = inst.Poll()
-		if !assert.NoError(t, err) {
-			return
-		}
+		require.NoError(t, err)
+
 		if state == "" {
 			if !assert.EqualValues(t, app.Upgrading, man.State()) {
 				return
@@ -178,9 +169,8 @@ func TestKonnectorInstallWithUpgrade(t *testing.T) {
 			if !assert.EqualValues(t, app.Ready, man.State()) {
 				return
 			}
-			if !assert.True(t, done) {
-				return
-			}
+			require.True(t, done)
+
 			break
 		} else {
 			t.Fatalf("invalid state")
@@ -269,9 +259,7 @@ func TestKonnectorUpdateSkipPerms(t *testing.T) {
 		Slug:      "cozy-konnector-test-skip",
 		SourceURL: "git://localhost/",
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	var man app.Manifest
 
@@ -289,9 +277,7 @@ func TestKonnectorUpdateSkipPerms(t *testing.T) {
 		Type:      consts.KonnectorType,
 		Slug:      "cozy-konnector-test-skip",
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	man, err = inst.RunSync()
 	konnManifest = man.(*app.KonnManifest)
@@ -326,9 +312,7 @@ func TestKonnectorInstallAndUpgradeWithBranch(t *testing.T) {
 		Slug:      "local-konnector-branch",
 		SourceURL: "git://localhost/#branch",
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	go inst.Run()
 
@@ -338,9 +322,8 @@ func TestKonnectorInstallAndUpgradeWithBranch(t *testing.T) {
 		var done bool
 		var err2 error
 		man, done, err2 = inst.Poll()
-		if !assert.NoError(t, err2) {
-			return
-		}
+		require.NoError(t, err2)
+
 		if state == "" {
 			if !assert.EqualValues(t, app.Installing, man.State()) {
 				return
@@ -349,9 +332,8 @@ func TestKonnectorInstallAndUpgradeWithBranch(t *testing.T) {
 			if !assert.EqualValues(t, app.Ready, man.State()) {
 				return
 			}
-			if !assert.True(t, done) {
-				return
-			}
+			require.True(t, done)
+
 			break
 		} else {
 			t.Fatalf("invalid state")
@@ -374,9 +356,7 @@ func TestKonnectorInstallAndUpgradeWithBranch(t *testing.T) {
 		Type:      consts.KonnectorType,
 		Slug:      "local-konnector-branch",
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	go inst.Run()
 
@@ -385,9 +365,8 @@ func TestKonnectorInstallAndUpgradeWithBranch(t *testing.T) {
 		var done bool
 		var err2 error
 		man, done, err2 = inst.Poll()
-		if !assert.NoError(t, err2) {
-			return
-		}
+		require.NoError(t, err2)
+
 		if state == "" {
 			if !assert.EqualValues(t, app.Upgrading, man.State()) {
 				return
@@ -396,9 +375,8 @@ func TestKonnectorInstallAndUpgradeWithBranch(t *testing.T) {
 			if !assert.EqualValues(t, app.Ready, man.State()) {
 				return
 			}
-			if !assert.True(t, done) {
-				return
-			}
+			require.True(t, done)
+
 			break
 		} else {
 			t.Fatalf("invalid state")
@@ -424,16 +402,14 @@ func TestKonnectorUninstall(t *testing.T) {
 		Slug:      "konnector-delete",
 		SourceURL: "git://localhost/",
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	go inst1.Run()
 	for {
 		var done bool
 		_, done, err = inst1.Poll()
-		if !assert.NoError(t, err) {
-			return
-		}
+		require.NoError(t, err)
+
 		if done {
 			break
 		}
@@ -443,13 +419,11 @@ func TestKonnectorUninstall(t *testing.T) {
 		Type:      consts.KonnectorType,
 		Slug:      "konnector-delete",
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	_, err = inst2.RunSync()
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	inst3, err := app.NewInstaller(db, fs, &app.InstallerOptions{
 		Operation: app.Delete,
 		Type:      consts.KonnectorType,

--- a/model/app/installer_webapp_test.go
+++ b/model/app/installer_webapp_test.go
@@ -86,9 +86,7 @@ func TestWebappInstallSuccessful(t *testing.T) {
 		Slug:      "local-cozy-mini",
 		SourceURL: "git://localhost/",
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	go inst.Run()
 
@@ -98,9 +96,8 @@ func TestWebappInstallSuccessful(t *testing.T) {
 		var done bool
 		var err2 error
 		man, done, err2 = inst.Poll()
-		if !assert.NoError(t, err2) {
-			return
-		}
+		require.NoError(t, err2)
+
 		if state == "" {
 			if !assert.EqualValues(t, app.Installing, man.State()) {
 				return
@@ -109,9 +106,8 @@ func TestWebappInstallSuccessful(t *testing.T) {
 			if !assert.EqualValues(t, app.Ready, man.State()) {
 				return
 			}
-			if !assert.True(t, done) {
-				return
-			}
+			require.True(t, done)
+
 			break
 		} else {
 			t.Fatalf("invalid state")
@@ -234,9 +230,7 @@ func TestWebappInstallSuccessfulWithExtraPerms(t *testing.T) {
 		Slug:      "mini-test-perms",
 		SourceURL: "git://localhost/",
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	man, err := inst.RunSync()
 	assert.NoError(t, err)
@@ -359,9 +353,7 @@ func TestWebappInstallWithUpgrade(t *testing.T) {
 		Slug:      "cozy-app-b",
 		SourceURL: "git://localhost/",
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	man, err := inst.RunSync()
 	assert.NoError(t, err)
@@ -391,9 +383,7 @@ func TestWebappInstallWithUpgrade(t *testing.T) {
 		Type:      consts.WebappType,
 		Slug:      "cozy-app-b",
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	go inst.Run()
 
@@ -401,9 +391,8 @@ func TestWebappInstallWithUpgrade(t *testing.T) {
 	for {
 		var done bool
 		man, done, err = inst.Poll()
-		if !assert.NoError(t, err) {
-			return
-		}
+		require.NoError(t, err)
+
 		if state == "" {
 			if !assert.EqualValues(t, app.Upgrading, man.State()) {
 				return
@@ -412,9 +401,8 @@ func TestWebappInstallWithUpgrade(t *testing.T) {
 			if !assert.EqualValues(t, app.Ready, man.State()) {
 				return
 			}
-			if !assert.True(t, done) {
-				return
-			}
+			require.True(t, done)
+
 			break
 		} else {
 			t.Fatalf("invalid state")
@@ -649,9 +637,7 @@ func TestWebappInstallAndUpgradeWithBranch(t *testing.T) {
 		Slug:      "local-cozy-mini-branch",
 		SourceURL: "git://localhost/#branch",
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	go inst.Run()
 
@@ -661,9 +647,8 @@ func TestWebappInstallAndUpgradeWithBranch(t *testing.T) {
 		var done bool
 		var err2 error
 		man, done, err2 = inst.Poll()
-		if !assert.NoError(t, err2) {
-			return
-		}
+		require.NoError(t, err2)
+
 		if state == "" {
 			if !assert.EqualValues(t, app.Installing, man.State()) {
 				return
@@ -672,9 +657,8 @@ func TestWebappInstallAndUpgradeWithBranch(t *testing.T) {
 			if !assert.EqualValues(t, app.Ready, man.State()) {
 				return
 			}
-			if !assert.True(t, done) {
-				return
-			}
+			require.True(t, done)
+
 			break
 		} else {
 			t.Fatalf("invalid state")
@@ -700,9 +684,7 @@ func TestWebappInstallAndUpgradeWithBranch(t *testing.T) {
 		Type:      consts.WebappType,
 		Slug:      "local-cozy-mini-branch",
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	go inst.Run()
 
@@ -711,9 +693,8 @@ func TestWebappInstallAndUpgradeWithBranch(t *testing.T) {
 		var done bool
 		var err2 error
 		man, done, err2 = inst.Poll()
-		if !assert.NoError(t, err2) {
-			return
-		}
+		require.NoError(t, err2)
+
 		if state == "" {
 			if !assert.EqualValues(t, app.Upgrading, man.State()) {
 				return
@@ -722,9 +703,8 @@ func TestWebappInstallAndUpgradeWithBranch(t *testing.T) {
 			if !assert.EqualValues(t, app.Ready, man.State()) {
 				return
 			}
-			if !assert.True(t, done) {
-				return
-			}
+			require.True(t, done)
+
 			break
 		} else {
 			t.Fatalf("invalid state")
@@ -751,14 +731,11 @@ func TestWebappInstallAndUpgradeWithBranch(t *testing.T) {
 		Slug:      "local-cozy-mini-branch",
 		SourceURL: "git://localhost/",
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	man, err = inst.RunSync()
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, "git://localhost/", man.Source())
 
 	ok, err = afero.Exists(baseFS, path.Join("/", man.Slug(), man.Version(), app.WebappManifestName+".br"))
@@ -781,18 +758,15 @@ func TestWebappInstallFromGithub(t *testing.T) {
 		Slug:      "github-cozy-mini",
 		SourceURL: "git://github.com/nono/cozy-mini.git",
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	go inst.Run()
 
 	var state app.State
 	for {
 		man, done, err := inst.Poll()
-		if !assert.NoError(t, err) {
-			return
-		}
+		require.NoError(t, err)
+
 		if state == "" {
 			if !assert.EqualValues(t, app.Installing, man.State()) {
 				return
@@ -801,9 +775,8 @@ func TestWebappInstallFromGithub(t *testing.T) {
 			if !assert.EqualValues(t, app.Ready, man.State()) {
 				return
 			}
-			if !assert.True(t, done) {
-				return
-			}
+			require.True(t, done)
+
 			break
 		} else {
 			t.Fatalf("invalid state")
@@ -822,18 +795,15 @@ func TestWebappInstallFromHTTP(t *testing.T) {
 		Slug:      "http-cozy-drive",
 		SourceURL: "https://github.com/cozy/cozy-drive/archive/71e5cde66f754f986afc7111962ed2dd361bd5e4.tar.gz",
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	go inst.Run()
 
 	var state app.State
 	for {
 		man, done, err := inst.Poll()
-		if !assert.NoError(t, err) {
-			return
-		}
+		require.NoError(t, err)
+
 		if state == "" {
 			if !assert.EqualValues(t, app.Installing, man.State()) {
 				return
@@ -842,9 +812,8 @@ func TestWebappInstallFromHTTP(t *testing.T) {
 			if !assert.EqualValues(t, app.Ready, man.State()) {
 				return
 			}
-			if !assert.True(t, done) {
-				return
-			}
+			require.True(t, done)
+
 			break
 		} else {
 			t.Fatalf("invalid state")
@@ -937,9 +906,7 @@ func TestWebappUpdateWithService(t *testing.T) {
 		Slug:      "mini-test-service",
 		SourceURL: "git://localhost/",
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	man, err := inst.RunSync()
 	assert.NoError(t, err)
@@ -978,16 +945,14 @@ func TestWebappUninstall(t *testing.T) {
 		Slug:      "github-cozy-delete",
 		SourceURL: "git://localhost/",
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	go inst1.Run()
 	for {
 		var done bool
 		_, done, err = inst1.Poll()
-		if !assert.NoError(t, err) {
-			return
-		}
+		require.NoError(t, err)
+
 		if done {
 			break
 		}
@@ -997,13 +962,11 @@ func TestWebappUninstall(t *testing.T) {
 		Type:      consts.WebappType,
 		Slug:      "github-cozy-delete",
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	_, err = inst2.RunSync()
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	inst3, err := app.NewInstaller(db, fs, &app.InstallerOptions{
 		Operation: app.Delete,
 		Type:      consts.WebappType,
@@ -1023,16 +986,14 @@ func TestWebappUninstallErrored(t *testing.T) {
 		Slug:      "github-cozy-delete-errored",
 		SourceURL: "git://localhost/",
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	go inst1.Run()
 	for {
 		var done bool
 		_, done, err = inst1.Poll()
-		if !assert.NoError(t, err) {
-			return
-		}
+		require.NoError(t, err)
+
 		if done {
 			break
 		}
@@ -1044,9 +1005,8 @@ func TestWebappUninstallErrored(t *testing.T) {
 		Slug:      "github-cozy-delete-errored",
 		SourceURL: "git://foobar.does.not.exist/",
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	go inst2.Run()
 	for {
 		var done bool
@@ -1055,22 +1015,17 @@ func TestWebappUninstallErrored(t *testing.T) {
 			break
 		}
 	}
-	if !assert.Error(t, err) {
-		return
-	}
+	require.Error(t, err)
 
 	inst3, err := app.NewInstaller(db, fs, &app.InstallerOptions{
 		Operation: app.Delete,
 		Type:      consts.WebappType,
 		Slug:      "github-cozy-delete-errored",
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	_, err = inst3.RunSync()
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	inst4, err := app.NewInstaller(db, fs, &app.InstallerOptions{
 		Operation: app.Delete,

--- a/model/instance/lifecycle/lifecycle_test.go
+++ b/model/instance/lifecycle/lifecycle_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
 	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	_ "github.com/cozy/cozy-stack/worker/mails"
 )
@@ -298,30 +299,24 @@ func TestRequestPassphraseReset(t *testing.T) {
 		Domain: "test.cozycloud.cc.pass_reset",
 		Locale: "en",
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	err = lifecycle.RequestPassphraseReset(in)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	// token should not have been generated since we have not set a passphrase
 	// yet
-	if !assert.Nil(t, in.PassphraseResetToken) {
-		return
-	}
+	require.Nil(t, in.PassphraseResetToken)
+
 	err = lifecycle.RegisterPassphrase(in, in.RegisterToken, lifecycle.PassParameters{
 		Pass:       []byte("MyPassphrase"),
 		Iterations: 5000,
 		Key:        "0.uRcMe+Mc2nmOet4yWx9BwA==|PGQhpYUlTUq/vBEDj1KOHVMlTIH1eecMl0j80+Zu0VRVfFa7X/MWKdVM6OM/NfSZicFEwaLWqpyBlOrBXhR+trkX/dPRnfwJD2B93hnLNGQ=",
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	err = lifecycle.RequestPassphraseReset(in)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	regToken := in.PassphraseResetToken
 	regTime := in.PassphraseResetTime
@@ -339,46 +334,40 @@ func TestPassphraseRenew(t *testing.T) {
 		Domain: "test.cozycloud.cc.pass_renew",
 		Locale: "en",
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	err = lifecycle.RegisterPassphrase(in, in.RegisterToken, lifecycle.PassParameters{
 		Pass:       []byte("MyPassphrase"),
 		Iterations: 5000,
 		Key:        "0.uRcMe+Mc2nmOet4yWx9BwA==|PGQhpYUlTUq/vBEDj1KOHVMlTIH1eecMl0j80+Zu0VRVfFa7X/MWKdVM6OM/NfSZicFEwaLWqpyBlOrBXhR+trkX/dPRnfwJD2B93hnLNGQ=",
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	passHash := in.PassphraseHash
 	err = lifecycle.PassphraseRenew(in, nil, lifecycle.PassParameters{
 		Pass:       []byte("NewPass"),
 		Iterations: 5000,
 		Key:        "0.uRcMe+Mc2nmOet4yWx9BwA==|PGQhpYUlTUq/vBEDj1KOHVMlTIH1eecMl0j80+Zu0VRVfFa7X/MWKdVM6OM/NfSZicFEwaLWqpyBlOrBXhR+trkX/dPRnfwJD2B93hnLNGQ=",
 	})
-	if !assert.Error(t, err) {
-		return
-	}
+	require.Error(t, err)
+
 	err = lifecycle.RequestPassphraseReset(in)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	err = lifecycle.PassphraseRenew(in, []byte("token"), lifecycle.PassParameters{
 		Pass:       []byte("NewPass"),
 		Iterations: 5000,
 		Key:        "0.uRcMe+Mc2nmOet4yWx9BwA==|PGQhpYUlTUq/vBEDj1KOHVMlTIH1eecMl0j80+Zu0VRVfFa7X/MWKdVM6OM/NfSZicFEwaLWqpyBlOrBXhR+trkX/dPRnfwJD2B93hnLNGQ=",
 	})
-	if !assert.Error(t, err) {
-		return
-	}
+	require.Error(t, err)
+
 	err = lifecycle.PassphraseRenew(in, in.PassphraseResetToken, lifecycle.PassParameters{
 		Pass:       []byte("NewPass"),
 		Iterations: 5000,
 		Key:        "0.uRcMe+Mc2nmOet4yWx9BwA==|PGQhpYUlTUq/vBEDj1KOHVMlTIH1eecMl0j80+Zu0VRVfFa7X/MWKdVM6OM/NfSZicFEwaLWqpyBlOrBXhR+trkX/dPRnfwJD2B93hnLNGQ=",
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.False(t, bytes.Equal(passHash, in.PassphraseHash))
 }
 
@@ -387,9 +376,8 @@ func TestInstanceNoDuplicate(t *testing.T) {
 		Domain: "test.cozycloud.cc.duplicate",
 		Locale: "en",
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	i, err := lifecycle.Create(&lifecycle.Options{
 		Domain: "test.cozycloud.cc.duplicate",
 		Locale: "en",
@@ -423,9 +411,7 @@ func TestCheckTOSNotSigned(t *testing.T) {
 		Locale:    "en",
 		TOSSigned: "1.0.0-" + now.Format("20060102"),
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	notSigned, deadline := i.CheckTOSNotSignedAndDeadline()
 	assert.Empty(t, i.TOSLatest)
@@ -435,9 +421,7 @@ func TestCheckTOSNotSigned(t *testing.T) {
 	err = lifecycle.Patch(i, &lifecycle.Options{
 		TOSLatest: "1.0.1-" + now.Format("20060102"),
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	notSigned, deadline = i.CheckTOSNotSignedAndDeadline()
 	assert.Empty(t, i.TOSLatest)
@@ -447,9 +431,7 @@ func TestCheckTOSNotSigned(t *testing.T) {
 	err = lifecycle.Patch(i, &lifecycle.Options{
 		TOSLatest: "2.0.1-" + now.Add(40*24*time.Hour).Format("20060102"),
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	notSigned, deadline = i.CheckTOSNotSignedAndDeadline()
 	assert.NotEmpty(t, i.TOSLatest)
@@ -459,9 +441,8 @@ func TestCheckTOSNotSigned(t *testing.T) {
 	err = lifecycle.Patch(i, &lifecycle.Options{
 		TOSLatest: "2.0.1-" + now.Add(10*24*time.Hour).Format("20060102"),
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	notSigned, deadline = i.CheckTOSNotSignedAndDeadline()
 	assert.NotEmpty(t, i.TOSLatest)
 	assert.True(t, notSigned)
@@ -470,9 +451,8 @@ func TestCheckTOSNotSigned(t *testing.T) {
 	err = lifecycle.Patch(i, &lifecycle.Options{
 		TOSLatest: "2.0.1-" + now.Format("20060102"),
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	notSigned, deadline = i.CheckTOSNotSignedAndDeadline()
 	assert.NotEmpty(t, i.TOSLatest)
 	assert.True(t, notSigned)
@@ -481,9 +461,8 @@ func TestCheckTOSNotSigned(t *testing.T) {
 	err = lifecycle.Patch(i, &lifecycle.Options{
 		TOSSigned: "2.0.1-" + now.Format("20060102"),
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	notSigned, deadline = i.CheckTOSNotSignedAndDeadline()
 	assert.Empty(t, i.TOSLatest)
 	assert.False(t, notSigned)
@@ -497,9 +476,7 @@ func TestInstanceDestroy(t *testing.T) {
 		Domain: "test.cozycloud.cc",
 		Locale: "en",
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	err = lifecycle.Destroy("test.cozycloud.cc")
 	assert.NoError(t, err)

--- a/model/job/mem_scheduler_test.go
+++ b/model/job/mem_scheduler_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/realtime"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTriggersBadArguments(t *testing.T) {
@@ -80,13 +81,11 @@ func TestMemSchedulerWithDebounce(t *testing.T) {
 
 	for _, infos := range triggersInfos {
 		trigger, err := jobs.NewTrigger(testInstance, infos, msg)
-		if !assert.NoError(t, err) {
-			return
-		}
+		require.NoError(t, err)
+
 		err = sch.AddTrigger(trigger)
-		if !assert.NoError(t, err) {
-			return
-		}
+		require.NoError(t, err)
+
 		triggers = append(triggers, trigger)
 	}
 

--- a/model/job/redis_scheduler_test.go
+++ b/model/job/redis_scheduler_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cozy/cozy-stack/tests/testutils"
 	"github.com/go-redis/redis/v8"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const redisURL = "redis://localhost:6379/15"
@@ -308,9 +309,7 @@ func TestRedisTriggerEvent(t *testing.T) {
 	time.Sleep(1 * time.Second)
 
 	count, _ := bro.WorkerQueueLen("incr")
-	if !assert.Equal(t, 1, count) {
-		return
-	}
+	require.Equal(t, 1, count)
 
 	var evt struct {
 		Domain string `json:"domain"`
@@ -381,9 +380,7 @@ func TestRedisTriggerEventForDirectories(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 	count, _ := bro.WorkerQueueLen("incr")
-	if !assert.Equal(t, 0, count) {
-		return
-	}
+	require.Equal(t, 0, count)
 
 	barID := utils.RandomString(10)
 	realtime.GetHub().Publish(testInstance, realtime.EventCreate,

--- a/model/job/trigger_event_test.go
+++ b/model/job/trigger_event_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/realtime"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func makeMessage(t *testing.T, msg string) jobs.Message {
@@ -100,13 +101,11 @@ func TestTriggerEvent(t *testing.T) {
 
 	for _, infos := range triggersInfos {
 		trigger, err := jobs.NewTrigger(testInstance, infos, infos.Message)
-		if !assert.NoError(t, err) {
-			return
-		}
+		require.NoError(t, err)
+
 		err = sch.AddTrigger(trigger)
-		if !assert.NoError(t, err) {
-			return
-		}
+		require.NoError(t, err)
+
 		triggers = append(triggers, trigger)
 	}
 

--- a/model/oauth/client_test.go
+++ b/model/oauth/client_test.go
@@ -116,7 +116,6 @@ func TestCreateClientWithNotifications(t *testing.T) {
 		var err error
 		goodClient, err = oauth.FindClient(testInstance, goodClient.ClientID)
 		require.NoError(t, err)
-
 	}
 
 	{

--- a/model/oauth/client_test.go
+++ b/model/oauth/client_test.go
@@ -115,9 +115,8 @@ func TestCreateClientWithNotifications(t *testing.T) {
 	{
 		var err error
 		goodClient, err = oauth.FindClient(testInstance, goodClient.ClientID)
-		if !assert.NoError(t, err) {
-			return
-		}
+		require.NoError(t, err)
+
 	}
 
 	{

--- a/model/remote/remote_test.go
+++ b/model/remote/remote_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const doctype = "org.example.request"
@@ -106,9 +107,7 @@ Accept-Language: {{lang}},en
 { "one": "{{ json one }}", "two": "{{ json two }}" }
 <p>{{html content}}</p>`
 	r, err := ParseRawRequest(doctype, raw)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	vars := map[string]string{
 		"contentType": "application/json",

--- a/model/vfs/permissions_test.go
+++ b/model/vfs/permissions_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPermissions(t *testing.T) {
@@ -30,42 +31,33 @@ func TestPermissions(t *testing.T) {
 		},
 	}
 	O, err := createTree(origtree, consts.RootDirID)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	A, err := fs.DirByPath("/O/A")
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	B, err := fs.DirByPath("/O/B")
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	_, err = vfs.ModifyDirMetadata(fs, B, &vfs.DocPatch{
 		Tags: &[]string{"testtagparent"},
 	})
 	assert.NoError(t, err)
 
 	B2, err := fs.DirByPath("/O/B2")
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	f, err := fs.FileByPath("/O/B/b1.txt")
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	_, err = vfs.ModifyFileMetadata(fs, f, &vfs.DocPatch{
 		Tags: &[]string{"testtag"},
 	})
 	assert.NoError(t, err)
 	// reload
 	f, err = fs.FileByPath("/O/B/b1.txt")
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	// hack to have a Class attribute
 	f.Class = "superfile"
 

--- a/model/vfs/vfs_test.go
+++ b/model/vfs/vfs_test.go
@@ -200,13 +200,11 @@ func TestRemoveAll(t *testing.T) {
 		},
 	}
 	_, err := createTree(origtree, consts.RootDirID)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	err = vfs.RemoveAll(fs, "/removemeall", fs.EnsureErased)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	_, err = fs.DirByPath("/removemeall/dirchild1")
 	assert.Error(t, err)
 	_, err = fs.DirByPath("/removemeall")
@@ -264,40 +262,31 @@ func TestCreateGetAndModifyFile(t *testing.T) {
 
 	olddoc, err := createTree(origtree, consts.RootDirID)
 
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	newname := "createandget2"
 	_, err = vfs.ModifyDirMetadata(fs, olddoc, &vfs.DocPatch{
 		Name: &newname,
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	tree, err := fetchTree("/createandget2")
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	assert.EqualValues(t, origtree["createandget1/"], tree["createandget2/"], "should have same tree")
 
 	fileBefore, err := fs.FileByPath("/createandget2/dirchild2/foof")
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	newfilename := "foof.jpg"
 	_, err = vfs.ModifyFileMetadata(fs, fileBefore, &vfs.DocPatch{
 		Name: &newfilename,
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	fileAfter, err := fs.FileByPath("/createandget2/dirchild2/foof.jpg")
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, "files", fileBefore.Class)
 	assert.Equal(t, "application/octet-stream", fileBefore.Mime)
 	assert.Equal(t, "image", fileAfter.Class)
@@ -321,49 +310,35 @@ func TestUpdateDir(t *testing.T) {
 	}
 
 	doc1, err := createTree(origtree, consts.RootDirID)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	newname := "update2"
 	_, err = vfs.ModifyDirMetadata(fs, doc1, &vfs.DocPatch{
 		Name: &newname,
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	tree, err := fetchTree("/update2")
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	if !assert.EqualValues(t, origtree["update1/"], tree["update2/"], "should have same tree") {
 		return
 	}
 
 	dirchild2, err := fs.DirByPath("/update2/dirchild2")
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	dirchild3, err := fs.DirByPath("/update2/dirchild3")
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	newfolid := dirchild2.ID()
 	_, err = vfs.ModifyDirMetadata(fs, dirchild3, &vfs.DocPatch{
 		DirID: &newfolid,
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	tree, err = fetchTree("/update2")
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	assert.EqualValues(t, H{
 		"update2/": H{
@@ -455,9 +430,7 @@ func TestWalk(t *testing.T) {
 	}
 
 	_, err := createTree(walktree, consts.RootDirID)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	walked := H{}
 	err = vfs.Walk(fs, "/walk", func(name string, dir *vfs.DirDoc, file *vfs.FileDoc, err error) error {
@@ -510,9 +483,7 @@ func TestWalkAlreadyLocked(t *testing.T) {
 	}
 
 	_, err := createTree(walktree, consts.RootDirID)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	done := make(chan bool)
 
@@ -622,9 +593,7 @@ func TestCreateFileTooBig(t *testing.T) {
 	defer func() { diskQuota = 0 }()
 
 	diskUsage1, err := fs.DiskUsage()
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	doc1, err := vfs.NewFileDoc(
 		"too-big",
@@ -639,9 +608,8 @@ func TestCreateFileTooBig(t *testing.T) {
 		false,
 		nil,
 	)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	_, err = fs.CreateFile(doc1, nil)
 	assert.Equal(t, vfs.ErrFileTooBig, err)
 
@@ -658,9 +626,8 @@ func TestCreateFileTooBig(t *testing.T) {
 		false,
 		nil,
 	)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	f, err := fs.CreateFile(doc2, nil)
 	assert.NoError(t, err)
 	assert.Error(t, f.Close())
@@ -681,9 +648,8 @@ func TestCreateFileTooBig(t *testing.T) {
 		false,
 		nil,
 	)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	f, err = fs.CreateFile(doc3, nil)
 	assert.NoError(t, err)
 	_, err = io.Copy(f, bytes.NewReader(crypto.GenerateRandomBytes(int(doc3.ByteSize))))
@@ -708,9 +674,8 @@ func TestCreateFileTooBig(t *testing.T) {
 		false,
 		nil,
 	)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	f, err = fs.CreateFile(doc4, nil)
 	assert.NoError(t, err)
 	_, err = io.Copy(f, bytes.NewReader(crypto.GenerateRandomBytes(int(diskQuota/2+1))))
@@ -724,9 +689,8 @@ func TestCreateFileTooBig(t *testing.T) {
 	assert.True(t, os.IsNotExist(err))
 
 	root, err := fs.DirByPath("/")
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.NoError(t, fs.DestroyDirContent(root, fs.EnsureErased))
 }
 

--- a/pkg/config/config/config_test.go
+++ b/pkg/config/config/config_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUseViper(t *testing.T) {
@@ -22,9 +23,8 @@ func TestUseViper(t *testing.T) {
 func TestSetup(t *testing.T) {
 	tmpdir := os.TempDir()
 	tmpfile, err := os.OpenFile(filepath.Join(tmpdir, "cozy.yaml"), os.O_RDWR|os.O_CREATE|os.O_EXCL, 0600)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	defer tmpfile.Close()
 	defer os.Remove(tmpfile.Name())
 
@@ -71,13 +71,10 @@ registries:
   default:
     - https://default
 `))
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	err = Setup(tmpfile.Name())
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	assert.Equal(t, "myhost", GetConfig().Host)
 	assert.Equal(t, 1235, GetConfig().Port)

--- a/pkg/crypto/mac_test.go
+++ b/pkg/crypto/mac_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var testStrings = []string{"foo", "bar", "baz"}
@@ -22,42 +23,32 @@ func TestMACMessageWithName(t *testing.T) {
 	o3 := MACConfig{Name: "message1"}
 
 	encoded, err1 := EncodeAuthMessage(o1, k1, value, nil)
-	if !assert.NoError(t, err1) {
-		return
-	}
+	require.NoError(t, err1)
+
 	v, err2 := DecodeAuthMessage(o1, k1, encoded, nil)
-	if !assert.NoError(t, err2) {
-		return
-	}
+	require.NoError(t, err2)
+
 	if !assert.EqualValues(t, v, value) {
 		t.Fatalf("Expected %v, got %v.", v, value)
 	}
 	_, err3 := DecodeAuthMessage(o2, k2, encoded, nil)
-	if !assert.Error(t, err3) {
-		return
-	}
+	require.Error(t, err3)
+
 	_, err4 := DecodeAuthMessage(o3, k3, encoded, nil)
-	if !assert.Error(t, err4) {
-		return
-	}
+	require.Error(t, err4)
+
 	_, err5 := DecodeAuthMessage(o1, k1, encoded, []byte("plop"))
-	if !assert.Error(t, err5) {
-		return
-	}
+	require.Error(t, err5)
 
 	encoded2, err6 := EncodeAuthMessage(o1, k1, value, []byte("foo"))
-	if !assert.NoError(t, err6) {
-		return
-	}
+	require.NoError(t, err6)
 
 	_, err7 := DecodeAuthMessage(o1, k1, encoded2, []byte("foo"))
-	if !assert.NoError(t, err7) {
-		return
-	}
+	require.NoError(t, err7)
+
 	_, err8 := DecodeAuthMessage(o1, k1, encoded2, []byte("plop"))
-	if !assert.Error(t, err8) {
-		return
-	}
+	require.Error(t, err8)
+
 }
 
 func TestMACMessageWithoutName(t *testing.T) {
@@ -71,24 +62,20 @@ func TestMACMessageWithoutName(t *testing.T) {
 	o3 := MACConfig{Name: ""}
 
 	encoded, err1 := EncodeAuthMessage(o1, k1, value, nil)
-	if !assert.NoError(t, err1) {
-		return
-	}
+	require.NoError(t, err1)
+
 	v, err2 := DecodeAuthMessage(o1, k1, encoded, nil)
-	if !assert.NoError(t, err2) {
-		return
-	}
+	require.NoError(t, err2)
+
 	if !reflect.DeepEqual(v, value) {
 		t.Fatalf("Expected %v, got %v.", value, v)
 	}
 	_, err3 := DecodeAuthMessage(o2, k2, encoded, nil)
-	if !assert.Error(t, err3) {
-		return
-	}
+	require.Error(t, err3)
+
 	_, err4 := DecodeAuthMessage(o3, k3, encoded, nil)
-	if !assert.Error(t, err4) {
-		return
-	}
+	require.Error(t, err4)
+
 }
 
 func TestMACWrongMessage(t *testing.T) {
@@ -100,41 +87,36 @@ func TestMACWrongMessage(t *testing.T) {
 
 	{
 		_, err := DecodeAuthMessage(o, k, []byte(""), nil)
-		if !assert.Equal(t, errMACInvalid, err) {
-			return
-		}
+		require.Equal(t, errMACInvalid, err)
+
 	}
 
 	{
 		_, err := DecodeAuthMessage(o, k, []byte("ccc"), nil)
-		if !assert.Equal(t, errMACInvalid, err) {
-			return
-		}
+		require.Equal(t, errMACInvalid, err)
+
 	}
 
 	{
 		buf := Base64Encode(GenerateRandomBytes(32))
 		_, err := DecodeAuthMessage(o, k, buf, nil)
-		if !assert.Equal(t, errMACInvalid, err) {
-			return
-		}
+		require.Equal(t, errMACInvalid, err)
+
 	}
 
 	{
 		buf := Base64Encode(createMAC(k, []byte("")))
 		_, err := DecodeAuthMessage(o, k, buf, nil)
-		if !assert.Equal(t, errMACInvalid, err) {
-			return
-		}
+		require.Equal(t, errMACInvalid, err)
+
 	}
 
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 	for i := 0; i < 10000; i++ {
 		buf := Base64Encode(GenerateRandomBytes(rng.Intn(1000)))
 		_, err := DecodeAuthMessage(o, k, buf, nil)
-		if !assert.Equal(t, errMACInvalid, err) {
-			return
-		}
+		require.Equal(t, errMACInvalid, err)
+
 	}
 }
 
@@ -156,26 +138,22 @@ func TestMACMaxAge(t *testing.T) {
 	{
 		var err error
 		msg1, err = EncodeAuthMessage(c1, key, val, add)
-		if !assert.NoError(t, err) {
-			return
-		}
+		require.NoError(t, err)
+
 		msg2, err = EncodeAuthMessage(c2, key, val, add)
-		if !assert.NoError(t, err) {
-			return
-		}
+		require.NoError(t, err)
+
 	}
 
 	{
 		ret1, err := DecodeAuthMessage(c1, key, msg1, add)
-		if !assert.NoError(t, err) {
-			return
-		}
+		require.NoError(t, err)
+
 		assert.Equal(t, val, ret1)
 
 		ret2, err := DecodeAuthMessage(c2, key, msg2, add)
-		if !assert.NoError(t, err) {
-			return
-		}
+		require.NoError(t, err)
+
 		assert.Equal(t, val, ret2)
 	}
 
@@ -197,16 +175,13 @@ func TestAuthentication(t *testing.T) {
 	hashKey := []byte("secret-key")
 	for _, value := range testStrings {
 		mac := createMAC(hashKey, []byte(value))
-		if !assert.Len(t, mac, macLen) {
-			return
-		}
+		require.Len(t, mac, macLen)
+
 		ok1 := verifyMAC(hashKey, []byte(value), mac)
-		if !assert.True(t, ok1) {
-			return
-		}
+		require.True(t, ok1)
+
 		ok2 := verifyMAC(hashKey, GenerateRandomBytes(32), mac)
-		if !assert.False(t, ok2) {
-			return
-		}
+		require.False(t, ok2)
+
 	}
 }

--- a/pkg/crypto/mac_test.go
+++ b/pkg/crypto/mac_test.go
@@ -48,7 +48,6 @@ func TestMACMessageWithName(t *testing.T) {
 
 	_, err8 := DecodeAuthMessage(o1, k1, encoded2, []byte("plop"))
 	require.Error(t, err8)
-
 }
 
 func TestMACMessageWithoutName(t *testing.T) {
@@ -75,7 +74,6 @@ func TestMACMessageWithoutName(t *testing.T) {
 
 	_, err4 := DecodeAuthMessage(o3, k3, encoded, nil)
 	require.Error(t, err4)
-
 }
 
 func TestMACWrongMessage(t *testing.T) {
@@ -88,27 +86,23 @@ func TestMACWrongMessage(t *testing.T) {
 	{
 		_, err := DecodeAuthMessage(o, k, []byte(""), nil)
 		require.Equal(t, errMACInvalid, err)
-
 	}
 
 	{
 		_, err := DecodeAuthMessage(o, k, []byte("ccc"), nil)
 		require.Equal(t, errMACInvalid, err)
-
 	}
 
 	{
 		buf := Base64Encode(GenerateRandomBytes(32))
 		_, err := DecodeAuthMessage(o, k, buf, nil)
 		require.Equal(t, errMACInvalid, err)
-
 	}
 
 	{
 		buf := Base64Encode(createMAC(k, []byte("")))
 		_, err := DecodeAuthMessage(o, k, buf, nil)
 		require.Equal(t, errMACInvalid, err)
-
 	}
 
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
@@ -116,7 +110,6 @@ func TestMACWrongMessage(t *testing.T) {
 		buf := Base64Encode(GenerateRandomBytes(rng.Intn(1000)))
 		_, err := DecodeAuthMessage(o, k, buf, nil)
 		require.Equal(t, errMACInvalid, err)
-
 	}
 }
 
@@ -142,7 +135,6 @@ func TestMACMaxAge(t *testing.T) {
 
 		msg2, err = EncodeAuthMessage(c2, key, val, add)
 		require.NoError(t, err)
-
 	}
 
 	{
@@ -182,6 +174,5 @@ func TestAuthentication(t *testing.T) {
 
 		ok2 := verifyMAC(hashKey, GenerateRandomBytes(32), mac)
 		require.False(t, ok2)
-
 	}
 }

--- a/pkg/crypto/utils_test.go
+++ b/pkg/crypto/utils_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGenerateRandomBytes(t *testing.T) {
@@ -16,9 +17,8 @@ func TestEncoding(t *testing.T) {
 	for _, value := range testStrings {
 		encoded := Base64Encode([]byte(value))
 		decoded, err := Base64Decode(encoded)
-		if !assert.NoError(t, err) {
-			return
-		}
+		require.NoError(t, err)
+
 		if !assert.Equal(t, value, string(decoded)) {
 			return
 		}

--- a/web/accounts/oauth_test.go
+++ b/web/accounts/oauth_test.go
@@ -47,9 +47,8 @@ func TestAccessCodeOauthFlow(t *testing.T) {
 		RegisteredRedirectURI: redirectURI,
 	}
 	err := couchdb.CreateNamedDoc(prefixer.SecretsPrefixer, &serviceType)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	defer func() {
 		_ = couchdb.DeleteDoc(prefixer.SecretsPrefixer, &serviceType)
 	}()
@@ -57,14 +56,11 @@ func TestAccessCodeOauthFlow(t *testing.T) {
 	u := ts.URL + "/accounts/test-service/start?scope=the+world&state=somesecretstate"
 
 	res, err := client.Get(u)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	bb, err := ioutil.ReadAll(res.Body)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	res.Body.Close()
 	okURL := string(bb)
 
@@ -75,14 +71,12 @@ func TestAccessCodeOauthFlow(t *testing.T) {
 
 	// the user click the oauth link
 	res2, err := (&http.Client{CheckRedirect: stopBeforeDataCollectFail}).Get(okURL)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, http.StatusSeeOther, res2.StatusCode)
 	finalURL, err := res2.Location()
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	if !assert.Contains(t, finalURL.String(), "home") {
 		return
 	}
@@ -107,9 +101,8 @@ func TestRedirectURLOauthFlow(t *testing.T) {
 		AuthEndpoint: service.URL + "/oauth2/v2/auth",
 	}
 	err := couchdb.CreateNamedDoc(prefixer.SecretsPrefixer, &serviceType)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	defer func() {
 		_ = couchdb.DeleteDoc(prefixer.SecretsPrefixer, &serviceType)
 	}()
@@ -117,14 +110,11 @@ func TestRedirectURLOauthFlow(t *testing.T) {
 	u := ts.URL + "/accounts/test-service2/start?scope=the+world"
 
 	res, err := client.Get(u)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	bb, err := ioutil.ReadAll(res.Body)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	res.Body.Close()
 	okURL := string(bb)
 
@@ -134,14 +124,12 @@ func TestRedirectURLOauthFlow(t *testing.T) {
 	}
 
 	res2, err := (&http.Client{CheckRedirect: stopBeforeDataCollectFail}).Get(okURL)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, http.StatusSeeOther, res2.StatusCode)
 	finalURL, err := res2.Location()
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	if !assert.Contains(t, finalURL.String(), "home") {
 		return
 	}
@@ -223,27 +211,21 @@ func TestFixedRedirectURIOauthFlow(t *testing.T) {
 		RegisteredRedirectURI: redirectURI,
 	}
 	err := couchdb.CreateNamedDoc(prefixer.SecretsPrefixer, &serviceType)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	defer func() {
 		_ = couchdb.DeleteDoc(prefixer.SecretsPrefixer, &serviceType)
 	}()
 
 	startURL, err := url.Parse(ts.URL + "/accounts/test-service3/start?scope=the+world")
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	res, err := client.Get(startURL.String())
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	bb, err := ioutil.ReadAll(res.Body)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	res.Body.Close()
 	okURL := string(bb)
 
@@ -253,28 +235,23 @@ func TestFixedRedirectURIOauthFlow(t *testing.T) {
 	}
 
 	okURLObj, err := url.Parse(okURL)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	// hack, we want to speak with ts.URL but setting Host to _oauth_callback
 	host := okURLObj.Host
 	okURLObj.Host = startURL.Host
 	req2, err := http.NewRequest("GET", okURLObj.String(), nil)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	req2.Host = host
 
 	res2, err := (&http.Client{CheckRedirect: stopBeforeDataCollectFail}).Do(req2)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, http.StatusSeeOther, res2.StatusCode)
 	finalURL, err := res2.Location()
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	if !assert.Contains(t, finalURL.String(), "home") {
 		return
 	}
@@ -299,9 +276,8 @@ func TestCheckLogin(t *testing.T) {
 		RegisteredRedirectURI: "https://oauth_callback.cozy.localhost/accounts/test-service4/redirect",
 	}
 	err := couchdb.CreateNamedDoc(prefixer.SecretsPrefixer, &serviceType)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	defer func() {
 		_ = couchdb.DeleteDoc(prefixer.SecretsPrefixer, &serviceType)
 	}()

--- a/web/auth/auth_test.go
+++ b/web/auth/auth_test.go
@@ -1559,9 +1559,8 @@ func TestPassphraseResetLoggedIn(t *testing.T) {
 	req, _ := http.NewRequest("GET", ts.URL+"/auth/passphrase_reset", nil)
 	req.Host = domain
 	res, err := client.Do(req)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	defer res.Body.Close()
 	assert.Equal(t, "200 OK", res.Status)
 	body, _ := ioutil.ReadAll(res.Body)
@@ -1573,9 +1572,8 @@ func TestPassphraseReset(t *testing.T) {
 	req1, _ := http.NewRequest("GET", ts.URL+"/auth/passphrase_reset", nil)
 	req1.Host = domain
 	res1, err := client.Do(req1)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	defer res1.Body.Close()
 	assert.Equal(t, "200 OK", res1.Status)
 	csrfCookie := res1.Cookies()[0]
@@ -1583,9 +1581,8 @@ func TestPassphraseReset(t *testing.T) {
 	res2, err := postForm("/auth/passphrase_reset", &url.Values{
 		"csrf_token": {csrfCookie.Value},
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	defer res2.Body.Close()
 	assert.Equal(t, "200 OK", res2.Status)
 	assert.Equal(t, "text/html; charset=UTF-8", res2.Header.Get("Content-Type"))
@@ -1595,9 +1592,8 @@ func TestPassphraseRenewFormNoToken(t *testing.T) {
 	req, _ := http.NewRequest("GET", ts.URL+"/auth/passphrase_renew", nil)
 	req.Host = domain
 	res, err := client.Do(req)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	defer res.Body.Close()
 	assert.Equal(t, "400 Bad Request", res.Status)
 	body, _ := ioutil.ReadAll(res.Body)
@@ -1608,9 +1604,8 @@ func TestPassphraseRenewFormBadToken(t *testing.T) {
 	req, _ := http.NewRequest("GET", ts.URL+"/auth/passphrase_renew?token=zzzz", nil)
 	req.Host = domain
 	res, err := client.Do(req)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	defer res.Body.Close()
 	assert.Equal(t, "400 Bad Request", res.Status)
 	body, _ := ioutil.ReadAll(res.Body)
@@ -1621,9 +1616,8 @@ func TestPassphraseRenewFormWithToken(t *testing.T) {
 	req, _ := http.NewRequest("GET", ts.URL+"/auth/passphrase_renew?token=badbee", nil)
 	req.Host = domain
 	res, err := client.Do(req)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	defer res.Body.Close()
 	assert.Equal(t, "400 Bad Request", res.Status)
 }
@@ -1636,9 +1630,8 @@ func TestPassphraseRenew(t *testing.T) {
 		Locale: "en",
 		Email:  "alice@example.com",
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	defer func() {
 		_ = lifecycle.Destroy(d)
 	}()
@@ -1647,38 +1640,33 @@ func TestPassphraseRenew(t *testing.T) {
 		Iterations: 5000,
 		Key:        "0.uRcMe+Mc2nmOet4yWx9BwA==|PGQhpYUlTUq/vBEDj1KOHVMlTIH1eecMl0j80+Zu0VRVfFa7X/MWKdVM6OM/NfSZicFEwaLWqpyBlOrBXhR+trkX/dPRnfwJD2B93hnLNGQ=",
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	req1, _ := http.NewRequest("GET", ts.URL+"/auth/passphrase_reset", nil)
 	req1.Host = domain
 	res1, err := client.Do(req1)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	defer res1.Body.Close()
 	csrfCookie := res1.Cookies()[0]
 	assert.Equal(t, "_csrf", csrfCookie.Name)
 	res2, err := postFormDomain(d, "/auth/passphrase_reset", &url.Values{
 		"csrf_token": {csrfCookie.Value},
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	defer res2.Body.Close()
 	assert.Equal(t, "200 OK", res2.Status)
 	in2, err := instance.GetFromCouch(d)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	res3, err := postFormDomain(d, "/auth/passphrase_renew", &url.Values{
 		"passphrase_reset_token": {hex.EncodeToString(in2.PassphraseResetToken)},
 		"passphrase":             {"NewPassphrase"},
 		"csrf_token":             {csrfCookie.Value},
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	defer res3.Body.Close()
 	if assert.Equal(t, "303 See Other", res3.Status) {
 		assert.Equal(t, "https://test.cozycloud.cc.web_reset_form/auth/login",
@@ -1709,9 +1697,7 @@ func TestSecretExchangeGoodSecret(t *testing.T) {
 	req.Header.Add("Accept", "application/json")
 
 	res, err := client.Do(req)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	resBody, _ := ioutil.ReadAll(res.Body)
 	assert.Contains(t, string(resBody), "client_secret")
@@ -1736,9 +1722,7 @@ func TestSecretExchangeBadSecret(t *testing.T) {
 
 	res, err := client.Do(req)
 
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	resBody, _ := ioutil.ReadAll(res.Body)
 	assert.Contains(t, string(resBody), "errors")
@@ -1755,9 +1739,7 @@ func TestSecretExchangeBadPayload(t *testing.T) {
 	req.Header.Add("Accept", "application/json")
 
 	res, err := client.Do(req)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	resBody, _ := ioutil.ReadAll(res.Body)
 	assert.Contains(t, string(resBody), "Missing secret")
@@ -1771,9 +1753,7 @@ func TestSecretExchangeNoPayload(t *testing.T) {
 	req.Header.Add("Accept", "application/json")
 
 	res, err := client.Do(req)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	assert.Equal(t, res.StatusCode, 400)
 	defer res.Body.Close()
@@ -1795,9 +1775,8 @@ func TestPassphraseOnboarding(t *testing.T) {
 	req, _ := http.NewRequest("GET", ts.URL+"/?registerToken="+hex.EncodeToString(inst.RegisterToken), nil)
 	req.Host = inst.Domain
 	res, err := client.Do(req)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, 303, res.StatusCode)
 	assert.Contains(t, res.Header.Get("Location"), "/auth/passphrase?registerToken=")
 
@@ -1826,9 +1805,8 @@ func TestPassphraseOnboardingFinished(t *testing.T) {
 	req.Host = domain
 
 	res, err := client.Do(req)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, res.StatusCode, 303)
 	assert.Equal(t, res.Header.Get("Location"), "https://home.cozy.example.net/")
 }
@@ -1849,9 +1827,8 @@ func TestPassphraseOnboardingBadRegisterToken(t *testing.T) {
 	req, _ := http.NewRequest("GET", ts.URL+"/auth/passphrase?registerToken=coincoin", nil)
 	req.Host = inst.Domain
 	res, err := client.Do(req)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	content, _ := ioutil.ReadAll(res.Body)
 	assert.Equal(t, 200, res.StatusCode)
 	assert.Contains(t, string(content), "Your Cozy has not been yet activated.")
@@ -1873,9 +1850,8 @@ func TestLoginOnboardingNotFinished(t *testing.T) {
 	req, _ := http.NewRequest("GET", ts.URL+"/auth/login", nil)
 	req.Host = inst.Domain
 	res, err := client.Do(req)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	content, _ := ioutil.ReadAll(res.Body)
 	assert.Equal(t, 200, res.StatusCode)
 	assert.Contains(t, string(content), "Your Cozy has not been yet activated.")

--- a/web/data/references_test.go
+++ b/web/data/references_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/jsonapi"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestListNotSynchronizedOn(t *testing.T) {
@@ -91,14 +92,11 @@ func TestAddReferencesHandler(t *testing.T) {
 	dirID := consts.RootDirID
 	mime, class := vfs.ExtractMimeAndClassFromFilename(name)
 	filedoc, err := vfs.NewFileDoc(name, dirID, -1, nil, mime, class, time.Now(), false, false, false, nil)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	f, err := testInstance.VFS().CreateFile(filedoc, nil)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	if err = f.Close(); !assert.NoError(t, err) {
 		return
 	}
@@ -174,13 +172,11 @@ func TestReferencesWithSlash(t *testing.T) {
 	dirID := consts.RootDirID
 	mime, class := vfs.ExtractMimeAndClassFromFilename(name)
 	filedoc, err := vfs.NewFileDoc(name, dirID, -1, nil, mime, class, time.Now(), false, false, false, nil)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	f, err := testInstance.VFS().CreateFile(filedoc, nil)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	if err = f.Close(); !assert.NoError(t, err) {
 		return
 	}

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -1878,7 +1878,6 @@ func TestArchiveDirectDownload(t *testing.T) {
 	for _, name := range names {
 		res2, _ := createDir(t, "/files/"+dirID+"?Name="+name+".jpg&Type=file")
 		require.Equal(t, 201, res2.StatusCode)
-
 	}
 
 	// direct download
@@ -1914,7 +1913,6 @@ func TestArchiveCreateAndDownload(t *testing.T) {
 	for _, name := range names {
 		res2, _ := createDir(t, "/files/"+dirID+"?Name="+name+".jpg&Type=file")
 		require.Equal(t, 201, res2.StatusCode)
-
 	}
 
 	body := bytes.NewBufferString(`{

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -67,15 +67,13 @@ func extractJSONRes(res *http.Response, mp *map[string]interface{}) error {
 
 func createDir(t *testing.T, path string) (res *http.Response, v map[string]interface{}) {
 	req, err := http.NewRequest("POST", ts.URL+path, strings.NewReader(""))
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	req.Header.Add("Content-Type", "text/plain")
 	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
 	res, err = http.DefaultClient.Do(req)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	defer res.Body.Close()
 
 	err = extractJSONRes(res, &v)
@@ -96,9 +94,7 @@ func doUploadOrMod(t *testing.T, req *http.Request, contentType, hash string) (r
 	}
 
 	res, err = http.DefaultClient.Do(req)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	defer res.Body.Close()
 
@@ -111,9 +107,8 @@ func doUploadOrMod(t *testing.T, req *http.Request, contentType, hash string) (r
 func upload(t *testing.T, path, contentType, body, hash string) (res *http.Response, v map[string]interface{}) {
 	buf := strings.NewReader(body)
 	req, err := http.NewRequest("POST", ts.URL+path, buf)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
 	if strings.Contains(path, "Size=") {
 		req.ContentLength = -1
@@ -125,23 +120,18 @@ func uploadMod(t *testing.T, path, contentType, body, hash string) (res *http.Re
 	buf := strings.NewReader(body)
 	req, err := http.NewRequest("PUT", ts.URL+path, buf)
 	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	return doUploadOrMod(t, req, contentType, hash)
 }
 
 func trash(t *testing.T, path string) (res *http.Response, v map[string]interface{}) {
 	req, err := http.NewRequest(http.MethodDelete, ts.URL+path, nil)
 	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	res, err = http.DefaultClient.Do(req)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	err = extractJSONRes(res, &v)
 	assert.NoError(t, err)
@@ -152,14 +142,10 @@ func trash(t *testing.T, path string) (res *http.Response, v map[string]interfac
 func restore(t *testing.T, path string) (res *http.Response, v map[string]interface{}) {
 	req, err := http.NewRequest(http.MethodPost, ts.URL+path, nil)
 	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	res, err = http.DefaultClient.Do(req)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	err = extractJSONRes(res, &v)
 	assert.NoError(t, err)
@@ -206,20 +192,14 @@ func patchFile(t *testing.T, path, docType, id string, attrs map[string]interfac
 	}
 
 	b, err := json.Marshal(map[string]*jsonData{"data": bodyreq})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	req, err := http.NewRequest("PATCH", ts.URL+path, bytes.NewReader(b))
 	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	res, err = http.DefaultClient.Do(req)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	defer res.Body.Close()
 
@@ -232,23 +212,17 @@ func patchFile(t *testing.T, path, docType, id string, attrs map[string]interfac
 func download(t *testing.T, path, byteRange string) (res *http.Response, body []byte) {
 	req, err := http.NewRequest("GET", ts.URL+path, nil)
 	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	if byteRange != "" {
 		req.Header.Add("Range", byteRange)
 	}
 
 	res, err = http.DefaultClient.Do(req)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	body, err = ioutil.ReadAll(res.Body)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	return
 }
@@ -1295,9 +1269,7 @@ func TestModifyContentConcurrently(t *testing.T) {
 	errs := make(chan *http.Response)
 
 	res, data := upload(t, "/files/?Type=file&Name=willbemodifiedconcurrently&Executable=true", "text/plain", "foo", "")
-	if !assert.Equal(t, 201, res.StatusCode) {
-		return
-	}
+	require.Equal(t, 201, res.StatusCode)
 
 	var ok bool
 	data, ok = data["data"].(map[string]interface{})
@@ -1879,15 +1851,12 @@ func TestArchiveNoFiles(t *testing.T) {
 		}
 	}`)
 	req, err := http.NewRequest("POST", ts.URL+"/files/archive", body)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	req.Header.Add("Content-Type", "application/vnd.api+json")
 	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
 	res, err := http.DefaultClient.Do(req)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 400, res.StatusCode)
@@ -1899,16 +1868,14 @@ func TestArchiveNoFiles(t *testing.T) {
 
 func TestArchiveDirectDownload(t *testing.T) {
 	res1, data1 := createDir(t, "/files/?Name=archive&Type=directory")
-	if !assert.Equal(t, 201, res1.StatusCode) {
-		return
-	}
+	require.Equal(t, 201, res1.StatusCode)
+
 	dirID, _ := extractDirData(t, data1)
 	names := []string{"foo", "bar", "baz"}
 	for _, name := range names {
 		res2, _ := createDir(t, "/files/"+dirID+"?Name="+name+".jpg&Type=file")
-		if !assert.Equal(t, 201, res2.StatusCode) {
-			return
-		}
+		require.Equal(t, 201, res2.StatusCode)
+
 	}
 
 	// direct download
@@ -1937,16 +1904,14 @@ func TestArchiveDirectDownload(t *testing.T) {
 
 func TestArchiveCreateAndDownload(t *testing.T) {
 	res1, data1 := createDir(t, "/files/?Name=archive2&Type=directory")
-	if !assert.Equal(t, 201, res1.StatusCode) {
-		return
-	}
+	require.Equal(t, 201, res1.StatusCode)
+
 	dirID, _ := extractDirData(t, data1)
 	names := []string{"foo", "bar", "baz"}
 	for _, name := range names {
 		res2, _ := createDir(t, "/files/"+dirID+"?Name="+name+".jpg&Type=file")
-		if !assert.Equal(t, 201, res2.StatusCode) {
-			return
-		}
+		require.Equal(t, 201, res2.StatusCode)
+
 	}
 
 	body := bytes.NewBufferString(`{
@@ -1962,15 +1927,12 @@ func TestArchiveCreateAndDownload(t *testing.T) {
 	}`)
 
 	req, err := http.NewRequest("POST", ts.URL+"/files/archive", body)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	req.Header.Add("Content-Type", "application/vnd.api+json")
 	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
 	res, err := http.DefaultClient.Do(req)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 200, res.StatusCode)
@@ -1989,22 +1951,17 @@ func TestArchiveCreateAndDownload(t *testing.T) {
 func TestFileCreateAndDownloadByPath(t *testing.T) {
 	body := "foo,bar"
 	res1, _ := upload(t, "/files/?Type=file&Name=todownload2steps", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
-	if !assert.Equal(t, 201, res1.StatusCode) {
-		return
-	}
+	require.Equal(t, 201, res1.StatusCode)
 
 	path := "/todownload2steps"
 
 	req, err := http.NewRequest("POST", ts.URL+"/files/downloads?Path="+path, nil)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	req.Header.Add("Content-Type", "")
 	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
 	res, err := http.DefaultClient.Do(req)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 200, res.StatusCode)
@@ -2030,21 +1987,17 @@ func TestFileCreateAndDownloadByPath(t *testing.T) {
 func TestFileCreateAndDownloadByID(t *testing.T) {
 	body := "foo,bar"
 	res1, v := upload(t, "/files/?Type=file&Name=todownload2stepsbis", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
-	if !assert.Equal(t, 201, res1.StatusCode) {
-		return
-	}
+	require.Equal(t, 201, res1.StatusCode)
+
 	id := v["data"].(map[string]interface{})["id"].(string)
 
 	req, err := http.NewRequest("POST", ts.URL+"/files/downloads?Id="+id, nil)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	req.Header.Add("Content-Type", "")
 	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
 	res, err := http.DefaultClient.Do(req)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 200, res.StatusCode)
@@ -2109,39 +2062,30 @@ func TestArchiveNotFound(t *testing.T) {
 		}
 	}`)
 	req, err := http.NewRequest("POST", ts.URL+"/files/archive", body)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	req.Header.Add("Content-Type", "application/vnd.api+json")
 	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
 	res, err := http.DefaultClient.Do(req)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, 404, res.StatusCode)
 }
 
 func TestDirTrash(t *testing.T) {
 	res1, data1 := createDir(t, "/files/?Name=totrashdir&Type=directory")
-	if !assert.Equal(t, 201, res1.StatusCode) {
-		return
-	}
+	require.Equal(t, 201, res1.StatusCode)
 
 	dirID, _ := extractDirData(t, data1)
 
 	res2, _ := createDir(t, "/files/"+dirID+"?Name=child1&Type=file")
-	if !assert.Equal(t, 201, res2.StatusCode) {
-		return
-	}
+	require.Equal(t, 201, res2.StatusCode)
+
 	res3, _ := createDir(t, "/files/"+dirID+"?Name=child2&Type=file")
-	if !assert.Equal(t, 201, res3.StatusCode) {
-		return
-	}
+	require.Equal(t, 201, res3.StatusCode)
 
 	res4, _ := trash(t, "/files/"+dirID)
-	if !assert.Equal(t, 200, res4.StatusCode) {
-		return
-	}
+	require.Equal(t, 200, res4.StatusCode)
 
 	res5, err := httpGet(ts.URL + "/files/" + dirID)
 	if !assert.NoError(t, err) || !assert.Equal(t, 200, res5.StatusCode) {
@@ -2159,24 +2103,19 @@ func TestDirTrash(t *testing.T) {
 	}
 
 	res8, _ := trash(t, "/files/"+dirID)
-	if !assert.Equal(t, 400, res8.StatusCode) {
-		return
-	}
+	require.Equal(t, 400, res8.StatusCode)
+
 }
 
 func TestFileTrash(t *testing.T) {
 	body := "foo,bar"
 	res1, data1 := upload(t, "/files/?Type=file&Name=totrashfile", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
-	if !assert.Equal(t, 201, res1.StatusCode) {
-		return
-	}
+	require.Equal(t, 201, res1.StatusCode)
 
 	fileID, _ := extractDirData(t, data1)
 
 	res2, _ := trash(t, "/files/"+fileID)
-	if !assert.Equal(t, 200, res2.StatusCode) {
-		return
-	}
+	require.Equal(t, 200, res2.StatusCode)
 
 	res3, err := httpGet(ts.URL + "/files/download?Path=" + url.QueryEscape(vfs.TrashDirName+"/totrashfile"))
 	if !assert.NoError(t, err) || !assert.Equal(t, 200, res3.StatusCode) {
@@ -2184,14 +2123,10 @@ func TestFileTrash(t *testing.T) {
 	}
 
 	res4, _ := trash(t, "/files/"+fileID)
-	if !assert.Equal(t, 400, res4.StatusCode) {
-		return
-	}
+	require.Equal(t, 400, res4.StatusCode)
 
 	res5, data2 := upload(t, "/files/?Type=file&Name=totrashfile2", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
-	if !assert.Equal(t, 201, res5.StatusCode) {
-		return
-	}
+	require.Equal(t, 201, res5.StatusCode)
 
 	fileID, v2 := extractDirData(t, data2)
 	meta2 := v2["meta"].(map[string]interface{})
@@ -2221,23 +2156,18 @@ func TestFileTrash(t *testing.T) {
 	assert.Equal(t, 200, res8.StatusCode)
 
 	res9, _ := trash(t, "/files/"+fileID)
-	if !assert.Equal(t, 400, res9.StatusCode) {
-		return
-	}
+	require.Equal(t, 400, res9.StatusCode)
+
 }
 
 func TestForbidMovingTrashedFile(t *testing.T) {
 	body := "foo,bar"
 	res1, data1 := upload(t, "/files/?Type=file&Name=forbidmovingtrashedfile", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
-	if !assert.Equal(t, 201, res1.StatusCode) {
-		return
-	}
+	require.Equal(t, 201, res1.StatusCode)
 
 	fileID, _ := extractDirData(t, data1)
 	res2, _ := trash(t, "/files/"+fileID)
-	if !assert.Equal(t, 200, res2.StatusCode) {
-		return
-	}
+	require.Equal(t, 200, res2.StatusCode)
 
 	attrs := map[string]interface{}{
 		"dir_id": consts.RootDirID,
@@ -2249,25 +2179,21 @@ func TestForbidMovingTrashedFile(t *testing.T) {
 func TestFileRestore(t *testing.T) {
 	body := "foo,bar"
 	res1, data1 := upload(t, "/files/?Type=file&Name=torestorefile", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
-	if !assert.Equal(t, 201, res1.StatusCode) {
-		return
-	}
+	require.Equal(t, 201, res1.StatusCode)
 
 	fileID, _ := extractDirData(t, data1)
 
 	res2, body2 := trash(t, "/files/"+fileID)
-	if !assert.Equal(t, 200, res2.StatusCode) {
-		return
-	}
+	require.Equal(t, 200, res2.StatusCode)
+
 	data2 := body2["data"].(map[string]interface{})
 	attrs2 := data2["attributes"].(map[string]interface{})
 	trashed := attrs2["trashed"].(bool)
 	assert.True(t, trashed)
 
 	res3, body3 := restore(t, "/files/trash/"+fileID)
-	if !assert.Equal(t, 200, res3.StatusCode) {
-		return
-	}
+	require.Equal(t, 200, res3.StatusCode)
+
 	data3 := body3["data"].(map[string]interface{})
 	attrs3 := data3["attributes"].(map[string]interface{})
 	trashed = attrs3["trashed"].(bool)
@@ -2282,31 +2208,22 @@ func TestFileRestore(t *testing.T) {
 func TestFileRestoreWithConflicts(t *testing.T) {
 	body := "foo,bar"
 	res1, data1 := upload(t, "/files/?Type=file&Name=torestorefilewithconflict", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
-	if !assert.Equal(t, 201, res1.StatusCode) {
-		return
-	}
+	require.Equal(t, 201, res1.StatusCode)
 
 	fileID, _ := extractDirData(t, data1)
 
 	res2, _ := trash(t, "/files/"+fileID)
-	if !assert.Equal(t, 200, res2.StatusCode) {
-		return
-	}
+	require.Equal(t, 200, res2.StatusCode)
 
 	res1, _ = upload(t, "/files/?Type=file&Name=torestorefilewithconflict", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
-	if !assert.Equal(t, 201, res1.StatusCode) {
-		return
-	}
+	require.Equal(t, 201, res1.StatusCode)
 
 	res3, data3 := restore(t, "/files/trash/"+fileID)
-	if !assert.Equal(t, 200, res3.StatusCode) {
-		return
-	}
+	require.Equal(t, 200, res3.StatusCode)
 
 	restoredID, restoredData := extractDirData(t, data3)
-	if !assert.Equal(t, fileID, restoredID) {
-		return
-	}
+	require.Equal(t, fileID, restoredID)
+
 	restoredData = restoredData["attributes"].(map[string]interface{})
 	assert.True(t, strings.HasPrefix(restoredData["name"].(string), "torestorefilewithconflict"))
 	assert.NotEqual(t, "torestorefilewithconflict", restoredData["name"].(string))
@@ -2314,39 +2231,28 @@ func TestFileRestoreWithConflicts(t *testing.T) {
 
 func TestFileRestoreWithWithoutParent(t *testing.T) {
 	res1, data1 := createDir(t, "/files/?Type=directory&Name=torestorein")
-	if !assert.Equal(t, 201, res1.StatusCode) {
-		return
-	}
+	require.Equal(t, 201, res1.StatusCode)
 
 	dirID, _ := extractDirData(t, data1)
 
 	body := "foo,bar"
 	res1, data1 = upload(t, "/files/"+dirID+"?Type=file&Name=torestorefilewithconflict", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
-	if !assert.Equal(t, 201, res1.StatusCode) {
-		return
-	}
+	require.Equal(t, 201, res1.StatusCode)
 
 	fileID, _ := extractDirData(t, data1)
 
 	res2, _ := trash(t, "/files/"+fileID)
-	if !assert.Equal(t, 200, res2.StatusCode) {
-		return
-	}
+	require.Equal(t, 200, res2.StatusCode)
 
 	res2, _ = trash(t, "/files/"+dirID)
-	if !assert.Equal(t, 200, res2.StatusCode) {
-		return
-	}
+	require.Equal(t, 200, res2.StatusCode)
 
 	res3, data3 := restore(t, "/files/trash/"+fileID)
-	if !assert.Equal(t, 200, res3.StatusCode) {
-		return
-	}
+	require.Equal(t, 200, res3.StatusCode)
 
 	restoredID, restoredData := extractDirData(t, data3)
-	if !assert.Equal(t, fileID, restoredID) {
-		return
-	}
+	require.Equal(t, fileID, restoredID)
+
 	restoredData = restoredData["attributes"].(map[string]interface{})
 	assert.Equal(t, "torestorefilewithconflict", restoredData["name"].(string))
 	assert.NotEqual(t, consts.RootDirID, restoredData["dir_id"].(string))
@@ -2354,34 +2260,25 @@ func TestFileRestoreWithWithoutParent(t *testing.T) {
 
 func TestFileRestoreWithWithoutParent2(t *testing.T) {
 	res1, data1 := createDir(t, "/files/?Type=directory&Name=torestorein2")
-	if !assert.Equal(t, 201, res1.StatusCode) {
-		return
-	}
+	require.Equal(t, 201, res1.StatusCode)
 
 	dirID, _ := extractDirData(t, data1)
 
 	body := "foo,bar"
 	res1, data1 = upload(t, "/files/"+dirID+"?Type=file&Name=torestorefilewithconflict2", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
-	if !assert.Equal(t, 201, res1.StatusCode) {
-		return
-	}
+	require.Equal(t, 201, res1.StatusCode)
 
 	fileID, _ := extractDirData(t, data1)
 
 	res2, _ := trash(t, "/files/"+dirID)
-	if !assert.Equal(t, 200, res2.StatusCode) {
-		return
-	}
+	require.Equal(t, 200, res2.StatusCode)
 
 	res3, data3 := restore(t, "/files/trash/"+fileID)
-	if !assert.Equal(t, 200, res3.StatusCode) {
-		return
-	}
+	require.Equal(t, 200, res3.StatusCode)
 
 	restoredID, restoredData := extractDirData(t, data3)
-	if !assert.Equal(t, fileID, restoredID) {
-		return
-	}
+	require.Equal(t, fileID, restoredID)
+
 	restoredData = restoredData["attributes"].(map[string]interface{})
 	assert.Equal(t, "torestorefilewithconflict2", restoredData["name"].(string))
 	assert.NotEqual(t, consts.RootDirID, restoredData["dir_id"].(string))
@@ -2389,24 +2286,18 @@ func TestFileRestoreWithWithoutParent2(t *testing.T) {
 
 func TestDirRestore(t *testing.T) {
 	res1, data1 := createDir(t, "/files/?Type=directory&Name=torestoredir")
-	if !assert.Equal(t, 201, res1.StatusCode) {
-		return
-	}
+	require.Equal(t, 201, res1.StatusCode)
 
 	dirID, _ := extractDirData(t, data1)
 
 	body := "foo,bar"
 	res2, data2 := upload(t, "/files/"+dirID+"?Type=file&Name=totrashfile", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
-	if !assert.Equal(t, 201, res2.StatusCode) {
-		return
-	}
+	require.Equal(t, 201, res2.StatusCode)
 
 	fileID, _ := extractDirData(t, data2)
 
 	res3, _ := trash(t, "/files/"+dirID)
-	if !assert.Equal(t, 200, res3.StatusCode) {
-		return
-	}
+	require.Equal(t, 200, res3.StatusCode)
 
 	res4, err := httpGet(ts.URL + "/files/" + fileID)
 	if !assert.NoError(t, err) || !assert.Equal(t, 200, res4.StatusCode) {
@@ -2422,9 +2313,7 @@ func TestDirRestore(t *testing.T) {
 	assert.True(t, trashed)
 
 	res5, _ := restore(t, "/files/trash/"+dirID)
-	if !assert.Equal(t, 200, res5.StatusCode) {
-		return
-	}
+	require.Equal(t, 200, res5.StatusCode)
 
 	res6, err := httpGet(ts.URL + "/files/" + fileID)
 	if !assert.NoError(t, err) || !assert.Equal(t, 200, res6.StatusCode) {
@@ -2441,31 +2330,22 @@ func TestDirRestore(t *testing.T) {
 
 func TestDirRestoreWithConflicts(t *testing.T) {
 	res1, data1 := createDir(t, "/files/?Type=directory&Name=torestoredirwithconflict")
-	if !assert.Equal(t, 201, res1.StatusCode) {
-		return
-	}
+	require.Equal(t, 201, res1.StatusCode)
 
 	dirID, _ := extractDirData(t, data1)
 
 	res2, _ := trash(t, "/files/"+dirID)
-	if !assert.Equal(t, 200, res2.StatusCode) {
-		return
-	}
+	require.Equal(t, 200, res2.StatusCode)
 
 	res1, _ = createDir(t, "/files/?Type=directory&Name=torestoredirwithconflict")
-	if !assert.Equal(t, 201, res1.StatusCode) {
-		return
-	}
+	require.Equal(t, 201, res1.StatusCode)
 
 	res3, data3 := restore(t, "/files/trash/"+dirID)
-	if !assert.Equal(t, 200, res3.StatusCode) {
-		return
-	}
+	require.Equal(t, 200, res3.StatusCode)
 
 	restoredID, restoredData := extractDirData(t, data3)
-	if !assert.Equal(t, dirID, restoredID) {
-		return
-	}
+	require.Equal(t, dirID, restoredID)
+
 	restoredData = restoredData["attributes"].(map[string]interface{})
 	assert.True(t, strings.HasPrefix(restoredData["name"].(string), "torestoredirwithconflict"))
 	assert.NotEqual(t, "torestoredirwithconflict", restoredData["name"].(string))
@@ -2474,32 +2354,23 @@ func TestDirRestoreWithConflicts(t *testing.T) {
 func TestTrashList(t *testing.T) {
 	body := "foo,bar"
 	res1, data1 := upload(t, "/files/?Type=file&Name=tolistfile", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
-	if !assert.Equal(t, 201, res1.StatusCode) {
-		return
-	}
+	require.Equal(t, 201, res1.StatusCode)
 
 	res2, data2 := createDir(t, "/files/?Name=tolistdir&Type=directory")
-	if !assert.Equal(t, 201, res2.StatusCode) {
-		return
-	}
+	require.Equal(t, 201, res2.StatusCode)
 
 	dirID, _ := extractDirData(t, data1)
 	fileID, _ := extractDirData(t, data2)
 
 	res3, _ := trash(t, "/files/"+dirID)
-	if !assert.Equal(t, 200, res3.StatusCode) {
-		return
-	}
+	require.Equal(t, 200, res3.StatusCode)
 
 	res4, _ := trash(t, "/files/"+fileID)
-	if !assert.Equal(t, 200, res4.StatusCode) {
-		return
-	}
+	require.Equal(t, 200, res4.StatusCode)
 
 	res5, err := httpGet(ts.URL + "/files/trash")
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	defer res5.Body.Close()
 
 	var v struct {
@@ -2507,9 +2378,7 @@ func TestTrashList(t *testing.T) {
 	}
 
 	err = json.NewDecoder(res5.Body).Decode(&v)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	assert.True(t, len(v.Data) >= 2, "response should contains at least 2 items")
 }
@@ -2517,44 +2386,31 @@ func TestTrashList(t *testing.T) {
 func TestTrashClear(t *testing.T) {
 	body := "foo,bar"
 	res1, data1 := upload(t, "/files/?Type=file&Name=tolistfile", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
-	if !assert.Equal(t, 201, res1.StatusCode) {
-		return
-	}
+	require.Equal(t, 201, res1.StatusCode)
 
 	res2, data2 := createDir(t, "/files/?Name=tolistdir&Type=directory")
-	if !assert.Equal(t, 201, res2.StatusCode) {
-		return
-	}
+	require.Equal(t, 201, res2.StatusCode)
 
 	dirID, _ := extractDirData(t, data1)
 	fileID, _ := extractDirData(t, data2)
 
 	res3, _ := trash(t, "/files/"+dirID)
-	if !assert.Equal(t, 200, res3.StatusCode) {
-		return
-	}
+	require.Equal(t, 200, res3.StatusCode)
 
 	res4, _ := trash(t, "/files/"+fileID)
-	if !assert.Equal(t, 200, res4.StatusCode) {
-		return
-	}
+	require.Equal(t, 200, res4.StatusCode)
 
 	path := "/files/trash"
 	req, err := http.NewRequest(http.MethodDelete, ts.URL+path, nil)
 	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	_, err = http.DefaultClient.Do(req)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	res5, err := httpGet(ts.URL + "/files/trash")
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	defer res5.Body.Close()
 
 	var v struct {
@@ -2562,9 +2418,7 @@ func TestTrashClear(t *testing.T) {
 	}
 
 	err = json.NewDecoder(res5.Body).Decode(&v)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	assert.True(t, len(v.Data) == 0)
 }
@@ -2572,44 +2426,31 @@ func TestTrashClear(t *testing.T) {
 func TestDestroyFile(t *testing.T) {
 	body := "foo,bar"
 	res1, data1 := upload(t, "/files/?Type=file&Name=tolistfile", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
-	if !assert.Equal(t, 201, res1.StatusCode) {
-		return
-	}
+	require.Equal(t, 201, res1.StatusCode)
 
 	res2, data2 := createDir(t, "/files/?Name=tolistdir&Type=directory")
-	if !assert.Equal(t, 201, res2.StatusCode) {
-		return
-	}
+	require.Equal(t, 201, res2.StatusCode)
 
 	dirID, _ := extractDirData(t, data1)
 	fileID, _ := extractDirData(t, data2)
 
 	res3, _ := trash(t, "/files/"+dirID)
-	if !assert.Equal(t, 200, res3.StatusCode) {
-		return
-	}
+	require.Equal(t, 200, res3.StatusCode)
 
 	res4, _ := trash(t, "/files/"+fileID)
-	if !assert.Equal(t, 200, res4.StatusCode) {
-		return
-	}
+	require.Equal(t, 200, res4.StatusCode)
 
 	path := "/files/trash/" + fileID
 	req, err := http.NewRequest(http.MethodDelete, ts.URL+path, nil)
 	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	_, err = http.DefaultClient.Do(req)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	res5, err := httpGet(ts.URL + "/files/trash")
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	defer res5.Body.Close()
 
 	var v struct {
@@ -2617,33 +2458,26 @@ func TestDestroyFile(t *testing.T) {
 	}
 
 	err = json.NewDecoder(res5.Body).Decode(&v)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.True(t, len(v.Data) == 1)
 
 	path = "/files/trash/" + dirID
 	req, err = http.NewRequest(http.MethodDelete, ts.URL+path, nil)
 	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	_, err = http.DefaultClient.Do(req)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	res5, err = httpGet(ts.URL + "/files/trash")
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	defer res5.Body.Close()
 
 	err = json.NewDecoder(res5.Body).Decode(&v)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.True(t, len(v.Data) == 0)
 }
 

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -36,14 +36,16 @@ import (
 	_ "github.com/cozy/cozy-stack/worker/thumbnail"
 )
 
-var ts *httptest.Server
-var testInstance *instance.Instance
-var setup *testutils.TestSetup
-var token string
-var clientID string
-var imgID string
-var fileID string
-var publicToken string
+var (
+	ts           *httptest.Server
+	testInstance *instance.Instance
+	setup        *testutils.TestSetup
+	token        string
+	clientID     string
+	imgID        string
+	fileID       string
+	publicToken  string
+)
 
 func readFile(fs vfs.VFS, name string) ([]byte, error) {
 	doc, err := fs.FileByPath(name)
@@ -427,6 +429,7 @@ func TestCreateDirWithDateSuccessAndUpdatedAt(t *testing.T) {
 	assert.NotEmpty(t, fcm["updatedAt"])
 	assert.NotContains(t, fcm, "uploadedAt")
 }
+
 func TestCreateDirWithParentSuccess(t *testing.T) {
 	res1, data1 := createDir(t, "/files/?Name=dirparent&Type=directory")
 	assert.Equal(t, 201, res1.StatusCode)
@@ -2088,23 +2091,19 @@ func TestDirTrash(t *testing.T) {
 	require.Equal(t, 200, res4.StatusCode)
 
 	res5, err := httpGet(ts.URL + "/files/" + dirID)
-	if !assert.NoError(t, err) || !assert.Equal(t, 200, res5.StatusCode) {
-		return
-	}
+	require.NoError(t, err)
+	require.Equal(t, 200, res5.StatusCode)
 
 	res6, err := httpGet(ts.URL + "/files/download?Path=" + url.QueryEscape(vfs.TrashDirName+"/totrashdir/child1"))
-	if !assert.NoError(t, err) || !assert.Equal(t, 200, res6.StatusCode) {
-		return
-	}
+	require.NoError(t, err)
+	require.Equal(t, 200, res6.StatusCode)
 
 	res7, err := httpGet(ts.URL + "/files/download?Path=" + url.QueryEscape(vfs.TrashDirName+"/totrashdir/child2"))
-	if !assert.NoError(t, err) || !assert.Equal(t, 200, res7.StatusCode) {
-		return
-	}
+	require.NoError(t, err)
+	require.Equal(t, 200, res7.StatusCode)
 
 	res8, _ := trash(t, "/files/"+dirID)
 	require.Equal(t, 400, res8.StatusCode)
-
 }
 
 func TestFileTrash(t *testing.T) {
@@ -2118,9 +2117,8 @@ func TestFileTrash(t *testing.T) {
 	require.Equal(t, 200, res2.StatusCode)
 
 	res3, err := httpGet(ts.URL + "/files/download?Path=" + url.QueryEscape(vfs.TrashDirName+"/totrashfile"))
-	if !assert.NoError(t, err) || !assert.Equal(t, 200, res3.StatusCode) {
-		return
-	}
+	require.NoError(t, err)
+	require.Equal(t, 200, res3.StatusCode)
 
 	res4, _ := trash(t, "/files/"+fileID)
 	require.Equal(t, 400, res4.StatusCode)
@@ -2142,9 +2140,8 @@ func TestFileTrash(t *testing.T) {
 	assert.Equal(t, 412, res6.StatusCode)
 
 	res7, err := httpGet(ts.URL + "/files/download?Path=" + url.QueryEscape(vfs.TrashDirName+"/totrashfile"))
-	if !assert.NoError(t, err) || !assert.Equal(t, 200, res7.StatusCode) {
-		return
-	}
+	require.NoError(t, err)
+	require.Equal(t, 200, res7.StatusCode)
 
 	req8, err := http.NewRequest("DELETE", ts.URL+"/files/"+fileID, nil)
 	req8.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
@@ -2157,7 +2154,6 @@ func TestFileTrash(t *testing.T) {
 
 	res9, _ := trash(t, "/files/"+fileID)
 	require.Equal(t, 400, res9.StatusCode)
-
 }
 
 func TestForbidMovingTrashedFile(t *testing.T) {
@@ -2200,9 +2196,8 @@ func TestFileRestore(t *testing.T) {
 	assert.False(t, trashed)
 
 	res4, err := httpGet(ts.URL + "/files/download?Path=" + url.QueryEscape("/torestorefile"))
-	if !assert.NoError(t, err) || !assert.Equal(t, 200, res4.StatusCode) {
-		return
-	}
+	require.NoError(t, err)
+	require.Equal(t, 200, res4.StatusCode)
 }
 
 func TestFileRestoreWithConflicts(t *testing.T) {
@@ -2300,9 +2295,8 @@ func TestDirRestore(t *testing.T) {
 	require.Equal(t, 200, res3.StatusCode)
 
 	res4, err := httpGet(ts.URL + "/files/" + fileID)
-	if !assert.NoError(t, err) || !assert.Equal(t, 200, res4.StatusCode) {
-		return
-	}
+	require.NoError(t, err)
+	require.Equal(t, 200, res4.StatusCode)
 
 	var v map[string]interface{}
 	err = extractJSONRes(res4, &v)
@@ -2316,9 +2310,8 @@ func TestDirRestore(t *testing.T) {
 	require.Equal(t, 200, res5.StatusCode)
 
 	res6, err := httpGet(ts.URL + "/files/" + fileID)
-	if !assert.NoError(t, err) || !assert.Equal(t, 200, res6.StatusCode) {
-		return
-	}
+	require.NoError(t, err)
+	require.Equal(t, 200, res6.StatusCode)
 
 	err = extractJSONRes(res6, &v)
 	assert.NoError(t, err)

--- a/web/files/notsynchronized_test.go
+++ b/web/files/notsynchronized_test.go
@@ -10,15 +10,14 @@ import (
 	"github.com/cozy/cozy-stack/pkg/jsonapi"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var dirID1, dirID2 string
 
 func TestAddNotSynchronizedOnOneRelation(t *testing.T) {
 	res1, data1 := createDir(t, "/files/?Type=directory&Name=to_sync_or_not_to_sync_1")
-	if !assert.Equal(t, 201, res1.StatusCode) {
-		return
-	}
+	require.Equal(t, 201, res1.StatusCode)
 
 	var dirData1 map[string]interface{}
 	dirID1, dirData1 = extractDirData(t, data1)
@@ -30,9 +29,7 @@ func TestAddNotSynchronizedOnOneRelation(t *testing.T) {
 			Type: "io.cozy.oauth.clients",
 		},
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	var result struct {
 		Data []couchdb.DocReference `json:"data"`
@@ -42,20 +39,17 @@ func TestAddNotSynchronizedOnOneRelation(t *testing.T) {
 		} `json:"meta"`
 	}
 	req, err := http.NewRequest(http.MethodPost, ts.URL+path, bytes.NewReader(content))
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
 
 	res, err := http.DefaultClient.Do(req)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, 200, res.StatusCode)
 	err = json.NewDecoder(res.Body).Decode(&result)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.NotEqual(t, result.Meta.Rev, dirData1["_rev"])
 	assert.Equal(t, result.Meta.Count, 1)
 	assert.Equal(t, result.Data, []couchdb.DocReference{
@@ -73,9 +67,7 @@ func TestAddNotSynchronizedOnOneRelation(t *testing.T) {
 
 func TestAddNotSynchronizedOnMultipleRelation(t *testing.T) {
 	res1, data1 := createDir(t, "/files/?Type=directory&Name=to_sync_or_not_to_sync_2")
-	if !assert.Equal(t, 201, res1.StatusCode) {
-		return
-	}
+	require.Equal(t, 201, res1.StatusCode)
 
 	var dirData2 map[string]interface{}
 	dirID2, dirData2 = extractDirData(t, data1)
@@ -88,14 +80,11 @@ func TestAddNotSynchronizedOnMultipleRelation(t *testing.T) {
 			{ID: "fooclientid3", Type: "io.cozy.oauth.clients"},
 		},
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodPost, ts.URL+path, bytes.NewReader(content))
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
 
 	var result struct {
@@ -106,14 +95,12 @@ func TestAddNotSynchronizedOnMultipleRelation(t *testing.T) {
 		} `json:"meta"`
 	}
 	res, err := http.DefaultClient.Do(req)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, 200, res.StatusCode)
 	err = json.NewDecoder(res.Body).Decode(&result)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.NotEqual(t, result.Meta.Rev, dirData2["_rev"])
 	assert.Equal(t, result.Meta.Count, 3)
 	assert.Equal(t, result.Data, []couchdb.DocReference{
@@ -152,9 +139,8 @@ func TestRemoveNotSynchronizedOnOneRelation(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 200, res.StatusCode)
 	err = json.NewDecoder(res.Body).Decode(&result)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, result.Meta.Count, 0)
 	assert.Equal(t, result.Data, []couchdb.DocReference{})
 
@@ -188,9 +174,8 @@ func TestRemoveNotSynchronizedOnMultipleRelation(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 200, res.StatusCode)
 	err = json.NewDecoder(res.Body).Decode(&result)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, result.Meta.Count, 1)
 	assert.Equal(t, result.Data, []couchdb.DocReference{
 		{ID: "fooclientid2", Type: "io.cozy.oauth.clients"},

--- a/web/files/referencedby_test.go
+++ b/web/files/referencedby_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/jsonapi"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var fileID1, fileID2 string
@@ -18,9 +19,7 @@ var fileData1, fileData2 map[string]interface{}
 func TestAddReferencedByOneRelation(t *testing.T) {
 	body := "foo,bar"
 	res1, data1 := upload(t, "/files/?Type=file&Name=toreference", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
-	if !assert.Equal(t, 201, res1.StatusCode) {
-		return
-	}
+	require.Equal(t, 201, res1.StatusCode)
 
 	fileID1, fileData1 = extractDirData(t, data1)
 
@@ -31,9 +30,7 @@ func TestAddReferencedByOneRelation(t *testing.T) {
 			Type: "io.cozy.photos.albums",
 		},
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	var result struct {
 		Data []couchdb.DocReference `json:"data"`
@@ -43,20 +40,17 @@ func TestAddReferencedByOneRelation(t *testing.T) {
 		} `json:"meta"`
 	}
 	req, err := http.NewRequest(http.MethodPost, ts.URL+path, bytes.NewReader(content))
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
 
 	res, err := http.DefaultClient.Do(req)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, 200, res.StatusCode)
 	err = json.NewDecoder(res.Body).Decode(&result)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.NotEqual(t, result.Meta.Rev, fileData1["_rev"])
 	assert.Equal(t, result.Meta.Count, 1)
 	assert.Equal(t, result.Data, []couchdb.DocReference{
@@ -75,9 +69,7 @@ func TestAddReferencedByOneRelation(t *testing.T) {
 func TestAddReferencedByMultipleRelation(t *testing.T) {
 	body := "foo,bar"
 	res1, data1 := upload(t, "/files/?Type=file&Name=toreference2", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
-	if !assert.Equal(t, 201, res1.StatusCode) {
-		return
-	}
+	require.Equal(t, 201, res1.StatusCode)
 
 	fileID2, fileData2 = extractDirData(t, data1)
 
@@ -89,14 +81,11 @@ func TestAddReferencedByMultipleRelation(t *testing.T) {
 			{ID: "fooalbumid3", Type: "io.cozy.photos.albums"},
 		},
 	})
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodPost, ts.URL+path, bytes.NewReader(content))
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
 
 	var result struct {
@@ -107,14 +96,12 @@ func TestAddReferencedByMultipleRelation(t *testing.T) {
 		} `json:"meta"`
 	}
 	res, err := http.DefaultClient.Do(req)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, 200, res.StatusCode)
 	err = json.NewDecoder(res.Body).Decode(&result)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.NotEqual(t, result.Meta.Rev, fileData2["_rev"])
 	assert.Equal(t, result.Meta.Count, 3)
 	assert.Equal(t, result.Data, []couchdb.DocReference{
@@ -153,9 +140,8 @@ func TestRemoveReferencedByOneRelation(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 200, res.StatusCode)
 	err = json.NewDecoder(res.Body).Decode(&result)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, result.Meta.Count, 0)
 	assert.Equal(t, result.Data, []couchdb.DocReference{})
 
@@ -189,9 +175,8 @@ func TestRemoveReferencedByMultipleRelation(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 200, res.StatusCode)
 	err = json.NewDecoder(res.Body).Decode(&result)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, result.Meta.Count, 1)
 	assert.Equal(t, result.Data, []couchdb.DocReference{
 		{ID: "fooalbumid2", Type: "io.cozy.photos.albums"},

--- a/web/jobs/jobs_test.go
+++ b/web/jobs/jobs_test.go
@@ -111,9 +111,8 @@ func TestCreateJobForReservedWorker(t *testing.T) {
 	req.Header.Add("Authorization", "Bearer "+token)
 	assert.NoError(t, err)
 	res, err := http.DefaultClient.Do(req)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, 403, res.StatusCode)
 }
 
@@ -130,9 +129,8 @@ func TestCreateJobNotExist(t *testing.T) {
 	req.Header.Add("Authorization", "Bearer "+tokenNone)
 	assert.NoError(t, err)
 	res, err := http.DefaultClient.Do(req)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, 404, res.StatusCode)
 }
 
@@ -152,9 +150,8 @@ func TestAddGetAndDeleteTriggerAt(t *testing.T) {
 	assert.NoError(t, err)
 	req1.Header.Add("Authorization", "Bearer "+token)
 	res1, err := http.DefaultClient.Do(req1)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	defer res1.Body.Close()
 	assert.Equal(t, http.StatusCreated, res1.StatusCode)
 
@@ -166,9 +163,8 @@ func TestAddGetAndDeleteTriggerAt(t *testing.T) {
 		}
 	}
 	err = json.NewDecoder(res1.Body).Decode(&v)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	if !assert.NotNil(t, v.Data) || !assert.NotNil(t, v.Data.Attributes) {
 		return
 	}
@@ -192,36 +188,32 @@ func TestAddGetAndDeleteTriggerAt(t *testing.T) {
 	assert.NoError(t, err)
 	req2.Header.Add("Authorization", "Bearer "+token)
 	res2, err := http.DefaultClient.Do(req2)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, http.StatusBadRequest, res2.StatusCode)
 
 	req3, err := http.NewRequest(http.MethodGet, ts.URL+"/jobs/triggers/"+triggerID, nil)
 	assert.NoError(t, err)
 	req3.Header.Add("Authorization", "Bearer "+token)
 	res3, err := http.DefaultClient.Do(req3)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, http.StatusOK, res3.StatusCode)
 
 	req4, err := http.NewRequest("DELETE", ts.URL+"/jobs/triggers/"+triggerID, nil)
 	assert.NoError(t, err)
 	req4.Header.Add("Authorization", "Bearer "+token)
 	res4, err := http.DefaultClient.Do(req4)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, http.StatusNoContent, res4.StatusCode)
 
 	req5, err := http.NewRequest(http.MethodGet, ts.URL+"/jobs/triggers/"+triggerID, nil)
 	assert.NoError(t, err)
 	req5.Header.Add("Authorization", "Bearer "+token)
 	res5, err := http.DefaultClient.Do(req5)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, http.StatusNotFound, res5.StatusCode)
 }
 
@@ -240,9 +232,8 @@ func TestAddGetAndDeleteTriggerIn(t *testing.T) {
 	assert.NoError(t, err)
 	req1.Header.Add("Authorization", "Bearer "+token)
 	res1, err := http.DefaultClient.Do(req1)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	defer res1.Body.Close()
 	assert.Equal(t, http.StatusCreated, res1.StatusCode)
 
@@ -254,9 +245,8 @@ func TestAddGetAndDeleteTriggerIn(t *testing.T) {
 		}
 	}
 	err = json.NewDecoder(res1.Body).Decode(&v)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	if !assert.NotNil(t, v.Data) || !assert.NotNil(t, v.Data.Attributes) {
 		return
 	}
@@ -280,36 +270,32 @@ func TestAddGetAndDeleteTriggerIn(t *testing.T) {
 	assert.NoError(t, err)
 	req2.Header.Add("Authorization", "Bearer "+token)
 	res2, err := http.DefaultClient.Do(req2)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, http.StatusBadRequest, res2.StatusCode)
 
 	req3, err := http.NewRequest(http.MethodGet, ts.URL+"/jobs/triggers/"+triggerID, nil)
 	assert.NoError(t, err)
 	req3.Header.Add("Authorization", "Bearer "+token)
 	res3, err := http.DefaultClient.Do(req3)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, http.StatusOK, res3.StatusCode)
 
 	req4, err := http.NewRequest("DELETE", ts.URL+"/jobs/triggers/"+triggerID, nil)
 	assert.NoError(t, err)
 	req4.Header.Add("Authorization", "Bearer "+token)
 	res4, err := http.DefaultClient.Do(req4)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, http.StatusNoContent, res4.StatusCode)
 
 	req5, err := http.NewRequest(http.MethodGet, ts.URL+"/jobs/triggers/"+triggerID, nil)
 	assert.NoError(t, err)
 	req5.Header.Add("Authorization", "Bearer "+token)
 	res5, err := http.DefaultClient.Do(req5)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, http.StatusNotFound, res5.StatusCode)
 }
 
@@ -328,9 +314,8 @@ func TestAddGetUpdateAndDeleteTriggerCron(t *testing.T) {
 	assert.NoError(t, err)
 	req1.Header.Add("Authorization", "Bearer "+token)
 	res1, err := http.DefaultClient.Do(req1)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	defer res1.Body.Close()
 	assert.Equal(t, http.StatusCreated, res1.StatusCode)
 
@@ -342,9 +327,8 @@ func TestAddGetUpdateAndDeleteTriggerCron(t *testing.T) {
 		}
 	}
 	err = json.NewDecoder(res1.Body).Decode(&v)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	if !assert.NotNil(t, v.Data) || !assert.NotNil(t, v.Data.Attributes) {
 		return
 	}
@@ -365,18 +349,16 @@ func TestAddGetUpdateAndDeleteTriggerCron(t *testing.T) {
 	assert.NoError(t, err)
 	req2.Header.Add("Authorization", "Bearer "+token)
 	res2, err := http.DefaultClient.Do(req2)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, http.StatusOK, res2.StatusCode)
 
 	req3, err := http.NewRequest(http.MethodGet, ts.URL+"/jobs/triggers/"+triggerID, nil)
 	assert.NoError(t, err)
 	req3.Header.Add("Authorization", "Bearer "+token)
 	res3, err := http.DefaultClient.Do(req3)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, http.StatusOK, res3.StatusCode)
 
 	var v2 struct {
@@ -387,9 +369,8 @@ func TestAddGetUpdateAndDeleteTriggerCron(t *testing.T) {
 		}
 	}
 	err = json.NewDecoder(res3.Body).Decode(&v2)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	if !assert.NotNil(t, v2.Data) || !assert.NotNil(t, v2.Data.Attributes) {
 		return
 	}
@@ -403,9 +384,8 @@ func TestAddGetUpdateAndDeleteTriggerCron(t *testing.T) {
 	assert.NoError(t, err)
 	req4.Header.Add("Authorization", "Bearer "+token)
 	res4, err := http.DefaultClient.Do(req4)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, http.StatusNoContent, res4.StatusCode)
 }
 
@@ -426,9 +406,8 @@ func TestAddTriggerWithMetadata(t *testing.T) {
 	assert.NoError(t, err)
 	req1.Header.Add("Authorization", "Bearer "+token)
 	res1, err := http.DefaultClient.Do(req1)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	defer res1.Body.Close()
 	assert.Equal(t, http.StatusCreated, res1.StatusCode)
 
@@ -442,9 +421,8 @@ func TestAddTriggerWithMetadata(t *testing.T) {
 	}
 
 	err = json.NewDecoder(res1.Body).Decode(&v)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	if !assert.NotNil(t, v.Data) || !assert.NotNil(t, v.Data.Attributes) {
 		return
 	}
@@ -466,9 +444,8 @@ func TestAddTriggerWithMetadata(t *testing.T) {
 	assert.NoError(t, err)
 	req2.Header.Add("Authorization", "Bearer "+token)
 	res2, err := http.DefaultClient.Do(req2)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, http.StatusOK, res2.StatusCode)
 
 	// Clean
@@ -476,9 +453,8 @@ func TestAddTriggerWithMetadata(t *testing.T) {
 	assert.NoError(t, err)
 	req3.Header.Add("Authorization", "Bearer "+token)
 	res3, err := http.DefaultClient.Do(req3)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, http.StatusNoContent, res3.StatusCode)
 }
 
@@ -496,15 +472,12 @@ func TestGetAllJobs(t *testing.T) {
 	tokenTriggers, _ := testInstance.MakeJWT(consts.CLIAudience, "CLI", consts.Triggers, "", time.Now())
 	req1.Header.Add("Authorization", "Bearer "+tokenTriggers)
 	res1, err := http.DefaultClient.Do(req1)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, http.StatusOK, res1.StatusCode)
 
 	err = json.NewDecoder(res1.Body).Decode(&v)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	assert.Len(t, v.Data, 0)
 
@@ -524,24 +497,20 @@ func TestGetAllJobs(t *testing.T) {
 	assert.NoError(t, err)
 	req2.Header.Add("Authorization", "Bearer "+token)
 	res2, err := http.DefaultClient.Do(req2)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, http.StatusCreated, res2.StatusCode)
 
 	req3, err := http.NewRequest(http.MethodGet, ts.URL+"/jobs/triggers", nil)
 	assert.NoError(t, err)
 	req3.Header.Add("Authorization", "Bearer "+tokenTriggers)
 	res3, err := http.DefaultClient.Do(req3)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, http.StatusOK, res3.StatusCode)
 
 	err = json.NewDecoder(res3.Body).Decode(&v)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	if assert.Len(t, v.Data, 1) {
 		assert.Equal(t, consts.Triggers, v.Data[0].Type)
@@ -554,15 +523,12 @@ func TestGetAllJobs(t *testing.T) {
 	assert.NoError(t, err)
 	req4.Header.Add("Authorization", "Bearer "+tokenTriggers)
 	res4, err := http.DefaultClient.Do(req4)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, http.StatusOK, res4.StatusCode)
 
 	err = json.NewDecoder(res4.Body).Decode(&v)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	if assert.Len(t, v.Data, 1) {
 		assert.Equal(t, consts.Triggers, v.Data[0].Type)
@@ -575,30 +541,25 @@ func TestGetAllJobs(t *testing.T) {
 	assert.NoError(t, err)
 	req5.Header.Add("Authorization", "Bearer "+tokenTriggers)
 	res5, err := http.DefaultClient.Do(req5)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, http.StatusOK, res5.StatusCode)
 
 	err = json.NewDecoder(res5.Body).Decode(&v)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Len(t, v.Data, 0)
 
 	req6, err := http.NewRequest(http.MethodGet, ts.URL+"/jobs/triggers?Type=@in", nil)
 	assert.NoError(t, err)
 	req6.Header.Add("Authorization", "Bearer "+tokenTriggers)
 	res6, err := http.DefaultClient.Do(req6)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, http.StatusOK, res6.StatusCode)
 
 	err = json.NewDecoder(res6.Body).Decode(&v)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	if assert.Len(t, v.Data, 1) {
 		assert.Equal(t, consts.Triggers, v.Data[0].Type)
@@ -624,9 +585,8 @@ func TestClientJobs(t *testing.T) {
 	assert.NoError(t, err)
 	req1.Header.Add("Authorization", "Bearer "+token2)
 	res1, err := http.DefaultClient.Do(req1)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	defer res1.Body.Close()
 	assert.Equal(t, http.StatusCreated, res1.StatusCode)
 
@@ -638,9 +598,8 @@ func TestClientJobs(t *testing.T) {
 		}
 	}
 	err = json.NewDecoder(res1.Body).Decode(&v1)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	if !assert.NotNil(t, v1.Data) || !assert.NotNil(t, v1.Data.Attributes) {
 		return
 	}
@@ -653,9 +612,8 @@ func TestClientJobs(t *testing.T) {
 	assert.NoError(t, err)
 	req2.Header.Add("Authorization", "Bearer "+token2)
 	res2, err := http.DefaultClient.Do(req2)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	defer res2.Body.Close()
 	assert.Equal(t, http.StatusCreated, res2.StatusCode)
 
@@ -667,9 +625,8 @@ func TestClientJobs(t *testing.T) {
 		}
 	}
 	err = json.NewDecoder(res2.Body).Decode(&v2)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	if !assert.NotNil(t, v2.Data) || !assert.NotNil(t, v2.Data.Attributes) {
 		return
 	}
@@ -692,9 +649,8 @@ func TestClientJobs(t *testing.T) {
 	assert.NoError(t, err)
 	req3.Header.Add("Authorization", "Bearer "+token2)
 	res3, err := http.DefaultClient.Do(req3)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	defer res3.Body.Close()
 	assert.Equal(t, http.StatusOK, res3.StatusCode)
 
@@ -706,9 +662,8 @@ func TestClientJobs(t *testing.T) {
 		}
 	}
 	err = json.NewDecoder(res3.Body).Decode(&v3)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	if !assert.NotNil(t, v3.Data) || !assert.NotNil(t, v3.Data.Attributes) {
 		return
 	}

--- a/web/jobs/jobs_test.go
+++ b/web/jobs/jobs_test.go
@@ -24,9 +24,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var ts *httptest.Server
-var testInstance *instance.Instance
-var token string
+var (
+	ts           *httptest.Server
+	testInstance *instance.Instance
+	token        string
+)
 
 type jobRequest struct {
 	Arguments interface{} `json:"arguments"`
@@ -165,9 +167,8 @@ func TestAddGetAndDeleteTriggerAt(t *testing.T) {
 	err = json.NewDecoder(res1.Body).Decode(&v)
 	require.NoError(t, err)
 
-	if !assert.NotNil(t, v.Data) || !assert.NotNil(t, v.Data.Attributes) {
-		return
-	}
+	require.NotNil(t, v.Data)
+	require.NotNil(t, v.Data.Attributes)
 	triggerID := v.Data.ID
 	assert.Equal(t, consts.Triggers, v.Data.Type)
 	assert.Equal(t, "@at", v.Data.Attributes.Type)
@@ -247,9 +248,8 @@ func TestAddGetAndDeleteTriggerIn(t *testing.T) {
 	err = json.NewDecoder(res1.Body).Decode(&v)
 	require.NoError(t, err)
 
-	if !assert.NotNil(t, v.Data) || !assert.NotNil(t, v.Data.Attributes) {
-		return
-	}
+	require.NotNil(t, v.Data)
+	require.NotNil(t, v.Data.Attributes)
 	triggerID := v.Data.ID
 	assert.Equal(t, consts.Triggers, v.Data.Type)
 	assert.Equal(t, "@in", v.Data.Attributes.Type)
@@ -329,9 +329,8 @@ func TestAddGetUpdateAndDeleteTriggerCron(t *testing.T) {
 	err = json.NewDecoder(res1.Body).Decode(&v)
 	require.NoError(t, err)
 
-	if !assert.NotNil(t, v.Data) || !assert.NotNil(t, v.Data.Attributes) {
-		return
-	}
+	require.NotNil(t, v.Data)
+	require.NotNil(t, v.Data.Attributes)
 	triggerID := v.Data.ID
 	assert.Equal(t, consts.Triggers, v.Data.Type)
 	assert.Equal(t, "@cron", v.Data.Attributes.Type)
@@ -371,9 +370,8 @@ func TestAddGetUpdateAndDeleteTriggerCron(t *testing.T) {
 	err = json.NewDecoder(res3.Body).Decode(&v2)
 	require.NoError(t, err)
 
-	if !assert.NotNil(t, v2.Data) || !assert.NotNil(t, v2.Data.Attributes) {
-		return
-	}
+	require.NotNil(t, v2.Data)
+	require.NotNil(t, v2.Data.Attributes)
 	assert.Equal(t, triggerID, v2.Data.ID)
 	assert.Equal(t, consts.Triggers, v2.Data.Type)
 	assert.Equal(t, "@cron", v2.Data.Attributes.Type)
@@ -423,9 +421,8 @@ func TestAddTriggerWithMetadata(t *testing.T) {
 	err = json.NewDecoder(res1.Body).Decode(&v)
 	require.NoError(t, err)
 
-	if !assert.NotNil(t, v.Data) || !assert.NotNil(t, v.Data.Attributes) {
-		return
-	}
+	require.NotNil(t, v.Data)
+	require.NotNil(t, v.Data.Attributes)
 	triggerID := v.Data.ID
 	assert.Equal(t, consts.Triggers, v.Data.Type)
 	assert.Equal(t, "@webhook", v.Data.Attributes.Type)
@@ -600,9 +597,8 @@ func TestClientJobs(t *testing.T) {
 	err = json.NewDecoder(res1.Body).Decode(&v1)
 	require.NoError(t, err)
 
-	if !assert.NotNil(t, v1.Data) || !assert.NotNil(t, v1.Data.Attributes) {
-		return
-	}
+	require.NotNil(t, v1.Data)
+	require.NotNil(t, v1.Data.Attributes)
 	triggerID := v1.Data.ID
 	assert.Equal(t, consts.Triggers, v1.Data.Type)
 	assert.Equal(t, "@client", v1.Data.Attributes.Type)
@@ -627,9 +623,8 @@ func TestClientJobs(t *testing.T) {
 	err = json.NewDecoder(res2.Body).Decode(&v2)
 	require.NoError(t, err)
 
-	if !assert.NotNil(t, v2.Data) || !assert.NotNil(t, v2.Data.Attributes) {
-		return
-	}
+	require.NotNil(t, v2.Data)
+	require.NotNil(t, v2.Data.Attributes)
 	jobID := v2.Data.ID
 	assert.Equal(t, consts.Jobs, v2.Data.Type)
 	assert.Equal(t, "client", v2.Data.Attributes.WorkerType)
@@ -664,9 +659,8 @@ func TestClientJobs(t *testing.T) {
 	err = json.NewDecoder(res3.Body).Decode(&v3)
 	require.NoError(t, err)
 
-	if !assert.NotNil(t, v3.Data) || !assert.NotNil(t, v3.Data.Attributes) {
-		return
-	}
+	require.NotNil(t, v3.Data)
+	require.NotNil(t, v3.Data.Attributes)
 	assert.Equal(t, consts.Jobs, v3.Data.Type)
 	assert.Equal(t, "client", v3.Data.Attributes.WorkerType)
 	assert.Equal(t, job.Errored, v3.Data.Attributes.State)

--- a/web/notes/notes_test.go
+++ b/web/notes/notes_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var ts *httptest.Server
@@ -369,9 +370,8 @@ func TestGetSteps(t *testing.T) {
 	meta2, _ := result2["meta"].(map[string]interface{})
 	assert.EqualValues(t, 2, meta2["count"])
 	data2, _ := result2["data"].([]interface{})
-	if !assert.Len(t, data2, 2) {
-		return
-	}
+	require.Len(t, data2, 2)
+
 	first, _ := data2[0].(map[string]interface{})
 	assert.NotNil(t, first["id"])
 	attrsF, _ := first["attributes"].(map[string]interface{})
@@ -562,30 +562,24 @@ func TestNoteMarkdown(t *testing.T) {
 func TestNoteRealtime(t *testing.T) {
 	u := strings.Replace(ts.URL+"/realtime/", "http", "ws", 1)
 	c, _, err := websocket.DefaultDialer.Dial(u, nil)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	defer c.Close()
 
 	auth := fmt.Sprintf(`{"method": "AUTH", "payload": "%s"}`, token)
 	err = c.WriteMessage(websocket.TextMessage, []byte(auth))
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	msg := `{"method": "SUBSCRIBE", "payload": { "type": "io.cozy.notes.events", "id": "` + noteID + `" }}`
 	err = c.WriteMessage(websocket.TextMessage, []byte(msg))
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	// To check that the realtime has made the subscription, we send a fake
 	// message and wait for its response.
 	msg = `{"method": "PING"}`
 	err = c.WriteMessage(websocket.TextMessage, []byte(msg))
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	var res map[string]interface{}
 	err = c.ReadJSON(&res)
 	assert.NoError(t, err)
@@ -639,9 +633,7 @@ func TestNoteRealtime(t *testing.T) {
 		{"sessionID": "543781490137", "stepType": "replace", "from": 3, "to": 3, "slice": slice},
 	}
 	file, err = note.ApplySteps(inst, file, fmt.Sprintf("%d", version), steps)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	var res4 map[string]interface{}
 	err = c.ReadJSON(&res4)

--- a/web/office/office_test.go
+++ b/web/office/office_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cozy/cozy-stack/web/errors"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var ts *httptest.Server
@@ -33,9 +34,8 @@ func TestOnlyOfficeLocal(t *testing.T) {
 	req.Header.Add("Authorization", "Bearer "+token)
 	res, err := http.DefaultClient.Do(req)
 	assert.NoError(t, err)
-	if !assert.Equal(t, 200, res.StatusCode) {
-		return
-	}
+	require.Equal(t, 200, res.StatusCode)
+
 	var doc map[string]interface{}
 	err = json.NewDecoder(res.Body).Decode(&doc)
 	assert.NoError(t, err)
@@ -73,9 +73,8 @@ func TestSaveOnlyOffice(t *testing.T) {
 	req.Header.Add("Content-Type", "application/json")
 	res, err := http.DefaultClient.Do(req)
 	assert.NoError(t, err)
-	if !assert.Equal(t, 200, res.StatusCode) {
-		return
-	}
+	require.Equal(t, 200, res.StatusCode)
+
 	var data map[string]interface{}
 	err = json.NewDecoder(res.Body).Decode(&data)
 	assert.NoError(t, err)
@@ -96,9 +95,8 @@ func TestSaveOnlyOffice(t *testing.T) {
 	req.Header.Add("Content-Type", "application/json")
 	res, err = http.DefaultClient.Do(req)
 	assert.NoError(t, err)
-	if !assert.Equal(t, 200, res.StatusCode) {
-		return
-	}
+	require.Equal(t, 200, res.StatusCode)
+
 	defer res.Body.Close()
 
 	doc, err = inst.VFS().FileByID(fileID)

--- a/web/permissions/permissions_test.go
+++ b/web/permissions/permissions_test.go
@@ -29,11 +29,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var ts *httptest.Server
-var token string
-var testInstance *instance.Instance
-var clientVal *oauth.Client
-var clientID string
+var (
+	ts           *httptest.Server
+	token        string
+	testInstance *instance.Instance
+	clientVal    *oauth.Client
+	clientID     string
+)
 
 func TestMain(m *testing.M) {
 	config.UseTestFile()
@@ -339,7 +341,6 @@ func TestCreateSubSubFail(t *testing.T) {
 	eveCode := codes["eve"].(string)
 	_, _, err = createTestSubPermissions(eveCode, "eve")
 	require.Error(t, err)
-
 }
 
 func TestPatchNoopFail(t *testing.T) {
@@ -545,7 +546,6 @@ func createTestSubPermissions(tok string, codes string) (string, map[string]inte
 	}
 }
 	}`)
-
 	if err != nil {
 		return "", nil, err
 	}
@@ -572,7 +572,6 @@ func createTestTinyCode(tok string, codes string, ttl string) (string, map[strin
 	}
 }
 	}`)
-
 	if err != nil {
 		return "", nil, err
 	}
@@ -769,13 +768,15 @@ func TestListPermission(t *testing.T) {
 			Type:   "io.cozy.events",
 			Verbs:  permission.Verbs(permission.DELETE, permission.PATCH),
 			Values: []string{ev1.ID()},
-		}}
+		},
+	}
 	p2 := permission.Set{
 		permission.Rule{
 			Type:   "io.cozy.events",
 			Verbs:  permission.Verbs(permission.GET),
 			Values: []string{ev2.ID()},
-		}}
+		},
+	}
 
 	perm1 := permission.Permission{
 		Permissions: p1,

--- a/web/permissions/permissions_test.go
+++ b/web/permissions/permissions_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var ts *httptest.Server
@@ -227,16 +228,14 @@ func TestGetPermissions(t *testing.T) {
 	req, _ := http.NewRequest("GET", ts.URL+"/permissions/self", nil)
 	req.Header.Add("Authorization", "Bearer "+token)
 	res, err := http.DefaultClient.Do(req)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, "200 OK", res.Status, "should get a 200")
 	defer res.Body.Close()
 
 	body, err := ioutil.ReadAll(res.Body)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	var out map[string]interface{}
 	err = json.Unmarshal(body, &out)
 	assert.NoError(t, err)
@@ -295,18 +294,15 @@ func TestBadPermissionsBearer(t *testing.T) {
 	req, _ := http.NewRequest("GET", ts.URL+"/permissions/self", nil)
 	req.Header.Add("Authorization", "Bearer garbage")
 	res, err := http.DefaultClient.Do(req)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	defer res.Body.Close()
 	assert.Equal(t, res.StatusCode, http.StatusBadRequest)
 }
 
 func TestCreateSubPermission(t *testing.T) {
 	_, codes, err := createTestSubPermissions(token, "alice,bob")
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	aCode := codes["alice"].(string)
 	bCode := codes["bob"].(string)
@@ -318,14 +314,12 @@ func TestCreateSubPermission(t *testing.T) {
 	req, _ := http.NewRequest("GET", ts.URL+"/permissions/self", nil)
 	req.Header.Add("Authorization", "Bearer "+aCode)
 	res, err := http.DefaultClient.Do(req)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	defer res.Body.Close()
 	body, err := ioutil.ReadAll(res.Body)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	var out map[string]interface{}
 	err = json.Unmarshal(body, &out)
 
@@ -340,21 +334,17 @@ func TestCreateSubPermission(t *testing.T) {
 
 func TestCreateSubSubFail(t *testing.T) {
 	_, codes, err := createTestSubPermissions(token, "eve")
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	eveCode := codes["eve"].(string)
 	_, _, err = createTestSubPermissions(eveCode, "eve")
-	if !assert.Error(t, err) {
-		return
-	}
+	require.Error(t, err)
+
 }
 
 func TestPatchNoopFail(t *testing.T) {
 	id, _, err := createTestSubPermissions(token, "pierre")
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	_, err = doRequest("PATCH", ts.URL+"/permissions/"+id, token, `{
 	  "data": {
@@ -371,9 +361,7 @@ func TestPatchNoopFail(t *testing.T) {
 
 func TestBadPatchAddRuleForbidden(t *testing.T) {
 	id, _, err := createTestSubPermissions(token, "jacque")
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	_, err = doRequest("PATCH", ts.URL+"/permissions/"+id, token, `{
 	  "data": {
@@ -393,9 +381,7 @@ func TestBadPatchAddRuleForbidden(t *testing.T) {
 
 func TestPatchAddRule(t *testing.T) {
 	id, _, err := createTestSubPermissions(token, "paul")
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	out, err := doRequest("PATCH", ts.URL+"/permissions/"+id, token, `{
 	  "data": {
@@ -423,9 +409,7 @@ func TestPatchAddRule(t *testing.T) {
 
 func TestPatchRemoveRule(t *testing.T) {
 	id, _, err := createTestSubPermissions(token, "paul")
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	out, err := doRequest("PATCH", ts.URL+"/permissions/"+id, token, `{
 	  "data": {
@@ -450,9 +434,7 @@ func TestPatchRemoveRule(t *testing.T) {
 
 func TestPatchChangesCodes(t *testing.T) {
 	id, codes, err := createTestSubPermissions(token, "john,jane")
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	assert.NotEmpty(t, codes["john"])
 	janeToken := codes["jane"].(string)
@@ -481,9 +463,8 @@ func TestPatchChangesCodes(t *testing.T) {
 	  }
 `)
 
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	data := out["data"].(map[string]interface{})
 	assert.Equal(t, id, data["id"])
 	attrs := data["attributes"].(map[string]interface{})
@@ -494,9 +475,7 @@ func TestPatchChangesCodes(t *testing.T) {
 
 func TestRevoke(t *testing.T) {
 	id, codes, err := createTestSubPermissions(token, "igor")
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	igorToken := codes["igor"].(string)
 	assert.NotEmpty(t, igorToken)
@@ -511,9 +490,7 @@ func TestRevoke(t *testing.T) {
 
 func TestRevokeByAnotherApp(t *testing.T) {
 	id, _, err := createTestSubPermissions(token, "roger")
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	installer, err := app.NewInstaller(testInstance, app.Copier(consts.WebappType, testInstance), &app.InstallerOptions{
 		Operation:  app.Install,
@@ -524,9 +501,7 @@ func TestRevokeByAnotherApp(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	_, err = installer.RunSync()
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	notesToken, err := testInstance.MakeJWT(consts.AppAudience, "notes", "", "", time.Now())
 	assert.NoError(t, err)
@@ -825,28 +800,22 @@ func TestListPermission(t *testing.T) {
 	req.Header.Add("Authorization", "Bearer "+token)
 	req.Header.Add("Content-Type", "application/json")
 	res, err := http.DefaultClient.Do(req)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	defer res.Body.Close()
 	assert.Equal(t, 200, res.StatusCode)
 	body, err := ioutil.ReadAll(res.Body)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	var out jsonapi.Document
 	err = json.Unmarshal(body, &out)
-	if !assert.NoError(t, err) {
-		return
-	}
-	if !assert.NotNil(t, out.Data) {
-		return
-	}
+	require.NoError(t, err)
+
+	require.NotNil(t, out.Data)
+
 	var results []refAndVerb
 	err = json.Unmarshal(*out.Data, &results)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	assert.Len(t, results, 2)
 	for _, result := range results {
@@ -863,9 +832,8 @@ func TestListPermission(t *testing.T) {
 	req2.Header.Add("Authorization", "Bearer "+token)
 	req2.Header.Add("Content-Type", "application/json")
 	res2, err := http.DefaultClient.Do(req2)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	defer res2.Body.Close()
 
 	var resBody struct {
@@ -880,9 +848,8 @@ func TestListPermission(t *testing.T) {
 	req3.Header.Add("Authorization", "Bearer "+token)
 	req3.Header.Add("Content-Type", "application/json")
 	res3, err := http.DefaultClient.Do(req3)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	defer res3.Body.Close()
 
 	var resBody3 struct {

--- a/web/realtime/realtime_test.go
+++ b/web/realtime/realtime_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cozy/cozy-stack/tests/testutils"
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var ts *httptest.Server
@@ -101,34 +102,25 @@ func TestWSNoPermissionsForADoctype(t *testing.T) {
 func TestWSSuccess(t *testing.T) {
 	u := strings.Replace(ts.URL+"/realtime/", "http", "ws", 1)
 	ws, _, err := websocket.DefaultDialer.Dial(u, nil)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	defer ws.Close()
 
 	auth := fmt.Sprintf(`{"method": "AUTH", "payload": "%s"}`, token)
 	err = ws.WriteMessage(websocket.TextMessage, []byte(auth))
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	msg := `{"method": "SUBSCRIBE", "payload": { "type": "io.cozy.foos" }}`
 	err = ws.WriteMessage(websocket.TextMessage, []byte(msg))
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	msg = `{"method": "SUBSCRIBE", "payload": { "type": "io.cozy.bars", "id": "bar-one" }}`
 	err = ws.WriteMessage(websocket.TextMessage, []byte(msg))
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	msg = `{"method": "SUBSCRIBE", "payload": { "type": "io.cozy.bars", "id": "bar-two" }}`
 	err = ws.WriteMessage(websocket.TextMessage, []byte(msg))
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	h := realtime.GetHub()
 	var res map[string]interface{}
@@ -175,9 +167,8 @@ func TestWSSuccess(t *testing.T) {
 
 	msg = `{"method": "UNSUBSCRIBE", "payload": { "type": "io.cozy.bars", "id": "bar-one" }}`
 	err = ws.WriteMessage(websocket.TextMessage, []byte(msg))
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	time.Sleep(30 * time.Millisecond)
 
 	h.Publish(inst, realtime.EventUpdate, &testDoc{
@@ -201,22 +192,17 @@ func TestWSSuccess(t *testing.T) {
 func TestWSNotify(t *testing.T) {
 	u := strings.Replace(ts.URL+"/realtime/", "http", "ws", 1)
 	ws, _, err := websocket.DefaultDialer.Dial(u, nil)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	defer ws.Close()
 
 	auth := fmt.Sprintf(`{"method": "AUTH", "payload": "%s"}`, token)
 	err = ws.WriteMessage(websocket.TextMessage, []byte(auth))
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	msg := `{"method": "SUBSCRIBE", "payload": { "type": "io.cozy.bazs", "id": "baz-one" }}`
 	err = ws.WriteMessage(websocket.TextMessage, []byte(msg))
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	time.Sleep(30 * time.Millisecond)
 	body := `{"hello": "world"}`
@@ -225,15 +211,12 @@ func TestWSNotify(t *testing.T) {
 	req.Header.Add("Authorization", "Bearer "+token)
 	res, err := http.DefaultClient.Do(req)
 	assert.NoError(t, err)
-	if !assert.Equal(t, http.StatusNoContent, res.StatusCode) {
-		return
-	}
+	require.Equal(t, http.StatusNoContent, res.StatusCode)
 
 	var resp map[string]interface{}
 	err = ws.ReadJSON(&resp)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	assert.Equal(t, "NOTIFIED", resp["event"])
 	payload := resp["payload"].(map[string]interface{})
 	assert.Equal(t, "io.cozy.bazs", payload["type"])

--- a/web/routing_test.go
+++ b/web/routing_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var domain string
@@ -19,9 +20,7 @@ var domain string
 func TestSetupAssets(t *testing.T) {
 	e := echo.New()
 	err := SetupAssets(e, "../assets")
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	ts := httptest.NewServer(e)
 	defer ts.Close()
@@ -44,9 +43,7 @@ func TestSetupAssets(t *testing.T) {
 func TestSetupAssetsStatik(t *testing.T) {
 	e := echo.New()
 	err := SetupAssets(e, "")
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	ts := httptest.NewServer(e)
 	defer ts.Close()
@@ -94,9 +91,7 @@ func TestSetupAssetsStatik(t *testing.T) {
 func TestSetupRoutes(t *testing.T) {
 	e := echo.New()
 	err := SetupRoutes(e)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	ts := httptest.NewServer(e)
 	defer ts.Close()
@@ -121,9 +116,7 @@ func TestParseHost(t *testing.T) {
 		return c.String(200, "OK:"+slug)
 	})
 
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	urls := map[string]string{
 		"https://" + domain + "/test":    "OK",

--- a/worker/exec/konnector_test.go
+++ b/worker/exec/konnector_test.go
@@ -130,7 +130,6 @@ echo "{\"type\": \"manifest\", \"message\": \"$(ls ${1}/manifest.konnector)\" }"
 
 		_, err = installer.RunSync()
 		require.NoError(t, err)
-
 	}
 
 	var wg sync.WaitGroup
@@ -235,7 +234,6 @@ echo "{\"type\": \"params\", \"message\": ${SECRET} }"
 
 		_, err = installer.RunSync()
 		require.NoError(t, err)
-
 	}
 
 	var wg sync.WaitGroup
@@ -306,7 +304,6 @@ echo "{\"type\": \"toto\", \"message\": \"COZY_URL=${COZY_URL}\"}"
 
 		_, err = installer.RunSync()
 		require.NoError(t, err)
-
 	}
 
 	var wg sync.WaitGroup

--- a/worker/exec/konnector_test.go
+++ b/worker/exec/konnector_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cozy/cozy-stack/tests/testutils"
 	jwt "github.com/golang-jwt/jwt/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var inst *instance.Instance
@@ -70,13 +71,10 @@ func TestBadFileExec(t *testing.T) {
 			SourceURL: "git://github.com/konnectors/cozy-konnector-trainline.git",
 		},
 	)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	_, err = installer.RunSync()
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	msg, err := job.NewMessage(map[string]interface{}{
 		"konnector":      "my-konnector-1",
@@ -114,14 +112,10 @@ echo "{\"type\": \"manifest\", \"message\": \"$(ls ${1}/manifest.konnector)\" }"
 	defer func() { _ = osFs.RemoveAll(tmpScript) }()
 
 	err := afero.WriteFile(osFs, tmpScript, []byte(script), 0)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	err = osFs.Chmod(tmpScript, 0777)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	installer, err := app.NewInstaller(inst, app.Copier(consts.KonnectorType, inst),
 		&app.InstallerOptions{
@@ -132,13 +126,11 @@ echo "{\"type\": \"manifest\", \"message\": \"$(ls ${1}/manifest.konnector)\" }"
 		},
 	)
 	if err != app.ErrAlreadyExists {
-		if !assert.NoError(t, err) {
-			return
-		}
+		require.NoError(t, err)
+
 		_, err = installer.RunSync()
-		if !assert.NoError(t, err) {
-			return
-		}
+		require.NoError(t, err)
+
 	}
 
 	var wg sync.WaitGroup
@@ -210,14 +202,10 @@ echo "{\"type\": \"params\", \"message\": ${SECRET} }"
 	defer func() { _ = osFs.RemoveAll(tmpScript) }()
 
 	err := afero.WriteFile(osFs, tmpScript, []byte(script), 0)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	err = osFs.Chmod(tmpScript, 0777)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	at := &account.AccountType{
 		GrantMode: account.SecretGrant,
@@ -243,13 +231,11 @@ echo "{\"type\": \"params\", \"message\": ${SECRET} }"
 		},
 	)
 	if err != app.ErrAlreadyExists {
-		if !assert.NoError(t, err) {
-			return
-		}
+		require.NoError(t, err)
+
 		_, err = installer.RunSync()
-		if !assert.NoError(t, err) {
-			return
-		}
+		require.NoError(t, err)
+
 	}
 
 	var wg sync.WaitGroup
@@ -302,14 +288,10 @@ echo "{\"type\": \"toto\", \"message\": \"COZY_URL=${COZY_URL}\"}"
 	defer func() { _ = osFs.RemoveAll(tmpScript) }()
 
 	err := afero.WriteFile(osFs, tmpScript, []byte(script), 0)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	err = osFs.Chmod(tmpScript, 0777)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	installer, err := app.NewInstaller(inst, app.Copier(consts.KonnectorType, inst),
 		&app.InstallerOptions{
@@ -320,13 +302,11 @@ echo "{\"type\": \"toto\", \"message\": \"COZY_URL=${COZY_URL}\"}"
 		},
 	)
 	if err != app.ErrAlreadyExists {
-		if !assert.NoError(t, err) {
-			return
-		}
+		require.NoError(t, err)
+
 		_, err = installer.RunSync()
-		if !assert.NoError(t, err) {
-			return
-		}
+		require.NoError(t, err)
+
 	}
 
 	var wg sync.WaitGroup

--- a/worker/push/push_test.go
+++ b/worker/push/push_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/cozy/cozy-stack/tests/testutils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetFirebaseClient(t *testing.T) {
@@ -30,9 +31,8 @@ func TestGetFirebaseClient(t *testing.T) {
 		AndroidAPIKey: "th3_f1r3b4s3_k3y",
 	}
 	err := couchdb.CreateNamedDoc(prefixer.SecretsPrefixer, &typ)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
+
 	defer func() {
 		_ = couchdb.DeleteDoc(prefixer.SecretsPrefixer, &typ)
 	}()


### PR DESCRIPTION
The following pattern:

```go
if !assert.NoError(t, err) {
  return
}
```

does the following steps:
- check if there is an error
- log the error with the assert package
- exit the test immediately

All those steps can be done with a single line:

```go
require.NoError(t, err)
```