### PR TITLE
Remove some useless `[:]` annotation

### DIFF
--- a/model/vfs/couchdb_indexer.go
+++ b/model/vfs/couchdb_indexer.go
@@ -328,7 +328,7 @@ func (c *couchdbIndexer) DeleteDirDocAndContent(doc *DirDoc, onlyContent bool) (
 }
 
 func (c *couchdbIndexer) BatchDelete(docs []couchdb.Doc) error {
-	remaining := docs[:]
+	remaining := docs
 	for len(remaining) > 0 {
 		n := 1000
 		if len(remaining) < n {

--- a/pkg/couchdb/bulk.go
+++ b/pkg/couchdb/bulk.go
@@ -263,8 +263,8 @@ func BulkUpdateDocs(db prefixer.Prefixer, doctype string, docs, olddocs []interf
 		return nil
 	}
 
-	remaining := docs[:]
-	olds := olddocs[:]
+	remaining := docs
+	olds := olddocs
 	for len(remaining) > 0 {
 		n := 1000
 		if len(remaining) < n {

--- a/pkg/keymgmt/nacl.go
+++ b/pkg/keymgmt/nacl.go
@@ -82,7 +82,7 @@ func UnmarshalNACLKey(marshaledKey []byte) (key *NACLKey, err error) {
 	}
 	publicKey := new([naclKeyLen]byte)
 	privateKey := new([naclKeyLen]byte)
-	copy(publicKey[:], keys[:])
+	copy(publicKey[:], keys)
 	copy(privateKey[:], keys[naclKeyLen:])
 	key = &NACLKey{
 		publicKey:  publicKey,
@@ -94,7 +94,7 @@ func UnmarshalNACLKey(marshaledKey []byte) (key *NACLKey, err error) {
 // MarshalNACLKey takes a key and returns its encoded version.
 func MarshalNACLKey(key *NACLKey) []byte {
 	keyBytes := make([]byte, 2*naclKeyLen)
-	copy(keyBytes[:], key.publicKey[:])
+	copy(keyBytes, key.publicKey[:])
 	copy(keyBytes[naclKeyLen:], key.privateKey[:])
 	return pem.EncodeToMemory(&pem.Block{
 		Type:  naclKeyBlockType,

--- a/web/bitwarden/ciphers.go
+++ b/web/bitwarden/ciphers.go
@@ -137,7 +137,7 @@ func titleizeKeys(data bitwarden.MapData) map[string]interface{} {
 		if k == "ssn" {
 			k = "SSN"
 		}
-		key := []byte(k[:])
+		key := []byte(k)
 		if 'a' <= key[0] && key[0] <= 'z' {
 			key[0] -= 'a' - 'A'
 		}


### PR DESCRIPTION
Those actions are done following the suggestions from the `gocritic` linter

The errors was:
```
pkg/keymgmt/nacl.go:97:7: unslice: could simplify keyBytes[:] to keyBytes (gocritic)
pkg/keymgmt/nacl.go:85:21: unslice: could simplify keys[:] to keys (gocritic)
web/bitwarden/ciphers.go:140:17: unslice: could simplify k[:] to k (gocritic)
model/vfs/couchdb_indexer.go:331:15: unslice: could simplify docs[:] to docs (gocritic)
pkg/couchdb/bulk.go:266:15: unslice: could simplify docs[:] to docs (gocritic)
pkg/couchdb/bulk.go:267:10: unslice: could simplify olddocs[:] to olddocs (gocritic)
```