### PR TITLE
Fix the gocritic `singleCaseSwitch` suggestions

### DIFF
--- a/model/account/accounts.go
+++ b/model/account/accounts.go
@@ -102,8 +102,9 @@ func (ac *Account) Fetch(field string) []string {
 	switch field {
 	case "account_type":
 		return []string{ac.AccountType}
+	default:
+		return nil
 	}
-	return nil
 }
 
 func (ac *Account) toJSONDoc() (*couchdb.JSONDoc, error) {

--- a/model/job/broker.go
+++ b/model/job/broker.go
@@ -198,8 +198,9 @@ func (jr *JobRequest) Fetch(field string) []string {
 	switch field {
 	case "worker":
 		return []string{jr.WorkerType}
+	default:
+		return nil
 	}
-	return nil
 }
 
 // Logger returns a logger associated with the job domain

--- a/model/job/scheduler.go
+++ b/model/job/scheduler.go
@@ -228,8 +228,9 @@ func (t *TriggerInfos) Fetch(field string) []string {
 	switch field {
 	case "worker":
 		return []string{t.WorkerType}
+	default:
+		return nil
 	}
-	return nil
 }
 
 func createTrigger(t Trigger) error {

--- a/model/sharing/shared.go
+++ b/model/sharing/shared.go
@@ -99,8 +99,9 @@ func (s *SharedRef) Fetch(field string) []string {
 			keys = append(keys, key)
 		}
 		return keys
+	default:
+		return nil
 	}
-	return nil
 }
 
 // FindReferences returns the io.cozy.shared references to the given identifiers

--- a/model/vfs/metadata.go
+++ b/model/vfs/metadata.go
@@ -173,11 +173,12 @@ func (e *ImageExtractor) Result() Metadata {
 	m := NewMetadata()
 	m["datetime"] = e.createdAt
 	cfg := <-e.ch
-	switch cfg := cfg.(type) {
-	case image.Config:
+
+	if cfg, ok := cfg.(image.Config); ok {
 		m["width"] = cfg.Width
 		m["height"] = cfg.Height
 	}
+
 	return m
 }
 
@@ -256,8 +257,7 @@ func (e *ExifExtractor) Result() Metadata {
 	}
 	select {
 	case x := <-e.ch:
-		switch x := x.(type) {
-		case *exif.Exif:
+		if x, ok := x.(*exif.Exif); ok {
 			localTZ := false
 			if dt, err := x.DateTime(); err == nil {
 				m["datetime"] = dt
@@ -422,8 +422,7 @@ func (e *AudioExtractor) Abort(err error) {
 func (e *AudioExtractor) Result() Metadata {
 	m := NewMetadata()
 	tags := <-e.ch
-	switch tags := tags.(type) {
-	case tag.Metadata:
+	if tags, ok := tags.(tag.Metadata); ok {
 		if album := tags.Album(); album != "" {
 			m["album"] = album
 		}
@@ -511,8 +510,7 @@ func (e *ShortcutExtractor) Abort(err error) {
 func (e *ShortcutExtractor) Result() Metadata {
 	m := NewMetadata()
 	link := <-e.ch
-	switch link := link.(type) {
-	case shortcut.Result:
+	if link, ok := link.(shortcut.Result); ok {
 		cozy, app := extractCozyLink(link, e.instance)
 		if cozy != "" {
 			target := map[string]interface{}{

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -1791,8 +1791,7 @@ func fsckHandler(c echo.Context) error {
 
 	logs := make([]*vfs.FsckLog, 0)
 	err := instance.VFS().CheckFilesConsistency(func(log *vfs.FsckLog) {
-		switch log.Type {
-		case vfs.ContentMismatch:
+		if log.Type == vfs.ContentMismatch {
 			logs = append(logs, log)
 		}
 	}, false)

--- a/web/jobs/jobs.go
+++ b/web/jobs/jobs.go
@@ -102,8 +102,9 @@ func (q apiQueue) Fetch(field string) []string {
 	switch field {
 	case "worker":
 		return []string{q.workerType}
+	default:
+		return nil
 	}
-	return nil
 }
 
 // NewAPITrigger creates a jsonapi representation of a trigger.

--- a/worker/sms/sms.go
+++ b/worker/sms/sms.go
@@ -59,8 +59,9 @@ func sendSMS(ctx *job.WorkerContext, msg *center.SMS) error {
 	case "api_sen":
 		log := ctx.Logger()
 		return sendSenAPI(cfg, msg, number, log)
+	default:
+		return errors.New("Unknown provider for sending SMS")
 	}
-	return errors.New("Unknown provider for sending SMS")
 }
 
 func sendSenAPI(cfg *config.SMS, msg *center.SMS, number string, log *logger.Entry) error {


### PR DESCRIPTION
Those fix have be done following the suggestions from the gocritic linter

This commit fix the followings errors:
```
model/job/broker.go:198:2: singleCaseSwitch: should rewrite switch statement to if statement (gocritic)
model/job/scheduler.go:228:2: singleCaseSwitch: should rewrite switch statement to if statement (gocritic)
model/vfs/metadata.go:176:2: singleCaseSwitch: should rewrite switch statement to if statement (gocritic)
```