### PR TITLE
Move the tests from `/web` to the sub-test pattern

### DIFF
--- a/scripts/migrate-test-init.sh
+++ b/scripts/migrate-test-init.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+
+if (( $# == 0 )); then
+  echo "Wait some files as argument"
+  exit 1
+fi
+
+
+function write_into_until_end_function  () {
+  outputfile=$1
+
+  # Retrieve the nth line inside the file
+  line=$(sed "${COUNTER}q;d" "$arg")
+
+  while [ $COUNTER -le $fileSize ]
+  do
+    if [[ "$line" == "}" ]];
+    then
+      # End of the function
+
+          # do not print the ending brack
+
+          # select the next line
+          COUNTER=$((COUNTER+1))
+          line=$(sed "${COUNTER}q;d" "$arg")
+
+          # leave the loop
+          return
+        else
+          # Inside the body function
+
+          # print the line
+          echo "$line" >> $outputfile
+
+          # select the next line
+          COUNTER=$((COUNTER+1))
+          line=$(sed "${COUNTER}q;d" "$arg")
+    fi
+  done
+}
+
+
+mkdir -p /tmp/migration
+
+# Iterate on all file path given in argument.
+for arg in "$@"
+do
+  rm -f "/tmp/migration/test.txt"
+  rm -f "/tmp/migration/utils.txt"
+  rm -f "/tmp/migration/other.txt"
+  rm -f "/tmp/migration/main.txt"
+  rm -f "/tmp/migration/out.go"
+
+  # Need to create this file manually because only one of the file inside
+  # the package have a `TestMain` function.
+  #
+  # If a test file doesn't have a TestMain we will need to copy/pasta it
+  # manually in a next commit.
+  touch /tmp/migration/main.txt
+  touch /tmp/migration/utils.txt
+  touch /tmp/migration/other.txt
+  touch /tmp/migration/test.txt
+
+  COUNTER=1
+
+  printf "===> Starting to migrate %s <===\n" $arg
+
+  # We need a empty line at the end of the file for some match
+  echo "" >> $arg
+
+  # Get the number of lines inside the file
+  fileSize=`wc -l $arg | cut -d' ' -f1`
+
+  echo "filesize: $fileSize"
+
+
+  fileTestName=$(echo $(basename $arg) | cut -d'_' -f1 | sed 's/^\(.\)/\U\1/')
+
+
+  # Loop from 0 to fileSize
+  while [ $COUNTER -le $fileSize ]
+  do
+
+    # Retrieve the nth line inside the file
+    line=$(sed "${COUNTER}q;d" "$arg")
+
+    case $line in
+      func\ TestMain*)
+        # Skip the proto
+        COUNTER=$((COUNTER+1))
+        write_into_until_end_function "/tmp/migration/main.txt"
+        echo "" >> "/tmp/migration/main.txt"
+        ;;
+
+      func\ Test*)
+        newProto=$(sed "s/func Test\([a-zA-Z0-9]*\)(t \*testing.T) {/t.Run(\"\1\", func(t *testing.T) {/g" <<< $line)
+        testName=$(sed "s/func Test\([a-zA-Z0-9]*\)(t \*testing.T) {/\1/g" <<< $line)
+        # echo "Migrate $fileTestName/$testName"
+        echo "$newProto" >> "/tmp/migration/test.txt"
+        COUNTER=$((COUNTER+1))
+        write_into_until_end_function "/tmp/migration/test.txt"
+        echo "})" >> "/tmp/migration/test.txt"
+        echo "" >> "/tmp/migration/test.txt"
+        ;;
+
+      func*)
+        write_into_until_end_function  "/tmp/migration/utils.txt"
+        echo "}" >> "/tmp/migration/utils.txt"
+        echo "" >> "/tmp/migration/utils.txt"
+        ;;
+
+      *)
+        echo $line >> "/tmp/migration/other.txt"
+        COUNTER=$((COUNTER+1))
+        ;;
+    esac
+  done
+
+  cat "/tmp/migration/other.txt" >> "/tmp/migration/out.go"
+
+  printf '%s\n' \
+    "func Test${fileTestName}(t *testing.T) {" \
+    " if testing.Short() {" \
+    " t.Skip(\"an instance is required for this test: test skipped due to the use of --short flag\")" \
+    "}" \
+    "" >> "/tmp/migration/out.go"
+
+  cat "/tmp/migration/main.txt" >> "/tmp/migration/out.go"
+  echo "" >> "/tmp/migration/out.go"
+
+# add the sub tests
+cat "/tmp/migration/test.txt" >> "/tmp/migration/out.go"
+
+# close the test
+echo "}" >> "/tmp/migration/out.go"
+echo "" >> "/tmp/migration/out.go"
+
+# add the helpers at the end
+cat "/tmp/migration/utils.txt" >> "/tmp/migration/out.go"
+
+# Replace original file by the newly created file
+mv /tmp/migration/out.go $arg
+
+gofmt -s -w $arg
+
+rm -f "/tmp/migration/test.txt"
+rm -f "/tmp/migration/utils.txt"
+rm -f "/tmp/migration/other.txt"
+rm -f "/tmp/migration/main.txt"
+rm -f "/tmp/migration/out.go"
+done
+
+rm -rf "/tmp/migration"

--- a/web/accounts/oauth_test.go
+++ b/web/accounts/oauth_test.go
@@ -26,7 +26,6 @@ import (
 
 var ts *httptest.Server
 var testInstance *instance.Instance
-var setup *testutils.TestSetup
 var jar *testutils.CookieJar
 var client *http.Client
 
@@ -39,7 +38,8 @@ func TestOauth(t *testing.T) {
 	build.BuildMode = build.ModeDev
 	testutils.NeedCouchdb()
 
-	setup = testutils.NewSetup(m, "oauth-konnectors")
+	setup := testutils.NewSetup(nil, t.Name())
+	t.Cleanup(setup.Cleanup)
 	ts = setup.GetTestServer("/accounts", Routes, func(r *echo.Echo) *echo.Echo {
 		r.POST("/login", func(c echo.Context) error {
 			sess, _ := session.New(testInstance, session.LongRun)
@@ -338,7 +338,6 @@ func TestOauth(t *testing.T) {
 		require.Len(t, cookies, 1)
 		assert.Equal(t, cookies[0].Name, "cozysessid")
 	})
-
 }
 
 func noRedirect(*http.Request, []*http.Request) error {

--- a/web/accounts/oauth_test.go
+++ b/web/accounts/oauth_test.go
@@ -31,281 +31,11 @@ var setup *testutils.TestSetup
 var jar *testutils.CookieJar
 var client *http.Client
 
-func TestAccessCodeOauthFlow(t *testing.T) {
-	redirectURI := ts.URL + "/accounts/test-service/redirect"
-
-	service := makeTestACService(redirectURI)
-	defer service.Close()
-
-	serviceType := account.AccountType{
-		DocID:                 "test-service",
-		GrantMode:             account.AuthorizationCode,
-		ClientID:              "the-client-id",
-		ClientSecret:          "the-client-secret",
-		AuthEndpoint:          service.URL + "/oauth2/v2/auth",
-		TokenEndpoint:         service.URL + "/oauth2/v4/token",
-		RegisteredRedirectURI: redirectURI,
-	}
-	err := couchdb.CreateNamedDoc(prefixer.SecretsPrefixer, &serviceType)
-	require.NoError(t, err)
-
-	defer func() {
-		_ = couchdb.DeleteDoc(prefixer.SecretsPrefixer, &serviceType)
-	}()
-
-	u := ts.URL + "/accounts/test-service/start?scope=the+world&state=somesecretstate"
-
-	res, err := client.Get(u)
-	require.NoError(t, err)
-
-	bb, err := io.ReadAll(res.Body)
-	require.NoError(t, err)
-
-	res.Body.Close()
-	okURL := string(bb)
-
-	if !assert.Equal(t, 200, res.StatusCode) {
-		fmt.Println("Bad response", res, okURL)
-		return
+func TestOauth(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
 	}
 
-	// the user click the oauth link
-	res2, err := (&http.Client{CheckRedirect: stopBeforeDataCollectFail}).Get(okURL)
-	require.NoError(t, err)
-
-	assert.Equal(t, http.StatusSeeOther, res2.StatusCode)
-	finalURL, err := res2.Location()
-	require.NoError(t, err)
-
-	if !assert.Contains(t, finalURL.String(), "home") {
-		return
-	}
-
-	var out couchdb.JSONDoc
-	err = couchdb.GetDoc(testInstance, consts.Accounts, finalURL.Query().Get("account"), &out)
-	assert.NoError(t, err)
-	assert.Equal(t, "the-access-token", out.M["oauth"].(map[string]interface{})["access_token"])
-	out.Type = consts.Accounts
-	out.M["manual_cleaning"] = true
-	_ = couchdb.DeleteDoc(testInstance, &out)
-}
-
-func TestRedirectURLOauthFlow(t *testing.T) {
-	redirectURI := "http://" + testInstance.Domain + "/accounts/test-service2/redirect"
-	service := makeTestRedirectURLService(redirectURI)
-	defer service.Close()
-
-	serviceType := account.AccountType{
-		DocID:        "test-service2",
-		GrantMode:    account.ImplicitGrantRedirectURL,
-		AuthEndpoint: service.URL + "/oauth2/v2/auth",
-	}
-	err := couchdb.CreateNamedDoc(prefixer.SecretsPrefixer, &serviceType)
-	require.NoError(t, err)
-
-	defer func() {
-		_ = couchdb.DeleteDoc(prefixer.SecretsPrefixer, &serviceType)
-	}()
-
-	u := ts.URL + "/accounts/test-service2/start?scope=the+world"
-
-	res, err := client.Get(u)
-	require.NoError(t, err)
-
-	bb, err := io.ReadAll(res.Body)
-	require.NoError(t, err)
-
-	res.Body.Close()
-	okURL := string(bb)
-
-	if !assert.Equal(t, 200, res.StatusCode) {
-		fmt.Println("Bad response", res, okURL)
-		return
-	}
-
-	res2, err := (&http.Client{CheckRedirect: stopBeforeDataCollectFail}).Get(okURL)
-	require.NoError(t, err)
-
-	assert.Equal(t, http.StatusSeeOther, res2.StatusCode)
-	finalURL, err := res2.Location()
-	require.NoError(t, err)
-
-	if !assert.Contains(t, finalURL.String(), "home") {
-		return
-	}
-
-	var out couchdb.JSONDoc
-	err = couchdb.GetDoc(testInstance, consts.Accounts, finalURL.Query().Get("account"), &out)
-	assert.NoError(t, err)
-	assert.Equal(t, "the-access-token2", out.M["oauth"].(map[string]interface{})["access_token"])
-	out.Type = consts.Accounts
-	out.M["manual_cleaning"] = true
-	_ = couchdb.DeleteDoc(testInstance, &out)
-}
-
-func TestDoNotRecreateAccountIfItAlreadyExists(t *testing.T) {
-	existingAccount := &couchdb.JSONDoc{
-		Type: consts.Accounts,
-		M: map[string]interface{}{
-			"account_type": "test-service3",
-			"oauth": map[string]interface{}{
-				"query": map[string]interface{}{
-					"connection_id": []interface{}{
-						"1750",
-					},
-				},
-			},
-		},
-	}
-	err := couchdb.CreateDoc(testInstance, existingAccount)
-	require.NoError(t, err)
-	defer func() {
-		existingAccount.M["manual_cleaning"] = true
-		_ = couchdb.DeleteDoc(testInstance, existingAccount)
-	}()
-
-	redirectURI := "http://" + testInstance.Domain + "/accounts/test-service3/redirect"
-	service := makeTestRedirectURLService(redirectURI)
-	defer service.Close()
-
-	serviceType := account.AccountType{
-		DocID:        "test-service3",
-		GrantMode:    account.ImplicitGrantRedirectURL,
-		AuthEndpoint: service.URL + "/oauth2/v2/auth",
-	}
-	err = couchdb.CreateNamedDoc(prefixer.SecretsPrefixer, &serviceType)
-	require.NoError(t, err)
-	defer func() {
-		_ = couchdb.DeleteDoc(prefixer.SecretsPrefixer, &serviceType)
-	}()
-
-	u := ts.URL + "/accounts/test-service3/start?scope=the+world"
-	res, err := client.Get(u)
-	require.NoError(t, err)
-	defer res.Body.Close()
-	require.Equal(t, 200, res.StatusCode)
-	bb, err := io.ReadAll(res.Body)
-	require.NoError(t, err)
-	okURL := string(bb)
-
-	res2, err := (&http.Client{CheckRedirect: stopBeforeDataCollectFail}).Get(okURL)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusSeeOther, res2.StatusCode)
-	finalURL, err := res2.Location()
-	require.NoError(t, err)
-	assert.Equal(t, finalURL.Query().Get("account"), existingAccount.ID())
-}
-
-func TestFixedRedirectURIOauthFlow(t *testing.T) {
-	redirectURI := "http://oauth_callback.cozy.localhost/accounts/test-service3/redirect"
-	service := makeTestACService(redirectURI)
-	defer service.Close()
-
-	serviceType := account.AccountType{
-		DocID:                 "test-service3",
-		GrantMode:             account.AuthorizationCode,
-		ClientID:              "the-client-id",
-		ClientSecret:          "the-client-secret",
-		AuthEndpoint:          service.URL + "/oauth2/v2/auth",
-		TokenEndpoint:         service.URL + "/oauth2/v4/token",
-		RegisteredRedirectURI: redirectURI,
-	}
-	err := couchdb.CreateNamedDoc(prefixer.SecretsPrefixer, &serviceType)
-	require.NoError(t, err)
-
-	defer func() {
-		_ = couchdb.DeleteDoc(prefixer.SecretsPrefixer, &serviceType)
-	}()
-
-	startURL, err := url.Parse(ts.URL + "/accounts/test-service3/start?scope=the+world")
-	require.NoError(t, err)
-
-	res, err := client.Get(startURL.String())
-	require.NoError(t, err)
-
-	bb, err := io.ReadAll(res.Body)
-	require.NoError(t, err)
-
-	res.Body.Close()
-	okURL := string(bb)
-
-	if !assert.Equal(t, 200, res.StatusCode) {
-		fmt.Println("Bad response", res, okURL)
-		return
-	}
-
-	okURLObj, err := url.Parse(okURL)
-	require.NoError(t, err)
-
-	// hack, we want to speak with ts.URL but setting Host to _oauth_callback
-	host := okURLObj.Host
-	okURLObj.Host = startURL.Host
-	req2, err := http.NewRequest("GET", okURLObj.String(), nil)
-	require.NoError(t, err)
-
-	req2.Host = host
-
-	res2, err := (&http.Client{CheckRedirect: stopBeforeDataCollectFail}).Do(req2)
-	require.NoError(t, err)
-
-	assert.Equal(t, http.StatusSeeOther, res2.StatusCode)
-	finalURL, err := res2.Location()
-	require.NoError(t, err)
-
-	if !assert.Contains(t, finalURL.String(), "home") {
-		return
-	}
-
-	var out couchdb.JSONDoc
-	err = couchdb.GetDoc(testInstance, consts.Accounts, finalURL.Query().Get("account"), &out)
-	assert.NoError(t, err)
-	assert.Equal(t, "the-access-token", out.M["oauth"].(map[string]interface{})["access_token"])
-	out.Type = consts.Accounts
-	out.M["manual_cleaning"] = true
-	_ = couchdb.DeleteDoc(testInstance, &out)
-}
-
-func TestCheckLogin(t *testing.T) {
-	serviceType := account.AccountType{
-		DocID:                 "test-service4",
-		GrantMode:             account.AuthorizationCode,
-		ClientID:              "the-client-id",
-		ClientSecret:          "the-client-secret",
-		AuthEndpoint:          "https://test-service4/auth",
-		TokenEndpoint:         "https://test-service4/token",
-		RegisteredRedirectURI: "https://oauth_callback.cozy.localhost/accounts/test-service4/redirect",
-	}
-	err := couchdb.CreateNamedDoc(prefixer.SecretsPrefixer, &serviceType)
-	require.NoError(t, err)
-
-	defer func() {
-		_ = couchdb.DeleteDoc(prefixer.SecretsPrefixer, &serviceType)
-	}()
-
-	u := ts.URL + "/accounts/test-service4/start?scope=foo&state=bar"
-	inAppBrowser := &http.Client{
-		CheckRedirect: noRedirect,
-		Jar:           setup.GetCookieJar(),
-	}
-	res, err := inAppBrowser.Get(u)
-	require.NoError(t, err)
-	res.Body.Close()
-	require.Equal(t, res.StatusCode, 403)
-
-	sessionCode, err := testInstance.CreateSessionCode()
-	require.NoError(t, err)
-	u2 := u + "&session_code=" + sessionCode
-	res2, err := inAppBrowser.Get(u2)
-	require.NoError(t, err)
-	res2.Body.Close()
-	require.Equal(t, res2.StatusCode, 303)
-	assert.Contains(t, res2.Header.Get("Location"), serviceType.AuthEndpoint)
-	cookies := res2.Cookies()
-	require.Len(t, cookies, 1)
-	assert.Equal(t, cookies[0].Name, "cozysessid")
-}
-
-func TestMain(m *testing.M) {
 	config.UseTestFile()
 	build.BuildMode = build.ModeDev
 	testutils.NeedCouchdb()
@@ -337,6 +67,281 @@ func TestMain(m *testing.M) {
 	_, _ = client.Do(req)
 
 	os.Exit(setup.Run())
+
+	t.Run("AccessCodeOauthFlow", func(t *testing.T) {
+		redirectURI := ts.URL + "/accounts/test-service/redirect"
+
+		service := makeTestACService(redirectURI)
+		defer service.Close()
+
+		serviceType := account.AccountType{
+			DocID:                 "test-service",
+			GrantMode:             account.AuthorizationCode,
+			ClientID:              "the-client-id",
+			ClientSecret:          "the-client-secret",
+			AuthEndpoint:          service.URL + "/oauth2/v2/auth",
+			TokenEndpoint:         service.URL + "/oauth2/v4/token",
+			RegisteredRedirectURI: redirectURI,
+		}
+		err := couchdb.CreateNamedDoc(prefixer.SecretsPrefixer, &serviceType)
+		require.NoError(t, err)
+
+		defer func() {
+			_ = couchdb.DeleteDoc(prefixer.SecretsPrefixer, &serviceType)
+		}()
+
+		u := ts.URL + "/accounts/test-service/start?scope=the+world&state=somesecretstate"
+
+		res, err := client.Get(u)
+		require.NoError(t, err)
+
+		bb, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+
+		res.Body.Close()
+		okURL := string(bb)
+
+		if !assert.Equal(t, 200, res.StatusCode) {
+			fmt.Println("Bad response", res, okURL)
+			return
+		}
+
+		// the user click the oauth link
+		res2, err := (&http.Client{CheckRedirect: stopBeforeDataCollectFail}).Get(okURL)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusSeeOther, res2.StatusCode)
+		finalURL, err := res2.Location()
+		require.NoError(t, err)
+
+		if !assert.Contains(t, finalURL.String(), "home") {
+			return
+		}
+
+		var out couchdb.JSONDoc
+		err = couchdb.GetDoc(testInstance, consts.Accounts, finalURL.Query().Get("account"), &out)
+		assert.NoError(t, err)
+		assert.Equal(t, "the-access-token", out.M["oauth"].(map[string]interface{})["access_token"])
+		out.Type = consts.Accounts
+		out.M["manual_cleaning"] = true
+		_ = couchdb.DeleteDoc(testInstance, &out)
+	})
+
+	t.Run("RedirectURLOauthFlow", func(t *testing.T) {
+		redirectURI := "http://" + testInstance.Domain + "/accounts/test-service2/redirect"
+		service := makeTestRedirectURLService(redirectURI)
+		defer service.Close()
+
+		serviceType := account.AccountType{
+			DocID:        "test-service2",
+			GrantMode:    account.ImplicitGrantRedirectURL,
+			AuthEndpoint: service.URL + "/oauth2/v2/auth",
+		}
+		err := couchdb.CreateNamedDoc(prefixer.SecretsPrefixer, &serviceType)
+		require.NoError(t, err)
+
+		defer func() {
+			_ = couchdb.DeleteDoc(prefixer.SecretsPrefixer, &serviceType)
+		}()
+
+		u := ts.URL + "/accounts/test-service2/start?scope=the+world"
+
+		res, err := client.Get(u)
+		require.NoError(t, err)
+
+		bb, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+
+		res.Body.Close()
+		okURL := string(bb)
+
+		if !assert.Equal(t, 200, res.StatusCode) {
+			fmt.Println("Bad response", res, okURL)
+			return
+		}
+
+		res2, err := (&http.Client{CheckRedirect: stopBeforeDataCollectFail}).Get(okURL)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusSeeOther, res2.StatusCode)
+		finalURL, err := res2.Location()
+		require.NoError(t, err)
+
+		if !assert.Contains(t, finalURL.String(), "home") {
+			return
+		}
+
+		var out couchdb.JSONDoc
+		err = couchdb.GetDoc(testInstance, consts.Accounts, finalURL.Query().Get("account"), &out)
+		assert.NoError(t, err)
+		assert.Equal(t, "the-access-token2", out.M["oauth"].(map[string]interface{})["access_token"])
+		out.Type = consts.Accounts
+		out.M["manual_cleaning"] = true
+		_ = couchdb.DeleteDoc(testInstance, &out)
+	})
+
+	t.Run("DoNotRecreateAccountIfItAlreadyExists", func(t *testing.T) {
+		existingAccount := &couchdb.JSONDoc{
+			Type: consts.Accounts,
+			M: map[string]interface{}{
+				"account_type": "test-service3",
+				"oauth": map[string]interface{}{
+					"query": map[string]interface{}{
+						"connection_id": []interface{}{
+							"1750",
+						},
+					},
+				},
+			},
+		}
+		err := couchdb.CreateDoc(testInstance, existingAccount)
+		require.NoError(t, err)
+		defer func() {
+			existingAccount.M["manual_cleaning"] = true
+			_ = couchdb.DeleteDoc(testInstance, existingAccount)
+		}()
+
+		redirectURI := "http://" + testInstance.Domain + "/accounts/test-service3/redirect"
+		service := makeTestRedirectURLService(redirectURI)
+		defer service.Close()
+
+		serviceType := account.AccountType{
+			DocID:        "test-service3",
+			GrantMode:    account.ImplicitGrantRedirectURL,
+			AuthEndpoint: service.URL + "/oauth2/v2/auth",
+		}
+		err = couchdb.CreateNamedDoc(prefixer.SecretsPrefixer, &serviceType)
+		require.NoError(t, err)
+		defer func() {
+			_ = couchdb.DeleteDoc(prefixer.SecretsPrefixer, &serviceType)
+		}()
+
+		u := ts.URL + "/accounts/test-service3/start?scope=the+world"
+		res, err := client.Get(u)
+		require.NoError(t, err)
+		defer res.Body.Close()
+		require.Equal(t, 200, res.StatusCode)
+		bb, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+		okURL := string(bb)
+
+		res2, err := (&http.Client{CheckRedirect: stopBeforeDataCollectFail}).Get(okURL)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusSeeOther, res2.StatusCode)
+		finalURL, err := res2.Location()
+		require.NoError(t, err)
+		assert.Equal(t, finalURL.Query().Get("account"), existingAccount.ID())
+	})
+
+	t.Run("FixedRedirectURIOauthFlow", func(t *testing.T) {
+		redirectURI := "http://oauth_callback.cozy.localhost/accounts/test-service3/redirect"
+		service := makeTestACService(redirectURI)
+		defer service.Close()
+
+		serviceType := account.AccountType{
+			DocID:                 "test-service3",
+			GrantMode:             account.AuthorizationCode,
+			ClientID:              "the-client-id",
+			ClientSecret:          "the-client-secret",
+			AuthEndpoint:          service.URL + "/oauth2/v2/auth",
+			TokenEndpoint:         service.URL + "/oauth2/v4/token",
+			RegisteredRedirectURI: redirectURI,
+		}
+		err := couchdb.CreateNamedDoc(prefixer.SecretsPrefixer, &serviceType)
+		require.NoError(t, err)
+
+		defer func() {
+			_ = couchdb.DeleteDoc(prefixer.SecretsPrefixer, &serviceType)
+		}()
+
+		startURL, err := url.Parse(ts.URL + "/accounts/test-service3/start?scope=the+world")
+		require.NoError(t, err)
+
+		res, err := client.Get(startURL.String())
+		require.NoError(t, err)
+
+		bb, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+
+		res.Body.Close()
+		okURL := string(bb)
+
+		if !assert.Equal(t, 200, res.StatusCode) {
+			fmt.Println("Bad response", res, okURL)
+			return
+		}
+
+		okURLObj, err := url.Parse(okURL)
+		require.NoError(t, err)
+
+		// hack, we want to speak with ts.URL but setting Host to _oauth_callback
+		host := okURLObj.Host
+		okURLObj.Host = startURL.Host
+		req2, err := http.NewRequest("GET", okURLObj.String(), nil)
+		require.NoError(t, err)
+
+		req2.Host = host
+
+		res2, err := (&http.Client{CheckRedirect: stopBeforeDataCollectFail}).Do(req2)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusSeeOther, res2.StatusCode)
+		finalURL, err := res2.Location()
+		require.NoError(t, err)
+
+		if !assert.Contains(t, finalURL.String(), "home") {
+			return
+		}
+
+		var out couchdb.JSONDoc
+		err = couchdb.GetDoc(testInstance, consts.Accounts, finalURL.Query().Get("account"), &out)
+		assert.NoError(t, err)
+		assert.Equal(t, "the-access-token", out.M["oauth"].(map[string]interface{})["access_token"])
+		out.Type = consts.Accounts
+		out.M["manual_cleaning"] = true
+		_ = couchdb.DeleteDoc(testInstance, &out)
+	})
+
+	t.Run("CheckLogin", func(t *testing.T) {
+		serviceType := account.AccountType{
+			DocID:                 "test-service4",
+			GrantMode:             account.AuthorizationCode,
+			ClientID:              "the-client-id",
+			ClientSecret:          "the-client-secret",
+			AuthEndpoint:          "https://test-service4/auth",
+			TokenEndpoint:         "https://test-service4/token",
+			RegisteredRedirectURI: "https://oauth_callback.cozy.localhost/accounts/test-service4/redirect",
+		}
+		err := couchdb.CreateNamedDoc(prefixer.SecretsPrefixer, &serviceType)
+		require.NoError(t, err)
+
+		defer func() {
+			_ = couchdb.DeleteDoc(prefixer.SecretsPrefixer, &serviceType)
+		}()
+
+		u := ts.URL + "/accounts/test-service4/start?scope=foo&state=bar"
+		inAppBrowser := &http.Client{
+			CheckRedirect: noRedirect,
+			Jar:           setup.GetCookieJar(),
+		}
+		res, err := inAppBrowser.Get(u)
+		require.NoError(t, err)
+		res.Body.Close()
+		require.Equal(t, res.StatusCode, 403)
+
+		sessionCode, err := testInstance.CreateSessionCode()
+		require.NoError(t, err)
+		u2 := u + "&session_code=" + sessionCode
+		res2, err := inAppBrowser.Get(u2)
+		require.NoError(t, err)
+		res2.Body.Close()
+		require.Equal(t, res2.StatusCode, 303)
+		assert.Contains(t, res2.Header.Get("Location"), serviceType.AuthEndpoint)
+		cookies := res2.Cookies()
+		require.Len(t, cookies, 1)
+		assert.Equal(t, cookies[0].Name, "cozysessid")
+	})
+
 }
 
 func noRedirect(*http.Request, []*http.Request) error {

--- a/web/accounts/oauth_test.go
+++ b/web/accounts/oauth_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"strings"
 	"testing"
 
@@ -65,8 +64,6 @@ func TestOauth(t *testing.T) {
 	req, _ := http.NewRequest("POST", ts.URL+"/login", nil)
 	req.Host = testInstance.Domain
 	_, _ = client.Do(req)
-
-	os.Exit(setup.Run())
 
 	t.Run("AccessCodeOauthFlow", func(t *testing.T) {
 		redirectURI := ts.URL + "/accounts/test-service/redirect"

--- a/web/apps/apps_test.go
+++ b/web/apps/apps_test.go
@@ -127,8 +127,6 @@ func TestApps(t *testing.T) {
 
 	_, token = setup.GetTestClient(consts.Apps + " " + consts.Konnectors)
 
-	os.Exit(setup.Run())
-
 	t.Run("Serve", func(t *testing.T) {
 		assertAuthGet(t, "/foo/", "text/html; charset=utf-8", `this is index.html. <a lang="en" href="https://cozywithapps.example.net/status/">Status</a>`)
 		assertAuthGet(t, "/foo/hello.html", "text/html; charset=utf-8", "world {{.Token}}")

--- a/web/apps/apps_test.go
+++ b/web/apps/apps_test.go
@@ -668,7 +668,6 @@ func TestApps(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 403, res.StatusCode)
 	})
-
 }
 
 func doGet(path string, auth bool) (*http.Response, error) {

--- a/web/apps/apps_test.go
+++ b/web/apps/apps_test.go
@@ -52,605 +52,11 @@ var slug string
 var jar *testutils.CookieJar
 var client *http.Client
 
-func doGet(path string, auth bool) (*http.Response, error) {
-	c := client
-	if !auth {
-		c = &http.Client{CheckRedirect: noRedirect}
-	}
-	req, err := http.NewRequest("GET", ts.URL+path, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Host = slug + "." + testInstance.Domain
-	return c.Do(req)
-}
-
-func doGetAll(t *testing.T, path string, auth bool) []byte {
-	res, err := doGet(path, auth)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	body, err := io.ReadAll(res.Body)
-	assert.NoError(t, err)
-	return body
-}
-
-func assertGet(t *testing.T, contentType, content string, res *http.Response) {
-	assert.Equal(t, 200, res.StatusCode)
-	actual := strings.ToLower(res.Header.Get("Content-Type"))
-	assert.Equal(t, contentType, actual)
-	body, _ := io.ReadAll(res.Body)
-	assert.Contains(t, string(body), content)
-}
-
-func assertAuthGet(t *testing.T, path, contentType, content string) {
-	res, err := doGet(path, true)
-	assert.NoError(t, err)
-	assertGet(t, contentType, content, res)
-}
-
-func assertAnonGet(t *testing.T, path, contentType, content string) {
-	res, err := doGet(path, false)
-	assert.NoError(t, err)
-	assertGet(t, contentType, content, res)
-}
-
-func assertNotPublic(t *testing.T, path string, code int, location string) {
-	res, err := doGet(path, false)
-	assert.NoError(t, err)
-	assert.Equal(t, code, res.StatusCode)
-	if 300 <= code && code < 400 {
-		assert.Equal(t, location, res.Header.Get("location"))
-	}
-}
-
-func assertNotFound(t *testing.T, path string) {
-	res, err := doGet(path, true)
-	assert.NoError(t, err)
-	assert.Equal(t, 404, res.StatusCode)
-}
-
-func TestServe(t *testing.T) {
-	assertAuthGet(t, "/foo/", "text/html; charset=utf-8", `this is index.html. <a lang="en" href="https://cozywithapps.example.net/status/">Status</a>`)
-	assertAuthGet(t, "/foo/hello.html", "text/html; charset=utf-8", "world {{.Token}}")
-	assertAuthGet(t, "/public", "text/html; charset=utf-8", "this is a file in public/")
-	assertAuthGet(t, "/public/index.html", "text/html; charset=utf-8", "this is a file in public/")
-	assertAnonGet(t, "/public", "text/html; charset=utf-8", "this is a file in public/")
-	assertAnonGet(t, "/public/index.html", "text/html; charset=utf-8", "this is a file in public/")
-	assertNotPublic(t, "/foo", 302, "https://cozywithapps.example.net/auth/login?redirect=https%3A%2F%2Fmini.cozywithapps.example.net%2Ffoo")
-	assertNotPublic(t, "/foo/hello.tml", 401, "")
-	assertNotFound(t, "/404")
-	assertNotFound(t, "/")
-	assertNotFound(t, "/index.html")
-	assertNotFound(t, "/public/hello.html")
-}
-
-func TestCozyBar(t *testing.T) {
-	body := doGetAll(t, "/bar/", true)
-	assert.Contains(t, string(body), `<link rel="stylesheet" type="text/css" href="//cozywithapps.example.net/assets/css/cozy-bar`)
-	assert.Contains(t, string(body), `<script src="//cozywithapps.example.net/assets/js/cozy-bar`)
-}
-
-func TestServeWithAnIntents(t *testing.T) {
-	intent := &intent.Intent{
-		Action: "PICK",
-		Type:   "io.cozy.foos",
-		Client: "io.cozy.apps/test-app",
-	}
-	err := intent.Save(testInstance)
-	assert.NoError(t, err)
-	err = intent.FillServices(testInstance)
-	assert.NoError(t, err)
-	assert.Len(t, intent.Services, 1)
-	err = intent.Save(testInstance)
-	assert.NoError(t, err)
-
-	path := strings.Replace(intent.Services[0].Href, "https://mini.cozywithapps.example.net", "", 1)
-	res, err := doGet(path, true)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	h := res.Header.Get(echo.HeaderContentSecurityPolicy)
-	assert.Contains(t, h, "frame-ancestors 'self' https://test-app.cozywithapps.example.net/;")
-}
-
-func TestFaviconWithContext(t *testing.T) {
-	context := "foo"
-
-	asset, ok := assets.Get("/favicon.ico", context)
-	if ok {
-		_ = assets.Remove(asset.Name, asset.Context)
-	}
-	// Create and insert an asset in foo context
-	tmpdir := os.TempDir()
-	_, err := os.OpenFile(filepath.Join(tmpdir, "custom_favicon.png"), os.O_RDWR|os.O_CREATE, 0600)
-	assert.NoError(t, err)
-
-	assetsOptions := []model.AssetOption{{
-		URL:     fmt.Sprintf("file://%s", filepath.Join(tmpdir, "custom_favicon.png")),
-		Name:    "/favicon.ico",
-		Context: context,
-	}}
-	err = dynamic.RegisterCustomExternals(assetsOptions, 1)
-	assert.NoError(t, err)
-
-	// Test the theme
-	assert.NoError(t, lifecycle.Patch(testInstance, &lifecycle.Options{
-		ContextName: context,
-	}))
-	assert.NoError(t, err)
-
-	res, err := doGet("/foo", true)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	body, _ := io.ReadAll(res.Body)
-	expected := `this is index.html. <a lang="en" href="https://cozywithapps.example.net/status/">Status</a>`
-	assert.Contains(t, string(body), expected)
-	assert.Contains(t, string(body), fmt.Sprintf("/assets/ext/%s/favicon.ico", context))
-	assert.NotContains(t, string(body), "/assets/favicon.ico")
-}
-
-func TestSessionCode(t *testing.T) {
-	// Create the OAuth client for the flagship app
-	flagship := oauth.Client{
-		RedirectURIs: []string{"cozy://flagship"},
-		ClientName:   "flagship-app",
-		SoftwareID:   "github.com/cozy/cozy-stack/testing/flagship",
-		Flagship:     true,
-	}
-	assert.Nil(t, flagship.Create(testInstance, oauth.NotPending))
-
-	// Create a maximal permission for it
-	token, err := testInstance.MakeJWT(consts.AccessTokenAudience,
-		flagship.ClientID, "*", "", time.Now())
-	assert.NoError(t, err)
-
-	// Create the session code
-	req, err := http.NewRequest("POST", ts.URL+"/auth/session_code", nil)
-	assert.NoError(t, err)
-	req.Host = testInstance.Domain
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 201, res.StatusCode)
-	var payload map[string]string
-	assert.NoError(t, json.NewDecoder(res.Body).Decode(&payload))
-	code := payload["session_code"]
-	assert.NotEmpty(t, code)
-
-	// Load a non-public page
-	assert.NoError(t, jar.Reset())
-	webview := &http.Client{Jar: jar}
-	req, err = http.NewRequest("GET", ts.URL+"/foo/?session_code="+code, nil)
-	assert.NoError(t, err)
-	req.Host = slug + "." + testInstance.Domain
-	res, err = webview.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	body, _ := io.ReadAll(res.Body)
-	assert.Contains(t, string(body), "this is index.html")
-
-	// Try again and check that the session code cannot be reused
-	assert.NoError(t, jar.Reset())
-	webview = &http.Client{Jar: jar, CheckRedirect: noRedirect}
-	req, err = http.NewRequest("GET", ts.URL+"/foo/?session_code="+code, nil)
-	assert.NoError(t, err)
-	req.Host = slug + "." + testInstance.Domain
-	res, err = webview.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 302, res.StatusCode)
-	assert.Contains(t, res.Header.Get("location"), "/auth/login")
-}
-
-func TestServeAppsWithJWTNotLogged(t *testing.T) {
-	config.GetConfig().Subdomains = config.FlatSubdomains
-	appHost := "cozywithapps-mini.example.net"
-
-	req, _ := http.NewRequest("GET", ts.URL+"/foo?jwt=abc", nil)
-	req.Host = appHost
-	c := &http.Client{CheckRedirect: noRedirect}
-	res, err := c.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 302, res.StatusCode)
-	location, err := url.Parse(res.Header.Get("Location"))
-	assert.NoError(t, err)
-	assert.Equal(t, "/auth/login", location.Path)
-
-	assert.Equal(t, testInstance.Domain, location.Host)
-	assert.NotEmpty(t, location.Query().Get("redirect"))
-	assert.Equal(t, "abc", location.Query().Get("jwt"))
-}
-
-func TestOauthAppCantInstallApp(t *testing.T) {
-	req, _ := http.NewRequest("POST", ts.URL+"/apps/mini-bis?Source=git://github.com/nono/cozy-mini.git", nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Host = testInstance.Domain
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 403, res.StatusCode)
-}
-
-func TestOauthAppCantUpdateApp(t *testing.T) {
-	req, _ := http.NewRequest("PUT", ts.URL+"/apps/mini", nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Host = testInstance.Domain
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 403, res.StatusCode)
-}
-
-func TestListApps(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/apps/", nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Host = testInstance.Domain
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-
-	var results map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&results)
-	assert.NoError(t, err)
-	objs := results["data"].([]interface{})
-	assert.Len(t, objs, 1)
-	data := objs[0].(map[string]interface{})
-	id := data["id"].(string)
-	assert.NotEmpty(t, id)
-	typ := data["type"].(string)
-	assert.Equal(t, "io.cozy.apps", typ)
-
-	attrs := data["attributes"].(map[string]interface{})
-	name := attrs["name"].(string)
-	assert.Equal(t, "Mini", name)
-	slug := attrs["slug"].(string)
-	assert.Equal(t, "mini", slug)
-
-	links := data["links"].(map[string]interface{})
-	self := links["self"].(string)
-	assert.Equal(t, "/apps/mini", self)
-	related := links["related"].(string)
-	assert.Equal(t, "https://cozywithapps-mini.example.net/", related)
-	icon := links["icon"].(string)
-	assert.Equal(t, "/apps/mini/icon/1.0.0", icon)
-}
-
-func TestIconForApp(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/apps/mini/icon", nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Host = testInstance.Domain
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	body, _ := io.ReadAll(res.Body)
-	assert.Equal(t, "<svg>...</svg>", string(body))
-}
-
-func TestDownloadApp(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/apps/mini/download", nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Host = testInstance.Domain
-	res, err := client.Do(req)
-	require.NoError(t, err)
-	require.Equal(t, 200, res.StatusCode)
-
-	mimeType, reader := filetype.FromReader(res.Body)
-	require.Equal(t, "application/gzip", mimeType)
-	gr, err := gzip.NewReader(reader)
-	require.NoError(t, err)
-	tr := tar.NewReader(gr)
-	indexFound := false
-	for {
-		header, err := tr.Next()
-		if err == io.EOF {
-			break
-		}
-		require.NoError(t, err)
-		if header.Name == "/index.html" {
-			indexFound = true
-		}
-	}
-	require.True(t, indexFound)
-}
-
-func TestDownloadKonnectorVersion(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/konnectors/mini/download/1.0.0", nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Host = testInstance.Domain
-	res, err := client.Do(req)
-	require.NoError(t, err)
-	require.Equal(t, 200, res.StatusCode)
-
-	mimeType, reader := filetype.FromReader(res.Body)
-	require.Equal(t, "application/gzip", mimeType)
-	gr, err := gzip.NewReader(reader)
-	require.NoError(t, err)
-	tr := tar.NewReader(gr)
-	iconFound := false
-	for {
-		header, err := tr.Next()
-		if err == io.EOF {
-			break
-		}
-		require.NoError(t, err)
-		if header.Name == "/icon.svg" {
-			iconFound = true
-		}
-	}
-	require.True(t, iconFound)
-}
-
-func TestOpenWebapp(t *testing.T) {
-	// Create the OAuth client for the flagship app
-	flagship := oauth.Client{
-		RedirectURIs: []string{"cozy://flagship"},
-		ClientName:   "flagship-app",
-		SoftwareID:   "github.com/cozy/cozy-stack/testing/flagship",
-		Flagship:     true,
-	}
-	require.Nil(t, flagship.Create(testInstance, oauth.NotPending))
-
-	// Create a maximal permission for it
-	token, err := testInstance.MakeJWT(consts.AccessTokenAudience,
-		flagship.ClientID, "*", "", time.Now())
-	require.NoError(t, err)
-
-	req, err := http.NewRequest("GET", ts.URL+"/apps/mini/open", nil)
-	require.NoError(t, err)
-	req.Host = testInstance.Domain
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-	require.Equal(t, 200, res.StatusCode)
-
-	var results map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&results)
-	assert.NoError(t, err)
-	data := results["data"].(map[string]interface{})
-	id := data["id"].(string)
-	assert.NotEmpty(t, id)
-	typ := data["type"].(string)
-	assert.Equal(t, "io.cozy.apps.open", typ)
-
-	attrs := data["attributes"].(map[string]interface{})
-	name := attrs["AppName"].(string)
-	assert.Equal(t, "Mini", name)
-	slug := attrs["AppSlug"].(string)
-	assert.Equal(t, "mini", slug)
-	icon := attrs["IconPath"].(string)
-	assert.Equal(t, "icon.svg", icon)
-	tracking := attrs["Tracking"].(string)
-	assert.Equal(t, "false", tracking)
-	subdomain := attrs["SubDomain"].(string)
-	assert.Equal(t, "flat", subdomain)
-	cookie := attrs["Cookie"].(string)
-	assert.Contains(t, cookie, "HttpOnly")
-	appToken := attrs["Token"].(string)
-	assert.NotEmpty(t, appToken)
-	flags := attrs["Flags"].(string)
-	assert.Equal(t, "{}", flags)
-
-	links := data["links"].(map[string]interface{})
-	self := links["self"].(string)
-	assert.Equal(t, "/apps/mini/open", self)
-}
-
-func TestUninstallAppWithLinkedClient(t *testing.T) {
-	// Install drive app
-	installer, err := apps.NewInstaller(testInstance, apps.Copier(consts.WebappType, testInstance),
-		&apps.InstallerOptions{
-			Operation:  apps.Install,
-			Type:       consts.WebappType,
-			Slug:       "drive",
-			SourceURL:  "registry://drive",
-			Registries: testInstance.Registries(),
-		},
-	)
-	assert.NoError(t, err)
-	_, err = installer.RunSync()
-	assert.NoError(t, err)
-
-	// Link an OAuthClient to drive
-	oauthClient := &oauth.Client{
-		ClientName:   "test-linked",
-		RedirectURIs: []string{"https://foobar"},
-		SoftwareID:   "registry://drive",
+func TestApps(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
 	}
 
-	oauthClient.Create(testInstance)
-	// Forcing the oauthClient to get a couchID for the purpose of later deletion
-	oauthClient, err = oauth.FindClient(testInstance, oauthClient.ClientID)
-	assert.NoError(t, err)
-
-	scope := "io.cozy.apps:ALL"
-	token, err := testInstance.MakeJWT("cli", "drive", scope, "", time.Now())
-	assert.NoError(t, err)
-
-	// Trying to remove this app
-	req, _ := http.NewRequest("DELETE", ts.URL+"/apps/drive", nil)
-	req.Host = testInstance.Domain
-
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 400, res.StatusCode)
-	body, err := io.ReadAll(res.Body)
-	assert.NoError(t, err)
-	assert.Contains(t, string(body), "linked OAuth client exists")
-
-	// Cleaning
-	uninstaller, err := apps.NewInstaller(testInstance, apps.Copier(consts.WebappType, testInstance),
-		&apps.InstallerOptions{
-			Operation:  apps.Delete,
-			Type:       consts.WebappType,
-			Slug:       "drive",
-			SourceURL:  "registry://drive",
-			Registries: testInstance.Registries(),
-		},
-	)
-	assert.NoError(t, err)
-	_, err = uninstaller.RunSync()
-	assert.NoError(t, err)
-	errc := oauthClient.Delete(testInstance)
-	assert.Nil(t, errc)
-}
-
-func TestUninstallAppWithoutLinkedClient(t *testing.T) {
-	// Install drive app
-	installer, err := apps.NewInstaller(testInstance, apps.Copier(consts.WebappType, testInstance),
-		&apps.InstallerOptions{
-			Operation:  apps.Install,
-			Type:       consts.WebappType,
-			Slug:       "drive",
-			SourceURL:  "registry://drive",
-			Registries: testInstance.Registries(),
-		},
-	)
-	assert.NoError(t, err)
-	_, err = installer.RunSync()
-	assert.NoError(t, err)
-
-	// Create an OAuth client not linked to drive
-	oauthClient := &oauth.Client{
-		ClientName:   "test-linked",
-		RedirectURIs: []string{"https://foobar"},
-		SoftwareID:   "foobarclient",
-	}
-	oauthClient.Create(testInstance)
-	// Forcing the oauthClient to get a couchID for the purpose of later deletion
-	oauthClient, err = oauth.FindClient(testInstance, oauthClient.ClientID)
-	assert.NoError(t, err)
-
-	scope := "io.cozy.apps:ALL"
-	token, err := testInstance.MakeJWT("cli", "drive", scope, "", time.Now())
-	assert.NoError(t, err)
-
-	// Trying to remove this app
-	req, _ := http.NewRequest("DELETE", ts.URL+"/apps/drive", nil)
-	req.Host = testInstance.Domain
-
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-
-	// Cleaning
-	errc := oauthClient.Delete(testInstance)
-	assert.Nil(t, errc)
-}
-
-func TestSendKonnectorLogsFromFlagshipApp(t *testing.T) {
-	initialOutput := logrus.New().Out
-	defer logrus.SetOutput(initialOutput)
-
-	testOutput := new(bytes.Buffer)
-	logrus.SetOutput(testOutput)
-
-	// Create the OAuth client for the flagship app
-	flagship := oauth.Client{
-		RedirectURIs: []string{"cozy://flagship"},
-		ClientName:   "flagship-app",
-		SoftwareID:   "github.com/cozy/cozy-stack/testing/flagship",
-		Flagship:     true,
-	}
-	require.Nil(t, flagship.Create(testInstance, oauth.NotPending))
-
-	// Give it the maximal permission
-	token, err := testInstance.MakeJWT(consts.AccessTokenAudience,
-		flagship.ClientID, "*", "", time.Now())
-	require.NoError(t, err)
-
-	// Send logs for a konnector
-	konnectorLogs := `[
-		{ "timestamp": "2022-10-27T17:13:38.382Z", "level": "error", "msg": "This is an error message" }
-	]`
-	req, _ := http.NewRequest("POST", ts.URL+"/konnectors/"+slug+"/logs", bytes.NewBufferString(konnectorLogs))
-	req.Host = testInstance.Domain
-	req.Header.Add("Authorization", "Bearer "+token)
-
-	res, err := client.Do(req)
-	require.NoError(t, err)
-	require.Equal(t, 204, res.StatusCode)
-
-	assert.Equal(t, `time="2022-10-27T17:13:38Z" level=error msg="This is an error message" domain=`+domain+" nspace=konnectors slug="+slug+"\n", testOutput.String())
-
-	// Send logs for a webapp
-	testOutput.Reset()
-	appLogs := `[
-		{ "timestamp": "2022-10-27T17:13:38.382Z", "level": "error", "msg": "This is an error message" }
-	]`
-	req, _ = http.NewRequest("POST", ts.URL+"/apps/"+slug+"/logs", bytes.NewBufferString(appLogs))
-	req.Host = testInstance.Domain
-	req.Header.Add("Authorization", "Bearer "+token)
-
-	res, err = client.Do(req)
-	require.NoError(t, err)
-	require.Equal(t, 204, res.StatusCode)
-
-	assert.Equal(t, `time="2022-10-27T17:13:38Z" level=error msg="This is an error message" domain=`+domain+" nspace=apps slug="+slug+"\n", testOutput.String())
-}
-
-func TestSendKonnectorLogsFromKonnector(t *testing.T) {
-	initialOutput := logrus.New().Out
-	defer logrus.SetOutput(initialOutput)
-
-	testOutput := new(bytes.Buffer)
-	logrus.SetOutput(testOutput)
-
-	token := testInstance.BuildKonnectorToken(slug)
-
-	konnectorLogs := `[
-		{ "timestamp": "2022-10-27T17:13:38.382Z", "level": "error", "msg": "This is an error message" }
-	]`
-	req, _ := http.NewRequest("POST", ts.URL+"/konnectors/"+slug+"/logs", bytes.NewBufferString(konnectorLogs))
-	req.Host = testInstance.Domain
-	req.Header.Add("Authorization", "Bearer "+token)
-
-	res, err := client.Do(req)
-	require.NoError(t, err)
-	require.Equal(t, 204, res.StatusCode)
-
-	assert.Equal(t, `time="2022-10-27T17:13:38Z" level=error msg="This is an error message" domain=`+domain+" nspace=konnectors slug="+slug+"\n", testOutput.String())
-
-	// Sending logs for a webapp should fail
-	req, _ = http.NewRequest("POST", ts.URL+"/apps/"+slug+"/logs", bytes.NewBufferString(konnectorLogs))
-	req.Host = testInstance.Domain
-	req.Header.Add("Authorization", "Bearer "+token)
-
-	res, err = client.Do(req)
-	require.NoError(t, err)
-	require.Equal(t, 403, res.StatusCode)
-}
-
-func TestSendAppLogsFromWebApp(t *testing.T) {
-	initialOutput := logrus.New().Out
-	defer logrus.SetOutput(initialOutput)
-
-	testOutput := new(bytes.Buffer)
-	logrus.SetOutput(testOutput)
-
-	token := testInstance.BuildAppToken(slug, "")
-
-	appLogs := `[
-		{ "timestamp": "2022-10-27T17:13:38.382Z", "level": "error", "msg": "This is an error message" }
-	]`
-	req, _ := http.NewRequest("POST", ts.URL+"/apps/"+slug+"/logs", bytes.NewBufferString(appLogs))
-	req.Host = testInstance.Domain
-	req.Header.Add("Authorization", "Bearer "+token)
-
-	res, err := client.Do(req)
-	require.NoError(t, err)
-	require.Equal(t, 204, res.StatusCode)
-
-	assert.Equal(t, `time="2022-10-27T17:13:38Z" level=error msg="This is an error message" domain=`+domain+" nspace=apps slug="+slug+"\n", testOutput.String())
-
-	// Sending logs for a konnector should fail
-	req, _ = http.NewRequest("POST", ts.URL+"/konnectors/"+slug+"/logs", bytes.NewBufferString(appLogs))
-	req.Host = testInstance.Domain
-	req.Header.Add("Authorization", "Bearer "+token)
-
-	res, err = client.Do(req)
-	require.NoError(t, err)
-	require.Equal(t, 403, res.StatusCode)
-}
-
-func TestMain(m *testing.M) {
 	config.UseTestFile()
 	config.GetConfig().Assets = "../../assets"
 	testutils.NeedCouchdb()
@@ -722,6 +128,605 @@ func TestMain(m *testing.M) {
 	_, token = setup.GetTestClient(consts.Apps + " " + consts.Konnectors)
 
 	os.Exit(setup.Run())
+
+	t.Run("Serve", func(t *testing.T) {
+		assertAuthGet(t, "/foo/", "text/html; charset=utf-8", `this is index.html. <a lang="en" href="https://cozywithapps.example.net/status/">Status</a>`)
+		assertAuthGet(t, "/foo/hello.html", "text/html; charset=utf-8", "world {{.Token}}")
+		assertAuthGet(t, "/public", "text/html; charset=utf-8", "this is a file in public/")
+		assertAuthGet(t, "/public/index.html", "text/html; charset=utf-8", "this is a file in public/")
+		assertAnonGet(t, "/public", "text/html; charset=utf-8", "this is a file in public/")
+		assertAnonGet(t, "/public/index.html", "text/html; charset=utf-8", "this is a file in public/")
+		assertNotPublic(t, "/foo", 302, "https://cozywithapps.example.net/auth/login?redirect=https%3A%2F%2Fmini.cozywithapps.example.net%2Ffoo")
+		assertNotPublic(t, "/foo/hello.tml", 401, "")
+		assertNotFound(t, "/404")
+		assertNotFound(t, "/")
+		assertNotFound(t, "/index.html")
+		assertNotFound(t, "/public/hello.html")
+	})
+
+	t.Run("CozyBar", func(t *testing.T) {
+		body := doGetAll(t, "/bar/", true)
+		assert.Contains(t, string(body), `<link rel="stylesheet" type="text/css" href="//cozywithapps.example.net/assets/css/cozy-bar`)
+		assert.Contains(t, string(body), `<script src="//cozywithapps.example.net/assets/js/cozy-bar`)
+	})
+
+	t.Run("ServeWithAnIntents", func(t *testing.T) {
+		intent := &intent.Intent{
+			Action: "PICK",
+			Type:   "io.cozy.foos",
+			Client: "io.cozy.apps/test-app",
+		}
+		err := intent.Save(testInstance)
+		assert.NoError(t, err)
+		err = intent.FillServices(testInstance)
+		assert.NoError(t, err)
+		assert.Len(t, intent.Services, 1)
+		err = intent.Save(testInstance)
+		assert.NoError(t, err)
+
+		path := strings.Replace(intent.Services[0].Href, "https://mini.cozywithapps.example.net", "", 1)
+		res, err := doGet(path, true)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		h := res.Header.Get(echo.HeaderContentSecurityPolicy)
+		assert.Contains(t, h, "frame-ancestors 'self' https://test-app.cozywithapps.example.net/;")
+	})
+
+	t.Run("FaviconWithContext", func(t *testing.T) {
+		context := "foo"
+
+		asset, ok := assets.Get("/favicon.ico", context)
+		if ok {
+			_ = assets.Remove(asset.Name, asset.Context)
+		}
+		// Create and insert an asset in foo context
+		tmpdir := os.TempDir()
+		_, err := os.OpenFile(filepath.Join(tmpdir, "custom_favicon.png"), os.O_RDWR|os.O_CREATE, 0600)
+		assert.NoError(t, err)
+
+		assetsOptions := []model.AssetOption{{
+			URL:     fmt.Sprintf("file://%s", filepath.Join(tmpdir, "custom_favicon.png")),
+			Name:    "/favicon.ico",
+			Context: context,
+		}}
+		err = dynamic.RegisterCustomExternals(assetsOptions, 1)
+		assert.NoError(t, err)
+
+		// Test the theme
+		assert.NoError(t, lifecycle.Patch(testInstance, &lifecycle.Options{
+			ContextName: context,
+		}))
+		assert.NoError(t, err)
+
+		res, err := doGet("/foo", true)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		body, _ := io.ReadAll(res.Body)
+		expected := `this is index.html. <a lang="en" href="https://cozywithapps.example.net/status/">Status</a>`
+		assert.Contains(t, string(body), expected)
+		assert.Contains(t, string(body), fmt.Sprintf("/assets/ext/%s/favicon.ico", context))
+		assert.NotContains(t, string(body), "/assets/favicon.ico")
+	})
+
+	t.Run("SessionCode", func(t *testing.T) {
+		// Create the OAuth client for the flagship app
+		flagship := oauth.Client{
+			RedirectURIs: []string{"cozy://flagship"},
+			ClientName:   "flagship-app",
+			SoftwareID:   "github.com/cozy/cozy-stack/testing/flagship",
+			Flagship:     true,
+		}
+		assert.Nil(t, flagship.Create(testInstance, oauth.NotPending))
+
+		// Create a maximal permission for it
+		token, err := testInstance.MakeJWT(consts.AccessTokenAudience,
+			flagship.ClientID, "*", "", time.Now())
+		assert.NoError(t, err)
+
+		// Create the session code
+		req, err := http.NewRequest("POST", ts.URL+"/auth/session_code", nil)
+		assert.NoError(t, err)
+		req.Host = testInstance.Domain
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 201, res.StatusCode)
+		var payload map[string]string
+		assert.NoError(t, json.NewDecoder(res.Body).Decode(&payload))
+		code := payload["session_code"]
+		assert.NotEmpty(t, code)
+
+		// Load a non-public page
+		assert.NoError(t, jar.Reset())
+		webview := &http.Client{Jar: jar}
+		req, err = http.NewRequest("GET", ts.URL+"/foo/?session_code="+code, nil)
+		assert.NoError(t, err)
+		req.Host = slug + "." + testInstance.Domain
+		res, err = webview.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		body, _ := io.ReadAll(res.Body)
+		assert.Contains(t, string(body), "this is index.html")
+
+		// Try again and check that the session code cannot be reused
+		assert.NoError(t, jar.Reset())
+		webview = &http.Client{Jar: jar, CheckRedirect: noRedirect}
+		req, err = http.NewRequest("GET", ts.URL+"/foo/?session_code="+code, nil)
+		assert.NoError(t, err)
+		req.Host = slug + "." + testInstance.Domain
+		res, err = webview.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 302, res.StatusCode)
+		assert.Contains(t, res.Header.Get("location"), "/auth/login")
+	})
+
+	t.Run("ServeAppsWithJWTNotLogged", func(t *testing.T) {
+		config.GetConfig().Subdomains = config.FlatSubdomains
+		appHost := "cozywithapps-mini.example.net"
+
+		req, _ := http.NewRequest("GET", ts.URL+"/foo?jwt=abc", nil)
+		req.Host = appHost
+		c := &http.Client{CheckRedirect: noRedirect}
+		res, err := c.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 302, res.StatusCode)
+		location, err := url.Parse(res.Header.Get("Location"))
+		assert.NoError(t, err)
+		assert.Equal(t, "/auth/login", location.Path)
+
+		assert.Equal(t, testInstance.Domain, location.Host)
+		assert.NotEmpty(t, location.Query().Get("redirect"))
+		assert.Equal(t, "abc", location.Query().Get("jwt"))
+	})
+
+	t.Run("OauthAppCantInstallApp", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", ts.URL+"/apps/mini-bis?Source=git://github.com/nono/cozy-mini.git", nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Host = testInstance.Domain
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 403, res.StatusCode)
+	})
+
+	t.Run("OauthAppCantUpdateApp", func(t *testing.T) {
+		req, _ := http.NewRequest("PUT", ts.URL+"/apps/mini", nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Host = testInstance.Domain
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 403, res.StatusCode)
+	})
+
+	t.Run("ListApps", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/apps/", nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Host = testInstance.Domain
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+
+		var results map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&results)
+		assert.NoError(t, err)
+		objs := results["data"].([]interface{})
+		assert.Len(t, objs, 1)
+		data := objs[0].(map[string]interface{})
+		id := data["id"].(string)
+		assert.NotEmpty(t, id)
+		typ := data["type"].(string)
+		assert.Equal(t, "io.cozy.apps", typ)
+
+		attrs := data["attributes"].(map[string]interface{})
+		name := attrs["name"].(string)
+		assert.Equal(t, "Mini", name)
+		slug := attrs["slug"].(string)
+		assert.Equal(t, "mini", slug)
+
+		links := data["links"].(map[string]interface{})
+		self := links["self"].(string)
+		assert.Equal(t, "/apps/mini", self)
+		related := links["related"].(string)
+		assert.Equal(t, "https://cozywithapps-mini.example.net/", related)
+		icon := links["icon"].(string)
+		assert.Equal(t, "/apps/mini/icon/1.0.0", icon)
+	})
+
+	t.Run("IconForApp", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/apps/mini/icon", nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Host = testInstance.Domain
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		body, _ := io.ReadAll(res.Body)
+		assert.Equal(t, "<svg>...</svg>", string(body))
+	})
+
+	t.Run("DownloadApp", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/apps/mini/download", nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Host = testInstance.Domain
+		res, err := client.Do(req)
+		require.NoError(t, err)
+		require.Equal(t, 200, res.StatusCode)
+
+		mimeType, reader := filetype.FromReader(res.Body)
+		require.Equal(t, "application/gzip", mimeType)
+		gr, err := gzip.NewReader(reader)
+		require.NoError(t, err)
+		tr := tar.NewReader(gr)
+		indexFound := false
+		for {
+			header, err := tr.Next()
+			if err == io.EOF {
+				break
+			}
+			require.NoError(t, err)
+			if header.Name == "/index.html" {
+				indexFound = true
+			}
+		}
+		require.True(t, indexFound)
+	})
+
+	t.Run("DownloadKonnectorVersion", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/konnectors/mini/download/1.0.0", nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Host = testInstance.Domain
+		res, err := client.Do(req)
+		require.NoError(t, err)
+		require.Equal(t, 200, res.StatusCode)
+
+		mimeType, reader := filetype.FromReader(res.Body)
+		require.Equal(t, "application/gzip", mimeType)
+		gr, err := gzip.NewReader(reader)
+		require.NoError(t, err)
+		tr := tar.NewReader(gr)
+		iconFound := false
+		for {
+			header, err := tr.Next()
+			if err == io.EOF {
+				break
+			}
+			require.NoError(t, err)
+			if header.Name == "/icon.svg" {
+				iconFound = true
+			}
+		}
+		require.True(t, iconFound)
+	})
+
+	t.Run("OpenWebapp", func(t *testing.T) {
+		// Create the OAuth client for the flagship app
+		flagship := oauth.Client{
+			RedirectURIs: []string{"cozy://flagship"},
+			ClientName:   "flagship-app",
+			SoftwareID:   "github.com/cozy/cozy-stack/testing/flagship",
+			Flagship:     true,
+		}
+		require.Nil(t, flagship.Create(testInstance, oauth.NotPending))
+
+		// Create a maximal permission for it
+		token, err := testInstance.MakeJWT(consts.AccessTokenAudience,
+			flagship.ClientID, "*", "", time.Now())
+		require.NoError(t, err)
+
+		req, err := http.NewRequest("GET", ts.URL+"/apps/mini/open", nil)
+		require.NoError(t, err)
+		req.Host = testInstance.Domain
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		require.Equal(t, 200, res.StatusCode)
+
+		var results map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&results)
+		assert.NoError(t, err)
+		data := results["data"].(map[string]interface{})
+		id := data["id"].(string)
+		assert.NotEmpty(t, id)
+		typ := data["type"].(string)
+		assert.Equal(t, "io.cozy.apps.open", typ)
+
+		attrs := data["attributes"].(map[string]interface{})
+		name := attrs["AppName"].(string)
+		assert.Equal(t, "Mini", name)
+		slug := attrs["AppSlug"].(string)
+		assert.Equal(t, "mini", slug)
+		icon := attrs["IconPath"].(string)
+		assert.Equal(t, "icon.svg", icon)
+		tracking := attrs["Tracking"].(string)
+		assert.Equal(t, "false", tracking)
+		subdomain := attrs["SubDomain"].(string)
+		assert.Equal(t, "flat", subdomain)
+		cookie := attrs["Cookie"].(string)
+		assert.Contains(t, cookie, "HttpOnly")
+		appToken := attrs["Token"].(string)
+		assert.NotEmpty(t, appToken)
+		flags := attrs["Flags"].(string)
+		assert.Equal(t, "{}", flags)
+
+		links := data["links"].(map[string]interface{})
+		self := links["self"].(string)
+		assert.Equal(t, "/apps/mini/open", self)
+	})
+
+	t.Run("UninstallAppWithLinkedClient", func(t *testing.T) {
+		// Install drive app
+		installer, err := apps.NewInstaller(testInstance, apps.Copier(consts.WebappType, testInstance),
+			&apps.InstallerOptions{
+				Operation:  apps.Install,
+				Type:       consts.WebappType,
+				Slug:       "drive",
+				SourceURL:  "registry://drive",
+				Registries: testInstance.Registries(),
+			},
+		)
+		assert.NoError(t, err)
+		_, err = installer.RunSync()
+		assert.NoError(t, err)
+
+		// Link an OAuthClient to drive
+		oauthClient := &oauth.Client{
+			ClientName:   "test-linked",
+			RedirectURIs: []string{"https://foobar"},
+			SoftwareID:   "registry://drive",
+		}
+
+		oauthClient.Create(testInstance)
+		// Forcing the oauthClient to get a couchID for the purpose of later deletion
+		oauthClient, err = oauth.FindClient(testInstance, oauthClient.ClientID)
+		assert.NoError(t, err)
+
+		scope := "io.cozy.apps:ALL"
+		token, err := testInstance.MakeJWT("cli", "drive", scope, "", time.Now())
+		assert.NoError(t, err)
+
+		// Trying to remove this app
+		req, _ := http.NewRequest("DELETE", ts.URL+"/apps/drive", nil)
+		req.Host = testInstance.Domain
+
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 400, res.StatusCode)
+		body, err := io.ReadAll(res.Body)
+		assert.NoError(t, err)
+		assert.Contains(t, string(body), "linked OAuth client exists")
+
+		// Cleaning
+		uninstaller, err := apps.NewInstaller(testInstance, apps.Copier(consts.WebappType, testInstance),
+			&apps.InstallerOptions{
+				Operation:  apps.Delete,
+				Type:       consts.WebappType,
+				Slug:       "drive",
+				SourceURL:  "registry://drive",
+				Registries: testInstance.Registries(),
+			},
+		)
+		assert.NoError(t, err)
+		_, err = uninstaller.RunSync()
+		assert.NoError(t, err)
+		errc := oauthClient.Delete(testInstance)
+		assert.Nil(t, errc)
+	})
+
+	t.Run("UninstallAppWithoutLinkedClient", func(t *testing.T) {
+		// Install drive app
+		installer, err := apps.NewInstaller(testInstance, apps.Copier(consts.WebappType, testInstance),
+			&apps.InstallerOptions{
+				Operation:  apps.Install,
+				Type:       consts.WebappType,
+				Slug:       "drive",
+				SourceURL:  "registry://drive",
+				Registries: testInstance.Registries(),
+			},
+		)
+		assert.NoError(t, err)
+		_, err = installer.RunSync()
+		assert.NoError(t, err)
+
+		// Create an OAuth client not linked to drive
+		oauthClient := &oauth.Client{
+			ClientName:   "test-linked",
+			RedirectURIs: []string{"https://foobar"},
+			SoftwareID:   "foobarclient",
+		}
+		oauthClient.Create(testInstance)
+		// Forcing the oauthClient to get a couchID for the purpose of later deletion
+		oauthClient, err = oauth.FindClient(testInstance, oauthClient.ClientID)
+		assert.NoError(t, err)
+
+		scope := "io.cozy.apps:ALL"
+		token, err := testInstance.MakeJWT("cli", "drive", scope, "", time.Now())
+		assert.NoError(t, err)
+
+		// Trying to remove this app
+		req, _ := http.NewRequest("DELETE", ts.URL+"/apps/drive", nil)
+		req.Host = testInstance.Domain
+
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+
+		// Cleaning
+		errc := oauthClient.Delete(testInstance)
+		assert.Nil(t, errc)
+	})
+
+	t.Run("SendKonnectorLogsFromFlagshipApp", func(t *testing.T) {
+		initialOutput := logrus.New().Out
+		defer logrus.SetOutput(initialOutput)
+
+		testOutput := new(bytes.Buffer)
+		logrus.SetOutput(testOutput)
+
+		// Create the OAuth client for the flagship app
+		flagship := oauth.Client{
+			RedirectURIs: []string{"cozy://flagship"},
+			ClientName:   "flagship-app",
+			SoftwareID:   "github.com/cozy/cozy-stack/testing/flagship",
+			Flagship:     true,
+		}
+		require.Nil(t, flagship.Create(testInstance, oauth.NotPending))
+
+		// Give it the maximal permission
+		token, err := testInstance.MakeJWT(consts.AccessTokenAudience,
+			flagship.ClientID, "*", "", time.Now())
+		require.NoError(t, err)
+
+		// Send logs for a konnector
+		konnectorLogs := `[
+		{ "timestamp": "2022-10-27T17:13:38.382Z", "level": "error", "msg": "This is an error message" }
+	]`
+		req, _ := http.NewRequest("POST", ts.URL+"/konnectors/"+slug+"/logs", bytes.NewBufferString(konnectorLogs))
+		req.Host = testInstance.Domain
+		req.Header.Add("Authorization", "Bearer "+token)
+
+		res, err := client.Do(req)
+		require.NoError(t, err)
+		require.Equal(t, 204, res.StatusCode)
+
+		assert.Equal(t, `time="2022-10-27T17:13:38Z" level=error msg="This is an error message" domain=`+domain+" nspace=konnectors slug="+slug+"\n", testOutput.String())
+
+		// Send logs for a webapp
+		testOutput.Reset()
+		appLogs := `[
+		{ "timestamp": "2022-10-27T17:13:38.382Z", "level": "error", "msg": "This is an error message" }
+	]`
+		req, _ = http.NewRequest("POST", ts.URL+"/apps/"+slug+"/logs", bytes.NewBufferString(appLogs))
+		req.Host = testInstance.Domain
+		req.Header.Add("Authorization", "Bearer "+token)
+
+		res, err = client.Do(req)
+		require.NoError(t, err)
+		require.Equal(t, 204, res.StatusCode)
+
+		assert.Equal(t, `time="2022-10-27T17:13:38Z" level=error msg="This is an error message" domain=`+domain+" nspace=apps slug="+slug+"\n", testOutput.String())
+	})
+
+	t.Run("SendKonnectorLogsFromKonnector", func(t *testing.T) {
+		initialOutput := logrus.New().Out
+		defer logrus.SetOutput(initialOutput)
+
+		testOutput := new(bytes.Buffer)
+		logrus.SetOutput(testOutput)
+
+		token := testInstance.BuildKonnectorToken(slug)
+
+		konnectorLogs := `[
+		{ "timestamp": "2022-10-27T17:13:38.382Z", "level": "error", "msg": "This is an error message" }
+	]`
+		req, _ := http.NewRequest("POST", ts.URL+"/konnectors/"+slug+"/logs", bytes.NewBufferString(konnectorLogs))
+		req.Host = testInstance.Domain
+		req.Header.Add("Authorization", "Bearer "+token)
+
+		res, err := client.Do(req)
+		require.NoError(t, err)
+		require.Equal(t, 204, res.StatusCode)
+
+		assert.Equal(t, `time="2022-10-27T17:13:38Z" level=error msg="This is an error message" domain=`+domain+" nspace=konnectors slug="+slug+"\n", testOutput.String())
+
+		// Sending logs for a webapp should fail
+		req, _ = http.NewRequest("POST", ts.URL+"/apps/"+slug+"/logs", bytes.NewBufferString(konnectorLogs))
+		req.Host = testInstance.Domain
+		req.Header.Add("Authorization", "Bearer "+token)
+
+		res, err = client.Do(req)
+		require.NoError(t, err)
+		require.Equal(t, 403, res.StatusCode)
+	})
+
+	t.Run("SendAppLogsFromWebApp", func(t *testing.T) {
+		initialOutput := logrus.New().Out
+		defer logrus.SetOutput(initialOutput)
+
+		testOutput := new(bytes.Buffer)
+		logrus.SetOutput(testOutput)
+
+		token := testInstance.BuildAppToken(slug, "")
+
+		appLogs := `[
+		{ "timestamp": "2022-10-27T17:13:38.382Z", "level": "error", "msg": "This is an error message" }
+	]`
+		req, _ := http.NewRequest("POST", ts.URL+"/apps/"+slug+"/logs", bytes.NewBufferString(appLogs))
+		req.Host = testInstance.Domain
+		req.Header.Add("Authorization", "Bearer "+token)
+
+		res, err := client.Do(req)
+		require.NoError(t, err)
+		require.Equal(t, 204, res.StatusCode)
+
+		assert.Equal(t, `time="2022-10-27T17:13:38Z" level=error msg="This is an error message" domain=`+domain+" nspace=apps slug="+slug+"\n", testOutput.String())
+
+		// Sending logs for a konnector should fail
+		req, _ = http.NewRequest("POST", ts.URL+"/konnectors/"+slug+"/logs", bytes.NewBufferString(appLogs))
+		req.Host = testInstance.Domain
+		req.Header.Add("Authorization", "Bearer "+token)
+
+		res, err = client.Do(req)
+		require.NoError(t, err)
+		require.Equal(t, 403, res.StatusCode)
+	})
+
+}
+
+func doGet(path string, auth bool) (*http.Response, error) {
+	c := client
+	if !auth {
+		c = &http.Client{CheckRedirect: noRedirect}
+	}
+	req, err := http.NewRequest("GET", ts.URL+path, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Host = slug + "." + testInstance.Domain
+	return c.Do(req)
+}
+
+func doGetAll(t *testing.T, path string, auth bool) []byte {
+	res, err := doGet(path, auth)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, res.StatusCode)
+	body, err := io.ReadAll(res.Body)
+	assert.NoError(t, err)
+	return body
+}
+
+func assertGet(t *testing.T, contentType, content string, res *http.Response) {
+	assert.Equal(t, 200, res.StatusCode)
+	actual := strings.ToLower(res.Header.Get("Content-Type"))
+	assert.Equal(t, contentType, actual)
+	body, _ := io.ReadAll(res.Body)
+	assert.Contains(t, string(body), content)
+}
+
+func assertAuthGet(t *testing.T, path, contentType, content string) {
+	res, err := doGet(path, true)
+	assert.NoError(t, err)
+	assertGet(t, contentType, content, res)
+}
+
+func assertAnonGet(t *testing.T, path, contentType, content string) {
+	res, err := doGet(path, false)
+	assert.NoError(t, err)
+	assertGet(t, contentType, content, res)
+}
+
+func assertNotPublic(t *testing.T, path string, code int, location string) {
+	res, err := doGet(path, false)
+	assert.NoError(t, err)
+	assert.Equal(t, code, res.StatusCode)
+	if 300 <= code && code < 400 {
+		assert.Equal(t, location, res.Header.Get("location"))
+	}
+}
+
+func assertNotFound(t *testing.T, path string) {
+	res, err := doGet(path, true)
+	assert.NoError(t, err)
+	assert.Equal(t, 404, res.StatusCode)
 }
 
 func noRedirect(*http.Request, []*http.Request) error {

--- a/web/apps/apps_test.go
+++ b/web/apps/apps_test.go
@@ -60,7 +60,8 @@ func TestApps(t *testing.T) {
 	config.UseTestFile()
 	config.GetConfig().Assets = "../../assets"
 	testutils.NeedCouchdb()
-	setup := testutils.NewSetup(m, "apps_test")
+	setup := testutils.NewSetup(nil, t.Name())
+	t.Cleanup(setup.Cleanup)
 	err := setup.SetupSwiftTest()
 	if err != nil {
 		panic("Could not init Swift test")

--- a/web/auth/auth_test.go
+++ b/web/auth/auth_test.go
@@ -2064,7 +2064,6 @@ func TestAuth(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "404 Not Found", res.Status)
 	})
-
 }
 
 func getSessionID(cookies []*http.Cookie) string {

--- a/web/auth/auth_test.go
+++ b/web/auth/auth_test.go
@@ -80,7 +80,8 @@ func TestAuth(t *testing.T) {
 
 	_ = web.LoadSupportedLocales()
 	testutils.NeedCouchdb()
-	setup := testutils.NewSetup(m, "auth_test")
+	setup := testutils.NewSetup(nil, t.Name())
+	t.Cleanup(setup.Cleanup)
 
 	testInstance = setup.GetTestInstance(&lifecycle.Options{
 		Domain:        domain,

--- a/web/auth/auth_test.go
+++ b/web/auth/auth_test.go
@@ -65,1987 +65,11 @@ var linkedCode string
 var confirmCode string
 var konnSlug string
 
-func getSessionID(cookies []*http.Cookie) string {
-	for _, c := range cookies {
-		if c.Name == session.CookieName(testInstance) {
-			b, err := base64.RawURLEncoding.DecodeString(c.Value)
-			if err != nil {
-				return ""
-			}
-			return string(b[8 : 8+32])
-		}
-	}
-	return ""
-}
-
-func TestInstanceBlocked(t *testing.T) {
-	// Block the instance
-	testInstance.Blocked = true
-	_ = testInstance.Update()
-
-	req, _ := http.NewRequest("GET", ts.URL+"/auth/login", nil)
-	req.Host = testInstance.Domain
-
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, http.StatusServiceUnavailable, res.StatusCode)
-
-	// Trying with a Accept: text/html header to simulate a browser
-	req.Header.Add("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
-	res2, err := client.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, http.StatusServiceUnavailable, res2.StatusCode)
-	body, err := io.ReadAll(res2.Body)
-	assert.NoError(t, err)
-	assert.Contains(t, string(body), "<title>Cozy</title>")
-	assert.Contains(t, string(body), "Your Cozy has been blocked</h1>")
-
-	// Unblock the instance
-	testInstance.Blocked = false
-	_ = testInstance.Update()
-}
-
-func TestIsLoggedInWhenNotLoggedIn(t *testing.T) {
-	content, err := getTestURL()
-	assert.NoError(t, err)
-	assert.Equal(t, "who_are_you", content)
-}
-
-func TestHomeWhenNotLoggedIn(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/", nil)
-	req.Host = domain
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	if assert.Equal(t, "303 See Other", res.Status) {
-		assert.Equal(t, "https://cozy.example.net/auth/login",
-			res.Header.Get("Location"))
-	}
-}
-
-func TestHomeWhenNotLoggedInWithJWT(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/?jwt=foobar", nil)
-	req.Host = domain
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	if assert.Equal(t, "303 See Other", res.Status) {
-		assert.Equal(t, "https://cozy.example.net/auth/login?jwt=foobar",
-			res.Header.Get("Location"))
-	}
-}
-
-func TestShowLoginPage(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/auth/login", nil)
-	req.Host = domain
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "200 OK", res.Status)
-	assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
-	body, _ := io.ReadAll(res.Body)
-	assert.Contains(t, string(body), "Log in")
-}
-
-func TestShowLoginPageWithRedirectBadURL(t *testing.T) {
-	req1, _ := http.NewRequest("GET", ts.URL+"/auth/login?redirect="+url.QueryEscape(" "), nil)
-	req1.Host = domain
-	res1, err := client.Do(req1)
-	assert.NoError(t, err)
-	defer res1.Body.Close()
-	assert.Equal(t, "400 Bad Request", res1.Status)
-	assert.Equal(t, "text/plain; charset=UTF-8", res1.Header.Get("Content-Type"))
-
-	req2, _ := http.NewRequest("GET", ts.URL+"/auth/login?redirect="+url.QueryEscape("foo.bar"), nil)
-	req2.Host = domain
-	res2, err := client.Do(req2)
-	assert.NoError(t, err)
-	defer res2.Body.Close()
-	assert.Equal(t, "400 Bad Request", res2.Status)
-	assert.Equal(t, "text/plain; charset=UTF-8", res2.Header.Get("Content-Type"))
-
-	req3, _ := http.NewRequest("GET", ts.URL+"/auth/login?redirect="+url.QueryEscape("ftp://sub."+domain+"/foo"), nil)
-	req3.Host = domain
-	res3, err := client.Do(req3)
-	assert.NoError(t, err)
-	defer res3.Body.Close()
-	assert.Equal(t, "400 Bad Request", res3.Status)
-	assert.Equal(t, "text/plain; charset=UTF-8", res3.Header.Get("Content-Type"))
-}
-
-func TestShowLoginPageWithRedirectXSS(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/auth/login?redirect="+url.QueryEscape("https://sub."+domain+"/<script>alert('foo')</script>"), nil)
-	req.Host = domain
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "200 OK", res.Status)
-	assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
-	body, _ := io.ReadAll(res.Body)
-	assert.NotContains(t, string(body), "<script>")
-	assert.Contains(t, string(body), "%3Cscript%3Ealert%28%27foo%27%29%3C/script%3E")
-}
-
-func TestShowLoginPageWithRedirectFragment(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/auth/login?redirect="+url.QueryEscape("https://"+domain+"/auth/authorize#myfragment"), nil)
-	req.Host = domain
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "200 OK", res.Status)
-	assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
-	body, _ := io.ReadAll(res.Body)
-	assert.NotContains(t, string(body), "myfragment")
-	assert.Contains(t, string(body), `<input id="redirect" type="hidden" name="redirect" value="https://cozy.example.net/auth/authorize#=" />`)
-}
-
-func TestShowLoginPageWithRedirectSuccess(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/auth/login?redirect="+url.QueryEscape("https://sub."+domain+"/foo/bar?query=foo#myfragment"), nil)
-	req.Host = domain
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "200 OK", res.Status)
-	assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
-	body, _ := io.ReadAll(res.Body)
-	assert.Contains(t, string(body), `<input id="redirect" type="hidden" name="redirect" value="https://sub.cozy.example.net/foo/bar?query=foo#myfragment" />`)
-}
-
-func getLoginCSRFToken(c *http.Client, t *testing.T) string {
-	req, _ := http.NewRequest("GET", ts.URL+"/auth/login", nil)
-	req.Host = domain
-	res, err := c.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	return res.Cookies()[0].Value
-}
-
-func TestLoginWithoutCSRFToken(t *testing.T) {
-	res, err := postForm("/auth/login", &url.Values{
-		"passphrase": {"MyPassphrase"},
-	})
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "400 Bad Request", res.Status)
-}
-
-func TestLoginWithBadPassphrase(t *testing.T) {
-	res, err := postForm("/auth/login", &url.Values{
-		"passphrase": {"Nope"},
-		"csrf_token": {getLoginCSRFToken(client, t)},
-	})
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "401 Unauthorized", res.Status)
-}
-
-func TestLoginWithGoodPassphrase(t *testing.T) {
-	token := getLoginCSRFToken(client, t)
-	res, err := postForm("/auth/login", &url.Values{
-		"passphrase": {"MyPassphrase"},
-		"csrf_token": {token},
-	})
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	if assert.Equal(t, "303 See Other", res.Status) {
-		assert.Equal(t, "https://home.cozy.example.net/",
-			res.Header.Get("Location"))
-		cookies := res.Cookies()
-		assert.Len(t, cookies, 2)
-		assert.Equal(t, cookies[0].Name, "_csrf")
-		assert.Equal(t, cookies[0].Value, token)
-		assert.Equal(t, cookies[1].Name, session.CookieName(testInstance))
-		assert.NotEmpty(t, cookies[1].Value)
-
-		var results []*session.LoginEntry
-		err = couchdb.GetAllDocs(
-			testInstance,
-			consts.SessionsLogins,
-			&couchdb.AllDocsRequest{Limit: 100},
-			&results,
-		)
-		assert.NoError(t, err)
-		assert.Equal(t, 1, len(results))
-		assert.Equal(t, "Go-http-client/1.1", results[0].UA)
-		assert.Equal(t, "127.0.0.1", results[0].IP)
-		assert.False(t, results[0].CreatedAt.IsZero())
-	}
-}
-
-func TestLoginWithRedirect(t *testing.T) {
-	res1, err := postForm("/auth/login", &url.Values{
-		"passphrase": {"MyPassphrase"},
-		"redirect":   {"foo.bar"},
-		"csrf_token": {getLoginCSRFToken(client, t)},
-	})
-	assert.NoError(t, err)
-	defer res1.Body.Close()
-	assert.Equal(t, "400 Bad Request", res1.Status)
-
-	res2, err := postForm("/auth/login", &url.Values{
-		"passphrase": {"MyPassphrase"},
-		"redirect":   {"https://sub." + domain + "/#myfragment"},
-		"csrf_token": {getLoginCSRFToken(client, t)},
-	})
-	assert.NoError(t, err)
-	defer res2.Body.Close()
-	if assert.Equal(t, "303 See Other", res2.Status) {
-		assert.Equal(t, "https://sub.cozy.example.net/#myfragment",
-			res2.Header.Get("Location"))
-	}
-}
-
-func TestDelegatedJWTLoginWithRedirect(t *testing.T) {
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, session.ExternalClaims{
-		RegisteredClaims: jwt.RegisteredClaims{
-			Subject:   "sruti",
-			IssuedAt:  jwt.NewNumericDate(time.Now()),
-			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
-		},
-		Name:  domain,
-		Email: "sruti@external.notmycozy.net",
-		Code:  "student",
-	})
-	signed, err := token.SignedString(JWTSecret)
-	assert.NoError(t, err)
-	req, _ := http.NewRequest("GET", ts.URL+"/auth/login?jwt="+signed, nil)
-	req.Host = domain
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, http.StatusSeeOther, res.StatusCode)
-}
-
-func TestIsLoggedInAfterLogin(t *testing.T) {
-	content, err := getTestURL()
-	assert.NoError(t, err)
-	assert.Equal(t, "logged_in", content)
-}
-
-func TestHomeWhenLoggedIn(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/", nil)
-	req.Host = domain
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	if assert.Equal(t, "303 See Other", res.Status) {
-		assert.Equal(t, "https://home.cozy.example.net/",
-			res.Header.Get("Location"))
-	}
-}
-
-func TestRegisterClientNotJSON(t *testing.T) {
-	res, err := postForm("/auth/register", &url.Values{"foo": {"bar"}})
-	assert.NoError(t, err)
-	assert.Equal(t, "400 Bad Request", res.Status)
-	res.Body.Close()
-}
-
-func TestRegisterClientNoRedirectURI(t *testing.T) {
-	res, err := postJSON("/auth/register", echo.Map{
-		"client_name": "cozy-test",
-		"software_id": "github.com/cozy/cozy-test",
-	})
-	assert.NoError(t, err)
-	assert.Equal(t, "400 Bad Request", res.Status)
-	var body map[string]string
-	err = json.NewDecoder(res.Body).Decode(&body)
-	assert.NoError(t, err)
-	assert.Equal(t, "invalid_redirect_uri", body["error"])
-	assert.Equal(t, "redirect_uris is mandatory", body["error_description"])
-}
-
-func TestRegisterClientInvalidRedirectURI(t *testing.T) {
-	res, err := postJSON("/auth/register", echo.Map{
-		"redirect_uris": []string{"http://example.org/foo#bar"},
-		"client_name":   "cozy-test",
-		"software_id":   "github.com/cozy/cozy-test",
-	})
-	assert.NoError(t, err)
-	assert.Equal(t, "400 Bad Request", res.Status)
-	var body map[string]string
-	err = json.NewDecoder(res.Body).Decode(&body)
-	assert.NoError(t, err)
-	assert.Equal(t, "invalid_redirect_uri", body["error"])
-	assert.Equal(t, "http://example.org/foo#bar is invalid", body["error_description"])
-}
-
-func TestRegisterClientNoClientName(t *testing.T) {
-	res, err := postJSON("/auth/register", echo.Map{
-		"redirect_uris": []string{"https://example.org/oauth/callback"},
-		"software_id":   "github.com/cozy/cozy-test",
-	})
-	assert.NoError(t, err)
-	assert.Equal(t, "400 Bad Request", res.Status)
-	var body map[string]string
-	err = json.NewDecoder(res.Body).Decode(&body)
-	assert.NoError(t, err)
-	assert.Equal(t, "invalid_client_metadata", body["error"])
-	assert.Equal(t, "client_name is mandatory", body["error_description"])
-}
-
-func TestRegisterClientNoSoftwareID(t *testing.T) {
-	res, err := postJSON("/auth/register", echo.Map{
-		"redirect_uris": []string{"https://example.org/oauth/callback"},
-		"client_name":   "cozy-test",
-	})
-	assert.NoError(t, err)
-	assert.Equal(t, "400 Bad Request", res.Status)
-	var body map[string]string
-	err = json.NewDecoder(res.Body).Decode(&body)
-	assert.NoError(t, err)
-	assert.Equal(t, "invalid_client_metadata", body["error"])
-	assert.Equal(t, "software_id is mandatory", body["error_description"])
-}
-
-func TestRegisterClientSuccessWithJustMandatoryFields(t *testing.T) {
-	res, err := postJSON("/auth/register", echo.Map{
-		"redirect_uris": []string{"https://example.org/oauth/callback"},
-		"client_name":   "cozy-test",
-		"software_id":   "github.com/cozy/cozy-test",
-	})
-	assert.NoError(t, err)
-	assert.Equal(t, "201 Created", res.Status)
-	var client oauth.Client
-	err = json.NewDecoder(res.Body).Decode(&client)
-	assert.NoError(t, err)
-	assert.NotEqual(t, client.ClientID, "")
-	assert.NotEqual(t, client.ClientID, "ignored")
-	assert.NotEqual(t, client.ClientSecret, "")
-	assert.NotEqual(t, client.ClientSecret, "ignored")
-	assert.NotEqual(t, client.RegistrationToken, "")
-	assert.NotEqual(t, client.RegistrationToken, "ignored")
-	assert.Equal(t, client.SecretExpiresAt, 0)
-	assert.Equal(t, client.RedirectURIs, []string{"https://example.org/oauth/callback"})
-	assert.Equal(t, client.GrantTypes, []string{"authorization_code", "refresh_token"})
-	assert.Equal(t, client.ResponseTypes, []string{"code"})
-	assert.Equal(t, client.ClientName, "cozy-test")
-	assert.Equal(t, client.SoftwareID, "github.com/cozy/cozy-test")
-	clientID = client.ClientID
-	clientSecret = client.ClientSecret
-	registrationToken = client.RegistrationToken
-}
-
-func TestRegisterClientSuccessWithAllFields(t *testing.T) {
-	res, err := postJSON("/auth/register", echo.Map{
-		"_id":                       "ignored",
-		"_rev":                      "ignored",
-		"client_id":                 "ignored",
-		"client_secret":             "ignored",
-		"client_secret_expires_at":  42,
-		"registration_access_token": "ignored",
-		"redirect_uris":             []string{"https://example.org/oauth/callback"},
-		"grant_types":               []string{"ignored"},
-		"response_types":            []string{"ignored"},
-		"client_name":               "new-cozy-test",
-		"client_kind":               "test",
-		"client_uri":                "https://github.com/cozy/cozy-test",
-		"logo_uri":                  "https://raw.github.com/cozy/cozy-setup/gh-pages/assets/images/happycloud.png",
-		"policy_uri":                "https://github/com/cozy/cozy-test/master/policy.md",
-		"software_id":               "github.com/cozy/cozy-test",
-		"software_version":          "v0.1.2",
-	})
-	assert.NoError(t, err)
-	assert.Equal(t, "201 Created", res.Status)
-	var client oauth.Client
-	err = json.NewDecoder(res.Body).Decode(&client)
-	assert.NoError(t, err)
-	assert.Equal(t, client.CouchID, "")
-	assert.Equal(t, client.CouchRev, "")
-	assert.NotEqual(t, client.ClientID, "")
-	assert.NotEqual(t, client.ClientID, "ignored")
-	assert.NotEqual(t, client.ClientID, clientID)
-	assert.NotEqual(t, client.ClientSecret, "")
-	assert.NotEqual(t, client.ClientSecret, "ignored")
-	assert.NotEqual(t, client.RegistrationToken, "")
-	assert.NotEqual(t, client.RegistrationToken, "ignored")
-	assert.Equal(t, client.SecretExpiresAt, 0)
-	assert.Equal(t, client.RedirectURIs, []string{"https://example.org/oauth/callback"})
-	assert.Equal(t, client.GrantTypes, []string{"authorization_code", "refresh_token"})
-	assert.Equal(t, client.ResponseTypes, []string{"code"})
-	assert.Equal(t, client.ClientName, "new-cozy-test")
-	assert.Equal(t, client.ClientKind, "test")
-	assert.Equal(t, client.ClientURI, "https://github.com/cozy/cozy-test")
-	assert.Equal(t, client.LogoURI, "https://raw.github.com/cozy/cozy-setup/gh-pages/assets/images/happycloud.png")
-	assert.Equal(t, client.PolicyURI, "https://github/com/cozy/cozy-test/master/policy.md")
-	assert.Equal(t, client.SoftwareID, "github.com/cozy/cozy-test")
-	assert.Equal(t, client.SoftwareVersion, "v0.1.2")
-	altClientID = client.ClientID
-	altRegistrationToken = client.RegistrationToken
-}
-
-func TestRegisterSharingClientSuccess(t *testing.T) {
-	res, err := postJSON("/auth/register", echo.Map{
-		"redirect_uris": []string{"https://cozy.example.org/sharings/answer"},
-		"client_name":   "John",
-		"software_id":   "github.com/cozy/cozy-stack",
-		"client_kind":   "sharing",
-		"client_uri":    "https://cozy.example.org",
-	})
-	assert.NoError(t, err)
-	assert.Equal(t, "201 Created", res.Status)
-	var client oauth.Client
-	err = json.NewDecoder(res.Body).Decode(&client)
-	assert.NoError(t, err)
-	assert.NotEqual(t, client.ClientID, "")
-	assert.NotEqual(t, client.ClientID, "ignored")
-	assert.NotEqual(t, client.ClientSecret, "")
-	assert.NotEqual(t, client.ClientSecret, "ignored")
-	assert.NotEqual(t, client.RegistrationToken, "")
-	assert.NotEqual(t, client.RegistrationToken, "ignored")
-	assert.Equal(t, client.SecretExpiresAt, 0)
-	assert.Equal(t, client.RedirectURIs, []string{"https://cozy.example.org/sharings/answer"})
-	assert.Equal(t, client.ClientName, "John")
-	assert.Equal(t, client.SoftwareID, "github.com/cozy/cozy-stack")
-	sharingClientID = client.ClientID
-}
-
-func TestDeleteClientNoToken(t *testing.T) {
-	req, _ := http.NewRequest("DELETE", ts.URL+"/auth/register/"+altClientID, nil)
-	req.Host = domain
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, "401 Unauthorized", res.Status)
-}
-
-func TestDeleteClientSuccess(t *testing.T) {
-	req, _ := http.NewRequest("DELETE", ts.URL+"/auth/register/"+altClientID, nil)
-	req.Host = domain
-	req.Header.Add("Authorization", "Bearer "+altRegistrationToken)
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, "204 No Content", res.Status)
-
-	// And next calls should return a 204 too
-	res2, err := client.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, "204 No Content", res2.Status)
-}
-
-func TestReadClientNoToken(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/auth/register/"+clientID, nil)
-	req.Host = domain
-	req.Header.Add("Accept", "application/json")
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, "401 Unauthorized", res.Status)
-	buf, _ := io.ReadAll(res.Body)
-	assert.NotContains(t, string(buf), clientSecret)
-}
-
-func TestReadClientInvalidToken(t *testing.T) {
-	res, err := getJSON("/auth/register/"+clientID, altRegistrationToken)
-	assert.NoError(t, err)
-	assert.Equal(t, "401 Unauthorized", res.Status)
-	buf, _ := io.ReadAll(res.Body)
-	assert.NotContains(t, string(buf), clientSecret)
-}
-
-func TestReadClientInvalidClientID(t *testing.T) {
-	res, err := getJSON("/auth/register/"+altClientID, registrationToken)
-	assert.NoError(t, err)
-	assert.Equal(t, "404 Not Found", res.Status)
-}
-
-func TestReadClientSuccess(t *testing.T) {
-	res, err := getJSON("/auth/register/"+clientID, registrationToken)
-	assert.NoError(t, err)
-	assert.Equal(t, "200 OK", res.Status)
-	var client oauth.Client
-	err = json.NewDecoder(res.Body).Decode(&client)
-	assert.NoError(t, err)
-	assert.Equal(t, client.ClientID, clientID)
-	assert.Equal(t, client.ClientSecret, clientSecret)
-	assert.Equal(t, client.SecretExpiresAt, 0)
-	assert.Equal(t, client.RegistrationToken, "")
-	assert.Equal(t, client.RedirectURIs, []string{"https://example.org/oauth/callback"})
-	assert.Equal(t, client.GrantTypes, []string{"authorization_code", "refresh_token"})
-	assert.Equal(t, client.ResponseTypes, []string{"code"})
-	assert.Equal(t, client.ClientName, "cozy-test")
-	assert.Equal(t, client.SoftwareID, "github.com/cozy/cozy-test")
-}
-
-func TestUpdateClientDeletedClientID(t *testing.T) {
-	res, err := putJSON("/auth/register/"+altClientID, registrationToken, echo.Map{
-		"client_id": altClientID,
-	})
-	assert.NoError(t, err)
-	assert.Equal(t, "404 Not Found", res.Status)
-}
-
-func TestUpdateClientInvalidClientID(t *testing.T) {
-	res, err := putJSON("/auth/register/"+clientID, registrationToken, echo.Map{
-		"client_id": "123456789",
-	})
-	assert.NoError(t, err)
-	assert.Equal(t, "400 Bad Request", res.Status)
-	var body map[string]string
-	err = json.NewDecoder(res.Body).Decode(&body)
-	assert.NoError(t, err)
-	assert.Equal(t, "invalid_client_id", body["error"])
-	assert.Equal(t, "client_id is mandatory", body["error_description"])
-}
-
-func TestUpdateClientNoRedirectURI(t *testing.T) {
-	res, err := putJSON("/auth/register/"+clientID, registrationToken, echo.Map{
-		"client_id":   clientID,
-		"client_name": "cozy-test",
-		"software_id": "github.com/cozy/cozy-test",
-	})
-	assert.NoError(t, err)
-	assert.Equal(t, "400 Bad Request", res.Status)
-	var body map[string]string
-	err = json.NewDecoder(res.Body).Decode(&body)
-	assert.NoError(t, err)
-	assert.Equal(t, "invalid_redirect_uri", body["error"])
-	assert.Equal(t, "redirect_uris is mandatory", body["error_description"])
-}
-
-func TestUpdateClientSuccess(t *testing.T) {
-	res, err := putJSON("/auth/register/"+clientID, registrationToken, echo.Map{
-		"client_id":        clientID,
-		"redirect_uris":    []string{"https://example.org/oauth/callback"},
-		"client_name":      "cozy-test",
-		"software_id":      "github.com/cozy/cozy-test",
-		"software_version": "v0.1.3",
-	})
-	assert.NoError(t, err)
-	assert.NoError(t, err)
-	assert.Equal(t, "200 OK", res.Status)
-	var client oauth.Client
-	err = json.NewDecoder(res.Body).Decode(&client)
-	assert.NoError(t, err)
-	assert.Equal(t, client.ClientID, clientID)
-	assert.Equal(t, client.ClientSecret, clientSecret)
-	assert.Equal(t, client.SecretExpiresAt, 0)
-	assert.Equal(t, client.RegistrationToken, "")
-	assert.Equal(t, client.RedirectURIs, []string{"https://example.org/oauth/callback"})
-	assert.Equal(t, client.GrantTypes, []string{"authorization_code", "refresh_token"})
-	assert.Equal(t, client.ResponseTypes, []string{"code"})
-	assert.Equal(t, client.ClientName, "cozy-test")
-	assert.Equal(t, client.SoftwareID, "github.com/cozy/cozy-test")
-	assert.Equal(t, client.SoftwareVersion, "v0.1.3")
-}
-
-func TestUpdateClientSecret(t *testing.T) {
-	res, err := putJSON("/auth/register/"+clientID, registrationToken, echo.Map{
-		"client_id":        clientID,
-		"client_secret":    clientSecret,
-		"redirect_uris":    []string{"https://example.org/oauth/callback"},
-		"client_name":      "cozy-test",
-		"software_id":      "github.com/cozy/cozy-test",
-		"software_version": "v0.1.4",
-	})
-	assert.NoError(t, err)
-	assert.NoError(t, err)
-	assert.Equal(t, "200 OK", res.Status)
-	var client oauth.Client
-	err = json.NewDecoder(res.Body).Decode(&client)
-	assert.NoError(t, err)
-	assert.Equal(t, client.ClientID, clientID)
-	assert.NotEqual(t, client.ClientSecret, "")
-	assert.NotEqual(t, client.ClientSecret, clientSecret)
-	assert.Equal(t, client.SecretExpiresAt, 0)
-	assert.Equal(t, client.RegistrationToken, "")
-	assert.Equal(t, client.RedirectURIs, []string{"https://example.org/oauth/callback"})
-	assert.Equal(t, client.GrantTypes, []string{"authorization_code", "refresh_token"})
-	assert.Equal(t, client.ResponseTypes, []string{"code"})
-	assert.Equal(t, client.ClientName, "cozy-test")
-	assert.Equal(t, client.SoftwareID, "github.com/cozy/cozy-test")
-	assert.Equal(t, client.SoftwareVersion, "v0.1.4")
-	clientSecret = client.ClientSecret
-}
-
-func TestAuthorizeFormRedirectsWhenNotLoggedIn(t *testing.T) {
-	anonymousClient := &http.Client{CheckRedirect: noRedirect}
-	u := url.QueryEscape("https://example.org/oauth/callback")
-	req, _ := http.NewRequest("GET", ts.URL+"/auth/authorize?response_type=code&state=123456&scope=files:read&redirect_uri="+u+"&client_id="+clientID, nil)
-	req.Host = domain
-	res, err := anonymousClient.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "303 See Other", res.Status)
-}
-
-func TestAuthorizeFormBadResponseType(t *testing.T) {
-	u := url.QueryEscape("https://example.org/oauth/callback")
-	req, _ := http.NewRequest("GET", ts.URL+"/auth/authorize?response_type=token&state=123456&scope=files:read&redirect_uri="+u+"&client_id="+clientID, nil)
-	req.Host = domain
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "400 Bad Request", res.Status)
-	assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
-	body, _ := io.ReadAll(res.Body)
-	assert.Contains(t, string(body), "Invalid response type")
-}
-
-func TestAuthorizeFormNoState(t *testing.T) {
-	u := url.QueryEscape("https://example.org/oauth/callback")
-	req, _ := http.NewRequest("GET", ts.URL+"/auth/authorize?response_type=code&scope=files:read&redirect_uri="+u+"&client_id="+clientID, nil)
-	req.Host = domain
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "400 Bad Request", res.Status)
-	assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
-	body, _ := io.ReadAll(res.Body)
-	assert.Contains(t, string(body), "The state parameter is mandatory")
-}
-
-func TestAuthorizeFormNoClientId(t *testing.T) {
-	u := url.QueryEscape("https://example.org/oauth/callback")
-	req, _ := http.NewRequest("GET", ts.URL+"/auth/authorize?response_type=code&state=123456&scope=files:read&redirect_uri="+u, nil)
-	req.Host = domain
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "400 Bad Request", res.Status)
-	assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
-	body, _ := io.ReadAll(res.Body)
-	assert.Contains(t, string(body), "The client_id parameter is mandatory")
-}
-
-func TestAuthorizeFormNoRedirectURI(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/auth/authorize?response_type=code&state=123456&scope=files:read&client_id="+clientID, nil)
-	req.Host = domain
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "400 Bad Request", res.Status)
-	assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
-	body, _ := io.ReadAll(res.Body)
-	assert.Contains(t, string(body), "The redirect_uri parameter is mandatory")
-}
-
-func TestAuthorizeFormNoScope(t *testing.T) {
-	u := url.QueryEscape("https://example.org/oauth/callback")
-	req, _ := http.NewRequest("GET", ts.URL+"/auth/authorize?response_type=code&state=123456&redirect_uri="+u+"&client_id="+clientID, nil)
-	req.Host = domain
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "400 Bad Request", res.Status)
-	assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
-	body, _ := io.ReadAll(res.Body)
-	assert.Contains(t, string(body), "The scope parameter is mandatory")
-}
-
-func TestAuthorizeFormInvalidClient(t *testing.T) {
-	u := url.QueryEscape("https://example.org/oauth/callback")
-	req, _ := http.NewRequest("GET", ts.URL+"/auth/authorize?response_type=code&state=123456&scope=files:read&redirect_uri="+u+"&client_id=f00", nil)
-	req.Host = domain
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "400 Bad Request", res.Status)
-	assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
-	body, _ := io.ReadAll(res.Body)
-	assert.Contains(t, string(body), "The client must be registered")
-}
-
-func TestAuthorizeFormInvalidRedirectURI(t *testing.T) {
-	u := url.QueryEscape("https://evil.com/")
-	req, _ := http.NewRequest("GET", ts.URL+"/auth/authorize?response_type=code&state=123456&scope=files:read&redirect_uri="+u+"&client_id="+clientID, nil)
-	req.Host = domain
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "400 Bad Request", res.Status)
-	assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
-	body, _ := io.ReadAll(res.Body)
-	assert.Contains(t, string(body), "The redirect_uri parameter doesn&#39;t match the registered ones")
-}
-
-func TestAuthorizeFormSuccess(t *testing.T) {
-	u := url.QueryEscape("https://example.org/oauth/callback")
-	req, _ := http.NewRequest("GET", ts.URL+"/auth/authorize?response_type=code&state=123456&scope=files:read&redirect_uri="+u+"&client_id="+clientID, nil)
-	req.Host = domain
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "200 OK", res.Status)
-	assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
-	body, _ := io.ReadAll(res.Body)
-	assert.Contains(t, string(body), "would like permission to access your Cozy")
-	re := regexp.MustCompile(`<input type="hidden" name="csrf_token" value="(\w+)"`)
-	matches := re.FindStringSubmatch(string(body))
-	if assert.Len(t, matches, 2) {
-		csrfToken = matches[1]
-	}
-}
-
-func TestAuthorizeFormClientMobileApp(t *testing.T) {
-	var oauthClient oauth.Client
-
-	u := "https://example.org/oauth/callback"
-	oauthClient.RedirectURIs = []string{u}
-	oauthClient.ClientName = "cozy-test-2"
-	oauthClient.SoftwareID = "registry://drive"
-	oauthClient.Create(testInstance)
-
-	req, _ := http.NewRequest("GET", ts.URL+"/auth/authorize?response_type=code&state=123456&redirect_uri="+u+"&client_id="+oauthClient.ClientID, nil)
-	req.Host = testInstance.Domain
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	content, _ := io.ReadAll(res.Body)
-	assert.Contains(t, string(content), "io.cozy.files")
-	defer res.Body.Close()
-}
-
-func TestAuthorizeFormFlagshipApp(t *testing.T) {
-	u := url.QueryEscape("https://example.org/oauth/callback")
-	req, _ := http.NewRequest("GET", ts.URL+"/auth/authorize?response_type=code&state=123456&scope=*&redirect_uri="+u+"&client_id="+clientID+"&code_challenge=w6uP8Tcg6K2QR905Rms8iXTlksL6OD1KOWBxTK7wxPI&code_challenge_method=S256", nil)
-	req.Host = domain
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "200 OK", res.Status)
-	assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
-	body, _ := io.ReadAll(res.Body)
-	assert.NotContains(t, string(body), "would like permission to access your Cozy")
-	assert.Contains(t, string(body), "The origin of this application is not certified.")
-}
-
-func TestAuthorizeWhenNotLoggedIn(t *testing.T) {
-	anonymousClient := &http.Client{CheckRedirect: noRedirect}
-	v := &url.Values{
-		"state":        {"123456"},
-		"client_id":    {clientID},
-		"redirect_uri": {"https://example.org/oauth/callback"},
-		"scope":        {"files:read"},
-		"csrf_token":   {csrfToken},
-	}
-	req, _ := http.NewRequest("POST", ts.URL+"/auth/authorize", bytes.NewBufferString(v.Encode()))
-	req.Host = domain
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	res, err := anonymousClient.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "403 Forbidden", res.Status)
-}
-
-func TestAuthorizeWithInvalidCSRFToken(t *testing.T) {
-	res, err := postForm("/auth/authorize", &url.Values{
-		"state":        {"123456"},
-		"client_id":    {clientID},
-		"redirect_uri": {"https://example.org/oauth/callback"},
-		"scope":        {"files:read"},
-		"csrf_token":   {"azertyuiop"},
-	})
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "403 Forbidden", res.Status)
-	body, _ := io.ReadAll(res.Body)
-	assert.Contains(t, string(body), "invalid csrf token")
-}
-
-func TestAuthorizeWithNoState(t *testing.T) {
-	res, err := postForm("/auth/authorize", &url.Values{
-		"client_id":    {clientID},
-		"redirect_uri": {"https://example.org/oauth/callback"},
-		"scope":        {"files:read"},
-		"csrf_token":   {csrfToken},
-	})
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "400 Bad Request", res.Status)
-	assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
-	body, _ := io.ReadAll(res.Body)
-	assert.Contains(t, string(body), "The state parameter is mandatory")
-}
-
-func TestAuthorizeWithNoClientID(t *testing.T) {
-	res, err := postForm("/auth/authorize", &url.Values{
-		"state":        {"123456"},
-		"redirect_uri": {"https://example.org/oauth/callback"},
-		"scope":        {"files:read"},
-		"csrf_token":   {csrfToken},
-	})
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "400 Bad Request", res.Status)
-	assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
-	body, _ := io.ReadAll(res.Body)
-	assert.Contains(t, string(body), "The client_id parameter is mandatory")
-}
-
-func TestAuthorizeWithInvalidClientID(t *testing.T) {
-	res, err := postForm("/auth/authorize", &url.Values{
-		"state":         {"123456"},
-		"client_id":     {"987"},
-		"redirect_uri":  {"https://example.org/oauth/callback"},
-		"scope":         {"files:read"},
-		"csrf_token":    {csrfToken},
-		"response_type": {"code"},
-	})
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "400 Bad Request", res.Status)
-	assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
-	body, _ := io.ReadAll(res.Body)
-	assert.Contains(t, string(body), "The client must be registered")
-}
-
-func TestAuthorizeWithNoRedirectURI(t *testing.T) {
-	res, err := postForm("/auth/authorize", &url.Values{
-		"state":         {"123456"},
-		"client_id":     {clientID},
-		"scope":         {"files:read"},
-		"csrf_token":    {csrfToken},
-		"response_type": {"code"},
-	})
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "400 Bad Request", res.Status)
-	assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
-	body, _ := io.ReadAll(res.Body)
-	assert.Contains(t, string(body), "The redirect_uri parameter is mandatory")
-}
-
-func TestAuthorizeWithInvalidURI(t *testing.T) {
-	res, err := postForm("/auth/authorize", &url.Values{
-		"state":         {"123456"},
-		"client_id":     {clientID},
-		"redirect_uri":  {"/oauth/callback"},
-		"scope":         {"files:read"},
-		"csrf_token":    {csrfToken},
-		"response_type": {"code"},
-	})
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "400 Bad Request", res.Status)
-	assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
-	body, _ := io.ReadAll(res.Body)
-	assert.Contains(t, string(body), "The redirect_uri parameter doesn&#39;t match the registered ones")
-}
-
-func TestAuthorizeWithNoScope(t *testing.T) {
-	res, err := postForm("/auth/authorize", &url.Values{
-		"state":         {"123456"},
-		"client_id":     {clientID},
-		"redirect_uri":  {"https://example.org/oauth/callback"},
-		"csrf_token":    {csrfToken},
-		"response_type": {"code"},
-	})
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "400 Bad Request", res.Status)
-	assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
-	body, _ := io.ReadAll(res.Body)
-	assert.Contains(t, string(body), "The scope parameter is mandatory")
-}
-
-func TestAuthorizeSuccess(t *testing.T) {
-	res, err := postForm("/auth/authorize", &url.Values{
-		"state":         {"123456"},
-		"client_id":     {clientID},
-		"redirect_uri":  {"https://example.org/oauth/callback"},
-		"scope":         {"files:read"},
-		"csrf_token":    {csrfToken},
-		"response_type": {"code"},
-	})
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	if assert.Equal(t, "302 Found", res.Status) {
-		var results []oauth.AccessCode
-		req := &couchdb.AllDocsRequest{}
-		err = couchdb.GetAllDocs(testInstance, consts.OAuthAccessCodes, req, &results)
-		assert.NoError(t, err)
-		if assert.Len(t, results, 1) {
-			code = results[0].Code
-			expected := fmt.Sprintf("https://example.org/oauth/callback?access_code=%s&code=%s&state=123456#", code, code)
-			assert.Equal(t, expected, res.Header.Get("Location"))
-			assert.Equal(t, results[0].ClientID, clientID)
-			assert.Equal(t, results[0].Scope, "files:read")
-		}
-	}
-}
-
-func TestAuthorizeSuccessOnboardingDeeplink(t *testing.T) {
-	var oauthClient oauth.Client
-	oauthClient.RedirectURIs = []string{"cozydrive://"}
-	oauthClient.ClientName = "cozy-test-install-app"
-	oauthClient.SoftwareID = "io.cozy.mobile.drive"
-	oauthClient.OnboardingSecret = "toto"
-	oauthClient.Create(testInstance)
-
-	u := url.QueryEscape("https://example.org/oauth/callback")
-	req, _ := http.NewRequest("GET", ts.URL+"/auth/authorize?response_type=code&state=123456&scope=files:read&redirect_uri="+u+"&client_id="+clientID, nil)
-	req.Host = domain
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "200 OK", res.Status)
-	assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
-	body, _ := io.ReadAll(res.Body)
-	assert.Contains(t, string(body), "would like permission to access your Cozy")
-	re := regexp.MustCompile(`<input type="hidden" name="csrf_token" value="(\w+)"`)
-	matches := re.FindStringSubmatch(string(body))
-	if assert.Len(t, matches, 2) {
-		csrfToken = matches[1]
+func TestAuth(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
 	}
 
-	v := &url.Values{
-		"state":         {"123456"},
-		"client_id":     {oauthClient.ClientID},
-		"redirect_uri":  {"cozydrive://"},
-		"scope":         {"files:read"},
-		"csrf_token":    {csrfToken},
-		"response_type": {"code"},
-	}
-	req, err = http.NewRequest("POST", ts.URL+"/auth/authorize", bytes.NewBufferString(v.Encode()))
-	assert.NoError(t, err)
-	req.Host = domain
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Add("Accept", "application/json")
-	res, err = client.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	if assert.Equal(t, 200, res.StatusCode) {
-		content, err := io.ReadAll(res.Body)
-		assert.NoError(t, err)
-		assert.Contains(t, string(content), "\"deeplink\":")
-	}
-}
-
-func TestAuthorizeSuccessOnboarding(t *testing.T) {
-	var oauthClient oauth.Client
-	u := "https://example.org/oauth/callback"
-	oauthClient.RedirectURIs = []string{u}
-	oauthClient.ClientName = "cozy-test-install-app"
-	oauthClient.SoftwareID = "io.cozy.mobile.drive"
-	oauthClient.OnboardingSecret = "toto"
-	oauthClient.Create(testInstance)
-
-	res, err := postForm("/auth/authorize", &url.Values{
-		"state":         {"123456"},
-		"client_id":     {oauthClient.ClientID},
-		"redirect_uri":  {"https://example.org/oauth/callback"},
-		"scope":         {"files:read"},
-		"csrf_token":    {csrfToken},
-		"response_type": {"code"},
-	})
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, 302, res.StatusCode)
-}
-
-func TestInstallAppWithLinkedApp(t *testing.T) {
-	var oauthClient oauth.Client
-	u := "https://example.org/oauth/callback"
-	oauthClient.RedirectURIs = []string{u}
-	oauthClient.ClientName = "cozy-test-install-app"
-	oauthClient.SoftwareID = "registry://drive"
-	oauthClient.Create(testInstance)
-
-	linkedClientID = oauthClient.ClientID         // Used for following tests
-	linkedClientSecret = oauthClient.ClientSecret // Used for following tests
-
-	res, err := postForm("/auth/authorize", &url.Values{
-		"state":         {"123456"},
-		"client_id":     {oauthClient.ClientID},
-		"redirect_uri":  {u},
-		"csrf_token":    {csrfToken},
-		"response_type": {"code"},
-	})
-
-	assert.NoError(t, err)
-	assert.Equal(t, 302, res.StatusCode)
-	defer res.Body.Close()
-	couch := config.CouchCluster(testInstance.DBCluster())
-	db := testInstance.DBPrefix() + "%2F" + consts.Apps
-	err = couchdb.EnsureDBExist(testInstance, consts.Apps)
-	assert.NoError(t, err)
-	reqGetChanges, err := http.NewRequest("GET", couch.URL.String()+couchdb.EscapeCouchdbName(db)+"/_changes?feed=longpoll", nil)
-	assert.NoError(t, err)
-	if auth := couch.Auth; auth != nil {
-		if p, ok := auth.Password(); ok {
-			reqGetChanges.SetBasicAuth(auth.Username(), p)
-		}
-	}
-	resGetChanges, err := config.CouchClient().Do(reqGetChanges)
-	assert.NoError(t, err)
-	defer resGetChanges.Body.Close()
-	assert.Equal(t, resGetChanges.StatusCode, 200)
-	body, err := io.ReadAll(resGetChanges.Body)
-	assert.NoError(t, err)
-	assert.Contains(t, string(body), "io.cozy.apps/drive")
-
-	var results []oauth.AccessCode
-	reqDocs := &couchdb.AllDocsRequest{}
-	err = couchdb.GetAllDocs(testInstance, consts.OAuthAccessCodes, reqDocs, &results)
-	assert.NoError(t, err)
-	for _, result := range results {
-		if result.ClientID == linkedClientID {
-			linkedCode = result.Code
-			break
-		}
-	}
-}
-
-func TestCheckLinkedAppInstalled(t *testing.T) {
-	// We use the webapp drive installed from the previous test
-	err := auth.CheckLinkedAppInstalled(testInstance, "drive")
-	assert.NoError(t, err)
-}
-
-func TestAccessTokenLinkedAppInstalled(t *testing.T) {
-	res, err := postForm("/auth/access_token", &url.Values{
-		"grant_type":    {"authorization_code"},
-		"client_id":     {linkedClientID},
-		"client_secret": {linkedClientSecret},
-		"code":          {linkedCode},
-	})
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, 200, res.StatusCode)
-	var response map[string]string
-	err = json.NewDecoder(res.Body).Decode(&response)
-	assert.NoError(t, err)
-	assert.Equal(t, "bearer", response["token_type"])
-	assert.Equal(t, "@io.cozy.apps/drive", response["scope"])
-	assertValidToken(t, response["access_token"], "access", linkedClientID, "@io.cozy.apps/drive")
-	assertValidToken(t, response["refresh_token"], "refresh", linkedClientID, "@io.cozy.apps/drive")
-}
-
-func TestAccessTokenNoGrantType(t *testing.T) {
-	res, err := postForm("/auth/access_token", &url.Values{
-		"client_id":     {clientID},
-		"client_secret": {clientSecret},
-		"code":          {code},
-	})
-	assert.NoError(t, err)
-	assertJSONError(t, res, "the grant_type parameter is mandatory")
-}
-
-func TestAccessTokenInvalidGrantType(t *testing.T) {
-	res, err := postForm("/auth/access_token", &url.Values{
-		"grant_type":    {"token"},
-		"client_id":     {clientID},
-		"client_secret": {clientSecret},
-		"code":          {code},
-	})
-	assert.NoError(t, err)
-	assertJSONError(t, res, "invalid grant type")
-}
-
-func TestAccessTokenNoClientID(t *testing.T) {
-	res, err := postForm("/auth/access_token", &url.Values{
-		"grant_type":    {"authorization_code"},
-		"client_secret": {clientSecret},
-		"code":          {code},
-	})
-	assert.NoError(t, err)
-	assertJSONError(t, res, "the client_id parameter is mandatory")
-}
-
-func TestAccessTokenInvalidClientID(t *testing.T) {
-	res, err := postForm("/auth/access_token", &url.Values{
-		"grant_type":    {"authorization_code"},
-		"client_id":     {"foo"},
-		"client_secret": {clientSecret},
-		"code":          {code},
-	})
-	assert.NoError(t, err)
-	assertJSONError(t, res, "the client must be registered")
-}
-
-func TestAccessTokenNoClientSecret(t *testing.T) {
-	res, err := postForm("/auth/access_token", &url.Values{
-		"grant_type": {"authorization_code"},
-		"client_id":  {clientID},
-		"code":       {code},
-	})
-	assert.NoError(t, err)
-	assertJSONError(t, res, "the client_secret parameter is mandatory")
-}
-
-func TestAccessTokenInvalidClientSecret(t *testing.T) {
-	res, err := postForm("/auth/access_token", &url.Values{
-		"grant_type":    {"authorization_code"},
-		"client_id":     {clientID},
-		"client_secret": {"foo"},
-		"code":          {code},
-	})
-	assert.NoError(t, err)
-	assertJSONError(t, res, "invalid client_secret")
-}
-
-func TestAccessTokenNoCode(t *testing.T) {
-	res, err := postForm("/auth/access_token", &url.Values{
-		"grant_type":    {"authorization_code"},
-		"client_id":     {clientID},
-		"client_secret": {clientSecret},
-	})
-	assert.NoError(t, err)
-	assertJSONError(t, res, "the code parameter is mandatory")
-}
-
-func TestAccessTokenInvalidCode(t *testing.T) {
-	res, err := postForm("/auth/access_token", &url.Values{
-		"grant_type":    {"authorization_code"},
-		"client_id":     {clientID},
-		"client_secret": {clientSecret},
-		"code":          {"foo"},
-	})
-	assert.NoError(t, err)
-	assertJSONError(t, res, "invalid code")
-}
-
-func TestAccessTokenSuccess(t *testing.T) {
-	res, err := postForm("/auth/access_token", &url.Values{
-		"grant_type":    {"authorization_code"},
-		"client_id":     {clientID},
-		"client_secret": {clientSecret},
-		"code":          {code},
-	})
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "200 OK", res.Status)
-	var response map[string]string
-	err = json.NewDecoder(res.Body).Decode(&response)
-	assert.NoError(t, err)
-	assert.Equal(t, "bearer", response["token_type"])
-	assert.Equal(t, "files:read", response["scope"])
-	assertValidToken(t, response["access_token"], "access", clientID, "files:read")
-	assertValidToken(t, response["refresh_token"], "refresh", clientID, "files:read")
-	refreshToken = response["refresh_token"]
-}
-
-func TestRefreshTokenNoToken(t *testing.T) {
-	res, err := postForm("/auth/access_token", &url.Values{
-		"grant_type":    {"refresh_token"},
-		"client_id":     {clientID},
-		"client_secret": {clientSecret},
-	})
-	assert.NoError(t, err)
-	assertJSONError(t, res, "invalid refresh token")
-}
-
-func TestRefreshTokenInvalidToken(t *testing.T) {
-	res, err := postForm("/auth/access_token", &url.Values{
-		"grant_type":    {"refresh_token"},
-		"client_id":     {clientID},
-		"client_secret": {clientSecret},
-		"refresh_token": {"foo"},
-	})
-	assert.NoError(t, err)
-	assertJSONError(t, res, "invalid refresh token")
-}
-
-func TestRefreshTokenInvalidSigningMethod(t *testing.T) {
-	claims := permission.Claims{
-		StandardClaims: crypto.StandardClaims{
-			Audience: consts.RefreshTokenAudience,
-			Issuer:   domain,
-			IssuedAt: crypto.Timestamp(),
-			Subject:  clientID,
-		},
-		Scope: "files:write",
-	}
-	token := jwt.NewWithClaims(jwt.GetSigningMethod("none"), claims)
-	fakeToken, err := token.SignedString(jwt.UnsafeAllowNoneSignatureType)
-	assert.NoError(t, err)
-	res, err := postForm("/auth/access_token", &url.Values{
-		"grant_type":    {"refresh_token"},
-		"client_id":     {clientID},
-		"client_secret": {clientSecret},
-		"refresh_token": {fakeToken},
-	})
-	assert.NoError(t, err)
-	assertJSONError(t, res, "invalid refresh token")
-}
-
-func TestRefreshTokenSuccess(t *testing.T) {
-	res, err := postForm("/auth/access_token", &url.Values{
-		"grant_type":    {"refresh_token"},
-		"client_id":     {clientID},
-		"client_secret": {clientSecret},
-		"refresh_token": {refreshToken},
-	})
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "200 OK", res.Status)
-	var response map[string]string
-	err = json.NewDecoder(res.Body).Decode(&response)
-	assert.NoError(t, err)
-	assert.Equal(t, "bearer", response["token_type"])
-	assert.Equal(t, "files:read", response["scope"])
-	assert.Equal(t, "", response["refresh_token"])
-	assertValidToken(t, response["access_token"], "access", clientID, "files:read")
-}
-
-func TestOAuthWithPKCE(t *testing.T) {
-	/* Values taken from https://datatracker.ietf.org/doc/html/rfc7636#appendix-B */
-	challenge := "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
-	verifier := "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
-
-	/* 1. GET /auth/authorize */
-	u := url.QueryEscape("https://example.org/oauth/callback")
-	req, _ := http.NewRequest("GET", ts.URL+"/auth/authorize?response_type=code&state=123456&scope=files:read&redirect_uri="+u+"&client_id="+clientID+"&code_challenge_method=S256&code_challenge="+challenge, nil)
-	req.Host = domain
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	require.Equal(t, res.StatusCode, 200)
-	body, _ := io.ReadAll(res.Body)
-	re := regexp.MustCompile(`<input type="hidden" name="csrf_token" value="(\w+)"`)
-	matches := re.FindStringSubmatch(string(body))
-	require.Len(t, matches, 2)
-	csrfToken = matches[1]
-
-	/* 2. POST /auth/authorize */
-	res, err = postForm("/auth/authorize", &url.Values{
-		"state":                 {"123456"},
-		"client_id":             {clientID},
-		"redirect_uri":          {"https://example.org/oauth/callback"},
-		"scope":                 {"files:read"},
-		"csrf_token":            {csrfToken},
-		"response_type":         {"code"},
-		"code_challenge":        {challenge},
-		"code_challenge_method": {"S256"},
-	})
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	require.Equal(t, "302 Found", res.Status)
-	var results []oauth.AccessCode
-	allReq := &couchdb.AllDocsRequest{}
-	err = couchdb.GetAllDocs(testInstance, consts.OAuthAccessCodes, allReq, &results)
-	assert.NoError(t, err)
-	var code string
-	for _, result := range results {
-		if result.Challenge != "" {
-			code = result.Code
-		}
-	}
-	require.NotEmpty(t, code)
-
-	/* 3. POST /auth/access_token without code_verifier must fail */
-	res, err = postForm("/auth/access_token", &url.Values{
-		"grant_type":    {"authorization_code"},
-		"client_id":     {clientID},
-		"client_secret": {clientSecret},
-		"code":          {code},
-	})
-	assert.NoError(t, err)
-	assertJSONError(t, res, "invalid code_verifier")
-
-	/* 4. POST /auth/access_token with code_verifier should succeed */
-	res, err = postForm("/auth/access_token", &url.Values{
-		"grant_type":    {"authorization_code"},
-		"client_id":     {clientID},
-		"client_secret": {clientSecret},
-		"code":          {code},
-		"code_verifier": {verifier},
-	})
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	require.Equal(t, res.StatusCode, 200)
-	var response map[string]string
-	err = json.NewDecoder(res.Body).Decode(&response)
-	assert.NoError(t, err)
-	assert.Equal(t, "bearer", response["token_type"])
-	assert.Equal(t, "files:read", response["scope"])
-	assertValidToken(t, response["access_token"], "access", clientID, "files:read")
-	assertValidToken(t, response["refresh_token"], "refresh", clientID, "files:read")
-}
-
-func TestConfirmFlagship(t *testing.T) {
-	token, code, err := oauth.GenerateConfirmCode(testInstance, clientID)
-	require.NoError(t, err)
-
-	res, err := postForm("/auth/clients/"+clientID+"/flagship", &url.Values{
-		"code":  {code},
-		"token": {string(token)},
-	})
-	require.NoError(t, err)
-	assert.Equal(t, 204, res.StatusCode)
-
-	client, err := oauth.FindClient(testInstance, clientID)
-	require.NoError(t, err)
-	assert.True(t, client.Flagship)
-}
-
-func TestLoginFlagship(t *testing.T) {
-	oauthClient := &oauth.Client{
-		RedirectURIs:    []string{"cozy://flagship"},
-		ClientName:      "Cozy Flagship",
-		ClientKind:      "mobile",
-		SoftwareID:      "cozy-flagship",
-		SoftwareVersion: "0.1.0",
-	}
-	require.Nil(t, oauthClient.Create(testInstance))
-	client, err := oauth.FindClient(testInstance, oauthClient.ClientID)
-	require.NoError(t, err)
-	client.CertifiedFromStore = true
-	require.NoError(t, client.SetFlagship(testInstance))
-
-	args, err := json.Marshal(&echo.Map{
-		"passphrase":    "InvalidPassphrase",
-		"client_id":     client.CouchID,
-		"client_secret": client.ClientSecret,
-	})
-	require.NoError(t, err)
-	req, err := http.NewRequest("POST", ts.URL+"/auth/login/flagship", bytes.NewReader(args))
-	require.NoError(t, err)
-	req.Host = domain
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Accept", "application/json")
-	res, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, 401, res.StatusCode)
-
-	args, err = json.Marshal(&echo.Map{
-		"passphrase":    "MyPassphrase",
-		"client_id":     client.CouchID,
-		"client_secret": "InvalidClientSecret",
-	})
-	require.NoError(t, err)
-	req, err = http.NewRequest("POST", ts.URL+"/auth/login/flagship", bytes.NewReader(args))
-	require.NoError(t, err)
-	req.Host = domain
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Accept", "application/json")
-	res, err = http.DefaultClient.Do(req)
-	require.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, 400, res.StatusCode)
-
-	args, err = json.Marshal(&echo.Map{
-		"passphrase":    "MyPassphrase",
-		"client_id":     client.CouchID,
-		"client_secret": client.ClientSecret,
-	})
-	require.NoError(t, err)
-	req, err = http.NewRequest("POST", ts.URL+"/auth/login/flagship", bytes.NewReader(args))
-	require.NoError(t, err)
-	req.Host = domain
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Accept", "application/json")
-	res, err = http.DefaultClient.Do(req)
-	require.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, 200, res.StatusCode)
-	var resbody map[string]interface{}
-	require.NoError(t, json.NewDecoder(res.Body).Decode(&resbody))
-	assert.NotNil(t, resbody["access_token"])
-	assert.NotNil(t, resbody["refresh_token"])
-	assert.Equal(t, "*", resbody["scope"])
-	assert.Equal(t, "bearer", resbody["token_type"])
-}
-
-func TestAppRedirectionOnLogin(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/auth/login?redirect=drive/%23/foobar", nil)
-	req.Host = domain
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	if assert.Equal(t, "303 See Other", res.Status) {
-		assert.Equal(t, "https://drive.cozy.example.net#/foobar",
-			res.Header.Get("Location"))
-	}
-}
-
-func TestLogoutNoToken(t *testing.T) {
-	req, _ := http.NewRequest("DELETE", ts.URL+"/auth/login", nil)
-	req.Host = domain
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "401 Unauthorized", res.Status)
-	cookies := jar.Cookies(nil)
-	assert.Len(t, cookies, 2) // cozysessid and _csrf
-}
-
-func TestLogoutSuccess(t *testing.T) {
-	token := testInstance.BuildAppToken("home", getSessionID(jar.Cookies(nil)))
-	_, err := permission.CreateWebappSet(testInstance, "home", permission.Set{}, "1.0.0")
-	assert.NoError(t, err)
-	req, _ := http.NewRequest("DELETE", ts.URL+"/auth/login", nil)
-	req.Host = domain
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	err = permission.DestroyWebapp(testInstance, "home")
-	assert.NoError(t, err)
-
-	assert.Equal(t, "204 No Content", res.Status)
-	cookies := jar.Cookies(nil)
-	assert.Len(t, cookies, 1) // _csrf
-	assert.Equal(t, "_csrf", cookies[0].Name)
-}
-
-func TestLogoutOthers(t *testing.T) {
-	var anonymousClient1, anonymousClient2 *http.Client
-	{
-		u1, _ := url.Parse(testInstance.PageURL("/auth", nil))
-		u2, _ := url.Parse(testInstance.PageURL("/auth", nil))
-		jar1, _ := cookiejar.New(nil)
-		jar2, _ := cookiejar.New(nil)
-		anonymousClient1 = &http.Client{
-			CheckRedirect: noRedirect,
-			Jar:           &testutils.CookieJar{Jar: jar1, URL: u1},
-		}
-		anonymousClient2 = &http.Client{
-			CheckRedirect: noRedirect,
-			Jar:           &testutils.CookieJar{Jar: jar2, URL: u2},
-		}
-	}
-
-	res1, err := postFormWithClient(anonymousClient1, "/auth/login", &url.Values{
-		"passphrase": {"MyPassphrase"},
-		"csrf_token": {getLoginCSRFToken(anonymousClient1, t)},
-	})
-	assert.NoError(t, err)
-	defer res1.Body.Close()
-
-	if !assert.Equal(t, "303 See Other", res1.Status) {
-		return
-	}
-	cookies1 := res1.Cookies()
-	assert.Len(t, cookies1, 2)
-
-	res2, err := postFormWithClient(anonymousClient2, "/auth/login", &url.Values{
-		"passphrase": {"MyPassphrase"},
-		"csrf_token": {getLoginCSRFToken(anonymousClient2, t)},
-	})
-	assert.NoError(t, err)
-	defer res2.Body.Close()
-	if !assert.Equal(t, "303 See Other", res2.Status) {
-		return
-	}
-	cookies2 := res2.Cookies()
-	assert.Len(t, cookies2, 2)
-
-	token := testInstance.BuildAppToken("home", getSessionID(cookies1))
-	_, err = permission.CreateWebappSet(testInstance, "home", permission.Set{}, "1.0.0")
-	assert.NoError(t, err)
-
-	reqLogout1, _ := http.NewRequest("DELETE", ts.URL+"/auth/login/others", nil)
-	reqLogout1.Host = domain
-	reqLogout1.Header.Add("Authorization", "Bearer "+token)
-	reqLogout1.AddCookie(cookies1[1])
-	resLogout1, err := client.Do(reqLogout1)
-	assert.NoError(t, err)
-	defer resLogout1.Body.Close()
-	assert.Equal(t, 204, resLogout1.StatusCode)
-
-	reqLogout2, _ := http.NewRequest("DELETE", ts.URL+"/auth/login/others", nil)
-	reqLogout2.Host = domain
-	reqLogout2.Header.Add("Authorization", "Bearer "+token)
-	reqLogout2.AddCookie(cookies2[1])
-	resLogout2, err := client.Do(reqLogout2)
-	assert.NoError(t, err)
-	defer resLogout2.Body.Close()
-	assert.Equal(t, 401, resLogout2.StatusCode)
-
-	reqLogout3, _ := http.NewRequest("DELETE", ts.URL+"/auth/login/others", nil)
-	reqLogout3.Host = domain
-	reqLogout3.Header.Add("Authorization", "Bearer "+token)
-	reqLogout3.AddCookie(cookies1[1])
-	resLogout3, err := client.Do(reqLogout3)
-	assert.NoError(t, err)
-	defer resLogout3.Body.Close()
-	assert.Equal(t, 204, resLogout3.StatusCode)
-
-	err = permission.DestroyWebapp(testInstance, "home")
-	assert.NoError(t, err)
-}
-
-func TestPassphraseResetLoggedIn(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/auth/passphrase_reset", nil)
-	req.Host = domain
-	res, err := client.Do(req)
-	require.NoError(t, err)
-
-	defer res.Body.Close()
-	assert.Equal(t, "200 OK", res.Status)
-	body, _ := io.ReadAll(res.Body)
-	assert.Contains(t, string(body), `my password`)
-	assert.Contains(t, string(body), `<input type="hidden" name="csrf_token"`)
-}
-
-func TestPassphraseReset(t *testing.T) {
-	req1, _ := http.NewRequest("GET", ts.URL+"/auth/passphrase_reset", nil)
-	req1.Host = domain
-	res1, err := client.Do(req1)
-	require.NoError(t, err)
-
-	defer res1.Body.Close()
-	assert.Equal(t, "200 OK", res1.Status)
-	csrfCookie := res1.Cookies()[0]
-	assert.Equal(t, "_csrf", csrfCookie.Name)
-	res2, err := postForm("/auth/passphrase_reset", &url.Values{
-		"csrf_token": {csrfCookie.Value},
-	})
-	require.NoError(t, err)
-
-	defer res2.Body.Close()
-	assert.Equal(t, "200 OK", res2.Status)
-	assert.Equal(t, "text/html; charset=UTF-8", res2.Header.Get("Content-Type"))
-}
-
-func TestPassphraseRenewFormNoToken(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/auth/passphrase_renew", nil)
-	req.Host = domain
-	res, err := client.Do(req)
-	require.NoError(t, err)
-
-	defer res.Body.Close()
-	assert.Equal(t, "400 Bad Request", res.Status)
-	body, _ := io.ReadAll(res.Body)
-	assert.Contains(t, string(body), `The link to reset the password is truncated or has expired`)
-}
-
-func TestPassphraseRenewFormBadToken(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/auth/passphrase_renew?token=zzzz", nil)
-	req.Host = domain
-	res, err := client.Do(req)
-	require.NoError(t, err)
-
-	defer res.Body.Close()
-	assert.Equal(t, "400 Bad Request", res.Status)
-	body, _ := io.ReadAll(res.Body)
-	assert.Contains(t, string(body), `The link to reset the password is truncated or has expired`)
-}
-
-func TestPassphraseRenewFormWithToken(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/auth/passphrase_renew?token=badbee", nil)
-	req.Host = domain
-	res, err := client.Do(req)
-	require.NoError(t, err)
-
-	defer res.Body.Close()
-	assert.Equal(t, "400 Bad Request", res.Status)
-}
-
-func TestPassphraseRenew(t *testing.T) {
-	d := "test.cozycloud.cc.web_reset_form"
-	_ = lifecycle.Destroy(d)
-	in1, err := lifecycle.Create(&lifecycle.Options{
-		Domain: d,
-		Locale: "en",
-		Email:  "alice@example.com",
-	})
-	require.NoError(t, err)
-
-	defer func() {
-		_ = lifecycle.Destroy(d)
-	}()
-	err = lifecycle.RegisterPassphrase(in1, in1.RegisterToken, lifecycle.PassParameters{
-		Pass:       []byte("MyPass"),
-		Iterations: 5000,
-		Key:        "0.uRcMe+Mc2nmOet4yWx9BwA==|PGQhpYUlTUq/vBEDj1KOHVMlTIH1eecMl0j80+Zu0VRVfFa7X/MWKdVM6OM/NfSZicFEwaLWqpyBlOrBXhR+trkX/dPRnfwJD2B93hnLNGQ=",
-	})
-	require.NoError(t, err)
-
-	req1, _ := http.NewRequest("GET", ts.URL+"/auth/passphrase_reset", nil)
-	req1.Host = domain
-	res1, err := client.Do(req1)
-	require.NoError(t, err)
-
-	defer res1.Body.Close()
-	csrfCookie := res1.Cookies()[0]
-	assert.Equal(t, "_csrf", csrfCookie.Name)
-	res2, err := postFormDomain(d, "/auth/passphrase_reset", &url.Values{
-		"csrf_token": {csrfCookie.Value},
-	})
-	require.NoError(t, err)
-
-	defer res2.Body.Close()
-	assert.Equal(t, "200 OK", res2.Status)
-	in2, err := instance.GetFromCouch(d)
-	require.NoError(t, err)
-
-	res3, err := postFormDomain(d, "/auth/passphrase_renew", &url.Values{
-		"passphrase_reset_token": {hex.EncodeToString(in2.PassphraseResetToken)},
-		"passphrase":             {"NewPassphrase"},
-		"csrf_token":             {csrfCookie.Value},
-	})
-	require.NoError(t, err)
-
-	defer res3.Body.Close()
-	if assert.Equal(t, "303 See Other", res3.Status) {
-		assert.Equal(t, "https://test.cozycloud.cc.web_reset_form/auth/login",
-			res3.Header.Get("Location"))
-	}
-}
-
-func TestIsLoggedOutAfterLogout(t *testing.T) {
-	content, err := getTestURL()
-	assert.NoError(t, err)
-	assert.Equal(t, "who_are_you", content)
-}
-
-func TestSecretExchangeGoodSecret(t *testing.T) {
-	body, _ := json.Marshal(echo.Map{"secret": "foobarsecret"})
-
-	var oauthClient oauth.Client
-
-	oauthClient.RedirectURIs = []string{"abc"}
-	oauthClient.ClientName = "cozy-test"
-	oauthClient.SoftwareID = "github.com/cozy/cozy-test"
-	oauthClient.OnboardingSecret = "foobarsecret"
-	oauthClient.Create(testInstance)
-
-	req, _ := http.NewRequest("POST", ts.URL+"/auth/secret_exchange", bytes.NewBuffer(body))
-	req.Host = domain
-	req.Header.Add("Content-Type", "application/json; charset=utf-8")
-	req.Header.Add("Accept", "application/json")
-
-	res, err := client.Do(req)
-	require.NoError(t, err)
-
-	resBody, _ := io.ReadAll(res.Body)
-	assert.Contains(t, string(resBody), "client_secret")
-	defer res.Body.Close()
-}
-
-func TestSecretExchangeBadSecret(t *testing.T) {
-	body, _ := json.Marshal(echo.Map{"secret": "badbarsecret"})
-
-	var oauthClient oauth.Client
-
-	oauthClient.RedirectURIs = []string{"abc"}
-	oauthClient.ClientName = "cozy-test"
-	oauthClient.SoftwareID = "github.com/cozy/cozy-test"
-	oauthClient.OnboardingSecret = "foobarsecret"
-	oauthClient.Create(testInstance)
-
-	req, _ := http.NewRequest("POST", ts.URL+"/auth/secret_exchange", bytes.NewBuffer(body))
-	req.Host = domain
-	req.Header.Add("Content-Type", "application/json; charset=utf-8")
-	req.Header.Add("Accept", "application/json")
-
-	res, err := client.Do(req)
-
-	require.NoError(t, err)
-
-	resBody, _ := io.ReadAll(res.Body)
-	assert.Contains(t, string(resBody), "errors")
-
-	defer res.Body.Close()
-}
-
-func TestSecretExchangeBadPayload(t *testing.T) {
-	body, _ := json.Marshal(echo.Map{"foo": "bar"})
-
-	req, _ := http.NewRequest("POST", ts.URL+"/auth/secret_exchange", bytes.NewBuffer(body))
-	req.Host = domain
-	req.Header.Add("Content-Type", "application/json; charset=utf-8")
-	req.Header.Add("Accept", "application/json")
-
-	res, err := client.Do(req)
-	require.NoError(t, err)
-
-	resBody, _ := io.ReadAll(res.Body)
-	assert.Contains(t, string(resBody), "Missing secret")
-	defer res.Body.Close()
-}
-
-func TestSecretExchangeNoPayload(t *testing.T) {
-	req, _ := http.NewRequest("POST", ts.URL+"/auth/secret_exchange", nil)
-	req.Host = domain
-	req.Header.Add("Content-Type", "application/json; charset=utf-8")
-	req.Header.Add("Accept", "application/json")
-
-	res, err := client.Do(req)
-	require.NoError(t, err)
-
-	assert.Equal(t, res.StatusCode, 400)
-	defer res.Body.Close()
-}
-
-func TestPassphraseOnboarding(t *testing.T) {
-	// Here we create a new instance without passphrase
-	d := "test.cozycloud.cc.web_passphrase"
-	_ = lifecycle.Destroy(d)
-	inst, err := lifecycle.Create(&lifecycle.Options{
-		Domain: d,
-		Locale: "en",
-		Email:  "alice@example.com",
-	})
-	assert.NoError(t, err)
-	assert.False(t, inst.OnboardingFinished)
-
-	// Should redirect to /auth/passphrase
-	req, _ := http.NewRequest("GET", ts.URL+"/?registerToken="+hex.EncodeToString(inst.RegisterToken), nil)
-	req.Host = inst.Domain
-	res, err := client.Do(req)
-	require.NoError(t, err)
-
-	assert.Equal(t, 303, res.StatusCode)
-	assert.Contains(t, res.Header.Get("Location"), "/auth/passphrase?registerToken=")
-
-	// Adding a passphrase and check if we are redirected to home
-	pass := []byte("passphrase")
-	err = lifecycle.RegisterPassphrase(inst, inst.RegisterToken, lifecycle.PassParameters{
-		Pass:       pass,
-		Iterations: 5000,
-		Key:        "0.uRcMe+Mc2nmOet4yWx9BwA==|PGQhpYUlTUq/vBEDj1KOHVMlTIH1eecMl0j80+Zu0VRVfFa7X/MWKdVM6OM/NfSZicFEwaLWqpyBlOrBXhR+trkX/dPRnfwJD2B93hnLNGQ=",
-	})
-	assert.NoError(t, err)
-
-	inst.OnboardingFinished = true
-
-	req2, _ := http.NewRequest("GET", ts.URL+"/?registerToken="+hex.EncodeToString(inst.RegisterToken), nil)
-	req2.Host = inst.Domain
-	res2, err2 := client.Do(req2)
-	assert.NoError(t, err2)
-	assert.Contains(t, res2.Header.Get("Location"), "/auth/login")
-}
-
-func TestPassphraseOnboardingFinished(t *testing.T) {
-	// Using the testInstance which had already been onboarded
-	// Should redirect to home
-	req, _ := http.NewRequest("GET", ts.URL+"/auth/passphrase", nil)
-	req.Host = domain
-
-	res, err := client.Do(req)
-	require.NoError(t, err)
-
-	assert.Equal(t, res.StatusCode, 303)
-	assert.Equal(t, res.Header.Get("Location"), "https://home.cozy.example.net/")
-}
-
-func TestPassphraseOnboardingBadRegisterToken(t *testing.T) {
-	// Should render need_onboarding
-	d := "test.cozycloud.cc.web_passphrase_bad_token"
-	_ = lifecycle.Destroy(d)
-	inst, err := lifecycle.Create(&lifecycle.Options{
-		Domain: d,
-		Locale: "en",
-		Email:  "alice@example.com",
-	})
-	assert.NoError(t, err)
-	assert.False(t, inst.OnboardingFinished)
-
-	// Should redirect to /auth/passphrase
-	req, _ := http.NewRequest("GET", ts.URL+"/auth/passphrase?registerToken=coincoin", nil)
-	req.Host = inst.Domain
-	res, err := client.Do(req)
-	require.NoError(t, err)
-
-	content, _ := io.ReadAll(res.Body)
-	assert.Equal(t, 200, res.StatusCode)
-	assert.Contains(t, string(content), "Your Cozy has not been yet activated.")
-}
-
-func TestLoginOnboardingNotFinished(t *testing.T) {
-	// Should render need_onboarding
-	d := "test.cozycloud.cc.web_login_onboarding_not_finished"
-	_ = lifecycle.Destroy(d)
-	inst, err := lifecycle.Create(&lifecycle.Options{
-		Domain: d,
-		Locale: "en",
-		Email:  "alice@example.com",
-	})
-	assert.NoError(t, err)
-	assert.False(t, inst.OnboardingFinished)
-
-	// Should redirect to /auth/passphrase
-	req, _ := http.NewRequest("GET", ts.URL+"/auth/login", nil)
-	req.Host = inst.Domain
-	res, err := client.Do(req)
-	require.NoError(t, err)
-
-	content, _ := io.ReadAll(res.Body)
-	assert.Equal(t, 200, res.StatusCode)
-	assert.Contains(t, string(content), "Your Cozy has not been yet activated.")
-}
-
-func TestShowConfirmForm(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/auth/confirm?state=342dd650-599b-0139-cfb0-543d7eb8149c", nil)
-	req.Host = domain
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, 200, res.StatusCode)
-	assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
-	body, _ := io.ReadAll(res.Body)
-	assert.NotContains(t, string(body), "myfragment")
-	assert.Contains(t, string(body), `<input id="state" type="hidden" name="state" value="342dd650-599b-0139-cfb0-543d7eb8149c" />`)
-}
-
-func getConfirmCSRFToken(c *http.Client, t *testing.T) string {
-	req, _ := http.NewRequest("GET", ts.URL+"/auth/confirm?state=123", nil)
-	req.Host = domain
-	res, err := c.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	return res.Cookies()[0].Value
-}
-
-func TestSendConfirmBadCSRFToken(t *testing.T) {
-	payload := url.Values{
-		"passphrase": {"MyPassphrase"},
-		"csrf_token": {"123456"},
-		"state":      {"342dd650-599b-0139-cfb0-543d7eb8149c"},
-	}.Encode()
-	req, _ := http.NewRequest("POST", ts.URL+"/auth/confirm", bytes.NewBufferString(payload))
-	req.Host = domain
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Add("Accept", "application/json")
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 403, res.StatusCode)
-}
-
-func TestSendConfirmBadPass(t *testing.T) {
-	token := getConfirmCSRFToken(client, t)
-	payload := url.Values{
-		"passphrase": {"InvalidPassphrase"},
-		"csrf_token": {token},
-		"state":      {"342dd650-599b-0139-cfb0-543d7eb8149c"},
-	}.Encode()
-	req, _ := http.NewRequest("POST", ts.URL+"/auth/confirm", bytes.NewBufferString(payload))
-	req.Host = domain
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Add("Accept", "application/json")
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 401, res.StatusCode)
-}
-
-func TestSendConfirmOK(t *testing.T) {
-	token := getConfirmCSRFToken(client, t)
-	payload := url.Values{
-		"passphrase": {"MyPassphrase"},
-		"csrf_token": {token},
-		"state":      {"342dd650-599b-0139-cfb0-543d7eb8149c"},
-	}.Encode()
-	req, _ := http.NewRequest("POST", ts.URL+"/auth/confirm", bytes.NewBufferString(payload))
-	req.Host = domain
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Add("Accept", "application/json")
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var body map[string]string
-	err = json.NewDecoder(res.Body).Decode(&body)
-	assert.NoError(t, err)
-	redirect := body["redirect"]
-	assert.NotEmpty(t, redirect)
-	u, err := url.Parse(redirect)
-	assert.NoError(t, err)
-	confirmCode = u.Query().Get("code")
-	assert.NotEmpty(t, confirmCode)
-	state := u.Query().Get("state")
-	assert.Equal(t, "342dd650-599b-0139-cfb0-543d7eb8149c", state)
-}
-
-func TestConfirmBadCode(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/auth/confirm/123456", nil)
-	req.Host = domain
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 401, res.StatusCode)
-}
-
-func TestConfirmCodeOK(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/auth/confirm/"+confirmCode, nil)
-	req.Host = domain
-	res, err := client.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 204, res.StatusCode)
-}
-
-func TestBuildKonnectorToken(t *testing.T) {
-	// Create an flagship OAuth client
-	oauthClient := oauth.Client{
-		RedirectURIs: []string{"cozy://client"},
-		ClientName:   "oauth-client",
-		SoftwareID:   "github.com/cozy/cozy-stack/testing/client",
-		Flagship:     true,
-	}
-	require.Nil(t, oauthClient.Create(testInstance, oauth.NotPending))
-
-	// Give it the maximal permission
-	token, err := testInstance.MakeJWT(consts.AccessTokenAudience,
-		oauthClient.ClientID, "*", "", time.Now())
-	require.NoError(t, err)
-
-	// Get konnector access_token
-	req, err := http.NewRequest("POST", ts.URL+"/auth/tokens/konnectors/"+konnSlug, nil)
-	require.NoError(t, err)
-	req.Host = domain
-	req.Header.Add("Accept", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := client.Do(req)
-	require.NoError(t, err)
-	assert.Equal(t, "201 Created", res.Status)
-
-	defer res.Body.Close()
-	var response string
-	err = json.NewDecoder(res.Body).Decode(&response)
-	require.NoError(t, err)
-
-	// Validate token
-	claims := permission.Claims{}
-	err = crypto.ParseJWT(response, func(token *jwt.Token) (interface{}, error) {
-		return testInstance.SessionSecret(), nil
-	}, &claims)
-	assert.NoError(t, err)
-	assert.Equal(t, consts.KonnectorAudience, claims.Audience)
-	assert.Equal(t, domain, claims.Issuer)
-	assert.Equal(t, konnSlug, claims.Subject)
-	assert.Equal(t, "", claims.Scope)
-}
-
-func TestBuildKonnectorTokenNotFlagshipApp(t *testing.T) {
-	// Create an OAuth client
-	oauthClient := oauth.Client{
-		RedirectURIs: []string{"cozy://client"},
-		ClientName:   "oauth-client",
-		SoftwareID:   "github.com/cozy/cozy-stack/testing/client",
-		Flagship:     false,
-	}
-	require.Nil(t, oauthClient.Create(testInstance, oauth.NotPending))
-
-	// Give it the maximal permission
-	token, err := testInstance.MakeJWT(consts.AccessTokenAudience,
-		oauthClient.ClientID, "*", "", time.Now())
-	require.NoError(t, err)
-
-	req, err := http.NewRequest("POST", ts.URL+"/auth/tokens/konnectors/"+konnSlug, nil)
-	require.NoError(t, err)
-	req.Host = domain
-	req.Header.Add("Accept", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := client.Do(req)
-	require.NoError(t, err)
-	assert.Equal(t, "403 Forbidden", res.Status)
-}
-
-func TestBuildKonnectorTokenInvalidSlug(t *testing.T) {
-	// Create an flagship OAuth client
-	oauthClient := oauth.Client{
-		RedirectURIs: []string{"cozy://client"},
-		ClientName:   "oauth-client",
-		SoftwareID:   "github.com/cozy/cozy-stack/testing/client",
-		Flagship:     true,
-	}
-	require.Nil(t, oauthClient.Create(testInstance, oauth.NotPending))
-
-	// Give it the maximal permission
-	token, err := testInstance.MakeJWT(consts.AccessTokenAudience,
-		oauthClient.ClientID, "*", "", time.Now())
-	require.NoError(t, err)
-
-	req, err := http.NewRequest("POST", ts.URL+"/auth/tokens/konnectors/missing", nil)
-	require.NoError(t, err)
-	req.Host = domain
-	req.Header.Add("Accept", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := client.Do(req)
-	require.NoError(t, err)
-	assert.Equal(t, "404 Not Found", res.Status)
-}
-
-func TestMain(m *testing.M) {
 	config.UseTestFile()
 	conf := config.GetConfig()
 	conf.Assets = "../../assets"
@@ -2093,6 +117,1987 @@ func TestMain(m *testing.M) {
 	}
 
 	os.Exit(setup.Run())
+
+	t.Run("InstanceBlocked", func(t *testing.T) {
+		// Block the instance
+		testInstance.Blocked = true
+		_ = testInstance.Update()
+
+		req, _ := http.NewRequest("GET", ts.URL+"/auth/login", nil)
+		req.Host = testInstance.Domain
+
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusServiceUnavailable, res.StatusCode)
+
+		// Trying with a Accept: text/html header to simulate a browser
+		req.Header.Add("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+		res2, err := client.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusServiceUnavailable, res2.StatusCode)
+		body, err := io.ReadAll(res2.Body)
+		assert.NoError(t, err)
+		assert.Contains(t, string(body), "<title>Cozy</title>")
+		assert.Contains(t, string(body), "Your Cozy has been blocked</h1>")
+
+		// Unblock the instance
+		testInstance.Blocked = false
+		_ = testInstance.Update()
+	})
+
+	t.Run("IsLoggedInWhenNotLoggedIn", func(t *testing.T) {
+		content, err := getTestURL()
+		assert.NoError(t, err)
+		assert.Equal(t, "who_are_you", content)
+	})
+
+	t.Run("HomeWhenNotLoggedIn", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/", nil)
+		req.Host = domain
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		if assert.Equal(t, "303 See Other", res.Status) {
+			assert.Equal(t, "https://cozy.example.net/auth/login",
+				res.Header.Get("Location"))
+		}
+	})
+
+	t.Run("HomeWhenNotLoggedInWithJWT", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/?jwt=foobar", nil)
+		req.Host = domain
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		if assert.Equal(t, "303 See Other", res.Status) {
+			assert.Equal(t, "https://cozy.example.net/auth/login?jwt=foobar",
+				res.Header.Get("Location"))
+		}
+	})
+
+	t.Run("ShowLoginPage", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/auth/login", nil)
+		req.Host = domain
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, "200 OK", res.Status)
+		assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
+		body, _ := io.ReadAll(res.Body)
+		assert.Contains(t, string(body), "Log in")
+	})
+
+	t.Run("ShowLoginPageWithRedirectBadURL", func(t *testing.T) {
+		req1, _ := http.NewRequest("GET", ts.URL+"/auth/login?redirect="+url.QueryEscape(" "), nil)
+		req1.Host = domain
+		res1, err := client.Do(req1)
+		assert.NoError(t, err)
+		defer res1.Body.Close()
+		assert.Equal(t, "400 Bad Request", res1.Status)
+		assert.Equal(t, "text/plain; charset=UTF-8", res1.Header.Get("Content-Type"))
+
+		req2, _ := http.NewRequest("GET", ts.URL+"/auth/login?redirect="+url.QueryEscape("foo.bar"), nil)
+		req2.Host = domain
+		res2, err := client.Do(req2)
+		assert.NoError(t, err)
+		defer res2.Body.Close()
+		assert.Equal(t, "400 Bad Request", res2.Status)
+		assert.Equal(t, "text/plain; charset=UTF-8", res2.Header.Get("Content-Type"))
+
+		req3, _ := http.NewRequest("GET", ts.URL+"/auth/login?redirect="+url.QueryEscape("ftp://sub."+domain+"/foo"), nil)
+		req3.Host = domain
+		res3, err := client.Do(req3)
+		assert.NoError(t, err)
+		defer res3.Body.Close()
+		assert.Equal(t, "400 Bad Request", res3.Status)
+		assert.Equal(t, "text/plain; charset=UTF-8", res3.Header.Get("Content-Type"))
+	})
+
+	t.Run("ShowLoginPageWithRedirectXSS", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/auth/login?redirect="+url.QueryEscape("https://sub."+domain+"/<script>alert('foo')</script>"), nil)
+		req.Host = domain
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, "200 OK", res.Status)
+		assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
+		body, _ := io.ReadAll(res.Body)
+		assert.NotContains(t, string(body), "<script>")
+		assert.Contains(t, string(body), "%3Cscript%3Ealert%28%27foo%27%29%3C/script%3E")
+	})
+
+	t.Run("ShowLoginPageWithRedirectFragment", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/auth/login?redirect="+url.QueryEscape("https://"+domain+"/auth/authorize#myfragment"), nil)
+		req.Host = domain
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, "200 OK", res.Status)
+		assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
+		body, _ := io.ReadAll(res.Body)
+		assert.NotContains(t, string(body), "myfragment")
+		assert.Contains(t, string(body), `<input id="redirect" type="hidden" name="redirect" value="https://cozy.example.net/auth/authorize#=" />`)
+	})
+
+	t.Run("ShowLoginPageWithRedirectSuccess", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/auth/login?redirect="+url.QueryEscape("https://sub."+domain+"/foo/bar?query=foo#myfragment"), nil)
+		req.Host = domain
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, "200 OK", res.Status)
+		assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
+		body, _ := io.ReadAll(res.Body)
+		assert.Contains(t, string(body), `<input id="redirect" type="hidden" name="redirect" value="https://sub.cozy.example.net/foo/bar?query=foo#myfragment" />`)
+	})
+
+	t.Run("LoginWithoutCSRFToken", func(t *testing.T) {
+		res, err := postForm("/auth/login", &url.Values{
+			"passphrase": {"MyPassphrase"},
+		})
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, "400 Bad Request", res.Status)
+	})
+
+	t.Run("LoginWithBadPassphrase", func(t *testing.T) {
+		res, err := postForm("/auth/login", &url.Values{
+			"passphrase": {"Nope"},
+			"csrf_token": {getLoginCSRFToken(client, t)},
+		})
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, "401 Unauthorized", res.Status)
+	})
+
+	t.Run("LoginWithGoodPassphrase", func(t *testing.T) {
+		token := getLoginCSRFToken(client, t)
+		res, err := postForm("/auth/login", &url.Values{
+			"passphrase": {"MyPassphrase"},
+			"csrf_token": {token},
+		})
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		if assert.Equal(t, "303 See Other", res.Status) {
+			assert.Equal(t, "https://home.cozy.example.net/",
+				res.Header.Get("Location"))
+			cookies := res.Cookies()
+			assert.Len(t, cookies, 2)
+			assert.Equal(t, cookies[0].Name, "_csrf")
+			assert.Equal(t, cookies[0].Value, token)
+			assert.Equal(t, cookies[1].Name, session.CookieName(testInstance))
+			assert.NotEmpty(t, cookies[1].Value)
+
+			var results []*session.LoginEntry
+			err = couchdb.GetAllDocs(
+				testInstance,
+				consts.SessionsLogins,
+				&couchdb.AllDocsRequest{Limit: 100},
+				&results,
+			)
+			assert.NoError(t, err)
+			assert.Equal(t, 1, len(results))
+			assert.Equal(t, "Go-http-client/1.1", results[0].UA)
+			assert.Equal(t, "127.0.0.1", results[0].IP)
+			assert.False(t, results[0].CreatedAt.IsZero())
+		}
+	})
+
+	t.Run("LoginWithRedirect", func(t *testing.T) {
+		res1, err := postForm("/auth/login", &url.Values{
+			"passphrase": {"MyPassphrase"},
+			"redirect":   {"foo.bar"},
+			"csrf_token": {getLoginCSRFToken(client, t)},
+		})
+		assert.NoError(t, err)
+		defer res1.Body.Close()
+		assert.Equal(t, "400 Bad Request", res1.Status)
+
+		res2, err := postForm("/auth/login", &url.Values{
+			"passphrase": {"MyPassphrase"},
+			"redirect":   {"https://sub." + domain + "/#myfragment"},
+			"csrf_token": {getLoginCSRFToken(client, t)},
+		})
+		assert.NoError(t, err)
+		defer res2.Body.Close()
+		if assert.Equal(t, "303 See Other", res2.Status) {
+			assert.Equal(t, "https://sub.cozy.example.net/#myfragment",
+				res2.Header.Get("Location"))
+		}
+	})
+
+	t.Run("DelegatedJWTLoginWithRedirect", func(t *testing.T) {
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, session.ExternalClaims{
+			RegisteredClaims: jwt.RegisteredClaims{
+				Subject:   "sruti",
+				IssuedAt:  jwt.NewNumericDate(time.Now()),
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			},
+			Name:  domain,
+			Email: "sruti@external.notmycozy.net",
+			Code:  "student",
+		})
+		signed, err := token.SignedString(JWTSecret)
+		assert.NoError(t, err)
+		req, _ := http.NewRequest("GET", ts.URL+"/auth/login?jwt="+signed, nil)
+		req.Host = domain
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, http.StatusSeeOther, res.StatusCode)
+	})
+
+	t.Run("IsLoggedInAfterLogin", func(t *testing.T) {
+		content, err := getTestURL()
+		assert.NoError(t, err)
+		assert.Equal(t, "logged_in", content)
+	})
+
+	t.Run("HomeWhenLoggedIn", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/", nil)
+		req.Host = domain
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		if assert.Equal(t, "303 See Other", res.Status) {
+			assert.Equal(t, "https://home.cozy.example.net/",
+				res.Header.Get("Location"))
+		}
+	})
+
+	t.Run("RegisterClientNotJSON", func(t *testing.T) {
+		res, err := postForm("/auth/register", &url.Values{"foo": {"bar"}})
+		assert.NoError(t, err)
+		assert.Equal(t, "400 Bad Request", res.Status)
+		res.Body.Close()
+	})
+
+	t.Run("RegisterClientNoRedirectURI", func(t *testing.T) {
+		res, err := postJSON("/auth/register", echo.Map{
+			"client_name": "cozy-test",
+			"software_id": "github.com/cozy/cozy-test",
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "400 Bad Request", res.Status)
+		var body map[string]string
+		err = json.NewDecoder(res.Body).Decode(&body)
+		assert.NoError(t, err)
+		assert.Equal(t, "invalid_redirect_uri", body["error"])
+		assert.Equal(t, "redirect_uris is mandatory", body["error_description"])
+	})
+
+	t.Run("RegisterClientInvalidRedirectURI", func(t *testing.T) {
+		res, err := postJSON("/auth/register", echo.Map{
+			"redirect_uris": []string{"http://example.org/foo#bar"},
+			"client_name":   "cozy-test",
+			"software_id":   "github.com/cozy/cozy-test",
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "400 Bad Request", res.Status)
+		var body map[string]string
+		err = json.NewDecoder(res.Body).Decode(&body)
+		assert.NoError(t, err)
+		assert.Equal(t, "invalid_redirect_uri", body["error"])
+		assert.Equal(t, "http://example.org/foo#bar is invalid", body["error_description"])
+	})
+
+	t.Run("RegisterClientNoClientName", func(t *testing.T) {
+		res, err := postJSON("/auth/register", echo.Map{
+			"redirect_uris": []string{"https://example.org/oauth/callback"},
+			"software_id":   "github.com/cozy/cozy-test",
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "400 Bad Request", res.Status)
+		var body map[string]string
+		err = json.NewDecoder(res.Body).Decode(&body)
+		assert.NoError(t, err)
+		assert.Equal(t, "invalid_client_metadata", body["error"])
+		assert.Equal(t, "client_name is mandatory", body["error_description"])
+	})
+
+	t.Run("RegisterClientNoSoftwareID", func(t *testing.T) {
+		res, err := postJSON("/auth/register", echo.Map{
+			"redirect_uris": []string{"https://example.org/oauth/callback"},
+			"client_name":   "cozy-test",
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "400 Bad Request", res.Status)
+		var body map[string]string
+		err = json.NewDecoder(res.Body).Decode(&body)
+		assert.NoError(t, err)
+		assert.Equal(t, "invalid_client_metadata", body["error"])
+		assert.Equal(t, "software_id is mandatory", body["error_description"])
+	})
+
+	t.Run("RegisterClientSuccessWithJustMandatoryFields", func(t *testing.T) {
+		res, err := postJSON("/auth/register", echo.Map{
+			"redirect_uris": []string{"https://example.org/oauth/callback"},
+			"client_name":   "cozy-test",
+			"software_id":   "github.com/cozy/cozy-test",
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "201 Created", res.Status)
+		var client oauth.Client
+		err = json.NewDecoder(res.Body).Decode(&client)
+		assert.NoError(t, err)
+		assert.NotEqual(t, client.ClientID, "")
+		assert.NotEqual(t, client.ClientID, "ignored")
+		assert.NotEqual(t, client.ClientSecret, "")
+		assert.NotEqual(t, client.ClientSecret, "ignored")
+		assert.NotEqual(t, client.RegistrationToken, "")
+		assert.NotEqual(t, client.RegistrationToken, "ignored")
+		assert.Equal(t, client.SecretExpiresAt, 0)
+		assert.Equal(t, client.RedirectURIs, []string{"https://example.org/oauth/callback"})
+		assert.Equal(t, client.GrantTypes, []string{"authorization_code", "refresh_token"})
+		assert.Equal(t, client.ResponseTypes, []string{"code"})
+		assert.Equal(t, client.ClientName, "cozy-test")
+		assert.Equal(t, client.SoftwareID, "github.com/cozy/cozy-test")
+		clientID = client.ClientID
+		clientSecret = client.ClientSecret
+		registrationToken = client.RegistrationToken
+	})
+
+	t.Run("RegisterClientSuccessWithAllFields", func(t *testing.T) {
+		res, err := postJSON("/auth/register", echo.Map{
+			"_id":                       "ignored",
+			"_rev":                      "ignored",
+			"client_id":                 "ignored",
+			"client_secret":             "ignored",
+			"client_secret_expires_at":  42,
+			"registration_access_token": "ignored",
+			"redirect_uris":             []string{"https://example.org/oauth/callback"},
+			"grant_types":               []string{"ignored"},
+			"response_types":            []string{"ignored"},
+			"client_name":               "new-cozy-test",
+			"client_kind":               "test",
+			"client_uri":                "https://github.com/cozy/cozy-test",
+			"logo_uri":                  "https://raw.github.com/cozy/cozy-setup/gh-pages/assets/images/happycloud.png",
+			"policy_uri":                "https://github/com/cozy/cozy-test/master/policy.md",
+			"software_id":               "github.com/cozy/cozy-test",
+			"software_version":          "v0.1.2",
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "201 Created", res.Status)
+		var client oauth.Client
+		err = json.NewDecoder(res.Body).Decode(&client)
+		assert.NoError(t, err)
+		assert.Equal(t, client.CouchID, "")
+		assert.Equal(t, client.CouchRev, "")
+		assert.NotEqual(t, client.ClientID, "")
+		assert.NotEqual(t, client.ClientID, "ignored")
+		assert.NotEqual(t, client.ClientID, clientID)
+		assert.NotEqual(t, client.ClientSecret, "")
+		assert.NotEqual(t, client.ClientSecret, "ignored")
+		assert.NotEqual(t, client.RegistrationToken, "")
+		assert.NotEqual(t, client.RegistrationToken, "ignored")
+		assert.Equal(t, client.SecretExpiresAt, 0)
+		assert.Equal(t, client.RedirectURIs, []string{"https://example.org/oauth/callback"})
+		assert.Equal(t, client.GrantTypes, []string{"authorization_code", "refresh_token"})
+		assert.Equal(t, client.ResponseTypes, []string{"code"})
+		assert.Equal(t, client.ClientName, "new-cozy-test")
+		assert.Equal(t, client.ClientKind, "test")
+		assert.Equal(t, client.ClientURI, "https://github.com/cozy/cozy-test")
+		assert.Equal(t, client.LogoURI, "https://raw.github.com/cozy/cozy-setup/gh-pages/assets/images/happycloud.png")
+		assert.Equal(t, client.PolicyURI, "https://github/com/cozy/cozy-test/master/policy.md")
+		assert.Equal(t, client.SoftwareID, "github.com/cozy/cozy-test")
+		assert.Equal(t, client.SoftwareVersion, "v0.1.2")
+		altClientID = client.ClientID
+		altRegistrationToken = client.RegistrationToken
+	})
+
+	t.Run("RegisterSharingClientSuccess", func(t *testing.T) {
+		res, err := postJSON("/auth/register", echo.Map{
+			"redirect_uris": []string{"https://cozy.example.org/sharings/answer"},
+			"client_name":   "John",
+			"software_id":   "github.com/cozy/cozy-stack",
+			"client_kind":   "sharing",
+			"client_uri":    "https://cozy.example.org",
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "201 Created", res.Status)
+		var client oauth.Client
+		err = json.NewDecoder(res.Body).Decode(&client)
+		assert.NoError(t, err)
+		assert.NotEqual(t, client.ClientID, "")
+		assert.NotEqual(t, client.ClientID, "ignored")
+		assert.NotEqual(t, client.ClientSecret, "")
+		assert.NotEqual(t, client.ClientSecret, "ignored")
+		assert.NotEqual(t, client.RegistrationToken, "")
+		assert.NotEqual(t, client.RegistrationToken, "ignored")
+		assert.Equal(t, client.SecretExpiresAt, 0)
+		assert.Equal(t, client.RedirectURIs, []string{"https://cozy.example.org/sharings/answer"})
+		assert.Equal(t, client.ClientName, "John")
+		assert.Equal(t, client.SoftwareID, "github.com/cozy/cozy-stack")
+		sharingClientID = client.ClientID
+	})
+
+	t.Run("DeleteClientNoToken", func(t *testing.T) {
+		req, _ := http.NewRequest("DELETE", ts.URL+"/auth/register/"+altClientID, nil)
+		req.Host = domain
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, "401 Unauthorized", res.Status)
+	})
+
+	t.Run("DeleteClientSuccess", func(t *testing.T) {
+		req, _ := http.NewRequest("DELETE", ts.URL+"/auth/register/"+altClientID, nil)
+		req.Host = domain
+		req.Header.Add("Authorization", "Bearer "+altRegistrationToken)
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, "204 No Content", res.Status)
+
+		// And next calls should return a 204 too
+		res2, err := client.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, "204 No Content", res2.Status)
+	})
+
+	t.Run("ReadClientNoToken", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/auth/register/"+clientID, nil)
+		req.Host = domain
+		req.Header.Add("Accept", "application/json")
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, "401 Unauthorized", res.Status)
+		buf, _ := io.ReadAll(res.Body)
+		assert.NotContains(t, string(buf), clientSecret)
+	})
+
+	t.Run("ReadClientInvalidToken", func(t *testing.T) {
+		res, err := getJSON("/auth/register/"+clientID, altRegistrationToken)
+		assert.NoError(t, err)
+		assert.Equal(t, "401 Unauthorized", res.Status)
+		buf, _ := io.ReadAll(res.Body)
+		assert.NotContains(t, string(buf), clientSecret)
+	})
+
+	t.Run("ReadClientInvalidClientID", func(t *testing.T) {
+		res, err := getJSON("/auth/register/"+altClientID, registrationToken)
+		assert.NoError(t, err)
+		assert.Equal(t, "404 Not Found", res.Status)
+	})
+
+	t.Run("ReadClientSuccess", func(t *testing.T) {
+		res, err := getJSON("/auth/register/"+clientID, registrationToken)
+		assert.NoError(t, err)
+		assert.Equal(t, "200 OK", res.Status)
+		var client oauth.Client
+		err = json.NewDecoder(res.Body).Decode(&client)
+		assert.NoError(t, err)
+		assert.Equal(t, client.ClientID, clientID)
+		assert.Equal(t, client.ClientSecret, clientSecret)
+		assert.Equal(t, client.SecretExpiresAt, 0)
+		assert.Equal(t, client.RegistrationToken, "")
+		assert.Equal(t, client.RedirectURIs, []string{"https://example.org/oauth/callback"})
+		assert.Equal(t, client.GrantTypes, []string{"authorization_code", "refresh_token"})
+		assert.Equal(t, client.ResponseTypes, []string{"code"})
+		assert.Equal(t, client.ClientName, "cozy-test")
+		assert.Equal(t, client.SoftwareID, "github.com/cozy/cozy-test")
+	})
+
+	t.Run("UpdateClientDeletedClientID", func(t *testing.T) {
+		res, err := putJSON("/auth/register/"+altClientID, registrationToken, echo.Map{
+			"client_id": altClientID,
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "404 Not Found", res.Status)
+	})
+
+	t.Run("UpdateClientInvalidClientID", func(t *testing.T) {
+		res, err := putJSON("/auth/register/"+clientID, registrationToken, echo.Map{
+			"client_id": "123456789",
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "400 Bad Request", res.Status)
+		var body map[string]string
+		err = json.NewDecoder(res.Body).Decode(&body)
+		assert.NoError(t, err)
+		assert.Equal(t, "invalid_client_id", body["error"])
+		assert.Equal(t, "client_id is mandatory", body["error_description"])
+	})
+
+	t.Run("UpdateClientNoRedirectURI", func(t *testing.T) {
+		res, err := putJSON("/auth/register/"+clientID, registrationToken, echo.Map{
+			"client_id":   clientID,
+			"client_name": "cozy-test",
+			"software_id": "github.com/cozy/cozy-test",
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "400 Bad Request", res.Status)
+		var body map[string]string
+		err = json.NewDecoder(res.Body).Decode(&body)
+		assert.NoError(t, err)
+		assert.Equal(t, "invalid_redirect_uri", body["error"])
+		assert.Equal(t, "redirect_uris is mandatory", body["error_description"])
+	})
+
+	t.Run("UpdateClientSuccess", func(t *testing.T) {
+		res, err := putJSON("/auth/register/"+clientID, registrationToken, echo.Map{
+			"client_id":        clientID,
+			"redirect_uris":    []string{"https://example.org/oauth/callback"},
+			"client_name":      "cozy-test",
+			"software_id":      "github.com/cozy/cozy-test",
+			"software_version": "v0.1.3",
+		})
+		assert.NoError(t, err)
+		assert.NoError(t, err)
+		assert.Equal(t, "200 OK", res.Status)
+		var client oauth.Client
+		err = json.NewDecoder(res.Body).Decode(&client)
+		assert.NoError(t, err)
+		assert.Equal(t, client.ClientID, clientID)
+		assert.Equal(t, client.ClientSecret, clientSecret)
+		assert.Equal(t, client.SecretExpiresAt, 0)
+		assert.Equal(t, client.RegistrationToken, "")
+		assert.Equal(t, client.RedirectURIs, []string{"https://example.org/oauth/callback"})
+		assert.Equal(t, client.GrantTypes, []string{"authorization_code", "refresh_token"})
+		assert.Equal(t, client.ResponseTypes, []string{"code"})
+		assert.Equal(t, client.ClientName, "cozy-test")
+		assert.Equal(t, client.SoftwareID, "github.com/cozy/cozy-test")
+		assert.Equal(t, client.SoftwareVersion, "v0.1.3")
+	})
+
+	t.Run("UpdateClientSecret", func(t *testing.T) {
+		res, err := putJSON("/auth/register/"+clientID, registrationToken, echo.Map{
+			"client_id":        clientID,
+			"client_secret":    clientSecret,
+			"redirect_uris":    []string{"https://example.org/oauth/callback"},
+			"client_name":      "cozy-test",
+			"software_id":      "github.com/cozy/cozy-test",
+			"software_version": "v0.1.4",
+		})
+		assert.NoError(t, err)
+		assert.NoError(t, err)
+		assert.Equal(t, "200 OK", res.Status)
+		var client oauth.Client
+		err = json.NewDecoder(res.Body).Decode(&client)
+		assert.NoError(t, err)
+		assert.Equal(t, client.ClientID, clientID)
+		assert.NotEqual(t, client.ClientSecret, "")
+		assert.NotEqual(t, client.ClientSecret, clientSecret)
+		assert.Equal(t, client.SecretExpiresAt, 0)
+		assert.Equal(t, client.RegistrationToken, "")
+		assert.Equal(t, client.RedirectURIs, []string{"https://example.org/oauth/callback"})
+		assert.Equal(t, client.GrantTypes, []string{"authorization_code", "refresh_token"})
+		assert.Equal(t, client.ResponseTypes, []string{"code"})
+		assert.Equal(t, client.ClientName, "cozy-test")
+		assert.Equal(t, client.SoftwareID, "github.com/cozy/cozy-test")
+		assert.Equal(t, client.SoftwareVersion, "v0.1.4")
+		clientSecret = client.ClientSecret
+	})
+
+	t.Run("AuthorizeFormRedirectsWhenNotLoggedIn", func(t *testing.T) {
+		anonymousClient := &http.Client{CheckRedirect: noRedirect}
+		u := url.QueryEscape("https://example.org/oauth/callback")
+		req, _ := http.NewRequest("GET", ts.URL+"/auth/authorize?response_type=code&state=123456&scope=files:read&redirect_uri="+u+"&client_id="+clientID, nil)
+		req.Host = domain
+		res, err := anonymousClient.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, "303 See Other", res.Status)
+	})
+
+	t.Run("AuthorizeFormBadResponseType", func(t *testing.T) {
+		u := url.QueryEscape("https://example.org/oauth/callback")
+		req, _ := http.NewRequest("GET", ts.URL+"/auth/authorize?response_type=token&state=123456&scope=files:read&redirect_uri="+u+"&client_id="+clientID, nil)
+		req.Host = domain
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, "400 Bad Request", res.Status)
+		assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
+		body, _ := io.ReadAll(res.Body)
+		assert.Contains(t, string(body), "Invalid response type")
+	})
+
+	t.Run("AuthorizeFormNoState", func(t *testing.T) {
+		u := url.QueryEscape("https://example.org/oauth/callback")
+		req, _ := http.NewRequest("GET", ts.URL+"/auth/authorize?response_type=code&scope=files:read&redirect_uri="+u+"&client_id="+clientID, nil)
+		req.Host = domain
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, "400 Bad Request", res.Status)
+		assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
+		body, _ := io.ReadAll(res.Body)
+		assert.Contains(t, string(body), "The state parameter is mandatory")
+	})
+
+	t.Run("AuthorizeFormNoClientId", func(t *testing.T) {
+		u := url.QueryEscape("https://example.org/oauth/callback")
+		req, _ := http.NewRequest("GET", ts.URL+"/auth/authorize?response_type=code&state=123456&scope=files:read&redirect_uri="+u, nil)
+		req.Host = domain
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, "400 Bad Request", res.Status)
+		assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
+		body, _ := io.ReadAll(res.Body)
+		assert.Contains(t, string(body), "The client_id parameter is mandatory")
+	})
+
+	t.Run("AuthorizeFormNoRedirectURI", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/auth/authorize?response_type=code&state=123456&scope=files:read&client_id="+clientID, nil)
+		req.Host = domain
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, "400 Bad Request", res.Status)
+		assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
+		body, _ := io.ReadAll(res.Body)
+		assert.Contains(t, string(body), "The redirect_uri parameter is mandatory")
+	})
+
+	t.Run("AuthorizeFormNoScope", func(t *testing.T) {
+		u := url.QueryEscape("https://example.org/oauth/callback")
+		req, _ := http.NewRequest("GET", ts.URL+"/auth/authorize?response_type=code&state=123456&redirect_uri="+u+"&client_id="+clientID, nil)
+		req.Host = domain
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, "400 Bad Request", res.Status)
+		assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
+		body, _ := io.ReadAll(res.Body)
+		assert.Contains(t, string(body), "The scope parameter is mandatory")
+	})
+
+	t.Run("AuthorizeFormInvalidClient", func(t *testing.T) {
+		u := url.QueryEscape("https://example.org/oauth/callback")
+		req, _ := http.NewRequest("GET", ts.URL+"/auth/authorize?response_type=code&state=123456&scope=files:read&redirect_uri="+u+"&client_id=f00", nil)
+		req.Host = domain
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, "400 Bad Request", res.Status)
+		assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
+		body, _ := io.ReadAll(res.Body)
+		assert.Contains(t, string(body), "The client must be registered")
+	})
+
+	t.Run("AuthorizeFormInvalidRedirectURI", func(t *testing.T) {
+		u := url.QueryEscape("https://evil.com/")
+		req, _ := http.NewRequest("GET", ts.URL+"/auth/authorize?response_type=code&state=123456&scope=files:read&redirect_uri="+u+"&client_id="+clientID, nil)
+		req.Host = domain
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, "400 Bad Request", res.Status)
+		assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
+		body, _ := io.ReadAll(res.Body)
+		assert.Contains(t, string(body), "The redirect_uri parameter doesn&#39;t match the registered ones")
+	})
+
+	t.Run("AuthorizeFormSuccess", func(t *testing.T) {
+		u := url.QueryEscape("https://example.org/oauth/callback")
+		req, _ := http.NewRequest("GET", ts.URL+"/auth/authorize?response_type=code&state=123456&scope=files:read&redirect_uri="+u+"&client_id="+clientID, nil)
+		req.Host = domain
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, "200 OK", res.Status)
+		assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
+		body, _ := io.ReadAll(res.Body)
+		assert.Contains(t, string(body), "would like permission to access your Cozy")
+		re := regexp.MustCompile(`<input type="hidden" name="csrf_token" value="(\w+)"`)
+		matches := re.FindStringSubmatch(string(body))
+		if assert.Len(t, matches, 2) {
+			csrfToken = matches[1]
+		}
+	})
+
+	t.Run("AuthorizeFormClientMobileApp", func(t *testing.T) {
+		var oauthClient oauth.Client
+
+		u := "https://example.org/oauth/callback"
+		oauthClient.RedirectURIs = []string{u}
+		oauthClient.ClientName = "cozy-test-2"
+		oauthClient.SoftwareID = "registry://drive"
+		oauthClient.Create(testInstance)
+
+		req, _ := http.NewRequest("GET", ts.URL+"/auth/authorize?response_type=code&state=123456&redirect_uri="+u+"&client_id="+oauthClient.ClientID, nil)
+		req.Host = testInstance.Domain
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		content, _ := io.ReadAll(res.Body)
+		assert.Contains(t, string(content), "io.cozy.files")
+		defer res.Body.Close()
+	})
+
+	t.Run("AuthorizeFormFlagshipApp", func(t *testing.T) {
+		u := url.QueryEscape("https://example.org/oauth/callback")
+		req, _ := http.NewRequest("GET", ts.URL+"/auth/authorize?response_type=code&state=123456&scope=*&redirect_uri="+u+"&client_id="+clientID+"&code_challenge=w6uP8Tcg6K2QR905Rms8iXTlksL6OD1KOWBxTK7wxPI&code_challenge_method=S256", nil)
+		req.Host = domain
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, "200 OK", res.Status)
+		assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
+		body, _ := io.ReadAll(res.Body)
+		assert.NotContains(t, string(body), "would like permission to access your Cozy")
+		assert.Contains(t, string(body), "The origin of this application is not certified.")
+	})
+
+	t.Run("AuthorizeWhenNotLoggedIn", func(t *testing.T) {
+		anonymousClient := &http.Client{CheckRedirect: noRedirect}
+		v := &url.Values{
+			"state":        {"123456"},
+			"client_id":    {clientID},
+			"redirect_uri": {"https://example.org/oauth/callback"},
+			"scope":        {"files:read"},
+			"csrf_token":   {csrfToken},
+		}
+		req, _ := http.NewRequest("POST", ts.URL+"/auth/authorize", bytes.NewBufferString(v.Encode()))
+		req.Host = domain
+		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+		res, err := anonymousClient.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, "403 Forbidden", res.Status)
+	})
+
+	t.Run("AuthorizeWithInvalidCSRFToken", func(t *testing.T) {
+		res, err := postForm("/auth/authorize", &url.Values{
+			"state":        {"123456"},
+			"client_id":    {clientID},
+			"redirect_uri": {"https://example.org/oauth/callback"},
+			"scope":        {"files:read"},
+			"csrf_token":   {"azertyuiop"},
+		})
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, "403 Forbidden", res.Status)
+		body, _ := io.ReadAll(res.Body)
+		assert.Contains(t, string(body), "invalid csrf token")
+	})
+
+	t.Run("AuthorizeWithNoState", func(t *testing.T) {
+		res, err := postForm("/auth/authorize", &url.Values{
+			"client_id":    {clientID},
+			"redirect_uri": {"https://example.org/oauth/callback"},
+			"scope":        {"files:read"},
+			"csrf_token":   {csrfToken},
+		})
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, "400 Bad Request", res.Status)
+		assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
+		body, _ := io.ReadAll(res.Body)
+		assert.Contains(t, string(body), "The state parameter is mandatory")
+	})
+
+	t.Run("AuthorizeWithNoClientID", func(t *testing.T) {
+		res, err := postForm("/auth/authorize", &url.Values{
+			"state":        {"123456"},
+			"redirect_uri": {"https://example.org/oauth/callback"},
+			"scope":        {"files:read"},
+			"csrf_token":   {csrfToken},
+		})
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, "400 Bad Request", res.Status)
+		assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
+		body, _ := io.ReadAll(res.Body)
+		assert.Contains(t, string(body), "The client_id parameter is mandatory")
+	})
+
+	t.Run("AuthorizeWithInvalidClientID", func(t *testing.T) {
+		res, err := postForm("/auth/authorize", &url.Values{
+			"state":         {"123456"},
+			"client_id":     {"987"},
+			"redirect_uri":  {"https://example.org/oauth/callback"},
+			"scope":         {"files:read"},
+			"csrf_token":    {csrfToken},
+			"response_type": {"code"},
+		})
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, "400 Bad Request", res.Status)
+		assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
+		body, _ := io.ReadAll(res.Body)
+		assert.Contains(t, string(body), "The client must be registered")
+	})
+
+	t.Run("AuthorizeWithNoRedirectURI", func(t *testing.T) {
+		res, err := postForm("/auth/authorize", &url.Values{
+			"state":         {"123456"},
+			"client_id":     {clientID},
+			"scope":         {"files:read"},
+			"csrf_token":    {csrfToken},
+			"response_type": {"code"},
+		})
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, "400 Bad Request", res.Status)
+		assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
+		body, _ := io.ReadAll(res.Body)
+		assert.Contains(t, string(body), "The redirect_uri parameter is mandatory")
+	})
+
+	t.Run("AuthorizeWithInvalidURI", func(t *testing.T) {
+		res, err := postForm("/auth/authorize", &url.Values{
+			"state":         {"123456"},
+			"client_id":     {clientID},
+			"redirect_uri":  {"/oauth/callback"},
+			"scope":         {"files:read"},
+			"csrf_token":    {csrfToken},
+			"response_type": {"code"},
+		})
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, "400 Bad Request", res.Status)
+		assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
+		body, _ := io.ReadAll(res.Body)
+		assert.Contains(t, string(body), "The redirect_uri parameter doesn&#39;t match the registered ones")
+	})
+
+	t.Run("AuthorizeWithNoScope", func(t *testing.T) {
+		res, err := postForm("/auth/authorize", &url.Values{
+			"state":         {"123456"},
+			"client_id":     {clientID},
+			"redirect_uri":  {"https://example.org/oauth/callback"},
+			"csrf_token":    {csrfToken},
+			"response_type": {"code"},
+		})
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, "400 Bad Request", res.Status)
+		assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
+		body, _ := io.ReadAll(res.Body)
+		assert.Contains(t, string(body), "The scope parameter is mandatory")
+	})
+
+	t.Run("AuthorizeSuccess", func(t *testing.T) {
+		res, err := postForm("/auth/authorize", &url.Values{
+			"state":         {"123456"},
+			"client_id":     {clientID},
+			"redirect_uri":  {"https://example.org/oauth/callback"},
+			"scope":         {"files:read"},
+			"csrf_token":    {csrfToken},
+			"response_type": {"code"},
+		})
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		if assert.Equal(t, "302 Found", res.Status) {
+			var results []oauth.AccessCode
+			req := &couchdb.AllDocsRequest{}
+			err = couchdb.GetAllDocs(testInstance, consts.OAuthAccessCodes, req, &results)
+			assert.NoError(t, err)
+			if assert.Len(t, results, 1) {
+				code = results[0].Code
+				expected := fmt.Sprintf("https://example.org/oauth/callback?access_code=%s&code=%s&state=123456#", code, code)
+				assert.Equal(t, expected, res.Header.Get("Location"))
+				assert.Equal(t, results[0].ClientID, clientID)
+				assert.Equal(t, results[0].Scope, "files:read")
+			}
+		}
+	})
+
+	t.Run("AuthorizeSuccessOnboardingDeeplink", func(t *testing.T) {
+		var oauthClient oauth.Client
+		oauthClient.RedirectURIs = []string{"cozydrive://"}
+		oauthClient.ClientName = "cozy-test-install-app"
+		oauthClient.SoftwareID = "io.cozy.mobile.drive"
+		oauthClient.OnboardingSecret = "toto"
+		oauthClient.Create(testInstance)
+
+		u := url.QueryEscape("https://example.org/oauth/callback")
+		req, _ := http.NewRequest("GET", ts.URL+"/auth/authorize?response_type=code&state=123456&scope=files:read&redirect_uri="+u+"&client_id="+clientID, nil)
+		req.Host = domain
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, "200 OK", res.Status)
+		assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
+		body, _ := io.ReadAll(res.Body)
+		assert.Contains(t, string(body), "would like permission to access your Cozy")
+		re := regexp.MustCompile(`<input type="hidden" name="csrf_token" value="(\w+)"`)
+		matches := re.FindStringSubmatch(string(body))
+		if assert.Len(t, matches, 2) {
+			csrfToken = matches[1]
+		}
+
+		v := &url.Values{
+			"state":         {"123456"},
+			"client_id":     {oauthClient.ClientID},
+			"redirect_uri":  {"cozydrive://"},
+			"scope":         {"files:read"},
+			"csrf_token":    {csrfToken},
+			"response_type": {"code"},
+		}
+		req, err = http.NewRequest("POST", ts.URL+"/auth/authorize", bytes.NewBufferString(v.Encode()))
+		assert.NoError(t, err)
+		req.Host = domain
+		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Add("Accept", "application/json")
+		res, err = client.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		if assert.Equal(t, 200, res.StatusCode) {
+			content, err := io.ReadAll(res.Body)
+			assert.NoError(t, err)
+			assert.Contains(t, string(content), "\"deeplink\":")
+		}
+	})
+
+	t.Run("AuthorizeSuccessOnboarding", func(t *testing.T) {
+		var oauthClient oauth.Client
+		u := "https://example.org/oauth/callback"
+		oauthClient.RedirectURIs = []string{u}
+		oauthClient.ClientName = "cozy-test-install-app"
+		oauthClient.SoftwareID = "io.cozy.mobile.drive"
+		oauthClient.OnboardingSecret = "toto"
+		oauthClient.Create(testInstance)
+
+		res, err := postForm("/auth/authorize", &url.Values{
+			"state":         {"123456"},
+			"client_id":     {oauthClient.ClientID},
+			"redirect_uri":  {"https://example.org/oauth/callback"},
+			"scope":         {"files:read"},
+			"csrf_token":    {csrfToken},
+			"response_type": {"code"},
+		})
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, 302, res.StatusCode)
+	})
+
+	t.Run("InstallAppWithLinkedApp", func(t *testing.T) {
+		var oauthClient oauth.Client
+		u := "https://example.org/oauth/callback"
+		oauthClient.RedirectURIs = []string{u}
+		oauthClient.ClientName = "cozy-test-install-app"
+		oauthClient.SoftwareID = "registry://drive"
+		oauthClient.Create(testInstance)
+
+		linkedClientID = oauthClient.ClientID         // Used for following tests
+		linkedClientSecret = oauthClient.ClientSecret // Used for following tests
+
+		res, err := postForm("/auth/authorize", &url.Values{
+			"state":         {"123456"},
+			"client_id":     {oauthClient.ClientID},
+			"redirect_uri":  {u},
+			"csrf_token":    {csrfToken},
+			"response_type": {"code"},
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, 302, res.StatusCode)
+		defer res.Body.Close()
+		couch := config.CouchCluster(testInstance.DBCluster())
+		db := testInstance.DBPrefix() + "%2F" + consts.Apps
+		err = couchdb.EnsureDBExist(testInstance, consts.Apps)
+		assert.NoError(t, err)
+		reqGetChanges, err := http.NewRequest("GET", couch.URL.String()+couchdb.EscapeCouchdbName(db)+"/_changes?feed=longpoll", nil)
+		assert.NoError(t, err)
+		if auth := couch.Auth; auth != nil {
+			if p, ok := auth.Password(); ok {
+				reqGetChanges.SetBasicAuth(auth.Username(), p)
+			}
+		}
+		resGetChanges, err := config.CouchClient().Do(reqGetChanges)
+		assert.NoError(t, err)
+		defer resGetChanges.Body.Close()
+		assert.Equal(t, resGetChanges.StatusCode, 200)
+		body, err := io.ReadAll(resGetChanges.Body)
+		assert.NoError(t, err)
+		assert.Contains(t, string(body), "io.cozy.apps/drive")
+
+		var results []oauth.AccessCode
+		reqDocs := &couchdb.AllDocsRequest{}
+		err = couchdb.GetAllDocs(testInstance, consts.OAuthAccessCodes, reqDocs, &results)
+		assert.NoError(t, err)
+		for _, result := range results {
+			if result.ClientID == linkedClientID {
+				linkedCode = result.Code
+				break
+			}
+		}
+	})
+
+	t.Run("CheckLinkedAppInstalled", func(t *testing.T) {
+		// We use the webapp drive installed from the previous test
+		err := auth.CheckLinkedAppInstalled(testInstance, "drive")
+		assert.NoError(t, err)
+	})
+
+	t.Run("AccessTokenLinkedAppInstalled", func(t *testing.T) {
+		res, err := postForm("/auth/access_token", &url.Values{
+			"grant_type":    {"authorization_code"},
+			"client_id":     {linkedClientID},
+			"client_secret": {linkedClientSecret},
+			"code":          {linkedCode},
+		})
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, 200, res.StatusCode)
+		var response map[string]string
+		err = json.NewDecoder(res.Body).Decode(&response)
+		assert.NoError(t, err)
+		assert.Equal(t, "bearer", response["token_type"])
+		assert.Equal(t, "@io.cozy.apps/drive", response["scope"])
+		assertValidToken(t, response["access_token"], "access", linkedClientID, "@io.cozy.apps/drive")
+		assertValidToken(t, response["refresh_token"], "refresh", linkedClientID, "@io.cozy.apps/drive")
+	})
+
+	t.Run("AccessTokenNoGrantType", func(t *testing.T) {
+		res, err := postForm("/auth/access_token", &url.Values{
+			"client_id":     {clientID},
+			"client_secret": {clientSecret},
+			"code":          {code},
+		})
+		assert.NoError(t, err)
+		assertJSONError(t, res, "the grant_type parameter is mandatory")
+	})
+
+	t.Run("AccessTokenInvalidGrantType", func(t *testing.T) {
+		res, err := postForm("/auth/access_token", &url.Values{
+			"grant_type":    {"token"},
+			"client_id":     {clientID},
+			"client_secret": {clientSecret},
+			"code":          {code},
+		})
+		assert.NoError(t, err)
+		assertJSONError(t, res, "invalid grant type")
+	})
+
+	t.Run("AccessTokenNoClientID", func(t *testing.T) {
+		res, err := postForm("/auth/access_token", &url.Values{
+			"grant_type":    {"authorization_code"},
+			"client_secret": {clientSecret},
+			"code":          {code},
+		})
+		assert.NoError(t, err)
+		assertJSONError(t, res, "the client_id parameter is mandatory")
+	})
+
+	t.Run("AccessTokenInvalidClientID", func(t *testing.T) {
+		res, err := postForm("/auth/access_token", &url.Values{
+			"grant_type":    {"authorization_code"},
+			"client_id":     {"foo"},
+			"client_secret": {clientSecret},
+			"code":          {code},
+		})
+		assert.NoError(t, err)
+		assertJSONError(t, res, "the client must be registered")
+	})
+
+	t.Run("AccessTokenNoClientSecret", func(t *testing.T) {
+		res, err := postForm("/auth/access_token", &url.Values{
+			"grant_type": {"authorization_code"},
+			"client_id":  {clientID},
+			"code":       {code},
+		})
+		assert.NoError(t, err)
+		assertJSONError(t, res, "the client_secret parameter is mandatory")
+	})
+
+	t.Run("AccessTokenInvalidClientSecret", func(t *testing.T) {
+		res, err := postForm("/auth/access_token", &url.Values{
+			"grant_type":    {"authorization_code"},
+			"client_id":     {clientID},
+			"client_secret": {"foo"},
+			"code":          {code},
+		})
+		assert.NoError(t, err)
+		assertJSONError(t, res, "invalid client_secret")
+	})
+
+	t.Run("AccessTokenNoCode", func(t *testing.T) {
+		res, err := postForm("/auth/access_token", &url.Values{
+			"grant_type":    {"authorization_code"},
+			"client_id":     {clientID},
+			"client_secret": {clientSecret},
+		})
+		assert.NoError(t, err)
+		assertJSONError(t, res, "the code parameter is mandatory")
+	})
+
+	t.Run("AccessTokenInvalidCode", func(t *testing.T) {
+		res, err := postForm("/auth/access_token", &url.Values{
+			"grant_type":    {"authorization_code"},
+			"client_id":     {clientID},
+			"client_secret": {clientSecret},
+			"code":          {"foo"},
+		})
+		assert.NoError(t, err)
+		assertJSONError(t, res, "invalid code")
+	})
+
+	t.Run("AccessTokenSuccess", func(t *testing.T) {
+		res, err := postForm("/auth/access_token", &url.Values{
+			"grant_type":    {"authorization_code"},
+			"client_id":     {clientID},
+			"client_secret": {clientSecret},
+			"code":          {code},
+		})
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, "200 OK", res.Status)
+		var response map[string]string
+		err = json.NewDecoder(res.Body).Decode(&response)
+		assert.NoError(t, err)
+		assert.Equal(t, "bearer", response["token_type"])
+		assert.Equal(t, "files:read", response["scope"])
+		assertValidToken(t, response["access_token"], "access", clientID, "files:read")
+		assertValidToken(t, response["refresh_token"], "refresh", clientID, "files:read")
+		refreshToken = response["refresh_token"]
+	})
+
+	t.Run("RefreshTokenNoToken", func(t *testing.T) {
+		res, err := postForm("/auth/access_token", &url.Values{
+			"grant_type":    {"refresh_token"},
+			"client_id":     {clientID},
+			"client_secret": {clientSecret},
+		})
+		assert.NoError(t, err)
+		assertJSONError(t, res, "invalid refresh token")
+	})
+
+	t.Run("RefreshTokenInvalidToken", func(t *testing.T) {
+		res, err := postForm("/auth/access_token", &url.Values{
+			"grant_type":    {"refresh_token"},
+			"client_id":     {clientID},
+			"client_secret": {clientSecret},
+			"refresh_token": {"foo"},
+		})
+		assert.NoError(t, err)
+		assertJSONError(t, res, "invalid refresh token")
+	})
+
+	t.Run("RefreshTokenInvalidSigningMethod", func(t *testing.T) {
+		claims := permission.Claims{
+			StandardClaims: crypto.StandardClaims{
+				Audience: consts.RefreshTokenAudience,
+				Issuer:   domain,
+				IssuedAt: crypto.Timestamp(),
+				Subject:  clientID,
+			},
+			Scope: "files:write",
+		}
+		token := jwt.NewWithClaims(jwt.GetSigningMethod("none"), claims)
+		fakeToken, err := token.SignedString(jwt.UnsafeAllowNoneSignatureType)
+		assert.NoError(t, err)
+		res, err := postForm("/auth/access_token", &url.Values{
+			"grant_type":    {"refresh_token"},
+			"client_id":     {clientID},
+			"client_secret": {clientSecret},
+			"refresh_token": {fakeToken},
+		})
+		assert.NoError(t, err)
+		assertJSONError(t, res, "invalid refresh token")
+	})
+
+	t.Run("RefreshTokenSuccess", func(t *testing.T) {
+		res, err := postForm("/auth/access_token", &url.Values{
+			"grant_type":    {"refresh_token"},
+			"client_id":     {clientID},
+			"client_secret": {clientSecret},
+			"refresh_token": {refreshToken},
+		})
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, "200 OK", res.Status)
+		var response map[string]string
+		err = json.NewDecoder(res.Body).Decode(&response)
+		assert.NoError(t, err)
+		assert.Equal(t, "bearer", response["token_type"])
+		assert.Equal(t, "files:read", response["scope"])
+		assert.Equal(t, "", response["refresh_token"])
+		assertValidToken(t, response["access_token"], "access", clientID, "files:read")
+	})
+
+	t.Run("OAuthWithPKCE", func(t *testing.T) {
+		/* Values taken from https://datatracker.ietf.org/doc/html/rfc7636#appendix-B */
+		challenge := "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+		verifier := "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+
+		/* 1. GET /auth/authorize */
+		u := url.QueryEscape("https://example.org/oauth/callback")
+		req, _ := http.NewRequest("GET", ts.URL+"/auth/authorize?response_type=code&state=123456&scope=files:read&redirect_uri="+u+"&client_id="+clientID+"&code_challenge_method=S256&code_challenge="+challenge, nil)
+		req.Host = domain
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		require.Equal(t, res.StatusCode, 200)
+		body, _ := io.ReadAll(res.Body)
+		re := regexp.MustCompile(`<input type="hidden" name="csrf_token" value="(\w+)"`)
+		matches := re.FindStringSubmatch(string(body))
+		require.Len(t, matches, 2)
+		csrfToken = matches[1]
+
+		/* 2. POST /auth/authorize */
+		res, err = postForm("/auth/authorize", &url.Values{
+			"state":                 {"123456"},
+			"client_id":             {clientID},
+			"redirect_uri":          {"https://example.org/oauth/callback"},
+			"scope":                 {"files:read"},
+			"csrf_token":            {csrfToken},
+			"response_type":         {"code"},
+			"code_challenge":        {challenge},
+			"code_challenge_method": {"S256"},
+		})
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		require.Equal(t, "302 Found", res.Status)
+		var results []oauth.AccessCode
+		allReq := &couchdb.AllDocsRequest{}
+		err = couchdb.GetAllDocs(testInstance, consts.OAuthAccessCodes, allReq, &results)
+		assert.NoError(t, err)
+		var code string
+		for _, result := range results {
+			if result.Challenge != "" {
+				code = result.Code
+			}
+		}
+		require.NotEmpty(t, code)
+
+		/* 3. POST /auth/access_token without code_verifier must fail */
+		res, err = postForm("/auth/access_token", &url.Values{
+			"grant_type":    {"authorization_code"},
+			"client_id":     {clientID},
+			"client_secret": {clientSecret},
+			"code":          {code},
+		})
+		assert.NoError(t, err)
+		assertJSONError(t, res, "invalid code_verifier")
+
+		/* 4. POST /auth/access_token with code_verifier should succeed */
+		res, err = postForm("/auth/access_token", &url.Values{
+			"grant_type":    {"authorization_code"},
+			"client_id":     {clientID},
+			"client_secret": {clientSecret},
+			"code":          {code},
+			"code_verifier": {verifier},
+		})
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		require.Equal(t, res.StatusCode, 200)
+		var response map[string]string
+		err = json.NewDecoder(res.Body).Decode(&response)
+		assert.NoError(t, err)
+		assert.Equal(t, "bearer", response["token_type"])
+		assert.Equal(t, "files:read", response["scope"])
+		assertValidToken(t, response["access_token"], "access", clientID, "files:read")
+		assertValidToken(t, response["refresh_token"], "refresh", clientID, "files:read")
+	})
+
+	t.Run("ConfirmFlagship", func(t *testing.T) {
+		token, code, err := oauth.GenerateConfirmCode(testInstance, clientID)
+		require.NoError(t, err)
+
+		res, err := postForm("/auth/clients/"+clientID+"/flagship", &url.Values{
+			"code":  {code},
+			"token": {string(token)},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 204, res.StatusCode)
+
+		client, err := oauth.FindClient(testInstance, clientID)
+		require.NoError(t, err)
+		assert.True(t, client.Flagship)
+	})
+
+	t.Run("LoginFlagship", func(t *testing.T) {
+		oauthClient := &oauth.Client{
+			RedirectURIs:    []string{"cozy://flagship"},
+			ClientName:      "Cozy Flagship",
+			ClientKind:      "mobile",
+			SoftwareID:      "cozy-flagship",
+			SoftwareVersion: "0.1.0",
+		}
+		require.Nil(t, oauthClient.Create(testInstance))
+		client, err := oauth.FindClient(testInstance, oauthClient.ClientID)
+		require.NoError(t, err)
+		client.CertifiedFromStore = true
+		require.NoError(t, client.SetFlagship(testInstance))
+
+		args, err := json.Marshal(&echo.Map{
+			"passphrase":    "InvalidPassphrase",
+			"client_id":     client.CouchID,
+			"client_secret": client.ClientSecret,
+		})
+		require.NoError(t, err)
+		req, err := http.NewRequest("POST", ts.URL+"/auth/login/flagship", bytes.NewReader(args))
+		require.NoError(t, err)
+		req.Host = domain
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("Accept", "application/json")
+		res, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, 401, res.StatusCode)
+
+		args, err = json.Marshal(&echo.Map{
+			"passphrase":    "MyPassphrase",
+			"client_id":     client.CouchID,
+			"client_secret": "InvalidClientSecret",
+		})
+		require.NoError(t, err)
+		req, err = http.NewRequest("POST", ts.URL+"/auth/login/flagship", bytes.NewReader(args))
+		require.NoError(t, err)
+		req.Host = domain
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("Accept", "application/json")
+		res, err = http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, 400, res.StatusCode)
+
+		args, err = json.Marshal(&echo.Map{
+			"passphrase":    "MyPassphrase",
+			"client_id":     client.CouchID,
+			"client_secret": client.ClientSecret,
+		})
+		require.NoError(t, err)
+		req, err = http.NewRequest("POST", ts.URL+"/auth/login/flagship", bytes.NewReader(args))
+		require.NoError(t, err)
+		req.Host = domain
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("Accept", "application/json")
+		res, err = http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, 200, res.StatusCode)
+		var resbody map[string]interface{}
+		require.NoError(t, json.NewDecoder(res.Body).Decode(&resbody))
+		assert.NotNil(t, resbody["access_token"])
+		assert.NotNil(t, resbody["refresh_token"])
+		assert.Equal(t, "*", resbody["scope"])
+		assert.Equal(t, "bearer", resbody["token_type"])
+	})
+
+	t.Run("AppRedirectionOnLogin", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/auth/login?redirect=drive/%23/foobar", nil)
+		req.Host = domain
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		if assert.Equal(t, "303 See Other", res.Status) {
+			assert.Equal(t, "https://drive.cozy.example.net#/foobar",
+				res.Header.Get("Location"))
+		}
+	})
+
+	t.Run("LogoutNoToken", func(t *testing.T) {
+		req, _ := http.NewRequest("DELETE", ts.URL+"/auth/login", nil)
+		req.Host = domain
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, "401 Unauthorized", res.Status)
+		cookies := jar.Cookies(nil)
+		assert.Len(t, cookies, 2) // cozysessid and _csrf
+	})
+
+	t.Run("LogoutSuccess", func(t *testing.T) {
+		token := testInstance.BuildAppToken("home", getSessionID(jar.Cookies(nil)))
+		_, err := permission.CreateWebappSet(testInstance, "home", permission.Set{}, "1.0.0")
+		assert.NoError(t, err)
+		req, _ := http.NewRequest("DELETE", ts.URL+"/auth/login", nil)
+		req.Host = domain
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		err = permission.DestroyWebapp(testInstance, "home")
+		assert.NoError(t, err)
+
+		assert.Equal(t, "204 No Content", res.Status)
+		cookies := jar.Cookies(nil)
+		assert.Len(t, cookies, 1) // _csrf
+		assert.Equal(t, "_csrf", cookies[0].Name)
+	})
+
+	t.Run("LogoutOthers", func(t *testing.T) {
+		var anonymousClient1, anonymousClient2 *http.Client
+		{
+			u1, _ := url.Parse(testInstance.PageURL("/auth", nil))
+			u2, _ := url.Parse(testInstance.PageURL("/auth", nil))
+			jar1, _ := cookiejar.New(nil)
+			jar2, _ := cookiejar.New(nil)
+			anonymousClient1 = &http.Client{
+				CheckRedirect: noRedirect,
+				Jar:           &testutils.CookieJar{Jar: jar1, URL: u1},
+			}
+			anonymousClient2 = &http.Client{
+				CheckRedirect: noRedirect,
+				Jar:           &testutils.CookieJar{Jar: jar2, URL: u2},
+			}
+		}
+
+		res1, err := postFormWithClient(anonymousClient1, "/auth/login", &url.Values{
+			"passphrase": {"MyPassphrase"},
+			"csrf_token": {getLoginCSRFToken(anonymousClient1, t)},
+		})
+		assert.NoError(t, err)
+		defer res1.Body.Close()
+
+		if !assert.Equal(t, "303 See Other", res1.Status) {
+			return
+		}
+		cookies1 := res1.Cookies()
+		assert.Len(t, cookies1, 2)
+
+		res2, err := postFormWithClient(anonymousClient2, "/auth/login", &url.Values{
+			"passphrase": {"MyPassphrase"},
+			"csrf_token": {getLoginCSRFToken(anonymousClient2, t)},
+		})
+		assert.NoError(t, err)
+		defer res2.Body.Close()
+		if !assert.Equal(t, "303 See Other", res2.Status) {
+			return
+		}
+		cookies2 := res2.Cookies()
+		assert.Len(t, cookies2, 2)
+
+		token := testInstance.BuildAppToken("home", getSessionID(cookies1))
+		_, err = permission.CreateWebappSet(testInstance, "home", permission.Set{}, "1.0.0")
+		assert.NoError(t, err)
+
+		reqLogout1, _ := http.NewRequest("DELETE", ts.URL+"/auth/login/others", nil)
+		reqLogout1.Host = domain
+		reqLogout1.Header.Add("Authorization", "Bearer "+token)
+		reqLogout1.AddCookie(cookies1[1])
+		resLogout1, err := client.Do(reqLogout1)
+		assert.NoError(t, err)
+		defer resLogout1.Body.Close()
+		assert.Equal(t, 204, resLogout1.StatusCode)
+
+		reqLogout2, _ := http.NewRequest("DELETE", ts.URL+"/auth/login/others", nil)
+		reqLogout2.Host = domain
+		reqLogout2.Header.Add("Authorization", "Bearer "+token)
+		reqLogout2.AddCookie(cookies2[1])
+		resLogout2, err := client.Do(reqLogout2)
+		assert.NoError(t, err)
+		defer resLogout2.Body.Close()
+		assert.Equal(t, 401, resLogout2.StatusCode)
+
+		reqLogout3, _ := http.NewRequest("DELETE", ts.URL+"/auth/login/others", nil)
+		reqLogout3.Host = domain
+		reqLogout3.Header.Add("Authorization", "Bearer "+token)
+		reqLogout3.AddCookie(cookies1[1])
+		resLogout3, err := client.Do(reqLogout3)
+		assert.NoError(t, err)
+		defer resLogout3.Body.Close()
+		assert.Equal(t, 204, resLogout3.StatusCode)
+
+		err = permission.DestroyWebapp(testInstance, "home")
+		assert.NoError(t, err)
+	})
+
+	t.Run("PassphraseResetLoggedIn", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/auth/passphrase_reset", nil)
+		req.Host = domain
+		res, err := client.Do(req)
+		require.NoError(t, err)
+
+		defer res.Body.Close()
+		assert.Equal(t, "200 OK", res.Status)
+		body, _ := io.ReadAll(res.Body)
+		assert.Contains(t, string(body), `my password`)
+		assert.Contains(t, string(body), `<input type="hidden" name="csrf_token"`)
+	})
+
+	t.Run("PassphraseReset", func(t *testing.T) {
+		req1, _ := http.NewRequest("GET", ts.URL+"/auth/passphrase_reset", nil)
+		req1.Host = domain
+		res1, err := client.Do(req1)
+		require.NoError(t, err)
+
+		defer res1.Body.Close()
+		assert.Equal(t, "200 OK", res1.Status)
+		csrfCookie := res1.Cookies()[0]
+		assert.Equal(t, "_csrf", csrfCookie.Name)
+		res2, err := postForm("/auth/passphrase_reset", &url.Values{
+			"csrf_token": {csrfCookie.Value},
+		})
+		require.NoError(t, err)
+
+		defer res2.Body.Close()
+		assert.Equal(t, "200 OK", res2.Status)
+		assert.Equal(t, "text/html; charset=UTF-8", res2.Header.Get("Content-Type"))
+	})
+
+	t.Run("PassphraseRenewFormNoToken", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/auth/passphrase_renew", nil)
+		req.Host = domain
+		res, err := client.Do(req)
+		require.NoError(t, err)
+
+		defer res.Body.Close()
+		assert.Equal(t, "400 Bad Request", res.Status)
+		body, _ := io.ReadAll(res.Body)
+		assert.Contains(t, string(body), `The link to reset the password is truncated or has expired`)
+	})
+
+	t.Run("PassphraseRenewFormBadToken", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/auth/passphrase_renew?token=zzzz", nil)
+		req.Host = domain
+		res, err := client.Do(req)
+		require.NoError(t, err)
+
+		defer res.Body.Close()
+		assert.Equal(t, "400 Bad Request", res.Status)
+		body, _ := io.ReadAll(res.Body)
+		assert.Contains(t, string(body), `The link to reset the password is truncated or has expired`)
+	})
+
+	t.Run("PassphraseRenewFormWithToken", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/auth/passphrase_renew?token=badbee", nil)
+		req.Host = domain
+		res, err := client.Do(req)
+		require.NoError(t, err)
+
+		defer res.Body.Close()
+		assert.Equal(t, "400 Bad Request", res.Status)
+	})
+
+	t.Run("PassphraseRenew", func(t *testing.T) {
+		d := "test.cozycloud.cc.web_reset_form"
+		_ = lifecycle.Destroy(d)
+		in1, err := lifecycle.Create(&lifecycle.Options{
+			Domain: d,
+			Locale: "en",
+			Email:  "alice@example.com",
+		})
+		require.NoError(t, err)
+
+		defer func() {
+			_ = lifecycle.Destroy(d)
+		}()
+		err = lifecycle.RegisterPassphrase(in1, in1.RegisterToken, lifecycle.PassParameters{
+			Pass:       []byte("MyPass"),
+			Iterations: 5000,
+			Key:        "0.uRcMe+Mc2nmOet4yWx9BwA==|PGQhpYUlTUq/vBEDj1KOHVMlTIH1eecMl0j80+Zu0VRVfFa7X/MWKdVM6OM/NfSZicFEwaLWqpyBlOrBXhR+trkX/dPRnfwJD2B93hnLNGQ=",
+		})
+		require.NoError(t, err)
+
+		req1, _ := http.NewRequest("GET", ts.URL+"/auth/passphrase_reset", nil)
+		req1.Host = domain
+		res1, err := client.Do(req1)
+		require.NoError(t, err)
+
+		defer res1.Body.Close()
+		csrfCookie := res1.Cookies()[0]
+		assert.Equal(t, "_csrf", csrfCookie.Name)
+		res2, err := postFormDomain(d, "/auth/passphrase_reset", &url.Values{
+			"csrf_token": {csrfCookie.Value},
+		})
+		require.NoError(t, err)
+
+		defer res2.Body.Close()
+		assert.Equal(t, "200 OK", res2.Status)
+		in2, err := instance.GetFromCouch(d)
+		require.NoError(t, err)
+
+		res3, err := postFormDomain(d, "/auth/passphrase_renew", &url.Values{
+			"passphrase_reset_token": {hex.EncodeToString(in2.PassphraseResetToken)},
+			"passphrase":             {"NewPassphrase"},
+			"csrf_token":             {csrfCookie.Value},
+		})
+		require.NoError(t, err)
+
+		defer res3.Body.Close()
+		if assert.Equal(t, "303 See Other", res3.Status) {
+			assert.Equal(t, "https://test.cozycloud.cc.web_reset_form/auth/login",
+				res3.Header.Get("Location"))
+		}
+	})
+
+	t.Run("IsLoggedOutAfterLogout", func(t *testing.T) {
+		content, err := getTestURL()
+		assert.NoError(t, err)
+		assert.Equal(t, "who_are_you", content)
+	})
+
+	t.Run("SecretExchangeGoodSecret", func(t *testing.T) {
+		body, _ := json.Marshal(echo.Map{"secret": "foobarsecret"})
+
+		var oauthClient oauth.Client
+
+		oauthClient.RedirectURIs = []string{"abc"}
+		oauthClient.ClientName = "cozy-test"
+		oauthClient.SoftwareID = "github.com/cozy/cozy-test"
+		oauthClient.OnboardingSecret = "foobarsecret"
+		oauthClient.Create(testInstance)
+
+		req, _ := http.NewRequest("POST", ts.URL+"/auth/secret_exchange", bytes.NewBuffer(body))
+		req.Host = domain
+		req.Header.Add("Content-Type", "application/json; charset=utf-8")
+		req.Header.Add("Accept", "application/json")
+
+		res, err := client.Do(req)
+		require.NoError(t, err)
+
+		resBody, _ := io.ReadAll(res.Body)
+		assert.Contains(t, string(resBody), "client_secret")
+		defer res.Body.Close()
+	})
+
+	t.Run("SecretExchangeBadSecret", func(t *testing.T) {
+		body, _ := json.Marshal(echo.Map{"secret": "badbarsecret"})
+
+		var oauthClient oauth.Client
+
+		oauthClient.RedirectURIs = []string{"abc"}
+		oauthClient.ClientName = "cozy-test"
+		oauthClient.SoftwareID = "github.com/cozy/cozy-test"
+		oauthClient.OnboardingSecret = "foobarsecret"
+		oauthClient.Create(testInstance)
+
+		req, _ := http.NewRequest("POST", ts.URL+"/auth/secret_exchange", bytes.NewBuffer(body))
+		req.Host = domain
+		req.Header.Add("Content-Type", "application/json; charset=utf-8")
+		req.Header.Add("Accept", "application/json")
+
+		res, err := client.Do(req)
+
+		require.NoError(t, err)
+
+		resBody, _ := io.ReadAll(res.Body)
+		assert.Contains(t, string(resBody), "errors")
+
+		defer res.Body.Close()
+	})
+
+	t.Run("SecretExchangeBadPayload", func(t *testing.T) {
+		body, _ := json.Marshal(echo.Map{"foo": "bar"})
+
+		req, _ := http.NewRequest("POST", ts.URL+"/auth/secret_exchange", bytes.NewBuffer(body))
+		req.Host = domain
+		req.Header.Add("Content-Type", "application/json; charset=utf-8")
+		req.Header.Add("Accept", "application/json")
+
+		res, err := client.Do(req)
+		require.NoError(t, err)
+
+		resBody, _ := io.ReadAll(res.Body)
+		assert.Contains(t, string(resBody), "Missing secret")
+		defer res.Body.Close()
+	})
+
+	t.Run("SecretExchangeNoPayload", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", ts.URL+"/auth/secret_exchange", nil)
+		req.Host = domain
+		req.Header.Add("Content-Type", "application/json; charset=utf-8")
+		req.Header.Add("Accept", "application/json")
+
+		res, err := client.Do(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, res.StatusCode, 400)
+		defer res.Body.Close()
+	})
+
+	t.Run("PassphraseOnboarding", func(t *testing.T) {
+		// Here we create a new instance without passphrase
+		d := "test.cozycloud.cc.web_passphrase"
+		_ = lifecycle.Destroy(d)
+		inst, err := lifecycle.Create(&lifecycle.Options{
+			Domain: d,
+			Locale: "en",
+			Email:  "alice@example.com",
+		})
+		assert.NoError(t, err)
+		assert.False(t, inst.OnboardingFinished)
+
+		// Should redirect to /auth/passphrase
+		req, _ := http.NewRequest("GET", ts.URL+"/?registerToken="+hex.EncodeToString(inst.RegisterToken), nil)
+		req.Host = inst.Domain
+		res, err := client.Do(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, 303, res.StatusCode)
+		assert.Contains(t, res.Header.Get("Location"), "/auth/passphrase?registerToken=")
+
+		// Adding a passphrase and check if we are redirected to home
+		pass := []byte("passphrase")
+		err = lifecycle.RegisterPassphrase(inst, inst.RegisterToken, lifecycle.PassParameters{
+			Pass:       pass,
+			Iterations: 5000,
+			Key:        "0.uRcMe+Mc2nmOet4yWx9BwA==|PGQhpYUlTUq/vBEDj1KOHVMlTIH1eecMl0j80+Zu0VRVfFa7X/MWKdVM6OM/NfSZicFEwaLWqpyBlOrBXhR+trkX/dPRnfwJD2B93hnLNGQ=",
+		})
+		assert.NoError(t, err)
+
+		inst.OnboardingFinished = true
+
+		req2, _ := http.NewRequest("GET", ts.URL+"/?registerToken="+hex.EncodeToString(inst.RegisterToken), nil)
+		req2.Host = inst.Domain
+		res2, err2 := client.Do(req2)
+		assert.NoError(t, err2)
+		assert.Contains(t, res2.Header.Get("Location"), "/auth/login")
+	})
+
+	t.Run("PassphraseOnboardingFinished", func(t *testing.T) {
+		// Using the testInstance which had already been onboarded
+		// Should redirect to home
+		req, _ := http.NewRequest("GET", ts.URL+"/auth/passphrase", nil)
+		req.Host = domain
+
+		res, err := client.Do(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, res.StatusCode, 303)
+		assert.Equal(t, res.Header.Get("Location"), "https://home.cozy.example.net/")
+	})
+
+	t.Run("PassphraseOnboardingBadRegisterToken", func(t *testing.T) {
+		// Should render need_onboarding
+		d := "test.cozycloud.cc.web_passphrase_bad_token"
+		_ = lifecycle.Destroy(d)
+		inst, err := lifecycle.Create(&lifecycle.Options{
+			Domain: d,
+			Locale: "en",
+			Email:  "alice@example.com",
+		})
+		assert.NoError(t, err)
+		assert.False(t, inst.OnboardingFinished)
+
+		// Should redirect to /auth/passphrase
+		req, _ := http.NewRequest("GET", ts.URL+"/auth/passphrase?registerToken=coincoin", nil)
+		req.Host = inst.Domain
+		res, err := client.Do(req)
+		require.NoError(t, err)
+
+		content, _ := io.ReadAll(res.Body)
+		assert.Equal(t, 200, res.StatusCode)
+		assert.Contains(t, string(content), "Your Cozy has not been yet activated.")
+	})
+
+	t.Run("LoginOnboardingNotFinished", func(t *testing.T) {
+		// Should render need_onboarding
+		d := "test.cozycloud.cc.web_login_onboarding_not_finished"
+		_ = lifecycle.Destroy(d)
+		inst, err := lifecycle.Create(&lifecycle.Options{
+			Domain: d,
+			Locale: "en",
+			Email:  "alice@example.com",
+		})
+		assert.NoError(t, err)
+		assert.False(t, inst.OnboardingFinished)
+
+		// Should redirect to /auth/passphrase
+		req, _ := http.NewRequest("GET", ts.URL+"/auth/login", nil)
+		req.Host = inst.Domain
+		res, err := client.Do(req)
+		require.NoError(t, err)
+
+		content, _ := io.ReadAll(res.Body)
+		assert.Equal(t, 200, res.StatusCode)
+		assert.Contains(t, string(content), "Your Cozy has not been yet activated.")
+	})
+
+	t.Run("ShowConfirmForm", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/auth/confirm?state=342dd650-599b-0139-cfb0-543d7eb8149c", nil)
+		req.Host = domain
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, 200, res.StatusCode)
+		assert.Equal(t, "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
+		body, _ := io.ReadAll(res.Body)
+		assert.NotContains(t, string(body), "myfragment")
+		assert.Contains(t, string(body), `<input id="state" type="hidden" name="state" value="342dd650-599b-0139-cfb0-543d7eb8149c" />`)
+	})
+
+	t.Run("SendConfirmBadCSRFToken", func(t *testing.T) {
+		payload := url.Values{
+			"passphrase": {"MyPassphrase"},
+			"csrf_token": {"123456"},
+			"state":      {"342dd650-599b-0139-cfb0-543d7eb8149c"},
+		}.Encode()
+		req, _ := http.NewRequest("POST", ts.URL+"/auth/confirm", bytes.NewBufferString(payload))
+		req.Host = domain
+		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Add("Accept", "application/json")
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 403, res.StatusCode)
+	})
+
+	t.Run("SendConfirmBadPass", func(t *testing.T) {
+		token := getConfirmCSRFToken(client, t)
+		payload := url.Values{
+			"passphrase": {"InvalidPassphrase"},
+			"csrf_token": {token},
+			"state":      {"342dd650-599b-0139-cfb0-543d7eb8149c"},
+		}.Encode()
+		req, _ := http.NewRequest("POST", ts.URL+"/auth/confirm", bytes.NewBufferString(payload))
+		req.Host = domain
+		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Add("Accept", "application/json")
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 401, res.StatusCode)
+	})
+
+	t.Run("SendConfirmOK", func(t *testing.T) {
+		token := getConfirmCSRFToken(client, t)
+		payload := url.Values{
+			"passphrase": {"MyPassphrase"},
+			"csrf_token": {token},
+			"state":      {"342dd650-599b-0139-cfb0-543d7eb8149c"},
+		}.Encode()
+		req, _ := http.NewRequest("POST", ts.URL+"/auth/confirm", bytes.NewBufferString(payload))
+		req.Host = domain
+		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Add("Accept", "application/json")
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var body map[string]string
+		err = json.NewDecoder(res.Body).Decode(&body)
+		assert.NoError(t, err)
+		redirect := body["redirect"]
+		assert.NotEmpty(t, redirect)
+		u, err := url.Parse(redirect)
+		assert.NoError(t, err)
+		confirmCode = u.Query().Get("code")
+		assert.NotEmpty(t, confirmCode)
+		state := u.Query().Get("state")
+		assert.Equal(t, "342dd650-599b-0139-cfb0-543d7eb8149c", state)
+	})
+
+	t.Run("ConfirmBadCode", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/auth/confirm/123456", nil)
+		req.Host = domain
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 401, res.StatusCode)
+	})
+
+	t.Run("ConfirmCodeOK", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/auth/confirm/"+confirmCode, nil)
+		req.Host = domain
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 204, res.StatusCode)
+	})
+
+	t.Run("BuildKonnectorToken", func(t *testing.T) {
+		// Create an flagship OAuth client
+		oauthClient := oauth.Client{
+			RedirectURIs: []string{"cozy://client"},
+			ClientName:   "oauth-client",
+			SoftwareID:   "github.com/cozy/cozy-stack/testing/client",
+			Flagship:     true,
+		}
+		require.Nil(t, oauthClient.Create(testInstance, oauth.NotPending))
+
+		// Give it the maximal permission
+		token, err := testInstance.MakeJWT(consts.AccessTokenAudience,
+			oauthClient.ClientID, "*", "", time.Now())
+		require.NoError(t, err)
+
+		// Get konnector access_token
+		req, err := http.NewRequest("POST", ts.URL+"/auth/tokens/konnectors/"+konnSlug, nil)
+		require.NoError(t, err)
+		req.Host = domain
+		req.Header.Add("Accept", "application/json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := client.Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, "201 Created", res.Status)
+
+		defer res.Body.Close()
+		var response string
+		err = json.NewDecoder(res.Body).Decode(&response)
+		require.NoError(t, err)
+
+		// Validate token
+		claims := permission.Claims{}
+		err = crypto.ParseJWT(response, func(token *jwt.Token) (interface{}, error) {
+			return testInstance.SessionSecret(), nil
+		}, &claims)
+		assert.NoError(t, err)
+		assert.Equal(t, consts.KonnectorAudience, claims.Audience)
+		assert.Equal(t, domain, claims.Issuer)
+		assert.Equal(t, konnSlug, claims.Subject)
+		assert.Equal(t, "", claims.Scope)
+	})
+
+	t.Run("BuildKonnectorTokenNotFlagshipApp", func(t *testing.T) {
+		// Create an OAuth client
+		oauthClient := oauth.Client{
+			RedirectURIs: []string{"cozy://client"},
+			ClientName:   "oauth-client",
+			SoftwareID:   "github.com/cozy/cozy-stack/testing/client",
+			Flagship:     false,
+		}
+		require.Nil(t, oauthClient.Create(testInstance, oauth.NotPending))
+
+		// Give it the maximal permission
+		token, err := testInstance.MakeJWT(consts.AccessTokenAudience,
+			oauthClient.ClientID, "*", "", time.Now())
+		require.NoError(t, err)
+
+		req, err := http.NewRequest("POST", ts.URL+"/auth/tokens/konnectors/"+konnSlug, nil)
+		require.NoError(t, err)
+		req.Host = domain
+		req.Header.Add("Accept", "application/json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := client.Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, "403 Forbidden", res.Status)
+	})
+
+	t.Run("BuildKonnectorTokenInvalidSlug", func(t *testing.T) {
+		// Create an flagship OAuth client
+		oauthClient := oauth.Client{
+			RedirectURIs: []string{"cozy://client"},
+			ClientName:   "oauth-client",
+			SoftwareID:   "github.com/cozy/cozy-stack/testing/client",
+			Flagship:     true,
+		}
+		require.Nil(t, oauthClient.Create(testInstance, oauth.NotPending))
+
+		// Give it the maximal permission
+		token, err := testInstance.MakeJWT(consts.AccessTokenAudience,
+			oauthClient.ClientID, "*", "", time.Now())
+		require.NoError(t, err)
+
+		req, err := http.NewRequest("POST", ts.URL+"/auth/tokens/konnectors/missing", nil)
+		require.NoError(t, err)
+		req.Host = domain
+		req.Header.Add("Accept", "application/json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := client.Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, "404 Not Found", res.Status)
+	})
+
+}
+
+func getSessionID(cookies []*http.Cookie) string {
+	for _, c := range cookies {
+		if c.Name == session.CookieName(testInstance) {
+			b, err := base64.RawURLEncoding.DecodeString(c.Value)
+			if err != nil {
+				return ""
+			}
+			return string(b[8 : 8+32])
+		}
+	}
+	return ""
+}
+
+func getLoginCSRFToken(c *http.Client, t *testing.T) string {
+	req, _ := http.NewRequest("GET", ts.URL+"/auth/login", nil)
+	req.Host = domain
+	res, err := c.Do(req)
+	assert.NoError(t, err)
+	defer res.Body.Close()
+	return res.Cookies()[0].Value
+}
+
+func getConfirmCSRFToken(c *http.Client, t *testing.T) string {
+	req, _ := http.NewRequest("GET", ts.URL+"/auth/confirm?state=123", nil)
+	req.Host = domain
+	res, err := c.Do(req)
+	assert.NoError(t, err)
+	defer res.Body.Close()
+	return res.Cookies()[0].Value
 }
 
 func fakeAPI(g *echo.Group) {

--- a/web/auth/auth_test.go
+++ b/web/auth/auth_test.go
@@ -14,7 +14,6 @@ import (
 	"net/http/cookiejar"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"regexp"
 	"testing"
 	"time"
@@ -115,8 +114,6 @@ func TestAuth(t *testing.T) {
 	if err != nil {
 		setup.CleanupAndDie("Could not install mini konnector.", err)
 	}
-
-	os.Exit(setup.Run())
 
 	t.Run("InstanceBlocked", func(t *testing.T) {
 		// Block the instance

--- a/web/bitwarden/bitwarden_test.go
+++ b/web/bitwarden/bitwarden_test.go
@@ -973,7 +973,6 @@ func TestBitwarden(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 200, res.StatusCode)
 	})
-
 }
 
 func assertCipherResponse(t *testing.T, result map[string]interface{}) {

--- a/web/bitwarden/bitwarden_test.go
+++ b/web/bitwarden/bitwarden_test.go
@@ -38,7 +38,8 @@ func TestBitwarden(t *testing.T) {
 
 	config.UseTestFile()
 	testutils.NeedCouchdb()
-	setup := testutils.NewSetup(m, "bitwarden_test")
+	setup := testutils.NewSetup(nil, t.Name())
+	t.Cleanup(setup.Cleanup)
 	inst = setup.GetTestInstance(&lifecycle.Options{
 		Domain:     "bitwarden.example.net",
 		Passphrase: "cozy",

--- a/web/bitwarden/bitwarden_test.go
+++ b/web/bitwarden/bitwarden_test.go
@@ -32,194 +32,213 @@ var inst *instance.Instance
 var token string
 var orgaID, collID, folderID, cipherID string
 
-func TestPrelogin(t *testing.T) {
-	body := `{ "email": "me@bitwarden.example.net" }`
-	req, _ := http.NewRequest("POST", ts.URL+"/bitwarden/api/accounts/prelogin", bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/json")
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	assert.EqualValues(t, 0, result["Kdf"])
-	assert.EqualValues(t, crypto.DefaultPBKDF2Iterations, result["KdfIterations"])
-	assert.Equal(t, false, result["OIDC"])
-	assert.Equal(t, false, result["HasCiphers"])
-}
-
-func TestConnect(t *testing.T) {
-	testLogger := test.NewGlobal()
-	setting, err := settings.Get(inst)
-	assert.NoError(t, err)
-	setting.EncryptedOrgKey = ""
-	err = setting.Save(inst)
-	assert.NoError(t, err)
-
-	email := inst.PassphraseSalt()
-	iter := crypto.DefaultPBKDF2Iterations
-	pass, _ := crypto.HashPassWithPBKDF2([]byte("cozy"), email, iter)
-	v := url.Values{
-		"grant_type": {"password"},
-		"username":   {string(email)},
-		"password":   {string(pass)},
-		"scope":      {"api offline_access"},
-		"client_id":  {"browser"},
-		"deviceType": {"3"},
+func TestBitwarden(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
 	}
-	res, err := http.PostForm(ts.URL+"/bitwarden/identity/connect/token", v)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	expiresIn := consts.AccessTokenValidityDuration.Seconds()
-	assert.Equal(t, "Bearer", result["token_type"])
-	assert.Equal(t, expiresIn, result["expires_in"])
-	if assert.NotEmpty(t, result["access_token"]) {
-		token = result["access_token"].(string)
-	}
-	assert.NotEmpty(t, result["refresh_token"])
-	assert.NotEmpty(t, result["Key"])
-	assert.NotEmpty(t, result["PrivateKey"])
-	assert.NotEmpty(t, result["client_id"])
-	assert.NotEmpty(t, result["registration_access_token"])
-	assert.NotNil(t, result["Kdf"])
-	assert.NotNil(t, result["KdfIterations"])
 
-	assert.NotZero(t, len(testLogger.Entries))
-	orgKeyDoesNotExist := false
-	for _, entry := range testLogger.Entries {
-		if entry.Message == "Organization key does not exist" {
-			orgKeyDoesNotExist = true
+	config.UseTestFile()
+	testutils.NeedCouchdb()
+	setup := testutils.NewSetup(m, "bitwarden_test")
+	inst = setup.GetTestInstance(&lifecycle.Options{
+		Domain:     "bitwarden.example.net",
+		Passphrase: "cozy",
+		PublicName: "Pierre",
+		Email:      "pierre@cozy.localhost",
+	})
+
+	ts = setup.GetTestServer("/bitwarden", Routes)
+	ts.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler
+	os.Exit(setup.Run())
+
+	t.Run("Prelogin", func(t *testing.T) {
+		body := `{ "email": "me@bitwarden.example.net" }`
+		req, _ := http.NewRequest("POST", ts.URL+"/bitwarden/api/accounts/prelogin", bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/json")
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		assert.EqualValues(t, 0, result["Kdf"])
+		assert.EqualValues(t, crypto.DefaultPBKDF2Iterations, result["KdfIterations"])
+		assert.Equal(t, false, result["OIDC"])
+		assert.Equal(t, false, result["HasCiphers"])
+	})
+
+	t.Run("Connect", func(t *testing.T) {
+		testLogger := test.NewGlobal()
+		setting, err := settings.Get(inst)
+		assert.NoError(t, err)
+		setting.EncryptedOrgKey = ""
+		err = setting.Save(inst)
+		assert.NoError(t, err)
+
+		email := inst.PassphraseSalt()
+		iter := crypto.DefaultPBKDF2Iterations
+		pass, _ := crypto.HashPassWithPBKDF2([]byte("cozy"), email, iter)
+		v := url.Values{
+			"grant_type": {"password"},
+			"username":   {string(email)},
+			"password":   {string(pass)},
+			"scope":      {"api offline_access"},
+			"client_id":  {"browser"},
+			"deviceType": {"3"},
 		}
-	}
-	assert.True(t, orgKeyDoesNotExist)
+		res, err := http.PostForm(ts.URL+"/bitwarden/identity/connect/token", v)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		expiresIn := consts.AccessTokenValidityDuration.Seconds()
+		assert.Equal(t, "Bearer", result["token_type"])
+		assert.Equal(t, expiresIn, result["expires_in"])
+		if assert.NotEmpty(t, result["access_token"]) {
+			token = result["access_token"].(string)
+		}
+		assert.NotEmpty(t, result["refresh_token"])
+		assert.NotEmpty(t, result["Key"])
+		assert.NotEmpty(t, result["PrivateKey"])
+		assert.NotEmpty(t, result["client_id"])
+		assert.NotEmpty(t, result["registration_access_token"])
+		assert.NotNil(t, result["Kdf"])
+		assert.NotNil(t, result["KdfIterations"])
 
-	setting, err = settings.Get(inst)
-	assert.NoError(t, err)
-	orgKey, err := setting.OrganizationKey()
-	assert.NoError(t, err)
-	assert.NotEmpty(t, orgKey)
-}
+		assert.NotZero(t, len(testLogger.Entries))
+		orgKeyDoesNotExist := false
+		for _, entry := range testLogger.Entries {
+			if entry.Message == "Organization key does not exist" {
+				orgKeyDoesNotExist = true
+			}
+		}
+		assert.True(t, orgKeyDoesNotExist)
 
-func TestGetCozyOrg(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/bitwarden/organizations/cozy", nil)
-	req.Header.Add("Authorization", "Bearer invalid-token")
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 401, res.StatusCode)
+		setting, err = settings.Get(inst)
+		assert.NoError(t, err)
+		orgKey, err := setting.OrganizationKey()
+		assert.NoError(t, err)
+		assert.NotEmpty(t, orgKey)
+	})
 
-	req, _ = http.NewRequest("GET", ts.URL+"/bitwarden/organizations/cozy", nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result map[string]string
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	orgaID = result["organizationId"]
-	assert.NotEmpty(t, orgaID)
-	collID = result["collectionId"]
-	assert.NotEmpty(t, collID)
-	orgKey := result["organizationKey"]
-	assert.NotEmpty(t, orgKey)
-	_, err = base64.StdEncoding.DecodeString(orgKey)
-	assert.NoError(t, err)
-}
+	t.Run("GetCozyOrg", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/bitwarden/organizations/cozy", nil)
+		req.Header.Add("Authorization", "Bearer invalid-token")
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 401, res.StatusCode)
 
-func TestCreateFolder(t *testing.T) {
-	body := `
+		req, _ = http.NewRequest("GET", ts.URL+"/bitwarden/organizations/cozy", nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result map[string]string
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		orgaID = result["organizationId"]
+		assert.NotEmpty(t, orgaID)
+		collID = result["collectionId"]
+		assert.NotEmpty(t, collID)
+		orgKey := result["organizationKey"]
+		assert.NotEmpty(t, orgKey)
+		_, err = base64.StdEncoding.DecodeString(orgKey)
+		assert.NoError(t, err)
+	})
+
+	t.Run("CreateFolder", func(t *testing.T) {
+		body := `
 {
 	"name": "2.FQAwIBaDbczEGnEJw4g4hw==|7KreXaC0duAj0ulzZJ8ncA==|nu2sEvotjd4zusvGF8YZJPnS9SiJPDqc1VIfCrfve/o="
 }`
-	req, _ := http.NewRequest("POST", ts.URL+"/bitwarden/api/folders", bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result map[string]string
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	assert.Equal(t, "2.FQAwIBaDbczEGnEJw4g4hw==|7KreXaC0duAj0ulzZJ8ncA==|nu2sEvotjd4zusvGF8YZJPnS9SiJPDqc1VIfCrfve/o=", result["Name"])
-	assert.Equal(t, "folder", result["Object"])
-	assert.NotEmpty(t, result["RevisionDate"])
-	assert.NotEmpty(t, result["Id"])
-	folderID = result["Id"]
-}
+		req, _ := http.NewRequest("POST", ts.URL+"/bitwarden/api/folders", bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result map[string]string
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		assert.Equal(t, "2.FQAwIBaDbczEGnEJw4g4hw==|7KreXaC0duAj0ulzZJ8ncA==|nu2sEvotjd4zusvGF8YZJPnS9SiJPDqc1VIfCrfve/o=", result["Name"])
+		assert.Equal(t, "folder", result["Object"])
+		assert.NotEmpty(t, result["RevisionDate"])
+		assert.NotEmpty(t, result["Id"])
+		folderID = result["Id"]
+	})
 
-func TestListFolders(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/bitwarden/api/folders", nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	assert.Equal(t, "list", result["Object"])
-	data := result["Data"].([]interface{})
-	assert.Len(t, data, 1)
-	item := data[0].(map[string]interface{})
-	assert.Equal(t, "2.FQAwIBaDbczEGnEJw4g4hw==|7KreXaC0duAj0ulzZJ8ncA==|nu2sEvotjd4zusvGF8YZJPnS9SiJPDqc1VIfCrfve/o=", item["Name"])
-	assert.Equal(t, "folder", item["Object"])
-	assert.Equal(t, folderID, item["Id"])
-	assert.NotEmpty(t, item["RevisionDate"])
-}
+	t.Run("ListFolders", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/bitwarden/api/folders", nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		assert.Equal(t, "list", result["Object"])
+		data := result["Data"].([]interface{})
+		assert.Len(t, data, 1)
+		item := data[0].(map[string]interface{})
+		assert.Equal(t, "2.FQAwIBaDbczEGnEJw4g4hw==|7KreXaC0duAj0ulzZJ8ncA==|nu2sEvotjd4zusvGF8YZJPnS9SiJPDqc1VIfCrfve/o=", item["Name"])
+		assert.Equal(t, "folder", item["Object"])
+		assert.Equal(t, folderID, item["Id"])
+		assert.NotEmpty(t, item["RevisionDate"])
+	})
 
-func TestGetFolder(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/bitwarden/api/folders/"+folderID, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	assert.Equal(t, "2.FQAwIBaDbczEGnEJw4g4hw==|7KreXaC0duAj0ulzZJ8ncA==|nu2sEvotjd4zusvGF8YZJPnS9SiJPDqc1VIfCrfve/o=", result["Name"])
-	assert.Equal(t, "folder", result["Object"])
-	assert.Equal(t, folderID, result["Id"])
-	assert.NotEmpty(t, result["RevisionDate"])
-}
+	t.Run("GetFolder", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/bitwarden/api/folders/"+folderID, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		assert.Equal(t, "2.FQAwIBaDbczEGnEJw4g4hw==|7KreXaC0duAj0ulzZJ8ncA==|nu2sEvotjd4zusvGF8YZJPnS9SiJPDqc1VIfCrfve/o=", result["Name"])
+		assert.Equal(t, "folder", result["Object"])
+		assert.Equal(t, folderID, result["Id"])
+		assert.NotEmpty(t, result["RevisionDate"])
+	})
 
-func TestRenameFolder(t *testing.T) {
-	body := `
+	t.Run("RenameFolder", func(t *testing.T) {
+		body := `
 {
 	"name": "2.d7MttWzJTSSKx1qXjHUxlQ==|01Ath5UqFZHk7csk5DVtkQ==|EMLoLREgCUP5Cu4HqIhcLqhiZHn+NsUDp8dAg1Xu0Io="
 }`
-	req, _ := http.NewRequest("PUT", ts.URL+"/bitwarden/api/folders/"+folderID, bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result map[string]string
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	assert.Equal(t, "2.d7MttWzJTSSKx1qXjHUxlQ==|01Ath5UqFZHk7csk5DVtkQ==|EMLoLREgCUP5Cu4HqIhcLqhiZHn+NsUDp8dAg1Xu0Io=", result["Name"])
-	assert.Equal(t, "folder", result["Object"])
-	assert.NotEmpty(t, result["RevisionDate"])
-	assert.Equal(t, folderID, result["Id"])
-}
+		req, _ := http.NewRequest("PUT", ts.URL+"/bitwarden/api/folders/"+folderID, bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result map[string]string
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		assert.Equal(t, "2.d7MttWzJTSSKx1qXjHUxlQ==|01Ath5UqFZHk7csk5DVtkQ==|EMLoLREgCUP5Cu4HqIhcLqhiZHn+NsUDp8dAg1Xu0Io=", result["Name"])
+		assert.Equal(t, "folder", result["Object"])
+		assert.NotEmpty(t, result["RevisionDate"])
+		assert.Equal(t, folderID, result["Id"])
+	})
 
-func TestDeleteFolder(t *testing.T) {
-	body := `
+	t.Run("DeleteFolder", func(t *testing.T) {
+		body := `
 {
 	"name": "2.FQAwIBaDbczEGnEJw4g4hw==|7KreXaC0duAj0ulzZJ8ncA==|nu2sEvotjd4zusvGF8YZJPnS9SiJPDqc1VIfCrfve/o="
 }`
-	req, _ := http.NewRequest("POST", ts.URL+"/bitwarden/api/folders", bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result map[string]string
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	id := result["Id"]
+		req, _ := http.NewRequest("POST", ts.URL+"/bitwarden/api/folders", bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result map[string]string
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		id := result["Id"]
 
-	body = `
+		body = `
 {
 	"type": 1,
 	"favorite": false,
@@ -234,64 +253,64 @@ func TestDeleteFolder(t *testing.T) {
 		"totp": null
 	}
 }`
-	req, _ = http.NewRequest("POST", ts.URL+"/bitwarden/api/ciphers", bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result2 map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result2)
-	assert.NoError(t, err)
-	cID := result2["Id"].(string)
+		req, _ = http.NewRequest("POST", ts.URL+"/bitwarden/api/ciphers", bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result2 map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result2)
+		assert.NoError(t, err)
+		cID := result2["Id"].(string)
 
-	req, _ = http.NewRequest("DELETE", ts.URL+"/bitwarden/api/folders/"+id, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
+		req, _ = http.NewRequest("DELETE", ts.URL+"/bitwarden/api/folders/"+id, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
 
-	// Check that the cipher in this folder has been moved out
-	req, _ = http.NewRequest("GET", ts.URL+"/bitwarden/api/ciphers/"+cID, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result3 map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result3)
-	assert.NoError(t, err)
-	assert.Equal(t, "2.d7MttWzJTSSKx1qXjHUxlQ==|01Ath5UqFZHk7csk5DVtkQ==|EMLoLREgCUP5Cu4HqIhcLqhiZHn+NsUDp8dAg1Xu0Io=", result3["Name"])
-	fID, ok := result3["FolderId"]
-	assert.True(t, ok)
-	assert.Empty(t, fID)
+		// Check that the cipher in this folder has been moved out
+		req, _ = http.NewRequest("GET", ts.URL+"/bitwarden/api/ciphers/"+cID, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result3 map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result3)
+		assert.NoError(t, err)
+		assert.Equal(t, "2.d7MttWzJTSSKx1qXjHUxlQ==|01Ath5UqFZHk7csk5DVtkQ==|EMLoLREgCUP5Cu4HqIhcLqhiZHn+NsUDp8dAg1Xu0Io=", result3["Name"])
+		fID, ok := result3["FolderId"]
+		assert.True(t, ok)
+		assert.Empty(t, fID)
 
-	req, _ = http.NewRequest("DELETE", ts.URL+"/bitwarden/api/ciphers/"+cID, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-}
+		req, _ = http.NewRequest("DELETE", ts.URL+"/bitwarden/api/ciphers/"+cID, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+	})
 
-func TestCreateNoType(t *testing.T) {
-	body := `
+	t.Run("CreateNoType", func(t *testing.T) {
+		body := `
 {
 	"name": "2.G38TIU3t1pGOfkzjCQE7OQ==|Xa1RupttU7zrWdzIT6oK+w==|J3C6qU1xDrfTgyJD+OrDri1GjgGhU2nmRK75FbZHXoI=",
 	"organizationId": null
 }`
-	req, _ := http.NewRequest("POST", ts.URL+"/bitwarden/api/ciphers", bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 400, res.StatusCode)
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	assert.NotEmpty(t, result["error"])
-}
+		req, _ := http.NewRequest("POST", ts.URL+"/bitwarden/api/ciphers", bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 400, res.StatusCode)
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, result["error"])
+	})
 
-func TestCreateLogin(t *testing.T) {
-	body := `
+	t.Run("CreateLogin", func(t *testing.T) {
+		body := `
 {
 	"type": 1,
 	"favorite": false,
@@ -307,54 +326,655 @@ func TestCreateLogin(t *testing.T) {
 		"totp": null
 	}
 }`
-	req, _ := http.NewRequest("POST", ts.URL+"/bitwarden/api/ciphers", bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	assertCipherResponse(t, result)
-	orgID, ok := result["OrganizationId"]
-	assert.True(t, ok)
-	assert.Empty(t, orgID)
-	cipherID = result["Id"].(string)
-}
+		req, _ := http.NewRequest("POST", ts.URL+"/bitwarden/api/ciphers", bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		assertCipherResponse(t, result)
+		orgID, ok := result["OrganizationId"]
+		assert.True(t, ok)
+		assert.Empty(t, orgID)
+		cipherID = result["Id"].(string)
+	})
 
-func TestListCiphers(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/bitwarden/api/ciphers", nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	assert.Equal(t, "list", result["Object"])
-	data := result["Data"].([]interface{})
-	assert.Len(t, data, 1)
-	item := data[0].(map[string]interface{})
-	assertCipherResponse(t, item)
-	orgID, ok := item["OrganizationId"]
-	assert.True(t, ok)
-	assert.Empty(t, orgID)
-}
+	t.Run("ListCiphers", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/bitwarden/api/ciphers", nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		assert.Equal(t, "list", result["Object"])
+		data := result["Data"].([]interface{})
+		assert.Len(t, data, 1)
+		item := data[0].(map[string]interface{})
+		assertCipherResponse(t, item)
+		orgID, ok := item["OrganizationId"]
+		assert.True(t, ok)
+		assert.Empty(t, orgID)
+	})
 
-func TestGetCipher(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/bitwarden/api/ciphers/"+cipherID, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	assertCipherResponse(t, result)
-	orgID, ok := result["OrganizationId"]
-	assert.True(t, ok)
-	assert.Empty(t, orgID)
+	t.Run("GetCipher", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/bitwarden/api/ciphers/"+cipherID, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		assertCipherResponse(t, result)
+		orgID, ok := result["OrganizationId"]
+		assert.True(t, ok)
+		assert.Empty(t, orgID)
+	})
+
+	t.Run("UpdateCipher", func(t *testing.T) {
+		body := `
+{
+	"type": 2,
+	"favorite": true,
+	"name": "2.G38TIU3t1pGOfkzjCQE7OQ==|Xa1RupttU7zrWdzIT6oK+w==|J3C6qU1xDrfTgyJD+OrDri1GjgGhU2nmRK75FbZHXoI=",
+	"folderId": "` + folderID + `",
+	"organizationId": null,
+	"notes": "2.rSw0uVQEFgUCEmOQx0JnDg==|MKqHLD25aqaXYHeYJPH/mor7l3EeSQKsI7A/R+0bFTI=|ODcUScISzKaZWHlUe4MRGuTT2S7jpyDmbOHl7d+6HiM=",
+	"secureNote": {
+		"type": 0
+	}
+}`
+		req, _ := http.NewRequest("PUT", ts.URL+"/bitwarden/api/ciphers/"+cipherID, bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		assertUpdatedCipherResponse(t, result)
+		orgID, ok := result["OrganizationId"]
+		assert.True(t, ok)
+		assert.Empty(t, orgID)
+	})
+
+	t.Run("DeleteCipher", func(t *testing.T) {
+		body := `
+{
+	"type": 1,
+	"favorite": false,
+	"name": "2.d7MttWzJTSSKx1qXjHUxlQ==|01Ath5UqFZHk7csk5DVtkQ==|EMLoLREgCUP5Cu4HqIhcLqhiZHn+NsUDp8dAg1Xu0Io=",
+	"notes": null,
+	"folderId": null,
+	"organizationId": null,
+	"login": {
+		"uri": "2.T57BwAuV8ubIn/sZPbQC+A==|EhUSSpJWSzSYOdJ/AQzfXuUXxwzcs/6C4tOXqhWAqcM=|OWV2VIqLfoWPs9DiouXGUOtTEkVeklbtJQHkQFIXkC8=",
+		"username": "2.JbFkAEZPnuMm70cdP44wtA==|fsN6nbT+udGmOWv8K4otgw==|JbtwmNQa7/48KszT2hAdxpmJ6DRPZst0EDEZx5GzesI=",
+		"password": "2.e83hIsk6IRevSr/H1lvZhg==|48KNkSCoTacopXRmIZsbWg==|CIcWgNbaIN2ix2Fx1Gar6rWQeVeboehp4bioAwngr0o=",
+		"totp": null
+	}
+}`
+		req, _ := http.NewRequest("POST", ts.URL+"/bitwarden/api/ciphers", bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		id := result["Id"].(string)
+
+		req, _ = http.NewRequest("DELETE", ts.URL+"/bitwarden/api/ciphers/"+id, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+	})
+
+	t.Run("SoftDeleteCipher", func(t *testing.T) {
+		body := `
+{
+	"type": 1,
+	"favorite": false,
+	"name": "2.d7MttWzJTSSKx1qXjHUxlQ==|01Ath5UqFZHk7csk5DVtkQ==|EMLoLREgCUP5Cu4HqIhcLqhiZHn+NsUDp8dAg1Xu0Io=",
+	"notes": null,
+	"folderId": null,
+	"organizationId": null,
+	"login": {
+		"uri": "2.T57BwAuV8ubIn/sZPbQC+A==|EhUSSpJWSzSYOdJ/AQzfXuUXxwzcs/6C4tOXqhWAqcM=|OWV2VIqLfoWPs9DiouXGUOtTEkVeklbtJQHkQFIXkC8=",
+		"username": "2.JbFkAEZPnuMm70cdP44wtA==|fsN6nbT+udGmOWv8K4otgw==|JbtwmNQa7/48KszT2hAdxpmJ6DRPZst0EDEZx5GzesI=",
+		"password": "2.e83hIsk6IRevSr/H1lvZhg==|48KNkSCoTacopXRmIZsbWg==|CIcWgNbaIN2ix2Fx1Gar6rWQeVeboehp4bioAwngr0o=",
+		"totp": null
+	}
+}`
+		req, _ := http.NewRequest("POST", ts.URL+"/bitwarden/api/ciphers", bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		id := result["Id"].(string)
+
+		req, _ = http.NewRequest("PUT", ts.URL+"/bitwarden/api/ciphers/"+id+"/delete", nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+
+		req, _ = http.NewRequest("GET", ts.URL+"/bitwarden/api/ciphers/"+id, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, result["DeletedDate"])
+	})
+
+	t.Run("RestoreCipher", func(t *testing.T) {
+		body := `
+{
+	"type": 1,
+	"favorite": false,
+	"name": "2.d7MttWzJTSSKx1qXjHUxlQ==|01Ath5UqFZHk7csk5DVtkQ==|EMLoLREgCUP5Cu4HqIhcLqhiZHn+NsUDp8dAg1Xu0Io=",
+	"notes": null,
+	"folderId": null,
+	"organizationId": null,
+	"login": {
+		"uri": "2.T57BwAuV8ubIn/sZPbQC+A==|EhUSSpJWSzSYOdJ/AQzfXuUXxwzcs/6C4tOXqhWAqcM=|OWV2VIqLfoWPs9DiouXGUOtTEkVeklbtJQHkQFIXkC8=",
+		"username": "2.JbFkAEZPnuMm70cdP44wtA==|fsN6nbT+udGmOWv8K4otgw==|JbtwmNQa7/48KszT2hAdxpmJ6DRPZst0EDEZx5GzesI=",
+		"password": "2.e83hIsk6IRevSr/H1lvZhg==|48KNkSCoTacopXRmIZsbWg==|CIcWgNbaIN2ix2Fx1Gar6rWQeVeboehp4bioAwngr0o=",
+		"totp": null
+	}
+}`
+		req, _ := http.NewRequest("POST", ts.URL+"/bitwarden/api/ciphers", bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		id := result["Id"].(string)
+
+		req, _ = http.NewRequest("PUT", ts.URL+"/bitwarden/api/ciphers/"+id+"/delete", nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+
+		req, _ = http.NewRequest("PUT", ts.URL+"/bitwarden/api/ciphers/"+id+"/restore", nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+
+		req, _ = http.NewRequest("GET", ts.URL+"/bitwarden/api/ciphers/"+id, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		assert.Empty(t, result["DeletedDate"])
+	})
+
+	t.Run("Sync", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/bitwarden/api/sync", nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		assert.Equal(t, "sync", result["Object"])
+
+		profile := result["Profile"].(map[string]interface{})
+		assert.NotEmpty(t, profile["Id"])
+		assert.Equal(t, "Pierre", profile["Name"])
+		assert.Equal(t, "me@bitwarden.example.net", profile["Email"])
+		assert.Equal(t, false, profile["EmailVerified"])
+		assert.Equal(t, true, profile["Premium"])
+		assert.Equal(t, nil, profile["MasterPasswordHint"])
+		assert.Equal(t, "en", profile["Culture"])
+		assert.Equal(t, false, profile["TwoFactorEnabled"])
+		assert.NotEmpty(t, profile["Key"])
+		assert.NotEmpty(t, profile["PrivateKey"])
+		assert.NotEmpty(t, profile["SecurityStamp"])
+		assert.Equal(t, "profile", profile["Object"])
+
+		ciphers := result["Ciphers"].([]interface{})
+		assert.Len(t, ciphers, 3)
+		c := ciphers[0].(map[string]interface{})
+		assertUpdatedCipherResponse(t, c)
+
+		folders := result["Folders"].([]interface{})
+		assert.Len(t, folders, 1)
+		f := folders[0].(map[string]interface{})
+		assert.Equal(t, "2.d7MttWzJTSSKx1qXjHUxlQ==|01Ath5UqFZHk7csk5DVtkQ==|EMLoLREgCUP5Cu4HqIhcLqhiZHn+NsUDp8dAg1Xu0Io=", f["Name"])
+		assert.Equal(t, "folder", f["Object"])
+		assert.NotEmpty(t, f["RevisionDate"])
+		assert.Equal(t, folderID, f["Id"])
+
+		domains := result["Domains"].(map[string]interface{})
+		ed, ok := domains["EquivalentDomains"]
+		assert.True(t, ok)
+		assert.Empty(t, ed)
+		ged, ok := domains["GlobalEquivalentDomains"]
+		assert.True(t, ok)
+		assert.NotEmpty(t, ged)
+		assert.Equal(t, "domains", domains["Object"])
+	})
+
+	t.Run("BulkDeleteCiphers", func(t *testing.T) {
+		// Setup
+		nbCiphersToDelete := 5
+		nbCiphers, err := couchdb.CountAllDocs(inst, consts.BitwardenCiphers)
+		assert.NoError(t, err)
+
+		var ids []string
+		for i := 0; i < nbCiphersToDelete; i++ {
+			body := `
+{
+	"type": 1,
+	"favorite": false,
+	"name": "2.d7MttWzJTSSKx1qXjHUxlQ==|01Ath5UqFZHk7csk5DVtkQ==|EMLoLREgCUP5Cu4HqIhcLqhiZHn+NsUDp8dAg1Xu0Io=",
+	"notes": null,
+	"folderId": null,
+	"organizationId": null,
+	"login": {
+		"uri": "2.T57BwAuV8ubIn/sZPbQC+A==|EhUSSpJWSzSYOdJ/AQzfXuUXxwzcs/6C4tOXqhWAqcM=|OWV2VIqLfoWPs9DiouXGUOtTEkVeklbtJQHkQFIXkC8=",
+		"username": "2.JbFkAEZPnuMm70cdP44wtA==|fsN6nbT+udGmOWv8K4otgw==|JbtwmNQa7/48KszT2hAdxpmJ6DRPZst0EDEZx5GzesI=",
+		"password": "2.e83hIsk6IRevSr/H1lvZhg==|48KNkSCoTacopXRmIZsbWg==|CIcWgNbaIN2ix2Fx1Gar6rWQeVeboehp4bioAwngr0o=",
+		"totp": null
+	}
+}`
+			req, _ := http.NewRequest("POST", ts.URL+"/bitwarden/api/ciphers", bytes.NewBufferString(body))
+			req.Header.Add("Content-Type", "application/json")
+			req.Header.Add("Authorization", "Bearer "+token)
+			res, err := http.DefaultClient.Do(req)
+			assert.NoError(t, err)
+			assert.Equal(t, 200, res.StatusCode)
+			var result map[string]interface{}
+			err = json.NewDecoder(res.Body).Decode(&result)
+			assert.NoError(t, err)
+			ids = append(ids, result["Id"].(string))
+		}
+
+		nb, err := couchdb.CountAllDocs(inst, consts.BitwardenCiphers)
+		assert.NoError(t, err)
+		assert.Equal(t, nbCiphers+nbCiphersToDelete, nb)
+
+		// Test soft delete in bulk
+		body, _ := json.Marshal(map[string][]string{
+			"ids": ids,
+		})
+		buf := bytes.NewBuffer(body)
+		req, _ := http.NewRequest("PUT", ts.URL+"/bitwarden/api/ciphers/delete", buf)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Add("Content-Type", "application/json")
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+
+		for _, id := range ids {
+			req, _ = http.NewRequest("GET", ts.URL+"/bitwarden/api/ciphers/"+id, nil)
+			req.Header.Add("Authorization", "Bearer "+token)
+			res, err = http.DefaultClient.Do(req)
+			assert.NoError(t, err)
+			assert.Equal(t, 200, res.StatusCode)
+			var result map[string]interface{}
+			err = json.NewDecoder(res.Body).Decode(&result)
+			assert.NoError(t, err)
+			assert.NotEmpty(t, result["DeletedDate"])
+		}
+
+		// Test restore in bulk
+		buf = bytes.NewBuffer(body)
+		req, _ = http.NewRequest("PUT", ts.URL+"/bitwarden/api/ciphers/restore", buf)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Add("Content-Type", "application/json")
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		assert.Equal(t, "list", result["Object"])
+		data := result["Data"].([]interface{})
+		assert.Len(t, data, nbCiphersToDelete)
+
+		for i := range data {
+			item := data[i].(map[string]interface{})
+			assert.Equal(t, ids[i], item["Id"])
+			assert.Empty(t, item["DeletedDate"])
+		}
+
+		// Test delete in bulk
+		buf = bytes.NewBuffer(body)
+		req, _ = http.NewRequest("DELETE", ts.URL+"/bitwarden/api/ciphers", buf)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Add("Content-Type", "application/json")
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+
+		nb, err = couchdb.CountAllDocs(inst, consts.BitwardenCiphers)
+		assert.NoError(t, err)
+		assert.Equal(t, nbCiphers, nb)
+	})
+
+	t.Run("SharedCipher", func(t *testing.T) {
+		body := `
+{
+	"cipher": {
+		"type": 1,
+		"favorite": false,
+		"name": "2.d7MttWzJTSSKx1qXjHUxlQ==|01Ath5UqFZHk7csk5DVtkQ==|EMLoLREgCUP5Cu4HqIhcLqhiZHn+NsUDp8dAg1Xu0Io=",
+		"notes": null,
+		"folderId": null,
+		"organizationId": "` + orgaID + `",
+		"login": {
+			"uri": "2.T57BwAuV8ubIn/sZPbQC+A==|EhUSSpJWSzSYOdJ/AQzfXuUXxwzcs/6C4tOXqhWAqcM=|OWV2VIqLfoWPs9DiouXGUOtTEkVeklbtJQHkQFIXkC8=",
+			"username": "2.JbFkAEZPnuMm70cdP44wtA==|fsN6nbT+udGmOWv8K4otgw==|JbtwmNQa7/48KszT2hAdxpmJ6DRPZst0EDEZx5GzesI=",
+			"password": "2.e83hIsk6IRevSr/H1lvZhg==|48KNkSCoTacopXRmIZsbWg==|CIcWgNbaIN2ix2Fx1Gar6rWQeVeboehp4bioAwngr0o=",
+			"passwordRevisionDate": "2019-09-13T12:26:42+02:00",
+			"totp": null
+		}
+	},
+	"collectionIds": ["` + collID + `"]
+}`
+		req, _ := http.NewRequest("POST", ts.URL+"/bitwarden/api/ciphers/create", bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		assertCipherResponse(t, result)
+		orgID, ok := result["OrganizationId"]
+		assert.True(t, ok)
+		assert.Equal(t, orgID, orgaID)
+		cipherID = result["Id"].(string)
+
+		body = `
+{
+	"type": 2,
+	"favorite": true,
+	"name": "2.G38TIU3t1pGOfkzjCQE7OQ==|Xa1RupttU7zrWdzIT6oK+w==|J3C6qU1xDrfTgyJD+OrDri1GjgGhU2nmRK75FbZHXoI=",
+	"folderId": "` + folderID + `",
+	"organizationId": "` + orgaID + `",
+	"notes": "2.rSw0uVQEFgUCEmOQx0JnDg==|MKqHLD25aqaXYHeYJPH/mor7l3EeSQKsI7A/R+0bFTI=|ODcUScISzKaZWHlUe4MRGuTT2S7jpyDmbOHl7d+6HiM=",
+	"secureNote": {
+		"type": 0
+	}
+}`
+		req, _ = http.NewRequest("PUT", ts.URL+"/bitwarden/api/ciphers/"+cipherID, bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result2 map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result2)
+		assert.NoError(t, err)
+		assertUpdatedCipherResponse(t, result2)
+		orgID, ok = result2["OrganizationId"]
+		assert.True(t, ok)
+		assert.Equal(t, orgID, orgaID)
+	})
+
+	t.Run("SetKeyPair", func(t *testing.T) {
+		body, _ := json.Marshal(map[string]string{
+			"encryptedPrivateKey": "2.demXNYbv8o47sG+fhYYvhg==|jXpxet7AApeIzrC3Yr752LwmjBdCZn6HJl6SjEOVP3rrOpGu5qV2rN0dBH5yXXWHusfxM7IvXkdC/fzBUAmFFOU5ubTp9kHFBqIn51tiJG6BRs5aTm7kF6TYSHVDIP5kUdX4O7DcmD23dqtq/8211DSAFR/DK1QDm5Da77Clh7NHxQE9Z9RTW1PBGV56DfzrY3N06H6vI+V6fTZ6HJRD2pdPczR2ZNC0ziQP7qCUYNlSjEv70O4VoYMSUsdb4UUE1YetcSdZ+dIAy+V2KHfoHmTFYI4DtMCW6WpDzp0ufPvszFjt1EwaMr78hujMrQr1gFWxgN8kOLJyYCrd1F5aIxWXHghBH/t+QU31gyQOxCdj18f10ssfuY/y7vocSJQ9pTRRPNh4beGAijV1AETaXWLK1L6oMnkbdhr9ZA2I6cZaHNCaHIynHQH7NUqKKQUJL/FyZ8rBv4YNnxCMRi9p88IoTb0oPsUCoNCaIZ2cvzXz+0VpU6zxj4ke7H6Bu7H46MSB1P+YHzGLtFNzZJVsUBEkz7dotUDeTeqlYKnq7oldWJ4HlqODevzCev+FRnYgrYpoXmYC/dxa1R5IlKCu6rEmP05A7Nw4h9cymnTwRMEoZRSppJ2O5FlSx/Go9Jz12g2Tfiaf+RvO7nkIb2qKiz7Jo2aJgakL5lMOlEdBA2+dsYSyX4Tvu8Ua4p0GcYaGOgSjXH27lQ73ZpHSicf4Q1kAooVl+6zTOPAqgMXOnyyVSRqBPse28HuDwGtmD8BAeVDIfkMW+a+PlWa+yoEWKfDHRduoxNod7Pc9xlNFt6eOeGoBQTEIiF7ccBDtNiSU1yfvqBZEgI8QF0QiGUo9eP7+59so5eu9/DuzjdqFMmGPtG3zHifMxuMzO5+E9UxTyHuCwvxuH93F4vmPC8zzXXn8/ErhEeqmYl1lxZbfJDm1qcjTkJibNKJ9+CXUeP0hq8yi07SEN1xJSZpupf90EUjrdFd3impz3gZKummEjTvzr3J1JX4gC/wD0mGkROHQwb0jCTDJNC18cX4usPYtNr3FxLZmxCGgPmZhkzFjF0qppN1aXTxQskdorEejQUwLL5EnWJySd9/W2P6PmjkJTAwKYUNHsmVUAfbMA7y7QBIjVFFWS4xYy0GJcc8NaLKkFMkGv/oluw552prWAJZ4aM2asoNgyv/JARrAF+JbOPSpax+CtUMO+LCFlBITHopbkHz0TwI1UMj/vIOh9wxDiMqe3YBiviymudX+B7awCaUPTLubWW1jwC4kBnXmRGAKyyIvzgOvwkdcKfQRxoTxq7JFTL/hWk7x4HlQqviSWGY166CLIp6SydCT+cqHMf3MHhe8AQZVC+nIDVNQZWfpFbOFb3nNDwlT+laWrtsiuX7hHiL0VLaCU4xzup5m4zvi59/Qxj0+d8n6M/3GP3/Tvp/bKY9m7CHoeimtGF9Ai2QFJFMOEQw3S1SUBL62ZsezKgBap6y1RqmMzdz/h3f5mhHxRMoQ0kgzZwMNWJvi2acGoIttcmBU7Cn6fqxYNi11dg17M7cFJAQCMicvd4pEwl8IBrm7uFrzbLvuLeolyiDx8GX3jfIo//Ceqa6P/RIqN8jKzH3nTSePuVqkXYiIdxhlAeF//EYW0CwOjd3GEoc=|aUt6NKqrLW4HeprkbwjuBzSQbR84imTujhUPxK17eX4=",
+			"publicKey":           "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmAYrTtY4FBJL/TeTGqr1uHCoMCzUDgwvgq7gBGiNrk24gPbb3xreM+HxubBvkzTlgoS6m1KKKKtD4tWrLU33Xc+PevbKSZDLvBfUe+golGU1XKFxUcIkgINtB0i8LmCVCShiCrlhn2VorcAbekR/1RXtoJqpqq1urhI+RdGVXy8HBBoULA7BoV7wC8dBdkRtnQMNuvGyHclV7yjgealKGqgxz4aNcgsfybquKvYg6PUj8dAxUy7KlmMR7klPyO8nahYqyhpQ/t0xle0WyCkdx5YuYhRSA67Tok+E8fCW5WXOPfIdPZDXS+6/wW1NhcQEa5j6EW11PF/Xq0awBUFwnwIDAQAB",
+		})
+		buf := bytes.NewBuffer(body)
+		req, _ := http.NewRequest("POST", ts.URL+"/bitwarden/api/accounts/keys", buf)
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+
+		setting, err := settings.Get(inst)
+		assert.NoError(t, err)
+		orgKey, err := setting.OrganizationKey()
+		assert.NoError(t, err)
+		assert.NotEmpty(t, orgKey)
+	})
+
+	t.Run("SettingsDomains", func(t *testing.T) {
+		body, _ := json.Marshal(map[string]interface{}{
+			"equivalentDomains": [][]string{
+				{"stackoverflow.com", "serverfault.com", "superuser.com"},
+			},
+			"globalEquivalentDomains": []int{42, 69},
+		})
+		buf := bytes.NewBuffer(body)
+		req, _ := http.NewRequest("POST", ts.URL+"/bitwarden/api/settings/domains", buf)
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assertDomainsReponse(t, res)
+
+		req, _ = http.NewRequest("GET", ts.URL+"/bitwarden/api/settings/domains", nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assertDomainsReponse(t, res)
+	})
+
+	t.Run("ImportCiphers", func(t *testing.T) {
+		nbCiphers, err := couchdb.CountAllDocs(inst, consts.BitwardenCiphers)
+		assert.NoError(t, err)
+		nbFolders, err := couchdb.CountAllDocs(inst, consts.BitwardenFolders)
+		assert.NoError(t, err)
+		body := `
+{
+  "ciphers": [{
+    "type": 2,
+    "favorite": true,
+    "name": "2.G38TIU3t1pGOfkzjCQE7OQ==|Xa1RupttU7zrWdzIT6oK+w==|J3C6qU1xDrfTgyJD+OrDri1GjgGhU2nmRK75FbZHXoI=",
+    "folderId": null,
+    "organizationId": null,
+    "notes": "2.rSw0uVQEFgUCEmOQx0JnDg==|MKqHLD25aqaXYHeYJPH/mor7l3EeSQKsI7A/R+0bFTI=|ODcUScISzKaZWHlUe4MRGuTT2S7jpyDmbOHl7d+6HiM=",
+    "secureNote": {
+      "type": 0
+    }
+  }, {
+    "type": 1,
+    "favorite": false,
+    "name": "2.d7MttWzJTSSKx1qXjHUxlQ==|01Ath5UqFZHk7csk5DVtkQ==|EMLoLREgCUP5Cu4HqIhcLqhiZHn+NsUDp8dAg1Xu0Io=",
+    "folderId": null,
+    "organizationId": null,
+    "notes": null,
+    "login": {
+      "uri": "2.T57BwAuV8ubIn/sZPbQC+A==|EhUSSpJWSzSYOdJ/AQzfXuUXxwzcs/6C4tOXqhWAqcM=|OWV2VIqLfoWPs9DiouXGUOtTEkVeklbtJQHkQFIXkC8=",
+      "username": "2.JbFkAEZPnuMm70cdP44wtA==|fsN6nbT+udGmOWv8K4otgw==|JbtwmNQa7/48KszT2hAdxpmJ6DRPZst0EDEZx5GzesI=",
+      "password": "2.e83hIsk6IRevSr/H1lvZhg==|48KNkSCoTacopXRmIZsbWg==|CIcWgNbaIN2ix2Fx1Gar6rWQeVeboehp4bioAwngr0o=",
+      "totp": null
+    }
+  }],
+  "folders": [{
+    "name": "2.FQAwIBaDbczEGnEJw4g4hw==|7KreXaC0duAj0ulzZJ8ncA==|nu2sEvotjd4zusvGF8YZJPnS9SiJPDqc1VIfCrfve/o="
+  }],
+  "folderRelationships": [
+    {"key": 1, "value": 0}
+  ]
+}`
+		req, _ := http.NewRequest("POST", ts.URL+"/bitwarden/api/ciphers/import", bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		nb, err := couchdb.CountAllDocs(inst, consts.BitwardenCiphers)
+		assert.NoError(t, err)
+		assert.Equal(t, nbCiphers+2, nb)
+		nb, err = couchdb.CountAllDocs(inst, consts.BitwardenFolders)
+		assert.NoError(t, err)
+		assert.Equal(t, nbFolders+1, nb)
+	})
+
+	t.Run("CreateOrganization", func(t *testing.T) {
+		body := `
+{
+	"name": "Family Organization",
+	"key": "bmFjbF53D9mrdGbVqQzMB54uIg678EIpU/uHFYjynSPSA6vIv5/6nUy4Uk22SjIuDB3pZ679wLE3o7R/Imzn47OjfT6IrJ8HaysEhsZA25Dn8zwEtTMtgNepUtH084wAMgNeIcElW24U/MfRscjAk8cDUIm5xnzyi2vtJfe9PcHTmzRXyng=",
+	"collectionName": "2.rrpSDDODsWZqL7EhLVsu/Q==|OSuh+MmmR89ppdb/A7KxBg==|kofpAocL2G4a3P1C2R1U+i9hWbhfKfsPKM6kfoyCg/M="
+}`
+		req, _ := http.NewRequest("POST", ts.URL+"/bitwarden/api/organizations", bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		assert.Equal(t, "Family Organization", result["Name"])
+		assert.Equal(t, "profileOrganization", result["Object"])
+		assert.Equal(t, true, result["Enabled"])
+		assert.EqualValues(t, 2, result["Status"])
+		assert.EqualValues(t, 0, result["Type"])
+		orgaID, _ = result["Id"].(string)
+		assert.NotEmpty(t, orgaID)
+		assert.NotEmpty(t, result["Key"])
+	})
+
+	t.Run("GetOrganization", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/bitwarden/api/organizations/"+orgaID, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		assert.Equal(t, "Family Organization", result["Name"])
+		assert.Equal(t, "profileOrganization", result["Object"])
+		assert.Equal(t, true, result["Enabled"])
+		assert.EqualValues(t, 2, result["Status"])
+		assert.EqualValues(t, 0, result["Type"])
+		assert.Equal(t, orgaID, result["Id"])
+		assert.NotEmpty(t, result["Key"])
+	})
+
+	t.Run("ListCollections", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/bitwarden/api/organizations/"+orgaID+"/collections", nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		assert.Equal(t, "list", result["Object"])
+		data := result["Data"].([]interface{})
+		assert.Len(t, data, 1)
+		coll := data[0].(map[string]interface{})
+		assert.NotEmpty(t, coll["Id"])
+		assert.Equal(t, "2.rrpSDDODsWZqL7EhLVsu/Q==|OSuh+MmmR89ppdb/A7KxBg==|kofpAocL2G4a3P1C2R1U+i9hWbhfKfsPKM6kfoyCg/M=", coll["Name"])
+		assert.Equal(t, "collection", coll["Object"])
+		assert.Equal(t, orgaID, coll["OrganizationId"])
+		assert.Equal(t, false, coll["ReadOnly"])
+	})
+
+	t.Run("SyncOrganizationAndCollection", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/bitwarden/api/sync", nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		assert.Equal(t, "sync", result["Object"])
+
+		profile := result["Profile"].(map[string]interface{})
+		orgs := profile["Organizations"].([]interface{})
+		for i := range orgs {
+			org := orgs[i].(map[string]interface{})
+			if org["Id"] == orgaID {
+				assert.Equal(t, "Family Organization", org["Name"])
+			} else {
+				assert.Equal(t, "Cozy", org["Name"])
+			}
+			assert.NotEmpty(t, org["Key"])
+			assert.Equal(t, "profileOrganization", org["Object"])
+		}
+		assert.Len(t, orgs, 2)
+
+		colls := result["Collections"].([]interface{})
+		for i := range colls {
+			coll := colls[i].(map[string]interface{})
+			if coll["Id"] != collID {
+				assert.Equal(t, coll["OrganizationId"], orgaID)
+				assert.Equal(t, coll["Name"], "2.rrpSDDODsWZqL7EhLVsu/Q==|OSuh+MmmR89ppdb/A7KxBg==|kofpAocL2G4a3P1C2R1U+i9hWbhfKfsPKM6kfoyCg/M=")
+			}
+			assert.Equal(t, "collection", coll["Object"])
+		}
+		assert.Len(t, colls, 2)
+	})
+
+	t.Run("DeleteOrganization", func(t *testing.T) {
+		email := inst.PassphraseSalt()
+		iter := crypto.DefaultPBKDF2Iterations
+		pass, _ := crypto.HashPassWithPBKDF2([]byte("cozy"), email, iter)
+		body := fmt.Sprintf(`{"masterPasswordHash": "%s"}`, pass)
+		req, _ := http.NewRequest("DELETE", ts.URL+"/bitwarden/api/organizations/"+orgaID, bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+	})
+
+	t.Run("ChangeSecurityStamp", func(t *testing.T) {
+		email := inst.PassphraseSalt()
+		iter := crypto.DefaultPBKDF2Iterations
+		pass, _ := crypto.HashPassWithPBKDF2([]byte("cozy"), email, iter)
+		body, _ := json.Marshal(map[string]string{
+			"masterPasswordHash": string(pass),
+		})
+		buf := bytes.NewBuffer(body)
+		res, err := http.Post(ts.URL+"/bitwarden/api/accounts/security-stamp", "application/json", buf)
+		assert.NoError(t, err)
+		assert.Equal(t, 204, res.StatusCode)
+
+		// Check that token is no longer valid
+		req, _ := http.NewRequest("GET", ts.URL+"/bitwarden/api/folders", nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 401, res.StatusCode)
+	})
+
+	t.Run("SendHint", func(t *testing.T) {
+		body := `{ "email": "me@bitwarden.example.net" }`
+		req, _ := http.NewRequest("POST", ts.URL+"/bitwarden/api/accounts/password-hint", bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/json")
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+	})
+
 }
 
 func assertCipherResponse(t *testing.T, result map[string]interface{}) {
@@ -394,34 +1014,6 @@ func assertCipherResponse(t *testing.T, result map[string]interface{}) {
 	assert.Equal(t, false, result["OrganizationUseTotp"])
 }
 
-func TestUpdateCipher(t *testing.T) {
-	body := `
-{
-	"type": 2,
-	"favorite": true,
-	"name": "2.G38TIU3t1pGOfkzjCQE7OQ==|Xa1RupttU7zrWdzIT6oK+w==|J3C6qU1xDrfTgyJD+OrDri1GjgGhU2nmRK75FbZHXoI=",
-	"folderId": "` + folderID + `",
-	"organizationId": null,
-	"notes": "2.rSw0uVQEFgUCEmOQx0JnDg==|MKqHLD25aqaXYHeYJPH/mor7l3EeSQKsI7A/R+0bFTI=|ODcUScISzKaZWHlUe4MRGuTT2S7jpyDmbOHl7d+6HiM=",
-	"secureNote": {
-		"type": 0
-	}
-}`
-	req, _ := http.NewRequest("PUT", ts.URL+"/bitwarden/api/ciphers/"+cipherID, bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	assertUpdatedCipherResponse(t, result)
-	orgID, ok := result["OrganizationId"]
-	assert.True(t, ok)
-	assert.Empty(t, orgID)
-}
-
 func assertUpdatedCipherResponse(t *testing.T, result map[string]interface{}) {
 	assert.Equal(t, "cipher", result["Object"])
 	assert.Equal(t, cipherID, result["Id"])
@@ -443,382 +1035,6 @@ func assertUpdatedCipherResponse(t *testing.T, result map[string]interface{}) {
 	assert.NotEmpty(t, result["RevisionDate"])
 	assert.Equal(t, true, result["Edit"])
 	assert.Equal(t, false, result["OrganizationUseTotp"])
-}
-
-func TestDeleteCipher(t *testing.T) {
-	body := `
-{
-	"type": 1,
-	"favorite": false,
-	"name": "2.d7MttWzJTSSKx1qXjHUxlQ==|01Ath5UqFZHk7csk5DVtkQ==|EMLoLREgCUP5Cu4HqIhcLqhiZHn+NsUDp8dAg1Xu0Io=",
-	"notes": null,
-	"folderId": null,
-	"organizationId": null,
-	"login": {
-		"uri": "2.T57BwAuV8ubIn/sZPbQC+A==|EhUSSpJWSzSYOdJ/AQzfXuUXxwzcs/6C4tOXqhWAqcM=|OWV2VIqLfoWPs9DiouXGUOtTEkVeklbtJQHkQFIXkC8=",
-		"username": "2.JbFkAEZPnuMm70cdP44wtA==|fsN6nbT+udGmOWv8K4otgw==|JbtwmNQa7/48KszT2hAdxpmJ6DRPZst0EDEZx5GzesI=",
-		"password": "2.e83hIsk6IRevSr/H1lvZhg==|48KNkSCoTacopXRmIZsbWg==|CIcWgNbaIN2ix2Fx1Gar6rWQeVeboehp4bioAwngr0o=",
-		"totp": null
-	}
-}`
-	req, _ := http.NewRequest("POST", ts.URL+"/bitwarden/api/ciphers", bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	id := result["Id"].(string)
-
-	req, _ = http.NewRequest("DELETE", ts.URL+"/bitwarden/api/ciphers/"+id, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-}
-
-func TestSoftDeleteCipher(t *testing.T) {
-	body := `
-{
-	"type": 1,
-	"favorite": false,
-	"name": "2.d7MttWzJTSSKx1qXjHUxlQ==|01Ath5UqFZHk7csk5DVtkQ==|EMLoLREgCUP5Cu4HqIhcLqhiZHn+NsUDp8dAg1Xu0Io=",
-	"notes": null,
-	"folderId": null,
-	"organizationId": null,
-	"login": {
-		"uri": "2.T57BwAuV8ubIn/sZPbQC+A==|EhUSSpJWSzSYOdJ/AQzfXuUXxwzcs/6C4tOXqhWAqcM=|OWV2VIqLfoWPs9DiouXGUOtTEkVeklbtJQHkQFIXkC8=",
-		"username": "2.JbFkAEZPnuMm70cdP44wtA==|fsN6nbT+udGmOWv8K4otgw==|JbtwmNQa7/48KszT2hAdxpmJ6DRPZst0EDEZx5GzesI=",
-		"password": "2.e83hIsk6IRevSr/H1lvZhg==|48KNkSCoTacopXRmIZsbWg==|CIcWgNbaIN2ix2Fx1Gar6rWQeVeboehp4bioAwngr0o=",
-		"totp": null
-	}
-}`
-	req, _ := http.NewRequest("POST", ts.URL+"/bitwarden/api/ciphers", bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	id := result["Id"].(string)
-
-	req, _ = http.NewRequest("PUT", ts.URL+"/bitwarden/api/ciphers/"+id+"/delete", nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-
-	req, _ = http.NewRequest("GET", ts.URL+"/bitwarden/api/ciphers/"+id, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	assert.NotEmpty(t, result["DeletedDate"])
-}
-
-func TestRestoreCipher(t *testing.T) {
-	body := `
-{
-	"type": 1,
-	"favorite": false,
-	"name": "2.d7MttWzJTSSKx1qXjHUxlQ==|01Ath5UqFZHk7csk5DVtkQ==|EMLoLREgCUP5Cu4HqIhcLqhiZHn+NsUDp8dAg1Xu0Io=",
-	"notes": null,
-	"folderId": null,
-	"organizationId": null,
-	"login": {
-		"uri": "2.T57BwAuV8ubIn/sZPbQC+A==|EhUSSpJWSzSYOdJ/AQzfXuUXxwzcs/6C4tOXqhWAqcM=|OWV2VIqLfoWPs9DiouXGUOtTEkVeklbtJQHkQFIXkC8=",
-		"username": "2.JbFkAEZPnuMm70cdP44wtA==|fsN6nbT+udGmOWv8K4otgw==|JbtwmNQa7/48KszT2hAdxpmJ6DRPZst0EDEZx5GzesI=",
-		"password": "2.e83hIsk6IRevSr/H1lvZhg==|48KNkSCoTacopXRmIZsbWg==|CIcWgNbaIN2ix2Fx1Gar6rWQeVeboehp4bioAwngr0o=",
-		"totp": null
-	}
-}`
-	req, _ := http.NewRequest("POST", ts.URL+"/bitwarden/api/ciphers", bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	id := result["Id"].(string)
-
-	req, _ = http.NewRequest("PUT", ts.URL+"/bitwarden/api/ciphers/"+id+"/delete", nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-
-	req, _ = http.NewRequest("PUT", ts.URL+"/bitwarden/api/ciphers/"+id+"/restore", nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-
-	req, _ = http.NewRequest("GET", ts.URL+"/bitwarden/api/ciphers/"+id, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	assert.Empty(t, result["DeletedDate"])
-}
-
-func TestSync(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/bitwarden/api/sync", nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	assert.Equal(t, "sync", result["Object"])
-
-	profile := result["Profile"].(map[string]interface{})
-	assert.NotEmpty(t, profile["Id"])
-	assert.Equal(t, "Pierre", profile["Name"])
-	assert.Equal(t, "me@bitwarden.example.net", profile["Email"])
-	assert.Equal(t, false, profile["EmailVerified"])
-	assert.Equal(t, true, profile["Premium"])
-	assert.Equal(t, nil, profile["MasterPasswordHint"])
-	assert.Equal(t, "en", profile["Culture"])
-	assert.Equal(t, false, profile["TwoFactorEnabled"])
-	assert.NotEmpty(t, profile["Key"])
-	assert.NotEmpty(t, profile["PrivateKey"])
-	assert.NotEmpty(t, profile["SecurityStamp"])
-	assert.Equal(t, "profile", profile["Object"])
-
-	ciphers := result["Ciphers"].([]interface{})
-	assert.Len(t, ciphers, 3)
-	c := ciphers[0].(map[string]interface{})
-	assertUpdatedCipherResponse(t, c)
-
-	folders := result["Folders"].([]interface{})
-	assert.Len(t, folders, 1)
-	f := folders[0].(map[string]interface{})
-	assert.Equal(t, "2.d7MttWzJTSSKx1qXjHUxlQ==|01Ath5UqFZHk7csk5DVtkQ==|EMLoLREgCUP5Cu4HqIhcLqhiZHn+NsUDp8dAg1Xu0Io=", f["Name"])
-	assert.Equal(t, "folder", f["Object"])
-	assert.NotEmpty(t, f["RevisionDate"])
-	assert.Equal(t, folderID, f["Id"])
-
-	domains := result["Domains"].(map[string]interface{})
-	ed, ok := domains["EquivalentDomains"]
-	assert.True(t, ok)
-	assert.Empty(t, ed)
-	ged, ok := domains["GlobalEquivalentDomains"]
-	assert.True(t, ok)
-	assert.NotEmpty(t, ged)
-	assert.Equal(t, "domains", domains["Object"])
-}
-
-func TestBulkDeleteCiphers(t *testing.T) {
-	// Setup
-	nbCiphersToDelete := 5
-	nbCiphers, err := couchdb.CountAllDocs(inst, consts.BitwardenCiphers)
-	assert.NoError(t, err)
-
-	var ids []string
-	for i := 0; i < nbCiphersToDelete; i++ {
-		body := `
-{
-	"type": 1,
-	"favorite": false,
-	"name": "2.d7MttWzJTSSKx1qXjHUxlQ==|01Ath5UqFZHk7csk5DVtkQ==|EMLoLREgCUP5Cu4HqIhcLqhiZHn+NsUDp8dAg1Xu0Io=",
-	"notes": null,
-	"folderId": null,
-	"organizationId": null,
-	"login": {
-		"uri": "2.T57BwAuV8ubIn/sZPbQC+A==|EhUSSpJWSzSYOdJ/AQzfXuUXxwzcs/6C4tOXqhWAqcM=|OWV2VIqLfoWPs9DiouXGUOtTEkVeklbtJQHkQFIXkC8=",
-		"username": "2.JbFkAEZPnuMm70cdP44wtA==|fsN6nbT+udGmOWv8K4otgw==|JbtwmNQa7/48KszT2hAdxpmJ6DRPZst0EDEZx5GzesI=",
-		"password": "2.e83hIsk6IRevSr/H1lvZhg==|48KNkSCoTacopXRmIZsbWg==|CIcWgNbaIN2ix2Fx1Gar6rWQeVeboehp4bioAwngr0o=",
-		"totp": null
-	}
-}`
-		req, _ := http.NewRequest("POST", ts.URL+"/bitwarden/api/ciphers", bytes.NewBufferString(body))
-		req.Header.Add("Content-Type", "application/json")
-		req.Header.Add("Authorization", "Bearer "+token)
-		res, err := http.DefaultClient.Do(req)
-		assert.NoError(t, err)
-		assert.Equal(t, 200, res.StatusCode)
-		var result map[string]interface{}
-		err = json.NewDecoder(res.Body).Decode(&result)
-		assert.NoError(t, err)
-		ids = append(ids, result["Id"].(string))
-	}
-
-	nb, err := couchdb.CountAllDocs(inst, consts.BitwardenCiphers)
-	assert.NoError(t, err)
-	assert.Equal(t, nbCiphers+nbCiphersToDelete, nb)
-
-	// Test soft delete in bulk
-	body, _ := json.Marshal(map[string][]string{
-		"ids": ids,
-	})
-	buf := bytes.NewBuffer(body)
-	req, _ := http.NewRequest("PUT", ts.URL+"/bitwarden/api/ciphers/delete", buf)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Add("Content-Type", "application/json")
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-
-	for _, id := range ids {
-		req, _ = http.NewRequest("GET", ts.URL+"/bitwarden/api/ciphers/"+id, nil)
-		req.Header.Add("Authorization", "Bearer "+token)
-		res, err = http.DefaultClient.Do(req)
-		assert.NoError(t, err)
-		assert.Equal(t, 200, res.StatusCode)
-		var result map[string]interface{}
-		err = json.NewDecoder(res.Body).Decode(&result)
-		assert.NoError(t, err)
-		assert.NotEmpty(t, result["DeletedDate"])
-	}
-
-	// Test restore in bulk
-	buf = bytes.NewBuffer(body)
-	req, _ = http.NewRequest("PUT", ts.URL+"/bitwarden/api/ciphers/restore", buf)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Add("Content-Type", "application/json")
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	assert.Equal(t, "list", result["Object"])
-	data := result["Data"].([]interface{})
-	assert.Len(t, data, nbCiphersToDelete)
-
-	for i := range data {
-		item := data[i].(map[string]interface{})
-		assert.Equal(t, ids[i], item["Id"])
-		assert.Empty(t, item["DeletedDate"])
-	}
-
-	// Test delete in bulk
-	buf = bytes.NewBuffer(body)
-	req, _ = http.NewRequest("DELETE", ts.URL+"/bitwarden/api/ciphers", buf)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Add("Content-Type", "application/json")
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-
-	nb, err = couchdb.CountAllDocs(inst, consts.BitwardenCiphers)
-	assert.NoError(t, err)
-	assert.Equal(t, nbCiphers, nb)
-}
-
-func TestSharedCipher(t *testing.T) {
-	body := `
-{
-	"cipher": {
-		"type": 1,
-		"favorite": false,
-		"name": "2.d7MttWzJTSSKx1qXjHUxlQ==|01Ath5UqFZHk7csk5DVtkQ==|EMLoLREgCUP5Cu4HqIhcLqhiZHn+NsUDp8dAg1Xu0Io=",
-		"notes": null,
-		"folderId": null,
-		"organizationId": "` + orgaID + `",
-		"login": {
-			"uri": "2.T57BwAuV8ubIn/sZPbQC+A==|EhUSSpJWSzSYOdJ/AQzfXuUXxwzcs/6C4tOXqhWAqcM=|OWV2VIqLfoWPs9DiouXGUOtTEkVeklbtJQHkQFIXkC8=",
-			"username": "2.JbFkAEZPnuMm70cdP44wtA==|fsN6nbT+udGmOWv8K4otgw==|JbtwmNQa7/48KszT2hAdxpmJ6DRPZst0EDEZx5GzesI=",
-			"password": "2.e83hIsk6IRevSr/H1lvZhg==|48KNkSCoTacopXRmIZsbWg==|CIcWgNbaIN2ix2Fx1Gar6rWQeVeboehp4bioAwngr0o=",
-			"passwordRevisionDate": "2019-09-13T12:26:42+02:00",
-			"totp": null
-		}
-	},
-	"collectionIds": ["` + collID + `"]
-}`
-	req, _ := http.NewRequest("POST", ts.URL+"/bitwarden/api/ciphers/create", bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	assertCipherResponse(t, result)
-	orgID, ok := result["OrganizationId"]
-	assert.True(t, ok)
-	assert.Equal(t, orgID, orgaID)
-	cipherID = result["Id"].(string)
-
-	body = `
-{
-	"type": 2,
-	"favorite": true,
-	"name": "2.G38TIU3t1pGOfkzjCQE7OQ==|Xa1RupttU7zrWdzIT6oK+w==|J3C6qU1xDrfTgyJD+OrDri1GjgGhU2nmRK75FbZHXoI=",
-	"folderId": "` + folderID + `",
-	"organizationId": "` + orgaID + `",
-	"notes": "2.rSw0uVQEFgUCEmOQx0JnDg==|MKqHLD25aqaXYHeYJPH/mor7l3EeSQKsI7A/R+0bFTI=|ODcUScISzKaZWHlUe4MRGuTT2S7jpyDmbOHl7d+6HiM=",
-	"secureNote": {
-		"type": 0
-	}
-}`
-	req, _ = http.NewRequest("PUT", ts.URL+"/bitwarden/api/ciphers/"+cipherID, bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result2 map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result2)
-	assert.NoError(t, err)
-	assertUpdatedCipherResponse(t, result2)
-	orgID, ok = result2["OrganizationId"]
-	assert.True(t, ok)
-	assert.Equal(t, orgID, orgaID)
-}
-
-func TestSetKeyPair(t *testing.T) {
-	body, _ := json.Marshal(map[string]string{
-		"encryptedPrivateKey": "2.demXNYbv8o47sG+fhYYvhg==|jXpxet7AApeIzrC3Yr752LwmjBdCZn6HJl6SjEOVP3rrOpGu5qV2rN0dBH5yXXWHusfxM7IvXkdC/fzBUAmFFOU5ubTp9kHFBqIn51tiJG6BRs5aTm7kF6TYSHVDIP5kUdX4O7DcmD23dqtq/8211DSAFR/DK1QDm5Da77Clh7NHxQE9Z9RTW1PBGV56DfzrY3N06H6vI+V6fTZ6HJRD2pdPczR2ZNC0ziQP7qCUYNlSjEv70O4VoYMSUsdb4UUE1YetcSdZ+dIAy+V2KHfoHmTFYI4DtMCW6WpDzp0ufPvszFjt1EwaMr78hujMrQr1gFWxgN8kOLJyYCrd1F5aIxWXHghBH/t+QU31gyQOxCdj18f10ssfuY/y7vocSJQ9pTRRPNh4beGAijV1AETaXWLK1L6oMnkbdhr9ZA2I6cZaHNCaHIynHQH7NUqKKQUJL/FyZ8rBv4YNnxCMRi9p88IoTb0oPsUCoNCaIZ2cvzXz+0VpU6zxj4ke7H6Bu7H46MSB1P+YHzGLtFNzZJVsUBEkz7dotUDeTeqlYKnq7oldWJ4HlqODevzCev+FRnYgrYpoXmYC/dxa1R5IlKCu6rEmP05A7Nw4h9cymnTwRMEoZRSppJ2O5FlSx/Go9Jz12g2Tfiaf+RvO7nkIb2qKiz7Jo2aJgakL5lMOlEdBA2+dsYSyX4Tvu8Ua4p0GcYaGOgSjXH27lQ73ZpHSicf4Q1kAooVl+6zTOPAqgMXOnyyVSRqBPse28HuDwGtmD8BAeVDIfkMW+a+PlWa+yoEWKfDHRduoxNod7Pc9xlNFt6eOeGoBQTEIiF7ccBDtNiSU1yfvqBZEgI8QF0QiGUo9eP7+59so5eu9/DuzjdqFMmGPtG3zHifMxuMzO5+E9UxTyHuCwvxuH93F4vmPC8zzXXn8/ErhEeqmYl1lxZbfJDm1qcjTkJibNKJ9+CXUeP0hq8yi07SEN1xJSZpupf90EUjrdFd3impz3gZKummEjTvzr3J1JX4gC/wD0mGkROHQwb0jCTDJNC18cX4usPYtNr3FxLZmxCGgPmZhkzFjF0qppN1aXTxQskdorEejQUwLL5EnWJySd9/W2P6PmjkJTAwKYUNHsmVUAfbMA7y7QBIjVFFWS4xYy0GJcc8NaLKkFMkGv/oluw552prWAJZ4aM2asoNgyv/JARrAF+JbOPSpax+CtUMO+LCFlBITHopbkHz0TwI1UMj/vIOh9wxDiMqe3YBiviymudX+B7awCaUPTLubWW1jwC4kBnXmRGAKyyIvzgOvwkdcKfQRxoTxq7JFTL/hWk7x4HlQqviSWGY166CLIp6SydCT+cqHMf3MHhe8AQZVC+nIDVNQZWfpFbOFb3nNDwlT+laWrtsiuX7hHiL0VLaCU4xzup5m4zvi59/Qxj0+d8n6M/3GP3/Tvp/bKY9m7CHoeimtGF9Ai2QFJFMOEQw3S1SUBL62ZsezKgBap6y1RqmMzdz/h3f5mhHxRMoQ0kgzZwMNWJvi2acGoIttcmBU7Cn6fqxYNi11dg17M7cFJAQCMicvd4pEwl8IBrm7uFrzbLvuLeolyiDx8GX3jfIo//Ceqa6P/RIqN8jKzH3nTSePuVqkXYiIdxhlAeF//EYW0CwOjd3GEoc=|aUt6NKqrLW4HeprkbwjuBzSQbR84imTujhUPxK17eX4=",
-		"publicKey":           "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmAYrTtY4FBJL/TeTGqr1uHCoMCzUDgwvgq7gBGiNrk24gPbb3xreM+HxubBvkzTlgoS6m1KKKKtD4tWrLU33Xc+PevbKSZDLvBfUe+golGU1XKFxUcIkgINtB0i8LmCVCShiCrlhn2VorcAbekR/1RXtoJqpqq1urhI+RdGVXy8HBBoULA7BoV7wC8dBdkRtnQMNuvGyHclV7yjgealKGqgxz4aNcgsfybquKvYg6PUj8dAxUy7KlmMR7klPyO8nahYqyhpQ/t0xle0WyCkdx5YuYhRSA67Tok+E8fCW5WXOPfIdPZDXS+6/wW1NhcQEa5j6EW11PF/Xq0awBUFwnwIDAQAB",
-	})
-	buf := bytes.NewBuffer(body)
-	req, _ := http.NewRequest("POST", ts.URL+"/bitwarden/api/accounts/keys", buf)
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-
-	setting, err := settings.Get(inst)
-	assert.NoError(t, err)
-	orgKey, err := setting.OrganizationKey()
-	assert.NoError(t, err)
-	assert.NotEmpty(t, orgKey)
-}
-
-func TestSettingsDomains(t *testing.T) {
-	body, _ := json.Marshal(map[string]interface{}{
-		"equivalentDomains": [][]string{
-			{"stackoverflow.com", "serverfault.com", "superuser.com"},
-		},
-		"globalEquivalentDomains": []int{42, 69},
-	})
-	buf := bytes.NewBuffer(body)
-	req, _ := http.NewRequest("POST", ts.URL+"/bitwarden/api/settings/domains", buf)
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assertDomainsReponse(t, res)
-
-	req, _ = http.NewRequest("GET", ts.URL+"/bitwarden/api/settings/domains", nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assertDomainsReponse(t, res)
 }
 
 func assertDomainsReponse(t *testing.T, res *http.Response) {
@@ -846,215 +1062,4 @@ func assertDomainsReponse(t *testing.T, res *http.Response) {
 		assert.Equal(t, item["Excluded"], excluded)
 		assert.True(t, len(item["Domains"].([]interface{})) > 0)
 	}
-}
-
-func TestImportCiphers(t *testing.T) {
-	nbCiphers, err := couchdb.CountAllDocs(inst, consts.BitwardenCiphers)
-	assert.NoError(t, err)
-	nbFolders, err := couchdb.CountAllDocs(inst, consts.BitwardenFolders)
-	assert.NoError(t, err)
-	body := `
-{
-  "ciphers": [{
-    "type": 2,
-    "favorite": true,
-    "name": "2.G38TIU3t1pGOfkzjCQE7OQ==|Xa1RupttU7zrWdzIT6oK+w==|J3C6qU1xDrfTgyJD+OrDri1GjgGhU2nmRK75FbZHXoI=",
-    "folderId": null,
-    "organizationId": null,
-    "notes": "2.rSw0uVQEFgUCEmOQx0JnDg==|MKqHLD25aqaXYHeYJPH/mor7l3EeSQKsI7A/R+0bFTI=|ODcUScISzKaZWHlUe4MRGuTT2S7jpyDmbOHl7d+6HiM=",
-    "secureNote": {
-      "type": 0
-    }
-  }, {
-    "type": 1,
-    "favorite": false,
-    "name": "2.d7MttWzJTSSKx1qXjHUxlQ==|01Ath5UqFZHk7csk5DVtkQ==|EMLoLREgCUP5Cu4HqIhcLqhiZHn+NsUDp8dAg1Xu0Io=",
-    "folderId": null,
-    "organizationId": null,
-    "notes": null,
-    "login": {
-      "uri": "2.T57BwAuV8ubIn/sZPbQC+A==|EhUSSpJWSzSYOdJ/AQzfXuUXxwzcs/6C4tOXqhWAqcM=|OWV2VIqLfoWPs9DiouXGUOtTEkVeklbtJQHkQFIXkC8=",
-      "username": "2.JbFkAEZPnuMm70cdP44wtA==|fsN6nbT+udGmOWv8K4otgw==|JbtwmNQa7/48KszT2hAdxpmJ6DRPZst0EDEZx5GzesI=",
-      "password": "2.e83hIsk6IRevSr/H1lvZhg==|48KNkSCoTacopXRmIZsbWg==|CIcWgNbaIN2ix2Fx1Gar6rWQeVeboehp4bioAwngr0o=",
-      "totp": null
-    }
-  }],
-  "folders": [{
-    "name": "2.FQAwIBaDbczEGnEJw4g4hw==|7KreXaC0duAj0ulzZJ8ncA==|nu2sEvotjd4zusvGF8YZJPnS9SiJPDqc1VIfCrfve/o="
-  }],
-  "folderRelationships": [
-    {"key": 1, "value": 0}
-  ]
-}`
-	req, _ := http.NewRequest("POST", ts.URL+"/bitwarden/api/ciphers/import", bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	nb, err := couchdb.CountAllDocs(inst, consts.BitwardenCiphers)
-	assert.NoError(t, err)
-	assert.Equal(t, nbCiphers+2, nb)
-	nb, err = couchdb.CountAllDocs(inst, consts.BitwardenFolders)
-	assert.NoError(t, err)
-	assert.Equal(t, nbFolders+1, nb)
-}
-
-func TestCreateOrganization(t *testing.T) {
-	body := `
-{
-	"name": "Family Organization",
-	"key": "bmFjbF53D9mrdGbVqQzMB54uIg678EIpU/uHFYjynSPSA6vIv5/6nUy4Uk22SjIuDB3pZ679wLE3o7R/Imzn47OjfT6IrJ8HaysEhsZA25Dn8zwEtTMtgNepUtH084wAMgNeIcElW24U/MfRscjAk8cDUIm5xnzyi2vtJfe9PcHTmzRXyng=",
-	"collectionName": "2.rrpSDDODsWZqL7EhLVsu/Q==|OSuh+MmmR89ppdb/A7KxBg==|kofpAocL2G4a3P1C2R1U+i9hWbhfKfsPKM6kfoyCg/M="
-}`
-	req, _ := http.NewRequest("POST", ts.URL+"/bitwarden/api/organizations", bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	assert.Equal(t, "Family Organization", result["Name"])
-	assert.Equal(t, "profileOrganization", result["Object"])
-	assert.Equal(t, true, result["Enabled"])
-	assert.EqualValues(t, 2, result["Status"])
-	assert.EqualValues(t, 0, result["Type"])
-	orgaID, _ = result["Id"].(string)
-	assert.NotEmpty(t, orgaID)
-	assert.NotEmpty(t, result["Key"])
-}
-
-func TestGetOrganization(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/bitwarden/api/organizations/"+orgaID, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	assert.Equal(t, "Family Organization", result["Name"])
-	assert.Equal(t, "profileOrganization", result["Object"])
-	assert.Equal(t, true, result["Enabled"])
-	assert.EqualValues(t, 2, result["Status"])
-	assert.EqualValues(t, 0, result["Type"])
-	assert.Equal(t, orgaID, result["Id"])
-	assert.NotEmpty(t, result["Key"])
-}
-
-func TestListCollections(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/bitwarden/api/organizations/"+orgaID+"/collections", nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	assert.Equal(t, "list", result["Object"])
-	data := result["Data"].([]interface{})
-	assert.Len(t, data, 1)
-	coll := data[0].(map[string]interface{})
-	assert.NotEmpty(t, coll["Id"])
-	assert.Equal(t, "2.rrpSDDODsWZqL7EhLVsu/Q==|OSuh+MmmR89ppdb/A7KxBg==|kofpAocL2G4a3P1C2R1U+i9hWbhfKfsPKM6kfoyCg/M=", coll["Name"])
-	assert.Equal(t, "collection", coll["Object"])
-	assert.Equal(t, orgaID, coll["OrganizationId"])
-	assert.Equal(t, false, coll["ReadOnly"])
-}
-
-func TestSyncOrganizationAndCollection(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/bitwarden/api/sync", nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	assert.Equal(t, "sync", result["Object"])
-
-	profile := result["Profile"].(map[string]interface{})
-	orgs := profile["Organizations"].([]interface{})
-	for i := range orgs {
-		org := orgs[i].(map[string]interface{})
-		if org["Id"] == orgaID {
-			assert.Equal(t, "Family Organization", org["Name"])
-		} else {
-			assert.Equal(t, "Cozy", org["Name"])
-		}
-		assert.NotEmpty(t, org["Key"])
-		assert.Equal(t, "profileOrganization", org["Object"])
-	}
-	assert.Len(t, orgs, 2)
-
-	colls := result["Collections"].([]interface{})
-	for i := range colls {
-		coll := colls[i].(map[string]interface{})
-		if coll["Id"] != collID {
-			assert.Equal(t, coll["OrganizationId"], orgaID)
-			assert.Equal(t, coll["Name"], "2.rrpSDDODsWZqL7EhLVsu/Q==|OSuh+MmmR89ppdb/A7KxBg==|kofpAocL2G4a3P1C2R1U+i9hWbhfKfsPKM6kfoyCg/M=")
-		}
-		assert.Equal(t, "collection", coll["Object"])
-	}
-	assert.Len(t, colls, 2)
-}
-
-func TestDeleteOrganization(t *testing.T) {
-	email := inst.PassphraseSalt()
-	iter := crypto.DefaultPBKDF2Iterations
-	pass, _ := crypto.HashPassWithPBKDF2([]byte("cozy"), email, iter)
-	body := fmt.Sprintf(`{"masterPasswordHash": "%s"}`, pass)
-	req, _ := http.NewRequest("DELETE", ts.URL+"/bitwarden/api/organizations/"+orgaID, bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-}
-
-func TestChangeSecurityStamp(t *testing.T) {
-	email := inst.PassphraseSalt()
-	iter := crypto.DefaultPBKDF2Iterations
-	pass, _ := crypto.HashPassWithPBKDF2([]byte("cozy"), email, iter)
-	body, _ := json.Marshal(map[string]string{
-		"masterPasswordHash": string(pass),
-	})
-	buf := bytes.NewBuffer(body)
-	res, err := http.Post(ts.URL+"/bitwarden/api/accounts/security-stamp", "application/json", buf)
-	assert.NoError(t, err)
-	assert.Equal(t, 204, res.StatusCode)
-
-	// Check that token is no longer valid
-	req, _ := http.NewRequest("GET", ts.URL+"/bitwarden/api/folders", nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 401, res.StatusCode)
-}
-
-func TestSendHint(t *testing.T) {
-	body := `{ "email": "me@bitwarden.example.net" }`
-	req, _ := http.NewRequest("POST", ts.URL+"/bitwarden/api/accounts/password-hint", bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/json")
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-}
-
-func TestMain(m *testing.M) {
-	config.UseTestFile()
-	testutils.NeedCouchdb()
-	setup := testutils.NewSetup(m, "bitwarden_test")
-	inst = setup.GetTestInstance(&lifecycle.Options{
-		Domain:     "bitwarden.example.net",
-		Passphrase: "cozy",
-		PublicName: "Pierre",
-		Email:      "pierre@cozy.localhost",
-	})
-
-	ts = setup.GetTestServer("/bitwarden", Routes)
-	ts.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler
-	os.Exit(setup.Run())
 }

--- a/web/bitwarden/bitwarden_test.go
+++ b/web/bitwarden/bitwarden_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"testing"
 
 	"github.com/cozy/cozy-stack/model/bitwarden"
@@ -49,7 +48,6 @@ func TestBitwarden(t *testing.T) {
 
 	ts = setup.GetTestServer("/bitwarden", Routes)
 	ts.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler
-	os.Exit(setup.Run())
 
 	t.Run("Prelogin", func(t *testing.T) {
 		body := `{ "email": "me@bitwarden.example.net" }`

--- a/web/contacts/contacts_test.go
+++ b/web/contacts/contacts_test.go
@@ -51,7 +51,6 @@ func TestContacts(t *testing.T) {
 		assert.NoError(t, err)
 		assertMyself(t, res2)
 	})
-
 }
 
 func assertMyself(t *testing.T, res *http.Response) {

--- a/web/contacts/contacts_test.go
+++ b/web/contacts/contacts_test.go
@@ -21,6 +21,40 @@ var ts *httptest.Server
 var testInstance *instance.Instance
 var token string
 
+func TestContacts(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	config.UseTestFile()
+	testutils.NeedCouchdb()
+	setup := testutils.NewSetup(m, "contacts_test")
+	testInstance = setup.GetTestInstance(&lifecycle.Options{
+		Email:      "alice@example.com",
+		PublicName: "Alice",
+	})
+	_, token = setup.GetTestClient(consts.Contacts)
+	ts = setup.GetTestServer("/contacts", Routes)
+	os.Exit(setup.Run())
+
+	t.Run("Myself", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", ts.URL+"/contacts/myself", nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assertMyself(t, res)
+
+		myself, err := contact.GetMyself(testInstance)
+		assert.NoError(t, err)
+		err = couchdb.DeleteDoc(testInstance, myself)
+		assert.NoError(t, err)
+		res2, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assertMyself(t, res2)
+	})
+
+}
+
 func assertMyself(t *testing.T, res *http.Response) {
 	assert.Equal(t, 200, res.StatusCode)
 	var result map[string]interface{}
@@ -41,33 +75,4 @@ func assertMyself(t *testing.T, res *http.Response) {
 		assert.Equal(t, "alice@example.com", email["address"])
 		assert.Equal(t, true, email["primary"])
 	}
-}
-
-func TestMyself(t *testing.T) {
-	req, _ := http.NewRequest("POST", ts.URL+"/contacts/myself", nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assertMyself(t, res)
-
-	myself, err := contact.GetMyself(testInstance)
-	assert.NoError(t, err)
-	err = couchdb.DeleteDoc(testInstance, myself)
-	assert.NoError(t, err)
-	res2, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assertMyself(t, res2)
-}
-
-func TestMain(m *testing.M) {
-	config.UseTestFile()
-	testutils.NeedCouchdb()
-	setup := testutils.NewSetup(m, "contacts_test")
-	testInstance = setup.GetTestInstance(&lifecycle.Options{
-		Email:      "alice@example.com",
-		PublicName: "Alice",
-	})
-	_, token = setup.GetTestClient(consts.Contacts)
-	ts = setup.GetTestServer("/contacts", Routes)
-	os.Exit(setup.Run())
 }

--- a/web/contacts/contacts_test.go
+++ b/web/contacts/contacts_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/cozy/cozy-stack/model/contact"
@@ -35,7 +34,6 @@ func TestContacts(t *testing.T) {
 	})
 	_, token = setup.GetTestClient(consts.Contacts)
 	ts = setup.GetTestServer("/contacts", Routes)
-	os.Exit(setup.Run())
 
 	t.Run("Myself", func(t *testing.T) {
 		req, _ := http.NewRequest("POST", ts.URL+"/contacts/myself", nil)

--- a/web/contacts/contacts_test.go
+++ b/web/contacts/contacts_test.go
@@ -27,7 +27,8 @@ func TestContacts(t *testing.T) {
 
 	config.UseTestFile()
 	testutils.NeedCouchdb()
-	setup := testutils.NewSetup(m, "contacts_test")
+	setup := testutils.NewSetup(nil, t.Name())
+	t.Cleanup(setup.Cleanup)
 	testInstance = setup.GetTestInstance(&lifecycle.Options{
 		Email:      "alice@example.com",
 		PublicName: "Alice",

--- a/web/data/data_test.go
+++ b/web/data/data_test.go
@@ -866,10 +866,9 @@ func TestNormalDocs(t *testing.T) {
 		Name:    "foobar",
 		Doctype: Type,
 		Map: `
-function(doc) {
-  emit(doc.foobar, doc);
-}
-		`,
+  function(doc) {
+    emit(doc.foobar, doc);
+  }`,
 	}
 	g, _ := errgroup.WithContext(context.Background())
 	couchdb.DefineViews(g, testInstance, []*couchdb.View{view})

--- a/web/data/data_test.go
+++ b/web/data/data_test.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 
@@ -79,8 +78,6 @@ func TestData(t *testing.T) {
 			"test": "testvalue",
 		},
 	})
-
-	os.Exit(setup.Run())
 
 	t.Run("SuccessGet", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", ts.URL+"/data/"+Type+"/"+ID, nil)

--- a/web/data/data_test.go
+++ b/web/data/data_test.go
@@ -1093,7 +1093,6 @@ func TestData(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "403 Forbidden", res.Status)
 	})
-
 }
 
 func jsonReader(data interface{}) io.Reader {

--- a/web/data/data_test.go
+++ b/web/data/data_test.go
@@ -42,6 +42,1062 @@ type stackUpdateResponse struct {
 	Data    couchdb.JSONDoc `json:"data"`
 }
 
+// Test for having not the same ID in document and URL
+
+// Test for having an inexisting id at all
+
+type M map[string]interface{}
+type S []interface{}
+type indexCreationResponse struct {
+	Result string `json:"result"`
+	Error  string `json:"error"`
+	Reason string `json:"reason"`
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+}
+
+func TestData(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	config.UseTestFile()
+	testutils.NeedCouchdb()
+	setup := testutils.NewSetup(m, "data_test")
+	testInstance = setup.GetTestInstance()
+	scope := "io.cozy.doctypes io.cozy.files io.cozy.events " +
+		"io.cozy.anothertype io.cozy.nottype"
+
+	_, token = setup.GetTestClient(scope)
+	ts = setup.GetTestServer("/data", Routes)
+
+	_ = couchdb.ResetDB(testInstance, Type)
+	_ = couchdb.CreateNamedDoc(testInstance, &couchdb.JSONDoc{
+		Type: Type,
+		M: map[string]interface{}{
+			"_id":  ID,
+			"test": "testvalue",
+		},
+	})
+
+	os.Exit(setup.Run())
+
+	t.Run("SuccessGet", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/data/"+Type+"/"+ID, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		out, res, err := doRequest(req, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "200 OK", res.Status, "should get a 200")
+		if assert.Contains(t, out, "test") {
+			assert.Equal(t, out["test"], "testvalue", "should give the same doc")
+		}
+	})
+
+	t.Run("GetForMissingDoc", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/data/no.such.doctype/id", nil)
+		_, res, err := doRequest(req, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, 401, res.StatusCode)
+
+		req, _ = http.NewRequest("GET", ts.URL+"/data/"+Type+"/no.such.id", nil)
+		_, res, err = doRequest(req, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, 401, res.StatusCode)
+
+		req, _ = http.NewRequest("GET", ts.URL+"/data/"+Type+"/no-such-id", nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		_, res, err = doRequest(req, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, 404, res.StatusCode)
+	})
+
+	t.Run("GetWithSlash", func(t *testing.T) {
+		_ = couchdb.CreateNamedDoc(testInstance, &couchdb.JSONDoc{
+			Type: Type, M: map[string]interface{}{
+				"_id":  "with/slash",
+				"test": "valueslash",
+			}})
+
+		req, _ := http.NewRequest("GET", ts.URL+"/data/"+Type+"/with%2Fslash", nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		out, res, err := doRequest(req, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "200 OK", res.Status, "should get a 200")
+		if assert.Contains(t, out, "test") {
+			assert.Equal(t, out["test"], "valueslash", "should give the same doc")
+		}
+	})
+
+	t.Run("WrongDoctype", func(t *testing.T) {
+		_ = couchdb.DeleteDB(testInstance, "io.cozy.nottype")
+
+		req, _ := http.NewRequest("GET", ts.URL+"/data/io.cozy.nottype/"+ID, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		out, res, err := doRequest(req, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "404 Not Found", res.Status, "should get a 404")
+		if assert.Contains(t, out, "error") {
+			assert.Equal(t, "not_found", out["error"], "should give a json name")
+		}
+		if assert.Contains(t, out, "reason") {
+			assert.Equal(t, "wrong_doctype", out["reason"], "should give a reason")
+		}
+	})
+
+	t.Run("UnderscoreName", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/data/"+Type+"/_foo", nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		_, res, err := doRequest(req, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "400 Bad Request", res.Status, "should get a 400")
+	})
+
+	t.Run("VFSDoctype", func(t *testing.T) {
+		in := jsonReader(&map[string]interface{}{
+			"wrong-vfs": "structure",
+		})
+		req, _ := http.NewRequest("POST", ts.URL+"/data/io.cozy.files/", in)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		out, res, err := doRequest(req, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "403 Forbidden", res.Status, "should get a 403")
+		if assert.Contains(t, out, "error") {
+			assert.Contains(t, out["error"], "reserved", "should give a clear reason")
+		}
+	})
+
+	t.Run("WrongID", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/data/"+Type+"/NOTID", nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		out, res, err := doRequest(req, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "404 Not Found", res.Status, "should get a 404")
+		if assert.Contains(t, out, "error") {
+			assert.Equal(t, "not_found", out["error"], "should give a json name")
+		}
+		if assert.Contains(t, out, "reason") {
+			assert.Equal(t, "missing", out["reason"], "should give a reason")
+		}
+	})
+
+	t.Run("SuccessCreateKnownDoctype", func(t *testing.T) {
+		in := jsonReader(&map[string]interface{}{
+			"somefield": "avalue",
+		})
+		var sur stackUpdateResponse
+		req, _ := http.NewRequest("POST", ts.URL+"/data/"+Type+"/", in)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		_, res, err := doRequest(req, &sur)
+		assert.NoError(t, err)
+		assert.Equal(t, "201 Created", res.Status, "should get a 201")
+		assert.Equal(t, sur.Ok, true, "ok is true")
+		assert.NotContains(t, sur.ID, "/", "id is simple uuid")
+		assert.Equal(t, sur.Type, Type, "type is correct")
+		assert.NotEmpty(t, sur.Rev, "rev at top level (couchdb compatibility)")
+		assert.Equal(t, sur.ID, sur.Data.ID(), "id is simple uuid")
+		assert.Equal(t, sur.Type, sur.Data.Type, "type is correct")
+		assert.Equal(t, sur.Rev, sur.Data.Rev(), "rev is correct")
+		assert.Equal(t, "avalue", sur.Data.Get("somefield"), "content is correct")
+	})
+
+	t.Run("SuccessCreateUnknownDoctype", func(t *testing.T) {
+		in := jsonReader(&map[string]interface{}{
+			"somefield": "avalue",
+		})
+		var sur stackUpdateResponse
+		type2 := "io.cozy.anothertype"
+		req, _ := http.NewRequest("POST", ts.URL+"/data/"+type2+"/", in)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		_, res, err := doRequest(req, &sur)
+		assert.NoError(t, err)
+		assert.Equal(t, "201 Created", res.Status, "should get a 201")
+		assert.Equal(t, sur.Ok, true, "ok is true")
+		assert.NotContains(t, sur.ID, "/", "id is simple uuid")
+		assert.Equal(t, sur.Type, type2, "type is correct")
+		assert.NotEmpty(t, sur.Rev, "rev at top level (couchdb compatibility)")
+		assert.Equal(t, sur.ID, sur.Data.ID(), "in doc id is correct")
+		assert.Equal(t, sur.Type, sur.Data.Type, "in doc type is correct")
+		assert.Equal(t, sur.Rev, sur.Data.Rev(), "in doc rev is correct")
+		assert.Equal(t, "avalue", sur.Data.Get("somefield"), "content is correct")
+	})
+
+	t.Run("WrongCreateWithID", func(t *testing.T) {
+		in := jsonReader(&map[string]interface{}{
+			"_id":       "this-should-not-be-an-id",
+			"somefield": "avalue",
+		})
+		req, _ := http.NewRequest("POST", ts.URL+"/data/"+Type+"/", in)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		_, res, err := doRequest(req, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "400 Bad Request", res.Status, "should get a 400")
+	})
+
+	t.Run("SuccessUpdate", func(t *testing.T) {
+		// Get revision
+		doc := getDocForTest()
+		url := ts.URL + "/data/" + doc.DocType() + "/" + doc.ID()
+
+		// update it
+		in := jsonReader(&map[string]interface{}{
+			"_id":       doc.ID(),
+			"_rev":      doc.Rev(),
+			"test":      doc.Get("test"),
+			"somefield": "anewvalue",
+		})
+		req, _ := http.NewRequest("PUT", url, in)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		var out stackUpdateResponse
+		_, res, err := doRequest(req, &out)
+		assert.NoError(t, err)
+		assert.Equal(t, "200 OK", res.Status, "should get a 201")
+		assert.Empty(t, out.Error, "there is no error")
+		assert.Equal(t, out.ID, doc.ID(), "id has not changed")
+		assert.Equal(t, out.Ok, true, "ok is true")
+		assert.NotEmpty(t, out.Rev, "there is a rev")
+		assert.NotEqual(t, out.Rev, doc.Rev(), "rev has changed")
+		assert.Equal(t, out.ID, out.Data.ID(), "in doc id is simple uuid")
+		assert.Equal(t, out.Type, out.Data.Type, "in doc type is correct")
+		assert.Equal(t, out.Rev, out.Data.Rev(), "in doc rev is correct")
+		assert.Equal(t, "anewvalue", out.Data.Get("somefield"), "content has changed")
+	})
+
+	t.Run("WrongIDInDocUpdate", func(t *testing.T) {
+		// Get revision
+		doc := getDocForTest()
+		// update it
+		in := jsonReader(&map[string]interface{}{
+			"_id":       "this is not the id in the URL",
+			"_rev":      doc.Rev(),
+			"test":      doc.M["test"],
+			"somefield": "anewvalue",
+		})
+		url := ts.URL + "/data/" + doc.DocType() + "/" + doc.ID()
+		req, _ := http.NewRequest("PUT", url, in)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		_, res, err := doRequest(req, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "400 Bad Request", res.Status, "should get a 404")
+	})
+
+	t.Run("CreateDocWithAFixedID", func(t *testing.T) {
+		// update it
+		in := jsonReader(&map[string]interface{}{
+			"test":      "value",
+			"somefield": "anewvalue",
+		})
+		url := ts.URL + "/data/" + Type + "/specific-id"
+		req, _ := http.NewRequest("PUT", url, in)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		var out stackUpdateResponse
+		_, res, err := doRequest(req, &out)
+		assert.NoError(t, err)
+		assert.Equal(t, "200 OK", res.Status, "should get a 201")
+		assert.Empty(t, out.Error, "there is no error")
+		assert.Equal(t, out.ID, "specific-id", "id has not changed")
+		assert.Equal(t, out.Ok, true, "ok is true")
+		assert.NotEmpty(t, out.Rev, "there is a rev")
+		assert.Equal(t, out.ID, out.Data.ID(), "in doc id is simple uuid")
+		assert.Equal(t, out.Type, out.Data.Type, "in doc type is correct")
+		assert.Equal(t, out.Rev, out.Data.Rev(), "in doc rev is correct")
+		assert.Equal(t, "anewvalue", out.Data.Get("somefield"), "content has changed")
+	})
+
+	t.Run("NoRevInDocUpdate", func(t *testing.T) {
+		// Get revision
+		doc := getDocForTest()
+		// update it
+		in := jsonReader(&map[string]interface{}{
+			"_id":       doc.ID(),
+			"test":      doc.M["test"],
+			"somefield": "anewvalue",
+		})
+		url := ts.URL + "/data/" + doc.DocType() + "/" + doc.ID()
+		req, _ := http.NewRequest("PUT", url, in)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		_, res, err := doRequest(req, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "400 Bad Request", res.Status, "should get a 400")
+	})
+
+	t.Run("PreviousRevInDocUpdate", func(t *testing.T) {
+		// Get revision
+		doc := getDocForTest()
+		firstRev := doc.Rev()
+		url := ts.URL + "/data/" + doc.DocType() + "/" + doc.ID()
+
+		// correcly update it
+		in := jsonReader(&map[string]interface{}{
+			"_id":       doc.ID(),
+			"_rev":      doc.Rev(),
+			"somefield": "anewvalue",
+		})
+		req, _ := http.NewRequest("PUT", url, in)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		_, res, err := doRequest(req, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "200 OK", res.Status, "first update should work")
+
+		// update it
+		in2 := jsonReader(&map[string]interface{}{
+			"_id":       doc.ID(),
+			"_rev":      firstRev,
+			"somefield": "anewvalue2",
+		})
+		req2, _ := http.NewRequest("PUT", url, in2)
+		req2.Header.Add("Authorization", "Bearer "+token)
+		req2.Header.Set("Content-Type", "application/json")
+		_, res2, err := doRequest(req2, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "409 Conflict", res2.Status, "should get a 409")
+	})
+
+	t.Run("SuccessDeleteIfMatch", func(t *testing.T) {
+		// Get revision
+		doc := getDocForTest()
+		rev := doc.Rev()
+
+		// Do deletion
+		url := ts.URL + "/data/" + doc.DocType() + "/" + doc.ID()
+		req, _ := http.NewRequest("DELETE", url, nil)
+		req.Header.Add("If-Match", rev)
+		req.Header.Add("Authorization", "Bearer "+token)
+		var out stackUpdateResponse
+		_, res, err := doRequest(req, &out)
+		assert.NoError(t, err)
+		assert.Equal(t, "200 OK", res.Status, "should get a 201")
+		assert.Equal(t, out.Ok, true, "ok at top level (couchdb compatibility)")
+		assert.Equal(t, out.ID, doc.ID(), "id at top level (couchdb compatibility)")
+		assert.Equal(t, out.Deleted, true, "id at top level (couchdb compatibility)")
+		assert.NotEqual(t, out.Rev, doc.Rev(), "id at top level (couchdb compatibility)")
+	})
+
+	t.Run("FailDeleteIfNotMatch", func(t *testing.T) {
+		// Get revision
+		doc := getDocForTest()
+
+		// Do deletion
+		url := ts.URL + "/data/" + doc.DocType() + "/" + doc.ID()
+		req, _ := http.NewRequest("DELETE", url, nil)
+		req.Header.Add("If-Match", "1-238238232322121") // not correct rev
+		req.Header.Add("Authorization", "Bearer "+token)
+		var out stackUpdateResponse
+		_, res, err := doRequest(req, &out)
+		assert.NoError(t, err)
+		assert.Equal(t, "409 Conflict", res.Status, "should get a 409")
+	})
+
+	t.Run("FailDeleteIfHeaderAndRevMismatch", func(t *testing.T) {
+		// Get revision
+		doc := getDocForTest()
+
+		// Do deletion
+		url := ts.URL + "/data/" + doc.DocType() + "/" + doc.ID() + "?rev=1-238238232322121"
+		req, _ := http.NewRequest("DELETE", url, nil)
+		req.Header.Add("If-Match", "1-23823823231") // not same rev
+		req.Header.Add("Authorization", "Bearer "+token)
+		var out stackUpdateResponse
+		_, res, err := doRequest(req, &out)
+		assert.NoError(t, err)
+		assert.Equal(t, "400 Bad Request", res.Status, "should get a 400")
+	})
+
+	t.Run("FailDeleteIfNoRev", func(t *testing.T) {
+		// Get revision
+		doc := getDocForTest()
+
+		// Do deletion
+		url := ts.URL + "/data/" + doc.DocType() + "/" + doc.ID()
+		req, _ := http.NewRequest("DELETE", url, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		var out stackUpdateResponse
+		_, res, err := doRequest(req, &out)
+		assert.NoError(t, err)
+		assert.Equal(t, "400 Bad Request", res.Status, "should get a 400")
+	})
+
+	t.Run("DefineIndex", func(t *testing.T) {
+		def := M{"index": M{"fields": S{"foo"}}}
+		url := ts.URL + "/data/" + Type + "/_index"
+		req, _ := http.NewRequest("POST", url, jsonReader(&def))
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		var out indexCreationResponse
+		_, res, err := doRequest(req, &out)
+		assert.NoError(t, err)
+		assert.Equal(t, "200 OK", res.Status, "first update should work")
+		assert.Empty(t, out.Error, "should have no error")
+		assert.Empty(t, out.Reason, "should have no error")
+		assert.Equal(t, "created", out.Result, "should have created result")
+		assert.NotEmpty(t, out.Name, "should have a name")
+		assert.NotEmpty(t, out.ID, "should have an design doc ID")
+	})
+
+	t.Run("ReDefineIndex", func(t *testing.T) {
+		def := M{"index": M{"fields": S{"foo"}}}
+		url := ts.URL + "/data/" + Type + "/_index"
+		req, _ := http.NewRequest("POST", url, jsonReader(&def))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		var out indexCreationResponse
+		_, res, err := doRequest(req, &out)
+		assert.NoError(t, err)
+		assert.Equal(t, "200 OK", res.Status)
+		assert.Empty(t, out.Error, "should have no error")
+		assert.Empty(t, out.Reason, "should have no error")
+		assert.Equal(t, "exists", out.Result, "should have exists result")
+		assert.NotEmpty(t, out.Name, "should have a name")
+		assert.NotEmpty(t, out.ID, "should have an design doc ID")
+	})
+
+	t.Run("DefineIndexUnexistingDoctype", func(t *testing.T) {
+		_ = couchdb.DeleteDB(testInstance, "io.cozy.nottype")
+
+		def := M{"index": M{"fields": S{"foo"}}}
+		url := ts.URL + "/data/io.cozy.nottype/_index"
+		req, _ := http.NewRequest("POST", url, jsonReader(&def))
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		var out indexCreationResponse
+		_, res, err := doRequest(req, &out)
+		assert.NoError(t, err)
+		assert.Equal(t, "200 OK", res.Status)
+		assert.Empty(t, out.Error, "should have no error")
+		assert.Empty(t, out.Reason, "should have no error")
+		assert.Equal(t, "created", out.Result, "should have created result")
+		assert.NotEmpty(t, out.Name, "should have a name")
+		assert.NotEmpty(t, out.ID, "should have an design doc ID")
+	})
+
+	t.Run("FindDocuments", func(t *testing.T) {
+		_ = couchdb.ResetDB(testInstance, Type)
+
+		_ = getDocForTest()
+		_ = getDocForTest()
+		_ = getDocForTest()
+
+		def := M{"index": M{"fields": S{"test"}}}
+		url := ts.URL + "/data/" + Type + "/_index"
+		req, _ := http.NewRequest("POST", url, jsonReader(&def))
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		var out indexCreationResponse
+		_, _, err := doRequest(req, &out)
+		assert.NoError(t, err)
+		assert.Empty(t, out.Error, "should have no error")
+
+		query := M{"selector": M{"test": "value"}}
+		url2 := ts.URL + "/data/" + Type + "/_find"
+		req, _ = http.NewRequest("POST", url2, jsonReader(&query))
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		var out2 struct {
+			Docs           []couchdb.JSONDoc       `json:"docs"`
+			ExecutionStats *couchdb.ExecutionStats `json:"execution_stats,omitempty"`
+		}
+		_, res, err := doRequest(req, &out2)
+		assert.Equal(t, "200 OK", res.Status, "should get a 200")
+		assert.NoError(t, err)
+		assert.Len(t, out2.Docs, 3, "should have found 3 docs")
+		assert.Nil(t, out2.ExecutionStats)
+	})
+
+	t.Run("FindDocumentsWithStats", func(t *testing.T) {
+		_ = couchdb.ResetDB(testInstance, Type)
+
+		_ = getDocForTest()
+
+		def := M{"index": M{"fields": S{"test"}}}
+		url := ts.URL + "/data/" + Type + "/_index"
+		req, _ := http.NewRequest("POST", url, jsonReader(&def))
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		var out indexCreationResponse
+		_, _, err := doRequest(req, &out)
+		assert.NoError(t, err)
+		assert.Empty(t, out.Error, "should have no error")
+
+		query := M{"selector": M{"test": "value"}, "execution_stats": true}
+		url2 := ts.URL + "/data/" + Type + "/_find"
+		req, _ = http.NewRequest("POST", url2, jsonReader(&query))
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		var out2 struct {
+			Docs           []couchdb.JSONDoc       `json:"docs"`
+			ExecutionStats *couchdb.ExecutionStats `json:"execution_stats,omitempty"`
+		}
+		_, res, err := doRequest(req, &out2)
+		assert.Equal(t, "200 OK", res.Status, "should get a 200")
+		assert.NoError(t, err)
+		assert.NotEmpty(t, out2.ExecutionStats)
+	})
+
+	t.Run("FindDocumentsPaginated", func(t *testing.T) {
+		_ = couchdb.ResetDB(testInstance, Type)
+
+		for i := 1; i <= 150; i++ {
+			_ = getDocForTest()
+		}
+
+		def := M{"index": M{"fields": S{"test"}}}
+		url := ts.URL + "/data/" + Type + "/_index"
+		req, _ := http.NewRequest("POST", url, jsonReader(&def))
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		var out indexCreationResponse
+		_, _, err := doRequest(req, &out)
+		assert.NoError(t, err)
+		assert.Empty(t, out.Error, "should have no error")
+
+		query := M{"selector": M{"test": "value"}}
+		url2 := ts.URL + "/data/" + Type + "/_find"
+		req, _ = http.NewRequest("POST", url2, jsonReader(&query))
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		var out2 struct {
+			Limit int
+			Next  bool
+			Docs  []couchdb.JSONDoc `json:"docs"`
+		}
+		_, res, err := doRequest(req, &out2)
+		assert.Equal(t, "200 OK", res.Status, "should get a 200")
+		assert.NoError(t, err)
+		assert.Len(t, out2.Docs, 100, "should stop at 100 docs")
+		assert.Equal(t, 100, out2.Limit)
+		assert.Equal(t, true, out2.Next)
+
+		query2 := M{"selector": M{"test": "value"}, "limit": 10}
+		req, _ = http.NewRequest("POST", url2, jsonReader(&query2))
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		var out3 struct {
+			Limit int
+			Next  bool
+			Docs  []couchdb.JSONDoc `json:"docs"`
+		}
+		_, res, err = doRequest(req, &out3)
+		assert.Equal(t, "200 OK", res.Status, "should get a 200")
+		assert.NoError(t, err)
+		// assert.Len(t, out3.Docs, 10, "should stop at 100 docs")
+		assert.Equal(t, 10, out3.Limit)
+		assert.Equal(t, true, out3.Next)
+	})
+
+	t.Run("FindDocumentsPaginatedBookmark", func(t *testing.T) {
+		_ = couchdb.ResetDB(testInstance, Type)
+
+		for i := 1; i <= 200; i++ {
+			_ = getDocForTest()
+		}
+
+		def := M{"index": M{"fields": S{"test"}}}
+		url := ts.URL + "/data/" + Type + "/_index"
+		req, _ := http.NewRequest("POST", url, jsonReader(&def))
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		var out indexCreationResponse
+		_, _, err := doRequest(req, &out)
+		assert.NoError(t, err)
+		assert.Empty(t, out.Error, "should have no error")
+
+		query := M{"selector": M{"test": "value"}}
+		url2 := ts.URL + "/data/" + Type + "/_find"
+		req, _ = http.NewRequest("POST", url2, jsonReader(&query))
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		var out2 struct {
+			Limit    int
+			Next     bool
+			Docs     []couchdb.JSONDoc `json:"docs"`
+			Bookmark string
+		}
+		_, res, err := doRequest(req, &out2)
+		assert.Equal(t, 200, res.StatusCode)
+		assert.NoError(t, err)
+		assert.Len(t, out2.Docs, 100, "should stop at 100 docs")
+		assert.Equal(t, 100, out2.Limit)
+		assert.Equal(t, true, out2.Next)
+		assert.NotEmpty(t, out2.Bookmark)
+
+		query2 := M{"selector": M{"test": "value"}, "bookmark": out2.Bookmark}
+		req, _ = http.NewRequest("POST", url2, jsonReader(&query2))
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+
+		_, res, err = doRequest(req, &out2)
+		assert.Equal(t, 200, res.StatusCode)
+		assert.NoError(t, err)
+		assert.Len(t, out2.Docs, 100)
+		assert.Equal(t, 100, out2.Limit)
+		assert.Equal(t, true, out2.Next)
+
+		query3 := M{"selector": M{"test": "value"}, "bookmark": out2.Bookmark}
+		req, _ = http.NewRequest("POST", url2, jsonReader(&query3))
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		_, res, err = doRequest(req, &out2)
+		assert.Equal(t, 200, res.StatusCode)
+		assert.NoError(t, err)
+		assert.Len(t, out2.Docs, 0)
+		assert.Equal(t, false, out2.Next)
+
+		var query4 = M{"selector": M{"test": "novalue"}}
+		req, _ = http.NewRequest("POST", url2, jsonReader(&query4))
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		_, res, err = doRequest(req, &out2)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		assert.Len(t, out2.Docs, 0)
+		assert.Equal(t, "", out2.Bookmark)
+	})
+
+	t.Run("FindDocumentsWithoutIndex", func(t *testing.T) {
+		query := M{"selector": M{"no-index-for-this-field": "value"}}
+		url2 := ts.URL + "/data/" + Type + "/_find"
+		req, _ := http.NewRequest("POST", url2, jsonReader(&query))
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		var out2 struct {
+			Error  string `json:"error"`
+			Reason string `json:"reason"`
+		}
+		_, res, err := doRequest(req, &out2)
+		assert.Equal(t, "400 Bad Request", res.Status, "should get a 200")
+		assert.NoError(t, err)
+		assert.Contains(t, out2.Error, "no_index")
+		assert.Contains(t, out2.Reason, "no matching index")
+	})
+
+	t.Run("GetChanges", func(t *testing.T) {
+		assert.NoError(t, couchdb.ResetDB(testInstance, Type))
+
+		url := ts.URL + "/data/" + Type + "/_changes?style=all_docs"
+		req, _ := http.NewRequest("GET", url, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		out, res, err := doRequest(req, nil)
+		assert.Equal(t, "200 OK", res.Status, "should get a 200")
+		assert.NoError(t, err)
+		seqno := out["last_seq"].(string)
+
+		// creates 3 docs
+		_ = getDocForTest()
+		_ = getDocForTest()
+		_ = getDocForTest()
+
+		url = ts.URL + "/data/" + Type + "/_changes?limit=2&since=" + seqno
+		req, _ = http.NewRequest("GET", url, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		out, res, err = doRequest(req, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		assert.Len(t, out["results"].([]interface{}), 2)
+
+		url = ts.URL + "/data/" + Type + "/_changes?since=" + seqno
+		req, _ = http.NewRequest("GET", url, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		out, res, err = doRequest(req, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		assert.Len(t, out["results"].([]interface{}), 3)
+	})
+
+	t.Run("PostChanges", func(t *testing.T) {
+		assert.NoError(t, couchdb.ResetDB(testInstance, Type))
+
+		// creates 3 docs
+		doc1 := getDocForTest()
+		_ = getDocForTest()
+		doc2 := getDocForTest()
+
+		payload := fmt.Sprintf(`{"doc_ids": ["%s", "%s"]}`, doc1.ID(), doc2.ID())
+
+		url := ts.URL + "/data/" + Type + "/_changes?include_docs=true&filter=_doc_ids"
+		req, _ := http.NewRequest("POST", url, bytes.NewReader([]byte(payload)))
+		req.Header.Add("Authorization", "Bearer "+token)
+		out, res, err := doRequest(req, nil)
+		assert.Equal(t, 200, res.StatusCode, "should get a 200")
+		assert.NoError(t, err)
+		assert.Len(t, out["results"].([]interface{}), 2)
+	})
+
+	t.Run("WrongFeedChanges", func(t *testing.T) {
+		url := ts.URL + "/data/" + Type + "/_changes?feed=continuous"
+		req, _ := http.NewRequest("POST", url, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		_, res, err := doRequest(req, nil)
+		assert.Equal(t, "400 Bad Request", res.Status, "should get a 400")
+		assert.NoError(t, err)
+	})
+
+	t.Run("WrongStyleChanges", func(t *testing.T) {
+		url := ts.URL + "/data/" + Type + "/_changes?style=not_a_valid_style"
+		req, _ := http.NewRequest("POST", url, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		_, res, err := doRequest(req, nil)
+		assert.Equal(t, "400 Bad Request", res.Status, "should get a 400")
+		assert.NoError(t, err)
+	})
+
+	t.Run("LimitIsNoNumber", func(t *testing.T) {
+		url := ts.URL + "/data/" + Type + "/_changes?limit=not_a_number"
+		req, _ := http.NewRequest("POST", url, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		_, res, err := doRequest(req, nil)
+		assert.Equal(t, "400 Bad Request", res.Status, "should get a 400")
+		assert.NoError(t, err)
+	})
+
+	t.Run("UnsupportedOption", func(t *testing.T) {
+		url := ts.URL + "/data/" + Type + "/_changes?inlude_docs=true"
+		req, _ := http.NewRequest("POST", url, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		_, res, err := doRequest(req, nil)
+		assert.Equal(t, "400 Bad Request", res.Status, "should get a 400")
+		assert.NoError(t, err)
+	})
+
+	t.Run("GetAllDocs", func(t *testing.T) {
+		url := ts.URL + "/data/" + Type + "/_all_docs?include_docs=true"
+		req, _ := http.NewRequest("GET", url, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		out, res, err := doRequest(req, nil)
+		assert.Equal(t, "200 OK", res.Status, "should get a 200")
+		assert.NoError(t, err)
+		totalRows := out["total_rows"].(float64)
+		assert.Equal(t, float64(3), totalRows)
+		offset := out["offset"].(float64)
+		assert.Equal(t, float64(0), offset)
+		rows := out["rows"].([]interface{})
+		assert.Len(t, rows, 3)
+		row := rows[0].(map[string]interface{})
+		id := row["id"].(string)
+		assert.NotEmpty(t, id)
+		doc, ok := row["doc"].(map[string]interface{})
+		assert.True(t, ok)
+		value := doc["test"].(string)
+		assert.Equal(t, "value", value)
+		foo := doc["foo"].(map[string]interface{})
+		bar := foo["bar"].(string)
+		assert.Equal(t, "one", bar)
+		baz := foo["baz"].(string)
+		assert.Equal(t, "two", baz)
+		qux := foo["qux"].(string)
+		assert.Equal(t, "quux", qux)
+	})
+
+	t.Run("GetAllDocsWithFields", func(t *testing.T) {
+		url := ts.URL + "/data/" + Type + "/_all_docs?include_docs=true&Fields=test,nosuchfield,foo.qux"
+		req, _ := http.NewRequest("GET", url, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		out, res, err := doRequest(req, nil)
+		assert.Equal(t, "200 OK", res.Status, "should get a 200")
+		require.NoError(t, err)
+		totalRows := out["total_rows"].(float64)
+		assert.Equal(t, float64(3), totalRows)
+		offset := out["offset"].(float64)
+		assert.Equal(t, float64(0), offset)
+		rows := out["rows"].([]interface{})
+		assert.Len(t, rows, 3)
+		row := rows[0].(map[string]interface{})
+		id := row["id"].(string)
+		assert.NotEmpty(t, id)
+		doc, ok := row["doc"].(map[string]interface{})
+		assert.True(t, ok)
+		value := doc["test"].(string)
+		assert.Equal(t, "value", value)
+		foo := doc["foo"].(map[string]interface{})
+		assert.NotContains(t, foo, "bar")
+		assert.NotContains(t, foo, "baz")
+		qux := foo["qux"].(string)
+		assert.Equal(t, "quux", qux)
+		assert.NotContains(t, doc, "courge")
+	})
+
+	t.Run("NormalDocs", func(t *testing.T) {
+		view := &couchdb.View{
+			Name:    "foobar",
+			Doctype: Type,
+			Map: `
+  function(doc) {
+    emit(doc.foobar, doc);
+  }`,
+		}
+		g, _ := errgroup.WithContext(context.Background())
+		couchdb.DefineViews(g, testInstance, []*couchdb.View{view})
+		assert.NoError(t, g.Wait())
+
+		err := couchdb.CreateNamedDoc(testInstance, &couchdb.JSONDoc{
+			Type: Type,
+			M: map[string]interface{}{
+				"_id":  "four",
+				"test": "fourthvalue",
+			},
+		})
+		assert.NoError(t, err)
+
+		url := ts.URL + "/data/" + Type + "/_normal_docs?limit=2"
+		req, _ := http.NewRequest("GET", url, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		out, res, err := doRequest(req, nil)
+		assert.Equal(t, "200 OK", res.Status, "should get a 200")
+		assert.NoError(t, err)
+		totalRows := out["total_rows"].(float64)
+		assert.Equal(t, float64(4), totalRows)
+		rows := out["rows"].([]interface{})
+		assert.Len(t, rows, 2)
+		row := rows[0].(map[string]interface{})
+		id := row["_id"].(string)
+		assert.NotEmpty(t, id)
+		value := row["test"].(string)
+		assert.Equal(t, "value", value)
+		bookmark := out["bookmark"].(string)
+		assert.NotEmpty(t, bookmark)
+		executionStats := out["execution_stats"]
+		assert.Nil(t, executionStats)
+
+		// skip pagination
+		url = ts.URL + "/data/" + Type + "/_normal_docs?limit=2&skip=2"
+		req, _ = http.NewRequest("GET", url, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		out, res, err = doRequest(req, nil)
+		assert.Equal(t, "200 OK", res.Status, "should get a 200")
+		assert.NoError(t, err)
+		totalRows = out["total_rows"].(float64)
+		assert.Equal(t, float64(4), totalRows)
+		rows = out["rows"].([]interface{})
+		assert.Len(t, rows, 2)
+		row = rows[1].(map[string]interface{})
+		id = row["_id"].(string)
+		assert.NotEmpty(t, id)
+		value = row["test"].(string)
+		assert.Equal(t, "fourthvalue", value)
+
+		// bookmark pagination
+		url = ts.URL + "/data/" + Type + "/_normal_docs?bookmark=" + bookmark
+		req, _ = http.NewRequest("GET", url, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		out, res, err = doRequest(req, nil)
+		assert.Equal(t, "200 OK", res.Status, "should get a 200")
+		assert.NoError(t, err)
+		totalRows = out["total_rows"].(float64)
+		assert.Equal(t, float64(4), totalRows)
+		rows = out["rows"].([]interface{})
+		assert.Len(t, rows, 2)
+		row = rows[1].(map[string]interface{})
+		id = row["_id"].(string)
+		assert.NotEmpty(t, id)
+		value = row["test"].(string)
+		assert.Equal(t, "fourthvalue", value)
+
+		emptyType := "io.cozy.anothertype"
+		_ = couchdb.ResetDB(testInstance, emptyType)
+		url = ts.URL + "/data/" + emptyType + "/_normal_docs"
+		req, _ = http.NewRequest("GET", url, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		out, res, err = doRequest(req, nil)
+		assert.Equal(t, "200 OK", res.Status, "should get a 200")
+		assert.NoError(t, err)
+		totalRows = out["total_rows"].(float64)
+		assert.Equal(t, float64(0), totalRows)
+		bookmark = out["bookmark"].(string)
+		assert.Equal(t, "", bookmark)
+
+		// execution stats
+		url = ts.URL + "/data/" + emptyType + "/_normal_docs?execution_stats=true"
+		req, _ = http.NewRequest("GET", url, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		out, res, err = doRequest(req, nil)
+		assert.Equal(t, "200 OK", res.Status, "should get a 200")
+		assert.NoError(t, err)
+		assert.NotEmpty(t, out["execution_stats"])
+	})
+
+	t.Run("GetDesignDocs", func(t *testing.T) {
+		def := M{"index": M{"fields": S{"foo"}}}
+		_, err := couchdb.DefineIndexRaw(testInstance, Type, &def)
+		assert.NoError(t, err)
+
+		url := ts.URL + "/data/" + Type + "/_design_docs"
+		req, _ := http.NewRequest("GET", url, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		out, res, err := doRequest(req, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "200 OK", res.Status)
+		rows := out["rows"].([]interface{})
+		nDesignDocs := len(rows)
+		assert.Greater(t, nDesignDocs, 0)
+		firstRow := rows[0].(map[string]interface{})
+		id := firstRow["id"].(string)
+		rev := firstRow["value"].(map[string]interface{})["rev"].(string)
+		assert.NotEmpty(t, id)
+		assert.NotEmpty(t, rev)
+	})
+
+	t.Run("GetDesignDoc", func(t *testing.T) {
+		ddoc := "myindex"
+		def := M{"index": M{"fields": S{"foo"}}, "ddoc": ddoc}
+		_, err := couchdb.DefineIndexRaw(testInstance, Type, &def)
+		assert.NoError(t, err)
+
+		url := ts.URL + "/data/" + Type + "/_design/" + ddoc
+		req, _ := http.NewRequest("GET", url, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		out, res, err := doRequest(req, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "200 OK", res.Status)
+
+		id := out["_id"].(string)
+		rev := out["_rev"].(string)
+
+		assert.Equal(t, "_design/"+ddoc, id)
+		assert.NotEmpty(t, rev)
+	})
+
+	t.Run("DeleteDesignDoc", func(t *testing.T) {
+		def := M{"index": M{"fields": S{"foo"}}}
+		_, err := couchdb.DefineIndexRaw(testInstance, Type, &def)
+		assert.NoError(t, err)
+
+		url := ts.URL + "/data/" + Type + "/_design_docs"
+		req, _ := http.NewRequest("GET", url, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		out, res, err := doRequest(req, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "200 OK", res.Status)
+		rows := out["rows"].([]interface{})
+		nDesignDocs := len(rows)
+		assert.Greater(t, nDesignDocs, 0)
+		firstRow := rows[0].(map[string]interface{})
+		id := firstRow["id"].(string)
+		ddoc := strings.Split(id, "/")[1]
+		rev := firstRow["value"].(map[string]interface{})["rev"].(string)
+
+		url = ts.URL + "/data/" + Type + "/_design/" + ddoc + "?rev=" + rev
+		req, _ = http.NewRequest("DELETE", url, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		_, res, err = doRequest(req, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "200 OK", res.Status)
+
+		url = ts.URL + "/data/" + Type + "/_design_docs"
+		req, _ = http.NewRequest("GET", url, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		out, res, err = doRequest(req, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "200 OK", res.Status)
+
+		rows = out["rows"].([]interface{})
+		assert.Less(t, len(rows), nDesignDocs)
+	})
+
+	t.Run("CannotDeleteStackDesignDoc", func(t *testing.T) {
+		url := ts.URL + "/data/io.cozy.files/_design_docs"
+		req, _ := http.NewRequest("GET", url, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		out, res, err := doRequest(req, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		rows := out["rows"].([]interface{})
+		var indexRev, viewRev string
+		for _, row := range rows {
+			info := row.(map[string]interface{})
+			if info["id"] == "_design/dir-by-path" {
+				value := info["value"].(map[string]interface{})
+				indexRev = value["rev"].(string)
+			}
+			if info["id"] == "_design/by-parent-type-name" {
+				value := info["value"].(map[string]interface{})
+				viewRev = value["rev"].(string)
+			}
+		}
+
+		url = ts.URL + "/data/io.cozy.files/_design/dir-by-path?rev=" + indexRev
+		req, _ = http.NewRequest("DELETE", url, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		_, res, err = doRequest(req, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, 403, res.StatusCode)
+
+		url = ts.URL + "/data/io.cozy.files/_design/by-parent-type-name?rev=" + viewRev
+		req, _ = http.NewRequest("DELETE", url, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		_, res, err = doRequest(req, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, 403, res.StatusCode)
+	})
+
+	t.Run("CopyDesignDoc", func(t *testing.T) {
+		srcDdoc := "indextocopy"
+		targetID := "_design/indexcopied"
+		def := M{"index": M{"fields": S{"foo"}}, "ddoc": srcDdoc}
+		_, err := couchdb.DefineIndexRaw(testInstance, Type, &def)
+		assert.NoError(t, err)
+
+		url := ts.URL + "/data/" + Type + "/_design/" + srcDdoc
+		req, _ := http.NewRequest("GET", url, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		out, res, err := doRequest(req, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "200 OK", res.Status)
+
+		rev := out["_rev"].(string)
+
+		url = ts.URL + "/data/" + Type + "/_design/" + srcDdoc + "/copy?rev=" + rev
+		req, _ = http.NewRequest("POST", url, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Destination", targetID)
+		out, res, err = doRequest(req, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "201 Created", res.Status)
+
+		assert.Equal(t, targetID, out["id"].(string))
+		assert.Equal(t, rev, out["rev"].(string))
+	})
+
+	t.Run("DeleteDatabase", func(t *testing.T) {
+		url := ts.URL + "/data/" + Type + "/"
+		req, _ := http.NewRequest("DELETE", url, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		out, res, err := doRequest(req, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "200 OK", res.Status)
+		assert.Equal(t, true, out["deleted"].(bool))
+	})
+
+	t.Run("DeleteDatabaseNoPermission", func(t *testing.T) {
+		doctype := "io.cozy.forbidden"
+		url := ts.URL + "/data/" + doctype + "/"
+		req, _ := http.NewRequest("DELETE", url, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		_, res, err := doRequest(req, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "403 Forbidden", res.Status)
+	})
+
+}
+
 func jsonReader(data interface{}) io.Reader {
 	bs, _ := json.Marshal(&data)
 	return bytes.NewReader(bs)
@@ -83,1053 +1139,4 @@ func getDocForTest() *couchdb.JSONDoc {
 	}
 	_ = couchdb.CreateDoc(testInstance, &doc)
 	return &doc
-}
-
-func TestMain(m *testing.M) {
-	config.UseTestFile()
-	testutils.NeedCouchdb()
-	setup := testutils.NewSetup(m, "data_test")
-	testInstance = setup.GetTestInstance()
-	scope := "io.cozy.doctypes io.cozy.files io.cozy.events " +
-		"io.cozy.anothertype io.cozy.nottype"
-
-	_, token = setup.GetTestClient(scope)
-	ts = setup.GetTestServer("/data", Routes)
-
-	_ = couchdb.ResetDB(testInstance, Type)
-	_ = couchdb.CreateNamedDoc(testInstance, &couchdb.JSONDoc{
-		Type: Type,
-		M: map[string]interface{}{
-			"_id":  ID,
-			"test": "testvalue",
-		},
-	})
-
-	os.Exit(setup.Run())
-}
-
-func TestSuccessGet(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/data/"+Type+"/"+ID, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	out, res, err := doRequest(req, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, "200 OK", res.Status, "should get a 200")
-	if assert.Contains(t, out, "test") {
-		assert.Equal(t, out["test"], "testvalue", "should give the same doc")
-	}
-}
-
-func TestGetForMissingDoc(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/data/no.such.doctype/id", nil)
-	_, res, err := doRequest(req, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, 401, res.StatusCode)
-
-	req, _ = http.NewRequest("GET", ts.URL+"/data/"+Type+"/no.such.id", nil)
-	_, res, err = doRequest(req, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, 401, res.StatusCode)
-
-	req, _ = http.NewRequest("GET", ts.URL+"/data/"+Type+"/no-such-id", nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	_, res, err = doRequest(req, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, 404, res.StatusCode)
-}
-
-func TestGetWithSlash(t *testing.T) {
-	_ = couchdb.CreateNamedDoc(testInstance, &couchdb.JSONDoc{
-		Type: Type, M: map[string]interface{}{
-			"_id":  "with/slash",
-			"test": "valueslash",
-		}})
-
-	req, _ := http.NewRequest("GET", ts.URL+"/data/"+Type+"/with%2Fslash", nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	out, res, err := doRequest(req, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, "200 OK", res.Status, "should get a 200")
-	if assert.Contains(t, out, "test") {
-		assert.Equal(t, out["test"], "valueslash", "should give the same doc")
-	}
-}
-
-func TestWrongDoctype(t *testing.T) {
-	_ = couchdb.DeleteDB(testInstance, "io.cozy.nottype")
-
-	req, _ := http.NewRequest("GET", ts.URL+"/data/io.cozy.nottype/"+ID, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	out, res, err := doRequest(req, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, "404 Not Found", res.Status, "should get a 404")
-	if assert.Contains(t, out, "error") {
-		assert.Equal(t, "not_found", out["error"], "should give a json name")
-	}
-	if assert.Contains(t, out, "reason") {
-		assert.Equal(t, "wrong_doctype", out["reason"], "should give a reason")
-	}
-}
-
-func TestUnderscoreName(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/data/"+Type+"/_foo", nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	_, res, err := doRequest(req, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, "400 Bad Request", res.Status, "should get a 400")
-}
-
-func TestVFSDoctype(t *testing.T) {
-	in := jsonReader(&map[string]interface{}{
-		"wrong-vfs": "structure",
-	})
-	req, _ := http.NewRequest("POST", ts.URL+"/data/io.cozy.files/", in)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	out, res, err := doRequest(req, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, "403 Forbidden", res.Status, "should get a 403")
-	if assert.Contains(t, out, "error") {
-		assert.Contains(t, out["error"], "reserved", "should give a clear reason")
-	}
-}
-
-func TestWrongID(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/data/"+Type+"/NOTID", nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	out, res, err := doRequest(req, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, "404 Not Found", res.Status, "should get a 404")
-	if assert.Contains(t, out, "error") {
-		assert.Equal(t, "not_found", out["error"], "should give a json name")
-	}
-	if assert.Contains(t, out, "reason") {
-		assert.Equal(t, "missing", out["reason"], "should give a reason")
-	}
-}
-
-func TestSuccessCreateKnownDoctype(t *testing.T) {
-	in := jsonReader(&map[string]interface{}{
-		"somefield": "avalue",
-	})
-	var sur stackUpdateResponse
-	req, _ := http.NewRequest("POST", ts.URL+"/data/"+Type+"/", in)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	_, res, err := doRequest(req, &sur)
-	assert.NoError(t, err)
-	assert.Equal(t, "201 Created", res.Status, "should get a 201")
-	assert.Equal(t, sur.Ok, true, "ok is true")
-	assert.NotContains(t, sur.ID, "/", "id is simple uuid")
-	assert.Equal(t, sur.Type, Type, "type is correct")
-	assert.NotEmpty(t, sur.Rev, "rev at top level (couchdb compatibility)")
-	assert.Equal(t, sur.ID, sur.Data.ID(), "id is simple uuid")
-	assert.Equal(t, sur.Type, sur.Data.Type, "type is correct")
-	assert.Equal(t, sur.Rev, sur.Data.Rev(), "rev is correct")
-	assert.Equal(t, "avalue", sur.Data.Get("somefield"), "content is correct")
-}
-
-func TestSuccessCreateUnknownDoctype(t *testing.T) {
-	in := jsonReader(&map[string]interface{}{
-		"somefield": "avalue",
-	})
-	var sur stackUpdateResponse
-	type2 := "io.cozy.anothertype"
-	req, _ := http.NewRequest("POST", ts.URL+"/data/"+type2+"/", in)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	_, res, err := doRequest(req, &sur)
-	assert.NoError(t, err)
-	assert.Equal(t, "201 Created", res.Status, "should get a 201")
-	assert.Equal(t, sur.Ok, true, "ok is true")
-	assert.NotContains(t, sur.ID, "/", "id is simple uuid")
-	assert.Equal(t, sur.Type, type2, "type is correct")
-	assert.NotEmpty(t, sur.Rev, "rev at top level (couchdb compatibility)")
-	assert.Equal(t, sur.ID, sur.Data.ID(), "in doc id is correct")
-	assert.Equal(t, sur.Type, sur.Data.Type, "in doc type is correct")
-	assert.Equal(t, sur.Rev, sur.Data.Rev(), "in doc rev is correct")
-	assert.Equal(t, "avalue", sur.Data.Get("somefield"), "content is correct")
-}
-
-func TestWrongCreateWithID(t *testing.T) {
-	in := jsonReader(&map[string]interface{}{
-		"_id":       "this-should-not-be-an-id",
-		"somefield": "avalue",
-	})
-	req, _ := http.NewRequest("POST", ts.URL+"/data/"+Type+"/", in)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	_, res, err := doRequest(req, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, "400 Bad Request", res.Status, "should get a 400")
-}
-
-func TestSuccessUpdate(t *testing.T) {
-	// Get revision
-	doc := getDocForTest()
-	url := ts.URL + "/data/" + doc.DocType() + "/" + doc.ID()
-
-	// update it
-	in := jsonReader(&map[string]interface{}{
-		"_id":       doc.ID(),
-		"_rev":      doc.Rev(),
-		"test":      doc.Get("test"),
-		"somefield": "anewvalue",
-	})
-	req, _ := http.NewRequest("PUT", url, in)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	var out stackUpdateResponse
-	_, res, err := doRequest(req, &out)
-	assert.NoError(t, err)
-	assert.Equal(t, "200 OK", res.Status, "should get a 201")
-	assert.Empty(t, out.Error, "there is no error")
-	assert.Equal(t, out.ID, doc.ID(), "id has not changed")
-	assert.Equal(t, out.Ok, true, "ok is true")
-	assert.NotEmpty(t, out.Rev, "there is a rev")
-	assert.NotEqual(t, out.Rev, doc.Rev(), "rev has changed")
-	assert.Equal(t, out.ID, out.Data.ID(), "in doc id is simple uuid")
-	assert.Equal(t, out.Type, out.Data.Type, "in doc type is correct")
-	assert.Equal(t, out.Rev, out.Data.Rev(), "in doc rev is correct")
-	assert.Equal(t, "anewvalue", out.Data.Get("somefield"), "content has changed")
-}
-
-// Test for having not the same ID in document and URL
-func TestWrongIDInDocUpdate(t *testing.T) {
-	// Get revision
-	doc := getDocForTest()
-	// update it
-	in := jsonReader(&map[string]interface{}{
-		"_id":       "this is not the id in the URL",
-		"_rev":      doc.Rev(),
-		"test":      doc.M["test"],
-		"somefield": "anewvalue",
-	})
-	url := ts.URL + "/data/" + doc.DocType() + "/" + doc.ID()
-	req, _ := http.NewRequest("PUT", url, in)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	_, res, err := doRequest(req, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, "400 Bad Request", res.Status, "should get a 404")
-}
-
-// Test for having an inexisting id at all
-func TestCreateDocWithAFixedID(t *testing.T) {
-	// update it
-	in := jsonReader(&map[string]interface{}{
-		"test":      "value",
-		"somefield": "anewvalue",
-	})
-	url := ts.URL + "/data/" + Type + "/specific-id"
-	req, _ := http.NewRequest("PUT", url, in)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	var out stackUpdateResponse
-	_, res, err := doRequest(req, &out)
-	assert.NoError(t, err)
-	assert.Equal(t, "200 OK", res.Status, "should get a 201")
-	assert.Empty(t, out.Error, "there is no error")
-	assert.Equal(t, out.ID, "specific-id", "id has not changed")
-	assert.Equal(t, out.Ok, true, "ok is true")
-	assert.NotEmpty(t, out.Rev, "there is a rev")
-	assert.Equal(t, out.ID, out.Data.ID(), "in doc id is simple uuid")
-	assert.Equal(t, out.Type, out.Data.Type, "in doc type is correct")
-	assert.Equal(t, out.Rev, out.Data.Rev(), "in doc rev is correct")
-	assert.Equal(t, "anewvalue", out.Data.Get("somefield"), "content has changed")
-}
-
-func TestNoRevInDocUpdate(t *testing.T) {
-	// Get revision
-	doc := getDocForTest()
-	// update it
-	in := jsonReader(&map[string]interface{}{
-		"_id":       doc.ID(),
-		"test":      doc.M["test"],
-		"somefield": "anewvalue",
-	})
-	url := ts.URL + "/data/" + doc.DocType() + "/" + doc.ID()
-	req, _ := http.NewRequest("PUT", url, in)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	_, res, err := doRequest(req, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, "400 Bad Request", res.Status, "should get a 400")
-}
-
-func TestPreviousRevInDocUpdate(t *testing.T) {
-	// Get revision
-	doc := getDocForTest()
-	firstRev := doc.Rev()
-	url := ts.URL + "/data/" + doc.DocType() + "/" + doc.ID()
-
-	// correcly update it
-	in := jsonReader(&map[string]interface{}{
-		"_id":       doc.ID(),
-		"_rev":      doc.Rev(),
-		"somefield": "anewvalue",
-	})
-	req, _ := http.NewRequest("PUT", url, in)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	_, res, err := doRequest(req, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, "200 OK", res.Status, "first update should work")
-
-	// update it
-	in2 := jsonReader(&map[string]interface{}{
-		"_id":       doc.ID(),
-		"_rev":      firstRev,
-		"somefield": "anewvalue2",
-	})
-	req2, _ := http.NewRequest("PUT", url, in2)
-	req2.Header.Add("Authorization", "Bearer "+token)
-	req2.Header.Set("Content-Type", "application/json")
-	_, res2, err := doRequest(req2, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, "409 Conflict", res2.Status, "should get a 409")
-}
-
-func TestSuccessDeleteIfMatch(t *testing.T) {
-	// Get revision
-	doc := getDocForTest()
-	rev := doc.Rev()
-
-	// Do deletion
-	url := ts.URL + "/data/" + doc.DocType() + "/" + doc.ID()
-	req, _ := http.NewRequest("DELETE", url, nil)
-	req.Header.Add("If-Match", rev)
-	req.Header.Add("Authorization", "Bearer "+token)
-	var out stackUpdateResponse
-	_, res, err := doRequest(req, &out)
-	assert.NoError(t, err)
-	assert.Equal(t, "200 OK", res.Status, "should get a 201")
-	assert.Equal(t, out.Ok, true, "ok at top level (couchdb compatibility)")
-	assert.Equal(t, out.ID, doc.ID(), "id at top level (couchdb compatibility)")
-	assert.Equal(t, out.Deleted, true, "id at top level (couchdb compatibility)")
-	assert.NotEqual(t, out.Rev, doc.Rev(), "id at top level (couchdb compatibility)")
-}
-
-func TestFailDeleteIfNotMatch(t *testing.T) {
-	// Get revision
-	doc := getDocForTest()
-
-	// Do deletion
-	url := ts.URL + "/data/" + doc.DocType() + "/" + doc.ID()
-	req, _ := http.NewRequest("DELETE", url, nil)
-	req.Header.Add("If-Match", "1-238238232322121") // not correct rev
-	req.Header.Add("Authorization", "Bearer "+token)
-	var out stackUpdateResponse
-	_, res, err := doRequest(req, &out)
-	assert.NoError(t, err)
-	assert.Equal(t, "409 Conflict", res.Status, "should get a 409")
-}
-
-func TestFailDeleteIfHeaderAndRevMismatch(t *testing.T) {
-	// Get revision
-	doc := getDocForTest()
-
-	// Do deletion
-	url := ts.URL + "/data/" + doc.DocType() + "/" + doc.ID() + "?rev=1-238238232322121"
-	req, _ := http.NewRequest("DELETE", url, nil)
-	req.Header.Add("If-Match", "1-23823823231") // not same rev
-	req.Header.Add("Authorization", "Bearer "+token)
-	var out stackUpdateResponse
-	_, res, err := doRequest(req, &out)
-	assert.NoError(t, err)
-	assert.Equal(t, "400 Bad Request", res.Status, "should get a 400")
-}
-
-func TestFailDeleteIfNoRev(t *testing.T) {
-	// Get revision
-	doc := getDocForTest()
-
-	// Do deletion
-	url := ts.URL + "/data/" + doc.DocType() + "/" + doc.ID()
-	req, _ := http.NewRequest("DELETE", url, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	var out stackUpdateResponse
-	_, res, err := doRequest(req, &out)
-	assert.NoError(t, err)
-	assert.Equal(t, "400 Bad Request", res.Status, "should get a 400")
-}
-
-type M map[string]interface{}
-type S []interface{}
-type indexCreationResponse struct {
-	Result string `json:"result"`
-	Error  string `json:"error"`
-	Reason string `json:"reason"`
-	ID     string `json:"id"`
-	Name   string `json:"name"`
-}
-
-func TestDefineIndex(t *testing.T) {
-	def := M{"index": M{"fields": S{"foo"}}}
-	url := ts.URL + "/data/" + Type + "/_index"
-	req, _ := http.NewRequest("POST", url, jsonReader(&def))
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	var out indexCreationResponse
-	_, res, err := doRequest(req, &out)
-	assert.NoError(t, err)
-	assert.Equal(t, "200 OK", res.Status, "first update should work")
-	assert.Empty(t, out.Error, "should have no error")
-	assert.Empty(t, out.Reason, "should have no error")
-	assert.Equal(t, "created", out.Result, "should have created result")
-	assert.NotEmpty(t, out.Name, "should have a name")
-	assert.NotEmpty(t, out.ID, "should have an design doc ID")
-}
-
-func TestReDefineIndex(t *testing.T) {
-	def := M{"index": M{"fields": S{"foo"}}}
-	url := ts.URL + "/data/" + Type + "/_index"
-	req, _ := http.NewRequest("POST", url, jsonReader(&def))
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	var out indexCreationResponse
-	_, res, err := doRequest(req, &out)
-	assert.NoError(t, err)
-	assert.Equal(t, "200 OK", res.Status)
-	assert.Empty(t, out.Error, "should have no error")
-	assert.Empty(t, out.Reason, "should have no error")
-	assert.Equal(t, "exists", out.Result, "should have exists result")
-	assert.NotEmpty(t, out.Name, "should have a name")
-	assert.NotEmpty(t, out.ID, "should have an design doc ID")
-}
-
-func TestDefineIndexUnexistingDoctype(t *testing.T) {
-	_ = couchdb.DeleteDB(testInstance, "io.cozy.nottype")
-
-	def := M{"index": M{"fields": S{"foo"}}}
-	url := ts.URL + "/data/io.cozy.nottype/_index"
-	req, _ := http.NewRequest("POST", url, jsonReader(&def))
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	var out indexCreationResponse
-	_, res, err := doRequest(req, &out)
-	assert.NoError(t, err)
-	assert.Equal(t, "200 OK", res.Status)
-	assert.Empty(t, out.Error, "should have no error")
-	assert.Empty(t, out.Reason, "should have no error")
-	assert.Equal(t, "created", out.Result, "should have created result")
-	assert.NotEmpty(t, out.Name, "should have a name")
-	assert.NotEmpty(t, out.ID, "should have an design doc ID")
-}
-
-func TestFindDocuments(t *testing.T) {
-	_ = couchdb.ResetDB(testInstance, Type)
-
-	_ = getDocForTest()
-	_ = getDocForTest()
-	_ = getDocForTest()
-
-	def := M{"index": M{"fields": S{"test"}}}
-	url := ts.URL + "/data/" + Type + "/_index"
-	req, _ := http.NewRequest("POST", url, jsonReader(&def))
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	var out indexCreationResponse
-	_, _, err := doRequest(req, &out)
-	assert.NoError(t, err)
-	assert.Empty(t, out.Error, "should have no error")
-
-	query := M{"selector": M{"test": "value"}}
-	url2 := ts.URL + "/data/" + Type + "/_find"
-	req, _ = http.NewRequest("POST", url2, jsonReader(&query))
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	var out2 struct {
-		Docs           []couchdb.JSONDoc       `json:"docs"`
-		ExecutionStats *couchdb.ExecutionStats `json:"execution_stats,omitempty"`
-	}
-	_, res, err := doRequest(req, &out2)
-	assert.Equal(t, "200 OK", res.Status, "should get a 200")
-	assert.NoError(t, err)
-	assert.Len(t, out2.Docs, 3, "should have found 3 docs")
-	assert.Nil(t, out2.ExecutionStats)
-}
-
-func TestFindDocumentsWithStats(t *testing.T) {
-	_ = couchdb.ResetDB(testInstance, Type)
-
-	_ = getDocForTest()
-
-	def := M{"index": M{"fields": S{"test"}}}
-	url := ts.URL + "/data/" + Type + "/_index"
-	req, _ := http.NewRequest("POST", url, jsonReader(&def))
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	var out indexCreationResponse
-	_, _, err := doRequest(req, &out)
-	assert.NoError(t, err)
-	assert.Empty(t, out.Error, "should have no error")
-
-	query := M{"selector": M{"test": "value"}, "execution_stats": true}
-	url2 := ts.URL + "/data/" + Type + "/_find"
-	req, _ = http.NewRequest("POST", url2, jsonReader(&query))
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	var out2 struct {
-		Docs           []couchdb.JSONDoc       `json:"docs"`
-		ExecutionStats *couchdb.ExecutionStats `json:"execution_stats,omitempty"`
-	}
-	_, res, err := doRequest(req, &out2)
-	assert.Equal(t, "200 OK", res.Status, "should get a 200")
-	assert.NoError(t, err)
-	assert.NotEmpty(t, out2.ExecutionStats)
-}
-
-func TestFindDocumentsPaginated(t *testing.T) {
-	_ = couchdb.ResetDB(testInstance, Type)
-
-	for i := 1; i <= 150; i++ {
-		_ = getDocForTest()
-	}
-
-	def := M{"index": M{"fields": S{"test"}}}
-	url := ts.URL + "/data/" + Type + "/_index"
-	req, _ := http.NewRequest("POST", url, jsonReader(&def))
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	var out indexCreationResponse
-	_, _, err := doRequest(req, &out)
-	assert.NoError(t, err)
-	assert.Empty(t, out.Error, "should have no error")
-
-	query := M{"selector": M{"test": "value"}}
-	url2 := ts.URL + "/data/" + Type + "/_find"
-	req, _ = http.NewRequest("POST", url2, jsonReader(&query))
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	var out2 struct {
-		Limit int
-		Next  bool
-		Docs  []couchdb.JSONDoc `json:"docs"`
-	}
-	_, res, err := doRequest(req, &out2)
-	assert.Equal(t, "200 OK", res.Status, "should get a 200")
-	assert.NoError(t, err)
-	assert.Len(t, out2.Docs, 100, "should stop at 100 docs")
-	assert.Equal(t, 100, out2.Limit)
-	assert.Equal(t, true, out2.Next)
-
-	query2 := M{"selector": M{"test": "value"}, "limit": 10}
-	req, _ = http.NewRequest("POST", url2, jsonReader(&query2))
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	var out3 struct {
-		Limit int
-		Next  bool
-		Docs  []couchdb.JSONDoc `json:"docs"`
-	}
-	_, res, err = doRequest(req, &out3)
-	assert.Equal(t, "200 OK", res.Status, "should get a 200")
-	assert.NoError(t, err)
-	// assert.Len(t, out3.Docs, 10, "should stop at 100 docs")
-	assert.Equal(t, 10, out3.Limit)
-	assert.Equal(t, true, out3.Next)
-}
-
-func TestFindDocumentsPaginatedBookmark(t *testing.T) {
-	_ = couchdb.ResetDB(testInstance, Type)
-
-	for i := 1; i <= 200; i++ {
-		_ = getDocForTest()
-	}
-
-	def := M{"index": M{"fields": S{"test"}}}
-	url := ts.URL + "/data/" + Type + "/_index"
-	req, _ := http.NewRequest("POST", url, jsonReader(&def))
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	var out indexCreationResponse
-	_, _, err := doRequest(req, &out)
-	assert.NoError(t, err)
-	assert.Empty(t, out.Error, "should have no error")
-
-	query := M{"selector": M{"test": "value"}}
-	url2 := ts.URL + "/data/" + Type + "/_find"
-	req, _ = http.NewRequest("POST", url2, jsonReader(&query))
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	var out2 struct {
-		Limit    int
-		Next     bool
-		Docs     []couchdb.JSONDoc `json:"docs"`
-		Bookmark string
-	}
-	_, res, err := doRequest(req, &out2)
-	assert.Equal(t, 200, res.StatusCode)
-	assert.NoError(t, err)
-	assert.Len(t, out2.Docs, 100, "should stop at 100 docs")
-	assert.Equal(t, 100, out2.Limit)
-	assert.Equal(t, true, out2.Next)
-	assert.NotEmpty(t, out2.Bookmark)
-
-	query2 := M{"selector": M{"test": "value"}, "bookmark": out2.Bookmark}
-	req, _ = http.NewRequest("POST", url2, jsonReader(&query2))
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-
-	_, res, err = doRequest(req, &out2)
-	assert.Equal(t, 200, res.StatusCode)
-	assert.NoError(t, err)
-	assert.Len(t, out2.Docs, 100)
-	assert.Equal(t, 100, out2.Limit)
-	assert.Equal(t, true, out2.Next)
-
-	query3 := M{"selector": M{"test": "value"}, "bookmark": out2.Bookmark}
-	req, _ = http.NewRequest("POST", url2, jsonReader(&query3))
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	_, res, err = doRequest(req, &out2)
-	assert.Equal(t, 200, res.StatusCode)
-	assert.NoError(t, err)
-	assert.Len(t, out2.Docs, 0)
-	assert.Equal(t, false, out2.Next)
-
-	var query4 = M{"selector": M{"test": "novalue"}}
-	req, _ = http.NewRequest("POST", url2, jsonReader(&query4))
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	_, res, err = doRequest(req, &out2)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	assert.Len(t, out2.Docs, 0)
-	assert.Equal(t, "", out2.Bookmark)
-}
-
-func TestFindDocumentsWithoutIndex(t *testing.T) {
-	query := M{"selector": M{"no-index-for-this-field": "value"}}
-	url2 := ts.URL + "/data/" + Type + "/_find"
-	req, _ := http.NewRequest("POST", url2, jsonReader(&query))
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	var out2 struct {
-		Error  string `json:"error"`
-		Reason string `json:"reason"`
-	}
-	_, res, err := doRequest(req, &out2)
-	assert.Equal(t, "400 Bad Request", res.Status, "should get a 200")
-	assert.NoError(t, err)
-	assert.Contains(t, out2.Error, "no_index")
-	assert.Contains(t, out2.Reason, "no matching index")
-}
-
-func TestGetChanges(t *testing.T) {
-	assert.NoError(t, couchdb.ResetDB(testInstance, Type))
-
-	url := ts.URL + "/data/" + Type + "/_changes?style=all_docs"
-	req, _ := http.NewRequest("GET", url, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	out, res, err := doRequest(req, nil)
-	assert.Equal(t, "200 OK", res.Status, "should get a 200")
-	assert.NoError(t, err)
-	seqno := out["last_seq"].(string)
-
-	// creates 3 docs
-	_ = getDocForTest()
-	_ = getDocForTest()
-	_ = getDocForTest()
-
-	url = ts.URL + "/data/" + Type + "/_changes?limit=2&since=" + seqno
-	req, _ = http.NewRequest("GET", url, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	out, res, err = doRequest(req, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	assert.Len(t, out["results"].([]interface{}), 2)
-
-	url = ts.URL + "/data/" + Type + "/_changes?since=" + seqno
-	req, _ = http.NewRequest("GET", url, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	out, res, err = doRequest(req, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	assert.Len(t, out["results"].([]interface{}), 3)
-}
-
-func TestPostChanges(t *testing.T) {
-	assert.NoError(t, couchdb.ResetDB(testInstance, Type))
-
-	// creates 3 docs
-	doc1 := getDocForTest()
-	_ = getDocForTest()
-	doc2 := getDocForTest()
-
-	payload := fmt.Sprintf(`{"doc_ids": ["%s", "%s"]}`, doc1.ID(), doc2.ID())
-
-	url := ts.URL + "/data/" + Type + "/_changes?include_docs=true&filter=_doc_ids"
-	req, _ := http.NewRequest("POST", url, bytes.NewReader([]byte(payload)))
-	req.Header.Add("Authorization", "Bearer "+token)
-	out, res, err := doRequest(req, nil)
-	assert.Equal(t, 200, res.StatusCode, "should get a 200")
-	assert.NoError(t, err)
-	assert.Len(t, out["results"].([]interface{}), 2)
-}
-
-func TestWrongFeedChanges(t *testing.T) {
-	url := ts.URL + "/data/" + Type + "/_changes?feed=continuous"
-	req, _ := http.NewRequest("POST", url, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	_, res, err := doRequest(req, nil)
-	assert.Equal(t, "400 Bad Request", res.Status, "should get a 400")
-	assert.NoError(t, err)
-}
-
-func TestWrongStyleChanges(t *testing.T) {
-	url := ts.URL + "/data/" + Type + "/_changes?style=not_a_valid_style"
-	req, _ := http.NewRequest("POST", url, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	_, res, err := doRequest(req, nil)
-	assert.Equal(t, "400 Bad Request", res.Status, "should get a 400")
-	assert.NoError(t, err)
-}
-
-func TestLimitIsNoNumber(t *testing.T) {
-	url := ts.URL + "/data/" + Type + "/_changes?limit=not_a_number"
-	req, _ := http.NewRequest("POST", url, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	_, res, err := doRequest(req, nil)
-	assert.Equal(t, "400 Bad Request", res.Status, "should get a 400")
-	assert.NoError(t, err)
-}
-
-func TestUnsupportedOption(t *testing.T) {
-	url := ts.URL + "/data/" + Type + "/_changes?inlude_docs=true"
-	req, _ := http.NewRequest("POST", url, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	_, res, err := doRequest(req, nil)
-	assert.Equal(t, "400 Bad Request", res.Status, "should get a 400")
-	assert.NoError(t, err)
-}
-
-func TestGetAllDocs(t *testing.T) {
-	url := ts.URL + "/data/" + Type + "/_all_docs?include_docs=true"
-	req, _ := http.NewRequest("GET", url, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	out, res, err := doRequest(req, nil)
-	assert.Equal(t, "200 OK", res.Status, "should get a 200")
-	assert.NoError(t, err)
-	totalRows := out["total_rows"].(float64)
-	assert.Equal(t, float64(3), totalRows)
-	offset := out["offset"].(float64)
-	assert.Equal(t, float64(0), offset)
-	rows := out["rows"].([]interface{})
-	assert.Len(t, rows, 3)
-	row := rows[0].(map[string]interface{})
-	id := row["id"].(string)
-	assert.NotEmpty(t, id)
-	doc, ok := row["doc"].(map[string]interface{})
-	assert.True(t, ok)
-	value := doc["test"].(string)
-	assert.Equal(t, "value", value)
-	foo := doc["foo"].(map[string]interface{})
-	bar := foo["bar"].(string)
-	assert.Equal(t, "one", bar)
-	baz := foo["baz"].(string)
-	assert.Equal(t, "two", baz)
-	qux := foo["qux"].(string)
-	assert.Equal(t, "quux", qux)
-}
-
-func TestGetAllDocsWithFields(t *testing.T) {
-	url := ts.URL + "/data/" + Type + "/_all_docs?include_docs=true&Fields=test,nosuchfield,foo.qux"
-	req, _ := http.NewRequest("GET", url, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	out, res, err := doRequest(req, nil)
-	assert.Equal(t, "200 OK", res.Status, "should get a 200")
-	require.NoError(t, err)
-	totalRows := out["total_rows"].(float64)
-	assert.Equal(t, float64(3), totalRows)
-	offset := out["offset"].(float64)
-	assert.Equal(t, float64(0), offset)
-	rows := out["rows"].([]interface{})
-	assert.Len(t, rows, 3)
-	row := rows[0].(map[string]interface{})
-	id := row["id"].(string)
-	assert.NotEmpty(t, id)
-	doc, ok := row["doc"].(map[string]interface{})
-	assert.True(t, ok)
-	value := doc["test"].(string)
-	assert.Equal(t, "value", value)
-	foo := doc["foo"].(map[string]interface{})
-	assert.NotContains(t, foo, "bar")
-	assert.NotContains(t, foo, "baz")
-	qux := foo["qux"].(string)
-	assert.Equal(t, "quux", qux)
-	assert.NotContains(t, doc, "courge")
-}
-
-func TestNormalDocs(t *testing.T) {
-	view := &couchdb.View{
-		Name:    "foobar",
-		Doctype: Type,
-		Map: `
-  function(doc) {
-    emit(doc.foobar, doc);
-  }`,
-	}
-	g, _ := errgroup.WithContext(context.Background())
-	couchdb.DefineViews(g, testInstance, []*couchdb.View{view})
-	assert.NoError(t, g.Wait())
-
-	err := couchdb.CreateNamedDoc(testInstance, &couchdb.JSONDoc{
-		Type: Type,
-		M: map[string]interface{}{
-			"_id":  "four",
-			"test": "fourthvalue",
-		},
-	})
-	assert.NoError(t, err)
-
-	url := ts.URL + "/data/" + Type + "/_normal_docs?limit=2"
-	req, _ := http.NewRequest("GET", url, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	out, res, err := doRequest(req, nil)
-	assert.Equal(t, "200 OK", res.Status, "should get a 200")
-	assert.NoError(t, err)
-	totalRows := out["total_rows"].(float64)
-	assert.Equal(t, float64(4), totalRows)
-	rows := out["rows"].([]interface{})
-	assert.Len(t, rows, 2)
-	row := rows[0].(map[string]interface{})
-	id := row["_id"].(string)
-	assert.NotEmpty(t, id)
-	value := row["test"].(string)
-	assert.Equal(t, "value", value)
-	bookmark := out["bookmark"].(string)
-	assert.NotEmpty(t, bookmark)
-	executionStats := out["execution_stats"]
-	assert.Nil(t, executionStats)
-
-	// skip pagination
-	url = ts.URL + "/data/" + Type + "/_normal_docs?limit=2&skip=2"
-	req, _ = http.NewRequest("GET", url, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	out, res, err = doRequest(req, nil)
-	assert.Equal(t, "200 OK", res.Status, "should get a 200")
-	assert.NoError(t, err)
-	totalRows = out["total_rows"].(float64)
-	assert.Equal(t, float64(4), totalRows)
-	rows = out["rows"].([]interface{})
-	assert.Len(t, rows, 2)
-	row = rows[1].(map[string]interface{})
-	id = row["_id"].(string)
-	assert.NotEmpty(t, id)
-	value = row["test"].(string)
-	assert.Equal(t, "fourthvalue", value)
-
-	// bookmark pagination
-	url = ts.URL + "/data/" + Type + "/_normal_docs?bookmark=" + bookmark
-	req, _ = http.NewRequest("GET", url, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	out, res, err = doRequest(req, nil)
-	assert.Equal(t, "200 OK", res.Status, "should get a 200")
-	assert.NoError(t, err)
-	totalRows = out["total_rows"].(float64)
-	assert.Equal(t, float64(4), totalRows)
-	rows = out["rows"].([]interface{})
-	assert.Len(t, rows, 2)
-	row = rows[1].(map[string]interface{})
-	id = row["_id"].(string)
-	assert.NotEmpty(t, id)
-	value = row["test"].(string)
-	assert.Equal(t, "fourthvalue", value)
-
-	emptyType := "io.cozy.anothertype"
-	_ = couchdb.ResetDB(testInstance, emptyType)
-	url = ts.URL + "/data/" + emptyType + "/_normal_docs"
-	req, _ = http.NewRequest("GET", url, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	out, res, err = doRequest(req, nil)
-	assert.Equal(t, "200 OK", res.Status, "should get a 200")
-	assert.NoError(t, err)
-	totalRows = out["total_rows"].(float64)
-	assert.Equal(t, float64(0), totalRows)
-	bookmark = out["bookmark"].(string)
-	assert.Equal(t, "", bookmark)
-
-	// execution stats
-	url = ts.URL + "/data/" + emptyType + "/_normal_docs?execution_stats=true"
-	req, _ = http.NewRequest("GET", url, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	out, res, err = doRequest(req, nil)
-	assert.Equal(t, "200 OK", res.Status, "should get a 200")
-	assert.NoError(t, err)
-	assert.NotEmpty(t, out["execution_stats"])
-}
-
-func TestGetDesignDocs(t *testing.T) {
-	def := M{"index": M{"fields": S{"foo"}}}
-	_, err := couchdb.DefineIndexRaw(testInstance, Type, &def)
-	assert.NoError(t, err)
-
-	url := ts.URL + "/data/" + Type + "/_design_docs"
-	req, _ := http.NewRequest("GET", url, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	out, res, err := doRequest(req, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, "200 OK", res.Status)
-	rows := out["rows"].([]interface{})
-	nDesignDocs := len(rows)
-	assert.Greater(t, nDesignDocs, 0)
-	firstRow := rows[0].(map[string]interface{})
-	id := firstRow["id"].(string)
-	rev := firstRow["value"].(map[string]interface{})["rev"].(string)
-	assert.NotEmpty(t, id)
-	assert.NotEmpty(t, rev)
-}
-
-func TestGetDesignDoc(t *testing.T) {
-	ddoc := "myindex"
-	def := M{"index": M{"fields": S{"foo"}}, "ddoc": ddoc}
-	_, err := couchdb.DefineIndexRaw(testInstance, Type, &def)
-	assert.NoError(t, err)
-
-	url := ts.URL + "/data/" + Type + "/_design/" + ddoc
-	req, _ := http.NewRequest("GET", url, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	out, res, err := doRequest(req, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, "200 OK", res.Status)
-
-	id := out["_id"].(string)
-	rev := out["_rev"].(string)
-
-	assert.Equal(t, "_design/"+ddoc, id)
-	assert.NotEmpty(t, rev)
-}
-
-func TestDeleteDesignDoc(t *testing.T) {
-	def := M{"index": M{"fields": S{"foo"}}}
-	_, err := couchdb.DefineIndexRaw(testInstance, Type, &def)
-	assert.NoError(t, err)
-
-	url := ts.URL + "/data/" + Type + "/_design_docs"
-	req, _ := http.NewRequest("GET", url, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	out, res, err := doRequest(req, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, "200 OK", res.Status)
-	rows := out["rows"].([]interface{})
-	nDesignDocs := len(rows)
-	assert.Greater(t, nDesignDocs, 0)
-	firstRow := rows[0].(map[string]interface{})
-	id := firstRow["id"].(string)
-	ddoc := strings.Split(id, "/")[1]
-	rev := firstRow["value"].(map[string]interface{})["rev"].(string)
-
-	url = ts.URL + "/data/" + Type + "/_design/" + ddoc + "?rev=" + rev
-	req, _ = http.NewRequest("DELETE", url, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	_, res, err = doRequest(req, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, "200 OK", res.Status)
-
-	url = ts.URL + "/data/" + Type + "/_design_docs"
-	req, _ = http.NewRequest("GET", url, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	out, res, err = doRequest(req, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, "200 OK", res.Status)
-
-	rows = out["rows"].([]interface{})
-	assert.Less(t, len(rows), nDesignDocs)
-}
-
-func TestCannotDeleteStackDesignDoc(t *testing.T) {
-	url := ts.URL + "/data/io.cozy.files/_design_docs"
-	req, _ := http.NewRequest("GET", url, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	out, res, err := doRequest(req, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	rows := out["rows"].([]interface{})
-	var indexRev, viewRev string
-	for _, row := range rows {
-		info := row.(map[string]interface{})
-		if info["id"] == "_design/dir-by-path" {
-			value := info["value"].(map[string]interface{})
-			indexRev = value["rev"].(string)
-		}
-		if info["id"] == "_design/by-parent-type-name" {
-			value := info["value"].(map[string]interface{})
-			viewRev = value["rev"].(string)
-		}
-	}
-
-	url = ts.URL + "/data/io.cozy.files/_design/dir-by-path?rev=" + indexRev
-	req, _ = http.NewRequest("DELETE", url, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	_, res, err = doRequest(req, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, 403, res.StatusCode)
-
-	url = ts.URL + "/data/io.cozy.files/_design/by-parent-type-name?rev=" + viewRev
-	req, _ = http.NewRequest("DELETE", url, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	_, res, err = doRequest(req, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, 403, res.StatusCode)
-}
-
-func TestCopyDesignDoc(t *testing.T) {
-	srcDdoc := "indextocopy"
-	targetID := "_design/indexcopied"
-	def := M{"index": M{"fields": S{"foo"}}, "ddoc": srcDdoc}
-	_, err := couchdb.DefineIndexRaw(testInstance, Type, &def)
-	assert.NoError(t, err)
-
-	url := ts.URL + "/data/" + Type + "/_design/" + srcDdoc
-	req, _ := http.NewRequest("GET", url, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	out, res, err := doRequest(req, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, "200 OK", res.Status)
-
-	rev := out["_rev"].(string)
-
-	url = ts.URL + "/data/" + Type + "/_design/" + srcDdoc + "/copy?rev=" + rev
-	req, _ = http.NewRequest("POST", url, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Destination", targetID)
-	out, res, err = doRequest(req, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, "201 Created", res.Status)
-
-	assert.Equal(t, targetID, out["id"].(string))
-	assert.Equal(t, rev, out["rev"].(string))
-}
-
-func TestDeleteDatabase(t *testing.T) {
-	url := ts.URL + "/data/" + Type + "/"
-	req, _ := http.NewRequest("DELETE", url, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	out, res, err := doRequest(req, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, "200 OK", res.Status)
-	assert.Equal(t, true, out["deleted"].(bool))
-}
-
-func TestDeleteDatabaseNoPermission(t *testing.T) {
-	doctype := "io.cozy.forbidden"
-	url := ts.URL + "/data/" + doctype + "/"
-	req, _ := http.NewRequest("DELETE", url, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	_, res, err := doRequest(req, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, "403 Forbidden", res.Status)
 }

--- a/web/data/data_test.go
+++ b/web/data/data_test.go
@@ -62,7 +62,8 @@ func TestData(t *testing.T) {
 
 	config.UseTestFile()
 	testutils.NeedCouchdb()
-	setup := testutils.NewSetup(m, "data_test")
+	setup := testutils.NewSetup(nil, t.Name())
+	t.Cleanup(setup.Cleanup)
 	testInstance = setup.GetTestInstance()
 	scope := "io.cozy.doctypes io.cozy.files io.cozy.events " +
 		"io.cozy.anothertype io.cozy.nottype"

--- a/web/data/not_synchronizing_test.go
+++ b/web/data/not_synchronizing_test.go
@@ -11,146 +11,153 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestListNotSynchronizingHandler(t *testing.T) {
-	// Make doc
-	doc := getDocForTest()
-	url := ts.URL + "/data/" + doc.DocType() + "/" + doc.ID() + "/relationships/not_synchronizing"
-
-	// Make directories
-	makeNotSynchronzedOnTestDir(t, doc, "test_not_sync_on_1")
-	makeNotSynchronzedOnTestDir(t, doc, "test_not_sync_on_2")
-	makeNotSynchronzedOnTestDir(t, doc, "test_not_sync_on_3")
-	makeNotSynchronzedOnTestDir(t, doc, "test_not_sync_on_4")
-
-	req, _ := http.NewRequest("GET", url, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-
-	var result struct {
-		Links jsonapi.LinksList
-		Data  []couchdb.DocReference `json:"data"`
-		Meta  jsonapi.Meta
+func TestNot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
 	}
-	_, res, err := doRequest(req, &result)
 
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	assert.Len(t, result.Data, 4)
-	assert.Equal(t, *result.Meta.Count, 4)
-	assert.Empty(t, result.Links.Next)
+	t.Run("ListNotSynchronizingHandler", func(t *testing.T) {
+		// Make doc
+		doc := getDocForTest()
+		url := ts.URL + "/data/" + doc.DocType() + "/" + doc.ID() + "/relationships/not_synchronizing"
 
-	var result2 struct {
-		Links jsonapi.LinksList
-		Data  []couchdb.DocReference `json:"data"`
-	}
-	req2, _ := http.NewRequest("GET", url+"?page[limit]=3", nil)
-	req2.Header.Add("Authorization", "Bearer "+token)
-	_, res2, err := doRequest(req2, &result2)
+		// Make directories
+		makeNotSynchronzedOnTestDir(t, doc, "test_not_sync_on_1")
+		makeNotSynchronzedOnTestDir(t, doc, "test_not_sync_on_2")
+		makeNotSynchronzedOnTestDir(t, doc, "test_not_sync_on_3")
+		makeNotSynchronzedOnTestDir(t, doc, "test_not_sync_on_4")
 
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res2.StatusCode)
-	assert.Len(t, result2.Data, 3)
-	assert.Equal(t, *result.Meta.Count, 4)
-	assert.NotEmpty(t, result2.Links.Next)
+		req, _ := http.NewRequest("GET", url, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
 
-	var result3 struct {
-		Links jsonapi.LinksList
-		Data  []couchdb.DocReference `json:"data"`
-	}
-	req3, _ := http.NewRequest("GET", ts.URL+result2.Links.Next, nil)
-	req3.Header.Add("Authorization", "Bearer "+token)
-	_, res3, err := doRequest(req3, &result3)
+		var result struct {
+			Links jsonapi.LinksList
+			Data  []couchdb.DocReference `json:"data"`
+			Meta  jsonapi.Meta
+		}
+		_, res, err := doRequest(req, &result)
 
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res3.StatusCode)
-	assert.Len(t, result3.Data, 1)
-	assert.Empty(t, result3.Links.Next)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		assert.Len(t, result.Data, 4)
+		assert.Equal(t, *result.Meta.Count, 4)
+		assert.Empty(t, result.Links.Next)
 
-	var result4 struct {
-		Links    jsonapi.LinksList
-		Data     []couchdb.DocReference `json:"data"`
-		Included []interface{}          `json:"included"`
-	}
-	req4, _ := http.NewRequest("GET", url+"?include=files", nil)
-	req4.Header.Add("Authorization", "Bearer "+token)
-	_, res4, err := doRequest(req4, &result4)
+		var result2 struct {
+			Links jsonapi.LinksList
+			Data  []couchdb.DocReference `json:"data"`
+		}
+		req2, _ := http.NewRequest("GET", url+"?page[limit]=3", nil)
+		req2.Header.Add("Authorization", "Bearer "+token)
+		_, res2, err := doRequest(req2, &result2)
 
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res4.StatusCode)
-	assert.Len(t, result4.Included, 4)
-	assert.NotEmpty(t, result4.Included[0].(map[string]interface{})["id"])
-}
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res2.StatusCode)
+		assert.Len(t, result2.Data, 3)
+		assert.Equal(t, *result.Meta.Count, 4)
+		assert.NotEmpty(t, result2.Links.Next)
 
-func TestAddNotSynchronizing(t *testing.T) {
-	// Make doc
-	doc := getDocForTest()
-	url := ts.URL + "/data/" + doc.DocType() + "/" + doc.ID() + "/relationships/not_synchronizing"
+		var result3 struct {
+			Links jsonapi.LinksList
+			Data  []couchdb.DocReference `json:"data"`
+		}
+		req3, _ := http.NewRequest("GET", ts.URL+result2.Links.Next, nil)
+		req3.Header.Add("Authorization", "Bearer "+token)
+		_, res3, err := doRequest(req3, &result3)
 
-	// Make dir
-	dir := makeNotSynchronzedOnTestDir(t, nil, "test_not_sync_on")
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res3.StatusCode)
+		assert.Len(t, result3.Data, 1)
+		assert.Empty(t, result3.Links.Next)
 
-	// update it
-	in := jsonReader(jsonapi.Relationship{
-		Data: []couchdb.DocReference{
-			{
-				ID:   dir.ID(),
-				Type: dir.DocType(),
+		var result4 struct {
+			Links    jsonapi.LinksList
+			Data     []couchdb.DocReference `json:"data"`
+			Included []interface{}          `json:"included"`
+		}
+		req4, _ := http.NewRequest("GET", url+"?include=files", nil)
+		req4.Header.Add("Authorization", "Bearer "+token)
+		_, res4, err := doRequest(req4, &result4)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res4.StatusCode)
+		assert.Len(t, result4.Included, 4)
+		assert.NotEmpty(t, result4.Included[0].(map[string]interface{})["id"])
+	})
+
+	t.Run("AddNotSynchronizing", func(t *testing.T) {
+		// Make doc
+		doc := getDocForTest()
+		url := ts.URL + "/data/" + doc.DocType() + "/" + doc.ID() + "/relationships/not_synchronizing"
+
+		// Make dir
+		dir := makeNotSynchronzedOnTestDir(t, nil, "test_not_sync_on")
+
+		// update it
+		in := jsonReader(jsonapi.Relationship{
+			Data: []couchdb.DocReference{
+				{
+					ID:   dir.ID(),
+					Type: dir.DocType(),
+				},
 			},
-		},
+		})
+		req, _ := http.NewRequest("POST", url, in)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/vnd.api+json")
+
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, 204, res.StatusCode)
+
+		dirdoc, err := testInstance.VFS().DirByID(dir.ID())
+		assert.NoError(t, err)
+		assert.Len(t, dirdoc.NotSynchronizedOn, 1)
 	})
-	req, _ := http.NewRequest("POST", url, in)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/vnd.api+json")
 
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, 204, res.StatusCode)
+	t.Run("RemoveNotSynchronizing", func(t *testing.T) {
+		// Make doc
+		doc := getDocForTest()
+		url := ts.URL + "/data/" + doc.DocType() + "/" + doc.ID() + "/relationships/not_synchronizing"
 
-	dirdoc, err := testInstance.VFS().DirByID(dir.ID())
-	assert.NoError(t, err)
-	assert.Len(t, dirdoc.NotSynchronizedOn, 1)
-}
+		// Make directories
+		d6 := makeNotSynchronzedOnTestDir(t, doc, "test_not_sync_on_6").ID()
+		d7 := makeNotSynchronzedOnTestDir(t, doc, "test_not_sync_on_7").ID()
+		d8 := makeNotSynchronzedOnTestDir(t, doc, "test_not_sync_on_8").ID()
+		d9 := makeNotSynchronzedOnTestDir(t, doc, "test_not_sync_on_9").ID()
 
-func TestRemoveNotSynchronizing(t *testing.T) {
-	// Make doc
-	doc := getDocForTest()
-	url := ts.URL + "/data/" + doc.DocType() + "/" + doc.ID() + "/relationships/not_synchronizing"
+		// update it
+		in := jsonReader(jsonapi.Relationship{
+			Data: []couchdb.DocReference{
+				{ID: d8, Type: consts.Files},
+				{ID: d6, Type: consts.Files},
+			},
+		})
+		req, _ := http.NewRequest("DELETE", url, in)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/vnd.api+json")
 
-	// Make directories
-	d6 := makeNotSynchronzedOnTestDir(t, doc, "test_not_sync_on_6").ID()
-	d7 := makeNotSynchronzedOnTestDir(t, doc, "test_not_sync_on_7").ID()
-	d8 := makeNotSynchronzedOnTestDir(t, doc, "test_not_sync_on_8").ID()
-	d9 := makeNotSynchronzedOnTestDir(t, doc, "test_not_sync_on_9").ID()
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, 204, res.StatusCode)
 
-	// update it
-	in := jsonReader(jsonapi.Relationship{
-		Data: []couchdb.DocReference{
-			{ID: d8, Type: consts.Files},
-			{ID: d6, Type: consts.Files},
-		},
+		doc6, err := testInstance.VFS().DirByID(d6)
+		assert.NoError(t, err)
+		assert.Len(t, doc6.NotSynchronizedOn, 0)
+		doc8, err := testInstance.VFS().DirByID(d8)
+		assert.NoError(t, err)
+		assert.Len(t, doc8.NotSynchronizedOn, 0)
+
+		doc7, err := testInstance.VFS().DirByID(d7)
+		assert.NoError(t, err)
+		assert.Len(t, doc7.NotSynchronizedOn, 1)
+		doc9, err := testInstance.VFS().DirByID(d9)
+		assert.NoError(t, err)
+		assert.Len(t, doc9.NotSynchronizedOn, 1)
 	})
-	req, _ := http.NewRequest("DELETE", url, in)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/vnd.api+json")
 
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, 204, res.StatusCode)
-
-	doc6, err := testInstance.VFS().DirByID(d6)
-	assert.NoError(t, err)
-	assert.Len(t, doc6.NotSynchronizedOn, 0)
-	doc8, err := testInstance.VFS().DirByID(d8)
-	assert.NoError(t, err)
-	assert.Len(t, doc8.NotSynchronizedOn, 0)
-
-	doc7, err := testInstance.VFS().DirByID(d7)
-	assert.NoError(t, err)
-	assert.Len(t, doc7.NotSynchronizedOn, 1)
-	doc9, err := testInstance.VFS().DirByID(d9)
-	assert.NoError(t, err)
-	assert.Len(t, doc9.NotSynchronizedOn, 1)
 }
 
 func makeNotSynchronzedOnTestDir(t *testing.T, doc couchdb.Doc, name string) *vfs.DirDoc {

--- a/web/data/not_synchronizing_test.go
+++ b/web/data/not_synchronizing_test.go
@@ -157,7 +157,6 @@ func TestNot(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Len(t, doc9.NotSynchronizedOn, 1)
 	})
-
 }
 
 func makeNotSynchronzedOnTestDir(t *testing.T, doc couchdb.Doc, name string) *vfs.DirDoc {

--- a/web/data/references_test.go
+++ b/web/data/references_test.go
@@ -13,242 +13,249 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestListNotSynchronizedOn(t *testing.T) {
-	// Make doc
-	doc := getDocForTest()
-	url := ts.URL + "/data/" + doc.DocType() + "/" + doc.ID() + "/relationships/references"
-
-	// Make Files
-	makeReferencedTestFile(t, doc, "testtoref2.txt")
-	makeReferencedTestFile(t, doc, "testtoref3.txt")
-	makeReferencedTestFile(t, doc, "testtoref4.txt")
-	makeReferencedTestFile(t, doc, "testtoref5.txt")
-
-	req, _ := http.NewRequest("GET", url, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-
-	var result struct {
-		Links jsonapi.LinksList
-		Data  []couchdb.DocReference `json:"data"`
-		Meta  jsonapi.Meta
-	}
-	_, res, err := doRequest(req, &result)
-
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	assert.Len(t, result.Data, 4)
-	assert.Equal(t, *result.Meta.Count, 4)
-	assert.Empty(t, result.Links.Next)
-
-	var result2 struct {
-		Links jsonapi.LinksList
-		Data  []couchdb.DocReference `json:"data"`
-	}
-	req2, _ := http.NewRequest("GET", url+"?page[limit]=3", nil)
-	req2.Header.Add("Authorization", "Bearer "+token)
-	_, res2, err := doRequest(req2, &result2)
-
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res2.StatusCode)
-	assert.Len(t, result2.Data, 3)
-	assert.Equal(t, *result.Meta.Count, 4)
-	assert.NotEmpty(t, result2.Links.Next)
-
-	var result3 struct {
-		Links jsonapi.LinksList
-		Data  []couchdb.DocReference `json:"data"`
-	}
-	req3, _ := http.NewRequest("GET", ts.URL+result2.Links.Next, nil)
-	req3.Header.Add("Authorization", "Bearer "+token)
-	_, res3, err := doRequest(req3, &result3)
-
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res3.StatusCode)
-	assert.Len(t, result3.Data, 1)
-	assert.Empty(t, result3.Links.Next)
-
-	var result4 struct {
-		Links    jsonapi.LinksList
-		Data     []couchdb.DocReference `json:"data"`
-		Included []interface{}          `json:"included"`
-	}
-	req4, _ := http.NewRequest("GET", url+"?include=files", nil)
-	req4.Header.Add("Authorization", "Bearer "+token)
-	_, res4, err := doRequest(req4, &result4)
-
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res4.StatusCode)
-	assert.Len(t, result4.Included, 4)
-	assert.NotEmpty(t, result4.Included[0].(map[string]interface{})["id"])
-}
-
-func TestAddReferencesHandler(t *testing.T) {
-	// Make doc
-	doc := getDocForTest()
-	url := ts.URL + "/data/" + doc.DocType() + "/" + doc.ID() + "/relationships/references"
-
-	// Make File
-	name := "testtoref.txt"
-	dirID := consts.RootDirID
-	mime, class := vfs.ExtractMimeAndClassFromFilename(name)
-	filedoc, err := vfs.NewFileDoc(name, dirID, -1, nil, mime, class, time.Now(), false, false, false, nil)
-	require.NoError(t, err)
-
-	f, err := testInstance.VFS().CreateFile(filedoc, nil)
-	require.NoError(t, err)
-
-	if err = f.Close(); !assert.NoError(t, err) {
-		return
+func TestReferences(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
 	}
 
-	// update it
-	in := jsonReader(jsonapi.Relationship{
-		Data: []couchdb.DocReference{
-			{
-				ID:   filedoc.ID(),
-				Type: filedoc.DocType(),
+	t.Run("ListNotSynchronizedOn", func(t *testing.T) {
+		// Make doc
+		doc := getDocForTest()
+		url := ts.URL + "/data/" + doc.DocType() + "/" + doc.ID() + "/relationships/references"
+
+		// Make Files
+		makeReferencedTestFile(t, doc, "testtoref2.txt")
+		makeReferencedTestFile(t, doc, "testtoref3.txt")
+		makeReferencedTestFile(t, doc, "testtoref4.txt")
+		makeReferencedTestFile(t, doc, "testtoref5.txt")
+
+		req, _ := http.NewRequest("GET", url, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+
+		var result struct {
+			Links jsonapi.LinksList
+			Data  []couchdb.DocReference `json:"data"`
+			Meta  jsonapi.Meta
+		}
+		_, res, err := doRequest(req, &result)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		assert.Len(t, result.Data, 4)
+		assert.Equal(t, *result.Meta.Count, 4)
+		assert.Empty(t, result.Links.Next)
+
+		var result2 struct {
+			Links jsonapi.LinksList
+			Data  []couchdb.DocReference `json:"data"`
+		}
+		req2, _ := http.NewRequest("GET", url+"?page[limit]=3", nil)
+		req2.Header.Add("Authorization", "Bearer "+token)
+		_, res2, err := doRequest(req2, &result2)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res2.StatusCode)
+		assert.Len(t, result2.Data, 3)
+		assert.Equal(t, *result.Meta.Count, 4)
+		assert.NotEmpty(t, result2.Links.Next)
+
+		var result3 struct {
+			Links jsonapi.LinksList
+			Data  []couchdb.DocReference `json:"data"`
+		}
+		req3, _ := http.NewRequest("GET", ts.URL+result2.Links.Next, nil)
+		req3.Header.Add("Authorization", "Bearer "+token)
+		_, res3, err := doRequest(req3, &result3)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res3.StatusCode)
+		assert.Len(t, result3.Data, 1)
+		assert.Empty(t, result3.Links.Next)
+
+		var result4 struct {
+			Links    jsonapi.LinksList
+			Data     []couchdb.DocReference `json:"data"`
+			Included []interface{}          `json:"included"`
+		}
+		req4, _ := http.NewRequest("GET", url+"?include=files", nil)
+		req4.Header.Add("Authorization", "Bearer "+token)
+		_, res4, err := doRequest(req4, &result4)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res4.StatusCode)
+		assert.Len(t, result4.Included, 4)
+		assert.NotEmpty(t, result4.Included[0].(map[string]interface{})["id"])
+	})
+
+	t.Run("AddReferencesHandler", func(t *testing.T) {
+		// Make doc
+		doc := getDocForTest()
+		url := ts.URL + "/data/" + doc.DocType() + "/" + doc.ID() + "/relationships/references"
+
+		// Make File
+		name := "testtoref.txt"
+		dirID := consts.RootDirID
+		mime, class := vfs.ExtractMimeAndClassFromFilename(name)
+		filedoc, err := vfs.NewFileDoc(name, dirID, -1, nil, mime, class, time.Now(), false, false, false, nil)
+		require.NoError(t, err)
+
+		f, err := testInstance.VFS().CreateFile(filedoc, nil)
+		require.NoError(t, err)
+
+		if err = f.Close(); !assert.NoError(t, err) {
+			return
+		}
+
+		// update it
+		in := jsonReader(jsonapi.Relationship{
+			Data: []couchdb.DocReference{
+				{
+					ID:   filedoc.ID(),
+					Type: filedoc.DocType(),
+				},
 			},
-		},
+		})
+		req, _ := http.NewRequest("POST", url, in)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/vnd.api+json")
+
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, 204, res.StatusCode)
+
+		fdoc, err := testInstance.VFS().FileByID(filedoc.ID())
+		assert.NoError(t, err)
+		assert.Len(t, fdoc.ReferencedBy, 1)
 	})
-	req, _ := http.NewRequest("POST", url, in)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/vnd.api+json")
 
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, 204, res.StatusCode)
+	t.Run("RemoveReferencesHandler", func(t *testing.T) {
+		// Make doc
+		doc := getDocForTest()
+		url := ts.URL + "/data/" + doc.DocType() + "/" + doc.ID() + "/relationships/references"
 
-	fdoc, err := testInstance.VFS().FileByID(filedoc.ID())
-	assert.NoError(t, err)
-	assert.Len(t, fdoc.ReferencedBy, 1)
-}
+		// Make Files
+		f6 := makeReferencedTestFile(t, doc, "testtoref6.txt")
+		f7 := makeReferencedTestFile(t, doc, "testtoref7.txt")
+		f8 := makeReferencedTestFile(t, doc, "testtoref8.txt")
+		f9 := makeReferencedTestFile(t, doc, "testtoref9.txt")
 
-func TestRemoveReferencesHandler(t *testing.T) {
-	// Make doc
-	doc := getDocForTest()
-	url := ts.URL + "/data/" + doc.DocType() + "/" + doc.ID() + "/relationships/references"
-
-	// Make Files
-	f6 := makeReferencedTestFile(t, doc, "testtoref6.txt")
-	f7 := makeReferencedTestFile(t, doc, "testtoref7.txt")
-	f8 := makeReferencedTestFile(t, doc, "testtoref8.txt")
-	f9 := makeReferencedTestFile(t, doc, "testtoref9.txt")
-
-	// update it
-	in := jsonReader(jsonapi.Relationship{
-		Data: []couchdb.DocReference{
-			{ID: f8, Type: consts.Files},
-			{ID: f6, Type: consts.Files},
-		},
-	})
-	req, _ := http.NewRequest("DELETE", url, in)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/vnd.api+json")
-
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, 204, res.StatusCode)
-
-	fdoc6, err := testInstance.VFS().FileByID(f6)
-	assert.NoError(t, err)
-	assert.Len(t, fdoc6.ReferencedBy, 0)
-	fdoc8, err := testInstance.VFS().FileByID(f8)
-	assert.NoError(t, err)
-	assert.Len(t, fdoc8.ReferencedBy, 0)
-
-	fdoc7, err := testInstance.VFS().FileByID(f7)
-	assert.NoError(t, err)
-	assert.Len(t, fdoc7.ReferencedBy, 1)
-	fdoc9, err := testInstance.VFS().FileByID(f9)
-	assert.NoError(t, err)
-	assert.Len(t, fdoc9.ReferencedBy, 1)
-}
-
-func TestReferencesWithSlash(t *testing.T) {
-	// Make File
-	name := "test-ref-with-slash.txt"
-	dirID := consts.RootDirID
-	mime, class := vfs.ExtractMimeAndClassFromFilename(name)
-	filedoc, err := vfs.NewFileDoc(name, dirID, -1, nil, mime, class, time.Now(), false, false, false, nil)
-	require.NoError(t, err)
-
-	f, err := testInstance.VFS().CreateFile(filedoc, nil)
-	require.NoError(t, err)
-
-	if err = f.Close(); !assert.NoError(t, err) {
-		return
-	}
-
-	// Add a reference to io.cozy.apps/foobar
-	url := ts.URL + "/data/" + Type + "/io.cozy.apps%2ffoobar/relationships/references"
-	in := jsonReader(jsonapi.Relationship{
-		Data: []couchdb.DocReference{
-			{
-				ID:   filedoc.ID(),
-				Type: filedoc.DocType(),
+		// update it
+		in := jsonReader(jsonapi.Relationship{
+			Data: []couchdb.DocReference{
+				{ID: f8, Type: consts.Files},
+				{ID: f6, Type: consts.Files},
 			},
-		},
+		})
+		req, _ := http.NewRequest("DELETE", url, in)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/vnd.api+json")
+
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, 204, res.StatusCode)
+
+		fdoc6, err := testInstance.VFS().FileByID(f6)
+		assert.NoError(t, err)
+		assert.Len(t, fdoc6.ReferencedBy, 0)
+		fdoc8, err := testInstance.VFS().FileByID(f8)
+		assert.NoError(t, err)
+		assert.Len(t, fdoc8.ReferencedBy, 0)
+
+		fdoc7, err := testInstance.VFS().FileByID(f7)
+		assert.NoError(t, err)
+		assert.Len(t, fdoc7.ReferencedBy, 1)
+		fdoc9, err := testInstance.VFS().FileByID(f9)
+		assert.NoError(t, err)
+		assert.Len(t, fdoc9.ReferencedBy, 1)
 	})
-	req, _ := http.NewRequest("POST", url, in)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/vnd.api+json")
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, 204, res.StatusCode)
 
-	fdoc, err := testInstance.VFS().FileByID(filedoc.ID())
-	assert.NoError(t, err)
-	assert.Len(t, fdoc.ReferencedBy, 1)
-	assert.Equal(t, "io.cozy.apps/foobar", fdoc.ReferencedBy[0].ID)
+	t.Run("ReferencesWithSlash", func(t *testing.T) {
+		// Make File
+		name := "test-ref-with-slash.txt"
+		dirID := consts.RootDirID
+		mime, class := vfs.ExtractMimeAndClassFromFilename(name)
+		filedoc, err := vfs.NewFileDoc(name, dirID, -1, nil, mime, class, time.Now(), false, false, false, nil)
+		require.NoError(t, err)
 
-	// Check that we can find the reference with /
-	var result struct {
-		Data []couchdb.DocReference `json:"data"`
-		Meta jsonapi.Meta
-	}
-	req, _ = http.NewRequest("GET", url, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	_, res, err = doRequest(req, &result)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	assert.Len(t, result.Data, 1)
-	assert.Equal(t, *result.Meta.Count, 1)
-	assert.Equal(t, fdoc.ID(), result.Data[0].ID)
+		f, err := testInstance.VFS().CreateFile(filedoc, nil)
+		require.NoError(t, err)
 
-	// Try again, but this time encode / as %2F instead of %2f
-	url = ts.URL + "/data/" + Type + "/io.cozy.apps%2Ffoobar/relationships/references"
-	result.Data = result.Data[:0]
-	result.Meta = jsonapi.Meta{}
-	req, _ = http.NewRequest("GET", url, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	_, res, err = doRequest(req, &result)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	assert.Len(t, result.Data, 1)
-	assert.Equal(t, *result.Meta.Count, 1)
-	assert.Equal(t, fdoc.ID(), result.Data[0].ID)
+		if err = f.Close(); !assert.NoError(t, err) {
+			return
+		}
 
-	// Remove the reference with a /
-	in = jsonReader(jsonapi.Relationship{
-		Data: []couchdb.DocReference{
-			{ID: fdoc.ID(), Type: consts.Files},
-		},
+		// Add a reference to io.cozy.apps/foobar
+		url := ts.URL + "/data/" + Type + "/io.cozy.apps%2ffoobar/relationships/references"
+		in := jsonReader(jsonapi.Relationship{
+			Data: []couchdb.DocReference{
+				{
+					ID:   filedoc.ID(),
+					Type: filedoc.DocType(),
+				},
+			},
+		})
+		req, _ := http.NewRequest("POST", url, in)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/vnd.api+json")
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, 204, res.StatusCode)
+
+		fdoc, err := testInstance.VFS().FileByID(filedoc.ID())
+		assert.NoError(t, err)
+		assert.Len(t, fdoc.ReferencedBy, 1)
+		assert.Equal(t, "io.cozy.apps/foobar", fdoc.ReferencedBy[0].ID)
+
+		// Check that we can find the reference with /
+		var result struct {
+			Data []couchdb.DocReference `json:"data"`
+			Meta jsonapi.Meta
+		}
+		req, _ = http.NewRequest("GET", url, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		_, res, err = doRequest(req, &result)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		assert.Len(t, result.Data, 1)
+		assert.Equal(t, *result.Meta.Count, 1)
+		assert.Equal(t, fdoc.ID(), result.Data[0].ID)
+
+		// Try again, but this time encode / as %2F instead of %2f
+		url = ts.URL + "/data/" + Type + "/io.cozy.apps%2Ffoobar/relationships/references"
+		result.Data = result.Data[:0]
+		result.Meta = jsonapi.Meta{}
+		req, _ = http.NewRequest("GET", url, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		_, res, err = doRequest(req, &result)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		assert.Len(t, result.Data, 1)
+		assert.Equal(t, *result.Meta.Count, 1)
+		assert.Equal(t, fdoc.ID(), result.Data[0].ID)
+
+		// Remove the reference with a /
+		in = jsonReader(jsonapi.Relationship{
+			Data: []couchdb.DocReference{
+				{ID: fdoc.ID(), Type: consts.Files},
+			},
+		})
+		req, _ = http.NewRequest("DELETE", url, in)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/vnd.api+json")
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, 204, res.StatusCode)
+
+		// Check that all the references have been removed
+		fdoc2, err := testInstance.VFS().FileByID(fdoc.ID())
+		assert.NoError(t, err)
+		assert.Len(t, fdoc2.ReferencedBy, 0)
 	})
-	req, _ = http.NewRequest("DELETE", url, in)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/vnd.api+json")
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, 204, res.StatusCode)
 
-	// Check that all the references have been removed
-	fdoc2, err := testInstance.VFS().FileByID(fdoc.ID())
-	assert.NoError(t, err)
-	assert.Len(t, fdoc2.ReferencedBy, 0)
 }
 
 func makeReferencedTestFile(t *testing.T, doc couchdb.Doc, name string) string {

--- a/web/data/references_test.go
+++ b/web/data/references_test.go
@@ -255,7 +255,6 @@ func TestReferences(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Len(t, fdoc2.ReferencedBy, 0)
 	})
-
 }
 
 func makeReferencedTestFile(t *testing.T, doc couchdb.Doc, name string) string {

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -95,8 +95,6 @@ func TestFiles(t *testing.T) {
 	})
 	ts.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler
 
-	os.Exit(setup.Run())
-
 	t.Run("Changes", func(t *testing.T) {
 		_, foo := createDir(t, "/files/?Name=foo&Type=directory")
 		fooID := foo["data"].(map[string]interface{})["id"].(string)

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -66,7 +66,8 @@ func TestFiles(t *testing.T) {
 		os.Exit(1)
 	}
 	testutils.NeedCouchdb()
-	setup = testutils.NewSetup(m, "files_test")
+	setup := testutils.NewSetup(nil, t.Name())
+	t.Cleanup(setup.Cleanup)
 
 	tempdir, err := os.MkdirTemp("", "cozy-stack")
 	if err != nil {

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -39,7 +39,6 @@ import (
 var (
 	ts           *httptest.Server
 	testInstance *instance.Instance
-	setup        *testutils.TestSetup
 	token        string
 	clientID     string
 	imgID        string
@@ -2745,7 +2744,6 @@ func TestFiles(t *testing.T) {
 	t.Run("DeprecatePreviewAndIcon", func(t *testing.T) {
 		testutils.TODO(t, "2023-12-01", "Remove the deprecated preview and icon for PDF files")
 	})
-
 }
 
 func readFile(fs vfs.VFS, name string) ([]byte, error) {

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -47,6 +47,2708 @@ var (
 	publicToken  string
 )
 
+type jsonData struct {
+	Type  string                 `json:"type"`
+	ID    string                 `json:"id"`
+	Attrs map[string]interface{} `json:"attributes,omitempty"`
+	Rels  map[string]interface{} `json:"relationships,omitempty"`
+}
+
+func TestFiles(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	config.UseTestFile()
+	err := loadLocale()
+	if err != nil {
+		fmt.Println("Could not load default locale translations: ", err)
+		os.Exit(1)
+	}
+	testutils.NeedCouchdb()
+	setup = testutils.NewSetup(m, "files_test")
+
+	tempdir, err := os.MkdirTemp("", "cozy-stack")
+	if err != nil {
+		fmt.Println("Could not create temporary directory.")
+		os.Exit(1)
+	}
+	setup.AddCleanup(func() error { return os.RemoveAll(tempdir) })
+
+	config.GetConfig().Fs.URL = &url.URL{
+		Scheme: "file",
+		Host:   "localhost",
+		Path:   tempdir,
+	}
+
+	testInstance = setup.GetTestInstance()
+	client, tok := setup.GetTestClient(consts.Files + " " + consts.CertifiedCarbonCopy + " " + consts.CertifiedElectronicSafe)
+	clientID = client.ClientID
+	token = tok
+	ts = setup.GetTestServer("/files", Routes, func(r *echo.Echo) *echo.Echo {
+		secure := middlewares.Secure(&middlewares.SecureConfig{
+			CSPDefaultSrc:     []middlewares.CSPSource{middlewares.CSPSrcSelf},
+			CSPFrameAncestors: []middlewares.CSPSource{middlewares.CSPSrcNone},
+		})
+		r.Use(secure)
+		return r
+	})
+	ts.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler
+
+	os.Exit(setup.Run())
+
+	t.Run("Changes", func(t *testing.T) {
+		_, foo := createDir(t, "/files/?Name=foo&Type=directory")
+		fooID := foo["data"].(map[string]interface{})["id"].(string)
+		_, bar := createDir(t, "/files/"+fooID+"?Name=bar&Type=directory")
+		barID := bar["data"].(map[string]interface{})["id"].(string)
+		_, _ = upload(t, "/files/"+barID+"?Type=file&Name=baz", "text/plain", "baz", "")
+
+		_, qux := createDir(t, "/files/?Name=qux&Type=directory")
+		quxID := qux["data"].(map[string]interface{})["id"].(string)
+		_, _ = trash(t, "/files/"+quxID)
+		req, err := http.NewRequest(http.MethodDelete, ts.URL+"/files/trash", nil)
+		assert.NoError(t, err)
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		_, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+
+		req, _ = http.NewRequest("GET", ts.URL+"/files/_changes?include_docs=true&include_file_path=true", nil)
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+
+		var obj map[string]interface{}
+		err = extractJSONRes(res, &obj)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, obj["last_seq"])
+		assert.NotNil(t, obj["pending"])
+		results := obj["results"].([]interface{})
+		hasDeleted := false
+		hasTrashed := false
+		for _, result := range results {
+			result, _ := result.(map[string]interface{})
+			assert.NotEmpty(t, result["id"])
+			if result["deleted"] == true {
+				hasDeleted = true
+			} else {
+				doc, _ := result["doc"].(map[string]interface{})
+				assert.NotEmpty(t, doc["type"])
+				assert.NotEmpty(t, doc["path"])
+				if doc["path"] == "/.cozy_trash" {
+					hasTrashed = true
+				}
+			}
+		}
+		assert.True(t, hasDeleted)
+		assert.True(t, hasTrashed)
+
+		req, _ = http.NewRequest("GET", ts.URL+"/files/_changes?include_docs=true&fields=type,name,dir_id", nil)
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+
+		err = extractJSONRes(res, &obj)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, obj["last_seq"])
+		assert.NotNil(t, obj["pending"])
+		results = obj["results"].([]interface{})
+		for _, result := range results {
+			result, _ := result.(map[string]interface{})
+			assert.NotEmpty(t, result["id"])
+			if result["deleted"] != true && result["id"] != "io.cozy.files.root-dir" {
+				doc, _ := result["doc"].(map[string]interface{})
+				assert.NotEmpty(t, doc["type"])
+				assert.NotEmpty(t, doc["name"])
+				assert.NotEmpty(t, doc["dir_id"])
+				assert.Empty(t, doc["path"])
+				assert.Empty(t, doc["metadata"])
+				assert.Empty(t, doc["created_at"])
+			}
+		}
+
+		_, _ = trash(t, "/files/"+barID)
+		req, _ = http.NewRequest("GET", ts.URL+"/files/_changes?include_docs=true&skip_deleted=true&skip_trashed=true", nil)
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+
+		err = extractJSONRes(res, &obj)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, obj["last_seq"])
+		assert.NotNil(t, obj["pending"])
+		results = obj["results"].([]interface{})
+		hasDeleted = false
+		hasTrashed = false
+		for _, result := range results {
+			result, _ := result.(map[string]interface{})
+			assert.NotEmpty(t, result["id"])
+			if result["deleted"] == true {
+				hasDeleted = true
+			} else {
+				doc, _ := result["doc"].(map[string]interface{})
+				assert.NotEmpty(t, doc["type"])
+				assert.NotEmpty(t, doc["path"])
+				if doc["path"] == "/.cozy_trash" {
+					hasTrashed = true
+				}
+				if doc["type"] == "directory" && strings.HasPrefix(doc["path"].(string), "/.cozy_trash") {
+					hasTrashed = true
+				}
+				if doc["type"] == "file" && doc["trashed"] == true {
+					hasTrashed = true
+				}
+			}
+		}
+		assert.False(t, hasDeleted)
+		assert.False(t, hasTrashed)
+
+		_, _ = trash(t, "/files/"+fooID)
+		req, err = http.NewRequest(http.MethodDelete, ts.URL+"/files/trash", nil)
+		assert.NoError(t, err)
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		_, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+	})
+
+	t.Run("CreateDirWithNoType", func(t *testing.T) {
+		res, _ := createDir(t, "/files/")
+		assert.Equal(t, 422, res.StatusCode)
+	})
+
+	t.Run("CreateDirWithNoName", func(t *testing.T) {
+		res, _ := createDir(t, "/files/?Type=directory")
+		assert.Equal(t, 422, res.StatusCode)
+	})
+
+	t.Run("CreateDirOnNonExistingParent", func(t *testing.T) {
+		res, _ := createDir(t, "/files/noooop?Name=foo&Type=directory")
+		assert.Equal(t, 404, res.StatusCode)
+	})
+
+	t.Run("CreateDirAlreadyExists", func(t *testing.T) {
+		res1, _ := createDir(t, "/files/?Name=iexist&Type=directory")
+		assert.Equal(t, 201, res1.StatusCode)
+
+		res2, _ := createDir(t, "/files/?Name=iexist&Type=directory")
+		assert.Equal(t, 409, res2.StatusCode)
+	})
+
+	t.Run("CreateDirRootSuccess", func(t *testing.T) {
+		res, _ := createDir(t, "/files/?Name=coucou&Type=directory")
+		assert.Equal(t, 201, res.StatusCode)
+
+		storage := testInstance.VFS()
+		exists, err := vfs.DirExists(storage, "/coucou")
+		assert.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("CreateDirWithDateSuccess", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", ts.URL+"/files/?Type=directory&Name=dir-with-date&CreatedAt=2016-09-18T10:24:53Z", strings.NewReader(""))
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		req.Header.Add("Date", "Mon, 19 Sep 2016 12:35:08 GMT")
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 201, res.StatusCode)
+
+		var obj map[string]interface{}
+		err = extractJSONRes(res, &obj)
+		assert.NoError(t, err)
+		data := obj["data"].(map[string]interface{})
+		attrs := data["attributes"].(map[string]interface{})
+		createdAt := attrs["created_at"].(string)
+		assert.Equal(t, "2016-09-18T10:24:53Z", createdAt)
+		updatedAt := attrs["updated_at"].(string)
+		assert.Equal(t, "2016-09-19T12:35:08Z", updatedAt)
+		fcm := attrs["cozyMetadata"].(map[string]interface{})
+		assert.Equal(t, float64(1), fcm["metadataVersion"])
+		assert.Equal(t, "1", fcm["doctypeVersion"])
+		assert.Contains(t, fcm["createdOn"], testInstance.Domain)
+		assert.NotEmpty(t, fcm["createdAt"])
+		assert.NotEmpty(t, fcm["updatedAt"])
+		assert.NotContains(t, fcm, "uploadedAt")
+	})
+
+	t.Run("CreateDirWithDateSuccessAndUpdatedAt", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", ts.URL+"/files/?Type=directory&Name=dir-with-date-and-updatedat&CreatedAt=2016-09-18T10:24:53Z&UpdatedAt=2020-05-12T12:25:00Z", strings.NewReader(""))
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 201, res.StatusCode)
+
+		var obj map[string]interface{}
+		err = extractJSONRes(res, &obj)
+		assert.NoError(t, err)
+		data := obj["data"].(map[string]interface{})
+		attrs := data["attributes"].(map[string]interface{})
+		createdAt := attrs["created_at"].(string)
+		assert.Equal(t, "2016-09-18T10:24:53Z", createdAt)
+		updatedAt := attrs["updated_at"].(string)
+		assert.Equal(t, "2020-05-12T12:25:00Z", updatedAt)
+		fcm := attrs["cozyMetadata"].(map[string]interface{})
+		assert.Equal(t, float64(1), fcm["metadataVersion"])
+		assert.Equal(t, "1", fcm["doctypeVersion"])
+		assert.Contains(t, fcm["createdOn"], testInstance.Domain)
+		assert.NotEmpty(t, fcm["createdAt"])
+		assert.NotEmpty(t, fcm["updatedAt"])
+		assert.NotContains(t, fcm, "uploadedAt")
+	})
+
+	t.Run("CreateDirWithParentSuccess", func(t *testing.T) {
+		res1, data1 := createDir(t, "/files/?Name=dirparent&Type=directory")
+		assert.Equal(t, 201, res1.StatusCode)
+
+		var ok bool
+		data1, ok = data1["data"].(map[string]interface{})
+		assert.True(t, ok)
+
+		parentID, ok := data1["id"].(string)
+		assert.True(t, ok)
+
+		res2, _ := createDir(t, "/files/"+parentID+"?Name=child&Type=directory")
+		assert.Equal(t, 201, res2.StatusCode)
+
+		storage := testInstance.VFS()
+		exists, err := vfs.DirExists(storage, "/dirparent/child")
+		assert.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("CreateDirWithIllegalCharacter", func(t *testing.T) {
+		res1, _ := createDir(t, "/files/?Name=coucou/les/copains!&Type=directory")
+		assert.Equal(t, 422, res1.StatusCode)
+	})
+
+	t.Run("CreateDirConcurrently", func(t *testing.T) {
+		done := make(chan *http.Response)
+		errs := make(chan *http.Response)
+
+		doCreateDir := func(name string) {
+			res, _ := createDir(t, "/files/?Name="+name+"&Type=directory")
+			if res.StatusCode == 201 {
+				done <- res
+			} else {
+				errs <- res
+			}
+		}
+
+		n := 100
+		c := 0
+
+		for i := 0; i < n; i++ {
+			go doCreateDir("foo")
+		}
+
+		for i := 0; i < n; i++ {
+			select {
+			case res := <-errs:
+				assert.True(t, res.StatusCode == 409 || res.StatusCode == 503)
+			case <-done:
+				c += 1
+			}
+		}
+
+		assert.Equal(t, 1, c)
+	})
+
+	t.Run("UploadWithNoType", func(t *testing.T) {
+		res, _ := upload(t, "/files/", "text/plain", "foo", "")
+		assert.Equal(t, 422, res.StatusCode)
+	})
+
+	t.Run("UploadWithNoName", func(t *testing.T) {
+		res, _ := upload(t, "/files/?Type=file", "text/plain", "foo", "")
+		assert.Equal(t, 422, res.StatusCode)
+	})
+
+	t.Run("UploadToNonExistingParent", func(t *testing.T) {
+		res, _ := upload(t, "/files/nooop?Type=file&Name=no-parent", "text/plain", "foo", "")
+		assert.Equal(t, 404, res.StatusCode)
+	})
+
+	t.Run("UploadWithInvalidContentType", func(t *testing.T) {
+		res, _ := upload(t, "/files/?Type=file&Name=InvalidMime", "foo € / bar", "foo", "")
+		assert.Equal(t, 422, res.StatusCode)
+	})
+
+	t.Run("UploadToTrashedFolder", func(t *testing.T) {
+		res1, data1 := createDir(t, "/files/?Name=trashed-parent&Type=directory")
+		assert.Equal(t, 201, res1.StatusCode)
+		dirID, _ := extractDirData(t, data1)
+		res2, _ := trash(t, "/files/"+dirID)
+		assert.Equal(t, 200, res2.StatusCode)
+		res3, _ := upload(t, "/files/"+dirID+"?Type=file&Name=trashed-parent", "text/plain", "foo", "")
+		assert.Equal(t, 404, res3.StatusCode)
+	})
+
+	t.Run("UploadBadSize", func(t *testing.T) {
+		body := "foo"
+		res, _ := upload(t, "/files/?Type=file&Name=badsize&Size=42", "text/plain", body, "")
+		assert.Equal(t, 412, res.StatusCode)
+
+		storage := testInstance.VFS()
+		_, err := readFile(storage, "/badsize")
+		assert.Error(t, err)
+	})
+
+	t.Run("UploadBadHash", func(t *testing.T) {
+		body := "foo"
+		res, _ := upload(t, "/files/?Type=file&Name=badhash", "text/plain", body, "3FbbMXfH+PdjAlWFfVb1dQ==")
+		assert.Equal(t, 412, res.StatusCode)
+
+		storage := testInstance.VFS()
+		_, err := readFile(storage, "/badhash")
+		assert.Error(t, err)
+	})
+
+	t.Run("UploadAtRootSuccess", func(t *testing.T) {
+		body := "foo"
+		res, _ := upload(t, "/files/?Type=file&Name=goodhash", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
+		assert.Equal(t, 201, res.StatusCode)
+
+		storage := testInstance.VFS()
+		buf, err := readFile(storage, "/goodhash")
+		assert.NoError(t, err)
+		assert.Equal(t, body, string(buf))
+	})
+
+	t.Run("UploadImage", func(t *testing.T) {
+		f, err := os.Open("../../tests/fixtures/wet-cozy_20160910__M4Dz.jpg")
+		assert.NoError(t, err)
+		defer f.Close()
+		m := `{"gps":{"city":"Paris","country":"France"}}`
+		req, err := http.NewRequest("POST", ts.URL+"/files/?Type=file&Name=wet.jpg&Metadata="+m, f)
+		assert.NoError(t, err)
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		res, obj := doUploadOrMod(t, req, "image/jpeg", "tHWYYuXBBflJ8wXgJ2c2yg==")
+		assert.Equal(t, 201, res.StatusCode)
+		data := obj["data"].(map[string]interface{})
+		imgID = data["id"].(string)
+		attrs := data["attributes"].(map[string]interface{})
+		meta := attrs["metadata"].(map[string]interface{})
+		v := meta["extractor_version"].(float64)
+		assert.Equal(t, float64(vfs.MetadataExtractorVersion), v)
+		flash := meta["flash"].(string)
+		assert.Equal(t, "Off, Did not fire", flash)
+		gps := meta["gps"].(map[string]interface{})
+		assert.Equal(t, "Paris", gps["city"])
+		assert.Equal(t, "France", gps["country"])
+		assert.Contains(t, attrs["created_at"], "2016-09-10T")
+	})
+
+	t.Run("UploadShortcut", func(t *testing.T) {
+		f, err := os.Open("../../tests/fixtures/shortcut.url")
+		assert.NoError(t, err)
+		defer f.Close()
+		req, err := http.NewRequest("POST", ts.URL+"/files/?Type=file&Name=shortcut.url", f)
+		assert.NoError(t, err)
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		res, obj := doUploadOrMod(t, req, "application/octet-stream", "+tHtr9V8+4gcCDxTFAqt3w==")
+		assert.Equal(t, 201, res.StatusCode)
+		data := obj["data"].(map[string]interface{})
+		attrs := data["attributes"].(map[string]interface{})
+		assert.Equal(t, "application/internet-shortcut", attrs["mime"])
+		assert.Equal(t, "shortcut", attrs["class"])
+	})
+
+	t.Run("UploadWithParentSuccess", func(t *testing.T) {
+		res1, data1 := createDir(t, "/files/?Name=fileparent&Type=directory")
+		assert.Equal(t, 201, res1.StatusCode)
+
+		var ok bool
+		data1, ok = data1["data"].(map[string]interface{})
+		assert.True(t, ok)
+
+		parentID, ok := data1["id"].(string)
+		assert.True(t, ok)
+
+		body := "foo"
+		res2, _ := upload(t, "/files/"+parentID+"?Type=file&Name=goodhash", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
+		assert.Equal(t, 201, res2.StatusCode)
+
+		storage := testInstance.VFS()
+		buf, err := readFile(storage, "/fileparent/goodhash")
+		assert.NoError(t, err)
+		assert.Equal(t, body, string(buf))
+	})
+
+	t.Run("UploadAtRootAlreadyExists", func(t *testing.T) {
+		body := "foo"
+		res1, _ := upload(t, "/files/?Type=file&Name=iexistfile", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
+		assert.Equal(t, 201, res1.StatusCode)
+
+		res2, _ := upload(t, "/files/?Type=file&Name=iexistfile", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
+		assert.Equal(t, 409, res2.StatusCode)
+	})
+
+	t.Run("UploadWithParentAlreadyExists", func(t *testing.T) {
+		_, dirdata := createDir(t, "/files/?Type=directory&Name=container")
+
+		var ok bool
+		dirdata, ok = dirdata["data"].(map[string]interface{})
+		assert.True(t, ok)
+
+		parentID, ok := dirdata["id"].(string)
+		assert.True(t, ok)
+
+		body := "foo"
+		res1, _ := upload(t, "/files/"+parentID+"?Type=file&Name=iexistfile", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
+		assert.Equal(t, 201, res1.StatusCode)
+
+		res2, _ := upload(t, "/files/"+parentID+"?Type=file&Name=iexistfile", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
+		assert.Equal(t, 409, res2.StatusCode)
+	})
+
+	t.Run("UploadWithCreatedAtAndHeaderDate", func(t *testing.T) {
+		buf := strings.NewReader("foo")
+		req, err := http.NewRequest("POST", ts.URL+"/files/?Type=file&Name=withcdate&CreatedAt=2016-09-18T10:24:53Z", buf)
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		assert.NoError(t, err)
+		req.Header.Add("Date", "Mon, 19 Sep 2016 12:38:04 GMT")
+		res, obj := doUploadOrMod(t, req, "text/plain", "rL0Y20zC+Fzt72VPzMSk2A==")
+		assert.Equal(t, 201, res.StatusCode)
+		data := obj["data"].(map[string]interface{})
+		attrs := data["attributes"].(map[string]interface{})
+		createdAt := attrs["created_at"].(string)
+		assert.Equal(t, "2016-09-18T10:24:53Z", createdAt)
+		updatedAt := attrs["updated_at"].(string)
+		assert.Equal(t, "2016-09-19T12:38:04Z", updatedAt)
+	})
+
+	t.Run("UploadWithCreatedAtAndUpdatedAt", func(t *testing.T) {
+		buf := strings.NewReader("foo")
+		req, err := http.NewRequest("POST", ts.URL+"/files/?Type=file&Name=TestUploadWithCreatedAtAndUpdatedAt&CreatedAt=2016-09-18T10:24:53Z&UpdatedAt=2020-05-12T12:25:00Z", buf)
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		assert.NoError(t, err)
+		res, obj := doUploadOrMod(t, req, "text/plain", "rL0Y20zC+Fzt72VPzMSk2A==")
+		assert.Equal(t, 201, res.StatusCode)
+		data := obj["data"].(map[string]interface{})
+		attrs := data["attributes"].(map[string]interface{})
+		createdAt := attrs["created_at"].(string)
+		assert.Equal(t, "2016-09-18T10:24:53Z", createdAt)
+		updatedAt := attrs["updated_at"].(string)
+		assert.Equal(t, "2020-05-12T12:25:00Z", updatedAt)
+	})
+
+	t.Run("UploadWithCreatedAtAndUpdatedAtAndDateHeader", func(t *testing.T) {
+		buf := strings.NewReader("foo")
+		req, err := http.NewRequest("POST", ts.URL+"/files/?Type=file&Name=TestUploadWithCreatedAtAndUpdatedAtAndDateHeader&CreatedAt=2016-09-18T10:24:53Z&UpdatedAt=2020-05-12T12:25:00Z", buf)
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		assert.NoError(t, err)
+		req.Header.Add("Date", "Mon, 19 Sep 2016 12:38:04 GMT")
+		res, obj := doUploadOrMod(t, req, "text/plain", "rL0Y20zC+Fzt72VPzMSk2A==")
+		assert.Equal(t, 201, res.StatusCode)
+		data := obj["data"].(map[string]interface{})
+		attrs := data["attributes"].(map[string]interface{})
+		createdAt := attrs["created_at"].(string)
+		assert.Equal(t, "2016-09-18T10:24:53Z", createdAt)
+		updatedAt := attrs["updated_at"].(string)
+		assert.Equal(t, "2020-05-12T12:25:00Z", updatedAt)
+	})
+
+	t.Run("UploadWithMetadata", func(t *testing.T) {
+		buf := strings.NewReader(`{
+    "data": {
+        "type": "io.cozy.files.metadata",
+        "attributes": {
+            "category": "report",
+            "subCategory": "theft",
+            "datetime": "2017-04-22T01:00:00-05:00",
+            "label": "foobar"
+        }
+    }
+}`)
+		req, err := http.NewRequest("POST", ts.URL+"/files/upload/metadata", buf)
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		assert.NoError(t, err)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, 201, res.StatusCode)
+		var obj map[string]interface{}
+		err = extractJSONRes(res, &obj)
+		assert.NoError(t, err)
+		data := obj["data"].(map[string]interface{})
+		assert.Equal(t, consts.FilesMetadata, data["type"])
+		secret := data["id"].(string)
+		attrs := data["attributes"].(map[string]interface{})
+		assert.Equal(t, "report", attrs["category"])
+		assert.Equal(t, "theft", attrs["subCategory"])
+		assert.Equal(t, "foobar", attrs["label"])
+		assert.Equal(t, "2017-04-22T01:00:00-05:00", attrs["datetime"])
+
+		u := "/files/?Type=file&Name=withmetadataid&MetadataID=" + secret
+		buf = strings.NewReader("foo")
+		req, err = http.NewRequest("POST", ts.URL+u, buf)
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		assert.NoError(t, err)
+		res, obj = doUploadOrMod(t, req, "text/plain", "rL0Y20zC+Fzt72VPzMSk2A==")
+		assert.Equal(t, 201, res.StatusCode)
+		data = obj["data"].(map[string]interface{})
+		attrs = data["attributes"].(map[string]interface{})
+		meta := attrs["metadata"].(map[string]interface{})
+		assert.Equal(t, "report", meta["category"])
+		assert.Equal(t, "theft", meta["subCategory"])
+		assert.Equal(t, "foobar", meta["label"])
+		assert.Equal(t, "2017-04-22T01:00:00-05:00", meta["datetime"])
+	})
+
+	t.Run("UploadWithSourceAccount", func(t *testing.T) {
+		buf := strings.NewReader("foo")
+		account := "0c5a0a1e-8eb1-11e9-93f3-934f3a2c181d"
+		identifier := "11f68e48"
+		req, err := http.NewRequest("POST", ts.URL+"/files/?Type=file&Name=with-sourceAccount&SourceAccount="+account+"&SourceAccountIdentifier="+identifier, buf)
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		assert.NoError(t, err)
+		res, obj := doUploadOrMod(t, req, "text/plain", "rL0Y20zC+Fzt72VPzMSk2A==")
+		assert.Equal(t, 201, res.StatusCode)
+		data := obj["data"].(map[string]interface{})
+		attrs := data["attributes"].(map[string]interface{})
+		fcm := attrs["cozyMetadata"].(map[string]interface{})
+		assert.Equal(t, account, fcm["sourceAccount"])
+		assert.Equal(t, identifier, fcm["sourceAccountIdentifier"])
+	})
+
+	t.Run("CopyFile", func(t *testing.T) {
+		_, copyFileDir := createDir(t, "/files/?Name=copyFileDir&Type=directory")
+		fmt.Println(copyFileDir)
+		copyFileDirID := copyFileDir["data"].(map[string]interface{})["id"].(string)
+
+		fileName := "bar"
+		fileExt := ".txt"
+		fileContent := "file content"
+
+		// 1. Upload file and get its id
+		res, obj := upload(t, "/files/"+copyFileDirID+"?Type=file&Name="+fileName+fileExt, "text/plain", fileContent, "")
+		require.Equal(t, 201, res.StatusCode)
+		data := obj["data"].(map[string]interface{})
+		fileID = data["id"].(string)
+		fileAttributes := data["attributes"].(map[string]interface{})
+
+		var body map[string]interface{}
+
+		// 2. Send file copy request
+		res, _ = httpPost(ts.URL+"/files/"+fileID+"/copy", "")
+		require.Equal(t, 201, res.StatusCode)
+		require.NoError(t, json.NewDecoder(res.Body).Decode(&body))
+		copyID := body["data"].(map[string]interface{})["id"].(string)
+		require.NotEqual(t, fileID, copyID)
+
+		// 3. Fetch copy metadata and compare with file
+		res, _ = httpGet(ts.URL + "/files/" + copyID)
+		require.Equal(t, 200, res.StatusCode)
+		require.NoError(t, json.NewDecoder(res.Body).Decode(&body))
+		data = body["data"].(map[string]interface{})
+
+		copyAttributes := data["attributes"].(map[string]interface{})
+		assert.NotEmpty(t, copyAttributes["created_at"])
+		assert.NotEqual(t, fileAttributes["created_at"], copyAttributes["created_at"])
+		assert.Equal(t, fileAttributes["dir_id"], copyAttributes["dir_id"])
+		assert.Equal(t, fileName+" (copy)"+fileExt, copyAttributes["name"])
+		assert.Equal(t, fileAttributes["md5sum"], copyAttributes["md5sum"])
+
+		rels := data["relationships"].(map[string]interface{})
+		assert.Nil(t, rels["old_versions"])
+
+		// 4. fetch copy and check its content
+		res, resbody := download(t, "/files/download/"+copyID, "")
+		require.Equal(t, 200, res.StatusCode)
+		assert.True(t, strings.HasPrefix(res.Header.Get("Content-Disposition"), "inline"))
+		assert.True(t, strings.Contains(res.Header.Get("Content-Disposition"), `filename="`+fileName+"(copy)"+fileExt+`"`))
+		assert.True(t, strings.HasPrefix(res.Header.Get("Content-Type"), "text/plain"))
+		assert.NotEmpty(t, res.Header.Get("Etag"))
+		assert.Equal(t, res.Header.Get("Etag")[:1], `"`)
+		assert.Equal(t, res.Header.Get("Content-Length"), strconv.Itoa(len(fileContent)))
+		assert.Equal(t, res.Header.Get("Accept-Ranges"), "bytes")
+		assert.Equal(t, fileContent, string(resbody))
+
+		// 5. Send file copy request specifying copy name and parent id
+		_, destDir := createDir(t, "/files/?Name=destDir&Type=directory")
+		destDirID := destDir["data"].(map[string]interface{})["id"].(string)
+		copyName := "My-file-copy"
+
+		res, _ = httpPost(ts.URL+"/files/"+fileID+"/copy?Name="+copyName+"&DirID="+destDirID, "")
+		require.Equal(t, 201, res.StatusCode)
+		require.NoError(t, json.NewDecoder(res.Body).Decode(&body))
+		copyID = body["data"].(map[string]interface{})["id"].(string)
+		assert.NotEqual(t, fileID, copyID)
+
+		// 6. Fetch copy metadata and compare with file
+		res, _ = httpGet(ts.URL + "/files/" + copyID)
+		require.Equal(t, 200, res.StatusCode)
+		require.NoError(t, json.NewDecoder(res.Body).Decode(&body))
+		data = body["data"].(map[string]interface{})
+
+		copyAttributes = data["attributes"].(map[string]interface{})
+		assert.Equal(t, destDirID, copyAttributes["dir_id"])
+		assert.Equal(t, copyName, copyAttributes["name"])
+	})
+
+	t.Run("ModifyMetadataByPath", func(t *testing.T) {
+		body := "foo"
+		res1, data1 := upload(t, "/files/?Type=file&Name=file-move-me-by-path", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
+		assert.Equal(t, 201, res1.StatusCode)
+
+		var ok bool
+		data1, ok = data1["data"].(map[string]interface{})
+		assert.True(t, ok)
+
+		fileID, ok := data1["id"].(string)
+		assert.True(t, ok)
+
+		res2, data2 := createDir(t, "/files/?Name=move-by-path&Type=directory")
+		assert.Equal(t, 201, res2.StatusCode)
+
+		data2, ok = data2["data"].(map[string]interface{})
+		assert.True(t, ok)
+
+		dirID, ok := data2["id"].(string)
+		assert.True(t, ok)
+
+		attrs := map[string]interface{}{
+			"tags":       []string{"bar", "bar", "baz"},
+			"name":       "moved",
+			"dir_id":     dirID,
+			"executable": true,
+		}
+
+		res3, data3 := patchFile(t, "/files/metadata?Path=/file-move-me-by-path", "file", fileID, attrs, nil)
+		assert.Equal(t, 200, res3.StatusCode)
+
+		data3, ok = data3["data"].(map[string]interface{})
+		assert.True(t, ok)
+
+		attrs3, ok := data3["attributes"].(map[string]interface{})
+		assert.True(t, ok)
+
+		assert.Equal(t, "text/plain", attrs3["mime"])
+		assert.Equal(t, "moved", attrs3["name"])
+		assert.EqualValues(t, []interface{}{"bar", "baz"}, attrs3["tags"])
+		assert.Equal(t, "text", attrs3["class"])
+		assert.Equal(t, "rL0Y20zC+Fzt72VPzMSk2A==", attrs3["md5sum"])
+		assert.Equal(t, true, attrs3["executable"])
+		assert.Equal(t, "3", attrs3["size"])
+	})
+
+	t.Run("ModifyMetadataFileMove", func(t *testing.T) {
+		body := "foo"
+		res1, data1 := upload(t, "/files/?Type=file&Name=filemoveme&Tags=foo,bar", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
+		assert.Equal(t, 201, res1.StatusCode)
+
+		var ok bool
+		data1, ok = data1["data"].(map[string]interface{})
+		assert.True(t, ok)
+
+		fileID, ok := data1["id"].(string)
+		assert.True(t, ok)
+
+		res2, data2 := createDir(t, "/files/?Name=movemeinme&Type=directory")
+		assert.Equal(t, 201, res2.StatusCode)
+
+		data2, ok = data2["data"].(map[string]interface{})
+		assert.True(t, ok)
+
+		dirID, ok := data2["id"].(string)
+		assert.True(t, ok)
+
+		attrs := map[string]interface{}{
+			"tags":       []string{"bar", "bar", "baz"},
+			"name":       "moved",
+			"dir_id":     dirID,
+			"executable": true,
+		}
+
+		res3, data3 := patchFile(t, "/files/"+fileID, "file", fileID, attrs, nil)
+		assert.Equal(t, 200, res3.StatusCode)
+
+		data3, ok = data3["data"].(map[string]interface{})
+		assert.True(t, ok)
+
+		attrs3, ok := data3["attributes"].(map[string]interface{})
+		assert.True(t, ok)
+
+		assert.Equal(t, "text/plain", attrs3["mime"])
+		assert.Equal(t, "moved", attrs3["name"])
+		assert.EqualValues(t, []interface{}{"bar", "baz"}, attrs3["tags"])
+		assert.Equal(t, "text", attrs3["class"])
+		assert.Equal(t, "rL0Y20zC+Fzt72VPzMSk2A==", attrs3["md5sum"])
+		assert.Equal(t, true, attrs3["executable"])
+		assert.Equal(t, "3", attrs3["size"])
+	})
+
+	t.Run("ModifyMetadataFileConflict", func(t *testing.T) {
+		body := "foo"
+		res1, data1 := upload(t, "/files/?Type=file&Name=fmodme1&Tags=foo,bar", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
+		assert.Equal(t, 201, res1.StatusCode)
+
+		res2, _ := upload(t, "/files/?Type=file&Name=fmodme2&Tags=foo,bar", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
+		assert.Equal(t, 201, res2.StatusCode)
+
+		file1ID, _ := extractDirData(t, data1)
+
+		attrs := map[string]interface{}{
+			"name": "fmodme2",
+		}
+
+		res3, _ := patchFile(t, "/files/"+file1ID, "file", file1ID, attrs, nil)
+		assert.Equal(t, 409, res3.StatusCode)
+	})
+
+	t.Run("ModifyMetadataDirMove", func(t *testing.T) {
+		res1, data1 := createDir(t, "/files/?Name=dirmodme&Type=directory&Tags=foo,bar,bar")
+		assert.Equal(t, 201, res1.StatusCode)
+
+		dir1ID, _ := extractDirData(t, data1)
+
+		reschild1, _ := createDir(t, "/files/"+dir1ID+"?Name=child1&Type=directory")
+		assert.Equal(t, 201, reschild1.StatusCode)
+
+		reschild2, _ := createDir(t, "/files/"+dir1ID+"?Name=child2&Type=directory")
+		assert.Equal(t, 201, reschild2.StatusCode)
+
+		res2, data2 := createDir(t, "/files/?Name=dirmodmemoveinme&Type=directory")
+		assert.Equal(t, 201, res2.StatusCode)
+
+		dir2ID, _ := extractDirData(t, data2)
+
+		attrs1 := map[string]interface{}{
+			"tags":   []string{"bar", "baz"},
+			"name":   "renamed",
+			"dir_id": dir2ID,
+		}
+
+		res3, _ := patchFile(t, "/files/"+dir1ID, "directory", dir1ID, attrs1, nil)
+		assert.Equal(t, 200, res3.StatusCode)
+
+		storage := testInstance.VFS()
+		exists, err := vfs.DirExists(storage, "/dirmodmemoveinme/renamed")
+		assert.NoError(t, err)
+		assert.True(t, exists)
+
+		attrs2 := map[string]interface{}{
+			"tags":   []string{"bar", "baz"},
+			"name":   "renamed",
+			"dir_id": dir1ID,
+		}
+
+		res4, _ := patchFile(t, "/files/"+dir2ID, "directory", dir2ID, attrs2, nil)
+		assert.Equal(t, 412, res4.StatusCode)
+
+		res5, _ := patchFile(t, "/files/"+dir1ID, "directory", dir1ID, attrs2, nil)
+		assert.Equal(t, 412, res5.StatusCode)
+	})
+
+	t.Run("ModifyMetadataDirMoveWithRel", func(t *testing.T) {
+		res1, data1 := createDir(t, "/files/?Name=dirmodmewithrel&Type=directory&Tags=foo,bar,bar")
+		assert.Equal(t, 201, res1.StatusCode)
+
+		dir1ID, _ := extractDirData(t, data1)
+
+		reschild1, datachild1 := createDir(t, "/files/"+dir1ID+"?Name=child1&Type=directory")
+		assert.Equal(t, 201, reschild1.StatusCode)
+
+		reschild2, datachild2 := createDir(t, "/files/"+dir1ID+"?Name=child2&Type=directory")
+		assert.Equal(t, 201, reschild2.StatusCode)
+
+		res2, data2 := createDir(t, "/files/?Name=dirmodmemoveinmewithrel&Type=directory")
+		assert.Equal(t, 201, res2.StatusCode)
+
+		dir2ID, _ := extractDirData(t, data2)
+		extractDirData(t, datachild1)
+		extractDirData(t, datachild2)
+
+		parent := &jsonData{
+			ID:   dir2ID,
+			Type: "io.cozy.files",
+		}
+
+		res3, _ := patchFile(t, "/files/"+dir1ID, "directory", dir1ID, nil, parent)
+		assert.Equal(t, 200, res3.StatusCode)
+
+		storage := testInstance.VFS()
+		exists, err := vfs.DirExists(storage, "/dirmodmemoveinmewithrel/dirmodmewithrel")
+		assert.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("ModifyMetadataDirMoveConflict", func(t *testing.T) {
+		res1, _ := createDir(t, "/files/?Name=conflictmodme1&Type=directory&Tags=foo,bar,bar")
+		assert.Equal(t, 201, res1.StatusCode)
+
+		res2, data2 := createDir(t, "/files/?Name=conflictmodme2&Type=directory")
+		assert.Equal(t, 201, res2.StatusCode)
+
+		dir2ID, _ := extractDirData(t, data2)
+
+		attrs1 := map[string]interface{}{
+			"tags": []string{"bar", "baz"},
+			"name": "conflictmodme1",
+		}
+
+		res3, _ := patchFile(t, "/files/"+dir2ID, "directory", dir2ID, attrs1, nil)
+		assert.Equal(t, 409, res3.StatusCode)
+	})
+
+	t.Run("ModifyContentNoFileID", func(t *testing.T) {
+		res, _ := uploadMod(t, "/files/badid", "text/plain", "nil", "")
+		assert.Equal(t, 404, res.StatusCode)
+	})
+
+	t.Run("ModifyContentBadRev", func(t *testing.T) {
+		res1, data1 := upload(t, "/files/?Type=file&Name=modbadrev&Executable=true", "text/plain", "foo", "")
+		assert.Equal(t, 201, res1.StatusCode)
+
+		var ok bool
+		data1, ok = data1["data"].(map[string]interface{})
+		assert.True(t, ok)
+
+		meta1, ok := data1["meta"].(map[string]interface{})
+		assert.True(t, ok)
+
+		fileID, ok := data1["id"].(string)
+		assert.True(t, ok)
+		fileRev, ok := meta1["rev"].(string)
+		assert.True(t, ok)
+
+		newcontent := "newcontent :)"
+
+		req2, err := http.NewRequest("PUT", ts.URL+"/files/"+fileID, strings.NewReader(newcontent))
+		req2.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		assert.NoError(t, err)
+
+		req2.Header.Add("If-Match", "badrev")
+		res2, _ := doUploadOrMod(t, req2, "text/plain", "")
+		assert.Equal(t, 412, res2.StatusCode)
+
+		req3, err := http.NewRequest("PUT", ts.URL+"/files/"+fileID, strings.NewReader(newcontent))
+		req3.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		assert.NoError(t, err)
+
+		req3.Header.Add("If-Match", fileRev)
+		res3, _ := doUploadOrMod(t, req3, "text/plain", "")
+		assert.Equal(t, 200, res3.StatusCode)
+	})
+
+	t.Run("ModifyContentSuccess", func(t *testing.T) {
+		var err error
+		var buf []byte
+		var fileInfo os.FileInfo
+
+		storage := testInstance.VFS()
+		res1, data1 := upload(t, "/files/?Type=file&Name=willbemodified&Executable=true", "text/plain", "foo", "")
+		assert.Equal(t, 201, res1.StatusCode)
+
+		buf, err = readFile(storage, "/willbemodified")
+		assert.NoError(t, err)
+		assert.Equal(t, "foo", string(buf))
+		fileInfo, err = storage.FileByPath("/willbemodified")
+		assert.NoError(t, err)
+		assert.Equal(t, fileInfo.Mode().String(), "-rwxr-xr-x")
+
+		var ok bool
+		data1, ok = data1["data"].(map[string]interface{})
+		assert.True(t, ok)
+
+		attrs1, ok := data1["attributes"].(map[string]interface{})
+		assert.True(t, ok)
+
+		links1, ok := data1["links"].(map[string]interface{})
+		assert.True(t, ok)
+
+		fileID, ok := data1["id"].(string)
+		assert.True(t, ok)
+
+		newcontent := "newcontent :)"
+		res2, data2 := uploadMod(t, "/files/"+fileID+"?Executable=false", "audio/mp3", newcontent, "")
+		assert.Equal(t, 200, res2.StatusCode)
+
+		data2, ok = data2["data"].(map[string]interface{})
+		assert.True(t, ok)
+
+		meta2, ok := data2["meta"].(map[string]interface{})
+		assert.True(t, ok)
+
+		attrs2, ok := data2["attributes"].(map[string]interface{})
+		assert.True(t, ok)
+
+		links2, ok := data2["links"].(map[string]interface{})
+		assert.True(t, ok)
+
+		assert.Equal(t, data2["id"], data1["id"], "same id")
+		assert.Equal(t, data2["path"], data1["path"], "same path")
+		assert.NotEqual(t, meta2["rev"], data1["rev"], "different rev")
+		assert.Equal(t, links2["self"], links1["self"], "same self link")
+
+		assert.Equal(t, attrs2["name"], attrs1["name"])
+		assert.Equal(t, attrs2["created_at"], attrs1["created_at"])
+		assert.NotEqual(t, attrs2["updated_at"], attrs1["updated_at"])
+		assert.NotEqual(t, attrs2["size"], attrs1["size"])
+
+		assert.Equal(t, attrs2["size"], strconv.Itoa(len(newcontent)))
+		assert.NotEqual(t, attrs2["md5sum"], attrs1["md5sum"])
+		assert.NotEqual(t, attrs2["class"], attrs1["class"])
+		assert.NotEqual(t, attrs2["mime"], attrs1["mime"])
+		assert.NotEqual(t, attrs2["executable"], attrs1["executable"])
+		assert.Equal(t, attrs2["class"], "audio")
+		assert.Equal(t, attrs2["mime"], "audio/mp3")
+		assert.Equal(t, attrs2["executable"], false)
+
+		buf, err = readFile(storage, "/willbemodified")
+		assert.NoError(t, err)
+		assert.Equal(t, newcontent, string(buf))
+		fileInfo, err = storage.FileByPath("/willbemodified")
+		assert.NoError(t, err)
+		assert.Equal(t, fileInfo.Mode().String(), "-rw-r--r--")
+
+		req, err := http.NewRequest("PUT", ts.URL+"/files/"+fileID, strings.NewReader(""))
+		assert.NoError(t, err)
+
+		req.Header.Add("Date", "Mon, 02 Jan 2006 15:04:05 MST")
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+
+		res3, data3 := doUploadOrMod(t, req, "what/ever", "")
+		assert.Equal(t, 200, res3.StatusCode)
+
+		data3, ok = data3["data"].(map[string]interface{})
+		assert.True(t, ok)
+
+		attrs3, ok := data3["attributes"].(map[string]interface{})
+		assert.True(t, ok)
+
+		assert.Equal(t, "2006-01-02T15:04:05Z", attrs3["updated_at"])
+
+		newcontent = "encryptedcontent"
+		res4, data4 := uploadMod(t, "/files/"+fileID+"?Encrypted=true", "audio/mp3", newcontent, "")
+		assert.Equal(t, 200, res4.StatusCode)
+
+		data4, ok = data4["data"].(map[string]interface{})
+		assert.True(t, ok)
+		attrs4, ok := data4["attributes"].(map[string]interface{})
+		assert.True(t, ok)
+		assert.Equal(t, attrs4["encrypted"], true)
+	})
+
+	t.Run("ModifyContentWithSourceAccount", func(t *testing.T) {
+		buf := strings.NewReader("foo")
+		req, err := http.NewRequest("POST", ts.URL+"/files/?Type=file&Name=old-file-to-migrate", buf)
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		assert.NoError(t, err)
+		res, obj := doUploadOrMod(t, req, "text/plain", "rL0Y20zC+Fzt72VPzMSk2A==")
+		assert.Equal(t, 201, res.StatusCode)
+		data := obj["data"].(map[string]interface{})
+		fileID, ok := data["id"].(string)
+		assert.True(t, ok)
+
+		account := "0c5a0a1e-8eb1-11e9-93f3-934f3a2c181d"
+		identifier := "11f68e48"
+		newcontent := "updated by a konnector to add the sourceAccount"
+		res2, obj2 := uploadMod(t, "/files/"+fileID+"?SourceAccount="+account+"&SourceAccountIdentifier="+identifier, "text/plain", newcontent, "")
+		assert.Equal(t, 200, res2.StatusCode)
+		data2 := obj2["data"].(map[string]interface{})
+		attrs2 := data2["attributes"].(map[string]interface{})
+		fcm := attrs2["cozyMetadata"].(map[string]interface{})
+		assert.Equal(t, account, fcm["sourceAccount"])
+		assert.Equal(t, identifier, fcm["sourceAccountIdentifier"])
+	})
+
+	t.Run("ModifyContentWithCreatedAt", func(t *testing.T) {
+		buf := strings.NewReader("foo")
+		req, err := http.NewRequest("POST", ts.URL+"/files/?Type=file&Name=old-file-with-c", buf)
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		assert.NoError(t, err)
+		res, obj := doUploadOrMod(t, req, "text/plain", "rL0Y20zC+Fzt72VPzMSk2A==")
+		assert.Equal(t, 201, res.StatusCode)
+		data := obj["data"].(map[string]interface{})
+		fileID, ok := data["id"].(string)
+		assert.True(t, ok)
+		attrs := data["attributes"].(map[string]interface{})
+		createdAt := attrs["created_at"].(string)
+		updatedAt := attrs["updated_at"].(string)
+
+		createdAt2 := "2017-11-16T13:37:01.345Z"
+		newcontent := "updated by a client with a new CreatedAt"
+		res2, obj2 := uploadMod(t, "/files/"+fileID+"?CreatedAt="+createdAt2, "text/plain", newcontent, "")
+		assert.Equal(t, 200, res2.StatusCode)
+		data2 := obj2["data"].(map[string]interface{})
+		attrs2 := data2["attributes"].(map[string]interface{})
+		createdAt3 := attrs2["created_at"].(string)
+		updatedAt2 := attrs2["updated_at"].(string)
+		assert.Equal(t, createdAt3, createdAt)
+		assert.NotEqual(t, updatedAt2, updatedAt)
+	})
+
+	t.Run("ModifyContentWithUpdatedAt", func(t *testing.T) {
+		buf := strings.NewReader("foo")
+		createdAt := "2017-11-16T13:37:01.345Z"
+		req, err := http.NewRequest("POST", ts.URL+"/files/?Type=file&Name=old-file-with-u&CreatedAt="+createdAt, buf)
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		assert.NoError(t, err)
+		res, obj := doUploadOrMod(t, req, "text/plain", "rL0Y20zC+Fzt72VPzMSk2A==")
+		assert.Equal(t, 201, res.StatusCode)
+		data := obj["data"].(map[string]interface{})
+		fileID, ok := data["id"].(string)
+		assert.True(t, ok)
+
+		updatedAt2 := "2017-12-16T13:37:01.345Z"
+		newcontent := "updated by a client with a new UpdatedAt"
+		res2, obj2 := uploadMod(t, "/files/"+fileID+"?UpdatedAt="+updatedAt2, "text/plain", newcontent, "")
+		assert.Equal(t, 200, res2.StatusCode)
+		data2 := obj2["data"].(map[string]interface{})
+		attrs2 := data2["attributes"].(map[string]interface{})
+		createdAt2 := attrs2["created_at"].(string)
+		updatedAt3 := attrs2["updated_at"].(string)
+		assert.Equal(t, createdAt2, createdAt)
+		assert.Equal(t, updatedAt3, updatedAt2)
+	})
+
+	t.Run("ModifyContentWithUpdatedAtAndCreatedAt", func(t *testing.T) {
+		buf := strings.NewReader("foo")
+		createdAt := "2017-11-16T13:37:01.345Z"
+		req, err := http.NewRequest("POST", ts.URL+"/files/?Type=file&Name=old-file-with-u-and-c&CreatedAt="+createdAt, buf)
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		assert.NoError(t, err)
+		res, obj := doUploadOrMod(t, req, "text/plain", "rL0Y20zC+Fzt72VPzMSk2A==")
+		assert.Equal(t, 201, res.StatusCode)
+		data := obj["data"].(map[string]interface{})
+		fileID, ok := data["id"].(string)
+		assert.True(t, ok)
+
+		createdAt2 := "2017-10-16T13:37:01.345Z"
+		updatedAt2 := "2017-12-16T13:37:01.345Z"
+		newcontent := "updated by a client with a CreatedAt older than UpdatedAt"
+		res2, obj2 := uploadMod(t, "/files/"+fileID+"?CreatedAt="+createdAt2+"&UpdatedAt="+updatedAt2, "text/plain", newcontent, "")
+		assert.Equal(t, 200, res2.StatusCode)
+		data2 := obj2["data"].(map[string]interface{})
+		attrs2 := data2["attributes"].(map[string]interface{})
+		createdAt3 := attrs2["created_at"].(string)
+		updatedAt3 := attrs2["updated_at"].(string)
+		assert.Equal(t, createdAt3, createdAt)
+		assert.Equal(t, updatedAt3, updatedAt2)
+	})
+
+	t.Run("ModifyContentConcurrently", func(t *testing.T) {
+		type result struct {
+			rev string
+			idx int64
+		}
+
+		done := make(chan *result)
+		errs := make(chan *http.Response)
+
+		res, data := upload(t, "/files/?Type=file&Name=willbemodifiedconcurrently&Executable=true", "text/plain", "foo", "")
+		require.Equal(t, 201, res.StatusCode)
+
+		var ok bool
+		data, ok = data["data"].(map[string]interface{})
+		assert.True(t, ok)
+
+		fileID, ok := data["id"].(string)
+		assert.True(t, ok)
+
+		var c int64
+
+		doModContent := func() {
+			idx := atomic.AddInt64(&c, 1)
+			res, data := uploadMod(t, "/files/"+fileID, "plain/text", "newcontent "+strconv.FormatInt(idx, 10), "")
+			if res.StatusCode == 200 {
+				data = data["data"].(map[string]interface{})
+				meta := data["meta"].(map[string]interface{})
+				done <- &result{meta["rev"].(string), idx}
+			} else {
+				errs <- res
+			}
+		}
+
+		n := 100
+
+		for i := 0; i < n; i++ {
+			go doModContent()
+		}
+
+		var successes []*result
+		for i := 0; i < n; i++ {
+			select {
+			case res := <-errs:
+				assert.True(t, res.StatusCode == 409 || res.StatusCode == 503, "status code is %v and not 409 or 503", res.StatusCode)
+			case res := <-done:
+				successes = append(successes, res)
+			}
+		}
+
+		assert.True(t, len(successes) >= 1, "there is at least one success")
+
+		for i, s := range successes {
+			assert.True(t, strings.HasPrefix(s.rev, strconv.Itoa(i+2)+"-"))
+		}
+
+		storage := testInstance.VFS()
+		buf, err := readFile(storage, "/willbemodifiedconcurrently")
+		assert.NoError(t, err)
+
+		found := false
+		for _, s := range successes {
+			if string(buf) == "newcontent "+strconv.FormatInt(s.idx, 10) {
+				found = true
+				break
+			}
+		}
+
+		assert.True(t, found)
+	})
+
+	t.Run("DownloadFileBadID", func(t *testing.T) {
+		res, _ := download(t, "/files/download/badid", "")
+		assert.Equal(t, 404, res.StatusCode)
+	})
+
+	t.Run("DownloadFileBadPath", func(t *testing.T) {
+		res, _ := download(t, "/files/download?Path=/i/do/not/exist", "")
+		assert.Equal(t, 404, res.StatusCode)
+	})
+
+	t.Run("DownloadFileByIDSuccess", func(t *testing.T) {
+		body := "foo"
+		res1, filedata := upload(t, "/files/?Type=file&Name=downloadme1", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
+		assert.Equal(t, 201, res1.StatusCode)
+
+		var ok bool
+		filedata, ok = filedata["data"].(map[string]interface{})
+		assert.True(t, ok)
+
+		fileID, ok := filedata["id"].(string)
+		assert.True(t, ok)
+
+		res2, resbody := download(t, "/files/download/"+fileID, "")
+		assert.Equal(t, 200, res2.StatusCode)
+		assert.True(t, strings.HasPrefix(res2.Header.Get("Content-Disposition"), "inline"))
+		assert.True(t, strings.Contains(res2.Header.Get("Content-Disposition"), `filename="downloadme1"`))
+		assert.True(t, strings.HasPrefix(res2.Header.Get("Content-Type"), "text/plain"))
+		assert.NotEmpty(t, res2.Header.Get("Etag"))
+		assert.Equal(t, res2.Header.Get("Etag")[:1], `"`)
+		assert.Equal(t, res2.Header.Get("Content-Length"), "3")
+		assert.Equal(t, res2.Header.Get("Accept-Ranges"), "bytes")
+		assert.Equal(t, body, string(resbody))
+	})
+
+	t.Run("DownloadFileByPathSuccess", func(t *testing.T) {
+		body := "foo"
+		res1, _ := upload(t, "/files/?Type=file&Name=downloadme2", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
+		assert.Equal(t, 201, res1.StatusCode)
+
+		res2, resbody := download(t, "/files/download?Dl=1&Path="+url.QueryEscape("/downloadme2"), "")
+		assert.Equal(t, 200, res2.StatusCode)
+		assert.True(t, strings.HasPrefix(res2.Header.Get("Content-Disposition"), "attachment"))
+		assert.True(t, strings.Contains(res2.Header.Get("Content-Disposition"), `filename="downloadme2"`))
+		assert.True(t, strings.HasPrefix(res2.Header.Get("Content-Type"), "text/plain"))
+		assert.Equal(t, res2.Header.Get("Content-Length"), "3")
+		assert.Equal(t, res2.Header.Get("Accept-Ranges"), "bytes")
+		assert.Equal(t, body, string(resbody))
+	})
+
+	t.Run("DownloadRangeSuccess", func(t *testing.T) {
+		body := "foo,bar"
+		res1, _ := upload(t, "/files/?Type=file&Name=downloadmebyrange", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
+		assert.Equal(t, 201, res1.StatusCode)
+
+		res2, _ := download(t, "/files/download?Path="+url.QueryEscape("/downloadmebyrange"), "nimp")
+		assert.Equal(t, 416, res2.StatusCode)
+
+		res3, res3body := download(t, "/files/download?Path="+url.QueryEscape("/downloadmebyrange"), "bytes=0-2")
+		assert.Equal(t, 206, res3.StatusCode)
+		assert.Equal(t, "foo", string(res3body))
+
+		res4, res4body := download(t, "/files/download?Path="+url.QueryEscape("/downloadmebyrange"), "bytes=4-")
+		assert.Equal(t, 206, res4.StatusCode)
+		assert.Equal(t, "bar", string(res4body))
+	})
+
+	t.Run("GetFileMetadataFromPath", func(t *testing.T) {
+		res1, _ := httpGet(ts.URL + "/files/metadata?Path=/noooooop")
+		assert.Equal(t, 404, res1.StatusCode)
+
+		body := "foo,bar"
+		res2, _ := upload(t, "/files/?Type=file&Name=getmetadata", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
+		assert.Equal(t, 201, res2.StatusCode)
+
+		res3, _ := httpGet(ts.URL + "/files/metadata?Path=/getmetadata")
+		assert.Equal(t, 200, res3.StatusCode)
+	})
+
+	t.Run("GetDirMetadataFromPath", func(t *testing.T) {
+		res1, _ := createDir(t, "/files/?Name=getdirmeta&Type=directory")
+		assert.Equal(t, 201, res1.StatusCode)
+
+		res2, _ := httpGet(ts.URL + "/files/metadata?Path=/getdirmeta")
+		assert.Equal(t, 200, res2.StatusCode)
+	})
+
+	t.Run("GetFileMetadataFromID", func(t *testing.T) {
+		res1, _ := httpGet(ts.URL + "/files/qsdqsd")
+		assert.Equal(t, 404, res1.StatusCode)
+
+		body := "foo,bar"
+		res2, data2 := upload(t, "/files/?Type=file&Name=getmetadatafromid", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
+		assert.Equal(t, 201, res2.StatusCode)
+
+		fileID, _ := extractDirData(t, data2)
+
+		res3, _ := httpGet(ts.URL + "/files/" + fileID)
+		assert.Equal(t, 200, res3.StatusCode)
+	})
+
+	t.Run("GetDirMetadataFromID", func(t *testing.T) {
+		res1, data1 := createDir(t, "/files/?Name=getdirmetafromid&Type=directory")
+		assert.Equal(t, 201, res1.StatusCode)
+
+		parentID, _ := extractDirData(t, data1)
+
+		body := "foo"
+		res2, data2 := upload(t, "/files/"+parentID+"?Type=file&Name=firstfile", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
+		assert.Equal(t, 201, res2.StatusCode)
+
+		fileID, _ := extractDirData(t, data2)
+
+		res3, _ := httpGet(ts.URL + "/files/" + fileID)
+		assert.Equal(t, 200, res3.StatusCode)
+	})
+
+	t.Run("Versions", func(t *testing.T) {
+		cfg := config.GetConfig()
+		oldDelay := cfg.Fs.Versioning.MinDelayBetweenTwoVersions
+		cfg.Fs.Versioning.MinDelayBetweenTwoVersions = 10 * time.Millisecond
+		defer func() {
+			cfg.Fs.Versioning.MinDelayBetweenTwoVersions = oldDelay
+		}()
+
+		res1, body1 := upload(t, "/files/?Type=file&Name=versioned", "text/plain", "one", "")
+		assert.Equal(t, 201, res1.StatusCode)
+		data1 := body1["data"].(map[string]interface{})
+		attr1 := data1["attributes"].(map[string]interface{})
+		sum1 := attr1["md5sum"]
+		fileID := data1["id"].(string)
+		time.Sleep(20 * time.Millisecond)
+		res2, body2 := uploadMod(t, "/files/"+fileID, "text/plain", "two", "")
+		assert.Equal(t, 200, res2.StatusCode)
+		data2 := body2["data"].(map[string]interface{})
+		attr2 := data2["attributes"].(map[string]interface{})
+		sum2 := attr2["md5sum"]
+		time.Sleep(20 * time.Millisecond)
+		res3, body3 := uploadMod(t, "/files/"+fileID, "text/plain", "three", "")
+		assert.Equal(t, 200, res3.StatusCode)
+		data3 := body3["data"].(map[string]interface{})
+		attr3 := data3["attributes"].(map[string]interface{})
+		sum3 := attr3["md5sum"]
+
+		res4, _ := httpGet(ts.URL + "/files/" + fileID)
+		assert.Equal(t, 200, res4.StatusCode)
+		var body map[string]interface{}
+		assert.NoError(t, json.NewDecoder(res4.Body).Decode(&body))
+		data := body["data"].(map[string]interface{})
+		attr := data["attributes"].(map[string]interface{})
+		assert.Equal(t, sum3, attr["md5sum"])
+
+		rels := data["relationships"].(map[string]interface{})
+		old := rels["old_versions"].(map[string]interface{})
+		refs := old["data"].([]interface{})
+		assert.Len(t, refs, 2)
+		first := refs[0].(map[string]interface{})
+		assert.Equal(t, consts.FilesVersions, first["type"])
+		oneID := first["id"]
+		second := refs[1].(map[string]interface{})
+		assert.Equal(t, consts.FilesVersions, second["type"])
+		twoID := second["id"]
+
+		included := body["included"].([]interface{})
+		vone := included[0].(map[string]interface{})
+		assert.Equal(t, oneID, vone["id"])
+		attrv1 := vone["attributes"].(map[string]interface{})
+		assert.Equal(t, sum1, attrv1["md5sum"])
+		vtwo := included[1].(map[string]interface{})
+		assert.Equal(t, twoID, vtwo["id"])
+		attrv2 := vtwo["attributes"].(map[string]interface{})
+		assert.Equal(t, sum2, attrv2["md5sum"])
+	})
+
+	t.Run("PatchVersion", func(t *testing.T) {
+		res1, body1 := upload(t, "/files/?Type=file&Name=patch-version", "text/plain", "one", "")
+		assert.Equal(t, 201, res1.StatusCode)
+		data1 := body1["data"].(map[string]interface{})
+		fileID := data1["id"].(string)
+		res2, _ := uploadMod(t, "/files/"+fileID, "text/plain", "two", "")
+		assert.Equal(t, 200, res2.StatusCode)
+
+		res3, _ := httpGet(ts.URL + "/files/" + fileID)
+		assert.Equal(t, 200, res3.StatusCode)
+		var body3 map[string]interface{}
+		assert.NoError(t, json.NewDecoder(res3.Body).Decode(&body3))
+		data3 := body3["data"].(map[string]interface{})
+		rels := data3["relationships"].(map[string]interface{})
+		old := rels["old_versions"].(map[string]interface{})
+		refs := old["data"].([]interface{})
+		assert.Len(t, refs, 1)
+		ref := refs[0].(map[string]interface{})
+		assert.Equal(t, consts.FilesVersions, ref["type"])
+		versionID := ref["id"].(string)
+
+		attrs := map[string]interface{}{
+			"tags": []string{"qux"},
+		}
+		res4, body4 := patchFile(t, "/files/"+versionID, consts.FilesVersions, versionID, attrs, nil)
+		assert.Equal(t, 200, res4.StatusCode)
+		data4 := body4["data"].(map[string]interface{})
+		assert.Equal(t, versionID, data4["id"])
+		attrs4 := data4["attributes"].(map[string]interface{})
+		tags := attrs4["tags"].([]interface{})
+		assert.Len(t, tags, 1)
+		assert.Equal(t, "qux", tags[0])
+	})
+
+	t.Run("DownloadVersion", func(t *testing.T) {
+		content := "one"
+		res1, body1 := upload(t, "/files/?Type=file&Name=downloadme-versioned", "text/plain", content, "")
+		assert.Equal(t, 201, res1.StatusCode)
+		data := body1["data"].(map[string]interface{})
+		fileID := data["id"].(string)
+		meta := data["meta"].(map[string]interface{})
+		firstRev := meta["rev"].(string)
+
+		res2, _ := uploadMod(t, "/files/"+fileID, "text/plain", "two", "")
+		assert.Equal(t, 200, res2.StatusCode)
+
+		res3, resbody := download(t, "/files/download/"+fileID+"/"+firstRev, "")
+		assert.Equal(t, 200, res3.StatusCode)
+		assert.True(t, strings.HasPrefix(res3.Header.Get("Content-Disposition"), "inline"))
+		assert.True(t, strings.Contains(res3.Header.Get("Content-Disposition"), `filename="downloadme-versioned"`))
+		assert.True(t, strings.HasPrefix(res3.Header.Get("Content-Type"), "text/plain"))
+		assert.Equal(t, content, string(resbody))
+	})
+
+	t.Run("FileCreateAndDownloadByVersionID", func(t *testing.T) {
+		content := "one"
+		res1, body1 := upload(t, "/files/?Type=file&Name=direct-downloadme-versioned", "text/plain", content, "")
+		assert.Equal(t, 201, res1.StatusCode)
+		data := body1["data"].(map[string]interface{})
+		fileID := data["id"].(string)
+		meta := data["meta"].(map[string]interface{})
+		firstRev := meta["rev"].(string)
+
+		res2, _ := uploadMod(t, "/files/"+fileID, "text/plain", "two", "")
+		assert.Equal(t, 200, res2.StatusCode)
+
+		req, err := http.NewRequest("POST", ts.URL+"/files/downloads?VersionId="+fileID+"/"+firstRev, nil)
+		assert.NoError(t, err)
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var data2 map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&data2)
+		assert.NoError(t, err)
+
+		displayURL := ts.URL + data2["links"].(map[string]interface{})["related"].(string)
+		res3, err := http.Get(displayURL)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res3.StatusCode)
+		disposition := res3.Header.Get("Content-Disposition")
+		assert.Equal(t, `inline; filename="direct-downloadme-versioned"`, disposition)
+	})
+
+	t.Run("RevertVersion", func(t *testing.T) {
+		content := "one"
+		res1, body1 := upload(t, "/files/?Type=file&Name=downloadme-reverted", "text/plain", content, "")
+		assert.Equal(t, 201, res1.StatusCode)
+		data := body1["data"].(map[string]interface{})
+		fileID := data["id"].(string)
+
+		res2, _ := uploadMod(t, "/files/"+fileID, "text/plain", "two", "")
+		assert.Equal(t, 200, res2.StatusCode)
+
+		res3, _ := httpGet(ts.URL + "/files/" + fileID)
+		assert.Equal(t, 200, res3.StatusCode)
+		var body map[string]interface{}
+		assert.NoError(t, json.NewDecoder(res3.Body).Decode(&body))
+		data = body["data"].(map[string]interface{})
+		rels := data["relationships"].(map[string]interface{})
+		old := rels["old_versions"].(map[string]interface{})
+		refs := old["data"].([]interface{})
+		assert.Len(t, refs, 1)
+		version := refs[0].(map[string]interface{})
+		versionID := version["id"].(string)
+
+		req4, _ := http.NewRequest("POST", ts.URL+"/files/revert/"+versionID, strings.NewReader(""))
+		req4.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		res4, err := http.DefaultClient.Do(req4)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res4.StatusCode)
+
+		res5, resbody := download(t, "/files/download/"+fileID, "")
+		assert.Equal(t, 200, res5.StatusCode)
+		assert.True(t, strings.HasPrefix(res5.Header.Get("Content-Disposition"), "inline"))
+		assert.True(t, strings.Contains(res5.Header.Get("Content-Disposition"), `filename="downloadme-reverted"`))
+		assert.True(t, strings.HasPrefix(res5.Header.Get("Content-Type"), "text/plain"))
+		assert.Equal(t, content, string(resbody))
+	})
+
+	t.Run("CleanOldVersion", func(t *testing.T) {
+		content := "one"
+		res1, body1 := upload(t, "/files/?Type=file&Name=downloadme-toclean", "text/plain", content, "")
+		assert.Equal(t, 201, res1.StatusCode)
+		data := body1["data"].(map[string]interface{})
+		fileID := data["id"].(string)
+
+		res2, _ := uploadMod(t, "/files/"+fileID, "text/plain", "two", "")
+		assert.Equal(t, 200, res2.StatusCode)
+
+		res3, _ := httpGet(ts.URL + "/files/" + fileID)
+		assert.Equal(t, 200, res3.StatusCode)
+		var body map[string]interface{}
+		assert.NoError(t, json.NewDecoder(res3.Body).Decode(&body))
+		data = body["data"].(map[string]interface{})
+		rels := data["relationships"].(map[string]interface{})
+		old := rels["old_versions"].(map[string]interface{})
+		refs := old["data"].([]interface{})
+		assert.Len(t, refs, 1)
+		version := refs[0].(map[string]interface{})
+		versionID := version["id"].(string)
+
+		req4, _ := http.NewRequest("DELETE", ts.URL+"/files/"+versionID, nil)
+		req4.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		res4, err := http.DefaultClient.Do(req4)
+		assert.NoError(t, err)
+		assert.Equal(t, 204, res4.StatusCode)
+
+		res5, _ := download(t, "/files/download/"+versionID, "")
+		assert.Equal(t, 404, res5.StatusCode)
+	})
+
+	t.Run("CopyVersion", func(t *testing.T) {
+		buf := strings.NewReader(`{
+    "data": {
+        "type": "io.cozy.files.metadata",
+        "attributes": {
+            "category": "report",
+            "label": "foo"
+        }
+    }
+}`)
+		req1, err := http.NewRequest("POST", ts.URL+"/files/upload/metadata", buf)
+		req1.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		assert.NoError(t, err)
+		res1, err := http.DefaultClient.Do(req1)
+		assert.NoError(t, err)
+		defer res1.Body.Close()
+		assert.Equal(t, 201, res1.StatusCode)
+		var obj1 map[string]interface{}
+		err = extractJSONRes(res1, &obj1)
+		assert.NoError(t, err)
+		data1 := obj1["data"].(map[string]interface{})
+		secret := data1["id"].(string)
+
+		content := "should-be-the-same-after-copy"
+		u := "/files/?Type=file&Name=version-to-be-copied&MetadataID=" + secret
+		res2, body2 := upload(t, u, "text/plain", content, "")
+		assert.Equal(t, 201, res2.StatusCode)
+		data2 := body2["data"].(map[string]interface{})
+		fileID := data2["id"].(string)
+		attrs2 := data2["attributes"].(map[string]interface{})
+		meta2 := attrs2["metadata"].(map[string]interface{})
+		assert.Equal(t, "report", meta2["category"])
+		assert.Equal(t, "foo", meta2["label"])
+
+		buf = strings.NewReader(`{
+    "data": {
+        "type": "io.cozy.files.metadata",
+        "attributes": {
+            "label": "bar"
+        }
+    }
+}`)
+		req3, err := http.NewRequest("POST", ts.URL+"/files/"+fileID+"/versions?Tags=qux", buf)
+		req3.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		assert.NoError(t, err)
+		res3, err := http.DefaultClient.Do(req3)
+		assert.NoError(t, err)
+		defer res3.Body.Close()
+		assert.Equal(t, 200, res3.StatusCode)
+		var obj3 map[string]interface{}
+		err = extractJSONRes(res3, &obj3)
+		assert.NoError(t, err)
+		data3 := obj3["data"].(map[string]interface{})
+		attrs3 := data3["attributes"].(map[string]interface{})
+		meta3 := attrs3["metadata"].(map[string]interface{})
+		assert.Nil(t, meta3["category"])
+		assert.Equal(t, "bar", meta3["label"])
+		assert.Len(t, attrs3["tags"], 1)
+		tags := attrs3["tags"].([]interface{})
+		assert.Equal(t, "qux", tags[0])
+	})
+
+	t.Run("CopyVersionWithCertified", func(t *testing.T) {
+		buf := strings.NewReader(`{
+    "data": {
+        "type": "io.cozy.files.metadata",
+        "attributes": {
+            "carbonCopy": true,
+            "electronicSafe": true
+        }
+    }
+}`)
+		req1, err := http.NewRequest("POST", ts.URL+"/files/upload/metadata", buf)
+		req1.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		assert.NoError(t, err)
+		res1, err := http.DefaultClient.Do(req1)
+		assert.NoError(t, err)
+		defer res1.Body.Close()
+		assert.Equal(t, 201, res1.StatusCode)
+		var obj1 map[string]interface{}
+		err = extractJSONRes(res1, &obj1)
+		assert.NoError(t, err)
+		data1 := obj1["data"].(map[string]interface{})
+		secret := data1["id"].(string)
+
+		content := "certified carbonCopy and electronicSafe must be kept if only the qualification change"
+		u := "/files/?Type=file&Name=copy-version-with-certified&MetadataID=" + secret
+		res2, body2 := upload(t, u, "text/plain", content, "")
+		assert.Equal(t, 201, res2.StatusCode)
+		data2 := body2["data"].(map[string]interface{})
+		fileID := data2["id"].(string)
+		attrs2 := data2["attributes"].(map[string]interface{})
+		meta2 := attrs2["metadata"].(map[string]interface{})
+		assert.NotNil(t, meta2["carbonCopy"])
+		assert.NotNil(t, meta2["electronicSafe"])
+
+		buf = strings.NewReader(`{
+    "data": {
+        "type": "io.cozy.files.metadata",
+        "attributes": {
+			"qualification": { "purpose": "attestation" }
+        }
+    }
+}`)
+		req3, err := http.NewRequest("POST", ts.URL+"/files/"+fileID+"/versions", buf)
+		req3.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		assert.NoError(t, err)
+		res3, err := http.DefaultClient.Do(req3)
+		assert.NoError(t, err)
+		defer res3.Body.Close()
+		assert.Equal(t, 200, res3.StatusCode)
+		var obj3 map[string]interface{}
+		err = extractJSONRes(res3, &obj3)
+		assert.NoError(t, err)
+		data3 := obj3["data"].(map[string]interface{})
+		attrs3 := data3["attributes"].(map[string]interface{})
+		meta3 := attrs3["metadata"].(map[string]interface{})
+		assert.NotNil(t, meta3["qualification"])
+		assert.NotNil(t, meta3["carbonCopy"])
+		assert.NotNil(t, meta3["electronicSafe"])
+
+		buf = strings.NewReader(`{
+    "data": {
+        "type": "io.cozy.files.metadata",
+        "attributes": {
+            "label": "bar"
+        }
+    }
+}`)
+		req4, err := http.NewRequest("POST", ts.URL+"/files/"+fileID+"/versions", buf)
+		req4.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		assert.NoError(t, err)
+		res4, err := http.DefaultClient.Do(req4)
+		assert.NoError(t, err)
+		defer res4.Body.Close()
+		assert.Equal(t, 200, res4.StatusCode)
+		var obj4 map[string]interface{}
+		err = extractJSONRes(res4, &obj4)
+		assert.NoError(t, err)
+		data4 := obj4["data"].(map[string]interface{})
+		attrs4 := data4["attributes"].(map[string]interface{})
+		meta4 := attrs4["metadata"].(map[string]interface{})
+		assert.NotNil(t, meta4["label"])
+		assert.Nil(t, meta4["qualification"])
+		assert.Nil(t, meta4["carbonCopy"])
+		assert.Nil(t, meta4["electronicSafe"])
+	})
+
+	t.Run("CopyVersionWorksForNotes", func(t *testing.T) {
+		content := "# Title\n\n* foo\n* bar\n"
+		u := "/files/?Type=file&Name=test.cozy-note"
+		res, body := upload(t, u, consts.NoteMimeType, content, "")
+		assert.Equal(t, 201, res.StatusCode)
+		data := body["data"].(map[string]interface{})
+		fileID := data["id"].(string)
+		attrs := data["attributes"].(map[string]interface{})
+		meta := attrs["metadata"].(map[string]interface{})
+		assert.NotNil(t, meta["title"])
+		assert.NotNil(t, meta["content"])
+		assert.NotNil(t, meta["schema"])
+		assert.NotNil(t, meta["version"])
+
+		buf := strings.NewReader(`{
+    "data": {
+        "type": "io.cozy.files.metadata",
+        "attributes": {
+			"qualification": { "purpose": "attestation" }
+        }
+    }
+}`)
+		req2, err := http.NewRequest("POST", ts.URL+"/files/"+fileID+"/versions", buf)
+		req2.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		assert.NoError(t, err)
+		res2, err := http.DefaultClient.Do(req2)
+		assert.NoError(t, err)
+		defer res2.Body.Close()
+		assert.Equal(t, 200, res2.StatusCode)
+		var obj2 map[string]interface{}
+		err = extractJSONRes(res2, &obj2)
+		assert.NoError(t, err)
+		data2 := obj2["data"].(map[string]interface{})
+		attrs2 := data2["attributes"].(map[string]interface{})
+		meta2 := attrs2["metadata"].(map[string]interface{})
+		assert.NotNil(t, meta2["qualification"])
+		assert.Equal(t, meta["title"], meta2["title"])
+		assert.Equal(t, meta["content"], meta2["content"])
+		assert.Equal(t, meta["schema"], meta2["schema"])
+		assert.Equal(t, meta["version"], meta2["version"])
+	})
+
+	t.Run("ArchiveNoFiles", func(t *testing.T) {
+		body := bytes.NewBufferString(`{
+		"data": {
+			"attributes": {}
+		}
+	}`)
+		req, err := http.NewRequest("POST", ts.URL+"/files/archive", body)
+		require.NoError(t, err)
+
+		req.Header.Add("Content-Type", "application/vnd.api+json")
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 400, res.StatusCode)
+		msg, err := io.ReadAll(res.Body)
+		assert.NoError(t, err)
+		actual := strings.TrimSpace(string(msg))
+		assert.Equal(t, `"Can't create an archive with no files"`, actual)
+	})
+
+	t.Run("ArchiveDirectDownload", func(t *testing.T) {
+		res1, data1 := createDir(t, "/files/?Name=archive&Type=directory")
+		require.Equal(t, 201, res1.StatusCode)
+
+		dirID, _ := extractDirData(t, data1)
+		names := []string{"foo", "bar", "baz"}
+		for _, name := range names {
+			res2, _ := createDir(t, "/files/"+dirID+"?Name="+name+".jpg&Type=file")
+			require.Equal(t, 201, res2.StatusCode)
+		}
+
+		// direct download
+		body := bytes.NewBufferString(`{
+		"data": {
+			"attributes": {
+				"files": [
+					"/archive/foo.jpg",
+					"/archive/bar.jpg",
+					"/archive/baz.jpg"
+				]
+			}
+		}
+	}`)
+
+		req, err := http.NewRequest("POST", ts.URL+"/files/archive", body)
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		req.Header.Add("Content-Type", "application/zip")
+		req.Header.Add("Accept", "application/zip")
+		assert.NoError(t, err)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		assert.Equal(t, "application/zip", res.Header.Get("Content-Type"))
+	})
+
+	t.Run("ArchiveCreateAndDownload", func(t *testing.T) {
+		res1, data1 := createDir(t, "/files/?Name=archive2&Type=directory")
+		require.Equal(t, 201, res1.StatusCode)
+
+		dirID, _ := extractDirData(t, data1)
+		names := []string{"foo", "bar", "baz"}
+		for _, name := range names {
+			res2, _ := createDir(t, "/files/"+dirID+"?Name="+name+".jpg&Type=file")
+			require.Equal(t, 201, res2.StatusCode)
+		}
+
+		body := bytes.NewBufferString(`{
+		"data": {
+			"attributes": {
+				"files": [
+					"/archive/foo.jpg",
+					"/archive/bar.jpg",
+					"/archive/baz.jpg"
+				]
+			}
+		}
+	}`)
+
+		req, err := http.NewRequest("POST", ts.URL+"/files/archive", body)
+		require.NoError(t, err)
+
+		req.Header.Add("Content-Type", "application/vnd.api+json")
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var data map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&data)
+		assert.NoError(t, err)
+
+		downloadURL := ts.URL + data["links"].(map[string]interface{})["related"].(string)
+		res2, err := httpGet(downloadURL)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res2.StatusCode)
+		disposition := res2.Header.Get("Content-Disposition")
+		assert.Equal(t, `attachment; filename="archive.zip"`, disposition)
+	})
+
+	t.Run("FileCreateAndDownloadByPath", func(t *testing.T) {
+		body := "foo,bar"
+		res1, _ := upload(t, "/files/?Type=file&Name=todownload2steps", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
+		require.Equal(t, 201, res1.StatusCode)
+
+		path := "/todownload2steps"
+
+		req, err := http.NewRequest("POST", ts.URL+"/files/downloads?Path="+path, nil)
+		require.NoError(t, err)
+
+		req.Header.Add("Content-Type", "")
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var data map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&data)
+		assert.NoError(t, err)
+
+		displayURL := ts.URL + data["links"].(map[string]interface{})["related"].(string)
+		res2, err := http.Get(displayURL)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res2.StatusCode)
+		disposition := res2.Header.Get("Content-Disposition")
+		assert.Equal(t, `inline; filename="todownload2steps"`, disposition)
+
+		downloadURL := ts.URL + data["links"].(map[string]interface{})["related"].(string) + "?Dl=1"
+		res3, err := http.Get(downloadURL)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res3.StatusCode)
+		disposition = res3.Header.Get("Content-Disposition")
+		assert.Equal(t, `attachment; filename="todownload2steps"`, disposition)
+	})
+
+	t.Run("FileCreateAndDownloadByID", func(t *testing.T) {
+		body := "foo,bar"
+		res1, v := upload(t, "/files/?Type=file&Name=todownload2stepsbis", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
+		require.Equal(t, 201, res1.StatusCode)
+
+		id := v["data"].(map[string]interface{})["id"].(string)
+
+		req, err := http.NewRequest("POST", ts.URL+"/files/downloads?Id="+id, nil)
+		require.NoError(t, err)
+
+		req.Header.Add("Content-Type", "")
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var data map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&data)
+		assert.NoError(t, err)
+
+		displayURL := ts.URL + data["links"].(map[string]interface{})["related"].(string)
+		res2, err := http.Get(displayURL)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res2.StatusCode)
+		disposition := res2.Header.Get("Content-Disposition")
+		assert.Equal(t, `inline; filename="todownload2stepsbis"`, disposition)
+	})
+
+	t.Run("EncryptedFileCreate", func(t *testing.T) {
+		res1, data1 := upload(t, "/files/?Type=file&Name=encryptedfile&Encrypted=true", "text/plain", "foo", "")
+		assert.Equal(t, 201, res1.StatusCode)
+
+		var ok bool
+		resData, ok := data1["data"].(map[string]interface{})
+		assert.True(t, ok)
+
+		attrs := resData["attributes"].(map[string]interface{})
+		assert.Equal(t, attrs["name"].(string), "encryptedfile")
+		assert.True(t, attrs["encrypted"].(bool))
+	})
+
+	t.Run("HeadDirOrFileNotFound", func(t *testing.T) {
+		req, _ := http.NewRequest("HEAD", ts.URL+"/files/fakeid/?Type=directory", strings.NewReader(""))
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 404, res.StatusCode)
+	})
+
+	t.Run("HeadDirOrFileExists", func(t *testing.T) {
+		res, _ := createDir(t, "/files/?Name=hellothere&Type=directory")
+		assert.Equal(t, 201, res.StatusCode)
+
+		storage := testInstance.VFS()
+		dir, err := storage.DirByPath("/hellothere")
+		assert.NoError(t, err)
+		id := dir.ID()
+		req, _ := http.NewRequest("HEAD", ts.URL+"/files/"+id+"?Type=directory", strings.NewReader(""))
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+	})
+
+	t.Run("ArchiveNotFound", func(t *testing.T) {
+		body := bytes.NewBufferString(`{
+		"data": {
+			"attributes": {
+				"files": [
+					"/archive/foo.jpg",
+					"/no/such/file",
+					"/archive/baz.jpg"
+				]
+			}
+		}
+	}`)
+		req, err := http.NewRequest("POST", ts.URL+"/files/archive", body)
+		require.NoError(t, err)
+
+		req.Header.Add("Content-Type", "application/vnd.api+json")
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, 404, res.StatusCode)
+	})
+
+	t.Run("DirTrash", func(t *testing.T) {
+		res1, data1 := createDir(t, "/files/?Name=totrashdir&Type=directory")
+		require.Equal(t, 201, res1.StatusCode)
+
+		dirID, _ := extractDirData(t, data1)
+
+		res2, _ := createDir(t, "/files/"+dirID+"?Name=child1&Type=file")
+		require.Equal(t, 201, res2.StatusCode)
+
+		res3, _ := createDir(t, "/files/"+dirID+"?Name=child2&Type=file")
+		require.Equal(t, 201, res3.StatusCode)
+
+		res4, _ := trash(t, "/files/"+dirID)
+		require.Equal(t, 200, res4.StatusCode)
+
+		res5, err := httpGet(ts.URL + "/files/" + dirID)
+		require.NoError(t, err)
+		require.Equal(t, 200, res5.StatusCode)
+
+		res6, err := httpGet(ts.URL + "/files/download?Path=" + url.QueryEscape(vfs.TrashDirName+"/totrashdir/child1"))
+		require.NoError(t, err)
+		require.Equal(t, 200, res6.StatusCode)
+
+		res7, err := httpGet(ts.URL + "/files/download?Path=" + url.QueryEscape(vfs.TrashDirName+"/totrashdir/child2"))
+		require.NoError(t, err)
+		require.Equal(t, 200, res7.StatusCode)
+
+		res8, _ := trash(t, "/files/"+dirID)
+		require.Equal(t, 400, res8.StatusCode)
+	})
+
+	t.Run("FileTrash", func(t *testing.T) {
+		body := "foo,bar"
+		res1, data1 := upload(t, "/files/?Type=file&Name=totrashfile", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
+		require.Equal(t, 201, res1.StatusCode)
+
+		fileID, _ := extractDirData(t, data1)
+
+		res2, _ := trash(t, "/files/"+fileID)
+		require.Equal(t, 200, res2.StatusCode)
+
+		res3, err := httpGet(ts.URL + "/files/download?Path=" + url.QueryEscape(vfs.TrashDirName+"/totrashfile"))
+		require.NoError(t, err)
+		require.Equal(t, 200, res3.StatusCode)
+
+		res4, _ := trash(t, "/files/"+fileID)
+		require.Equal(t, 400, res4.StatusCode)
+
+		res5, data2 := upload(t, "/files/?Type=file&Name=totrashfile2", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
+		require.Equal(t, 201, res5.StatusCode)
+
+		fileID, v2 := extractDirData(t, data2)
+		meta2 := v2["meta"].(map[string]interface{})
+		rev2 := meta2["rev"].(string)
+
+		req6, err := http.NewRequest("DELETE", ts.URL+"/files/"+fileID, nil)
+		req6.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		assert.NoError(t, err)
+
+		req6.Header.Add("If-Match", "badrev")
+		res6, err := http.DefaultClient.Do(req6)
+		assert.NoError(t, err)
+		assert.Equal(t, 412, res6.StatusCode)
+
+		res7, err := httpGet(ts.URL + "/files/download?Path=" + url.QueryEscape(vfs.TrashDirName+"/totrashfile"))
+		require.NoError(t, err)
+		require.Equal(t, 200, res7.StatusCode)
+
+		req8, err := http.NewRequest("DELETE", ts.URL+"/files/"+fileID, nil)
+		req8.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		assert.NoError(t, err)
+
+		req8.Header.Add("If-Match", rev2)
+		res8, err := http.DefaultClient.Do(req8)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res8.StatusCode)
+
+		res9, _ := trash(t, "/files/"+fileID)
+		require.Equal(t, 400, res9.StatusCode)
+	})
+
+	t.Run("ForbidMovingTrashedFile", func(t *testing.T) {
+		body := "foo,bar"
+		res1, data1 := upload(t, "/files/?Type=file&Name=forbidmovingtrashedfile", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
+		require.Equal(t, 201, res1.StatusCode)
+
+		fileID, _ := extractDirData(t, data1)
+		res2, _ := trash(t, "/files/"+fileID)
+		require.Equal(t, 200, res2.StatusCode)
+
+		attrs := map[string]interface{}{
+			"dir_id": consts.RootDirID,
+		}
+		res3, _ := patchFile(t, "/files/"+fileID, "file", fileID, attrs, nil)
+		assert.Equal(t, 400, res3.StatusCode)
+	})
+
+	t.Run("FileRestore", func(t *testing.T) {
+		body := "foo,bar"
+		res1, data1 := upload(t, "/files/?Type=file&Name=torestorefile", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
+		require.Equal(t, 201, res1.StatusCode)
+
+		fileID, _ := extractDirData(t, data1)
+
+		res2, body2 := trash(t, "/files/"+fileID)
+		require.Equal(t, 200, res2.StatusCode)
+
+		data2 := body2["data"].(map[string]interface{})
+		attrs2 := data2["attributes"].(map[string]interface{})
+		trashed := attrs2["trashed"].(bool)
+		assert.True(t, trashed)
+
+		res3, body3 := restore(t, "/files/trash/"+fileID)
+		require.Equal(t, 200, res3.StatusCode)
+
+		data3 := body3["data"].(map[string]interface{})
+		attrs3 := data3["attributes"].(map[string]interface{})
+		trashed = attrs3["trashed"].(bool)
+		assert.False(t, trashed)
+
+		res4, err := httpGet(ts.URL + "/files/download?Path=" + url.QueryEscape("/torestorefile"))
+		require.NoError(t, err)
+		require.Equal(t, 200, res4.StatusCode)
+	})
+
+	t.Run("FileRestoreWithConflicts", func(t *testing.T) {
+		body := "foo,bar"
+		res1, data1 := upload(t, "/files/?Type=file&Name=torestorefilewithconflict", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
+		require.Equal(t, 201, res1.StatusCode)
+
+		fileID, _ := extractDirData(t, data1)
+
+		res2, _ := trash(t, "/files/"+fileID)
+		require.Equal(t, 200, res2.StatusCode)
+
+		res1, _ = upload(t, "/files/?Type=file&Name=torestorefilewithconflict", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
+		require.Equal(t, 201, res1.StatusCode)
+
+		res3, data3 := restore(t, "/files/trash/"+fileID)
+		require.Equal(t, 200, res3.StatusCode)
+
+		restoredID, restoredData := extractDirData(t, data3)
+		require.Equal(t, fileID, restoredID)
+
+		restoredData = restoredData["attributes"].(map[string]interface{})
+		assert.True(t, strings.HasPrefix(restoredData["name"].(string), "torestorefilewithconflict"))
+		assert.NotEqual(t, "torestorefilewithconflict", restoredData["name"].(string))
+	})
+
+	t.Run("FileRestoreWithWithoutParent", func(t *testing.T) {
+		res1, data1 := createDir(t, "/files/?Type=directory&Name=torestorein")
+		require.Equal(t, 201, res1.StatusCode)
+
+		dirID, _ := extractDirData(t, data1)
+
+		body := "foo,bar"
+		res1, data1 = upload(t, "/files/"+dirID+"?Type=file&Name=torestorefilewithconflict", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
+		require.Equal(t, 201, res1.StatusCode)
+
+		fileID, _ := extractDirData(t, data1)
+
+		res2, _ := trash(t, "/files/"+fileID)
+		require.Equal(t, 200, res2.StatusCode)
+
+		res2, _ = trash(t, "/files/"+dirID)
+		require.Equal(t, 200, res2.StatusCode)
+
+		res3, data3 := restore(t, "/files/trash/"+fileID)
+		require.Equal(t, 200, res3.StatusCode)
+
+		restoredID, restoredData := extractDirData(t, data3)
+		require.Equal(t, fileID, restoredID)
+
+		restoredData = restoredData["attributes"].(map[string]interface{})
+		assert.Equal(t, "torestorefilewithconflict", restoredData["name"].(string))
+		assert.NotEqual(t, consts.RootDirID, restoredData["dir_id"].(string))
+	})
+
+	t.Run("FileRestoreWithWithoutParent2", func(t *testing.T) {
+		res1, data1 := createDir(t, "/files/?Type=directory&Name=torestorein2")
+		require.Equal(t, 201, res1.StatusCode)
+
+		dirID, _ := extractDirData(t, data1)
+
+		body := "foo,bar"
+		res1, data1 = upload(t, "/files/"+dirID+"?Type=file&Name=torestorefilewithconflict2", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
+		require.Equal(t, 201, res1.StatusCode)
+
+		fileID, _ := extractDirData(t, data1)
+
+		res2, _ := trash(t, "/files/"+dirID)
+		require.Equal(t, 200, res2.StatusCode)
+
+		res3, data3 := restore(t, "/files/trash/"+fileID)
+		require.Equal(t, 200, res3.StatusCode)
+
+		restoredID, restoredData := extractDirData(t, data3)
+		require.Equal(t, fileID, restoredID)
+
+		restoredData = restoredData["attributes"].(map[string]interface{})
+		assert.Equal(t, "torestorefilewithconflict2", restoredData["name"].(string))
+		assert.NotEqual(t, consts.RootDirID, restoredData["dir_id"].(string))
+	})
+
+	t.Run("DirRestore", func(t *testing.T) {
+		res1, data1 := createDir(t, "/files/?Type=directory&Name=torestoredir")
+		require.Equal(t, 201, res1.StatusCode)
+
+		dirID, _ := extractDirData(t, data1)
+
+		body := "foo,bar"
+		res2, data2 := upload(t, "/files/"+dirID+"?Type=file&Name=totrashfile", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
+		require.Equal(t, 201, res2.StatusCode)
+
+		fileID, _ := extractDirData(t, data2)
+
+		res3, _ := trash(t, "/files/"+dirID)
+		require.Equal(t, 200, res3.StatusCode)
+
+		res4, err := httpGet(ts.URL + "/files/" + fileID)
+		require.NoError(t, err)
+		require.Equal(t, 200, res4.StatusCode)
+
+		var v map[string]interface{}
+		err = extractJSONRes(res4, &v)
+		assert.NoError(t, err)
+		data := v["data"].(map[string]interface{})
+		attrs := data["attributes"].(map[string]interface{})
+		trashed := attrs["trashed"].(bool)
+		assert.True(t, trashed)
+
+		res5, _ := restore(t, "/files/trash/"+dirID)
+		require.Equal(t, 200, res5.StatusCode)
+
+		res6, err := httpGet(ts.URL + "/files/" + fileID)
+		require.NoError(t, err)
+		require.Equal(t, 200, res6.StatusCode)
+
+		err = extractJSONRes(res6, &v)
+		assert.NoError(t, err)
+		data = v["data"].(map[string]interface{})
+		attrs = data["attributes"].(map[string]interface{})
+		trashed = attrs["trashed"].(bool)
+		assert.False(t, trashed)
+	})
+
+	t.Run("DirRestoreWithConflicts", func(t *testing.T) {
+		res1, data1 := createDir(t, "/files/?Type=directory&Name=torestoredirwithconflict")
+		require.Equal(t, 201, res1.StatusCode)
+
+		dirID, _ := extractDirData(t, data1)
+
+		res2, _ := trash(t, "/files/"+dirID)
+		require.Equal(t, 200, res2.StatusCode)
+
+		res1, _ = createDir(t, "/files/?Type=directory&Name=torestoredirwithconflict")
+		require.Equal(t, 201, res1.StatusCode)
+
+		res3, data3 := restore(t, "/files/trash/"+dirID)
+		require.Equal(t, 200, res3.StatusCode)
+
+		restoredID, restoredData := extractDirData(t, data3)
+		require.Equal(t, dirID, restoredID)
+
+		restoredData = restoredData["attributes"].(map[string]interface{})
+		assert.True(t, strings.HasPrefix(restoredData["name"].(string), "torestoredirwithconflict"))
+		assert.NotEqual(t, "torestoredirwithconflict", restoredData["name"].(string))
+	})
+
+	t.Run("TrashList", func(t *testing.T) {
+		body := "foo,bar"
+		res1, data1 := upload(t, "/files/?Type=file&Name=tolistfile", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
+		require.Equal(t, 201, res1.StatusCode)
+
+		res2, data2 := createDir(t, "/files/?Name=tolistdir&Type=directory")
+		require.Equal(t, 201, res2.StatusCode)
+
+		dirID, _ := extractDirData(t, data1)
+		fileID, _ := extractDirData(t, data2)
+
+		res3, _ := trash(t, "/files/"+dirID)
+		require.Equal(t, 200, res3.StatusCode)
+
+		res4, _ := trash(t, "/files/"+fileID)
+		require.Equal(t, 200, res4.StatusCode)
+
+		res5, err := httpGet(ts.URL + "/files/trash")
+		require.NoError(t, err)
+
+		defer res5.Body.Close()
+
+		var v struct {
+			Data []interface{} `json:"data"`
+		}
+
+		err = json.NewDecoder(res5.Body).Decode(&v)
+		require.NoError(t, err)
+
+		assert.True(t, len(v.Data) >= 2, "response should contains at least 2 items")
+	})
+
+	t.Run("TrashClear", func(t *testing.T) {
+		body := "foo,bar"
+		res1, data1 := upload(t, "/files/?Type=file&Name=tolistfile", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
+		require.Equal(t, 201, res1.StatusCode)
+
+		res2, data2 := createDir(t, "/files/?Name=tolistdir&Type=directory")
+		require.Equal(t, 201, res2.StatusCode)
+
+		dirID, _ := extractDirData(t, data1)
+		fileID, _ := extractDirData(t, data2)
+
+		res3, _ := trash(t, "/files/"+dirID)
+		require.Equal(t, 200, res3.StatusCode)
+
+		res4, _ := trash(t, "/files/"+fileID)
+		require.Equal(t, 200, res4.StatusCode)
+
+		path := "/files/trash"
+		req, err := http.NewRequest(http.MethodDelete, ts.URL+path, nil)
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		require.NoError(t, err)
+
+		_, err = http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		res5, err := httpGet(ts.URL + "/files/trash")
+		require.NoError(t, err)
+
+		defer res5.Body.Close()
+
+		var v struct {
+			Data []interface{} `json:"data"`
+		}
+
+		err = json.NewDecoder(res5.Body).Decode(&v)
+		require.NoError(t, err)
+
+		assert.True(t, len(v.Data) == 0)
+	})
+
+	t.Run("DestroyFile", func(t *testing.T) {
+		body := "foo,bar"
+		res1, data1 := upload(t, "/files/?Type=file&Name=tolistfile", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
+		require.Equal(t, 201, res1.StatusCode)
+
+		res2, data2 := createDir(t, "/files/?Name=tolistdir&Type=directory")
+		require.Equal(t, 201, res2.StatusCode)
+
+		dirID, _ := extractDirData(t, data1)
+		fileID, _ := extractDirData(t, data2)
+
+		res3, _ := trash(t, "/files/"+dirID)
+		require.Equal(t, 200, res3.StatusCode)
+
+		res4, _ := trash(t, "/files/"+fileID)
+		require.Equal(t, 200, res4.StatusCode)
+
+		path := "/files/trash/" + fileID
+		req, err := http.NewRequest(http.MethodDelete, ts.URL+path, nil)
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		require.NoError(t, err)
+
+		_, err = http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		res5, err := httpGet(ts.URL + "/files/trash")
+		require.NoError(t, err)
+
+		defer res5.Body.Close()
+
+		var v struct {
+			Data []interface{} `json:"data"`
+		}
+
+		err = json.NewDecoder(res5.Body).Decode(&v)
+		require.NoError(t, err)
+
+		assert.True(t, len(v.Data) == 1)
+
+		path = "/files/trash/" + dirID
+		req, err = http.NewRequest(http.MethodDelete, ts.URL+path, nil)
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		require.NoError(t, err)
+
+		_, err = http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		res5, err = httpGet(ts.URL + "/files/trash")
+		require.NoError(t, err)
+
+		defer res5.Body.Close()
+
+		err = json.NewDecoder(res5.Body).Decode(&v)
+		require.NoError(t, err)
+
+		assert.True(t, len(v.Data) == 0)
+	})
+
+	t.Run("ThumbnailImages", func(t *testing.T) {
+		res1, _ := httpGet(ts.URL + "/files/" + imgID)
+		assert.Equal(t, 200, res1.StatusCode)
+		var obj map[string]interface{}
+		err := extractJSONRes(res1, &obj)
+		assert.NoError(t, err)
+		data := obj["data"].(map[string]interface{})
+		links := data["links"].(map[string]interface{})
+		large := links["large"].(string)
+		medium := links["medium"].(string)
+		small := links["small"].(string)
+		tiny := links["tiny"].(string)
+
+		res2, _ := download(t, large, "")
+		assert.Equal(t, 200, res2.StatusCode)
+		assert.True(t, strings.HasPrefix(res2.Header.Get("Content-Type"), "image/jpeg"))
+		res3, _ := download(t, medium, "")
+		assert.Equal(t, 200, res3.StatusCode)
+		assert.True(t, strings.HasPrefix(res3.Header.Get("Content-Type"), "image/jpeg"))
+		res4, _ := download(t, small, "")
+		assert.Equal(t, 200, res4.StatusCode)
+		assert.True(t, strings.HasPrefix(res4.Header.Get("Content-Type"), "image/jpeg"))
+		res5, _ := download(t, tiny, "")
+		assert.Equal(t, 200, res5.StatusCode)
+		assert.True(t, strings.HasPrefix(res5.Header.Get("Content-Type"), "image/jpeg"))
+	})
+
+	t.Run("ThumbnailPDFs", func(t *testing.T) {
+		if testing.Short() {
+			return
+		}
+
+		f, err := os.Open("../../tests/fixtures/dev-desktop.pdf")
+		assert.NoError(t, err)
+		defer f.Close()
+		req, err := http.NewRequest("POST", ts.URL+"/files/?Type=file&Name=dev-desktop.pdf", f)
+		assert.NoError(t, err)
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		res, obj := doUploadOrMod(t, req, "application/pdf", "")
+		assert.Equal(t, 201, res.StatusCode)
+		data := obj["data"].(map[string]interface{})
+		pdfID := data["id"].(string)
+
+		res2, _ := httpGet(ts.URL + "/files/" + pdfID)
+		assert.Equal(t, 200, res2.StatusCode)
+		var obj2 map[string]interface{}
+		err = extractJSONRes(res2, &obj2)
+		assert.NoError(t, err)
+		data2 := obj2["data"].(map[string]interface{})
+		links := data2["links"].(map[string]interface{})
+		large := links["large"].(string)
+		medium := links["medium"].(string)
+		small := links["small"].(string)
+		tiny := links["tiny"].(string)
+
+		// Large, medium, and small are not generated automatically
+		res3, _ := download(t, large, "")
+		assert.Equal(t, 404, res3.StatusCode)
+		assert.Equal(t, res3.Header.Get("Content-Type"), "image/png")
+		res4, _ := download(t, medium, "")
+		assert.Equal(t, 404, res4.StatusCode)
+		assert.Equal(t, res4.Header.Get("Content-Type"), "image/png")
+		res5, _ := download(t, small, "")
+		assert.Equal(t, 404, res5.StatusCode)
+		assert.Equal(t, res5.Header.Get("Content-Type"), "image/png")
+
+		// Wait for tiny thumbnail generation
+		time.Sleep(1 * time.Second)
+
+		res6, _ := download(t, tiny, "")
+		assert.Equal(t, 200, res6.StatusCode)
+		assert.Equal(t, res6.Header.Get("Content-Type"), "image/jpeg")
+
+		// Wait for other thumbnails generation
+		time.Sleep(2 * time.Second)
+
+		res7, _ := download(t, large, "")
+		assert.Equal(t, 200, res7.StatusCode)
+		assert.Equal(t, res7.Header.Get("Content-Type"), "image/jpeg")
+		res8, _ := download(t, medium, "")
+		assert.Equal(t, 200, res8.StatusCode)
+		assert.Equal(t, res8.Header.Get("Content-Type"), "image/jpeg")
+		res9, _ := download(t, small, "")
+		assert.Equal(t, 200, res9.StatusCode)
+		assert.Equal(t, res9.Header.Get("Content-Type"), "image/jpeg")
+	})
+
+	t.Run("GetFileByPublicLink", func(t *testing.T) {
+		var err error
+		body := "foo"
+		res1, filedata := upload(t, "/files/?Type=file&Name=publicfile", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
+		assert.Equal(t, 201, res1.StatusCode)
+
+		var ok bool
+		filedata, ok = filedata["data"].(map[string]interface{})
+		assert.True(t, ok)
+
+		fileID, ok = filedata["id"].(string)
+		assert.True(t, ok)
+
+		// Generating a new token
+		publicToken, err = testInstance.MakeJWT(consts.ShareAudience, "email", "io.cozy.files", "", time.Now())
+		assert.NoError(t, err)
+
+		expires := time.Now().Add(2 * time.Minute)
+		rules := permission.Set{
+			permission.Rule{
+				Type:   "io.cozy.files",
+				Verbs:  permission.Verbs(permission.GET),
+				Values: []string{fileID},
+			},
+		}
+		perms := permission.Permission{
+			Permissions: rules,
+		}
+		_, err = permission.CreateShareSet(testInstance, &permission.Permission{Type: "app", Permissions: rules}, "", map[string]string{"email": publicToken}, nil, perms, &expires)
+		assert.NoError(t, err)
+
+		req, err := http.NewRequest("GET", ts.URL+"/files/"+fileID, nil)
+		assert.NoError(t, err)
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+publicToken)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+	})
+
+	t.Run("GetFileByPublicLinkRateExceeded", func(t *testing.T) {
+		var err error
+		// Blocking the file by accessing it a lot of times
+		for i := 0; i < 1999; i++ {
+			err = limits.CheckRateLimitKey(fileID, limits.SharingPublicLinkType)
+			assert.NoError(t, err)
+		}
+
+		err = limits.CheckRateLimitKey(fileID, limits.SharingPublicLinkType)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "Rate limit reached")
+		req, err := http.NewRequest("GET", ts.URL+"/files/"+fileID, nil)
+		assert.NoError(t, err)
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+publicToken)
+
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 500, res.StatusCode)
+		resbody, err := io.ReadAll(res.Body)
+		assert.NoError(t, err)
+		assert.Contains(t, string(resbody), "Rate limit exceeded")
+	})
+
+	t.Run("Find", func(t *testing.T) {
+		type M map[string]interface{}
+		type S []interface{}
+
+		defIndex := M{"index": M{"fields": S{"_id"}}}
+		_, err := couchdb.DefineIndexRaw(testInstance, "io.cozy.files", &defIndex)
+		assert.NoError(t, err)
+
+		defIndex2 := M{"index": M{"fields": S{"type"}}}
+		_, err = couchdb.DefineIndexRaw(testInstance, "io.cozy.files", &defIndex2)
+		assert.NoError(t, err)
+
+		query := strings.NewReader(`{
+		"selector": {
+			"type": "file"
+		},
+		"limit": 1
+	}`)
+		req, _ := http.NewRequest("POST", ts.URL+"/files/_find", query)
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var obj map[string]interface{}
+		err = extractJSONRes(res, &obj)
+		assert.NoError(t, err)
+
+		data := obj["data"].([]interface{})
+		meta := obj["meta"].(map[string]interface{})
+		if assert.Len(t, data, 1) {
+			doc := data[0].(map[string]interface{})
+			attrs := doc["attributes"].(map[string]interface{})
+			assert.NotEmpty(t, attrs["name"])
+			assert.NotEmpty(t, attrs["type"])
+			assert.NotEmpty(t, attrs["size"])
+			assert.NotEmpty(t, attrs["path"])
+		}
+		assert.NotNil(t, meta)
+		assert.Nil(t, meta["execution_stats"])
+
+		query2 := strings.NewReader(`{
+		"selector": {
+			"_id": {
+				"$gt": null
+			}
+		},
+		"limit": 1,
+		"execution_stats": true
+	}`)
+		req, _ = http.NewRequest("POST", ts.URL+"/files/_find", query2)
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		err = extractJSONRes(res, &obj)
+		assert.NoError(t, err)
+		data = obj["data"].([]interface{})
+		meta = obj["meta"].(map[string]interface{})
+		assert.Equal(t, len(data), 1)
+		id1 := data[0].(map[string]interface{})["id"]
+		assert.NotNil(t, meta)
+		assert.NotEmpty(t, meta["execution_stats"])
+		links := obj["links"].(map[string]interface{})
+		next := links["next"].(string)
+
+		query2 = strings.NewReader(`{
+		"selector": {
+			"_id": {
+				"$gt": null
+			}
+		},
+		"limit": 1,
+		"execution_stats": true
+	}`)
+		req, _ = http.NewRequest("POST", ts.URL+next, query2)
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		err = extractJSONRes(res, &obj)
+		assert.NoError(t, err)
+		data = obj["data"].([]interface{})
+		assert.Equal(t, len(data), 1)
+		id2 := data[0].(map[string]interface{})["id"]
+		assert.NotEqual(t, id1, id2)
+
+		query3 := strings.NewReader(`{
+		"selector": {
+			"_id": {
+				"$gt": null
+			}
+		},
+		"fields": ["dir_id", "name", "name"],
+		"limit": 1
+	}`)
+		req, _ = http.NewRequest("POST", ts.URL+"/files/_find", query3)
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+
+		err = extractJSONRes(res, &obj)
+		assert.NoError(t, err)
+		resData := obj["data"].([]interface{})
+		dataFields := resData[0].(map[string]interface{})
+		attrs := dataFields["attributes"].(map[string]interface{})
+		assert.NotEmpty(t, attrs["name"].(string))
+		assert.NotEmpty(t, attrs["dir_id"].(string))
+		assert.NotEmpty(t, attrs["type"].(string))
+		assert.Nil(t, attrs["path"])
+		assert.Nil(t, attrs["created_at"])
+		assert.Nil(t, attrs["updated_at"])
+		assert.Nil(t, attrs["tags"])
+
+		query4 := strings.NewReader(`{
+		"selector": {
+			"type": "file"
+		},
+		"fields": ["name"],
+		"limit": 1
+	}`)
+		req, _ = http.NewRequest("POST", ts.URL+"/files/_find", query4)
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+
+		err = extractJSONRes(res, &obj)
+		assert.NoError(t, err)
+		resData = obj["data"].([]interface{})
+		if assert.Len(t, resData, 1) {
+			dataFields = resData[0].(map[string]interface{})
+			attrs = dataFields["attributes"].(map[string]interface{})
+			assert.NotEmpty(t, attrs["name"].(string))
+			assert.NotEmpty(t, attrs["type"].(string))
+			assert.NotEmpty(t, attrs["size"].(string))
+			assert.False(t, attrs["trashed"].(bool))
+			assert.False(t, attrs["encrypted"].(bool))
+			assert.Nil(t, attrs["created_at"])
+			assert.Nil(t, attrs["updated_at"])
+			assert.Nil(t, attrs["tags"])
+			assert.Nil(t, attrs["executable"])
+			assert.Nil(t, attrs["dir_id"])
+			assert.Nil(t, attrs["path"])
+		}
+
+		_, dirdata := createDir(t, "/files/?Type=directory&Name=aDirectoryWithReferencedBy")
+		dirdata, ok := dirdata["data"].(map[string]interface{})
+		assert.True(t, ok)
+		dirID, ok := dirdata["id"].(string)
+		assert.True(t, ok)
+		path := "/files/" + dirID + "/relationships/referenced_by"
+		content, err := json.Marshal(&jsonapi.Relationship{
+			Data: couchdb.DocReference{
+				ID:   "fooalbumid",
+				Type: "io.cozy.photos.albums",
+			},
+		})
+		require.NoError(t, err)
+		req, err = http.NewRequest(http.MethodPost, ts.URL+path, bytes.NewReader(content))
+		require.NoError(t, err)
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		res, err = http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+
+		query5 := strings.NewReader(`{
+		"selector": {
+			"name": "aDirectoryWithReferencedBy"
+		},
+		"limit": 1
+	}`)
+		req, _ = http.NewRequest("POST", ts.URL+"/files/_find", query5)
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		res, err = http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+
+		err = extractJSONRes(res, &obj)
+		require.NoError(t, err)
+		resData = obj["data"].([]interface{})
+		require.Len(t, resData, 1)
+		dataFields = resData[0].(map[string]interface{})
+		attrs = dataFields["attributes"].(map[string]interface{})
+		assert.Equal(t, "aDirectoryWithReferencedBy", attrs["name"])
+		assert.NotEmpty(t, attrs["referenced_by"])
+		relationships, ok := dataFields["relationships"].(map[string]interface{})
+		require.True(t, ok)
+		referencedBy, ok := relationships["referenced_by"].(map[string]interface{})
+		require.True(t, ok)
+		dataRef, ok := referencedBy["data"].([]interface{})
+		require.True(t, ok)
+		require.Len(t, dataRef, 1)
+		ref := dataRef[0].(map[string]interface{})
+		assert.Equal(t, "fooalbumid", ref["id"])
+		assert.Equal(t, "io.cozy.photos.albums", ref["type"])
+	})
+
+	t.Run("DirSize", func(t *testing.T) {
+		_, dirdata := createDir(t, "/files/?Type=directory&Name=dirsizeparent")
+		dirdata, ok := dirdata["data"].(map[string]interface{})
+		assert.True(t, ok)
+		parentID, ok := dirdata["id"].(string)
+		assert.True(t, ok)
+
+		_, dirdata = createDir(t, "/files/"+parentID+"?Type=directory&Name=dirsizesub")
+		dirdata, ok = dirdata["data"].(map[string]interface{})
+		assert.True(t, ok)
+		subID, ok := dirdata["id"].(string)
+		assert.True(t, ok)
+
+		_, dirdata = createDir(t, "/files/"+subID+"?Type=directory&Name=dirsizesubsub")
+		dirdata, ok = dirdata["data"].(map[string]interface{})
+		assert.True(t, ok)
+		subsubID, ok := dirdata["id"].(string)
+		assert.True(t, ok)
+
+		nb := 10
+		body := "foo"
+		for i := 0; i < nb; i++ {
+			name := "file" + strconv.Itoa(i)
+			upload(t, "/files/"+parentID+"?Type=file&Name="+name, "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
+			upload(t, "/files/"+subID+"?Type=file&Name="+name, "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
+			upload(t, "/files/"+subsubID+"?Type=file&Name="+name, "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
+		}
+
+		var result struct {
+			Data struct {
+				Type       string
+				ID         string
+				Attributes struct {
+					Size string
+				}
+			}
+		}
+		err := getJSON(t, "/files/"+subsubID+"/size", &result)
+		assert.NoError(t, err)
+		assert.Equal(t, consts.DirSizes, result.Data.Type)
+		assert.Equal(t, subsubID, result.Data.ID)
+		assert.Equal(t, "30", result.Data.Attributes.Size)
+
+		err = getJSON(t, "/files/"+subID+"/size", &result)
+		assert.NoError(t, err)
+		assert.Equal(t, consts.DirSizes, result.Data.Type)
+		assert.Equal(t, subID, result.Data.ID)
+		assert.Equal(t, "60", result.Data.Attributes.Size)
+
+		err = getJSON(t, "/files/"+parentID+"/size", &result)
+		assert.NoError(t, err)
+		assert.Equal(t, consts.DirSizes, result.Data.Type)
+		assert.Equal(t, parentID, result.Data.ID)
+		assert.Equal(t, "90", result.Data.Attributes.Size)
+	})
+
+	t.Run("DeprecatePreviewAndIcon", func(t *testing.T) {
+		testutils.TODO(t, "2023-12-01", "Remove the deprecated preview and icon for PDF files")
+	})
+
+}
+
 func readFile(fs vfs.VFS, name string) ([]byte, error) {
 	doc, err := fs.FileByPath(name)
 	if err != nil {
@@ -171,13 +2873,6 @@ func extractDirData(t *testing.T, data map[string]interface{}) (string, map[stri
 	return id, data
 }
 
-type jsonData struct {
-	Type  string                 `json:"type"`
-	ID    string                 `json:"id"`
-	Attrs map[string]interface{} `json:"attributes,omitempty"`
-	Rels  map[string]interface{} `json:"relationships,omitempty"`
-}
-
 func patchFile(t *testing.T, path, docType, id string, attrs map[string]interface{}, parent *jsonData) (res *http.Response, v map[string]interface{}) {
 	bodyreq := &jsonData{
 		Type:  docType,
@@ -227,2696 +2922,6 @@ func download(t *testing.T, path, byteRange string) (res *http.Response, body []
 	require.NoError(t, err)
 
 	return
-}
-
-func TestChanges(t *testing.T) {
-	_, foo := createDir(t, "/files/?Name=foo&Type=directory")
-	fooID := foo["data"].(map[string]interface{})["id"].(string)
-	_, bar := createDir(t, "/files/"+fooID+"?Name=bar&Type=directory")
-	barID := bar["data"].(map[string]interface{})["id"].(string)
-	_, _ = upload(t, "/files/"+barID+"?Type=file&Name=baz", "text/plain", "baz", "")
-
-	_, qux := createDir(t, "/files/?Name=qux&Type=directory")
-	quxID := qux["data"].(map[string]interface{})["id"].(string)
-	_, _ = trash(t, "/files/"+quxID)
-	req, err := http.NewRequest(http.MethodDelete, ts.URL+"/files/trash", nil)
-	assert.NoError(t, err)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	_, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-
-	req, _ = http.NewRequest("GET", ts.URL+"/files/_changes?include_docs=true&include_file_path=true", nil)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-
-	var obj map[string]interface{}
-	err = extractJSONRes(res, &obj)
-	assert.NoError(t, err)
-	assert.NotEmpty(t, obj["last_seq"])
-	assert.NotNil(t, obj["pending"])
-	results := obj["results"].([]interface{})
-	hasDeleted := false
-	hasTrashed := false
-	for _, result := range results {
-		result, _ := result.(map[string]interface{})
-		assert.NotEmpty(t, result["id"])
-		if result["deleted"] == true {
-			hasDeleted = true
-		} else {
-			doc, _ := result["doc"].(map[string]interface{})
-			assert.NotEmpty(t, doc["type"])
-			assert.NotEmpty(t, doc["path"])
-			if doc["path"] == "/.cozy_trash" {
-				hasTrashed = true
-			}
-		}
-	}
-	assert.True(t, hasDeleted)
-	assert.True(t, hasTrashed)
-
-	req, _ = http.NewRequest("GET", ts.URL+"/files/_changes?include_docs=true&fields=type,name,dir_id", nil)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-
-	err = extractJSONRes(res, &obj)
-	assert.NoError(t, err)
-	assert.NotEmpty(t, obj["last_seq"])
-	assert.NotNil(t, obj["pending"])
-	results = obj["results"].([]interface{})
-	for _, result := range results {
-		result, _ := result.(map[string]interface{})
-		assert.NotEmpty(t, result["id"])
-		if result["deleted"] != true && result["id"] != "io.cozy.files.root-dir" {
-			doc, _ := result["doc"].(map[string]interface{})
-			assert.NotEmpty(t, doc["type"])
-			assert.NotEmpty(t, doc["name"])
-			assert.NotEmpty(t, doc["dir_id"])
-			assert.Empty(t, doc["path"])
-			assert.Empty(t, doc["metadata"])
-			assert.Empty(t, doc["created_at"])
-		}
-	}
-
-	_, _ = trash(t, "/files/"+barID)
-	req, _ = http.NewRequest("GET", ts.URL+"/files/_changes?include_docs=true&skip_deleted=true&skip_trashed=true", nil)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-
-	err = extractJSONRes(res, &obj)
-	assert.NoError(t, err)
-	assert.NotEmpty(t, obj["last_seq"])
-	assert.NotNil(t, obj["pending"])
-	results = obj["results"].([]interface{})
-	hasDeleted = false
-	hasTrashed = false
-	for _, result := range results {
-		result, _ := result.(map[string]interface{})
-		assert.NotEmpty(t, result["id"])
-		if result["deleted"] == true {
-			hasDeleted = true
-		} else {
-			doc, _ := result["doc"].(map[string]interface{})
-			assert.NotEmpty(t, doc["type"])
-			assert.NotEmpty(t, doc["path"])
-			if doc["path"] == "/.cozy_trash" {
-				hasTrashed = true
-			}
-			if doc["type"] == "directory" && strings.HasPrefix(doc["path"].(string), "/.cozy_trash") {
-				hasTrashed = true
-			}
-			if doc["type"] == "file" && doc["trashed"] == true {
-				hasTrashed = true
-			}
-		}
-	}
-	assert.False(t, hasDeleted)
-	assert.False(t, hasTrashed)
-
-	_, _ = trash(t, "/files/"+fooID)
-	req, err = http.NewRequest(http.MethodDelete, ts.URL+"/files/trash", nil)
-	assert.NoError(t, err)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	_, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-}
-
-func TestCreateDirWithNoType(t *testing.T) {
-	res, _ := createDir(t, "/files/")
-	assert.Equal(t, 422, res.StatusCode)
-}
-
-func TestCreateDirWithNoName(t *testing.T) {
-	res, _ := createDir(t, "/files/?Type=directory")
-	assert.Equal(t, 422, res.StatusCode)
-}
-
-func TestCreateDirOnNonExistingParent(t *testing.T) {
-	res, _ := createDir(t, "/files/noooop?Name=foo&Type=directory")
-	assert.Equal(t, 404, res.StatusCode)
-}
-
-func TestCreateDirAlreadyExists(t *testing.T) {
-	res1, _ := createDir(t, "/files/?Name=iexist&Type=directory")
-	assert.Equal(t, 201, res1.StatusCode)
-
-	res2, _ := createDir(t, "/files/?Name=iexist&Type=directory")
-	assert.Equal(t, 409, res2.StatusCode)
-}
-
-func TestCreateDirRootSuccess(t *testing.T) {
-	res, _ := createDir(t, "/files/?Name=coucou&Type=directory")
-	assert.Equal(t, 201, res.StatusCode)
-
-	storage := testInstance.VFS()
-	exists, err := vfs.DirExists(storage, "/coucou")
-	assert.NoError(t, err)
-	assert.True(t, exists)
-}
-
-func TestCreateDirWithDateSuccess(t *testing.T) {
-	req, _ := http.NewRequest("POST", ts.URL+"/files/?Type=directory&Name=dir-with-date&CreatedAt=2016-09-18T10:24:53Z", strings.NewReader(""))
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	req.Header.Add("Date", "Mon, 19 Sep 2016 12:35:08 GMT")
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 201, res.StatusCode)
-
-	var obj map[string]interface{}
-	err = extractJSONRes(res, &obj)
-	assert.NoError(t, err)
-	data := obj["data"].(map[string]interface{})
-	attrs := data["attributes"].(map[string]interface{})
-	createdAt := attrs["created_at"].(string)
-	assert.Equal(t, "2016-09-18T10:24:53Z", createdAt)
-	updatedAt := attrs["updated_at"].(string)
-	assert.Equal(t, "2016-09-19T12:35:08Z", updatedAt)
-	fcm := attrs["cozyMetadata"].(map[string]interface{})
-	assert.Equal(t, float64(1), fcm["metadataVersion"])
-	assert.Equal(t, "1", fcm["doctypeVersion"])
-	assert.Contains(t, fcm["createdOn"], testInstance.Domain)
-	assert.NotEmpty(t, fcm["createdAt"])
-	assert.NotEmpty(t, fcm["updatedAt"])
-	assert.NotContains(t, fcm, "uploadedAt")
-}
-
-func TestCreateDirWithDateSuccessAndUpdatedAt(t *testing.T) {
-	req, _ := http.NewRequest("POST", ts.URL+"/files/?Type=directory&Name=dir-with-date-and-updatedat&CreatedAt=2016-09-18T10:24:53Z&UpdatedAt=2020-05-12T12:25:00Z", strings.NewReader(""))
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 201, res.StatusCode)
-
-	var obj map[string]interface{}
-	err = extractJSONRes(res, &obj)
-	assert.NoError(t, err)
-	data := obj["data"].(map[string]interface{})
-	attrs := data["attributes"].(map[string]interface{})
-	createdAt := attrs["created_at"].(string)
-	assert.Equal(t, "2016-09-18T10:24:53Z", createdAt)
-	updatedAt := attrs["updated_at"].(string)
-	assert.Equal(t, "2020-05-12T12:25:00Z", updatedAt)
-	fcm := attrs["cozyMetadata"].(map[string]interface{})
-	assert.Equal(t, float64(1), fcm["metadataVersion"])
-	assert.Equal(t, "1", fcm["doctypeVersion"])
-	assert.Contains(t, fcm["createdOn"], testInstance.Domain)
-	assert.NotEmpty(t, fcm["createdAt"])
-	assert.NotEmpty(t, fcm["updatedAt"])
-	assert.NotContains(t, fcm, "uploadedAt")
-}
-
-func TestCreateDirWithParentSuccess(t *testing.T) {
-	res1, data1 := createDir(t, "/files/?Name=dirparent&Type=directory")
-	assert.Equal(t, 201, res1.StatusCode)
-
-	var ok bool
-	data1, ok = data1["data"].(map[string]interface{})
-	assert.True(t, ok)
-
-	parentID, ok := data1["id"].(string)
-	assert.True(t, ok)
-
-	res2, _ := createDir(t, "/files/"+parentID+"?Name=child&Type=directory")
-	assert.Equal(t, 201, res2.StatusCode)
-
-	storage := testInstance.VFS()
-	exists, err := vfs.DirExists(storage, "/dirparent/child")
-	assert.NoError(t, err)
-	assert.True(t, exists)
-}
-
-func TestCreateDirWithIllegalCharacter(t *testing.T) {
-	res1, _ := createDir(t, "/files/?Name=coucou/les/copains!&Type=directory")
-	assert.Equal(t, 422, res1.StatusCode)
-}
-
-func TestCreateDirConcurrently(t *testing.T) {
-	done := make(chan *http.Response)
-	errs := make(chan *http.Response)
-
-	doCreateDir := func(name string) {
-		res, _ := createDir(t, "/files/?Name="+name+"&Type=directory")
-		if res.StatusCode == 201 {
-			done <- res
-		} else {
-			errs <- res
-		}
-	}
-
-	n := 100
-	c := 0
-
-	for i := 0; i < n; i++ {
-		go doCreateDir("foo")
-	}
-
-	for i := 0; i < n; i++ {
-		select {
-		case res := <-errs:
-			assert.True(t, res.StatusCode == 409 || res.StatusCode == 503)
-		case <-done:
-			c += 1
-		}
-	}
-
-	assert.Equal(t, 1, c)
-}
-
-func TestUploadWithNoType(t *testing.T) {
-	res, _ := upload(t, "/files/", "text/plain", "foo", "")
-	assert.Equal(t, 422, res.StatusCode)
-}
-
-func TestUploadWithNoName(t *testing.T) {
-	res, _ := upload(t, "/files/?Type=file", "text/plain", "foo", "")
-	assert.Equal(t, 422, res.StatusCode)
-}
-
-func TestUploadToNonExistingParent(t *testing.T) {
-	res, _ := upload(t, "/files/nooop?Type=file&Name=no-parent", "text/plain", "foo", "")
-	assert.Equal(t, 404, res.StatusCode)
-}
-
-func TestUploadWithInvalidContentType(t *testing.T) {
-	res, _ := upload(t, "/files/?Type=file&Name=InvalidMime", "foo € / bar", "foo", "")
-	assert.Equal(t, 422, res.StatusCode)
-}
-
-func TestUploadToTrashedFolder(t *testing.T) {
-	res1, data1 := createDir(t, "/files/?Name=trashed-parent&Type=directory")
-	assert.Equal(t, 201, res1.StatusCode)
-	dirID, _ := extractDirData(t, data1)
-	res2, _ := trash(t, "/files/"+dirID)
-	assert.Equal(t, 200, res2.StatusCode)
-	res3, _ := upload(t, "/files/"+dirID+"?Type=file&Name=trashed-parent", "text/plain", "foo", "")
-	assert.Equal(t, 404, res3.StatusCode)
-}
-
-func TestUploadBadSize(t *testing.T) {
-	body := "foo"
-	res, _ := upload(t, "/files/?Type=file&Name=badsize&Size=42", "text/plain", body, "")
-	assert.Equal(t, 412, res.StatusCode)
-
-	storage := testInstance.VFS()
-	_, err := readFile(storage, "/badsize")
-	assert.Error(t, err)
-}
-
-func TestUploadBadHash(t *testing.T) {
-	body := "foo"
-	res, _ := upload(t, "/files/?Type=file&Name=badhash", "text/plain", body, "3FbbMXfH+PdjAlWFfVb1dQ==")
-	assert.Equal(t, 412, res.StatusCode)
-
-	storage := testInstance.VFS()
-	_, err := readFile(storage, "/badhash")
-	assert.Error(t, err)
-}
-
-func TestUploadAtRootSuccess(t *testing.T) {
-	body := "foo"
-	res, _ := upload(t, "/files/?Type=file&Name=goodhash", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
-	assert.Equal(t, 201, res.StatusCode)
-
-	storage := testInstance.VFS()
-	buf, err := readFile(storage, "/goodhash")
-	assert.NoError(t, err)
-	assert.Equal(t, body, string(buf))
-}
-
-func TestUploadImage(t *testing.T) {
-	f, err := os.Open("../../tests/fixtures/wet-cozy_20160910__M4Dz.jpg")
-	assert.NoError(t, err)
-	defer f.Close()
-	m := `{"gps":{"city":"Paris","country":"France"}}`
-	req, err := http.NewRequest("POST", ts.URL+"/files/?Type=file&Name=wet.jpg&Metadata="+m, f)
-	assert.NoError(t, err)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	res, obj := doUploadOrMod(t, req, "image/jpeg", "tHWYYuXBBflJ8wXgJ2c2yg==")
-	assert.Equal(t, 201, res.StatusCode)
-	data := obj["data"].(map[string]interface{})
-	imgID = data["id"].(string)
-	attrs := data["attributes"].(map[string]interface{})
-	meta := attrs["metadata"].(map[string]interface{})
-	v := meta["extractor_version"].(float64)
-	assert.Equal(t, float64(vfs.MetadataExtractorVersion), v)
-	flash := meta["flash"].(string)
-	assert.Equal(t, "Off, Did not fire", flash)
-	gps := meta["gps"].(map[string]interface{})
-	assert.Equal(t, "Paris", gps["city"])
-	assert.Equal(t, "France", gps["country"])
-	assert.Contains(t, attrs["created_at"], "2016-09-10T")
-}
-
-func TestUploadShortcut(t *testing.T) {
-	f, err := os.Open("../../tests/fixtures/shortcut.url")
-	assert.NoError(t, err)
-	defer f.Close()
-	req, err := http.NewRequest("POST", ts.URL+"/files/?Type=file&Name=shortcut.url", f)
-	assert.NoError(t, err)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	res, obj := doUploadOrMod(t, req, "application/octet-stream", "+tHtr9V8+4gcCDxTFAqt3w==")
-	assert.Equal(t, 201, res.StatusCode)
-	data := obj["data"].(map[string]interface{})
-	attrs := data["attributes"].(map[string]interface{})
-	assert.Equal(t, "application/internet-shortcut", attrs["mime"])
-	assert.Equal(t, "shortcut", attrs["class"])
-}
-
-func TestUploadWithParentSuccess(t *testing.T) {
-	res1, data1 := createDir(t, "/files/?Name=fileparent&Type=directory")
-	assert.Equal(t, 201, res1.StatusCode)
-
-	var ok bool
-	data1, ok = data1["data"].(map[string]interface{})
-	assert.True(t, ok)
-
-	parentID, ok := data1["id"].(string)
-	assert.True(t, ok)
-
-	body := "foo"
-	res2, _ := upload(t, "/files/"+parentID+"?Type=file&Name=goodhash", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
-	assert.Equal(t, 201, res2.StatusCode)
-
-	storage := testInstance.VFS()
-	buf, err := readFile(storage, "/fileparent/goodhash")
-	assert.NoError(t, err)
-	assert.Equal(t, body, string(buf))
-}
-
-func TestUploadAtRootAlreadyExists(t *testing.T) {
-	body := "foo"
-	res1, _ := upload(t, "/files/?Type=file&Name=iexistfile", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
-	assert.Equal(t, 201, res1.StatusCode)
-
-	res2, _ := upload(t, "/files/?Type=file&Name=iexistfile", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
-	assert.Equal(t, 409, res2.StatusCode)
-}
-
-func TestUploadWithParentAlreadyExists(t *testing.T) {
-	_, dirdata := createDir(t, "/files/?Type=directory&Name=container")
-
-	var ok bool
-	dirdata, ok = dirdata["data"].(map[string]interface{})
-	assert.True(t, ok)
-
-	parentID, ok := dirdata["id"].(string)
-	assert.True(t, ok)
-
-	body := "foo"
-	res1, _ := upload(t, "/files/"+parentID+"?Type=file&Name=iexistfile", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
-	assert.Equal(t, 201, res1.StatusCode)
-
-	res2, _ := upload(t, "/files/"+parentID+"?Type=file&Name=iexistfile", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
-	assert.Equal(t, 409, res2.StatusCode)
-}
-
-func TestUploadWithCreatedAtAndHeaderDate(t *testing.T) {
-	buf := strings.NewReader("foo")
-	req, err := http.NewRequest("POST", ts.URL+"/files/?Type=file&Name=withcdate&CreatedAt=2016-09-18T10:24:53Z", buf)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	assert.NoError(t, err)
-	req.Header.Add("Date", "Mon, 19 Sep 2016 12:38:04 GMT")
-	res, obj := doUploadOrMod(t, req, "text/plain", "rL0Y20zC+Fzt72VPzMSk2A==")
-	assert.Equal(t, 201, res.StatusCode)
-	data := obj["data"].(map[string]interface{})
-	attrs := data["attributes"].(map[string]interface{})
-	createdAt := attrs["created_at"].(string)
-	assert.Equal(t, "2016-09-18T10:24:53Z", createdAt)
-	updatedAt := attrs["updated_at"].(string)
-	assert.Equal(t, "2016-09-19T12:38:04Z", updatedAt)
-}
-
-func TestUploadWithCreatedAtAndUpdatedAt(t *testing.T) {
-	buf := strings.NewReader("foo")
-	req, err := http.NewRequest("POST", ts.URL+"/files/?Type=file&Name=TestUploadWithCreatedAtAndUpdatedAt&CreatedAt=2016-09-18T10:24:53Z&UpdatedAt=2020-05-12T12:25:00Z", buf)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	assert.NoError(t, err)
-	res, obj := doUploadOrMod(t, req, "text/plain", "rL0Y20zC+Fzt72VPzMSk2A==")
-	assert.Equal(t, 201, res.StatusCode)
-	data := obj["data"].(map[string]interface{})
-	attrs := data["attributes"].(map[string]interface{})
-	createdAt := attrs["created_at"].(string)
-	assert.Equal(t, "2016-09-18T10:24:53Z", createdAt)
-	updatedAt := attrs["updated_at"].(string)
-	assert.Equal(t, "2020-05-12T12:25:00Z", updatedAt)
-}
-
-func TestUploadWithCreatedAtAndUpdatedAtAndDateHeader(t *testing.T) {
-	buf := strings.NewReader("foo")
-	req, err := http.NewRequest("POST", ts.URL+"/files/?Type=file&Name=TestUploadWithCreatedAtAndUpdatedAtAndDateHeader&CreatedAt=2016-09-18T10:24:53Z&UpdatedAt=2020-05-12T12:25:00Z", buf)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	assert.NoError(t, err)
-	req.Header.Add("Date", "Mon, 19 Sep 2016 12:38:04 GMT")
-	res, obj := doUploadOrMod(t, req, "text/plain", "rL0Y20zC+Fzt72VPzMSk2A==")
-	assert.Equal(t, 201, res.StatusCode)
-	data := obj["data"].(map[string]interface{})
-	attrs := data["attributes"].(map[string]interface{})
-	createdAt := attrs["created_at"].(string)
-	assert.Equal(t, "2016-09-18T10:24:53Z", createdAt)
-	updatedAt := attrs["updated_at"].(string)
-	assert.Equal(t, "2020-05-12T12:25:00Z", updatedAt)
-}
-
-func TestUploadWithMetadata(t *testing.T) {
-	buf := strings.NewReader(`{
-    "data": {
-        "type": "io.cozy.files.metadata",
-        "attributes": {
-            "category": "report",
-            "subCategory": "theft",
-            "datetime": "2017-04-22T01:00:00-05:00",
-            "label": "foobar"
-        }
-    }
-}`)
-	req, err := http.NewRequest("POST", ts.URL+"/files/upload/metadata", buf)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	assert.NoError(t, err)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, 201, res.StatusCode)
-	var obj map[string]interface{}
-	err = extractJSONRes(res, &obj)
-	assert.NoError(t, err)
-	data := obj["data"].(map[string]interface{})
-	assert.Equal(t, consts.FilesMetadata, data["type"])
-	secret := data["id"].(string)
-	attrs := data["attributes"].(map[string]interface{})
-	assert.Equal(t, "report", attrs["category"])
-	assert.Equal(t, "theft", attrs["subCategory"])
-	assert.Equal(t, "foobar", attrs["label"])
-	assert.Equal(t, "2017-04-22T01:00:00-05:00", attrs["datetime"])
-
-	u := "/files/?Type=file&Name=withmetadataid&MetadataID=" + secret
-	buf = strings.NewReader("foo")
-	req, err = http.NewRequest("POST", ts.URL+u, buf)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	assert.NoError(t, err)
-	res, obj = doUploadOrMod(t, req, "text/plain", "rL0Y20zC+Fzt72VPzMSk2A==")
-	assert.Equal(t, 201, res.StatusCode)
-	data = obj["data"].(map[string]interface{})
-	attrs = data["attributes"].(map[string]interface{})
-	meta := attrs["metadata"].(map[string]interface{})
-	assert.Equal(t, "report", meta["category"])
-	assert.Equal(t, "theft", meta["subCategory"])
-	assert.Equal(t, "foobar", meta["label"])
-	assert.Equal(t, "2017-04-22T01:00:00-05:00", meta["datetime"])
-}
-
-func TestUploadWithSourceAccount(t *testing.T) {
-	buf := strings.NewReader("foo")
-	account := "0c5a0a1e-8eb1-11e9-93f3-934f3a2c181d"
-	identifier := "11f68e48"
-	req, err := http.NewRequest("POST", ts.URL+"/files/?Type=file&Name=with-sourceAccount&SourceAccount="+account+"&SourceAccountIdentifier="+identifier, buf)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	assert.NoError(t, err)
-	res, obj := doUploadOrMod(t, req, "text/plain", "rL0Y20zC+Fzt72VPzMSk2A==")
-	assert.Equal(t, 201, res.StatusCode)
-	data := obj["data"].(map[string]interface{})
-	attrs := data["attributes"].(map[string]interface{})
-	fcm := attrs["cozyMetadata"].(map[string]interface{})
-	assert.Equal(t, account, fcm["sourceAccount"])
-	assert.Equal(t, identifier, fcm["sourceAccountIdentifier"])
-}
-
-func TestCopyFile(t *testing.T) {
-	_, copyFileDir := createDir(t, "/files/?Name=copyFileDir&Type=directory")
-	fmt.Println(copyFileDir)
-	copyFileDirID := copyFileDir["data"].(map[string]interface{})["id"].(string)
-
-	fileName := "bar"
-	fileExt := ".txt"
-	fileContent := "file content"
-
-	// 1. Upload file and get its id
-	res, obj := upload(t, "/files/"+copyFileDirID+"?Type=file&Name="+fileName+fileExt, "text/plain", fileContent, "")
-	require.Equal(t, 201, res.StatusCode)
-	data := obj["data"].(map[string]interface{})
-	fileID = data["id"].(string)
-	fileAttributes := data["attributes"].(map[string]interface{})
-
-	var body map[string]interface{}
-
-	// 2. Send file copy request
-	res, _ = httpPost(ts.URL+"/files/"+fileID+"/copy", "")
-	require.Equal(t, 201, res.StatusCode)
-	require.NoError(t, json.NewDecoder(res.Body).Decode(&body))
-	copyID := body["data"].(map[string]interface{})["id"].(string)
-	require.NotEqual(t, fileID, copyID)
-
-	// 3. Fetch copy metadata and compare with file
-	res, _ = httpGet(ts.URL + "/files/" + copyID)
-	require.Equal(t, 200, res.StatusCode)
-	require.NoError(t, json.NewDecoder(res.Body).Decode(&body))
-	data = body["data"].(map[string]interface{})
-
-	copyAttributes := data["attributes"].(map[string]interface{})
-	assert.NotEmpty(t, copyAttributes["created_at"])
-	assert.NotEqual(t, fileAttributes["created_at"], copyAttributes["created_at"])
-	assert.Equal(t, fileAttributes["dir_id"], copyAttributes["dir_id"])
-	assert.Equal(t, fileName+" (copy)"+fileExt, copyAttributes["name"])
-	assert.Equal(t, fileAttributes["md5sum"], copyAttributes["md5sum"])
-
-	rels := data["relationships"].(map[string]interface{})
-	assert.Nil(t, rels["old_versions"])
-
-	// 4. fetch copy and check its content
-	res, resbody := download(t, "/files/download/"+copyID, "")
-	require.Equal(t, 200, res.StatusCode)
-	assert.True(t, strings.HasPrefix(res.Header.Get("Content-Disposition"), "inline"))
-	assert.True(t, strings.Contains(res.Header.Get("Content-Disposition"), `filename="`+fileName+"(copy)"+fileExt+`"`))
-	assert.True(t, strings.HasPrefix(res.Header.Get("Content-Type"), "text/plain"))
-	assert.NotEmpty(t, res.Header.Get("Etag"))
-	assert.Equal(t, res.Header.Get("Etag")[:1], `"`)
-	assert.Equal(t, res.Header.Get("Content-Length"), strconv.Itoa(len(fileContent)))
-	assert.Equal(t, res.Header.Get("Accept-Ranges"), "bytes")
-	assert.Equal(t, fileContent, string(resbody))
-
-	// 5. Send file copy request specifying copy name and parent id
-	_, destDir := createDir(t, "/files/?Name=destDir&Type=directory")
-	destDirID := destDir["data"].(map[string]interface{})["id"].(string)
-	copyName := "My-file-copy"
-
-	res, _ = httpPost(ts.URL+"/files/"+fileID+"/copy?Name="+copyName+"&DirID="+destDirID, "")
-	require.Equal(t, 201, res.StatusCode)
-	require.NoError(t, json.NewDecoder(res.Body).Decode(&body))
-	copyID = body["data"].(map[string]interface{})["id"].(string)
-	assert.NotEqual(t, fileID, copyID)
-
-	// 6. Fetch copy metadata and compare with file
-	res, _ = httpGet(ts.URL + "/files/" + copyID)
-	require.Equal(t, 200, res.StatusCode)
-	require.NoError(t, json.NewDecoder(res.Body).Decode(&body))
-	data = body["data"].(map[string]interface{})
-
-	copyAttributes = data["attributes"].(map[string]interface{})
-	assert.Equal(t, destDirID, copyAttributes["dir_id"])
-	assert.Equal(t, copyName, copyAttributes["name"])
-}
-
-func TestModifyMetadataByPath(t *testing.T) {
-	body := "foo"
-	res1, data1 := upload(t, "/files/?Type=file&Name=file-move-me-by-path", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
-	assert.Equal(t, 201, res1.StatusCode)
-
-	var ok bool
-	data1, ok = data1["data"].(map[string]interface{})
-	assert.True(t, ok)
-
-	fileID, ok := data1["id"].(string)
-	assert.True(t, ok)
-
-	res2, data2 := createDir(t, "/files/?Name=move-by-path&Type=directory")
-	assert.Equal(t, 201, res2.StatusCode)
-
-	data2, ok = data2["data"].(map[string]interface{})
-	assert.True(t, ok)
-
-	dirID, ok := data2["id"].(string)
-	assert.True(t, ok)
-
-	attrs := map[string]interface{}{
-		"tags":       []string{"bar", "bar", "baz"},
-		"name":       "moved",
-		"dir_id":     dirID,
-		"executable": true,
-	}
-
-	res3, data3 := patchFile(t, "/files/metadata?Path=/file-move-me-by-path", "file", fileID, attrs, nil)
-	assert.Equal(t, 200, res3.StatusCode)
-
-	data3, ok = data3["data"].(map[string]interface{})
-	assert.True(t, ok)
-
-	attrs3, ok := data3["attributes"].(map[string]interface{})
-	assert.True(t, ok)
-
-	assert.Equal(t, "text/plain", attrs3["mime"])
-	assert.Equal(t, "moved", attrs3["name"])
-	assert.EqualValues(t, []interface{}{"bar", "baz"}, attrs3["tags"])
-	assert.Equal(t, "text", attrs3["class"])
-	assert.Equal(t, "rL0Y20zC+Fzt72VPzMSk2A==", attrs3["md5sum"])
-	assert.Equal(t, true, attrs3["executable"])
-	assert.Equal(t, "3", attrs3["size"])
-}
-
-func TestModifyMetadataFileMove(t *testing.T) {
-	body := "foo"
-	res1, data1 := upload(t, "/files/?Type=file&Name=filemoveme&Tags=foo,bar", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
-	assert.Equal(t, 201, res1.StatusCode)
-
-	var ok bool
-	data1, ok = data1["data"].(map[string]interface{})
-	assert.True(t, ok)
-
-	fileID, ok := data1["id"].(string)
-	assert.True(t, ok)
-
-	res2, data2 := createDir(t, "/files/?Name=movemeinme&Type=directory")
-	assert.Equal(t, 201, res2.StatusCode)
-
-	data2, ok = data2["data"].(map[string]interface{})
-	assert.True(t, ok)
-
-	dirID, ok := data2["id"].(string)
-	assert.True(t, ok)
-
-	attrs := map[string]interface{}{
-		"tags":       []string{"bar", "bar", "baz"},
-		"name":       "moved",
-		"dir_id":     dirID,
-		"executable": true,
-	}
-
-	res3, data3 := patchFile(t, "/files/"+fileID, "file", fileID, attrs, nil)
-	assert.Equal(t, 200, res3.StatusCode)
-
-	data3, ok = data3["data"].(map[string]interface{})
-	assert.True(t, ok)
-
-	attrs3, ok := data3["attributes"].(map[string]interface{})
-	assert.True(t, ok)
-
-	assert.Equal(t, "text/plain", attrs3["mime"])
-	assert.Equal(t, "moved", attrs3["name"])
-	assert.EqualValues(t, []interface{}{"bar", "baz"}, attrs3["tags"])
-	assert.Equal(t, "text", attrs3["class"])
-	assert.Equal(t, "rL0Y20zC+Fzt72VPzMSk2A==", attrs3["md5sum"])
-	assert.Equal(t, true, attrs3["executable"])
-	assert.Equal(t, "3", attrs3["size"])
-}
-
-func TestModifyMetadataFileConflict(t *testing.T) {
-	body := "foo"
-	res1, data1 := upload(t, "/files/?Type=file&Name=fmodme1&Tags=foo,bar", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
-	assert.Equal(t, 201, res1.StatusCode)
-
-	res2, _ := upload(t, "/files/?Type=file&Name=fmodme2&Tags=foo,bar", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
-	assert.Equal(t, 201, res2.StatusCode)
-
-	file1ID, _ := extractDirData(t, data1)
-
-	attrs := map[string]interface{}{
-		"name": "fmodme2",
-	}
-
-	res3, _ := patchFile(t, "/files/"+file1ID, "file", file1ID, attrs, nil)
-	assert.Equal(t, 409, res3.StatusCode)
-}
-
-func TestModifyMetadataDirMove(t *testing.T) {
-	res1, data1 := createDir(t, "/files/?Name=dirmodme&Type=directory&Tags=foo,bar,bar")
-	assert.Equal(t, 201, res1.StatusCode)
-
-	dir1ID, _ := extractDirData(t, data1)
-
-	reschild1, _ := createDir(t, "/files/"+dir1ID+"?Name=child1&Type=directory")
-	assert.Equal(t, 201, reschild1.StatusCode)
-
-	reschild2, _ := createDir(t, "/files/"+dir1ID+"?Name=child2&Type=directory")
-	assert.Equal(t, 201, reschild2.StatusCode)
-
-	res2, data2 := createDir(t, "/files/?Name=dirmodmemoveinme&Type=directory")
-	assert.Equal(t, 201, res2.StatusCode)
-
-	dir2ID, _ := extractDirData(t, data2)
-
-	attrs1 := map[string]interface{}{
-		"tags":   []string{"bar", "baz"},
-		"name":   "renamed",
-		"dir_id": dir2ID,
-	}
-
-	res3, _ := patchFile(t, "/files/"+dir1ID, "directory", dir1ID, attrs1, nil)
-	assert.Equal(t, 200, res3.StatusCode)
-
-	storage := testInstance.VFS()
-	exists, err := vfs.DirExists(storage, "/dirmodmemoveinme/renamed")
-	assert.NoError(t, err)
-	assert.True(t, exists)
-
-	attrs2 := map[string]interface{}{
-		"tags":   []string{"bar", "baz"},
-		"name":   "renamed",
-		"dir_id": dir1ID,
-	}
-
-	res4, _ := patchFile(t, "/files/"+dir2ID, "directory", dir2ID, attrs2, nil)
-	assert.Equal(t, 412, res4.StatusCode)
-
-	res5, _ := patchFile(t, "/files/"+dir1ID, "directory", dir1ID, attrs2, nil)
-	assert.Equal(t, 412, res5.StatusCode)
-}
-
-func TestModifyMetadataDirMoveWithRel(t *testing.T) {
-	res1, data1 := createDir(t, "/files/?Name=dirmodmewithrel&Type=directory&Tags=foo,bar,bar")
-	assert.Equal(t, 201, res1.StatusCode)
-
-	dir1ID, _ := extractDirData(t, data1)
-
-	reschild1, datachild1 := createDir(t, "/files/"+dir1ID+"?Name=child1&Type=directory")
-	assert.Equal(t, 201, reschild1.StatusCode)
-
-	reschild2, datachild2 := createDir(t, "/files/"+dir1ID+"?Name=child2&Type=directory")
-	assert.Equal(t, 201, reschild2.StatusCode)
-
-	res2, data2 := createDir(t, "/files/?Name=dirmodmemoveinmewithrel&Type=directory")
-	assert.Equal(t, 201, res2.StatusCode)
-
-	dir2ID, _ := extractDirData(t, data2)
-	extractDirData(t, datachild1)
-	extractDirData(t, datachild2)
-
-	parent := &jsonData{
-		ID:   dir2ID,
-		Type: "io.cozy.files",
-	}
-
-	res3, _ := patchFile(t, "/files/"+dir1ID, "directory", dir1ID, nil, parent)
-	assert.Equal(t, 200, res3.StatusCode)
-
-	storage := testInstance.VFS()
-	exists, err := vfs.DirExists(storage, "/dirmodmemoveinmewithrel/dirmodmewithrel")
-	assert.NoError(t, err)
-	assert.True(t, exists)
-}
-
-func TestModifyMetadataDirMoveConflict(t *testing.T) {
-	res1, _ := createDir(t, "/files/?Name=conflictmodme1&Type=directory&Tags=foo,bar,bar")
-	assert.Equal(t, 201, res1.StatusCode)
-
-	res2, data2 := createDir(t, "/files/?Name=conflictmodme2&Type=directory")
-	assert.Equal(t, 201, res2.StatusCode)
-
-	dir2ID, _ := extractDirData(t, data2)
-
-	attrs1 := map[string]interface{}{
-		"tags": []string{"bar", "baz"},
-		"name": "conflictmodme1",
-	}
-
-	res3, _ := patchFile(t, "/files/"+dir2ID, "directory", dir2ID, attrs1, nil)
-	assert.Equal(t, 409, res3.StatusCode)
-}
-
-func TestModifyContentNoFileID(t *testing.T) {
-	res, _ := uploadMod(t, "/files/badid", "text/plain", "nil", "")
-	assert.Equal(t, 404, res.StatusCode)
-}
-
-func TestModifyContentBadRev(t *testing.T) {
-	res1, data1 := upload(t, "/files/?Type=file&Name=modbadrev&Executable=true", "text/plain", "foo", "")
-	assert.Equal(t, 201, res1.StatusCode)
-
-	var ok bool
-	data1, ok = data1["data"].(map[string]interface{})
-	assert.True(t, ok)
-
-	meta1, ok := data1["meta"].(map[string]interface{})
-	assert.True(t, ok)
-
-	fileID, ok := data1["id"].(string)
-	assert.True(t, ok)
-	fileRev, ok := meta1["rev"].(string)
-	assert.True(t, ok)
-
-	newcontent := "newcontent :)"
-
-	req2, err := http.NewRequest("PUT", ts.URL+"/files/"+fileID, strings.NewReader(newcontent))
-	req2.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	assert.NoError(t, err)
-
-	req2.Header.Add("If-Match", "badrev")
-	res2, _ := doUploadOrMod(t, req2, "text/plain", "")
-	assert.Equal(t, 412, res2.StatusCode)
-
-	req3, err := http.NewRequest("PUT", ts.URL+"/files/"+fileID, strings.NewReader(newcontent))
-	req3.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	assert.NoError(t, err)
-
-	req3.Header.Add("If-Match", fileRev)
-	res3, _ := doUploadOrMod(t, req3, "text/plain", "")
-	assert.Equal(t, 200, res3.StatusCode)
-}
-
-func TestModifyContentSuccess(t *testing.T) {
-	var err error
-	var buf []byte
-	var fileInfo os.FileInfo
-
-	storage := testInstance.VFS()
-	res1, data1 := upload(t, "/files/?Type=file&Name=willbemodified&Executable=true", "text/plain", "foo", "")
-	assert.Equal(t, 201, res1.StatusCode)
-
-	buf, err = readFile(storage, "/willbemodified")
-	assert.NoError(t, err)
-	assert.Equal(t, "foo", string(buf))
-	fileInfo, err = storage.FileByPath("/willbemodified")
-	assert.NoError(t, err)
-	assert.Equal(t, fileInfo.Mode().String(), "-rwxr-xr-x")
-
-	var ok bool
-	data1, ok = data1["data"].(map[string]interface{})
-	assert.True(t, ok)
-
-	attrs1, ok := data1["attributes"].(map[string]interface{})
-	assert.True(t, ok)
-
-	links1, ok := data1["links"].(map[string]interface{})
-	assert.True(t, ok)
-
-	fileID, ok := data1["id"].(string)
-	assert.True(t, ok)
-
-	newcontent := "newcontent :)"
-	res2, data2 := uploadMod(t, "/files/"+fileID+"?Executable=false", "audio/mp3", newcontent, "")
-	assert.Equal(t, 200, res2.StatusCode)
-
-	data2, ok = data2["data"].(map[string]interface{})
-	assert.True(t, ok)
-
-	meta2, ok := data2["meta"].(map[string]interface{})
-	assert.True(t, ok)
-
-	attrs2, ok := data2["attributes"].(map[string]interface{})
-	assert.True(t, ok)
-
-	links2, ok := data2["links"].(map[string]interface{})
-	assert.True(t, ok)
-
-	assert.Equal(t, data2["id"], data1["id"], "same id")
-	assert.Equal(t, data2["path"], data1["path"], "same path")
-	assert.NotEqual(t, meta2["rev"], data1["rev"], "different rev")
-	assert.Equal(t, links2["self"], links1["self"], "same self link")
-
-	assert.Equal(t, attrs2["name"], attrs1["name"])
-	assert.Equal(t, attrs2["created_at"], attrs1["created_at"])
-	assert.NotEqual(t, attrs2["updated_at"], attrs1["updated_at"])
-	assert.NotEqual(t, attrs2["size"], attrs1["size"])
-
-	assert.Equal(t, attrs2["size"], strconv.Itoa(len(newcontent)))
-	assert.NotEqual(t, attrs2["md5sum"], attrs1["md5sum"])
-	assert.NotEqual(t, attrs2["class"], attrs1["class"])
-	assert.NotEqual(t, attrs2["mime"], attrs1["mime"])
-	assert.NotEqual(t, attrs2["executable"], attrs1["executable"])
-	assert.Equal(t, attrs2["class"], "audio")
-	assert.Equal(t, attrs2["mime"], "audio/mp3")
-	assert.Equal(t, attrs2["executable"], false)
-
-	buf, err = readFile(storage, "/willbemodified")
-	assert.NoError(t, err)
-	assert.Equal(t, newcontent, string(buf))
-	fileInfo, err = storage.FileByPath("/willbemodified")
-	assert.NoError(t, err)
-	assert.Equal(t, fileInfo.Mode().String(), "-rw-r--r--")
-
-	req, err := http.NewRequest("PUT", ts.URL+"/files/"+fileID, strings.NewReader(""))
-	assert.NoError(t, err)
-
-	req.Header.Add("Date", "Mon, 02 Jan 2006 15:04:05 MST")
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-
-	res3, data3 := doUploadOrMod(t, req, "what/ever", "")
-	assert.Equal(t, 200, res3.StatusCode)
-
-	data3, ok = data3["data"].(map[string]interface{})
-	assert.True(t, ok)
-
-	attrs3, ok := data3["attributes"].(map[string]interface{})
-	assert.True(t, ok)
-
-	assert.Equal(t, "2006-01-02T15:04:05Z", attrs3["updated_at"])
-
-	newcontent = "encryptedcontent"
-	res4, data4 := uploadMod(t, "/files/"+fileID+"?Encrypted=true", "audio/mp3", newcontent, "")
-	assert.Equal(t, 200, res4.StatusCode)
-
-	data4, ok = data4["data"].(map[string]interface{})
-	assert.True(t, ok)
-	attrs4, ok := data4["attributes"].(map[string]interface{})
-	assert.True(t, ok)
-	assert.Equal(t, attrs4["encrypted"], true)
-}
-
-func TestModifyContentWithSourceAccount(t *testing.T) {
-	buf := strings.NewReader("foo")
-	req, err := http.NewRequest("POST", ts.URL+"/files/?Type=file&Name=old-file-to-migrate", buf)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	assert.NoError(t, err)
-	res, obj := doUploadOrMod(t, req, "text/plain", "rL0Y20zC+Fzt72VPzMSk2A==")
-	assert.Equal(t, 201, res.StatusCode)
-	data := obj["data"].(map[string]interface{})
-	fileID, ok := data["id"].(string)
-	assert.True(t, ok)
-
-	account := "0c5a0a1e-8eb1-11e9-93f3-934f3a2c181d"
-	identifier := "11f68e48"
-	newcontent := "updated by a konnector to add the sourceAccount"
-	res2, obj2 := uploadMod(t, "/files/"+fileID+"?SourceAccount="+account+"&SourceAccountIdentifier="+identifier, "text/plain", newcontent, "")
-	assert.Equal(t, 200, res2.StatusCode)
-	data2 := obj2["data"].(map[string]interface{})
-	attrs2 := data2["attributes"].(map[string]interface{})
-	fcm := attrs2["cozyMetadata"].(map[string]interface{})
-	assert.Equal(t, account, fcm["sourceAccount"])
-	assert.Equal(t, identifier, fcm["sourceAccountIdentifier"])
-}
-
-func TestModifyContentWithCreatedAt(t *testing.T) {
-	buf := strings.NewReader("foo")
-	req, err := http.NewRequest("POST", ts.URL+"/files/?Type=file&Name=old-file-with-c", buf)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	assert.NoError(t, err)
-	res, obj := doUploadOrMod(t, req, "text/plain", "rL0Y20zC+Fzt72VPzMSk2A==")
-	assert.Equal(t, 201, res.StatusCode)
-	data := obj["data"].(map[string]interface{})
-	fileID, ok := data["id"].(string)
-	assert.True(t, ok)
-	attrs := data["attributes"].(map[string]interface{})
-	createdAt := attrs["created_at"].(string)
-	updatedAt := attrs["updated_at"].(string)
-
-	createdAt2 := "2017-11-16T13:37:01.345Z"
-	newcontent := "updated by a client with a new CreatedAt"
-	res2, obj2 := uploadMod(t, "/files/"+fileID+"?CreatedAt="+createdAt2, "text/plain", newcontent, "")
-	assert.Equal(t, 200, res2.StatusCode)
-	data2 := obj2["data"].(map[string]interface{})
-	attrs2 := data2["attributes"].(map[string]interface{})
-	createdAt3 := attrs2["created_at"].(string)
-	updatedAt2 := attrs2["updated_at"].(string)
-	assert.Equal(t, createdAt3, createdAt)
-	assert.NotEqual(t, updatedAt2, updatedAt)
-}
-
-func TestModifyContentWithUpdatedAt(t *testing.T) {
-	buf := strings.NewReader("foo")
-	createdAt := "2017-11-16T13:37:01.345Z"
-	req, err := http.NewRequest("POST", ts.URL+"/files/?Type=file&Name=old-file-with-u&CreatedAt="+createdAt, buf)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	assert.NoError(t, err)
-	res, obj := doUploadOrMod(t, req, "text/plain", "rL0Y20zC+Fzt72VPzMSk2A==")
-	assert.Equal(t, 201, res.StatusCode)
-	data := obj["data"].(map[string]interface{})
-	fileID, ok := data["id"].(string)
-	assert.True(t, ok)
-
-	updatedAt2 := "2017-12-16T13:37:01.345Z"
-	newcontent := "updated by a client with a new UpdatedAt"
-	res2, obj2 := uploadMod(t, "/files/"+fileID+"?UpdatedAt="+updatedAt2, "text/plain", newcontent, "")
-	assert.Equal(t, 200, res2.StatusCode)
-	data2 := obj2["data"].(map[string]interface{})
-	attrs2 := data2["attributes"].(map[string]interface{})
-	createdAt2 := attrs2["created_at"].(string)
-	updatedAt3 := attrs2["updated_at"].(string)
-	assert.Equal(t, createdAt2, createdAt)
-	assert.Equal(t, updatedAt3, updatedAt2)
-}
-
-func TestModifyContentWithUpdatedAtAndCreatedAt(t *testing.T) {
-	buf := strings.NewReader("foo")
-	createdAt := "2017-11-16T13:37:01.345Z"
-	req, err := http.NewRequest("POST", ts.URL+"/files/?Type=file&Name=old-file-with-u-and-c&CreatedAt="+createdAt, buf)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	assert.NoError(t, err)
-	res, obj := doUploadOrMod(t, req, "text/plain", "rL0Y20zC+Fzt72VPzMSk2A==")
-	assert.Equal(t, 201, res.StatusCode)
-	data := obj["data"].(map[string]interface{})
-	fileID, ok := data["id"].(string)
-	assert.True(t, ok)
-
-	createdAt2 := "2017-10-16T13:37:01.345Z"
-	updatedAt2 := "2017-12-16T13:37:01.345Z"
-	newcontent := "updated by a client with a CreatedAt older than UpdatedAt"
-	res2, obj2 := uploadMod(t, "/files/"+fileID+"?CreatedAt="+createdAt2+"&UpdatedAt="+updatedAt2, "text/plain", newcontent, "")
-	assert.Equal(t, 200, res2.StatusCode)
-	data2 := obj2["data"].(map[string]interface{})
-	attrs2 := data2["attributes"].(map[string]interface{})
-	createdAt3 := attrs2["created_at"].(string)
-	updatedAt3 := attrs2["updated_at"].(string)
-	assert.Equal(t, createdAt3, createdAt)
-	assert.Equal(t, updatedAt3, updatedAt2)
-}
-
-func TestModifyContentConcurrently(t *testing.T) {
-	type result struct {
-		rev string
-		idx int64
-	}
-
-	done := make(chan *result)
-	errs := make(chan *http.Response)
-
-	res, data := upload(t, "/files/?Type=file&Name=willbemodifiedconcurrently&Executable=true", "text/plain", "foo", "")
-	require.Equal(t, 201, res.StatusCode)
-
-	var ok bool
-	data, ok = data["data"].(map[string]interface{})
-	assert.True(t, ok)
-
-	fileID, ok := data["id"].(string)
-	assert.True(t, ok)
-
-	var c int64
-
-	doModContent := func() {
-		idx := atomic.AddInt64(&c, 1)
-		res, data := uploadMod(t, "/files/"+fileID, "plain/text", "newcontent "+strconv.FormatInt(idx, 10), "")
-		if res.StatusCode == 200 {
-			data = data["data"].(map[string]interface{})
-			meta := data["meta"].(map[string]interface{})
-			done <- &result{meta["rev"].(string), idx}
-		} else {
-			errs <- res
-		}
-	}
-
-	n := 100
-
-	for i := 0; i < n; i++ {
-		go doModContent()
-	}
-
-	var successes []*result
-	for i := 0; i < n; i++ {
-		select {
-		case res := <-errs:
-			assert.True(t, res.StatusCode == 409 || res.StatusCode == 503, "status code is %v and not 409 or 503", res.StatusCode)
-		case res := <-done:
-			successes = append(successes, res)
-		}
-	}
-
-	assert.True(t, len(successes) >= 1, "there is at least one success")
-
-	for i, s := range successes {
-		assert.True(t, strings.HasPrefix(s.rev, strconv.Itoa(i+2)+"-"))
-	}
-
-	storage := testInstance.VFS()
-	buf, err := readFile(storage, "/willbemodifiedconcurrently")
-	assert.NoError(t, err)
-
-	found := false
-	for _, s := range successes {
-		if string(buf) == "newcontent "+strconv.FormatInt(s.idx, 10) {
-			found = true
-			break
-		}
-	}
-
-	assert.True(t, found)
-}
-
-func TestDownloadFileBadID(t *testing.T) {
-	res, _ := download(t, "/files/download/badid", "")
-	assert.Equal(t, 404, res.StatusCode)
-}
-
-func TestDownloadFileBadPath(t *testing.T) {
-	res, _ := download(t, "/files/download?Path=/i/do/not/exist", "")
-	assert.Equal(t, 404, res.StatusCode)
-}
-
-func TestDownloadFileByIDSuccess(t *testing.T) {
-	body := "foo"
-	res1, filedata := upload(t, "/files/?Type=file&Name=downloadme1", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
-	assert.Equal(t, 201, res1.StatusCode)
-
-	var ok bool
-	filedata, ok = filedata["data"].(map[string]interface{})
-	assert.True(t, ok)
-
-	fileID, ok := filedata["id"].(string)
-	assert.True(t, ok)
-
-	res2, resbody := download(t, "/files/download/"+fileID, "")
-	assert.Equal(t, 200, res2.StatusCode)
-	assert.True(t, strings.HasPrefix(res2.Header.Get("Content-Disposition"), "inline"))
-	assert.True(t, strings.Contains(res2.Header.Get("Content-Disposition"), `filename="downloadme1"`))
-	assert.True(t, strings.HasPrefix(res2.Header.Get("Content-Type"), "text/plain"))
-	assert.NotEmpty(t, res2.Header.Get("Etag"))
-	assert.Equal(t, res2.Header.Get("Etag")[:1], `"`)
-	assert.Equal(t, res2.Header.Get("Content-Length"), "3")
-	assert.Equal(t, res2.Header.Get("Accept-Ranges"), "bytes")
-	assert.Equal(t, body, string(resbody))
-}
-
-func TestDownloadFileByPathSuccess(t *testing.T) {
-	body := "foo"
-	res1, _ := upload(t, "/files/?Type=file&Name=downloadme2", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
-	assert.Equal(t, 201, res1.StatusCode)
-
-	res2, resbody := download(t, "/files/download?Dl=1&Path="+url.QueryEscape("/downloadme2"), "")
-	assert.Equal(t, 200, res2.StatusCode)
-	assert.True(t, strings.HasPrefix(res2.Header.Get("Content-Disposition"), "attachment"))
-	assert.True(t, strings.Contains(res2.Header.Get("Content-Disposition"), `filename="downloadme2"`))
-	assert.True(t, strings.HasPrefix(res2.Header.Get("Content-Type"), "text/plain"))
-	assert.Equal(t, res2.Header.Get("Content-Length"), "3")
-	assert.Equal(t, res2.Header.Get("Accept-Ranges"), "bytes")
-	assert.Equal(t, body, string(resbody))
-}
-
-func TestDownloadRangeSuccess(t *testing.T) {
-	body := "foo,bar"
-	res1, _ := upload(t, "/files/?Type=file&Name=downloadmebyrange", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
-	assert.Equal(t, 201, res1.StatusCode)
-
-	res2, _ := download(t, "/files/download?Path="+url.QueryEscape("/downloadmebyrange"), "nimp")
-	assert.Equal(t, 416, res2.StatusCode)
-
-	res3, res3body := download(t, "/files/download?Path="+url.QueryEscape("/downloadmebyrange"), "bytes=0-2")
-	assert.Equal(t, 206, res3.StatusCode)
-	assert.Equal(t, "foo", string(res3body))
-
-	res4, res4body := download(t, "/files/download?Path="+url.QueryEscape("/downloadmebyrange"), "bytes=4-")
-	assert.Equal(t, 206, res4.StatusCode)
-	assert.Equal(t, "bar", string(res4body))
-}
-
-func TestGetFileMetadataFromPath(t *testing.T) {
-	res1, _ := httpGet(ts.URL + "/files/metadata?Path=/noooooop")
-	assert.Equal(t, 404, res1.StatusCode)
-
-	body := "foo,bar"
-	res2, _ := upload(t, "/files/?Type=file&Name=getmetadata", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
-	assert.Equal(t, 201, res2.StatusCode)
-
-	res3, _ := httpGet(ts.URL + "/files/metadata?Path=/getmetadata")
-	assert.Equal(t, 200, res3.StatusCode)
-}
-
-func TestGetDirMetadataFromPath(t *testing.T) {
-	res1, _ := createDir(t, "/files/?Name=getdirmeta&Type=directory")
-	assert.Equal(t, 201, res1.StatusCode)
-
-	res2, _ := httpGet(ts.URL + "/files/metadata?Path=/getdirmeta")
-	assert.Equal(t, 200, res2.StatusCode)
-}
-
-func TestGetFileMetadataFromID(t *testing.T) {
-	res1, _ := httpGet(ts.URL + "/files/qsdqsd")
-	assert.Equal(t, 404, res1.StatusCode)
-
-	body := "foo,bar"
-	res2, data2 := upload(t, "/files/?Type=file&Name=getmetadatafromid", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
-	assert.Equal(t, 201, res2.StatusCode)
-
-	fileID, _ := extractDirData(t, data2)
-
-	res3, _ := httpGet(ts.URL + "/files/" + fileID)
-	assert.Equal(t, 200, res3.StatusCode)
-}
-
-func TestGetDirMetadataFromID(t *testing.T) {
-	res1, data1 := createDir(t, "/files/?Name=getdirmetafromid&Type=directory")
-	assert.Equal(t, 201, res1.StatusCode)
-
-	parentID, _ := extractDirData(t, data1)
-
-	body := "foo"
-	res2, data2 := upload(t, "/files/"+parentID+"?Type=file&Name=firstfile", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
-	assert.Equal(t, 201, res2.StatusCode)
-
-	fileID, _ := extractDirData(t, data2)
-
-	res3, _ := httpGet(ts.URL + "/files/" + fileID)
-	assert.Equal(t, 200, res3.StatusCode)
-}
-
-func TestVersions(t *testing.T) {
-	cfg := config.GetConfig()
-	oldDelay := cfg.Fs.Versioning.MinDelayBetweenTwoVersions
-	cfg.Fs.Versioning.MinDelayBetweenTwoVersions = 10 * time.Millisecond
-	defer func() {
-		cfg.Fs.Versioning.MinDelayBetweenTwoVersions = oldDelay
-	}()
-
-	res1, body1 := upload(t, "/files/?Type=file&Name=versioned", "text/plain", "one", "")
-	assert.Equal(t, 201, res1.StatusCode)
-	data1 := body1["data"].(map[string]interface{})
-	attr1 := data1["attributes"].(map[string]interface{})
-	sum1 := attr1["md5sum"]
-	fileID := data1["id"].(string)
-	time.Sleep(20 * time.Millisecond)
-	res2, body2 := uploadMod(t, "/files/"+fileID, "text/plain", "two", "")
-	assert.Equal(t, 200, res2.StatusCode)
-	data2 := body2["data"].(map[string]interface{})
-	attr2 := data2["attributes"].(map[string]interface{})
-	sum2 := attr2["md5sum"]
-	time.Sleep(20 * time.Millisecond)
-	res3, body3 := uploadMod(t, "/files/"+fileID, "text/plain", "three", "")
-	assert.Equal(t, 200, res3.StatusCode)
-	data3 := body3["data"].(map[string]interface{})
-	attr3 := data3["attributes"].(map[string]interface{})
-	sum3 := attr3["md5sum"]
-
-	res4, _ := httpGet(ts.URL + "/files/" + fileID)
-	assert.Equal(t, 200, res4.StatusCode)
-	var body map[string]interface{}
-	assert.NoError(t, json.NewDecoder(res4.Body).Decode(&body))
-	data := body["data"].(map[string]interface{})
-	attr := data["attributes"].(map[string]interface{})
-	assert.Equal(t, sum3, attr["md5sum"])
-
-	rels := data["relationships"].(map[string]interface{})
-	old := rels["old_versions"].(map[string]interface{})
-	refs := old["data"].([]interface{})
-	assert.Len(t, refs, 2)
-	first := refs[0].(map[string]interface{})
-	assert.Equal(t, consts.FilesVersions, first["type"])
-	oneID := first["id"]
-	second := refs[1].(map[string]interface{})
-	assert.Equal(t, consts.FilesVersions, second["type"])
-	twoID := second["id"]
-
-	included := body["included"].([]interface{})
-	vone := included[0].(map[string]interface{})
-	assert.Equal(t, oneID, vone["id"])
-	attrv1 := vone["attributes"].(map[string]interface{})
-	assert.Equal(t, sum1, attrv1["md5sum"])
-	vtwo := included[1].(map[string]interface{})
-	assert.Equal(t, twoID, vtwo["id"])
-	attrv2 := vtwo["attributes"].(map[string]interface{})
-	assert.Equal(t, sum2, attrv2["md5sum"])
-}
-
-func TestPatchVersion(t *testing.T) {
-	res1, body1 := upload(t, "/files/?Type=file&Name=patch-version", "text/plain", "one", "")
-	assert.Equal(t, 201, res1.StatusCode)
-	data1 := body1["data"].(map[string]interface{})
-	fileID := data1["id"].(string)
-	res2, _ := uploadMod(t, "/files/"+fileID, "text/plain", "two", "")
-	assert.Equal(t, 200, res2.StatusCode)
-
-	res3, _ := httpGet(ts.URL + "/files/" + fileID)
-	assert.Equal(t, 200, res3.StatusCode)
-	var body3 map[string]interface{}
-	assert.NoError(t, json.NewDecoder(res3.Body).Decode(&body3))
-	data3 := body3["data"].(map[string]interface{})
-	rels := data3["relationships"].(map[string]interface{})
-	old := rels["old_versions"].(map[string]interface{})
-	refs := old["data"].([]interface{})
-	assert.Len(t, refs, 1)
-	ref := refs[0].(map[string]interface{})
-	assert.Equal(t, consts.FilesVersions, ref["type"])
-	versionID := ref["id"].(string)
-
-	attrs := map[string]interface{}{
-		"tags": []string{"qux"},
-	}
-	res4, body4 := patchFile(t, "/files/"+versionID, consts.FilesVersions, versionID, attrs, nil)
-	assert.Equal(t, 200, res4.StatusCode)
-	data4 := body4["data"].(map[string]interface{})
-	assert.Equal(t, versionID, data4["id"])
-	attrs4 := data4["attributes"].(map[string]interface{})
-	tags := attrs4["tags"].([]interface{})
-	assert.Len(t, tags, 1)
-	assert.Equal(t, "qux", tags[0])
-}
-
-func TestDownloadVersion(t *testing.T) {
-	content := "one"
-	res1, body1 := upload(t, "/files/?Type=file&Name=downloadme-versioned", "text/plain", content, "")
-	assert.Equal(t, 201, res1.StatusCode)
-	data := body1["data"].(map[string]interface{})
-	fileID := data["id"].(string)
-	meta := data["meta"].(map[string]interface{})
-	firstRev := meta["rev"].(string)
-
-	res2, _ := uploadMod(t, "/files/"+fileID, "text/plain", "two", "")
-	assert.Equal(t, 200, res2.StatusCode)
-
-	res3, resbody := download(t, "/files/download/"+fileID+"/"+firstRev, "")
-	assert.Equal(t, 200, res3.StatusCode)
-	assert.True(t, strings.HasPrefix(res3.Header.Get("Content-Disposition"), "inline"))
-	assert.True(t, strings.Contains(res3.Header.Get("Content-Disposition"), `filename="downloadme-versioned"`))
-	assert.True(t, strings.HasPrefix(res3.Header.Get("Content-Type"), "text/plain"))
-	assert.Equal(t, content, string(resbody))
-}
-
-func TestFileCreateAndDownloadByVersionID(t *testing.T) {
-	content := "one"
-	res1, body1 := upload(t, "/files/?Type=file&Name=direct-downloadme-versioned", "text/plain", content, "")
-	assert.Equal(t, 201, res1.StatusCode)
-	data := body1["data"].(map[string]interface{})
-	fileID := data["id"].(string)
-	meta := data["meta"].(map[string]interface{})
-	firstRev := meta["rev"].(string)
-
-	res2, _ := uploadMod(t, "/files/"+fileID, "text/plain", "two", "")
-	assert.Equal(t, 200, res2.StatusCode)
-
-	req, err := http.NewRequest("POST", ts.URL+"/files/downloads?VersionId="+fileID+"/"+firstRev, nil)
-	assert.NoError(t, err)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var data2 map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&data2)
-	assert.NoError(t, err)
-
-	displayURL := ts.URL + data2["links"].(map[string]interface{})["related"].(string)
-	res3, err := http.Get(displayURL)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res3.StatusCode)
-	disposition := res3.Header.Get("Content-Disposition")
-	assert.Equal(t, `inline; filename="direct-downloadme-versioned"`, disposition)
-}
-
-func TestRevertVersion(t *testing.T) {
-	content := "one"
-	res1, body1 := upload(t, "/files/?Type=file&Name=downloadme-reverted", "text/plain", content, "")
-	assert.Equal(t, 201, res1.StatusCode)
-	data := body1["data"].(map[string]interface{})
-	fileID := data["id"].(string)
-
-	res2, _ := uploadMod(t, "/files/"+fileID, "text/plain", "two", "")
-	assert.Equal(t, 200, res2.StatusCode)
-
-	res3, _ := httpGet(ts.URL + "/files/" + fileID)
-	assert.Equal(t, 200, res3.StatusCode)
-	var body map[string]interface{}
-	assert.NoError(t, json.NewDecoder(res3.Body).Decode(&body))
-	data = body["data"].(map[string]interface{})
-	rels := data["relationships"].(map[string]interface{})
-	old := rels["old_versions"].(map[string]interface{})
-	refs := old["data"].([]interface{})
-	assert.Len(t, refs, 1)
-	version := refs[0].(map[string]interface{})
-	versionID := version["id"].(string)
-
-	req4, _ := http.NewRequest("POST", ts.URL+"/files/revert/"+versionID, strings.NewReader(""))
-	req4.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	res4, err := http.DefaultClient.Do(req4)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res4.StatusCode)
-
-	res5, resbody := download(t, "/files/download/"+fileID, "")
-	assert.Equal(t, 200, res5.StatusCode)
-	assert.True(t, strings.HasPrefix(res5.Header.Get("Content-Disposition"), "inline"))
-	assert.True(t, strings.Contains(res5.Header.Get("Content-Disposition"), `filename="downloadme-reverted"`))
-	assert.True(t, strings.HasPrefix(res5.Header.Get("Content-Type"), "text/plain"))
-	assert.Equal(t, content, string(resbody))
-}
-
-func TestCleanOldVersion(t *testing.T) {
-	content := "one"
-	res1, body1 := upload(t, "/files/?Type=file&Name=downloadme-toclean", "text/plain", content, "")
-	assert.Equal(t, 201, res1.StatusCode)
-	data := body1["data"].(map[string]interface{})
-	fileID := data["id"].(string)
-
-	res2, _ := uploadMod(t, "/files/"+fileID, "text/plain", "two", "")
-	assert.Equal(t, 200, res2.StatusCode)
-
-	res3, _ := httpGet(ts.URL + "/files/" + fileID)
-	assert.Equal(t, 200, res3.StatusCode)
-	var body map[string]interface{}
-	assert.NoError(t, json.NewDecoder(res3.Body).Decode(&body))
-	data = body["data"].(map[string]interface{})
-	rels := data["relationships"].(map[string]interface{})
-	old := rels["old_versions"].(map[string]interface{})
-	refs := old["data"].([]interface{})
-	assert.Len(t, refs, 1)
-	version := refs[0].(map[string]interface{})
-	versionID := version["id"].(string)
-
-	req4, _ := http.NewRequest("DELETE", ts.URL+"/files/"+versionID, nil)
-	req4.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	res4, err := http.DefaultClient.Do(req4)
-	assert.NoError(t, err)
-	assert.Equal(t, 204, res4.StatusCode)
-
-	res5, _ := download(t, "/files/download/"+versionID, "")
-	assert.Equal(t, 404, res5.StatusCode)
-}
-
-func TestCopyVersion(t *testing.T) {
-	buf := strings.NewReader(`{
-    "data": {
-        "type": "io.cozy.files.metadata",
-        "attributes": {
-            "category": "report",
-            "label": "foo"
-        }
-    }
-}`)
-	req1, err := http.NewRequest("POST", ts.URL+"/files/upload/metadata", buf)
-	req1.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	assert.NoError(t, err)
-	res1, err := http.DefaultClient.Do(req1)
-	assert.NoError(t, err)
-	defer res1.Body.Close()
-	assert.Equal(t, 201, res1.StatusCode)
-	var obj1 map[string]interface{}
-	err = extractJSONRes(res1, &obj1)
-	assert.NoError(t, err)
-	data1 := obj1["data"].(map[string]interface{})
-	secret := data1["id"].(string)
-
-	content := "should-be-the-same-after-copy"
-	u := "/files/?Type=file&Name=version-to-be-copied&MetadataID=" + secret
-	res2, body2 := upload(t, u, "text/plain", content, "")
-	assert.Equal(t, 201, res2.StatusCode)
-	data2 := body2["data"].(map[string]interface{})
-	fileID := data2["id"].(string)
-	attrs2 := data2["attributes"].(map[string]interface{})
-	meta2 := attrs2["metadata"].(map[string]interface{})
-	assert.Equal(t, "report", meta2["category"])
-	assert.Equal(t, "foo", meta2["label"])
-
-	buf = strings.NewReader(`{
-    "data": {
-        "type": "io.cozy.files.metadata",
-        "attributes": {
-            "label": "bar"
-        }
-    }
-}`)
-	req3, err := http.NewRequest("POST", ts.URL+"/files/"+fileID+"/versions?Tags=qux", buf)
-	req3.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	assert.NoError(t, err)
-	res3, err := http.DefaultClient.Do(req3)
-	assert.NoError(t, err)
-	defer res3.Body.Close()
-	assert.Equal(t, 200, res3.StatusCode)
-	var obj3 map[string]interface{}
-	err = extractJSONRes(res3, &obj3)
-	assert.NoError(t, err)
-	data3 := obj3["data"].(map[string]interface{})
-	attrs3 := data3["attributes"].(map[string]interface{})
-	meta3 := attrs3["metadata"].(map[string]interface{})
-	assert.Nil(t, meta3["category"])
-	assert.Equal(t, "bar", meta3["label"])
-	assert.Len(t, attrs3["tags"], 1)
-	tags := attrs3["tags"].([]interface{})
-	assert.Equal(t, "qux", tags[0])
-}
-
-func TestCopyVersionWithCertified(t *testing.T) {
-	buf := strings.NewReader(`{
-    "data": {
-        "type": "io.cozy.files.metadata",
-        "attributes": {
-            "carbonCopy": true,
-            "electronicSafe": true
-        }
-    }
-}`)
-	req1, err := http.NewRequest("POST", ts.URL+"/files/upload/metadata", buf)
-	req1.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	assert.NoError(t, err)
-	res1, err := http.DefaultClient.Do(req1)
-	assert.NoError(t, err)
-	defer res1.Body.Close()
-	assert.Equal(t, 201, res1.StatusCode)
-	var obj1 map[string]interface{}
-	err = extractJSONRes(res1, &obj1)
-	assert.NoError(t, err)
-	data1 := obj1["data"].(map[string]interface{})
-	secret := data1["id"].(string)
-
-	content := "certified carbonCopy and electronicSafe must be kept if only the qualification change"
-	u := "/files/?Type=file&Name=copy-version-with-certified&MetadataID=" + secret
-	res2, body2 := upload(t, u, "text/plain", content, "")
-	assert.Equal(t, 201, res2.StatusCode)
-	data2 := body2["data"].(map[string]interface{})
-	fileID := data2["id"].(string)
-	attrs2 := data2["attributes"].(map[string]interface{})
-	meta2 := attrs2["metadata"].(map[string]interface{})
-	assert.NotNil(t, meta2["carbonCopy"])
-	assert.NotNil(t, meta2["electronicSafe"])
-
-	buf = strings.NewReader(`{
-    "data": {
-        "type": "io.cozy.files.metadata",
-        "attributes": {
-			"qualification": { "purpose": "attestation" }
-        }
-    }
-}`)
-	req3, err := http.NewRequest("POST", ts.URL+"/files/"+fileID+"/versions", buf)
-	req3.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	assert.NoError(t, err)
-	res3, err := http.DefaultClient.Do(req3)
-	assert.NoError(t, err)
-	defer res3.Body.Close()
-	assert.Equal(t, 200, res3.StatusCode)
-	var obj3 map[string]interface{}
-	err = extractJSONRes(res3, &obj3)
-	assert.NoError(t, err)
-	data3 := obj3["data"].(map[string]interface{})
-	attrs3 := data3["attributes"].(map[string]interface{})
-	meta3 := attrs3["metadata"].(map[string]interface{})
-	assert.NotNil(t, meta3["qualification"])
-	assert.NotNil(t, meta3["carbonCopy"])
-	assert.NotNil(t, meta3["electronicSafe"])
-
-	buf = strings.NewReader(`{
-    "data": {
-        "type": "io.cozy.files.metadata",
-        "attributes": {
-            "label": "bar"
-        }
-    }
-}`)
-	req4, err := http.NewRequest("POST", ts.URL+"/files/"+fileID+"/versions", buf)
-	req4.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	assert.NoError(t, err)
-	res4, err := http.DefaultClient.Do(req4)
-	assert.NoError(t, err)
-	defer res4.Body.Close()
-	assert.Equal(t, 200, res4.StatusCode)
-	var obj4 map[string]interface{}
-	err = extractJSONRes(res4, &obj4)
-	assert.NoError(t, err)
-	data4 := obj4["data"].(map[string]interface{})
-	attrs4 := data4["attributes"].(map[string]interface{})
-	meta4 := attrs4["metadata"].(map[string]interface{})
-	assert.NotNil(t, meta4["label"])
-	assert.Nil(t, meta4["qualification"])
-	assert.Nil(t, meta4["carbonCopy"])
-	assert.Nil(t, meta4["electronicSafe"])
-}
-
-func TestCopyVersionWorksForNotes(t *testing.T) {
-	content := "# Title\n\n* foo\n* bar\n"
-	u := "/files/?Type=file&Name=test.cozy-note"
-	res, body := upload(t, u, consts.NoteMimeType, content, "")
-	assert.Equal(t, 201, res.StatusCode)
-	data := body["data"].(map[string]interface{})
-	fileID := data["id"].(string)
-	attrs := data["attributes"].(map[string]interface{})
-	meta := attrs["metadata"].(map[string]interface{})
-	assert.NotNil(t, meta["title"])
-	assert.NotNil(t, meta["content"])
-	assert.NotNil(t, meta["schema"])
-	assert.NotNil(t, meta["version"])
-
-	buf := strings.NewReader(`{
-    "data": {
-        "type": "io.cozy.files.metadata",
-        "attributes": {
-			"qualification": { "purpose": "attestation" }
-        }
-    }
-}`)
-	req2, err := http.NewRequest("POST", ts.URL+"/files/"+fileID+"/versions", buf)
-	req2.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	assert.NoError(t, err)
-	res2, err := http.DefaultClient.Do(req2)
-	assert.NoError(t, err)
-	defer res2.Body.Close()
-	assert.Equal(t, 200, res2.StatusCode)
-	var obj2 map[string]interface{}
-	err = extractJSONRes(res2, &obj2)
-	assert.NoError(t, err)
-	data2 := obj2["data"].(map[string]interface{})
-	attrs2 := data2["attributes"].(map[string]interface{})
-	meta2 := attrs2["metadata"].(map[string]interface{})
-	assert.NotNil(t, meta2["qualification"])
-	assert.Equal(t, meta["title"], meta2["title"])
-	assert.Equal(t, meta["content"], meta2["content"])
-	assert.Equal(t, meta["schema"], meta2["schema"])
-	assert.Equal(t, meta["version"], meta2["version"])
-}
-
-func TestArchiveNoFiles(t *testing.T) {
-	body := bytes.NewBufferString(`{
-		"data": {
-			"attributes": {}
-		}
-	}`)
-	req, err := http.NewRequest("POST", ts.URL+"/files/archive", body)
-	require.NoError(t, err)
-
-	req.Header.Add("Content-Type", "application/vnd.api+json")
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-
-	assert.NoError(t, err)
-	assert.Equal(t, 400, res.StatusCode)
-	msg, err := io.ReadAll(res.Body)
-	assert.NoError(t, err)
-	actual := strings.TrimSpace(string(msg))
-	assert.Equal(t, `"Can't create an archive with no files"`, actual)
-}
-
-func TestArchiveDirectDownload(t *testing.T) {
-	res1, data1 := createDir(t, "/files/?Name=archive&Type=directory")
-	require.Equal(t, 201, res1.StatusCode)
-
-	dirID, _ := extractDirData(t, data1)
-	names := []string{"foo", "bar", "baz"}
-	for _, name := range names {
-		res2, _ := createDir(t, "/files/"+dirID+"?Name="+name+".jpg&Type=file")
-		require.Equal(t, 201, res2.StatusCode)
-	}
-
-	// direct download
-	body := bytes.NewBufferString(`{
-		"data": {
-			"attributes": {
-				"files": [
-					"/archive/foo.jpg",
-					"/archive/bar.jpg",
-					"/archive/baz.jpg"
-				]
-			}
-		}
-	}`)
-
-	req, err := http.NewRequest("POST", ts.URL+"/files/archive", body)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	req.Header.Add("Content-Type", "application/zip")
-	req.Header.Add("Accept", "application/zip")
-	assert.NoError(t, err)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	assert.Equal(t, "application/zip", res.Header.Get("Content-Type"))
-}
-
-func TestArchiveCreateAndDownload(t *testing.T) {
-	res1, data1 := createDir(t, "/files/?Name=archive2&Type=directory")
-	require.Equal(t, 201, res1.StatusCode)
-
-	dirID, _ := extractDirData(t, data1)
-	names := []string{"foo", "bar", "baz"}
-	for _, name := range names {
-		res2, _ := createDir(t, "/files/"+dirID+"?Name="+name+".jpg&Type=file")
-		require.Equal(t, 201, res2.StatusCode)
-	}
-
-	body := bytes.NewBufferString(`{
-		"data": {
-			"attributes": {
-				"files": [
-					"/archive/foo.jpg",
-					"/archive/bar.jpg",
-					"/archive/baz.jpg"
-				]
-			}
-		}
-	}`)
-
-	req, err := http.NewRequest("POST", ts.URL+"/files/archive", body)
-	require.NoError(t, err)
-
-	req.Header.Add("Content-Type", "application/vnd.api+json")
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var data map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&data)
-	assert.NoError(t, err)
-
-	downloadURL := ts.URL + data["links"].(map[string]interface{})["related"].(string)
-	res2, err := httpGet(downloadURL)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res2.StatusCode)
-	disposition := res2.Header.Get("Content-Disposition")
-	assert.Equal(t, `attachment; filename="archive.zip"`, disposition)
-}
-
-func TestFileCreateAndDownloadByPath(t *testing.T) {
-	body := "foo,bar"
-	res1, _ := upload(t, "/files/?Type=file&Name=todownload2steps", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
-	require.Equal(t, 201, res1.StatusCode)
-
-	path := "/todownload2steps"
-
-	req, err := http.NewRequest("POST", ts.URL+"/files/downloads?Path="+path, nil)
-	require.NoError(t, err)
-
-	req.Header.Add("Content-Type", "")
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var data map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&data)
-	assert.NoError(t, err)
-
-	displayURL := ts.URL + data["links"].(map[string]interface{})["related"].(string)
-	res2, err := http.Get(displayURL)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res2.StatusCode)
-	disposition := res2.Header.Get("Content-Disposition")
-	assert.Equal(t, `inline; filename="todownload2steps"`, disposition)
-
-	downloadURL := ts.URL + data["links"].(map[string]interface{})["related"].(string) + "?Dl=1"
-	res3, err := http.Get(downloadURL)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res3.StatusCode)
-	disposition = res3.Header.Get("Content-Disposition")
-	assert.Equal(t, `attachment; filename="todownload2steps"`, disposition)
-}
-
-func TestFileCreateAndDownloadByID(t *testing.T) {
-	body := "foo,bar"
-	res1, v := upload(t, "/files/?Type=file&Name=todownload2stepsbis", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
-	require.Equal(t, 201, res1.StatusCode)
-
-	id := v["data"].(map[string]interface{})["id"].(string)
-
-	req, err := http.NewRequest("POST", ts.URL+"/files/downloads?Id="+id, nil)
-	require.NoError(t, err)
-
-	req.Header.Add("Content-Type", "")
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var data map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&data)
-	assert.NoError(t, err)
-
-	displayURL := ts.URL + data["links"].(map[string]interface{})["related"].(string)
-	res2, err := http.Get(displayURL)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res2.StatusCode)
-	disposition := res2.Header.Get("Content-Disposition")
-	assert.Equal(t, `inline; filename="todownload2stepsbis"`, disposition)
-}
-
-func TestEncryptedFileCreate(t *testing.T) {
-	res1, data1 := upload(t, "/files/?Type=file&Name=encryptedfile&Encrypted=true", "text/plain", "foo", "")
-	assert.Equal(t, 201, res1.StatusCode)
-
-	var ok bool
-	resData, ok := data1["data"].(map[string]interface{})
-	assert.True(t, ok)
-
-	attrs := resData["attributes"].(map[string]interface{})
-	assert.Equal(t, attrs["name"].(string), "encryptedfile")
-	assert.True(t, attrs["encrypted"].(bool))
-}
-
-func TestHeadDirOrFileNotFound(t *testing.T) {
-	req, _ := http.NewRequest("HEAD", ts.URL+"/files/fakeid/?Type=directory", strings.NewReader(""))
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 404, res.StatusCode)
-}
-
-func TestHeadDirOrFileExists(t *testing.T) {
-	res, _ := createDir(t, "/files/?Name=hellothere&Type=directory")
-	assert.Equal(t, 201, res.StatusCode)
-
-	storage := testInstance.VFS()
-	dir, err := storage.DirByPath("/hellothere")
-	assert.NoError(t, err)
-	id := dir.ID()
-	req, _ := http.NewRequest("HEAD", ts.URL+"/files/"+id+"?Type=directory", strings.NewReader(""))
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-}
-
-func TestArchiveNotFound(t *testing.T) {
-	body := bytes.NewBufferString(`{
-		"data": {
-			"attributes": {
-				"files": [
-					"/archive/foo.jpg",
-					"/no/such/file",
-					"/archive/baz.jpg"
-				]
-			}
-		}
-	}`)
-	req, err := http.NewRequest("POST", ts.URL+"/files/archive", body)
-	require.NoError(t, err)
-
-	req.Header.Add("Content-Type", "application/vnd.api+json")
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-
-	assert.Equal(t, 404, res.StatusCode)
-}
-
-func TestDirTrash(t *testing.T) {
-	res1, data1 := createDir(t, "/files/?Name=totrashdir&Type=directory")
-	require.Equal(t, 201, res1.StatusCode)
-
-	dirID, _ := extractDirData(t, data1)
-
-	res2, _ := createDir(t, "/files/"+dirID+"?Name=child1&Type=file")
-	require.Equal(t, 201, res2.StatusCode)
-
-	res3, _ := createDir(t, "/files/"+dirID+"?Name=child2&Type=file")
-	require.Equal(t, 201, res3.StatusCode)
-
-	res4, _ := trash(t, "/files/"+dirID)
-	require.Equal(t, 200, res4.StatusCode)
-
-	res5, err := httpGet(ts.URL + "/files/" + dirID)
-	require.NoError(t, err)
-	require.Equal(t, 200, res5.StatusCode)
-
-	res6, err := httpGet(ts.URL + "/files/download?Path=" + url.QueryEscape(vfs.TrashDirName+"/totrashdir/child1"))
-	require.NoError(t, err)
-	require.Equal(t, 200, res6.StatusCode)
-
-	res7, err := httpGet(ts.URL + "/files/download?Path=" + url.QueryEscape(vfs.TrashDirName+"/totrashdir/child2"))
-	require.NoError(t, err)
-	require.Equal(t, 200, res7.StatusCode)
-
-	res8, _ := trash(t, "/files/"+dirID)
-	require.Equal(t, 400, res8.StatusCode)
-}
-
-func TestFileTrash(t *testing.T) {
-	body := "foo,bar"
-	res1, data1 := upload(t, "/files/?Type=file&Name=totrashfile", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
-	require.Equal(t, 201, res1.StatusCode)
-
-	fileID, _ := extractDirData(t, data1)
-
-	res2, _ := trash(t, "/files/"+fileID)
-	require.Equal(t, 200, res2.StatusCode)
-
-	res3, err := httpGet(ts.URL + "/files/download?Path=" + url.QueryEscape(vfs.TrashDirName+"/totrashfile"))
-	require.NoError(t, err)
-	require.Equal(t, 200, res3.StatusCode)
-
-	res4, _ := trash(t, "/files/"+fileID)
-	require.Equal(t, 400, res4.StatusCode)
-
-	res5, data2 := upload(t, "/files/?Type=file&Name=totrashfile2", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
-	require.Equal(t, 201, res5.StatusCode)
-
-	fileID, v2 := extractDirData(t, data2)
-	meta2 := v2["meta"].(map[string]interface{})
-	rev2 := meta2["rev"].(string)
-
-	req6, err := http.NewRequest("DELETE", ts.URL+"/files/"+fileID, nil)
-	req6.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	assert.NoError(t, err)
-
-	req6.Header.Add("If-Match", "badrev")
-	res6, err := http.DefaultClient.Do(req6)
-	assert.NoError(t, err)
-	assert.Equal(t, 412, res6.StatusCode)
-
-	res7, err := httpGet(ts.URL + "/files/download?Path=" + url.QueryEscape(vfs.TrashDirName+"/totrashfile"))
-	require.NoError(t, err)
-	require.Equal(t, 200, res7.StatusCode)
-
-	req8, err := http.NewRequest("DELETE", ts.URL+"/files/"+fileID, nil)
-	req8.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	assert.NoError(t, err)
-
-	req8.Header.Add("If-Match", rev2)
-	res8, err := http.DefaultClient.Do(req8)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res8.StatusCode)
-
-	res9, _ := trash(t, "/files/"+fileID)
-	require.Equal(t, 400, res9.StatusCode)
-}
-
-func TestForbidMovingTrashedFile(t *testing.T) {
-	body := "foo,bar"
-	res1, data1 := upload(t, "/files/?Type=file&Name=forbidmovingtrashedfile", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
-	require.Equal(t, 201, res1.StatusCode)
-
-	fileID, _ := extractDirData(t, data1)
-	res2, _ := trash(t, "/files/"+fileID)
-	require.Equal(t, 200, res2.StatusCode)
-
-	attrs := map[string]interface{}{
-		"dir_id": consts.RootDirID,
-	}
-	res3, _ := patchFile(t, "/files/"+fileID, "file", fileID, attrs, nil)
-	assert.Equal(t, 400, res3.StatusCode)
-}
-
-func TestFileRestore(t *testing.T) {
-	body := "foo,bar"
-	res1, data1 := upload(t, "/files/?Type=file&Name=torestorefile", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
-	require.Equal(t, 201, res1.StatusCode)
-
-	fileID, _ := extractDirData(t, data1)
-
-	res2, body2 := trash(t, "/files/"+fileID)
-	require.Equal(t, 200, res2.StatusCode)
-
-	data2 := body2["data"].(map[string]interface{})
-	attrs2 := data2["attributes"].(map[string]interface{})
-	trashed := attrs2["trashed"].(bool)
-	assert.True(t, trashed)
-
-	res3, body3 := restore(t, "/files/trash/"+fileID)
-	require.Equal(t, 200, res3.StatusCode)
-
-	data3 := body3["data"].(map[string]interface{})
-	attrs3 := data3["attributes"].(map[string]interface{})
-	trashed = attrs3["trashed"].(bool)
-	assert.False(t, trashed)
-
-	res4, err := httpGet(ts.URL + "/files/download?Path=" + url.QueryEscape("/torestorefile"))
-	require.NoError(t, err)
-	require.Equal(t, 200, res4.StatusCode)
-}
-
-func TestFileRestoreWithConflicts(t *testing.T) {
-	body := "foo,bar"
-	res1, data1 := upload(t, "/files/?Type=file&Name=torestorefilewithconflict", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
-	require.Equal(t, 201, res1.StatusCode)
-
-	fileID, _ := extractDirData(t, data1)
-
-	res2, _ := trash(t, "/files/"+fileID)
-	require.Equal(t, 200, res2.StatusCode)
-
-	res1, _ = upload(t, "/files/?Type=file&Name=torestorefilewithconflict", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
-	require.Equal(t, 201, res1.StatusCode)
-
-	res3, data3 := restore(t, "/files/trash/"+fileID)
-	require.Equal(t, 200, res3.StatusCode)
-
-	restoredID, restoredData := extractDirData(t, data3)
-	require.Equal(t, fileID, restoredID)
-
-	restoredData = restoredData["attributes"].(map[string]interface{})
-	assert.True(t, strings.HasPrefix(restoredData["name"].(string), "torestorefilewithconflict"))
-	assert.NotEqual(t, "torestorefilewithconflict", restoredData["name"].(string))
-}
-
-func TestFileRestoreWithWithoutParent(t *testing.T) {
-	res1, data1 := createDir(t, "/files/?Type=directory&Name=torestorein")
-	require.Equal(t, 201, res1.StatusCode)
-
-	dirID, _ := extractDirData(t, data1)
-
-	body := "foo,bar"
-	res1, data1 = upload(t, "/files/"+dirID+"?Type=file&Name=torestorefilewithconflict", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
-	require.Equal(t, 201, res1.StatusCode)
-
-	fileID, _ := extractDirData(t, data1)
-
-	res2, _ := trash(t, "/files/"+fileID)
-	require.Equal(t, 200, res2.StatusCode)
-
-	res2, _ = trash(t, "/files/"+dirID)
-	require.Equal(t, 200, res2.StatusCode)
-
-	res3, data3 := restore(t, "/files/trash/"+fileID)
-	require.Equal(t, 200, res3.StatusCode)
-
-	restoredID, restoredData := extractDirData(t, data3)
-	require.Equal(t, fileID, restoredID)
-
-	restoredData = restoredData["attributes"].(map[string]interface{})
-	assert.Equal(t, "torestorefilewithconflict", restoredData["name"].(string))
-	assert.NotEqual(t, consts.RootDirID, restoredData["dir_id"].(string))
-}
-
-func TestFileRestoreWithWithoutParent2(t *testing.T) {
-	res1, data1 := createDir(t, "/files/?Type=directory&Name=torestorein2")
-	require.Equal(t, 201, res1.StatusCode)
-
-	dirID, _ := extractDirData(t, data1)
-
-	body := "foo,bar"
-	res1, data1 = upload(t, "/files/"+dirID+"?Type=file&Name=torestorefilewithconflict2", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
-	require.Equal(t, 201, res1.StatusCode)
-
-	fileID, _ := extractDirData(t, data1)
-
-	res2, _ := trash(t, "/files/"+dirID)
-	require.Equal(t, 200, res2.StatusCode)
-
-	res3, data3 := restore(t, "/files/trash/"+fileID)
-	require.Equal(t, 200, res3.StatusCode)
-
-	restoredID, restoredData := extractDirData(t, data3)
-	require.Equal(t, fileID, restoredID)
-
-	restoredData = restoredData["attributes"].(map[string]interface{})
-	assert.Equal(t, "torestorefilewithconflict2", restoredData["name"].(string))
-	assert.NotEqual(t, consts.RootDirID, restoredData["dir_id"].(string))
-}
-
-func TestDirRestore(t *testing.T) {
-	res1, data1 := createDir(t, "/files/?Type=directory&Name=torestoredir")
-	require.Equal(t, 201, res1.StatusCode)
-
-	dirID, _ := extractDirData(t, data1)
-
-	body := "foo,bar"
-	res2, data2 := upload(t, "/files/"+dirID+"?Type=file&Name=totrashfile", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
-	require.Equal(t, 201, res2.StatusCode)
-
-	fileID, _ := extractDirData(t, data2)
-
-	res3, _ := trash(t, "/files/"+dirID)
-	require.Equal(t, 200, res3.StatusCode)
-
-	res4, err := httpGet(ts.URL + "/files/" + fileID)
-	require.NoError(t, err)
-	require.Equal(t, 200, res4.StatusCode)
-
-	var v map[string]interface{}
-	err = extractJSONRes(res4, &v)
-	assert.NoError(t, err)
-	data := v["data"].(map[string]interface{})
-	attrs := data["attributes"].(map[string]interface{})
-	trashed := attrs["trashed"].(bool)
-	assert.True(t, trashed)
-
-	res5, _ := restore(t, "/files/trash/"+dirID)
-	require.Equal(t, 200, res5.StatusCode)
-
-	res6, err := httpGet(ts.URL + "/files/" + fileID)
-	require.NoError(t, err)
-	require.Equal(t, 200, res6.StatusCode)
-
-	err = extractJSONRes(res6, &v)
-	assert.NoError(t, err)
-	data = v["data"].(map[string]interface{})
-	attrs = data["attributes"].(map[string]interface{})
-	trashed = attrs["trashed"].(bool)
-	assert.False(t, trashed)
-}
-
-func TestDirRestoreWithConflicts(t *testing.T) {
-	res1, data1 := createDir(t, "/files/?Type=directory&Name=torestoredirwithconflict")
-	require.Equal(t, 201, res1.StatusCode)
-
-	dirID, _ := extractDirData(t, data1)
-
-	res2, _ := trash(t, "/files/"+dirID)
-	require.Equal(t, 200, res2.StatusCode)
-
-	res1, _ = createDir(t, "/files/?Type=directory&Name=torestoredirwithconflict")
-	require.Equal(t, 201, res1.StatusCode)
-
-	res3, data3 := restore(t, "/files/trash/"+dirID)
-	require.Equal(t, 200, res3.StatusCode)
-
-	restoredID, restoredData := extractDirData(t, data3)
-	require.Equal(t, dirID, restoredID)
-
-	restoredData = restoredData["attributes"].(map[string]interface{})
-	assert.True(t, strings.HasPrefix(restoredData["name"].(string), "torestoredirwithconflict"))
-	assert.NotEqual(t, "torestoredirwithconflict", restoredData["name"].(string))
-}
-
-func TestTrashList(t *testing.T) {
-	body := "foo,bar"
-	res1, data1 := upload(t, "/files/?Type=file&Name=tolistfile", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
-	require.Equal(t, 201, res1.StatusCode)
-
-	res2, data2 := createDir(t, "/files/?Name=tolistdir&Type=directory")
-	require.Equal(t, 201, res2.StatusCode)
-
-	dirID, _ := extractDirData(t, data1)
-	fileID, _ := extractDirData(t, data2)
-
-	res3, _ := trash(t, "/files/"+dirID)
-	require.Equal(t, 200, res3.StatusCode)
-
-	res4, _ := trash(t, "/files/"+fileID)
-	require.Equal(t, 200, res4.StatusCode)
-
-	res5, err := httpGet(ts.URL + "/files/trash")
-	require.NoError(t, err)
-
-	defer res5.Body.Close()
-
-	var v struct {
-		Data []interface{} `json:"data"`
-	}
-
-	err = json.NewDecoder(res5.Body).Decode(&v)
-	require.NoError(t, err)
-
-	assert.True(t, len(v.Data) >= 2, "response should contains at least 2 items")
-}
-
-func TestTrashClear(t *testing.T) {
-	body := "foo,bar"
-	res1, data1 := upload(t, "/files/?Type=file&Name=tolistfile", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
-	require.Equal(t, 201, res1.StatusCode)
-
-	res2, data2 := createDir(t, "/files/?Name=tolistdir&Type=directory")
-	require.Equal(t, 201, res2.StatusCode)
-
-	dirID, _ := extractDirData(t, data1)
-	fileID, _ := extractDirData(t, data2)
-
-	res3, _ := trash(t, "/files/"+dirID)
-	require.Equal(t, 200, res3.StatusCode)
-
-	res4, _ := trash(t, "/files/"+fileID)
-	require.Equal(t, 200, res4.StatusCode)
-
-	path := "/files/trash"
-	req, err := http.NewRequest(http.MethodDelete, ts.URL+path, nil)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	require.NoError(t, err)
-
-	_, err = http.DefaultClient.Do(req)
-	require.NoError(t, err)
-
-	res5, err := httpGet(ts.URL + "/files/trash")
-	require.NoError(t, err)
-
-	defer res5.Body.Close()
-
-	var v struct {
-		Data []interface{} `json:"data"`
-	}
-
-	err = json.NewDecoder(res5.Body).Decode(&v)
-	require.NoError(t, err)
-
-	assert.True(t, len(v.Data) == 0)
-}
-
-func TestDestroyFile(t *testing.T) {
-	body := "foo,bar"
-	res1, data1 := upload(t, "/files/?Type=file&Name=tolistfile", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
-	require.Equal(t, 201, res1.StatusCode)
-
-	res2, data2 := createDir(t, "/files/?Name=tolistdir&Type=directory")
-	require.Equal(t, 201, res2.StatusCode)
-
-	dirID, _ := extractDirData(t, data1)
-	fileID, _ := extractDirData(t, data2)
-
-	res3, _ := trash(t, "/files/"+dirID)
-	require.Equal(t, 200, res3.StatusCode)
-
-	res4, _ := trash(t, "/files/"+fileID)
-	require.Equal(t, 200, res4.StatusCode)
-
-	path := "/files/trash/" + fileID
-	req, err := http.NewRequest(http.MethodDelete, ts.URL+path, nil)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	require.NoError(t, err)
-
-	_, err = http.DefaultClient.Do(req)
-	require.NoError(t, err)
-
-	res5, err := httpGet(ts.URL + "/files/trash")
-	require.NoError(t, err)
-
-	defer res5.Body.Close()
-
-	var v struct {
-		Data []interface{} `json:"data"`
-	}
-
-	err = json.NewDecoder(res5.Body).Decode(&v)
-	require.NoError(t, err)
-
-	assert.True(t, len(v.Data) == 1)
-
-	path = "/files/trash/" + dirID
-	req, err = http.NewRequest(http.MethodDelete, ts.URL+path, nil)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	require.NoError(t, err)
-
-	_, err = http.DefaultClient.Do(req)
-	require.NoError(t, err)
-
-	res5, err = httpGet(ts.URL + "/files/trash")
-	require.NoError(t, err)
-
-	defer res5.Body.Close()
-
-	err = json.NewDecoder(res5.Body).Decode(&v)
-	require.NoError(t, err)
-
-	assert.True(t, len(v.Data) == 0)
-}
-
-func TestThumbnailImages(t *testing.T) {
-	res1, _ := httpGet(ts.URL + "/files/" + imgID)
-	assert.Equal(t, 200, res1.StatusCode)
-	var obj map[string]interface{}
-	err := extractJSONRes(res1, &obj)
-	assert.NoError(t, err)
-	data := obj["data"].(map[string]interface{})
-	links := data["links"].(map[string]interface{})
-	large := links["large"].(string)
-	medium := links["medium"].(string)
-	small := links["small"].(string)
-	tiny := links["tiny"].(string)
-
-	res2, _ := download(t, large, "")
-	assert.Equal(t, 200, res2.StatusCode)
-	assert.True(t, strings.HasPrefix(res2.Header.Get("Content-Type"), "image/jpeg"))
-	res3, _ := download(t, medium, "")
-	assert.Equal(t, 200, res3.StatusCode)
-	assert.True(t, strings.HasPrefix(res3.Header.Get("Content-Type"), "image/jpeg"))
-	res4, _ := download(t, small, "")
-	assert.Equal(t, 200, res4.StatusCode)
-	assert.True(t, strings.HasPrefix(res4.Header.Get("Content-Type"), "image/jpeg"))
-	res5, _ := download(t, tiny, "")
-	assert.Equal(t, 200, res5.StatusCode)
-	assert.True(t, strings.HasPrefix(res5.Header.Get("Content-Type"), "image/jpeg"))
-}
-
-func TestThumbnailPDFs(t *testing.T) {
-	if testing.Short() {
-		return
-	}
-
-	f, err := os.Open("../../tests/fixtures/dev-desktop.pdf")
-	assert.NoError(t, err)
-	defer f.Close()
-	req, err := http.NewRequest("POST", ts.URL+"/files/?Type=file&Name=dev-desktop.pdf", f)
-	assert.NoError(t, err)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	res, obj := doUploadOrMod(t, req, "application/pdf", "")
-	assert.Equal(t, 201, res.StatusCode)
-	data := obj["data"].(map[string]interface{})
-	pdfID := data["id"].(string)
-
-	res2, _ := httpGet(ts.URL + "/files/" + pdfID)
-	assert.Equal(t, 200, res2.StatusCode)
-	var obj2 map[string]interface{}
-	err = extractJSONRes(res2, &obj2)
-	assert.NoError(t, err)
-	data2 := obj2["data"].(map[string]interface{})
-	links := data2["links"].(map[string]interface{})
-	large := links["large"].(string)
-	medium := links["medium"].(string)
-	small := links["small"].(string)
-	tiny := links["tiny"].(string)
-
-	// Large, medium, and small are not generated automatically
-	res3, _ := download(t, large, "")
-	assert.Equal(t, 404, res3.StatusCode)
-	assert.Equal(t, res3.Header.Get("Content-Type"), "image/png")
-	res4, _ := download(t, medium, "")
-	assert.Equal(t, 404, res4.StatusCode)
-	assert.Equal(t, res4.Header.Get("Content-Type"), "image/png")
-	res5, _ := download(t, small, "")
-	assert.Equal(t, 404, res5.StatusCode)
-	assert.Equal(t, res5.Header.Get("Content-Type"), "image/png")
-
-	// Wait for tiny thumbnail generation
-	time.Sleep(1 * time.Second)
-
-	res6, _ := download(t, tiny, "")
-	assert.Equal(t, 200, res6.StatusCode)
-	assert.Equal(t, res6.Header.Get("Content-Type"), "image/jpeg")
-
-	// Wait for other thumbnails generation
-	time.Sleep(2 * time.Second)
-
-	res7, _ := download(t, large, "")
-	assert.Equal(t, 200, res7.StatusCode)
-	assert.Equal(t, res7.Header.Get("Content-Type"), "image/jpeg")
-	res8, _ := download(t, medium, "")
-	assert.Equal(t, 200, res8.StatusCode)
-	assert.Equal(t, res8.Header.Get("Content-Type"), "image/jpeg")
-	res9, _ := download(t, small, "")
-	assert.Equal(t, 200, res9.StatusCode)
-	assert.Equal(t, res9.Header.Get("Content-Type"), "image/jpeg")
-}
-
-func TestGetFileByPublicLink(t *testing.T) {
-	var err error
-	body := "foo"
-	res1, filedata := upload(t, "/files/?Type=file&Name=publicfile", "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
-	assert.Equal(t, 201, res1.StatusCode)
-
-	var ok bool
-	filedata, ok = filedata["data"].(map[string]interface{})
-	assert.True(t, ok)
-
-	fileID, ok = filedata["id"].(string)
-	assert.True(t, ok)
-
-	// Generating a new token
-	publicToken, err = testInstance.MakeJWT(consts.ShareAudience, "email", "io.cozy.files", "", time.Now())
-	assert.NoError(t, err)
-
-	expires := time.Now().Add(2 * time.Minute)
-	rules := permission.Set{
-		permission.Rule{
-			Type:   "io.cozy.files",
-			Verbs:  permission.Verbs(permission.GET),
-			Values: []string{fileID},
-		},
-	}
-	perms := permission.Permission{
-		Permissions: rules,
-	}
-	_, err = permission.CreateShareSet(testInstance, &permission.Permission{Type: "app", Permissions: rules}, "", map[string]string{"email": publicToken}, nil, perms, &expires)
-	assert.NoError(t, err)
-
-	req, err := http.NewRequest("GET", ts.URL+"/files/"+fileID, nil)
-	assert.NoError(t, err)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+publicToken)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-}
-
-func TestGetFileByPublicLinkRateExceeded(t *testing.T) {
-	var err error
-	// Blocking the file by accessing it a lot of times
-	for i := 0; i < 1999; i++ {
-		err = limits.CheckRateLimitKey(fileID, limits.SharingPublicLinkType)
-		assert.NoError(t, err)
-	}
-
-	err = limits.CheckRateLimitKey(fileID, limits.SharingPublicLinkType)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "Rate limit reached")
-	req, err := http.NewRequest("GET", ts.URL+"/files/"+fileID, nil)
-	assert.NoError(t, err)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+publicToken)
-
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 500, res.StatusCode)
-	resbody, err := io.ReadAll(res.Body)
-	assert.NoError(t, err)
-	assert.Contains(t, string(resbody), "Rate limit exceeded")
-}
-
-func TestFind(t *testing.T) {
-	type M map[string]interface{}
-	type S []interface{}
-
-	defIndex := M{"index": M{"fields": S{"_id"}}}
-	_, err := couchdb.DefineIndexRaw(testInstance, "io.cozy.files", &defIndex)
-	assert.NoError(t, err)
-
-	defIndex2 := M{"index": M{"fields": S{"type"}}}
-	_, err = couchdb.DefineIndexRaw(testInstance, "io.cozy.files", &defIndex2)
-	assert.NoError(t, err)
-
-	query := strings.NewReader(`{
-		"selector": {
-			"type": "file"
-		},
-		"limit": 1
-	}`)
-	req, _ := http.NewRequest("POST", ts.URL+"/files/_find", query)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var obj map[string]interface{}
-	err = extractJSONRes(res, &obj)
-	assert.NoError(t, err)
-
-	data := obj["data"].([]interface{})
-	meta := obj["meta"].(map[string]interface{})
-	if assert.Len(t, data, 1) {
-		doc := data[0].(map[string]interface{})
-		attrs := doc["attributes"].(map[string]interface{})
-		assert.NotEmpty(t, attrs["name"])
-		assert.NotEmpty(t, attrs["type"])
-		assert.NotEmpty(t, attrs["size"])
-		assert.NotEmpty(t, attrs["path"])
-	}
-	assert.NotNil(t, meta)
-	assert.Nil(t, meta["execution_stats"])
-
-	query2 := strings.NewReader(`{
-		"selector": {
-			"_id": {
-				"$gt": null
-			}
-		},
-		"limit": 1,
-		"execution_stats": true
-	}`)
-	req, _ = http.NewRequest("POST", ts.URL+"/files/_find", query2)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	err = extractJSONRes(res, &obj)
-	assert.NoError(t, err)
-	data = obj["data"].([]interface{})
-	meta = obj["meta"].(map[string]interface{})
-	assert.Equal(t, len(data), 1)
-	id1 := data[0].(map[string]interface{})["id"]
-	assert.NotNil(t, meta)
-	assert.NotEmpty(t, meta["execution_stats"])
-	links := obj["links"].(map[string]interface{})
-	next := links["next"].(string)
-
-	query2 = strings.NewReader(`{
-		"selector": {
-			"_id": {
-				"$gt": null
-			}
-		},
-		"limit": 1,
-		"execution_stats": true
-	}`)
-	req, _ = http.NewRequest("POST", ts.URL+next, query2)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	err = extractJSONRes(res, &obj)
-	assert.NoError(t, err)
-	data = obj["data"].([]interface{})
-	assert.Equal(t, len(data), 1)
-	id2 := data[0].(map[string]interface{})["id"]
-	assert.NotEqual(t, id1, id2)
-
-	query3 := strings.NewReader(`{
-		"selector": {
-			"_id": {
-				"$gt": null
-			}
-		},
-		"fields": ["dir_id", "name", "name"],
-		"limit": 1
-	}`)
-	req, _ = http.NewRequest("POST", ts.URL+"/files/_find", query3)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-
-	err = extractJSONRes(res, &obj)
-	assert.NoError(t, err)
-	resData := obj["data"].([]interface{})
-	dataFields := resData[0].(map[string]interface{})
-	attrs := dataFields["attributes"].(map[string]interface{})
-	assert.NotEmpty(t, attrs["name"].(string))
-	assert.NotEmpty(t, attrs["dir_id"].(string))
-	assert.NotEmpty(t, attrs["type"].(string))
-	assert.Nil(t, attrs["path"])
-	assert.Nil(t, attrs["created_at"])
-	assert.Nil(t, attrs["updated_at"])
-	assert.Nil(t, attrs["tags"])
-
-	query4 := strings.NewReader(`{
-		"selector": {
-			"type": "file"
-		},
-		"fields": ["name"],
-		"limit": 1
-	}`)
-	req, _ = http.NewRequest("POST", ts.URL+"/files/_find", query4)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-
-	err = extractJSONRes(res, &obj)
-	assert.NoError(t, err)
-	resData = obj["data"].([]interface{})
-	if assert.Len(t, resData, 1) {
-		dataFields = resData[0].(map[string]interface{})
-		attrs = dataFields["attributes"].(map[string]interface{})
-		assert.NotEmpty(t, attrs["name"].(string))
-		assert.NotEmpty(t, attrs["type"].(string))
-		assert.NotEmpty(t, attrs["size"].(string))
-		assert.False(t, attrs["trashed"].(bool))
-		assert.False(t, attrs["encrypted"].(bool))
-		assert.Nil(t, attrs["created_at"])
-		assert.Nil(t, attrs["updated_at"])
-		assert.Nil(t, attrs["tags"])
-		assert.Nil(t, attrs["executable"])
-		assert.Nil(t, attrs["dir_id"])
-		assert.Nil(t, attrs["path"])
-	}
-
-	_, dirdata := createDir(t, "/files/?Type=directory&Name=aDirectoryWithReferencedBy")
-	dirdata, ok := dirdata["data"].(map[string]interface{})
-	assert.True(t, ok)
-	dirID, ok := dirdata["id"].(string)
-	assert.True(t, ok)
-	path := "/files/" + dirID + "/relationships/referenced_by"
-	content, err := json.Marshal(&jsonapi.Relationship{
-		Data: couchdb.DocReference{
-			ID:   "fooalbumid",
-			Type: "io.cozy.photos.albums",
-		},
-	})
-	require.NoError(t, err)
-	req, err = http.NewRequest(http.MethodPost, ts.URL+path, bytes.NewReader(content))
-	require.NoError(t, err)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	res, err = http.DefaultClient.Do(req)
-	require.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-
-	query5 := strings.NewReader(`{
-		"selector": {
-			"name": "aDirectoryWithReferencedBy"
-		},
-		"limit": 1
-	}`)
-	req, _ = http.NewRequest("POST", ts.URL+"/files/_find", query5)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	res, err = http.DefaultClient.Do(req)
-	require.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-
-	err = extractJSONRes(res, &obj)
-	require.NoError(t, err)
-	resData = obj["data"].([]interface{})
-	require.Len(t, resData, 1)
-	dataFields = resData[0].(map[string]interface{})
-	attrs = dataFields["attributes"].(map[string]interface{})
-	assert.Equal(t, "aDirectoryWithReferencedBy", attrs["name"])
-	assert.NotEmpty(t, attrs["referenced_by"])
-	relationships, ok := dataFields["relationships"].(map[string]interface{})
-	require.True(t, ok)
-	referencedBy, ok := relationships["referenced_by"].(map[string]interface{})
-	require.True(t, ok)
-	dataRef, ok := referencedBy["data"].([]interface{})
-	require.True(t, ok)
-	require.Len(t, dataRef, 1)
-	ref := dataRef[0].(map[string]interface{})
-	assert.Equal(t, "fooalbumid", ref["id"])
-	assert.Equal(t, "io.cozy.photos.albums", ref["type"])
-}
-
-func TestDirSize(t *testing.T) {
-	_, dirdata := createDir(t, "/files/?Type=directory&Name=dirsizeparent")
-	dirdata, ok := dirdata["data"].(map[string]interface{})
-	assert.True(t, ok)
-	parentID, ok := dirdata["id"].(string)
-	assert.True(t, ok)
-
-	_, dirdata = createDir(t, "/files/"+parentID+"?Type=directory&Name=dirsizesub")
-	dirdata, ok = dirdata["data"].(map[string]interface{})
-	assert.True(t, ok)
-	subID, ok := dirdata["id"].(string)
-	assert.True(t, ok)
-
-	_, dirdata = createDir(t, "/files/"+subID+"?Type=directory&Name=dirsizesubsub")
-	dirdata, ok = dirdata["data"].(map[string]interface{})
-	assert.True(t, ok)
-	subsubID, ok := dirdata["id"].(string)
-	assert.True(t, ok)
-
-	nb := 10
-	body := "foo"
-	for i := 0; i < nb; i++ {
-		name := "file" + strconv.Itoa(i)
-		upload(t, "/files/"+parentID+"?Type=file&Name="+name, "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
-		upload(t, "/files/"+subID+"?Type=file&Name="+name, "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
-		upload(t, "/files/"+subsubID+"?Type=file&Name="+name, "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
-	}
-
-	var result struct {
-		Data struct {
-			Type       string
-			ID         string
-			Attributes struct {
-				Size string
-			}
-		}
-	}
-	err := getJSON(t, "/files/"+subsubID+"/size", &result)
-	assert.NoError(t, err)
-	assert.Equal(t, consts.DirSizes, result.Data.Type)
-	assert.Equal(t, subsubID, result.Data.ID)
-	assert.Equal(t, "30", result.Data.Attributes.Size)
-
-	err = getJSON(t, "/files/"+subID+"/size", &result)
-	assert.NoError(t, err)
-	assert.Equal(t, consts.DirSizes, result.Data.Type)
-	assert.Equal(t, subID, result.Data.ID)
-	assert.Equal(t, "60", result.Data.Attributes.Size)
-
-	err = getJSON(t, "/files/"+parentID+"/size", &result)
-	assert.NoError(t, err)
-	assert.Equal(t, consts.DirSizes, result.Data.Type)
-	assert.Equal(t, parentID, result.Data.ID)
-	assert.Equal(t, "90", result.Data.Attributes.Size)
-}
-
-func TestDeprecatePreviewAndIcon(t *testing.T) {
-	testutils.TODO(t, "2023-12-01", "Remove the deprecated preview and icon for PDF files")
-}
-
-func TestMain(m *testing.M) {
-	config.UseTestFile()
-	err := loadLocale()
-	if err != nil {
-		fmt.Println("Could not load default locale translations: ", err)
-		os.Exit(1)
-	}
-	testutils.NeedCouchdb()
-	setup = testutils.NewSetup(m, "files_test")
-
-	tempdir, err := os.MkdirTemp("", "cozy-stack")
-	if err != nil {
-		fmt.Println("Could not create temporary directory.")
-		os.Exit(1)
-	}
-	setup.AddCleanup(func() error { return os.RemoveAll(tempdir) })
-
-	config.GetConfig().Fs.URL = &url.URL{
-		Scheme: "file",
-		Host:   "localhost",
-		Path:   tempdir,
-	}
-
-	testInstance = setup.GetTestInstance()
-	client, tok := setup.GetTestClient(consts.Files + " " + consts.CertifiedCarbonCopy + " " + consts.CertifiedElectronicSafe)
-	clientID = client.ClientID
-	token = tok
-	ts = setup.GetTestServer("/files", Routes, func(r *echo.Echo) *echo.Echo {
-		secure := middlewares.Secure(&middlewares.SecureConfig{
-			CSPDefaultSrc:     []middlewares.CSPSource{middlewares.CSPSrcSelf},
-			CSPFrameAncestors: []middlewares.CSPSource{middlewares.CSPSrcNone},
-		})
-		r.Use(secure)
-		return r
-	})
-	ts.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler
-
-	os.Exit(setup.Run())
 }
 
 func httpGet(url string) (*http.Response, error) {

--- a/web/files/notsynchronized_test.go
+++ b/web/files/notsynchronized_test.go
@@ -191,5 +191,4 @@ func TestNotsynchronized(t *testing.T) {
 		assert.Len(t, doc.NotSynchronizedOn, 1)
 		assert.Equal(t, "fooclientid2", doc.NotSynchronizedOn[0].ID)
 	})
-
 }

--- a/web/files/notsynchronized_test.go
+++ b/web/files/notsynchronized_test.go
@@ -15,174 +15,181 @@ import (
 
 var dirID1, dirID2 string
 
-func TestAddNotSynchronizedOnOneRelation(t *testing.T) {
-	res1, data1 := createDir(t, "/files/?Type=directory&Name=to_sync_or_not_to_sync_1")
-	require.Equal(t, 201, res1.StatusCode)
-
-	var dirData1 map[string]interface{}
-	dirID1, dirData1 = extractDirData(t, data1)
-
-	path := "/files/" + dirID1 + "/relationships/not_synchronized_on"
-	content, err := json.Marshal(&jsonapi.Relationship{
-		Data: couchdb.DocReference{
-			ID:   "fooclientid",
-			Type: "io.cozy.oauth.clients",
-		},
-	})
-	require.NoError(t, err)
-
-	var result struct {
-		Data []couchdb.DocReference `json:"data"`
-		Meta struct {
-			Rev   string `json:"rev"`
-			Count int    `json:"count"`
-		} `json:"meta"`
+func TestNotsynchronized(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
 	}
-	req, err := http.NewRequest(http.MethodPost, ts.URL+path, bytes.NewReader(content))
-	require.NoError(t, err)
 
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+	t.Run("AddNotSynchronizedOnOneRelation", func(t *testing.T) {
+		res1, data1 := createDir(t, "/files/?Type=directory&Name=to_sync_or_not_to_sync_1")
+		require.Equal(t, 201, res1.StatusCode)
 
-	res, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
+		var dirData1 map[string]interface{}
+		dirID1, dirData1 = extractDirData(t, data1)
 
-	assert.Equal(t, 200, res.StatusCode)
-	err = json.NewDecoder(res.Body).Decode(&result)
-	require.NoError(t, err)
+		path := "/files/" + dirID1 + "/relationships/not_synchronized_on"
+		content, err := json.Marshal(&jsonapi.Relationship{
+			Data: couchdb.DocReference{
+				ID:   "fooclientid",
+				Type: "io.cozy.oauth.clients",
+			},
+		})
+		require.NoError(t, err)
 
-	assert.NotEqual(t, result.Meta.Rev, dirData1["_rev"])
-	assert.Equal(t, result.Meta.Count, 1)
-	assert.Equal(t, result.Data, []couchdb.DocReference{
-		{
-			ID:   "fooclientid",
-			Type: "io.cozy.oauth.clients",
-		},
+		var result struct {
+			Data []couchdb.DocReference `json:"data"`
+			Meta struct {
+				Rev   string `json:"rev"`
+				Count int    `json:"count"`
+			} `json:"meta"`
+		}
+		req, err := http.NewRequest(http.MethodPost, ts.URL+path, bytes.NewReader(content))
+		require.NoError(t, err)
+
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+
+		res, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, 200, res.StatusCode)
+		err = json.NewDecoder(res.Body).Decode(&result)
+		require.NoError(t, err)
+
+		assert.NotEqual(t, result.Meta.Rev, dirData1["_rev"])
+		assert.Equal(t, result.Meta.Count, 1)
+		assert.Equal(t, result.Data, []couchdb.DocReference{
+			{
+				ID:   "fooclientid",
+				Type: "io.cozy.oauth.clients",
+			},
+		})
+
+		doc, err := testInstance.VFS().DirByID(dirID1)
+		assert.NoError(t, err)
+		assert.Len(t, doc.NotSynchronizedOn, 1)
+		assert.Equal(t, doc.Rev(), result.Meta.Rev)
 	})
 
-	doc, err := testInstance.VFS().DirByID(dirID1)
-	assert.NoError(t, err)
-	assert.Len(t, doc.NotSynchronizedOn, 1)
-	assert.Equal(t, doc.Rev(), result.Meta.Rev)
-}
+	t.Run("AddNotSynchronizedOnMultipleRelation", func(t *testing.T) {
+		res1, data1 := createDir(t, "/files/?Type=directory&Name=to_sync_or_not_to_sync_2")
+		require.Equal(t, 201, res1.StatusCode)
 
-func TestAddNotSynchronizedOnMultipleRelation(t *testing.T) {
-	res1, data1 := createDir(t, "/files/?Type=directory&Name=to_sync_or_not_to_sync_2")
-	require.Equal(t, 201, res1.StatusCode)
+		var dirData2 map[string]interface{}
+		dirID2, dirData2 = extractDirData(t, data1)
 
-	var dirData2 map[string]interface{}
-	dirID2, dirData2 = extractDirData(t, data1)
+		path := "/files/" + dirID2 + "/relationships/not_synchronized_on"
+		content, err := json.Marshal(&jsonapi.Relationship{
+			Data: []couchdb.DocReference{
+				{ID: "fooclientid1", Type: "io.cozy.oauth.clients"},
+				{ID: "fooclientid2", Type: "io.cozy.oauth.clients"},
+				{ID: "fooclientid3", Type: "io.cozy.oauth.clients"},
+			},
+		})
+		require.NoError(t, err)
 
-	path := "/files/" + dirID2 + "/relationships/not_synchronized_on"
-	content, err := json.Marshal(&jsonapi.Relationship{
-		Data: []couchdb.DocReference{
+		req, err := http.NewRequest(http.MethodPost, ts.URL+path, bytes.NewReader(content))
+		require.NoError(t, err)
+
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+
+		var result struct {
+			Data []couchdb.DocReference `json:"data"`
+			Meta struct {
+				Rev   string `json:"rev"`
+				Count int    `json:"count"`
+			} `json:"meta"`
+		}
+		res, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, 200, res.StatusCode)
+		err = json.NewDecoder(res.Body).Decode(&result)
+		require.NoError(t, err)
+
+		assert.NotEqual(t, result.Meta.Rev, dirData2["_rev"])
+		assert.Equal(t, result.Meta.Count, 3)
+		assert.Equal(t, result.Data, []couchdb.DocReference{
 			{ID: "fooclientid1", Type: "io.cozy.oauth.clients"},
 			{ID: "fooclientid2", Type: "io.cozy.oauth.clients"},
 			{ID: "fooclientid3", Type: "io.cozy.oauth.clients"},
-		},
-	})
-	require.NoError(t, err)
+		})
 
-	req, err := http.NewRequest(http.MethodPost, ts.URL+path, bytes.NewReader(content))
-	require.NoError(t, err)
-
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-
-	var result struct {
-		Data []couchdb.DocReference `json:"data"`
-		Meta struct {
-			Rev   string `json:"rev"`
-			Count int    `json:"count"`
-		} `json:"meta"`
-	}
-	res, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-
-	assert.Equal(t, 200, res.StatusCode)
-	err = json.NewDecoder(res.Body).Decode(&result)
-	require.NoError(t, err)
-
-	assert.NotEqual(t, result.Meta.Rev, dirData2["_rev"])
-	assert.Equal(t, result.Meta.Count, 3)
-	assert.Equal(t, result.Data, []couchdb.DocReference{
-		{ID: "fooclientid1", Type: "io.cozy.oauth.clients"},
-		{ID: "fooclientid2", Type: "io.cozy.oauth.clients"},
-		{ID: "fooclientid3", Type: "io.cozy.oauth.clients"},
+		doc, err := testInstance.VFS().DirByID(dirID2)
+		assert.NoError(t, err)
+		assert.Len(t, doc.NotSynchronizedOn, 3)
+		assert.Equal(t, doc.Rev(), result.Meta.Rev)
 	})
 
-	doc, err := testInstance.VFS().DirByID(dirID2)
-	assert.NoError(t, err)
-	assert.Len(t, doc.NotSynchronizedOn, 3)
-	assert.Equal(t, doc.Rev(), result.Meta.Rev)
-}
+	t.Run("RemoveNotSynchronizedOnOneRelation", func(t *testing.T) {
+		path := "/files/" + dirID1 + "/relationships/not_synchronized_on"
+		content, err := json.Marshal(&jsonapi.Relationship{
+			Data: couchdb.DocReference{
+				ID:   "fooclientid",
+				Type: "io.cozy.oauth.clients",
+			},
+		})
+		assert.NoError(t, err)
 
-func TestRemoveNotSynchronizedOnOneRelation(t *testing.T) {
-	path := "/files/" + dirID1 + "/relationships/not_synchronized_on"
-	content, err := json.Marshal(&jsonapi.Relationship{
-		Data: couchdb.DocReference{
-			ID:   "fooclientid",
-			Type: "io.cozy.oauth.clients",
-		},
-	})
-	assert.NoError(t, err)
+		var result struct {
+			Data []couchdb.DocReference `json:"data"`
+			Meta struct {
+				Rev   string `json:"rev"`
+				Count int    `json:"count"`
+			} `json:"meta"`
+		}
+		req, err := http.NewRequest(http.MethodDelete, ts.URL+path, bytes.NewReader(content))
+		assert.NoError(t, err)
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		err = json.NewDecoder(res.Body).Decode(&result)
+		require.NoError(t, err)
 
-	var result struct {
-		Data []couchdb.DocReference `json:"data"`
-		Meta struct {
-			Rev   string `json:"rev"`
-			Count int    `json:"count"`
-		} `json:"meta"`
-	}
-	req, err := http.NewRequest(http.MethodDelete, ts.URL+path, bytes.NewReader(content))
-	assert.NoError(t, err)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	err = json.NewDecoder(res.Body).Decode(&result)
-	require.NoError(t, err)
+		assert.Equal(t, result.Meta.Count, 0)
+		assert.Equal(t, result.Data, []couchdb.DocReference{})
 
-	assert.Equal(t, result.Meta.Count, 0)
-	assert.Equal(t, result.Data, []couchdb.DocReference{})
-
-	doc, err := testInstance.VFS().DirByID(dirID1)
-	assert.NoError(t, err)
-	assert.Len(t, doc.NotSynchronizedOn, 0)
-}
-
-func TestRemoveNotSynchronizedOnMultipleRelation(t *testing.T) {
-	path := "/files/" + dirID2 + "/relationships/not_synchronized_on"
-	content, err := json.Marshal(&jsonapi.Relationship{
-		Data: []couchdb.DocReference{
-			{ID: "fooclientid3", Type: "io.cozy.oauth.clients"},
-			{ID: "fooclientid5", Type: "io.cozy.oauth.clients"},
-			{ID: "fooclientid1", Type: "io.cozy.oauth.clients"},
-		},
-	})
-	assert.NoError(t, err)
-
-	var result struct {
-		Data []couchdb.DocReference `json:"data"`
-		Meta struct {
-			Rev   string `json:"rev"`
-			Count int    `json:"count"`
-		} `json:"meta"`
-	}
-	req, err := http.NewRequest(http.MethodDelete, ts.URL+path, bytes.NewReader(content))
-	assert.NoError(t, err)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	err = json.NewDecoder(res.Body).Decode(&result)
-	require.NoError(t, err)
-
-	assert.Equal(t, result.Meta.Count, 1)
-	assert.Equal(t, result.Data, []couchdb.DocReference{
-		{ID: "fooclientid2", Type: "io.cozy.oauth.clients"},
+		doc, err := testInstance.VFS().DirByID(dirID1)
+		assert.NoError(t, err)
+		assert.Len(t, doc.NotSynchronizedOn, 0)
 	})
 
-	doc, err := testInstance.VFS().DirByID(dirID2)
-	assert.NoError(t, err)
-	assert.Len(t, doc.NotSynchronizedOn, 1)
-	assert.Equal(t, "fooclientid2", doc.NotSynchronizedOn[0].ID)
+	t.Run("RemoveNotSynchronizedOnMultipleRelation", func(t *testing.T) {
+		path := "/files/" + dirID2 + "/relationships/not_synchronized_on"
+		content, err := json.Marshal(&jsonapi.Relationship{
+			Data: []couchdb.DocReference{
+				{ID: "fooclientid3", Type: "io.cozy.oauth.clients"},
+				{ID: "fooclientid5", Type: "io.cozy.oauth.clients"},
+				{ID: "fooclientid1", Type: "io.cozy.oauth.clients"},
+			},
+		})
+		assert.NoError(t, err)
+
+		var result struct {
+			Data []couchdb.DocReference `json:"data"`
+			Meta struct {
+				Rev   string `json:"rev"`
+				Count int    `json:"count"`
+			} `json:"meta"`
+		}
+		req, err := http.NewRequest(http.MethodDelete, ts.URL+path, bytes.NewReader(content))
+		assert.NoError(t, err)
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		err = json.NewDecoder(res.Body).Decode(&result)
+		require.NoError(t, err)
+
+		assert.Equal(t, result.Meta.Count, 1)
+		assert.Equal(t, result.Data, []couchdb.DocReference{
+			{ID: "fooclientid2", Type: "io.cozy.oauth.clients"},
+		})
+
+		doc, err := testInstance.VFS().DirByID(dirID2)
+		assert.NoError(t, err)
+		assert.Len(t, doc.NotSynchronizedOn, 1)
+		assert.Equal(t, "fooclientid2", doc.NotSynchronizedOn[0].ID)
+	})
+
 }

--- a/web/files/pagination_test.go
+++ b/web/files/pagination_test.go
@@ -268,7 +268,6 @@ func TestPagination(t *testing.T) {
 
 		trash(t, "/files/"+parentID)
 	})
-
 }
 
 func getJSON(t *testing.T, url string, out interface{}) error {

--- a/web/files/pagination_test.go
+++ b/web/files/pagination_test.go
@@ -12,6 +12,265 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestPagination(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	t.Run("TrashIsSkipped", func(t *testing.T) {
+		nb := 15
+		body := "foo"
+		for i := 0; i < nb; i++ {
+			name := "foo" + strconv.Itoa(i)
+			upload(t, "/files/io.cozy.files.root-dir?Type=file&Name="+name, "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
+		}
+
+		opts := &url.Values{}
+		opts.Add("page[limit]", "5")
+		var result struct {
+			Data struct {
+				Relationships struct {
+					Contents struct {
+						Links *jsonapi.LinksList
+						Data  []couchdb.DocReference
+					}
+				}
+			}
+			Included []interface{}
+			Links    *jsonapi.LinksList
+		}
+
+		ids := []string{}
+
+		assert.NoError(t, getJSON(t, "/files/io.cozy.files.root-dir?"+opts.Encode(), &result))
+		assert.Len(t, result.Data.Relationships.Contents.Data, 5)
+		assert.Len(t, result.Included, 5)
+
+		for i, ref := range result.Data.Relationships.Contents.Data {
+			id := result.Included[i].(map[string]interface{})["id"].(string)
+			assert.Equal(t, id, ref.ID)
+			assert.NotEqual(t, id, consts.TrashDirID)
+			for _, seen := range ids {
+				assert.NotEqual(t, id, seen)
+			}
+			ids = append(ids, id)
+		}
+
+		next := result.Links.Next
+		assert.NotEmpty(t, next)
+
+		assert.NoError(t, getJSON(t, next, &result))
+		assert.Len(t, result.Data.Relationships.Contents.Data, 5)
+		assert.Len(t, result.Included, 5)
+
+		for i, ref := range result.Data.Relationships.Contents.Data {
+			id := result.Included[i].(map[string]interface{})["id"].(string)
+			assert.Equal(t, id, ref.ID)
+			assert.NotEqual(t, id, consts.TrashDirID)
+			for _, seen := range ids {
+				assert.NotEqual(t, id, seen)
+			}
+			ids = append(ids, id)
+		}
+
+		next = result.Links.Next
+		assert.NotEmpty(t, next)
+
+		opts.Add("page[skip]", "10")
+		assert.NoError(t, getJSON(t, "/files/io.cozy.files.root-dir?"+opts.Encode(), &result))
+		assert.Len(t, result.Data.Relationships.Contents.Data, 5)
+		assert.Len(t, result.Included, 5)
+
+		for i, ref := range result.Data.Relationships.Contents.Data {
+			id := result.Included[i].(map[string]interface{})["id"].(string)
+			assert.Equal(t, id, ref.ID)
+			assert.NotEqual(t, id, consts.TrashDirID)
+			for _, seen := range ids {
+				assert.NotEqual(t, id, seen)
+			}
+			ids = append(ids, id)
+		}
+	})
+
+	t.Run("ZeroCountIsPresent", func(t *testing.T) {
+		_, dirdata := createDir(t, "/files/?Type=directory&Name=emptydirectory")
+		dirdata, ok := dirdata["data"].(map[string]interface{})
+		assert.True(t, ok)
+		parentID, ok := dirdata["id"].(string)
+		assert.True(t, ok)
+
+		var result map[string]interface{}
+		assert.NoError(t, getJSON(t, "/files/"+parentID, &result))
+
+		data := result["data"].(map[string]interface{})
+		rels := data["relationships"].(map[string]interface{})
+		contents := rels["contents"].(map[string]interface{})
+		meta := contents["meta"].(map[string]interface{})
+		count, ok := meta["count"].(float64)
+		assert.True(t, ok)
+		assert.Equal(t, float64(0), count)
+	})
+
+	t.Run("ListDirPaginated", func(t *testing.T) {
+		_, dirdata := createDir(t, "/files/?Type=directory&Name=paginationcontainer")
+
+		dirdata, ok := dirdata["data"].(map[string]interface{})
+		assert.True(t, ok)
+
+		parentID, ok := dirdata["id"].(string)
+		assert.True(t, ok)
+
+		nb := 15
+
+		body := "foo"
+		for i := 0; i < nb; i++ {
+			name := "file" + strconv.Itoa(i)
+			upload(t, "/files/"+parentID+"?Type=file&Name="+name, "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
+		}
+
+		opts := &url.Values{}
+		opts.Add("page[limit]", "7")
+		var result struct {
+			Data struct {
+				Relationships struct {
+					Contents struct {
+						Meta struct {
+							Count int
+						}
+						Links *jsonapi.LinksList
+						Data  []couchdb.DocReference
+					}
+				}
+			}
+			Included []interface{}
+		}
+		assert.NoError(t, getJSON(t, "/files/"+parentID+"?"+opts.Encode(), &result))
+
+		assert.Len(t, result.Data.Relationships.Contents.Data, 7)
+		assert.Len(t, result.Included, 7)
+
+		for i, ref := range result.Data.Relationships.Contents.Data {
+			id := result.Included[i].(map[string]interface{})["id"].(string)
+			assert.Equal(t, id, ref.ID)
+		}
+
+		assert.Equal(t, result.Data.Relationships.Contents.Meta.Count, 15)
+		next := result.Data.Relationships.Contents.Links.Next
+		assert.NotEmpty(t, next)
+
+		var result2 struct {
+			Links *jsonapi.LinksList
+			Meta  struct {
+				Count int
+			}
+			Data []interface{}
+		}
+		assert.NoError(t, getJSON(t, next, &result2))
+		assert.Len(t, result2.Data, 7)
+		assert.Equal(t, result2.Meta.Count, 15)
+
+		assert.NotEqual(t, result.Data.Relationships.Contents.Data[0].ID,
+			result2.Data[0].(map[string]interface{})["id"])
+
+		next = result2.Links.Next
+		assert.NotEmpty(t, next)
+
+		var result3 struct {
+			Lins *jsonapi.LinksList
+			Meta struct {
+				Count int
+			}
+			Data []interface{}
+		}
+		assert.NoError(t, getJSON(t, next, &result3))
+		assert.Len(t, result3.Data, 1)
+		assert.Equal(t, result3.Meta.Count, 15)
+
+		assert.NotEqual(t, result.Data.Relationships.Contents.Data[0].ID,
+			result3.Data[0].(map[string]interface{})["id"])
+
+		trash(t, "/files/"+parentID)
+	})
+
+	t.Run("ListDirPaginatedSkip", func(t *testing.T) {
+		_, dirdata := createDir(t, "/files/?Type=directory&Name=paginationcontainerskip")
+
+		dirdata, ok := dirdata["data"].(map[string]interface{})
+		assert.True(t, ok)
+
+		parentID, ok := dirdata["id"].(string)
+		assert.True(t, ok)
+
+		nb := 15
+
+		body := "foo"
+		for i := 0; i < nb; i++ {
+			name := "file" + strconv.Itoa(i)
+			upload(t, "/files/"+parentID+"?Type=file&Name="+name, "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
+		}
+
+		opts := &url.Values{}
+		opts.Add("page[limit]", "7")
+		opts.Add("page[skip]", "0")
+		var result struct {
+			Data struct {
+				Relationships struct {
+					Contents struct {
+						Meta struct {
+							Count int
+						}
+						Links *jsonapi.LinksList
+						Data  []couchdb.DocReference
+					}
+				}
+			}
+			Included []interface{}
+		}
+		assert.NoError(t, getJSON(t, "/files/"+parentID+"?"+opts.Encode(), &result))
+
+		assert.Len(t, result.Data.Relationships.Contents.Data, 7)
+		assert.Len(t, result.Included, 7)
+		assert.Equal(t, result.Data.Relationships.Contents.Meta.Count, 15)
+		next := result.Data.Relationships.Contents.Links.Next
+		assert.NotEmpty(t, next)
+		assert.Contains(t, next, "skip")
+
+		var result2 struct {
+			Links *jsonapi.LinksList
+			Meta  struct {
+				Count int
+			}
+			Data []interface{}
+		}
+		assert.NoError(t, getJSON(t, next, &result2))
+		assert.Len(t, result2.Data, 7)
+		assert.Equal(t, result2.Meta.Count, 15)
+
+		assert.NotEqual(t, result.Data.Relationships.Contents.Data[0].ID,
+			result2.Data[0].(map[string]interface{})["id"])
+
+		next = result2.Links.Next
+		assert.NotEmpty(t, next)
+
+		var result3 struct {
+			Lins *jsonapi.LinksList
+			Meta struct {
+				Count int
+			}
+			Data []interface{}
+		}
+		assert.NoError(t, getJSON(t, next, &result3))
+		assert.Len(t, result3.Data, 1)
+		assert.Equal(t, result3.Meta.Count, 15)
+
+		assert.NotEqual(t, result.Data.Relationships.Contents.Data[0].ID,
+			result3.Data[0].(map[string]interface{})["id"])
+
+		trash(t, "/files/"+parentID)
+	})
+
+}
+
 func getJSON(t *testing.T, url string, out interface{}) error {
 	res, err := httpGet(ts.URL + url)
 	assert.NoError(t, err)
@@ -19,256 +278,4 @@ func getJSON(t *testing.T, url string, out interface{}) error {
 
 	assert.Equal(t, 200, res.StatusCode)
 	return json.NewDecoder(res.Body).Decode(&out)
-}
-
-func TestTrashIsSkipped(t *testing.T) {
-	nb := 15
-	body := "foo"
-	for i := 0; i < nb; i++ {
-		name := "foo" + strconv.Itoa(i)
-		upload(t, "/files/io.cozy.files.root-dir?Type=file&Name="+name, "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
-	}
-
-	opts := &url.Values{}
-	opts.Add("page[limit]", "5")
-	var result struct {
-		Data struct {
-			Relationships struct {
-				Contents struct {
-					Links *jsonapi.LinksList
-					Data  []couchdb.DocReference
-				}
-			}
-		}
-		Included []interface{}
-		Links    *jsonapi.LinksList
-	}
-
-	ids := []string{}
-
-	assert.NoError(t, getJSON(t, "/files/io.cozy.files.root-dir?"+opts.Encode(), &result))
-	assert.Len(t, result.Data.Relationships.Contents.Data, 5)
-	assert.Len(t, result.Included, 5)
-
-	for i, ref := range result.Data.Relationships.Contents.Data {
-		id := result.Included[i].(map[string]interface{})["id"].(string)
-		assert.Equal(t, id, ref.ID)
-		assert.NotEqual(t, id, consts.TrashDirID)
-		for _, seen := range ids {
-			assert.NotEqual(t, id, seen)
-		}
-		ids = append(ids, id)
-	}
-
-	next := result.Links.Next
-	assert.NotEmpty(t, next)
-
-	assert.NoError(t, getJSON(t, next, &result))
-	assert.Len(t, result.Data.Relationships.Contents.Data, 5)
-	assert.Len(t, result.Included, 5)
-
-	for i, ref := range result.Data.Relationships.Contents.Data {
-		id := result.Included[i].(map[string]interface{})["id"].(string)
-		assert.Equal(t, id, ref.ID)
-		assert.NotEqual(t, id, consts.TrashDirID)
-		for _, seen := range ids {
-			assert.NotEqual(t, id, seen)
-		}
-		ids = append(ids, id)
-	}
-
-	next = result.Links.Next
-	assert.NotEmpty(t, next)
-
-	opts.Add("page[skip]", "10")
-	assert.NoError(t, getJSON(t, "/files/io.cozy.files.root-dir?"+opts.Encode(), &result))
-	assert.Len(t, result.Data.Relationships.Contents.Data, 5)
-	assert.Len(t, result.Included, 5)
-
-	for i, ref := range result.Data.Relationships.Contents.Data {
-		id := result.Included[i].(map[string]interface{})["id"].(string)
-		assert.Equal(t, id, ref.ID)
-		assert.NotEqual(t, id, consts.TrashDirID)
-		for _, seen := range ids {
-			assert.NotEqual(t, id, seen)
-		}
-		ids = append(ids, id)
-	}
-}
-
-func TestZeroCountIsPresent(t *testing.T) {
-	_, dirdata := createDir(t, "/files/?Type=directory&Name=emptydirectory")
-	dirdata, ok := dirdata["data"].(map[string]interface{})
-	assert.True(t, ok)
-	parentID, ok := dirdata["id"].(string)
-	assert.True(t, ok)
-
-	var result map[string]interface{}
-	assert.NoError(t, getJSON(t, "/files/"+parentID, &result))
-
-	data := result["data"].(map[string]interface{})
-	rels := data["relationships"].(map[string]interface{})
-	contents := rels["contents"].(map[string]interface{})
-	meta := contents["meta"].(map[string]interface{})
-	count, ok := meta["count"].(float64)
-	assert.True(t, ok)
-	assert.Equal(t, float64(0), count)
-}
-
-func TestListDirPaginated(t *testing.T) {
-	_, dirdata := createDir(t, "/files/?Type=directory&Name=paginationcontainer")
-
-	dirdata, ok := dirdata["data"].(map[string]interface{})
-	assert.True(t, ok)
-
-	parentID, ok := dirdata["id"].(string)
-	assert.True(t, ok)
-
-	nb := 15
-
-	body := "foo"
-	for i := 0; i < nb; i++ {
-		name := "file" + strconv.Itoa(i)
-		upload(t, "/files/"+parentID+"?Type=file&Name="+name, "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
-	}
-
-	opts := &url.Values{}
-	opts.Add("page[limit]", "7")
-	var result struct {
-		Data struct {
-			Relationships struct {
-				Contents struct {
-					Meta struct {
-						Count int
-					}
-					Links *jsonapi.LinksList
-					Data  []couchdb.DocReference
-				}
-			}
-		}
-		Included []interface{}
-	}
-	assert.NoError(t, getJSON(t, "/files/"+parentID+"?"+opts.Encode(), &result))
-
-	assert.Len(t, result.Data.Relationships.Contents.Data, 7)
-	assert.Len(t, result.Included, 7)
-
-	for i, ref := range result.Data.Relationships.Contents.Data {
-		id := result.Included[i].(map[string]interface{})["id"].(string)
-		assert.Equal(t, id, ref.ID)
-	}
-
-	assert.Equal(t, result.Data.Relationships.Contents.Meta.Count, 15)
-	next := result.Data.Relationships.Contents.Links.Next
-	assert.NotEmpty(t, next)
-
-	var result2 struct {
-		Links *jsonapi.LinksList
-		Meta  struct {
-			Count int
-		}
-		Data []interface{}
-	}
-	assert.NoError(t, getJSON(t, next, &result2))
-	assert.Len(t, result2.Data, 7)
-	assert.Equal(t, result2.Meta.Count, 15)
-
-	assert.NotEqual(t, result.Data.Relationships.Contents.Data[0].ID,
-		result2.Data[0].(map[string]interface{})["id"])
-
-	next = result2.Links.Next
-	assert.NotEmpty(t, next)
-
-	var result3 struct {
-		Lins *jsonapi.LinksList
-		Meta struct {
-			Count int
-		}
-		Data []interface{}
-	}
-	assert.NoError(t, getJSON(t, next, &result3))
-	assert.Len(t, result3.Data, 1)
-	assert.Equal(t, result3.Meta.Count, 15)
-
-	assert.NotEqual(t, result.Data.Relationships.Contents.Data[0].ID,
-		result3.Data[0].(map[string]interface{})["id"])
-
-	trash(t, "/files/"+parentID)
-}
-
-func TestListDirPaginatedSkip(t *testing.T) {
-	_, dirdata := createDir(t, "/files/?Type=directory&Name=paginationcontainerskip")
-
-	dirdata, ok := dirdata["data"].(map[string]interface{})
-	assert.True(t, ok)
-
-	parentID, ok := dirdata["id"].(string)
-	assert.True(t, ok)
-
-	nb := 15
-
-	body := "foo"
-	for i := 0; i < nb; i++ {
-		name := "file" + strconv.Itoa(i)
-		upload(t, "/files/"+parentID+"?Type=file&Name="+name, "text/plain", body, "rL0Y20zC+Fzt72VPzMSk2A==")
-	}
-
-	opts := &url.Values{}
-	opts.Add("page[limit]", "7")
-	opts.Add("page[skip]", "0")
-	var result struct {
-		Data struct {
-			Relationships struct {
-				Contents struct {
-					Meta struct {
-						Count int
-					}
-					Links *jsonapi.LinksList
-					Data  []couchdb.DocReference
-				}
-			}
-		}
-		Included []interface{}
-	}
-	assert.NoError(t, getJSON(t, "/files/"+parentID+"?"+opts.Encode(), &result))
-
-	assert.Len(t, result.Data.Relationships.Contents.Data, 7)
-	assert.Len(t, result.Included, 7)
-	assert.Equal(t, result.Data.Relationships.Contents.Meta.Count, 15)
-	next := result.Data.Relationships.Contents.Links.Next
-	assert.NotEmpty(t, next)
-	assert.Contains(t, next, "skip")
-
-	var result2 struct {
-		Links *jsonapi.LinksList
-		Meta  struct {
-			Count int
-		}
-		Data []interface{}
-	}
-	assert.NoError(t, getJSON(t, next, &result2))
-	assert.Len(t, result2.Data, 7)
-	assert.Equal(t, result2.Meta.Count, 15)
-
-	assert.NotEqual(t, result.Data.Relationships.Contents.Data[0].ID,
-		result2.Data[0].(map[string]interface{})["id"])
-
-	next = result2.Links.Next
-	assert.NotEmpty(t, next)
-
-	var result3 struct {
-		Lins *jsonapi.LinksList
-		Meta struct {
-			Count int
-		}
-		Data []interface{}
-	}
-	assert.NoError(t, getJSON(t, next, &result3))
-	assert.Len(t, result3.Data, 1)
-	assert.Equal(t, result3.Meta.Count, 15)
-
-	assert.NotEqual(t, result.Data.Relationships.Contents.Data[0].ID,
-		result3.Data[0].(map[string]interface{})["id"])
-
-	trash(t, "/files/"+parentID)
 }

--- a/web/files/permissions_test.go
+++ b/web/files/permissions_test.go
@@ -61,7 +61,6 @@ func TestPermissions(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 403, res.StatusCode)
 	})
-
 }
 
 func request(m, path, token string, body io.Reader) (*http.Response, error) {

--- a/web/files/permissions_test.go
+++ b/web/files/permissions_test.go
@@ -12,49 +12,56 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCreateDirNoToken(t *testing.T) {
-	noToken := ""
-	res, err := request("POST", "/files/?Name=icantcreateyou&Type=directory", noToken, strings.NewReader(""))
-	assert.NoError(t, err)
-	assert.Equal(t, 401, res.StatusCode)
-}
+func TestPermissions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
 
-func TestCreateDirBadType(t *testing.T) {
-	badtok, _ := testInstance.MakeJWT(consts.AccessTokenAudience, clientID, "io.cozy.events", "", time.Now())
-	res, err := request("POST", "/files/?Name=icantcreateyou&Type=directory", badtok, strings.NewReader(""))
-	assert.NoError(t, err)
-	assert.Equal(t, 403, res.StatusCode)
-}
+	t.Run("CreateDirNoToken", func(t *testing.T) {
+		noToken := ""
+		res, err := request("POST", "/files/?Name=icantcreateyou&Type=directory", noToken, strings.NewReader(""))
+		assert.NoError(t, err)
+		assert.Equal(t, 401, res.StatusCode)
+	})
 
-func TestCreateDirWildCard(t *testing.T) {
-	wildTok, _ := testInstance.MakeJWT(consts.AccessTokenAudience, clientID, "io.cozy.files.*", "", time.Now())
-	res, err := request("POST", "/files/?Name=icantcreateyou&Type=directory", wildTok, strings.NewReader(""))
-	assert.NoError(t, err)
-	assert.Equal(t, 201, res.StatusCode)
-}
+	t.Run("CreateDirBadType", func(t *testing.T) {
+		badtok, _ := testInstance.MakeJWT(consts.AccessTokenAudience, clientID, "io.cozy.events", "", time.Now())
+		res, err := request("POST", "/files/?Name=icantcreateyou&Type=directory", badtok, strings.NewReader(""))
+		assert.NoError(t, err)
+		assert.Equal(t, 403, res.StatusCode)
+	})
 
-func TestCreateDirLimitedScope(t *testing.T) {
-	res, data := createDir(t, "/files/?Name=permissionholder&Type=directory")
-	assert.Equal(t, 201, res.StatusCode)
-	id := data["data"].(map[string]interface{})["id"].(string)
-	badtok, _ := testInstance.MakeJWT(consts.AccessTokenAudience, clientID, "io.cozy.files:ALL:"+id, "", time.Now())
+	t.Run("CreateDirWildCard", func(t *testing.T) {
+		wildTok, _ := testInstance.MakeJWT(consts.AccessTokenAudience, clientID, "io.cozy.files.*", "", time.Now())
+		res, err := request("POST", "/files/?Name=icantcreateyou&Type=directory", wildTok, strings.NewReader(""))
+		assert.NoError(t, err)
+		assert.Equal(t, 201, res.StatusCode)
+	})
 
-	// not in authorized dir
-	res, err := request("POST", "/files/?Name=icantcreateyou&Type=directory", badtok, strings.NewReader(""))
-	assert.NoError(t, err)
-	assert.Equal(t, 403, res.StatusCode)
+	t.Run("CreateDirLimitedScope", func(t *testing.T) {
+		res, data := createDir(t, "/files/?Name=permissionholder&Type=directory")
+		assert.Equal(t, 201, res.StatusCode)
+		id := data["data"].(map[string]interface{})["id"].(string)
+		badtok, _ := testInstance.MakeJWT(consts.AccessTokenAudience, clientID, "io.cozy.files:ALL:"+id, "", time.Now())
 
-	// in authorized dir
-	res2, err := request("POST", "/files/"+id+"?Name=icancreateyou&Type=directory", token, strings.NewReader(""))
-	assert.NoError(t, err)
-	assert.Equal(t, 201, res2.StatusCode)
-}
+		// not in authorized dir
+		res, err := request("POST", "/files/?Name=icantcreateyou&Type=directory", badtok, strings.NewReader(""))
+		assert.NoError(t, err)
+		assert.Equal(t, 403, res.StatusCode)
 
-func TestCreateDirBadVerb(t *testing.T) {
-	badtok, _ := testInstance.MakeJWT(consts.AccessTokenAudience, clientID, "io.cozy.files:GET", "", time.Now())
-	res, err := request("POST", "/files/?Name=icantcreateyou&Type=directory", badtok, strings.NewReader(""))
-	assert.NoError(t, err)
-	assert.Equal(t, 403, res.StatusCode)
+		// in authorized dir
+		res2, err := request("POST", "/files/"+id+"?Name=icancreateyou&Type=directory", token, strings.NewReader(""))
+		assert.NoError(t, err)
+		assert.Equal(t, 201, res2.StatusCode)
+	})
+
+	t.Run("CreateDirBadVerb", func(t *testing.T) {
+		badtok, _ := testInstance.MakeJWT(consts.AccessTokenAudience, clientID, "io.cozy.files:GET", "", time.Now())
+		res, err := request("POST", "/files/?Name=icantcreateyou&Type=directory", badtok, strings.NewReader(""))
+		assert.NoError(t, err)
+		assert.Equal(t, 403, res.StatusCode)
+	})
+
 }
 
 func request(m, path, token string, body io.Reader) (*http.Response, error) {

--- a/web/files/referencedby_test.go
+++ b/web/files/referencedby_test.go
@@ -192,5 +192,4 @@ func TestReferencedby(t *testing.T) {
 		assert.Len(t, doc.ReferencedBy, 1)
 		assert.Equal(t, "fooalbumid2", doc.ReferencedBy[0].ID)
 	})
-
 }

--- a/web/files/referencedby_test.go
+++ b/web/files/referencedby_test.go
@@ -16,174 +16,181 @@ import (
 var fileID1, fileID2 string
 var fileData1, fileData2 map[string]interface{}
 
-func TestAddReferencedByOneRelation(t *testing.T) {
-	body := "foo,bar"
-	res1, data1 := upload(t, "/files/?Type=file&Name=toreference", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
-	require.Equal(t, 201, res1.StatusCode)
-
-	fileID1, fileData1 = extractDirData(t, data1)
-
-	path := "/files/" + fileID1 + "/relationships/referenced_by"
-	content, err := json.Marshal(&jsonapi.Relationship{
-		Data: couchdb.DocReference{
-			ID:   "fooalbumid",
-			Type: "io.cozy.photos.albums",
-		},
-	})
-	require.NoError(t, err)
-
-	var result struct {
-		Data []couchdb.DocReference `json:"data"`
-		Meta struct {
-			Rev   string `json:"rev"`
-			Count int    `json:"count"`
-		} `json:"meta"`
+func TestReferencedby(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
 	}
-	req, err := http.NewRequest(http.MethodPost, ts.URL+path, bytes.NewReader(content))
-	require.NoError(t, err)
 
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+	t.Run("AddReferencedByOneRelation", func(t *testing.T) {
+		body := "foo,bar"
+		res1, data1 := upload(t, "/files/?Type=file&Name=toreference", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
+		require.Equal(t, 201, res1.StatusCode)
 
-	res, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
+		fileID1, fileData1 = extractDirData(t, data1)
 
-	assert.Equal(t, 200, res.StatusCode)
-	err = json.NewDecoder(res.Body).Decode(&result)
-	require.NoError(t, err)
+		path := "/files/" + fileID1 + "/relationships/referenced_by"
+		content, err := json.Marshal(&jsonapi.Relationship{
+			Data: couchdb.DocReference{
+				ID:   "fooalbumid",
+				Type: "io.cozy.photos.albums",
+			},
+		})
+		require.NoError(t, err)
 
-	assert.NotEqual(t, result.Meta.Rev, fileData1["_rev"])
-	assert.Equal(t, result.Meta.Count, 1)
-	assert.Equal(t, result.Data, []couchdb.DocReference{
-		{
-			ID:   "fooalbumid",
-			Type: "io.cozy.photos.albums",
-		},
+		var result struct {
+			Data []couchdb.DocReference `json:"data"`
+			Meta struct {
+				Rev   string `json:"rev"`
+				Count int    `json:"count"`
+			} `json:"meta"`
+		}
+		req, err := http.NewRequest(http.MethodPost, ts.URL+path, bytes.NewReader(content))
+		require.NoError(t, err)
+
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+
+		res, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, 200, res.StatusCode)
+		err = json.NewDecoder(res.Body).Decode(&result)
+		require.NoError(t, err)
+
+		assert.NotEqual(t, result.Meta.Rev, fileData1["_rev"])
+		assert.Equal(t, result.Meta.Count, 1)
+		assert.Equal(t, result.Data, []couchdb.DocReference{
+			{
+				ID:   "fooalbumid",
+				Type: "io.cozy.photos.albums",
+			},
+		})
+
+		doc, err := testInstance.VFS().FileByID(fileID1)
+		assert.NoError(t, err)
+		assert.Len(t, doc.ReferencedBy, 1)
+		assert.Equal(t, doc.Rev(), result.Meta.Rev)
 	})
 
-	doc, err := testInstance.VFS().FileByID(fileID1)
-	assert.NoError(t, err)
-	assert.Len(t, doc.ReferencedBy, 1)
-	assert.Equal(t, doc.Rev(), result.Meta.Rev)
-}
+	t.Run("AddReferencedByMultipleRelation", func(t *testing.T) {
+		body := "foo,bar"
+		res1, data1 := upload(t, "/files/?Type=file&Name=toreference2", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
+		require.Equal(t, 201, res1.StatusCode)
 
-func TestAddReferencedByMultipleRelation(t *testing.T) {
-	body := "foo,bar"
-	res1, data1 := upload(t, "/files/?Type=file&Name=toreference2", "text/plain", body, "UmfjCVWct/albVkURcJJfg==")
-	require.Equal(t, 201, res1.StatusCode)
+		fileID2, fileData2 = extractDirData(t, data1)
 
-	fileID2, fileData2 = extractDirData(t, data1)
+		path := "/files/" + fileID2 + "/relationships/referenced_by"
+		content, err := json.Marshal(&jsonapi.Relationship{
+			Data: []couchdb.DocReference{
+				{ID: "fooalbumid1", Type: "io.cozy.photos.albums"},
+				{ID: "fooalbumid2", Type: "io.cozy.photos.albums"},
+				{ID: "fooalbumid3", Type: "io.cozy.photos.albums"},
+			},
+		})
+		require.NoError(t, err)
 
-	path := "/files/" + fileID2 + "/relationships/referenced_by"
-	content, err := json.Marshal(&jsonapi.Relationship{
-		Data: []couchdb.DocReference{
+		req, err := http.NewRequest(http.MethodPost, ts.URL+path, bytes.NewReader(content))
+		require.NoError(t, err)
+
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+
+		var result struct {
+			Data []couchdb.DocReference `json:"data"`
+			Meta struct {
+				Rev   string `json:"rev"`
+				Count int    `json:"count"`
+			} `json:"meta"`
+		}
+		res, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, 200, res.StatusCode)
+		err = json.NewDecoder(res.Body).Decode(&result)
+		require.NoError(t, err)
+
+		assert.NotEqual(t, result.Meta.Rev, fileData2["_rev"])
+		assert.Equal(t, result.Meta.Count, 3)
+		assert.Equal(t, result.Data, []couchdb.DocReference{
 			{ID: "fooalbumid1", Type: "io.cozy.photos.albums"},
 			{ID: "fooalbumid2", Type: "io.cozy.photos.albums"},
 			{ID: "fooalbumid3", Type: "io.cozy.photos.albums"},
-		},
-	})
-	require.NoError(t, err)
+		})
 
-	req, err := http.NewRequest(http.MethodPost, ts.URL+path, bytes.NewReader(content))
-	require.NoError(t, err)
-
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-
-	var result struct {
-		Data []couchdb.DocReference `json:"data"`
-		Meta struct {
-			Rev   string `json:"rev"`
-			Count int    `json:"count"`
-		} `json:"meta"`
-	}
-	res, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-
-	assert.Equal(t, 200, res.StatusCode)
-	err = json.NewDecoder(res.Body).Decode(&result)
-	require.NoError(t, err)
-
-	assert.NotEqual(t, result.Meta.Rev, fileData2["_rev"])
-	assert.Equal(t, result.Meta.Count, 3)
-	assert.Equal(t, result.Data, []couchdb.DocReference{
-		{ID: "fooalbumid1", Type: "io.cozy.photos.albums"},
-		{ID: "fooalbumid2", Type: "io.cozy.photos.albums"},
-		{ID: "fooalbumid3", Type: "io.cozy.photos.albums"},
+		doc, err := testInstance.VFS().FileByID(fileID2)
+		assert.NoError(t, err)
+		assert.Len(t, doc.ReferencedBy, 3)
+		assert.Equal(t, doc.Rev(), result.Meta.Rev)
 	})
 
-	doc, err := testInstance.VFS().FileByID(fileID2)
-	assert.NoError(t, err)
-	assert.Len(t, doc.ReferencedBy, 3)
-	assert.Equal(t, doc.Rev(), result.Meta.Rev)
-}
+	t.Run("RemoveReferencedByOneRelation", func(t *testing.T) {
+		path := "/files/" + fileID1 + "/relationships/referenced_by"
+		content, err := json.Marshal(&jsonapi.Relationship{
+			Data: couchdb.DocReference{
+				ID:   "fooalbumid",
+				Type: "io.cozy.photos.albums",
+			},
+		})
+		assert.NoError(t, err)
 
-func TestRemoveReferencedByOneRelation(t *testing.T) {
-	path := "/files/" + fileID1 + "/relationships/referenced_by"
-	content, err := json.Marshal(&jsonapi.Relationship{
-		Data: couchdb.DocReference{
-			ID:   "fooalbumid",
-			Type: "io.cozy.photos.albums",
-		},
-	})
-	assert.NoError(t, err)
+		var result struct {
+			Data []couchdb.DocReference `json:"data"`
+			Meta struct {
+				Rev   string `json:"rev"`
+				Count int    `json:"count"`
+			} `json:"meta"`
+		}
+		req, err := http.NewRequest(http.MethodDelete, ts.URL+path, bytes.NewReader(content))
+		assert.NoError(t, err)
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		err = json.NewDecoder(res.Body).Decode(&result)
+		require.NoError(t, err)
 
-	var result struct {
-		Data []couchdb.DocReference `json:"data"`
-		Meta struct {
-			Rev   string `json:"rev"`
-			Count int    `json:"count"`
-		} `json:"meta"`
-	}
-	req, err := http.NewRequest(http.MethodDelete, ts.URL+path, bytes.NewReader(content))
-	assert.NoError(t, err)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	err = json.NewDecoder(res.Body).Decode(&result)
-	require.NoError(t, err)
+		assert.Equal(t, result.Meta.Count, 0)
+		assert.Equal(t, result.Data, []couchdb.DocReference{})
 
-	assert.Equal(t, result.Meta.Count, 0)
-	assert.Equal(t, result.Data, []couchdb.DocReference{})
-
-	doc, err := testInstance.VFS().FileByID(fileID1)
-	assert.NoError(t, err)
-	assert.Len(t, doc.ReferencedBy, 0)
-}
-
-func TestRemoveReferencedByMultipleRelation(t *testing.T) {
-	path := "/files/" + fileID2 + "/relationships/referenced_by"
-	content, err := json.Marshal(&jsonapi.Relationship{
-		Data: []couchdb.DocReference{
-			{ID: "fooalbumid3", Type: "io.cozy.photos.albums"},
-			{ID: "fooalbumid5", Type: "io.cozy.photos.albums"},
-			{ID: "fooalbumid1", Type: "io.cozy.photos.albums"},
-		},
-	})
-	assert.NoError(t, err)
-
-	var result struct {
-		Data []couchdb.DocReference `json:"data"`
-		Meta struct {
-			Rev   string `json:"rev"`
-			Count int    `json:"count"`
-		} `json:"meta"`
-	}
-	req, err := http.NewRequest(http.MethodDelete, ts.URL+path, bytes.NewReader(content))
-	assert.NoError(t, err)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	err = json.NewDecoder(res.Body).Decode(&result)
-	require.NoError(t, err)
-
-	assert.Equal(t, result.Meta.Count, 1)
-	assert.Equal(t, result.Data, []couchdb.DocReference{
-		{ID: "fooalbumid2", Type: "io.cozy.photos.albums"},
+		doc, err := testInstance.VFS().FileByID(fileID1)
+		assert.NoError(t, err)
+		assert.Len(t, doc.ReferencedBy, 0)
 	})
 
-	doc, err := testInstance.VFS().FileByID(fileID2)
-	assert.NoError(t, err)
-	assert.Len(t, doc.ReferencedBy, 1)
-	assert.Equal(t, "fooalbumid2", doc.ReferencedBy[0].ID)
+	t.Run("RemoveReferencedByMultipleRelation", func(t *testing.T) {
+		path := "/files/" + fileID2 + "/relationships/referenced_by"
+		content, err := json.Marshal(&jsonapi.Relationship{
+			Data: []couchdb.DocReference{
+				{ID: "fooalbumid3", Type: "io.cozy.photos.albums"},
+				{ID: "fooalbumid5", Type: "io.cozy.photos.albums"},
+				{ID: "fooalbumid1", Type: "io.cozy.photos.albums"},
+			},
+		})
+		assert.NoError(t, err)
+
+		var result struct {
+			Data []couchdb.DocReference `json:"data"`
+			Meta struct {
+				Rev   string `json:"rev"`
+				Count int    `json:"count"`
+			} `json:"meta"`
+		}
+		req, err := http.NewRequest(http.MethodDelete, ts.URL+path, bytes.NewReader(content))
+		assert.NoError(t, err)
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		err = json.NewDecoder(res.Body).Decode(&result)
+		require.NoError(t, err)
+
+		assert.Equal(t, result.Meta.Count, 1)
+		assert.Equal(t, result.Data, []couchdb.DocReference{
+			{ID: "fooalbumid2", Type: "io.cozy.photos.albums"},
+		})
+
+		doc, err := testInstance.VFS().FileByID(fileID2)
+		assert.NoError(t, err)
+		assert.Len(t, doc.ReferencedBy, 1)
+		assert.Equal(t, "fooalbumid2", doc.ReferencedBy[0].ID)
+	})
+
 }

--- a/web/intents/intents_test.go
+++ b/web/intents/intents_test.go
@@ -87,7 +87,6 @@ func TestIntents(t *testing.T) {
 
 	ts = setup.GetTestServer("/intents", Routes)
 	ts.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler
-	os.Exit(setup.Run())
 
 	t.Run("CreateIntent", func(t *testing.T) {
 		body := `{

--- a/web/intents/intents_test.go
+++ b/web/intents/intents_test.go
@@ -30,92 +30,11 @@ var filesToken string
 var intentID string
 var appPerms *permission.Permission
 
-func checkIntentResult(t *testing.T, res *http.Response, fromWeb bool) {
-	assert.Equal(t, 200, res.StatusCode)
-	var result map[string]interface{}
-	err := json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	data, ok := result["data"].(map[string]interface{})
-	assert.True(t, ok)
-	assert.Equal(t, "io.cozy.intents", data["type"].(string))
-	intentID = data["id"].(string)
-	assert.NotEmpty(t, intentID)
-	attrs := data["attributes"].(map[string]interface{})
-	perms := attrs["permissions"].([]interface{})
-	assert.Len(t, perms, 1)
-	assert.Equal(t, "GET", perms[0].(string))
-	assert.Equal(t, "PICK", attrs["action"].(string))
-	assert.Equal(t, "io.cozy.files", attrs["type"].(string))
-	if !fromWeb {
-		return
+func TestIntents(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
 	}
-	assert.Equal(t, "https://app.cozy.example.net", attrs["client"].(string))
-	links := data["links"].(map[string]interface{})
-	assert.Equal(t, "/intents/"+intentID, links["self"].(string))
-	assert.Equal(t, "/permissions/"+appPerms.ID(), links["permissions"].(string))
-}
 
-func TestCreateIntent(t *testing.T) {
-	body := `{
-		"data": {
-			"type": "io.cozy.settings",
-			"attributes": {
-				"action": "PICK",
-				"type": "io.cozy.files",
-				"permissions": ["GET"]
-			}
-		}
-	}`
-	req, _ := http.NewRequest("POST", ts.URL+"/intents", bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/vnd.api+json")
-	req.Header.Add("Accept", "application/vnd.api+json")
-	req.Header.Add("Authorization", "Bearer "+appToken)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	checkIntentResult(t, res, true)
-}
-
-func TestGetIntent(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/intents/"+intentID, nil)
-	req.Header.Add("Content-Type", "application/vnd.api+json")
-	req.Header.Add("Accept", "application/vnd.api+json")
-	req.Header.Add("Authorization", "Bearer "+filesToken)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	checkIntentResult(t, res, true)
-}
-
-func TestGetIntentNotFromTheService(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/intents/"+intentID, nil)
-	req.Header.Add("Content-Type", "application/vnd.api+json")
-	req.Header.Add("Accept", "application/vnd.api+json")
-	req.Header.Add("Authorization", "Bearer "+appToken)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 403, res.StatusCode)
-}
-
-func TestCreateIntentOAuth(t *testing.T) {
-	body := `{
-		"data": {
-			"type": "io.cozy.settings",
-			"attributes": {
-				"action": "PICK",
-				"type": "io.cozy.files",
-				"permissions": ["GET"]
-			}
-		}
-	}`
-	req, _ := http.NewRequest("POST", ts.URL+"/intents", bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/vnd.api+json")
-	req.Header.Add("Accept", "application/vnd.api+json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	checkIntentResult(t, res, false)
-}
-
-func TestMain(m *testing.M) {
 	config.UseTestFile()
 	testutils.NeedCouchdb()
 	setup := testutils.NewSetup(m, "intents_test")
@@ -169,4 +88,90 @@ func TestMain(m *testing.M) {
 	ts = setup.GetTestServer("/intents", Routes)
 	ts.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler
 	os.Exit(setup.Run())
+
+	t.Run("CreateIntent", func(t *testing.T) {
+		body := `{
+		"data": {
+			"type": "io.cozy.settings",
+			"attributes": {
+				"action": "PICK",
+				"type": "io.cozy.files",
+				"permissions": ["GET"]
+			}
+		}
+	}`
+		req, _ := http.NewRequest("POST", ts.URL+"/intents", bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/vnd.api+json")
+		req.Header.Add("Accept", "application/vnd.api+json")
+		req.Header.Add("Authorization", "Bearer "+appToken)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		checkIntentResult(t, res, true)
+	})
+
+	t.Run("GetIntent", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/intents/"+intentID, nil)
+		req.Header.Add("Content-Type", "application/vnd.api+json")
+		req.Header.Add("Accept", "application/vnd.api+json")
+		req.Header.Add("Authorization", "Bearer "+filesToken)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		checkIntentResult(t, res, true)
+	})
+
+	t.Run("GetIntentNotFromTheService", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/intents/"+intentID, nil)
+		req.Header.Add("Content-Type", "application/vnd.api+json")
+		req.Header.Add("Accept", "application/vnd.api+json")
+		req.Header.Add("Authorization", "Bearer "+appToken)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 403, res.StatusCode)
+	})
+
+	t.Run("CreateIntentOAuth", func(t *testing.T) {
+		body := `{
+		"data": {
+			"type": "io.cozy.settings",
+			"attributes": {
+				"action": "PICK",
+				"type": "io.cozy.files",
+				"permissions": ["GET"]
+			}
+		}
+	}`
+		req, _ := http.NewRequest("POST", ts.URL+"/intents", bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/vnd.api+json")
+		req.Header.Add("Accept", "application/vnd.api+json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		checkIntentResult(t, res, false)
+	})
+
+}
+
+func checkIntentResult(t *testing.T, res *http.Response, fromWeb bool) {
+	assert.Equal(t, 200, res.StatusCode)
+	var result map[string]interface{}
+	err := json.NewDecoder(res.Body).Decode(&result)
+	assert.NoError(t, err)
+	data, ok := result["data"].(map[string]interface{})
+	assert.True(t, ok)
+	assert.Equal(t, "io.cozy.intents", data["type"].(string))
+	intentID = data["id"].(string)
+	assert.NotEmpty(t, intentID)
+	attrs := data["attributes"].(map[string]interface{})
+	perms := attrs["permissions"].([]interface{})
+	assert.Len(t, perms, 1)
+	assert.Equal(t, "GET", perms[0].(string))
+	assert.Equal(t, "PICK", attrs["action"].(string))
+	assert.Equal(t, "io.cozy.files", attrs["type"].(string))
+	if !fromWeb {
+		return
+	}
+	assert.Equal(t, "https://app.cozy.example.net", attrs["client"].(string))
+	links := data["links"].(map[string]interface{})
+	assert.Equal(t, "/intents/"+intentID, links["self"].(string))
+	assert.Equal(t, "/permissions/"+appPerms.ID(), links["permissions"].(string))
 }

--- a/web/intents/intents_test.go
+++ b/web/intents/intents_test.go
@@ -37,7 +37,8 @@ func TestIntents(t *testing.T) {
 
 	config.UseTestFile()
 	testutils.NeedCouchdb()
-	setup := testutils.NewSetup(m, "intents_test")
+	setup := testutils.NewSetup(nil, t.Name())
+	t.Cleanup(setup.Cleanup)
 	ins = setup.GetTestInstance(&lifecycle.Options{
 		Domain: "cozy.example.net",
 	})

--- a/web/intents/intents_test.go
+++ b/web/intents/intents_test.go
@@ -148,7 +148,6 @@ func TestIntents(t *testing.T) {
 		assert.NoError(t, err)
 		checkIntentResult(t, res, false)
 	})
-
 }
 
 func checkIntentResult(t *testing.T, res *http.Response, fromWeb bool) {

--- a/web/jobs/jobs_test.go
+++ b/web/jobs/jobs_test.go
@@ -706,7 +706,6 @@ func TestJobs(t *testing.T) {
 		assert.NotEmpty(t, v3.Data.Attributes.StartedAt)
 		assert.NotEmpty(t, v3.Data.Attributes.FinishedAt)
 	})
-
 }
 
 func SetToken(next echo.HandlerFunc) echo.HandlerFunc {

--- a/web/jobs/jobs_test.go
+++ b/web/jobs/jobs_test.go
@@ -43,634 +43,11 @@ type jsonapiData struct {
 	Attributes interface{} `json:"attributes"`
 }
 
-func TestGetQueue(t *testing.T) {
-	req, err := http.NewRequest(http.MethodGet, ts.URL+"/jobs/queue/print", nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	assert.NoError(t, err)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	data := result["data"].([]interface{})
-	assert.Equal(t, 0, len(data))
-}
-
-func TestCreateJob(t *testing.T) {
-	body, _ := json.Marshal(&jsonapiReq{
-		Data: &jsonapiData{
-			Attributes: &jobRequest{Arguments: "foobar"},
-		},
-	})
-	req, err := http.NewRequest(http.MethodPost, ts.URL+"/jobs/queue/print", bytes.NewReader(body))
-	req.Header.Add("Authorization", "Bearer "+token)
-	assert.NoError(t, err)
-	res, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-	assert.Equal(t, 202, res.StatusCode)
-	defer res.Body.Close()
-	var resbody map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&resbody)
-	require.NoError(t, err)
-	data, _ := resbody["data"].(map[string]interface{})
-	attrs, _ := data["attributes"].(map[string]interface{})
-	assert.Equal(t, "print", attrs["worker"])
-	assert.NotEqual(t, true, attrs["manual_execution"])
-}
-
-func TestCreateManualJob(t *testing.T) {
-	body, _ := json.Marshal(&jsonapiReq{
-		Data: &jsonapiData{
-			Attributes: &jobRequest{
-				Arguments: "foobar",
-				Manual:    true,
-			},
-		},
-	})
-	req, err := http.NewRequest(http.MethodPost, ts.URL+"/jobs/queue/print", bytes.NewReader(body))
-	req.Header.Add("Authorization", "Bearer "+token)
-	assert.NoError(t, err)
-	res, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-	assert.Equal(t, 202, res.StatusCode)
-	var resbody map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&resbody)
-	require.NoError(t, err)
-	data, _ := resbody["data"].(map[string]interface{})
-	attrs, _ := data["attributes"].(map[string]interface{})
-	assert.Equal(t, "print", attrs["worker"])
-	assert.Equal(t, true, attrs["manual_execution"])
-}
-
-func TestCreateJobForReservedWorker(t *testing.T) {
-	body, _ := json.Marshal(&jsonapiReq{
-		Data: &jsonapiData{
-			Attributes: &jobRequest{Arguments: "foobar"},
-		},
-	})
-	req, err := http.NewRequest(http.MethodPost, ts.URL+"/jobs/queue/trash-files", bytes.NewReader(body))
-	req.Header.Add("Authorization", "Bearer "+token)
-	assert.NoError(t, err)
-	res, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-
-	assert.Equal(t, 403, res.StatusCode)
-}
-
-func TestCreateJobNotExist(t *testing.T) {
-	body, _ := json.Marshal(&jsonapiReq{
-		Data: &jsonapiData{
-			Attributes: &jobRequest{Arguments: "foobar"},
-		},
-	})
-	req, err := http.NewRequest(http.MethodPost, ts.URL+"/jobs/queue/none", bytes.NewReader(body))
-	tokenNone, _ := testInstance.MakeJWT(consts.CLIAudience, "CLI",
-		consts.Jobs+":ALL:none:worker",
-		"", time.Now())
-	req.Header.Add("Authorization", "Bearer "+tokenNone)
-	assert.NoError(t, err)
-	res, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-
-	assert.Equal(t, 404, res.StatusCode)
-}
-
-func TestAddGetAndDeleteTriggerAt(t *testing.T) {
-	at := time.Now().Add(1100 * time.Millisecond).Format(time.RFC3339)
-	body, _ := json.Marshal(&jsonapiReq{
-		Data: &jsonapiData{
-			Attributes: &map[string]interface{}{
-				"type":      "@at",
-				"arguments": at,
-				"worker":    "print",
-				"message":   "foo",
-			},
-		},
-	})
-	req1, err := http.NewRequest(http.MethodPost, ts.URL+"/jobs/triggers", bytes.NewReader(body))
-	assert.NoError(t, err)
-	req1.Header.Add("Authorization", "Bearer "+token)
-	res1, err := http.DefaultClient.Do(req1)
-	require.NoError(t, err)
-
-	defer res1.Body.Close()
-	assert.Equal(t, http.StatusCreated, res1.StatusCode)
-
-	var v struct {
-		Data struct {
-			ID         string            `json:"id"`
-			Type       string            `json:"type"`
-			Attributes *job.TriggerInfos `json:"attributes"`
-		}
-	}
-	err = json.NewDecoder(res1.Body).Decode(&v)
-	require.NoError(t, err)
-
-	require.NotNil(t, v.Data)
-	require.NotNil(t, v.Data.Attributes)
-	triggerID := v.Data.ID
-	assert.Equal(t, consts.Triggers, v.Data.Type)
-	assert.Equal(t, "@at", v.Data.Attributes.Type)
-	assert.Equal(t, at, v.Data.Attributes.Arguments)
-	assert.Equal(t, "print", v.Data.Attributes.WorkerType)
-
-	body, _ = json.Marshal(&jsonapiReq{
-		Data: &jsonapiData{
-			Attributes: map[string]interface{}{
-				"type":      "@at",
-				"arguments": "garbage",
-				"worker":    "print",
-				"message":   "foo",
-			},
-		},
-	})
-	req2, err := http.NewRequest(http.MethodPost, ts.URL+"/jobs/triggers", bytes.NewReader(body))
-	assert.NoError(t, err)
-	req2.Header.Add("Authorization", "Bearer "+token)
-	res2, err := http.DefaultClient.Do(req2)
-	require.NoError(t, err)
-
-	assert.Equal(t, http.StatusBadRequest, res2.StatusCode)
-
-	req3, err := http.NewRequest(http.MethodGet, ts.URL+"/jobs/triggers/"+triggerID, nil)
-	assert.NoError(t, err)
-	req3.Header.Add("Authorization", "Bearer "+token)
-	res3, err := http.DefaultClient.Do(req3)
-	require.NoError(t, err)
-
-	assert.Equal(t, http.StatusOK, res3.StatusCode)
-
-	req4, err := http.NewRequest("DELETE", ts.URL+"/jobs/triggers/"+triggerID, nil)
-	assert.NoError(t, err)
-	req4.Header.Add("Authorization", "Bearer "+token)
-	res4, err := http.DefaultClient.Do(req4)
-	require.NoError(t, err)
-
-	assert.Equal(t, http.StatusNoContent, res4.StatusCode)
-
-	req5, err := http.NewRequest(http.MethodGet, ts.URL+"/jobs/triggers/"+triggerID, nil)
-	assert.NoError(t, err)
-	req5.Header.Add("Authorization", "Bearer "+token)
-	res5, err := http.DefaultClient.Do(req5)
-	require.NoError(t, err)
-
-	assert.Equal(t, http.StatusNotFound, res5.StatusCode)
-}
-
-func TestAddGetAndDeleteTriggerIn(t *testing.T) {
-	body, _ := json.Marshal(&jsonapiReq{
-		Data: &jsonapiData{
-			Attributes: map[string]interface{}{
-				"type":      "@in",
-				"arguments": "1s",
-				"worker":    "print",
-				"message":   "foo",
-			},
-		},
-	})
-	req1, err := http.NewRequest(http.MethodPost, ts.URL+"/jobs/triggers", bytes.NewReader(body))
-	assert.NoError(t, err)
-	req1.Header.Add("Authorization", "Bearer "+token)
-	res1, err := http.DefaultClient.Do(req1)
-	require.NoError(t, err)
-
-	defer res1.Body.Close()
-	assert.Equal(t, http.StatusCreated, res1.StatusCode)
-
-	var v struct {
-		Data struct {
-			ID         string            `json:"id"`
-			Type       string            `json:"type"`
-			Attributes *job.TriggerInfos `json:"attributes"`
-		}
-	}
-	err = json.NewDecoder(res1.Body).Decode(&v)
-	require.NoError(t, err)
-
-	require.NotNil(t, v.Data)
-	require.NotNil(t, v.Data.Attributes)
-	triggerID := v.Data.ID
-	assert.Equal(t, consts.Triggers, v.Data.Type)
-	assert.Equal(t, "@in", v.Data.Attributes.Type)
-	assert.Equal(t, "1s", v.Data.Attributes.Arguments)
-	assert.Equal(t, "print", v.Data.Attributes.WorkerType)
-
-	body, _ = json.Marshal(&jsonapiReq{
-		Data: &jsonapiData{
-			Attributes: map[string]interface{}{
-				"type":      "@in",
-				"arguments": "garbage",
-				"worker":    "print",
-				"message":   "foo",
-			},
-		},
-	})
-	req2, err := http.NewRequest(http.MethodPost, ts.URL+"/jobs/triggers", bytes.NewReader(body))
-	assert.NoError(t, err)
-	req2.Header.Add("Authorization", "Bearer "+token)
-	res2, err := http.DefaultClient.Do(req2)
-	require.NoError(t, err)
-
-	assert.Equal(t, http.StatusBadRequest, res2.StatusCode)
-
-	req3, err := http.NewRequest(http.MethodGet, ts.URL+"/jobs/triggers/"+triggerID, nil)
-	assert.NoError(t, err)
-	req3.Header.Add("Authorization", "Bearer "+token)
-	res3, err := http.DefaultClient.Do(req3)
-	require.NoError(t, err)
-
-	assert.Equal(t, http.StatusOK, res3.StatusCode)
-
-	req4, err := http.NewRequest("DELETE", ts.URL+"/jobs/triggers/"+triggerID, nil)
-	assert.NoError(t, err)
-	req4.Header.Add("Authorization", "Bearer "+token)
-	res4, err := http.DefaultClient.Do(req4)
-	require.NoError(t, err)
-
-	assert.Equal(t, http.StatusNoContent, res4.StatusCode)
-
-	req5, err := http.NewRequest(http.MethodGet, ts.URL+"/jobs/triggers/"+triggerID, nil)
-	assert.NoError(t, err)
-	req5.Header.Add("Authorization", "Bearer "+token)
-	res5, err := http.DefaultClient.Do(req5)
-	require.NoError(t, err)
-
-	assert.Equal(t, http.StatusNotFound, res5.StatusCode)
-}
-
-func TestAddGetUpdateAndDeleteTriggerCron(t *testing.T) {
-	body, _ := json.Marshal(&jsonapiReq{
-		Data: &jsonapiData{
-			Attributes: &map[string]interface{}{
-				"type":      "@cron",
-				"arguments": "0 0 0 * * 0",
-				"worker":    "print",
-				"message":   "foo",
-			},
-		},
-	})
-	req1, err := http.NewRequest(http.MethodPost, ts.URL+"/jobs/triggers", bytes.NewReader(body))
-	assert.NoError(t, err)
-	req1.Header.Add("Authorization", "Bearer "+token)
-	res1, err := http.DefaultClient.Do(req1)
-	require.NoError(t, err)
-
-	defer res1.Body.Close()
-	assert.Equal(t, http.StatusCreated, res1.StatusCode)
-
-	var v struct {
-		Data struct {
-			ID         string            `json:"id"`
-			Type       string            `json:"type"`
-			Attributes *job.TriggerInfos `json:"attributes"`
-		}
-	}
-	err = json.NewDecoder(res1.Body).Decode(&v)
-	require.NoError(t, err)
-
-	require.NotNil(t, v.Data)
-	require.NotNil(t, v.Data.Attributes)
-	triggerID := v.Data.ID
-	assert.Equal(t, consts.Triggers, v.Data.Type)
-	assert.Equal(t, "@cron", v.Data.Attributes.Type)
-	assert.Equal(t, "0 0 0 * * 0", v.Data.Attributes.Arguments)
-	assert.Equal(t, "print", v.Data.Attributes.WorkerType)
-
-	body, _ = json.Marshal(&jsonapiReq{
-		Data: &jsonapiData{
-			Attributes: map[string]interface{}{
-				"arguments": "0 0 0 * * 1",
-			},
-		},
-	})
-	req2, err := http.NewRequest(http.MethodPatch, ts.URL+"/jobs/triggers/"+triggerID, bytes.NewReader(body))
-	assert.NoError(t, err)
-	req2.Header.Add("Authorization", "Bearer "+token)
-	res2, err := http.DefaultClient.Do(req2)
-	require.NoError(t, err)
-
-	assert.Equal(t, http.StatusOK, res2.StatusCode)
-
-	req3, err := http.NewRequest(http.MethodGet, ts.URL+"/jobs/triggers/"+triggerID, nil)
-	assert.NoError(t, err)
-	req3.Header.Add("Authorization", "Bearer "+token)
-	res3, err := http.DefaultClient.Do(req3)
-	require.NoError(t, err)
-
-	assert.Equal(t, http.StatusOK, res3.StatusCode)
-
-	var v2 struct {
-		Data struct {
-			ID         string            `json:"id"`
-			Type       string            `json:"type"`
-			Attributes *job.TriggerInfos `json:"attributes"`
-		}
-	}
-	err = json.NewDecoder(res3.Body).Decode(&v2)
-	require.NoError(t, err)
-
-	require.NotNil(t, v2.Data)
-	require.NotNil(t, v2.Data.Attributes)
-	assert.Equal(t, triggerID, v2.Data.ID)
-	assert.Equal(t, consts.Triggers, v2.Data.Type)
-	assert.Equal(t, "@cron", v2.Data.Attributes.Type)
-	assert.Equal(t, "0 0 0 * * 1", v2.Data.Attributes.Arguments)
-	assert.Equal(t, "print", v2.Data.Attributes.WorkerType)
-
-	req4, err := http.NewRequest("DELETE", ts.URL+"/jobs/triggers/"+triggerID, nil)
-	assert.NoError(t, err)
-	req4.Header.Add("Authorization", "Bearer "+token)
-	res4, err := http.DefaultClient.Do(req4)
-	require.NoError(t, err)
-
-	assert.Equal(t, http.StatusNoContent, res4.StatusCode)
-}
-
-func TestAddTriggerWithMetadata(t *testing.T) {
-	at := time.Now().Add(1100 * time.Millisecond).Format(time.RFC3339)
-	body, _ := json.Marshal(&jsonapiReq{
-		Data: &jsonapiData{
-			Attributes: map[string]interface{}{
-				"type":      "@webhook",
-				"arguments": at,
-				"worker":    "print",
-				"message":   "foo",
-			},
-		},
-	})
-
-	req1, err := http.NewRequest(http.MethodPost, ts.URL+"/jobs/triggers", bytes.NewReader(body))
-	assert.NoError(t, err)
-	req1.Header.Add("Authorization", "Bearer "+token)
-	res1, err := http.DefaultClient.Do(req1)
-	require.NoError(t, err)
-
-	defer res1.Body.Close()
-	assert.Equal(t, http.StatusCreated, res1.StatusCode)
-
-	var v struct {
-		Data struct {
-			ID         string            `json:"id"`
-			Type       string            `json:"type"`
-			Attributes *job.TriggerInfos `json:"attributes"`
-			Links      jsonapi.LinksList `json:"links"`
-		}
+func TestJobs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
 	}
 
-	err = json.NewDecoder(res1.Body).Decode(&v)
-	require.NoError(t, err)
-
-	require.NotNil(t, v.Data)
-	require.NotNil(t, v.Data.Attributes)
-	triggerID := v.Data.ID
-	assert.Equal(t, consts.Triggers, v.Data.Type)
-	assert.Equal(t, "@webhook", v.Data.Attributes.Type)
-	assert.Equal(t, "https://"+testInstance.Domain+"/jobs/webhooks/"+triggerID, v.Data.Links.Webhook)
-	assert.Equal(t, at, v.Data.Attributes.Arguments)
-	assert.Equal(t, "print", v.Data.Attributes.WorkerType)
-
-	assert.Equal(t, "1", v.Data.Attributes.Metadata.DocTypeVersion)
-	assert.Equal(t, 1, v.Data.Attributes.Metadata.MetadataVersion)
-	// "CLI" is the token subject
-	assert.Equal(t, "CLI", v.Data.Attributes.Metadata.CreatedByApp)
-	assert.NotZero(t, v.Data.Attributes.Metadata.CreatedAt)
-	assert.NotZero(t, v.Data.Attributes.Metadata.UpdatedAt)
-
-	req2, err := http.NewRequest(http.MethodGet, ts.URL+"/jobs/triggers/"+triggerID, nil)
-	assert.NoError(t, err)
-	req2.Header.Add("Authorization", "Bearer "+token)
-	res2, err := http.DefaultClient.Do(req2)
-	require.NoError(t, err)
-
-	assert.Equal(t, http.StatusOK, res2.StatusCode)
-
-	// Clean
-	req3, err := http.NewRequest("DELETE", ts.URL+"/jobs/triggers/"+triggerID, nil)
-	assert.NoError(t, err)
-	req3.Header.Add("Authorization", "Bearer "+token)
-	res3, err := http.DefaultClient.Do(req3)
-	require.NoError(t, err)
-
-	assert.Equal(t, http.StatusNoContent, res3.StatusCode)
-}
-
-func TestGetAllJobs(t *testing.T) {
-	var v struct {
-		Data []struct {
-			ID         string            `json:"id"`
-			Type       string            `json:"type"`
-			Attributes *job.TriggerInfos `json:"attributes"`
-		}
-	}
-
-	req1, err := http.NewRequest(http.MethodGet, ts.URL+"/jobs/triggers", nil)
-	assert.NoError(t, err)
-	tokenTriggers, _ := testInstance.MakeJWT(consts.CLIAudience, "CLI", consts.Triggers, "", time.Now())
-	req1.Header.Add("Authorization", "Bearer "+tokenTriggers)
-	res1, err := http.DefaultClient.Do(req1)
-	require.NoError(t, err)
-
-	assert.Equal(t, http.StatusOK, res1.StatusCode)
-
-	err = json.NewDecoder(res1.Body).Decode(&v)
-	require.NoError(t, err)
-
-	assert.Len(t, v.Data, 0)
-
-	body, _ := json.Marshal(&jsonapiReq{
-		Data: &jsonapiData{
-			Attributes: map[string]interface{}{
-				"type":      "@in",
-				"arguments": "10s",
-				"worker":    "print",
-				// worker_arguments is deprecated but should still works
-				// we are using it here to check that it still works
-				"worker_arguments": "foo",
-			},
-		},
-	})
-	req2, err := http.NewRequest(http.MethodPost, ts.URL+"/jobs/triggers", bytes.NewReader(body))
-	assert.NoError(t, err)
-	req2.Header.Add("Authorization", "Bearer "+token)
-	res2, err := http.DefaultClient.Do(req2)
-	require.NoError(t, err)
-
-	assert.Equal(t, http.StatusCreated, res2.StatusCode)
-
-	req3, err := http.NewRequest(http.MethodGet, ts.URL+"/jobs/triggers", nil)
-	assert.NoError(t, err)
-	req3.Header.Add("Authorization", "Bearer "+tokenTriggers)
-	res3, err := http.DefaultClient.Do(req3)
-	require.NoError(t, err)
-
-	assert.Equal(t, http.StatusOK, res3.StatusCode)
-
-	err = json.NewDecoder(res3.Body).Decode(&v)
-	require.NoError(t, err)
-
-	if assert.Len(t, v.Data, 1) {
-		assert.Equal(t, consts.Triggers, v.Data[0].Type)
-		assert.Equal(t, "@in", v.Data[0].Attributes.Type)
-		assert.Equal(t, "10s", v.Data[0].Attributes.Arguments)
-		assert.Equal(t, "print", v.Data[0].Attributes.WorkerType)
-	}
-
-	req4, err := http.NewRequest(http.MethodGet, ts.URL+"/jobs/triggers?Worker=print", nil)
-	assert.NoError(t, err)
-	req4.Header.Add("Authorization", "Bearer "+tokenTriggers)
-	res4, err := http.DefaultClient.Do(req4)
-	require.NoError(t, err)
-
-	assert.Equal(t, http.StatusOK, res4.StatusCode)
-
-	err = json.NewDecoder(res4.Body).Decode(&v)
-	require.NoError(t, err)
-
-	if assert.Len(t, v.Data, 1) {
-		assert.Equal(t, consts.Triggers, v.Data[0].Type)
-		assert.Equal(t, "@in", v.Data[0].Attributes.Type)
-		assert.Equal(t, "10s", v.Data[0].Attributes.Arguments)
-		assert.Equal(t, "print", v.Data[0].Attributes.WorkerType)
-	}
-
-	req5, err := http.NewRequest(http.MethodGet, ts.URL+"/jobs/triggers?Worker=nojobforme", nil)
-	assert.NoError(t, err)
-	req5.Header.Add("Authorization", "Bearer "+tokenTriggers)
-	res5, err := http.DefaultClient.Do(req5)
-	require.NoError(t, err)
-
-	assert.Equal(t, http.StatusOK, res5.StatusCode)
-
-	err = json.NewDecoder(res5.Body).Decode(&v)
-	require.NoError(t, err)
-
-	assert.Len(t, v.Data, 0)
-
-	req6, err := http.NewRequest(http.MethodGet, ts.URL+"/jobs/triggers?Type=@in", nil)
-	assert.NoError(t, err)
-	req6.Header.Add("Authorization", "Bearer "+tokenTriggers)
-	res6, err := http.DefaultClient.Do(req6)
-	require.NoError(t, err)
-
-	assert.Equal(t, http.StatusOK, res6.StatusCode)
-
-	err = json.NewDecoder(res6.Body).Decode(&v)
-	require.NoError(t, err)
-
-	if assert.Len(t, v.Data, 1) {
-		assert.Equal(t, consts.Triggers, v.Data[0].Type)
-		assert.Equal(t, "@in", v.Data[0].Attributes.Type)
-		assert.Equal(t, "10s", v.Data[0].Attributes.Arguments)
-		assert.Equal(t, "print", v.Data[0].Attributes.WorkerType)
-	}
-}
-
-func TestClientJobs(t *testing.T) {
-	scope := consts.Jobs + " " + consts.Triggers
-	token2, _ := testInstance.MakeJWT(consts.CLIAudience, "CLI", scope, "", time.Now())
-
-	body, _ := json.Marshal(&jsonapiReq{
-		Data: &jsonapiData{
-			Attributes: &map[string]interface{}{
-				"type":    "@client",
-				"message": "foobar",
-			},
-		},
-	})
-	req1, err := http.NewRequest(http.MethodPost, ts.URL+"/jobs/triggers", bytes.NewReader(body))
-	assert.NoError(t, err)
-	req1.Header.Add("Authorization", "Bearer "+token2)
-	res1, err := http.DefaultClient.Do(req1)
-	require.NoError(t, err)
-
-	defer res1.Body.Close()
-	assert.Equal(t, http.StatusCreated, res1.StatusCode)
-
-	var v1 struct {
-		Data struct {
-			ID         string            `json:"id"`
-			Type       string            `json:"type"`
-			Attributes *job.TriggerInfos `json:"attributes"`
-		}
-	}
-	err = json.NewDecoder(res1.Body).Decode(&v1)
-	require.NoError(t, err)
-
-	require.NotNil(t, v1.Data)
-	require.NotNil(t, v1.Data.Attributes)
-	triggerID := v1.Data.ID
-	assert.Equal(t, consts.Triggers, v1.Data.Type)
-	assert.Equal(t, "@client", v1.Data.Attributes.Type)
-	assert.Equal(t, "client", v1.Data.Attributes.WorkerType)
-
-	req2, err := http.NewRequest(http.MethodPost, ts.URL+"/jobs/triggers/"+triggerID+"/launch", nil)
-	assert.NoError(t, err)
-	req2.Header.Add("Authorization", "Bearer "+token2)
-	res2, err := http.DefaultClient.Do(req2)
-	require.NoError(t, err)
-
-	defer res2.Body.Close()
-	assert.Equal(t, http.StatusCreated, res2.StatusCode)
-
-	var v2 struct {
-		Data struct {
-			ID         string   `json:"id"`
-			Type       string   `json:"type"`
-			Attributes *job.Job `json:"attributes"`
-		}
-	}
-	err = json.NewDecoder(res2.Body).Decode(&v2)
-	require.NoError(t, err)
-
-	require.NotNil(t, v2.Data)
-	require.NotNil(t, v2.Data.Attributes)
-	jobID := v2.Data.ID
-	assert.Equal(t, consts.Jobs, v2.Data.Type)
-	assert.Equal(t, "client", v2.Data.Attributes.WorkerType)
-	assert.Equal(t, job.Running, v2.Data.Attributes.State)
-	assert.NotEmpty(t, v2.Data.Attributes.QueuedAt)
-	assert.NotEmpty(t, v2.Data.Attributes.StartedAt)
-
-	body3, _ := json.Marshal(&jsonapiReq{
-		Data: &jsonapiData{
-			Attributes: &map[string]interface{}{
-				"state": "errored",
-				"error": "LOGIN_FAILED",
-			},
-		},
-	})
-	req3, err := http.NewRequest(http.MethodPatch, ts.URL+"/jobs/"+jobID, bytes.NewReader(body3))
-	assert.NoError(t, err)
-	req3.Header.Add("Authorization", "Bearer "+token2)
-	res3, err := http.DefaultClient.Do(req3)
-	require.NoError(t, err)
-
-	defer res3.Body.Close()
-	assert.Equal(t, http.StatusOK, res3.StatusCode)
-
-	var v3 struct {
-		Data struct {
-			ID         string   `json:"id"`
-			Type       string   `json:"type"`
-			Attributes *job.Job `json:"attributes"`
-		}
-	}
-	err = json.NewDecoder(res3.Body).Decode(&v3)
-	require.NoError(t, err)
-
-	require.NotNil(t, v3.Data)
-	require.NotNil(t, v3.Data.Attributes)
-	assert.Equal(t, consts.Jobs, v3.Data.Type)
-	assert.Equal(t, "client", v3.Data.Attributes.WorkerType)
-	assert.Equal(t, job.Errored, v3.Data.Attributes.State)
-	assert.Equal(t, "LOGIN_FAILED", v3.Data.Attributes.Error)
-	assert.NotEmpty(t, v3.Data.Attributes.QueuedAt)
-	assert.NotEmpty(t, v3.Data.Attributes.StartedAt)
-	assert.NotEmpty(t, v3.Data.Attributes.FinishedAt)
-}
-
-func TestMain(m *testing.M) {
 	config.UseTestFile()
 	testutils.NeedCouchdb()
 	setup := testutils.NewSetup(m, "jobs_test")
@@ -703,6 +80,634 @@ func TestMain(m *testing.M) {
 	})
 	ts.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler
 	os.Exit(setup.Run())
+
+	t.Run("GetQueue", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, ts.URL+"/jobs/queue/print", nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		assert.NoError(t, err)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		data := result["data"].([]interface{})
+		assert.Equal(t, 0, len(data))
+	})
+
+	t.Run("CreateJob", func(t *testing.T) {
+		body, _ := json.Marshal(&jsonapiReq{
+			Data: &jsonapiData{
+				Attributes: &jobRequest{Arguments: "foobar"},
+			},
+		})
+		req, err := http.NewRequest(http.MethodPost, ts.URL+"/jobs/queue/print", bytes.NewReader(body))
+		req.Header.Add("Authorization", "Bearer "+token)
+		assert.NoError(t, err)
+		res, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, 202, res.StatusCode)
+		defer res.Body.Close()
+		var resbody map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&resbody)
+		require.NoError(t, err)
+		data, _ := resbody["data"].(map[string]interface{})
+		attrs, _ := data["attributes"].(map[string]interface{})
+		assert.Equal(t, "print", attrs["worker"])
+		assert.NotEqual(t, true, attrs["manual_execution"])
+	})
+
+	t.Run("CreateManualJob", func(t *testing.T) {
+		body, _ := json.Marshal(&jsonapiReq{
+			Data: &jsonapiData{
+				Attributes: &jobRequest{
+					Arguments: "foobar",
+					Manual:    true,
+				},
+			},
+		})
+		req, err := http.NewRequest(http.MethodPost, ts.URL+"/jobs/queue/print", bytes.NewReader(body))
+		req.Header.Add("Authorization", "Bearer "+token)
+		assert.NoError(t, err)
+		res, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, 202, res.StatusCode)
+		var resbody map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&resbody)
+		require.NoError(t, err)
+		data, _ := resbody["data"].(map[string]interface{})
+		attrs, _ := data["attributes"].(map[string]interface{})
+		assert.Equal(t, "print", attrs["worker"])
+		assert.Equal(t, true, attrs["manual_execution"])
+	})
+
+	t.Run("CreateJobForReservedWorker", func(t *testing.T) {
+		body, _ := json.Marshal(&jsonapiReq{
+			Data: &jsonapiData{
+				Attributes: &jobRequest{Arguments: "foobar"},
+			},
+		})
+		req, err := http.NewRequest(http.MethodPost, ts.URL+"/jobs/queue/trash-files", bytes.NewReader(body))
+		req.Header.Add("Authorization", "Bearer "+token)
+		assert.NoError(t, err)
+		res, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, 403, res.StatusCode)
+	})
+
+	t.Run("CreateJobNotExist", func(t *testing.T) {
+		body, _ := json.Marshal(&jsonapiReq{
+			Data: &jsonapiData{
+				Attributes: &jobRequest{Arguments: "foobar"},
+			},
+		})
+		req, err := http.NewRequest(http.MethodPost, ts.URL+"/jobs/queue/none", bytes.NewReader(body))
+		tokenNone, _ := testInstance.MakeJWT(consts.CLIAudience, "CLI",
+			consts.Jobs+":ALL:none:worker",
+			"", time.Now())
+		req.Header.Add("Authorization", "Bearer "+tokenNone)
+		assert.NoError(t, err)
+		res, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, 404, res.StatusCode)
+	})
+
+	t.Run("AddGetAndDeleteTriggerAt", func(t *testing.T) {
+		at := time.Now().Add(1100 * time.Millisecond).Format(time.RFC3339)
+		body, _ := json.Marshal(&jsonapiReq{
+			Data: &jsonapiData{
+				Attributes: &map[string]interface{}{
+					"type":      "@at",
+					"arguments": at,
+					"worker":    "print",
+					"message":   "foo",
+				},
+			},
+		})
+		req1, err := http.NewRequest(http.MethodPost, ts.URL+"/jobs/triggers", bytes.NewReader(body))
+		assert.NoError(t, err)
+		req1.Header.Add("Authorization", "Bearer "+token)
+		res1, err := http.DefaultClient.Do(req1)
+		require.NoError(t, err)
+
+		defer res1.Body.Close()
+		assert.Equal(t, http.StatusCreated, res1.StatusCode)
+
+		var v struct {
+			Data struct {
+				ID         string            `json:"id"`
+				Type       string            `json:"type"`
+				Attributes *job.TriggerInfos `json:"attributes"`
+			}
+		}
+		err = json.NewDecoder(res1.Body).Decode(&v)
+		require.NoError(t, err)
+
+		require.NotNil(t, v.Data)
+		require.NotNil(t, v.Data.Attributes)
+		triggerID := v.Data.ID
+		assert.Equal(t, consts.Triggers, v.Data.Type)
+		assert.Equal(t, "@at", v.Data.Attributes.Type)
+		assert.Equal(t, at, v.Data.Attributes.Arguments)
+		assert.Equal(t, "print", v.Data.Attributes.WorkerType)
+
+		body, _ = json.Marshal(&jsonapiReq{
+			Data: &jsonapiData{
+				Attributes: map[string]interface{}{
+					"type":      "@at",
+					"arguments": "garbage",
+					"worker":    "print",
+					"message":   "foo",
+				},
+			},
+		})
+		req2, err := http.NewRequest(http.MethodPost, ts.URL+"/jobs/triggers", bytes.NewReader(body))
+		assert.NoError(t, err)
+		req2.Header.Add("Authorization", "Bearer "+token)
+		res2, err := http.DefaultClient.Do(req2)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusBadRequest, res2.StatusCode)
+
+		req3, err := http.NewRequest(http.MethodGet, ts.URL+"/jobs/triggers/"+triggerID, nil)
+		assert.NoError(t, err)
+		req3.Header.Add("Authorization", "Bearer "+token)
+		res3, err := http.DefaultClient.Do(req3)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusOK, res3.StatusCode)
+
+		req4, err := http.NewRequest("DELETE", ts.URL+"/jobs/triggers/"+triggerID, nil)
+		assert.NoError(t, err)
+		req4.Header.Add("Authorization", "Bearer "+token)
+		res4, err := http.DefaultClient.Do(req4)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusNoContent, res4.StatusCode)
+
+		req5, err := http.NewRequest(http.MethodGet, ts.URL+"/jobs/triggers/"+triggerID, nil)
+		assert.NoError(t, err)
+		req5.Header.Add("Authorization", "Bearer "+token)
+		res5, err := http.DefaultClient.Do(req5)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusNotFound, res5.StatusCode)
+	})
+
+	t.Run("AddGetAndDeleteTriggerIn", func(t *testing.T) {
+		body, _ := json.Marshal(&jsonapiReq{
+			Data: &jsonapiData{
+				Attributes: map[string]interface{}{
+					"type":      "@in",
+					"arguments": "1s",
+					"worker":    "print",
+					"message":   "foo",
+				},
+			},
+		})
+		req1, err := http.NewRequest(http.MethodPost, ts.URL+"/jobs/triggers", bytes.NewReader(body))
+		assert.NoError(t, err)
+		req1.Header.Add("Authorization", "Bearer "+token)
+		res1, err := http.DefaultClient.Do(req1)
+		require.NoError(t, err)
+
+		defer res1.Body.Close()
+		assert.Equal(t, http.StatusCreated, res1.StatusCode)
+
+		var v struct {
+			Data struct {
+				ID         string            `json:"id"`
+				Type       string            `json:"type"`
+				Attributes *job.TriggerInfos `json:"attributes"`
+			}
+		}
+		err = json.NewDecoder(res1.Body).Decode(&v)
+		require.NoError(t, err)
+
+		require.NotNil(t, v.Data)
+		require.NotNil(t, v.Data.Attributes)
+		triggerID := v.Data.ID
+		assert.Equal(t, consts.Triggers, v.Data.Type)
+		assert.Equal(t, "@in", v.Data.Attributes.Type)
+		assert.Equal(t, "1s", v.Data.Attributes.Arguments)
+		assert.Equal(t, "print", v.Data.Attributes.WorkerType)
+
+		body, _ = json.Marshal(&jsonapiReq{
+			Data: &jsonapiData{
+				Attributes: map[string]interface{}{
+					"type":      "@in",
+					"arguments": "garbage",
+					"worker":    "print",
+					"message":   "foo",
+				},
+			},
+		})
+		req2, err := http.NewRequest(http.MethodPost, ts.URL+"/jobs/triggers", bytes.NewReader(body))
+		assert.NoError(t, err)
+		req2.Header.Add("Authorization", "Bearer "+token)
+		res2, err := http.DefaultClient.Do(req2)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusBadRequest, res2.StatusCode)
+
+		req3, err := http.NewRequest(http.MethodGet, ts.URL+"/jobs/triggers/"+triggerID, nil)
+		assert.NoError(t, err)
+		req3.Header.Add("Authorization", "Bearer "+token)
+		res3, err := http.DefaultClient.Do(req3)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusOK, res3.StatusCode)
+
+		req4, err := http.NewRequest("DELETE", ts.URL+"/jobs/triggers/"+triggerID, nil)
+		assert.NoError(t, err)
+		req4.Header.Add("Authorization", "Bearer "+token)
+		res4, err := http.DefaultClient.Do(req4)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusNoContent, res4.StatusCode)
+
+		req5, err := http.NewRequest(http.MethodGet, ts.URL+"/jobs/triggers/"+triggerID, nil)
+		assert.NoError(t, err)
+		req5.Header.Add("Authorization", "Bearer "+token)
+		res5, err := http.DefaultClient.Do(req5)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusNotFound, res5.StatusCode)
+	})
+
+	t.Run("AddGetUpdateAndDeleteTriggerCron", func(t *testing.T) {
+		body, _ := json.Marshal(&jsonapiReq{
+			Data: &jsonapiData{
+				Attributes: &map[string]interface{}{
+					"type":      "@cron",
+					"arguments": "0 0 0 * * 0",
+					"worker":    "print",
+					"message":   "foo",
+				},
+			},
+		})
+		req1, err := http.NewRequest(http.MethodPost, ts.URL+"/jobs/triggers", bytes.NewReader(body))
+		assert.NoError(t, err)
+		req1.Header.Add("Authorization", "Bearer "+token)
+		res1, err := http.DefaultClient.Do(req1)
+		require.NoError(t, err)
+
+		defer res1.Body.Close()
+		assert.Equal(t, http.StatusCreated, res1.StatusCode)
+
+		var v struct {
+			Data struct {
+				ID         string            `json:"id"`
+				Type       string            `json:"type"`
+				Attributes *job.TriggerInfos `json:"attributes"`
+			}
+		}
+		err = json.NewDecoder(res1.Body).Decode(&v)
+		require.NoError(t, err)
+
+		require.NotNil(t, v.Data)
+		require.NotNil(t, v.Data.Attributes)
+		triggerID := v.Data.ID
+		assert.Equal(t, consts.Triggers, v.Data.Type)
+		assert.Equal(t, "@cron", v.Data.Attributes.Type)
+		assert.Equal(t, "0 0 0 * * 0", v.Data.Attributes.Arguments)
+		assert.Equal(t, "print", v.Data.Attributes.WorkerType)
+
+		body, _ = json.Marshal(&jsonapiReq{
+			Data: &jsonapiData{
+				Attributes: map[string]interface{}{
+					"arguments": "0 0 0 * * 1",
+				},
+			},
+		})
+		req2, err := http.NewRequest(http.MethodPatch, ts.URL+"/jobs/triggers/"+triggerID, bytes.NewReader(body))
+		assert.NoError(t, err)
+		req2.Header.Add("Authorization", "Bearer "+token)
+		res2, err := http.DefaultClient.Do(req2)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusOK, res2.StatusCode)
+
+		req3, err := http.NewRequest(http.MethodGet, ts.URL+"/jobs/triggers/"+triggerID, nil)
+		assert.NoError(t, err)
+		req3.Header.Add("Authorization", "Bearer "+token)
+		res3, err := http.DefaultClient.Do(req3)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusOK, res3.StatusCode)
+
+		var v2 struct {
+			Data struct {
+				ID         string            `json:"id"`
+				Type       string            `json:"type"`
+				Attributes *job.TriggerInfos `json:"attributes"`
+			}
+		}
+		err = json.NewDecoder(res3.Body).Decode(&v2)
+		require.NoError(t, err)
+
+		require.NotNil(t, v2.Data)
+		require.NotNil(t, v2.Data.Attributes)
+		assert.Equal(t, triggerID, v2.Data.ID)
+		assert.Equal(t, consts.Triggers, v2.Data.Type)
+		assert.Equal(t, "@cron", v2.Data.Attributes.Type)
+		assert.Equal(t, "0 0 0 * * 1", v2.Data.Attributes.Arguments)
+		assert.Equal(t, "print", v2.Data.Attributes.WorkerType)
+
+		req4, err := http.NewRequest("DELETE", ts.URL+"/jobs/triggers/"+triggerID, nil)
+		assert.NoError(t, err)
+		req4.Header.Add("Authorization", "Bearer "+token)
+		res4, err := http.DefaultClient.Do(req4)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusNoContent, res4.StatusCode)
+	})
+
+	t.Run("AddTriggerWithMetadata", func(t *testing.T) {
+		at := time.Now().Add(1100 * time.Millisecond).Format(time.RFC3339)
+		body, _ := json.Marshal(&jsonapiReq{
+			Data: &jsonapiData{
+				Attributes: map[string]interface{}{
+					"type":      "@webhook",
+					"arguments": at,
+					"worker":    "print",
+					"message":   "foo",
+				},
+			},
+		})
+
+		req1, err := http.NewRequest(http.MethodPost, ts.URL+"/jobs/triggers", bytes.NewReader(body))
+		assert.NoError(t, err)
+		req1.Header.Add("Authorization", "Bearer "+token)
+		res1, err := http.DefaultClient.Do(req1)
+		require.NoError(t, err)
+
+		defer res1.Body.Close()
+		assert.Equal(t, http.StatusCreated, res1.StatusCode)
+
+		var v struct {
+			Data struct {
+				ID         string            `json:"id"`
+				Type       string            `json:"type"`
+				Attributes *job.TriggerInfos `json:"attributes"`
+				Links      jsonapi.LinksList `json:"links"`
+			}
+		}
+
+		err = json.NewDecoder(res1.Body).Decode(&v)
+		require.NoError(t, err)
+
+		require.NotNil(t, v.Data)
+		require.NotNil(t, v.Data.Attributes)
+		triggerID := v.Data.ID
+		assert.Equal(t, consts.Triggers, v.Data.Type)
+		assert.Equal(t, "@webhook", v.Data.Attributes.Type)
+		assert.Equal(t, "https://"+testInstance.Domain+"/jobs/webhooks/"+triggerID, v.Data.Links.Webhook)
+		assert.Equal(t, at, v.Data.Attributes.Arguments)
+		assert.Equal(t, "print", v.Data.Attributes.WorkerType)
+
+		assert.Equal(t, "1", v.Data.Attributes.Metadata.DocTypeVersion)
+		assert.Equal(t, 1, v.Data.Attributes.Metadata.MetadataVersion)
+		// "CLI" is the token subject
+		assert.Equal(t, "CLI", v.Data.Attributes.Metadata.CreatedByApp)
+		assert.NotZero(t, v.Data.Attributes.Metadata.CreatedAt)
+		assert.NotZero(t, v.Data.Attributes.Metadata.UpdatedAt)
+
+		req2, err := http.NewRequest(http.MethodGet, ts.URL+"/jobs/triggers/"+triggerID, nil)
+		assert.NoError(t, err)
+		req2.Header.Add("Authorization", "Bearer "+token)
+		res2, err := http.DefaultClient.Do(req2)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusOK, res2.StatusCode)
+
+		// Clean
+		req3, err := http.NewRequest("DELETE", ts.URL+"/jobs/triggers/"+triggerID, nil)
+		assert.NoError(t, err)
+		req3.Header.Add("Authorization", "Bearer "+token)
+		res3, err := http.DefaultClient.Do(req3)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusNoContent, res3.StatusCode)
+	})
+
+	t.Run("GetAllJobs", func(t *testing.T) {
+		var v struct {
+			Data []struct {
+				ID         string            `json:"id"`
+				Type       string            `json:"type"`
+				Attributes *job.TriggerInfos `json:"attributes"`
+			}
+		}
+
+		req1, err := http.NewRequest(http.MethodGet, ts.URL+"/jobs/triggers", nil)
+		assert.NoError(t, err)
+		tokenTriggers, _ := testInstance.MakeJWT(consts.CLIAudience, "CLI", consts.Triggers, "", time.Now())
+		req1.Header.Add("Authorization", "Bearer "+tokenTriggers)
+		res1, err := http.DefaultClient.Do(req1)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusOK, res1.StatusCode)
+
+		err = json.NewDecoder(res1.Body).Decode(&v)
+		require.NoError(t, err)
+
+		assert.Len(t, v.Data, 0)
+
+		body, _ := json.Marshal(&jsonapiReq{
+			Data: &jsonapiData{
+				Attributes: map[string]interface{}{
+					"type":      "@in",
+					"arguments": "10s",
+					"worker":    "print",
+					// worker_arguments is deprecated but should still works
+					// we are using it here to check that it still works
+					"worker_arguments": "foo",
+				},
+			},
+		})
+		req2, err := http.NewRequest(http.MethodPost, ts.URL+"/jobs/triggers", bytes.NewReader(body))
+		assert.NoError(t, err)
+		req2.Header.Add("Authorization", "Bearer "+token)
+		res2, err := http.DefaultClient.Do(req2)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusCreated, res2.StatusCode)
+
+		req3, err := http.NewRequest(http.MethodGet, ts.URL+"/jobs/triggers", nil)
+		assert.NoError(t, err)
+		req3.Header.Add("Authorization", "Bearer "+tokenTriggers)
+		res3, err := http.DefaultClient.Do(req3)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusOK, res3.StatusCode)
+
+		err = json.NewDecoder(res3.Body).Decode(&v)
+		require.NoError(t, err)
+
+		if assert.Len(t, v.Data, 1) {
+			assert.Equal(t, consts.Triggers, v.Data[0].Type)
+			assert.Equal(t, "@in", v.Data[0].Attributes.Type)
+			assert.Equal(t, "10s", v.Data[0].Attributes.Arguments)
+			assert.Equal(t, "print", v.Data[0].Attributes.WorkerType)
+		}
+
+		req4, err := http.NewRequest(http.MethodGet, ts.URL+"/jobs/triggers?Worker=print", nil)
+		assert.NoError(t, err)
+		req4.Header.Add("Authorization", "Bearer "+tokenTriggers)
+		res4, err := http.DefaultClient.Do(req4)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusOK, res4.StatusCode)
+
+		err = json.NewDecoder(res4.Body).Decode(&v)
+		require.NoError(t, err)
+
+		if assert.Len(t, v.Data, 1) {
+			assert.Equal(t, consts.Triggers, v.Data[0].Type)
+			assert.Equal(t, "@in", v.Data[0].Attributes.Type)
+			assert.Equal(t, "10s", v.Data[0].Attributes.Arguments)
+			assert.Equal(t, "print", v.Data[0].Attributes.WorkerType)
+		}
+
+		req5, err := http.NewRequest(http.MethodGet, ts.URL+"/jobs/triggers?Worker=nojobforme", nil)
+		assert.NoError(t, err)
+		req5.Header.Add("Authorization", "Bearer "+tokenTriggers)
+		res5, err := http.DefaultClient.Do(req5)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusOK, res5.StatusCode)
+
+		err = json.NewDecoder(res5.Body).Decode(&v)
+		require.NoError(t, err)
+
+		assert.Len(t, v.Data, 0)
+
+		req6, err := http.NewRequest(http.MethodGet, ts.URL+"/jobs/triggers?Type=@in", nil)
+		assert.NoError(t, err)
+		req6.Header.Add("Authorization", "Bearer "+tokenTriggers)
+		res6, err := http.DefaultClient.Do(req6)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusOK, res6.StatusCode)
+
+		err = json.NewDecoder(res6.Body).Decode(&v)
+		require.NoError(t, err)
+
+		if assert.Len(t, v.Data, 1) {
+			assert.Equal(t, consts.Triggers, v.Data[0].Type)
+			assert.Equal(t, "@in", v.Data[0].Attributes.Type)
+			assert.Equal(t, "10s", v.Data[0].Attributes.Arguments)
+			assert.Equal(t, "print", v.Data[0].Attributes.WorkerType)
+		}
+	})
+
+	t.Run("ClientJobs", func(t *testing.T) {
+		scope := consts.Jobs + " " + consts.Triggers
+		token2, _ := testInstance.MakeJWT(consts.CLIAudience, "CLI", scope, "", time.Now())
+
+		body, _ := json.Marshal(&jsonapiReq{
+			Data: &jsonapiData{
+				Attributes: &map[string]interface{}{
+					"type":    "@client",
+					"message": "foobar",
+				},
+			},
+		})
+		req1, err := http.NewRequest(http.MethodPost, ts.URL+"/jobs/triggers", bytes.NewReader(body))
+		assert.NoError(t, err)
+		req1.Header.Add("Authorization", "Bearer "+token2)
+		res1, err := http.DefaultClient.Do(req1)
+		require.NoError(t, err)
+
+		defer res1.Body.Close()
+		assert.Equal(t, http.StatusCreated, res1.StatusCode)
+
+		var v1 struct {
+			Data struct {
+				ID         string            `json:"id"`
+				Type       string            `json:"type"`
+				Attributes *job.TriggerInfos `json:"attributes"`
+			}
+		}
+		err = json.NewDecoder(res1.Body).Decode(&v1)
+		require.NoError(t, err)
+
+		require.NotNil(t, v1.Data)
+		require.NotNil(t, v1.Data.Attributes)
+		triggerID := v1.Data.ID
+		assert.Equal(t, consts.Triggers, v1.Data.Type)
+		assert.Equal(t, "@client", v1.Data.Attributes.Type)
+		assert.Equal(t, "client", v1.Data.Attributes.WorkerType)
+
+		req2, err := http.NewRequest(http.MethodPost, ts.URL+"/jobs/triggers/"+triggerID+"/launch", nil)
+		assert.NoError(t, err)
+		req2.Header.Add("Authorization", "Bearer "+token2)
+		res2, err := http.DefaultClient.Do(req2)
+		require.NoError(t, err)
+
+		defer res2.Body.Close()
+		assert.Equal(t, http.StatusCreated, res2.StatusCode)
+
+		var v2 struct {
+			Data struct {
+				ID         string   `json:"id"`
+				Type       string   `json:"type"`
+				Attributes *job.Job `json:"attributes"`
+			}
+		}
+		err = json.NewDecoder(res2.Body).Decode(&v2)
+		require.NoError(t, err)
+
+		require.NotNil(t, v2.Data)
+		require.NotNil(t, v2.Data.Attributes)
+		jobID := v2.Data.ID
+		assert.Equal(t, consts.Jobs, v2.Data.Type)
+		assert.Equal(t, "client", v2.Data.Attributes.WorkerType)
+		assert.Equal(t, job.Running, v2.Data.Attributes.State)
+		assert.NotEmpty(t, v2.Data.Attributes.QueuedAt)
+		assert.NotEmpty(t, v2.Data.Attributes.StartedAt)
+
+		body3, _ := json.Marshal(&jsonapiReq{
+			Data: &jsonapiData{
+				Attributes: &map[string]interface{}{
+					"state": "errored",
+					"error": "LOGIN_FAILED",
+				},
+			},
+		})
+		req3, err := http.NewRequest(http.MethodPatch, ts.URL+"/jobs/"+jobID, bytes.NewReader(body3))
+		assert.NoError(t, err)
+		req3.Header.Add("Authorization", "Bearer "+token2)
+		res3, err := http.DefaultClient.Do(req3)
+		require.NoError(t, err)
+
+		defer res3.Body.Close()
+		assert.Equal(t, http.StatusOK, res3.StatusCode)
+
+		var v3 struct {
+			Data struct {
+				ID         string   `json:"id"`
+				Type       string   `json:"type"`
+				Attributes *job.Job `json:"attributes"`
+			}
+		}
+		err = json.NewDecoder(res3.Body).Decode(&v3)
+		require.NoError(t, err)
+
+		require.NotNil(t, v3.Data)
+		require.NotNil(t, v3.Data.Attributes)
+		assert.Equal(t, consts.Jobs, v3.Data.Type)
+		assert.Equal(t, "client", v3.Data.Attributes.WorkerType)
+		assert.Equal(t, job.Errored, v3.Data.Attributes.State)
+		assert.Equal(t, "LOGIN_FAILED", v3.Data.Attributes.Error)
+		assert.NotEmpty(t, v3.Data.Attributes.QueuedAt)
+		assert.NotEmpty(t, v3.Data.Attributes.StartedAt)
+		assert.NotEmpty(t, v3.Data.Attributes.FinishedAt)
+	})
+
 }
 
 func SetToken(next echo.HandlerFunc) echo.HandlerFunc {

--- a/web/jobs/jobs_test.go
+++ b/web/jobs/jobs_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -79,7 +78,6 @@ func TestJobs(t *testing.T) {
 		return r
 	})
 	ts.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler
-	os.Exit(setup.Run())
 
 	t.Run("GetQueue", func(t *testing.T) {
 		req, err := http.NewRequest(http.MethodGet, ts.URL+"/jobs/queue/print", nil)

--- a/web/jobs/jobs_test.go
+++ b/web/jobs/jobs_test.go
@@ -49,7 +49,8 @@ func TestJobs(t *testing.T) {
 
 	config.UseTestFile()
 	testutils.NeedCouchdb()
-	setup := testutils.NewSetup(m, "jobs_test")
+	setup := testutils.NewSetup(nil, t.Name())
+	t.Cleanup(setup.Cleanup)
 
 	job.AddWorker(&job.WorkerConfig{
 		WorkerType:  "print",

--- a/web/middlewares/cors_test.go
+++ b/web/middlewares/cors_test.go
@@ -9,25 +9,32 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCORSMiddleware(t *testing.T) {
-	e := echo.New()
-	req, _ := http.NewRequest(echo.OPTIONS, "http://cozy.local/data/io.cozy.files", nil)
-	req.Header.Set("Origin", "fakecozy.local")
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	h := CORS(CORSOptions{})(echo.NotFoundHandler)
-	_ = h(c)
-	assert.Equal(t, "fakecozy.local", rec.Header().Get(echo.HeaderAccessControlAllowOrigin))
-}
+func TestCors(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
 
-func TestCORSMiddlewareNotAuth(t *testing.T) {
-	e := echo.New()
-	req, _ := http.NewRequest(echo.OPTIONS, "http://cozy.local/auth/register", nil)
-	req.Header.Set("Origin", "fakecozy.local")
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	c.SetPath(req.URL.Path)
-	h := CORS(CORSOptions{BlockList: []string{"/auth/"}})(echo.NotFoundHandler)
-	_ = h(c)
-	assert.Equal(t, "", rec.Header().Get(echo.HeaderAccessControlAllowOrigin))
+	t.Run("CORSMiddleware", func(t *testing.T) {
+		e := echo.New()
+		req, _ := http.NewRequest(echo.OPTIONS, "http://cozy.local/data/io.cozy.files", nil)
+		req.Header.Set("Origin", "fakecozy.local")
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		h := CORS(CORSOptions{})(echo.NotFoundHandler)
+		_ = h(c)
+		assert.Equal(t, "fakecozy.local", rec.Header().Get(echo.HeaderAccessControlAllowOrigin))
+	})
+
+	t.Run("CORSMiddlewareNotAuth", func(t *testing.T) {
+		e := echo.New()
+		req, _ := http.NewRequest(echo.OPTIONS, "http://cozy.local/auth/register", nil)
+		req.Header.Set("Origin", "fakecozy.local")
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetPath(req.URL.Path)
+		h := CORS(CORSOptions{BlockList: []string{"/auth/"}})(echo.NotFoundHandler)
+		_ = h(c)
+		assert.Equal(t, "", rec.Header().Get(echo.HeaderAccessControlAllowOrigin))
+	})
+
 }

--- a/web/middlewares/cors_test.go
+++ b/web/middlewares/cors_test.go
@@ -36,5 +36,4 @@ func TestCors(t *testing.T) {
 		_ = h(c)
 		assert.Equal(t, "", rec.Header().Get(echo.HeaderAccessControlAllowOrigin))
 	})
-
 }

--- a/web/middlewares/csrf_test.go
+++ b/web/middlewares/csrf_test.go
@@ -12,72 +12,79 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCSRF(t *testing.T) {
-	e := echo.New()
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	csrf := CSRFWithConfig(CSRFConfig{
-		TokenLength: 16,
+func TestCsrf(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	t.Run("CSRF", func(t *testing.T) {
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		csrf := CSRFWithConfig(CSRFConfig{
+			TokenLength: 16,
+		})
+		h := csrf(func(c echo.Context) error {
+			return c.String(http.StatusOK, "test")
+		})
+
+		// Generate CSRF token
+		assert.NoError(t, h(c))
+		assert.Contains(t, rec.Header().Get(echo.HeaderSetCookie), "_csrf")
+
+		// Without CSRF cookie
+		req = httptest.NewRequest(http.MethodPost, "/", nil)
+		rec = httptest.NewRecorder()
+		c = e.NewContext(req, rec)
+		assert.Error(t, h(c))
+
+		// Empty/invalid CSRF token
+		req = httptest.NewRequest(http.MethodPost, "/", nil)
+		rec = httptest.NewRecorder()
+		c = e.NewContext(req, rec)
+		req.Header.Set(echo.HeaderXCSRFToken, "")
+		assert.Error(t, h(c))
+
+		// Valid CSRF token
+		token := utils.RandomString(16)
+		req.Header.Set(echo.HeaderCookie, "_csrf="+token)
+		req.Header.Set(echo.HeaderXCSRFToken, token)
+		if assert.NoError(t, h(c)) {
+			assert.Equal(t, http.StatusOK, rec.Code)
+		}
 	})
-	h := csrf(func(c echo.Context) error {
-		return c.String(http.StatusOK, "test")
+
+	t.Run("CSRFTokenFromForm", func(t *testing.T) {
+		f := make(url.Values)
+		f.Set("csrf", "token")
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(f.Encode()))
+		req.Header.Add(echo.HeaderContentType, echo.MIMEApplicationForm)
+		c := e.NewContext(req, nil)
+		token, err := csrfTokenFromForm("csrf")(c)
+		if assert.NoError(t, err) {
+			assert.Equal(t, "token", token)
+		}
+		_, err = csrfTokenFromForm("invalid")(c)
+		assert.Error(t, err)
 	})
 
-	// Generate CSRF token
-	assert.NoError(t, h(c))
-	assert.Contains(t, rec.Header().Get(echo.HeaderSetCookie), "_csrf")
+	t.Run("CSRFTokenFromQuery", func(t *testing.T) {
+		q := make(url.Values)
+		q.Set("csrf", "token")
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Add(echo.HeaderContentType, echo.MIMEApplicationForm)
+		req.URL.RawQuery = q.Encode()
+		c := e.NewContext(req, nil)
+		token, err := csrfTokenFromQuery("csrf")(c)
+		if assert.NoError(t, err) {
+			assert.Equal(t, "token", token)
+		}
+		_, err = csrfTokenFromQuery("invalid")(c)
+		assert.Error(t, err)
+		csrfTokenFromQuery("csrf")
+	})
 
-	// Without CSRF cookie
-	req = httptest.NewRequest(http.MethodPost, "/", nil)
-	rec = httptest.NewRecorder()
-	c = e.NewContext(req, rec)
-	assert.Error(t, h(c))
-
-	// Empty/invalid CSRF token
-	req = httptest.NewRequest(http.MethodPost, "/", nil)
-	rec = httptest.NewRecorder()
-	c = e.NewContext(req, rec)
-	req.Header.Set(echo.HeaderXCSRFToken, "")
-	assert.Error(t, h(c))
-
-	// Valid CSRF token
-	token := utils.RandomString(16)
-	req.Header.Set(echo.HeaderCookie, "_csrf="+token)
-	req.Header.Set(echo.HeaderXCSRFToken, token)
-	if assert.NoError(t, h(c)) {
-		assert.Equal(t, http.StatusOK, rec.Code)
-	}
-}
-
-func TestCSRFTokenFromForm(t *testing.T) {
-	f := make(url.Values)
-	f.Set("csrf", "token")
-	e := echo.New()
-	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(f.Encode()))
-	req.Header.Add(echo.HeaderContentType, echo.MIMEApplicationForm)
-	c := e.NewContext(req, nil)
-	token, err := csrfTokenFromForm("csrf")(c)
-	if assert.NoError(t, err) {
-		assert.Equal(t, "token", token)
-	}
-	_, err = csrfTokenFromForm("invalid")(c)
-	assert.Error(t, err)
-}
-
-func TestCSRFTokenFromQuery(t *testing.T) {
-	q := make(url.Values)
-	q.Set("csrf", "token")
-	e := echo.New()
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	req.Header.Add(echo.HeaderContentType, echo.MIMEApplicationForm)
-	req.URL.RawQuery = q.Encode()
-	c := e.NewContext(req, nil)
-	token, err := csrfTokenFromQuery("csrf")(c)
-	if assert.NoError(t, err) {
-		assert.Equal(t, "token", token)
-	}
-	_, err = csrfTokenFromQuery("invalid")(c)
-	assert.Error(t, err)
-	csrfTokenFromQuery("csrf")
 }

--- a/web/middlewares/csrf_test.go
+++ b/web/middlewares/csrf_test.go
@@ -86,5 +86,4 @@ func TestCsrf(t *testing.T) {
 		assert.Error(t, err)
 		csrfTokenFromQuery("csrf")
 	})
-
 }

--- a/web/middlewares/secure_test.go
+++ b/web/middlewares/secure_test.go
@@ -111,5 +111,4 @@ func TestSecure(t *testing.T) {
 		r = appendCSPRule("script '*'; toto;", "frame-ancestors", "new-rule")
 		assert.Equal(t, "script '*'; toto;frame-ancestors new-rule;", r)
 	})
-
 }

--- a/web/middlewares/secure_test.go
+++ b/web/middlewares/secure_test.go
@@ -11,98 +11,105 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSecureMiddlewareHSTS(t *testing.T) {
-	e := echo.New()
-	req, _ := http.NewRequest(echo.GET, "http://app.cozy.local/", nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	h := Secure(&SecureConfig{
-		HSTSMaxAge: 3600 * time.Second,
-	})(echo.NotFoundHandler)
-	_ = h(c)
-	assert.Equal(t, "max-age=3600; includeSubDomains", rec.Header().Get(echo.HeaderStrictTransportSecurity))
-}
+func TestSecure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
 
-func TestSecureMiddlewareCSP(t *testing.T) {
-	e1 := echo.New()
-	req1, _ := http.NewRequest(echo.GET, "http://app.cozy.local/", nil)
-	rec1 := httptest.NewRecorder()
-	c1 := e1.NewContext(req1, rec1)
-	h1 := Secure(&SecureConfig{
-		CSPConnectSrc: nil,
-		CSPFrameSrc:   nil,
-		CSPScriptSrc:  nil,
-	})(echo.NotFoundHandler)
-	_ = h1(c1)
+	t.Run("SecureMiddlewareHSTS", func(t *testing.T) {
+		e := echo.New()
+		req, _ := http.NewRequest(echo.GET, "http://app.cozy.local/", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		h := Secure(&SecureConfig{
+			HSTSMaxAge: 3600 * time.Second,
+		})(echo.NotFoundHandler)
+		_ = h(c)
+		assert.Equal(t, "max-age=3600; includeSubDomains", rec.Header().Get(echo.HeaderStrictTransportSecurity))
+	})
 
-	e2 := echo.New()
-	req2, _ := http.NewRequest(echo.GET, "http://app.cozy.local/", nil)
-	rec2 := httptest.NewRecorder()
-	c2 := e2.NewContext(req2, rec2)
-	h2 := Secure(&SecureConfig{
-		CSPConnectSrc: nil,
-		CSPFrameSrc:   []CSPSource{CSPSrcAny},
-		CSPScriptSrc:  []CSPSource{CSPSrcSelf},
-	})(echo.NotFoundHandler)
-	_ = h2(c2)
+	t.Run("SecureMiddlewareCSP", func(t *testing.T) {
+		e1 := echo.New()
+		req1, _ := http.NewRequest(echo.GET, "http://app.cozy.local/", nil)
+		rec1 := httptest.NewRecorder()
+		c1 := e1.NewContext(req1, rec1)
+		h1 := Secure(&SecureConfig{
+			CSPConnectSrc: nil,
+			CSPFrameSrc:   nil,
+			CSPScriptSrc:  nil,
+		})(echo.NotFoundHandler)
+		_ = h1(c1)
 
-	e3 := echo.New()
-	req3, _ := http.NewRequest(echo.GET, "http://app.cozy.local/", nil)
-	rec3 := httptest.NewRecorder()
-	c3 := e3.NewContext(req3, rec3)
-	h3 := Secure(&SecureConfig{
-		CSPConnectSrc: []CSPSource{CSPSrcParent, CSPSrcSelf},
-		CSPFrameSrc:   []CSPSource{CSPSrcAny},
-		CSPScriptSrc:  []CSPSource{CSPSrcSiblings},
-	})(echo.NotFoundHandler)
-	_ = h3(c3)
+		e2 := echo.New()
+		req2, _ := http.NewRequest(echo.GET, "http://app.cozy.local/", nil)
+		rec2 := httptest.NewRecorder()
+		c2 := e2.NewContext(req2, rec2)
+		h2 := Secure(&SecureConfig{
+			CSPConnectSrc: nil,
+			CSPFrameSrc:   []CSPSource{CSPSrcAny},
+			CSPScriptSrc:  []CSPSource{CSPSrcSelf},
+		})(echo.NotFoundHandler)
+		_ = h2(c2)
 
-	e4 := echo.New()
-	req4, _ := http.NewRequest(echo.GET, "http://app.cozy.local/", nil)
-	rec4 := httptest.NewRecorder()
-	c4 := e4.NewContext(req4, rec4)
-	c4.Set("instance", &instance.Instance{ContextName: "test"})
-	h4 := Secure(&SecureConfig{
-		CSPConnectSrc: nil,
-		CSPFrameSrc:   []CSPSource{CSPSrcAny},
-		CSPScriptSrc:  []CSPSource{CSPSrcSelf},
-		CSPPerContext: map[string]map[string]string{
-			"test": {
-				"frame":   "https://example.net",
-				"connect": "https://example.com",
+		e3 := echo.New()
+		req3, _ := http.NewRequest(echo.GET, "http://app.cozy.local/", nil)
+		rec3 := httptest.NewRecorder()
+		c3 := e3.NewContext(req3, rec3)
+		h3 := Secure(&SecureConfig{
+			CSPConnectSrc: []CSPSource{CSPSrcParent, CSPSrcSelf},
+			CSPFrameSrc:   []CSPSource{CSPSrcAny},
+			CSPScriptSrc:  []CSPSource{CSPSrcSiblings},
+		})(echo.NotFoundHandler)
+		_ = h3(c3)
+
+		e4 := echo.New()
+		req4, _ := http.NewRequest(echo.GET, "http://app.cozy.local/", nil)
+		rec4 := httptest.NewRecorder()
+		c4 := e4.NewContext(req4, rec4)
+		c4.Set("instance", &instance.Instance{ContextName: "test"})
+		h4 := Secure(&SecureConfig{
+			CSPConnectSrc: nil,
+			CSPFrameSrc:   []CSPSource{CSPSrcAny},
+			CSPScriptSrc:  []CSPSource{CSPSrcSelf},
+			CSPPerContext: map[string]map[string]string{
+				"test": {
+					"frame":   "https://example.net",
+					"connect": "https://example.com",
+				},
 			},
-		},
-	})(echo.NotFoundHandler)
-	_ = h4(c4)
+		})(echo.NotFoundHandler)
+		_ = h4(c4)
 
-	assert.Equal(t, "", rec1.Header().Get(echo.HeaderContentSecurityPolicy))
-	assert.Equal(t, "script-src 'self';frame-src *;", rec2.Header().Get(echo.HeaderContentSecurityPolicy))
-	assert.Equal(t, "script-src https://*.cozy.local;frame-src *;connect-src https://cozy.local 'self';", rec3.Header().Get(echo.HeaderContentSecurityPolicy))
-	assert.Equal(t, "script-src 'self';frame-src * https://example.net;connect-src https://example.com;", rec4.Header().Get(echo.HeaderContentSecurityPolicy))
-}
+		assert.Equal(t, "", rec1.Header().Get(echo.HeaderContentSecurityPolicy))
+		assert.Equal(t, "script-src 'self';frame-src *;", rec2.Header().Get(echo.HeaderContentSecurityPolicy))
+		assert.Equal(t, "script-src https://*.cozy.local;frame-src *;connect-src https://cozy.local 'self';", rec3.Header().Get(echo.HeaderContentSecurityPolicy))
+		assert.Equal(t, "script-src 'self';frame-src * https://example.net;connect-src https://example.com;", rec4.Header().Get(echo.HeaderContentSecurityPolicy))
+	})
 
-func TestAppendCSPRule(t *testing.T) {
-	r := appendCSPRule("", "frame-ancestors", "new-rule")
-	assert.Equal(t, "frame-ancestors new-rule;", r)
+	t.Run("AppendCSPRule", func(t *testing.T) {
+		r := appendCSPRule("", "frame-ancestors", "new-rule")
+		assert.Equal(t, "frame-ancestors new-rule;", r)
 
-	r = appendCSPRule("frame-ancestors;", "frame-ancestors", "new-rule")
-	assert.Equal(t, "frame-ancestors new-rule;", r)
+		r = appendCSPRule("frame-ancestors;", "frame-ancestors", "new-rule")
+		assert.Equal(t, "frame-ancestors new-rule;", r)
 
-	r = appendCSPRule("frame-ancestors 1 2 3 ;", "frame-ancestors", "new-rule")
-	assert.Equal(t, "frame-ancestors 1 2 3 new-rule;", r)
+		r = appendCSPRule("frame-ancestors 1 2 3 ;", "frame-ancestors", "new-rule")
+		assert.Equal(t, "frame-ancestors 1 2 3 new-rule;", r)
 
-	r = appendCSPRule("frame-ancestors 1 2 3 ;", "frame-ancestors", "new-rule", "new-rule-2")
-	assert.Equal(t, "frame-ancestors 1 2 3 new-rule new-rule-2;", r)
+		r = appendCSPRule("frame-ancestors 1 2 3 ;", "frame-ancestors", "new-rule", "new-rule-2")
+		assert.Equal(t, "frame-ancestors 1 2 3 new-rule new-rule-2;", r)
 
-	r = appendCSPRule("frame-ancestors 'none';", "frame-ancestors", "new-rule")
-	assert.Equal(t, "frame-ancestors new-rule;", r)
+		r = appendCSPRule("frame-ancestors 'none';", "frame-ancestors", "new-rule")
+		assert.Equal(t, "frame-ancestors new-rule;", r)
 
-	r = appendCSPRule("script '*'; frame-ancestors 'self';", "frame-ancestors", "new-rule")
-	assert.Equal(t, "script '*'; frame-ancestors 'self' new-rule;", r)
+		r = appendCSPRule("script '*'; frame-ancestors 'self';", "frame-ancestors", "new-rule")
+		assert.Equal(t, "script '*'; frame-ancestors 'self' new-rule;", r)
 
-	r = appendCSPRule("script '*'; frame-ancestors 'self'; plop plop;", "frame-ancestors", "new-rule")
-	assert.Equal(t, "script '*'; frame-ancestors 'self' new-rule; plop plop;", r)
+		r = appendCSPRule("script '*'; frame-ancestors 'self'; plop plop;", "frame-ancestors", "new-rule")
+		assert.Equal(t, "script '*'; frame-ancestors 'self' new-rule; plop plop;", r)
 
-	r = appendCSPRule("script '*'; toto;", "frame-ancestors", "new-rule")
-	assert.Equal(t, "script '*'; toto;frame-ancestors new-rule;", r)
+		r = appendCSPRule("script '*'; toto;", "frame-ancestors", "new-rule")
+		assert.Equal(t, "script '*'; toto;frame-ancestors new-rule;", r)
+	})
+
 }

--- a/web/middlewares/setup_test.go
+++ b/web/middlewares/setup_test.go
@@ -29,5 +29,4 @@ func TestSetup(t *testing.T) {
 		panic("Could not init dynamic FS")
 	}
 	_ = web.SetupAssets(echo.New(), config.GetConfig().Assets)
-
 }

--- a/web/middlewares/setup_test.go
+++ b/web/middlewares/setup_test.go
@@ -1,7 +1,6 @@
 package middlewares_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/cozy/cozy-stack/pkg/assets/dynamic"
@@ -29,7 +28,5 @@ func TestSetup(t *testing.T) {
 		panic("Could not init dynamic FS")
 	}
 	_ = web.SetupAssets(echo.New(), config.GetConfig().Assets)
-
-	os.Exit(setup.Run())
 
 }

--- a/web/middlewares/setup_test.go
+++ b/web/middlewares/setup_test.go
@@ -11,7 +11,11 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-func TestMain(m *testing.M) {
+func TestSetup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
 	config.UseTestFile()
 	config.GetConfig().Assets = "../../assets"
 	setup := testutils.NewSetup(m, "middlewares_test")
@@ -27,4 +31,5 @@ func TestMain(m *testing.M) {
 	_ = web.SetupAssets(echo.New(), config.GetConfig().Assets)
 
 	os.Exit(setup.Run())
+
 }

--- a/web/middlewares/setup_test.go
+++ b/web/middlewares/setup_test.go
@@ -17,7 +17,8 @@ func TestSetup(t *testing.T) {
 
 	config.UseTestFile()
 	config.GetConfig().Assets = "../../assets"
-	setup := testutils.NewSetup(m, "middlewares_test")
+	setup := testutils.NewSetup(nil, t.Name())
+	t.Cleanup(setup.Cleanup)
 
 	err := setup.SetupSwiftTest()
 	if err != nil {

--- a/web/middlewares/user_agent_test.go
+++ b/web/middlewares/user_agent_test.go
@@ -82,7 +82,6 @@ func TestUser(t *testing.T) {
 		assert.Equal(t, -1, v)
 		assert.Equal(t, false, ok)
 	})
-
 }
 
 func (sr *stupidRenderer) Render(w io.Writer, name string, data interface{}, c echo.Context) error {

--- a/web/middlewares/user_agent_test.go
+++ b/web/middlewares/user_agent_test.go
@@ -15,69 +15,76 @@ var ins *instance.Instance
 
 type stupidRenderer struct{}
 
+func TestUser(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	t.Run("UserAgent", func(t *testing.T) {
+		// middleware instance
+		e := echo.New()
+
+		e.Renderer = &stupidRenderer{}
+
+		req, _ := http.NewRequest(echo.GET, "http://cozy.local", nil)
+		req.Header.Set(echo.HeaderAccept, "text/html")
+		req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:96.0) Gecko/20100101 Firefox/96.0") // Firefox
+
+		ins = &instance.Instance{Domain: "cozy.local", Locale: "en"}
+
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.Set("instance", ins)
+
+		h := CheckUserAgent(echo.NotFoundHandler)
+		err := h(c)
+		assert.Error(t, err)
+
+		req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko") // IE 11
+		h2 := CheckUserAgent(echo.NotFoundHandler)
+		err2 := h2(c)
+		assert.NoError(t, err2, nil)
+
+		req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML like Gecko) Chrome/51.0.2704.79 Safari/537.36 Edge/17.14931") // Edge 17
+		h3 := CheckUserAgent(echo.NotFoundHandler)
+		err3 := h3(c)
+		assert.NoError(t, err3, nil)
+
+		req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.81 Safari/537.36 Edg/97.0.1072.69") // Edge 97
+		h4 := CheckUserAgent(echo.NotFoundHandler)
+		err4 := h4(c)
+		assert.Error(t, err4, nil)
+
+		req.Header.Set("User-Agent", "Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/97.0 Mobile/15E148 Safari/605.1.15") // Firefox for iOS
+		h5 := CheckUserAgent(echo.NotFoundHandler)
+		err5 := h5(c)
+		assert.Error(t, err5, nil)
+	})
+
+	t.Run("ParseEdgeVersion", func(t *testing.T) {
+		version := "15.123456"
+		v, ok := getMajorVersion(version)
+		assert.Equal(t, 15, v)
+		assert.Equal(t, true, ok)
+
+		version = "75.123456.6789"
+		v, ok = getMajorVersion(version)
+		assert.Equal(t, 75, v)
+		assert.Equal(t, true, ok)
+
+		version = "12"
+		v, ok = getMajorVersion(version)
+		assert.Equal(t, 12, v)
+		assert.Equal(t, true, ok)
+
+		version = "foobar"
+		v, ok = getMajorVersion(version)
+		assert.Equal(t, -1, v)
+		assert.Equal(t, false, ok)
+	})
+
+}
+
 func (sr *stupidRenderer) Render(w io.Writer, name string, data interface{}, c echo.Context) error {
 	return nil
-}
-
-func TestUserAgent(t *testing.T) {
-	// middleware instance
-	e := echo.New()
-
-	e.Renderer = &stupidRenderer{}
-
-	req, _ := http.NewRequest(echo.GET, "http://cozy.local", nil)
-	req.Header.Set(echo.HeaderAccept, "text/html")
-	req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:96.0) Gecko/20100101 Firefox/96.0") // Firefox
-
-	ins = &instance.Instance{Domain: "cozy.local", Locale: "en"}
-
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	c.Set("instance", ins)
-
-	h := CheckUserAgent(echo.NotFoundHandler)
-	err := h(c)
-	assert.Error(t, err)
-
-	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko") // IE 11
-	h2 := CheckUserAgent(echo.NotFoundHandler)
-	err2 := h2(c)
-	assert.NoError(t, err2, nil)
-
-	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML like Gecko) Chrome/51.0.2704.79 Safari/537.36 Edge/17.14931") // Edge 17
-	h3 := CheckUserAgent(echo.NotFoundHandler)
-	err3 := h3(c)
-	assert.NoError(t, err3, nil)
-
-	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.81 Safari/537.36 Edg/97.0.1072.69") // Edge 97
-	h4 := CheckUserAgent(echo.NotFoundHandler)
-	err4 := h4(c)
-	assert.Error(t, err4, nil)
-
-	req.Header.Set("User-Agent", "Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/97.0 Mobile/15E148 Safari/605.1.15") // Firefox for iOS
-	h5 := CheckUserAgent(echo.NotFoundHandler)
-	err5 := h5(c)
-	assert.Error(t, err5, nil)
-}
-
-func TestParseEdgeVersion(t *testing.T) {
-	version := "15.123456"
-	v, ok := getMajorVersion(version)
-	assert.Equal(t, 15, v)
-	assert.Equal(t, true, ok)
-
-	version = "75.123456.6789"
-	v, ok = getMajorVersion(version)
-	assert.Equal(t, 75, v)
-	assert.Equal(t, true, ok)
-
-	version = "12"
-	v, ok = getMajorVersion(version)
-	assert.Equal(t, 12, v)
-	assert.Equal(t, true, ok)
-
-	version = "foobar"
-	v, ok = getMajorVersion(version)
-	assert.Equal(t, -1, v)
-	assert.Equal(t, false, ok)
 }

--- a/web/notes/notes_test.go
+++ b/web/notes/notes_test.go
@@ -51,7 +51,6 @@ func TestNotes(t *testing.T) {
 		"/realtime": webRealtime.Routes,
 	})
 	ts.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler
-	os.Exit(setup.Run())
 
 	t.Run("CreateNote", func(t *testing.T) {
 		body := `

--- a/web/notes/notes_test.go
+++ b/web/notes/notes_test.go
@@ -837,7 +837,6 @@ Text with **bold** and [underlined]{.underlined}.
 		attrs, _ = data["attributes"].(map[string]interface{})
 		assert.Equal(t, inst.Domain, attrs["instance"])
 	})
-
 }
 
 func assertInitialNote(t *testing.T, result map[string]interface{}) {

--- a/web/notes/notes_test.go
+++ b/web/notes/notes_test.go
@@ -34,8 +34,27 @@ var token string
 var noteID string
 var version int64
 
-func TestCreateNote(t *testing.T) {
-	body := `
+func TestNotes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	config.UseTestFile()
+	testutils.NeedCouchdb()
+	setup := testutils.NewSetup(m, "notes_test")
+	inst = setup.GetTestInstance()
+	_, token = setup.GetTestClient(consts.Files)
+
+	ts = setup.GetTestServerMultipleRoutes(map[string]func(*echo.Group){
+		"/files":    files.Routes,
+		"/notes":    Routes,
+		"/realtime": webRealtime.Routes,
+	})
+	ts.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler
+	os.Exit(setup.Run())
+
+	t.Run("CreateNote", func(t *testing.T) {
+		body := `
 {
   "data": {
     "type": "io.cozy.notes.documents",
@@ -88,75 +107,52 @@ func TestCreateNote(t *testing.T) {
     }
   }
 }`
-	req, _ := http.NewRequest("POST", ts.URL+"/notes", bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 201, res.StatusCode)
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	assertInitialNote(t, result)
-}
+		req, _ := http.NewRequest("POST", ts.URL+"/notes", bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 201, res.StatusCode)
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		assertInitialNote(t, result)
+	})
 
-func TestGetNote(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/notes/"+noteID, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	assertInitialNote(t, result)
-}
+	t.Run("GetNote", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/notes/"+noteID, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		assertInitialNote(t, result)
+	})
 
-func TestOpenNote(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/notes/"+noteID+"/open", nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var doc map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&doc)
-	assert.NoError(t, err)
-	data, _ := doc["data"].(map[string]interface{})
-	assert.Equal(t, consts.NotesURL, data["type"])
-	assert.Equal(t, noteID, data["id"])
-	attrs, _ := data["attributes"].(map[string]interface{})
-	assert.Equal(t, noteID, attrs["note_id"])
-	assert.Equal(t, "nested", attrs["subdomain"])
-	assert.Contains(t, attrs["protocol"], "http")
-	assert.Equal(t, inst.Domain, attrs["instance"])
-	assert.NotEmpty(t, attrs["public_name"])
-}
-
-func assertInitialNote(t *testing.T, result map[string]interface{}) {
-	data, _ := result["data"].(map[string]interface{})
-	assert.Equal(t, "io.cozy.files", data["type"])
-	if noteID == "" {
-		assert.Contains(t, data, "id")
-		noteID = data["id"].(string)
-	} else {
+	t.Run("OpenNote", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/notes/"+noteID+"/open", nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var doc map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&doc)
+		assert.NoError(t, err)
+		data, _ := doc["data"].(map[string]interface{})
+		assert.Equal(t, consts.NotesURL, data["type"])
 		assert.Equal(t, noteID, data["id"])
-	}
-	attrs := data["attributes"].(map[string]interface{})
-	assert.Equal(t, "file", attrs["type"])
-	assert.Equal(t, "A super note.cozy-note", attrs["name"])
-	assert.Equal(t, "text/vnd.cozy.note+markdown", attrs["mime"])
-	fcm, _ := attrs["cozyMetadata"].(map[string]interface{})
-	assert.Contains(t, fcm, "createdAt")
-	assert.Contains(t, fcm, "createdOn")
-	meta, _ := attrs["metadata"].(map[string]interface{})
-	assert.Equal(t, "A super note", meta["title"])
-	assert.EqualValues(t, 0, meta["version"])
-	assert.NotNil(t, meta["schema"])
-	assert.NotNil(t, meta["content"])
-}
+		attrs, _ := data["attributes"].(map[string]interface{})
+		assert.Equal(t, noteID, attrs["note_id"])
+		assert.Equal(t, "nested", attrs["subdomain"])
+		assert.Contains(t, attrs["protocol"], "http")
+		assert.Equal(t, inst.Domain, attrs["instance"])
+		assert.NotEmpty(t, attrs["public_name"])
+	})
 
-func TestChangeTitleAndSync(t *testing.T) {
-	body := `
+	t.Run("ChangeTitleAndSync", func(t *testing.T) {
+		body := `
 {
   "data": {
     "type": "io.cozy.notes.documents",
@@ -166,57 +162,57 @@ func TestChangeTitleAndSync(t *testing.T) {
     }
   }
 }`
-	req, _ := http.NewRequest("PUT", ts.URL+"/notes/"+noteID+"/title", bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/vnd.api+json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
+		req, _ := http.NewRequest("PUT", ts.URL+"/notes/"+noteID+"/title", bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/vnd.api+json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
 
-	data, _ := result["data"].(map[string]interface{})
-	assert.Equal(t, "io.cozy.files", data["type"])
-	assert.Equal(t, noteID, data["id"])
-	attrs := data["attributes"].(map[string]interface{})
-	meta, _ := attrs["metadata"].(map[string]interface{})
-	assert.Equal(t, "A new title", meta["title"])
-	assert.EqualValues(t, 0, meta["version"])
-	assert.NotNil(t, meta["schema"])
-	assert.NotNil(t, meta["content"])
+		data, _ := result["data"].(map[string]interface{})
+		assert.Equal(t, "io.cozy.files", data["type"])
+		assert.Equal(t, noteID, data["id"])
+		attrs := data["attributes"].(map[string]interface{})
+		meta, _ := attrs["metadata"].(map[string]interface{})
+		assert.Equal(t, "A new title", meta["title"])
+		assert.EqualValues(t, 0, meta["version"])
+		assert.NotNil(t, meta["schema"])
+		assert.NotNil(t, meta["content"])
 
-	// The change was only made in cache, but we have to force persisting the
-	// change to the VFS to check that renaming the file works.
-	req2, _ := http.NewRequest("POST", ts.URL+"/notes/"+noteID+"/sync", nil)
-	req2.Header.Add("Authorization", "Bearer "+token)
-	res2, err := http.DefaultClient.Do(req2)
-	assert.NoError(t, err)
-	assert.Equal(t, 204, res2.StatusCode)
+		// The change was only made in cache, but we have to force persisting the
+		// change to the VFS to check that renaming the file works.
+		req2, _ := http.NewRequest("POST", ts.URL+"/notes/"+noteID+"/sync", nil)
+		req2.Header.Add("Authorization", "Bearer "+token)
+		res2, err := http.DefaultClient.Do(req2)
+		assert.NoError(t, err)
+		assert.Equal(t, 204, res2.StatusCode)
 
-	req3, _ := http.NewRequest("GET", ts.URL+"/notes/"+noteID, nil)
-	req3.Header.Add("Authorization", "Bearer "+token)
-	res3, err := http.DefaultClient.Do(req3)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res3.StatusCode)
-	var result3 map[string]interface{}
-	err = json.NewDecoder(res3.Body).Decode(&result3)
-	assert.NoError(t, err)
-	data3, _ := result3["data"].(map[string]interface{})
-	assert.Equal(t, "io.cozy.files", data3["type"])
-	assert.Equal(t, noteID, data3["id"])
-	attrs3 := data3["attributes"].(map[string]interface{})
-	assert.Equal(t, "A new title.cozy-note", attrs3["name"])
-	meta3, _ := attrs["metadata"].(map[string]interface{})
-	assert.Equal(t, "A new title", meta3["title"])
-	assert.EqualValues(t, 0, meta3["version"])
-	assert.NotNil(t, meta3["schema"])
-	assert.NotNil(t, meta3["content"])
-}
+		req3, _ := http.NewRequest("GET", ts.URL+"/notes/"+noteID, nil)
+		req3.Header.Add("Authorization", "Bearer "+token)
+		res3, err := http.DefaultClient.Do(req3)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res3.StatusCode)
+		var result3 map[string]interface{}
+		err = json.NewDecoder(res3.Body).Decode(&result3)
+		assert.NoError(t, err)
+		data3, _ := result3["data"].(map[string]interface{})
+		assert.Equal(t, "io.cozy.files", data3["type"])
+		assert.Equal(t, noteID, data3["id"])
+		attrs3 := data3["attributes"].(map[string]interface{})
+		assert.Equal(t, "A new title.cozy-note", attrs3["name"])
+		meta3, _ := attrs["metadata"].(map[string]interface{})
+		assert.Equal(t, "A new title", meta3["title"])
+		assert.EqualValues(t, 0, meta3["version"])
+		assert.NotNil(t, meta3["schema"])
+		assert.NotNil(t, meta3["content"])
+	})
 
-func TestListNotes(t *testing.T) {
-	// Change the title
-	body := `
+	t.Run("ListNotes", func(t *testing.T) {
+		// Change the title
+		body := `
 {
   "data": {
     "type": "io.cozy.notes.documents",
@@ -226,40 +222,40 @@ func TestListNotes(t *testing.T) {
     }
   }
 }`
-	req, _ := http.NewRequest("PUT", ts.URL+"/notes/"+noteID+"/title", bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/vnd.api+json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
+		req, _ := http.NewRequest("PUT", ts.URL+"/notes/"+noteID+"/title", bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/vnd.api+json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
 
-	// The title has been changed in cache, but we don't wait that the file has been renamed
-	req, _ = http.NewRequest("GET", ts.URL+"/notes", nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	data, _ := result["data"].([]interface{})
-	assert.Len(t, data, 1)
-	data2, _ := data[0].(map[string]interface{})
-	assert.Equal(t, "io.cozy.files", data2["type"])
-	assert.Equal(t, noteID, data2["id"])
-	attrs := data2["attributes"].(map[string]interface{})
-	assert.Equal(t, "A new title.cozy-note", attrs["name"])
-	assert.Contains(t, attrs["path"], "/A new title.cozy-note")
-	assert.Equal(t, "text/vnd.cozy.note+markdown", attrs["mime"])
-	meta, _ := attrs["metadata"].(map[string]interface{})
-	assert.Equal(t, "A title in cache", meta["title"])
-	assert.EqualValues(t, 0, meta["version"])
-	assert.NotNil(t, meta["schema"])
-	assert.NotNil(t, meta["content"])
-}
+		// The title has been changed in cache, but we don't wait that the file has been renamed
+		req, _ = http.NewRequest("GET", ts.URL+"/notes", nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		data, _ := result["data"].([]interface{})
+		assert.Len(t, data, 1)
+		data2, _ := data[0].(map[string]interface{})
+		assert.Equal(t, "io.cozy.files", data2["type"])
+		assert.Equal(t, noteID, data2["id"])
+		attrs := data2["attributes"].(map[string]interface{})
+		assert.Equal(t, "A new title.cozy-note", attrs["name"])
+		assert.Contains(t, attrs["path"], "/A new title.cozy-note")
+		assert.Equal(t, "text/vnd.cozy.note+markdown", attrs["mime"])
+		meta, _ := attrs["metadata"].(map[string]interface{})
+		assert.Equal(t, "A title in cache", meta["title"])
+		assert.EqualValues(t, 0, meta["version"])
+		assert.NotNil(t, meta["schema"])
+		assert.NotNil(t, meta["content"])
+	})
 
-func TestPatchNote(t *testing.T) {
-	body := `{
+	t.Run("PatchNote", func(t *testing.T) {
+		body := `{
   "data": [{
     "type": "io.cozy.notes.steps",
     "attributes": {
@@ -284,39 +280,39 @@ func TestPatchNote(t *testing.T) {
     }
   }]
 }`
-	req, _ := http.NewRequest("PATCH", ts.URL+"/notes/"+noteID, bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/vnd.api+json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Add("If-Match", "0")
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
+		req, _ := http.NewRequest("PATCH", ts.URL+"/notes/"+noteID, bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/vnd.api+json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Add("If-Match", "0")
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
 
-	data, _ := result["data"].(map[string]interface{})
-	assert.Equal(t, "io.cozy.files", data["type"])
-	assert.Equal(t, noteID, data["id"])
-	attrs := data["attributes"].(map[string]interface{})
-	meta, _ := attrs["metadata"].(map[string]interface{})
-	v, _ := meta["version"].(float64)
-	version = int64(v)
-	assert.Greater(t, version, int64(0))
-	assert.NotNil(t, meta["schema"])
-	assert.NotNil(t, meta["content"])
+		data, _ := result["data"].(map[string]interface{})
+		assert.Equal(t, "io.cozy.files", data["type"])
+		assert.Equal(t, noteID, data["id"])
+		attrs := data["attributes"].(map[string]interface{})
+		meta, _ := attrs["metadata"].(map[string]interface{})
+		v, _ := meta["version"].(float64)
+		version = int64(v)
+		assert.Greater(t, version, int64(0))
+		assert.NotNil(t, meta["schema"])
+		assert.NotNil(t, meta["content"])
 
-	req, _ = http.NewRequest("PATCH", ts.URL+"/notes/"+noteID, bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/vnd.api+json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Add("If-Match", "0")
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 409, res.StatusCode)
-}
+		req, _ = http.NewRequest("PATCH", ts.URL+"/notes/"+noteID, bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/vnd.api+json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Add("If-Match", "0")
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 409, res.StatusCode)
+	})
 
-func TestGetSteps(t *testing.T) {
-	body := `{
+	t.Run("GetSteps", func(t *testing.T) {
+		body := `{
   "data": [{
     "type": "io.cozy.notes.steps",
     "attributes": {
@@ -341,73 +337,73 @@ func TestGetSteps(t *testing.T) {
     }
   }]
 }`
-	req, _ := http.NewRequest("PATCH", ts.URL+"/notes/"+noteID, bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/vnd.api+json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Add("If-Match", fmt.Sprintf("%d", version))
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	data, _ := result["data"].(map[string]interface{})
-	attrs, _ := data["attributes"].(map[string]interface{})
-	meta, _ := attrs["metadata"].(map[string]interface{})
-	last, _ := meta["version"].(float64)
-	lastVersion := int64(last)
-	assert.Greater(t, lastVersion, int64(0))
+		req, _ := http.NewRequest("PATCH", ts.URL+"/notes/"+noteID, bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/vnd.api+json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Add("If-Match", fmt.Sprintf("%d", version))
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		data, _ := result["data"].(map[string]interface{})
+		attrs, _ := data["attributes"].(map[string]interface{})
+		meta, _ := attrs["metadata"].(map[string]interface{})
+		last, _ := meta["version"].(float64)
+		lastVersion := int64(last)
+		assert.Greater(t, lastVersion, int64(0))
 
-	path2 := fmt.Sprintf("/notes/%s/steps?Version=%d", noteID, version)
-	req2, _ := http.NewRequest("GET", ts.URL+path2, nil)
-	req2.Header.Add("Authorization", "Bearer "+token)
-	res2, err := http.DefaultClient.Do(req2)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res2.StatusCode)
-	var result2 map[string]interface{}
-	err = json.NewDecoder(res2.Body).Decode(&result2)
-	assert.NoError(t, err)
-	meta2, _ := result2["meta"].(map[string]interface{})
-	assert.EqualValues(t, 2, meta2["count"])
-	data2, _ := result2["data"].([]interface{})
-	require.Len(t, data2, 2)
+		path2 := fmt.Sprintf("/notes/%s/steps?Version=%d", noteID, version)
+		req2, _ := http.NewRequest("GET", ts.URL+path2, nil)
+		req2.Header.Add("Authorization", "Bearer "+token)
+		res2, err := http.DefaultClient.Do(req2)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res2.StatusCode)
+		var result2 map[string]interface{}
+		err = json.NewDecoder(res2.Body).Decode(&result2)
+		assert.NoError(t, err)
+		meta2, _ := result2["meta"].(map[string]interface{})
+		assert.EqualValues(t, 2, meta2["count"])
+		data2, _ := result2["data"].([]interface{})
+		require.Len(t, data2, 2)
 
-	first, _ := data2[0].(map[string]interface{})
-	assert.NotNil(t, first["id"])
-	attrsF, _ := first["attributes"].(map[string]interface{})
-	assert.Equal(t, "543781490137", attrsF["sessionID"])
-	assert.Equal(t, "replace", attrsF["stepType"])
-	assert.EqualValues(t, 6, attrsF["from"])
-	assert.EqualValues(t, 6, attrsF["to"])
-	assert.NotNil(t, attrsF["version"])
-	second, _ := data2[1].(map[string]interface{})
-	assert.NotNil(t, second["id"])
-	attrsS, _ := second["attributes"].(map[string]interface{})
-	assert.Equal(t, "543781490137", attrsS["sessionID"])
-	assert.Equal(t, "replace", attrsS["stepType"])
-	assert.EqualValues(t, 7, attrsS["from"])
-	assert.EqualValues(t, 7, attrsS["to"])
-	assert.EqualValues(t, lastVersion, attrsS["version"])
+		first, _ := data2[0].(map[string]interface{})
+		assert.NotNil(t, first["id"])
+		attrsF, _ := first["attributes"].(map[string]interface{})
+		assert.Equal(t, "543781490137", attrsF["sessionID"])
+		assert.Equal(t, "replace", attrsF["stepType"])
+		assert.EqualValues(t, 6, attrsF["from"])
+		assert.EqualValues(t, 6, attrsF["to"])
+		assert.NotNil(t, attrsF["version"])
+		second, _ := data2[1].(map[string]interface{})
+		assert.NotNil(t, second["id"])
+		attrsS, _ := second["attributes"].(map[string]interface{})
+		assert.Equal(t, "543781490137", attrsS["sessionID"])
+		assert.Equal(t, "replace", attrsS["stepType"])
+		assert.EqualValues(t, 7, attrsS["from"])
+		assert.EqualValues(t, 7, attrsS["to"])
+		assert.EqualValues(t, lastVersion, attrsS["version"])
 
-	path3 := fmt.Sprintf("/notes/%s/steps?Version=%d", noteID, lastVersion)
-	req3, _ := http.NewRequest("GET", ts.URL+path3, nil)
-	req3.Header.Add("Authorization", "Bearer "+token)
-	res3, err := http.DefaultClient.Do(req3)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res3.StatusCode)
-	var result3 map[string]interface{}
-	err = json.NewDecoder(res3.Body).Decode(&result3)
-	assert.NoError(t, err)
-	meta3, _ := result3["meta"].(map[string]interface{})
-	assert.EqualValues(t, 0, meta3["count"])
-	data3, ok := result3["data"].([]interface{})
-	assert.True(t, ok)
-	assert.Empty(t, data3)
-	version = lastVersion
-}
+		path3 := fmt.Sprintf("/notes/%s/steps?Version=%d", noteID, lastVersion)
+		req3, _ := http.NewRequest("GET", ts.URL+path3, nil)
+		req3.Header.Add("Authorization", "Bearer "+token)
+		res3, err := http.DefaultClient.Do(req3)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res3.StatusCode)
+		var result3 map[string]interface{}
+		err = json.NewDecoder(res3.Body).Decode(&result3)
+		assert.NoError(t, err)
+		meta3, _ := result3["meta"].(map[string]interface{})
+		assert.EqualValues(t, 0, meta3["count"])
+		data3, ok := result3["data"].([]interface{})
+		assert.True(t, ok)
+		assert.Empty(t, data3)
+		version = lastVersion
+	})
 
-func TestPutSchema(t *testing.T) {
-	body := `
+	t.Run("PutSchema", func(t *testing.T) {
+		body := `
 {
   "data": {
     "type": "io.cozy.notes.documents",
@@ -468,63 +464,63 @@ func TestPutSchema(t *testing.T) {
     }
   }
 }`
-	req, _ := http.NewRequest("PUT", ts.URL+"/notes/"+noteID+"/schema", bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
+		req, _ := http.NewRequest("PUT", ts.URL+"/notes/"+noteID+"/schema", bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
 
-	data, _ := result["data"].(map[string]interface{})
-	assert.Equal(t, "io.cozy.files", data["type"])
-	assert.Equal(t, noteID, data["id"])
-	attrs := data["attributes"].(map[string]interface{})
-	meta, _ := attrs["metadata"].(map[string]interface{})
-	schema := meta["schema"].(map[string]interface{})
-	assert.EqualValues(t, 2, schema["version"])
-	nodes, _ := schema["nodes"].([]interface{})
-	panel, _ := nodes[1].([]interface{})
-	assert.EqualValues(t, "panel", panel[0])
+		data, _ := result["data"].(map[string]interface{})
+		assert.Equal(t, "io.cozy.files", data["type"])
+		assert.Equal(t, noteID, data["id"])
+		attrs := data["attributes"].(map[string]interface{})
+		meta, _ := attrs["metadata"].(map[string]interface{})
+		schema := meta["schema"].(map[string]interface{})
+		assert.EqualValues(t, 2, schema["version"])
+		nodes, _ := schema["nodes"].([]interface{})
+		panel, _ := nodes[1].([]interface{})
+		assert.EqualValues(t, "panel", panel[0])
 
-	time.Sleep(1 * time.Second)
-	path2 := fmt.Sprintf("/notes/%s/steps?Version=%d", noteID, version)
-	req2, _ := http.NewRequest("GET", ts.URL+path2, nil)
-	req2.Header.Add("Authorization", "Bearer "+token)
-	res2, err := http.DefaultClient.Do(req2)
-	assert.NoError(t, err)
-	assert.Equal(t, 412, res2.StatusCode)
+		time.Sleep(1 * time.Second)
+		path2 := fmt.Sprintf("/notes/%s/steps?Version=%d", noteID, version)
+		req2, _ := http.NewRequest("GET", ts.URL+path2, nil)
+		req2.Header.Add("Authorization", "Bearer "+token)
+		res2, err := http.DefaultClient.Do(req2)
+		assert.NoError(t, err)
+		assert.Equal(t, 412, res2.StatusCode)
 
-	v, _ := meta["version"].(float64)
-	version = int64(v)
-}
+		v, _ := meta["version"].(float64)
+		version = int64(v)
+	})
 
-func TestPutTelepointer(t *testing.T) {
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
-		sub := realtime.GetHub().Subscriber(inst)
-		sub.Subscribe(consts.NotesEvents)
-		wg.Done()
-		e := <-sub.Channel
-		assert.Equal(t, "UPDATED", e.Verb)
-		assert.Equal(t, noteID, e.Doc.ID())
-		doc, ok := e.Doc.(note.Event)
-		assert.True(t, ok)
-		assert.Equal(t, consts.NotesTelepointers, doc["doctype"])
-		assert.Equal(t, "543781490137", doc["sessionID"])
-		assert.Equal(t, "textSelection", doc["type"])
-		assert.EqualValues(t, 7, doc["anchor"])
-		assert.EqualValues(t, 12, doc["head"])
-		wg.Done()
-	}()
+	t.Run("PutTelepointer", func(t *testing.T) {
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		go func() {
+			sub := realtime.GetHub().Subscriber(inst)
+			sub.Subscribe(consts.NotesEvents)
+			wg.Done()
+			e := <-sub.Channel
+			assert.Equal(t, "UPDATED", e.Verb)
+			assert.Equal(t, noteID, e.Doc.ID())
+			doc, ok := e.Doc.(note.Event)
+			assert.True(t, ok)
+			assert.Equal(t, consts.NotesTelepointers, doc["doctype"])
+			assert.Equal(t, "543781490137", doc["sessionID"])
+			assert.Equal(t, "textSelection", doc["type"])
+			assert.EqualValues(t, 7, doc["anchor"])
+			assert.EqualValues(t, 12, doc["head"])
+			wg.Done()
+		}()
 
-	// Wait that the goroutine has subscribed to the realtime
-	wg.Wait()
-	wg.Add(1)
-	body := `{
+		// Wait that the goroutine has subscribed to the realtime
+		wg.Wait()
+		wg.Add(1)
+		body := `{
   "data": {
     "type": "io.cozy.notes.telepointers",
     "attributes": {
@@ -535,149 +531,193 @@ func TestPutTelepointer(t *testing.T) {
     }
   }
 }`
-	req, _ := http.NewRequest("PUT", ts.URL+"/notes/"+noteID+"/telepointer", bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/vnd.api+json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 204, res.StatusCode)
-	// Wait that the goroutine has received the telepointer update
-	wg.Wait()
-}
+		req, _ := http.NewRequest("PUT", ts.URL+"/notes/"+noteID+"/telepointer", bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/vnd.api+json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 204, res.StatusCode)
+		// Wait that the goroutine has received the telepointer update
+		wg.Wait()
+	})
 
-func TestNoteMarkdown(t *testing.T) {
-	// Force the changes to the VFS
-	err := note.Update(inst, noteID)
-	assert.NoError(t, err)
-	doc, err := inst.VFS().FileByID(noteID)
-	assert.NoError(t, err)
-	file, err := inst.VFS().OpenFile(doc)
-	assert.NoError(t, err)
-	defer file.Close()
-	buf, err := io.ReadAll(file)
-	assert.NoError(t, err)
-	assert.Equal(t, "Hello world", string(buf))
-}
+	t.Run("NoteMarkdown", func(t *testing.T) {
+		// Force the changes to the VFS
+		err := note.Update(inst, noteID)
+		assert.NoError(t, err)
+		doc, err := inst.VFS().FileByID(noteID)
+		assert.NoError(t, err)
+		file, err := inst.VFS().OpenFile(doc)
+		assert.NoError(t, err)
+		defer file.Close()
+		buf, err := io.ReadAll(file)
+		assert.NoError(t, err)
+		assert.Equal(t, "Hello world", string(buf))
+	})
 
-func TestNoteRealtime(t *testing.T) {
-	u := strings.Replace(ts.URL+"/realtime/", "http", "ws", 1)
-	c, _, err := websocket.DefaultDialer.Dial(u, nil)
-	require.NoError(t, err)
+	t.Run("NoteRealtime", func(t *testing.T) {
+		u := strings.Replace(ts.URL+"/realtime/", "http", "ws", 1)
+		c, _, err := websocket.DefaultDialer.Dial(u, nil)
+		require.NoError(t, err)
 
-	defer c.Close()
+		defer c.Close()
 
-	auth := fmt.Sprintf(`{"method": "AUTH", "payload": "%s"}`, token)
-	err = c.WriteMessage(websocket.TextMessage, []byte(auth))
-	require.NoError(t, err)
+		auth := fmt.Sprintf(`{"method": "AUTH", "payload": "%s"}`, token)
+		err = c.WriteMessage(websocket.TextMessage, []byte(auth))
+		require.NoError(t, err)
 
-	msg := `{"method": "SUBSCRIBE", "payload": { "type": "io.cozy.notes.events", "id": "` + noteID + `" }}`
-	err = c.WriteMessage(websocket.TextMessage, []byte(msg))
-	require.NoError(t, err)
+		msg := `{"method": "SUBSCRIBE", "payload": { "type": "io.cozy.notes.events", "id": "` + noteID + `" }}`
+		err = c.WriteMessage(websocket.TextMessage, []byte(msg))
+		require.NoError(t, err)
 
-	// Wait a bit that the subscription is effective
-	time.Sleep(100 * time.Millisecond)
+		// To check that the realtime has made the subscription, we send a fake
+		// message and wait for its response.
+		msg = `{"method": "PING"}`
+		err = c.WriteMessage(websocket.TextMessage, []byte(msg))
+		require.NoError(t, err)
 
-	pointer := note.Event{
-		"sessionID": "543781490137",
-		"anchor":    7,
-		"head":      12,
-		"type":      "textSelection",
-	}
-	pointer.SetID(noteID)
-	err = note.PutTelepointer(inst, pointer)
-	assert.NoError(t, err)
-	var res2 map[string]interface{}
-	err = c.ReadJSON(&res2)
-	assert.NoError(t, err)
-	assert.Equal(t, "UPDATED", res2["event"])
-	payload2, _ := res2["payload"].(map[string]interface{})
-	assert.Equal(t, noteID, payload2["id"])
-	assert.Equal(t, "io.cozy.notes.events", payload2["type"])
-	doc2, _ := payload2["doc"].(map[string]interface{})
-	assert.Equal(t, "io.cozy.notes.telepointers", doc2["doctype"])
-	assert.Equal(t, "543781490137", doc2["sessionID"])
-	assert.EqualValues(t, 7, doc2["anchor"])
-	assert.EqualValues(t, 12, doc2["head"])
-	assert.Equal(t, "textSelection", doc2["type"])
+		var res map[string]interface{}
+		err = c.ReadJSON(&res)
+		assert.NoError(t, err)
 
-	file, err := inst.VFS().FileByID(noteID)
-	assert.NoError(t, err)
-	file, err = note.UpdateTitle(inst, file, "A very new title", "543781490137")
-	assert.NoError(t, err)
-	var res3 map[string]interface{}
-	err = c.ReadJSON(&res3)
-	assert.NoError(t, err)
-	assert.Equal(t, "UPDATED", res3["event"])
-	payload3, _ := res3["payload"].(map[string]interface{})
-	assert.Equal(t, noteID, payload3["id"])
-	assert.Equal(t, "io.cozy.notes.events", payload3["type"])
-	doc3, _ := payload3["doc"].(map[string]interface{})
-	assert.Equal(t, "io.cozy.notes.documents", doc3["doctype"])
-	assert.Equal(t, "A very new title", doc3["title"])
-	assert.Equal(t, "543781490137", doc3["sessionID"])
+		pointer := note.Event{
+			"sessionID": "543781490137",
+			"anchor":    7,
+			"head":      12,
+			"type":      "textSelection",
+		}
+		pointer.SetID(noteID)
+		err = note.PutTelepointer(inst, pointer)
+		assert.NoError(t, err)
+		var res2 map[string]interface{}
+		err = c.ReadJSON(&res2)
+		assert.NoError(t, err)
+		assert.Equal(t, "UPDATED", res2["event"])
+		payload2, _ := res2["payload"].(map[string]interface{})
+		assert.Equal(t, noteID, payload2["id"])
+		assert.Equal(t, "io.cozy.notes.events", payload2["type"])
+		doc2, _ := payload2["doc"].(map[string]interface{})
+		assert.Equal(t, "io.cozy.notes.telepointers", doc2["doctype"])
+		assert.Equal(t, "543781490137", doc2["sessionID"])
+		assert.EqualValues(t, 7, doc2["anchor"])
+		assert.EqualValues(t, 12, doc2["head"])
+		assert.Equal(t, "textSelection", doc2["type"])
 
-	slice := map[string]interface{}{
-		"content": []interface{}{
-			map[string]interface{}{"type": "text", "text": "X"},
-		},
-	}
-	steps := []note.Step{
-		{"sessionID": "543781490137", "stepType": "replace", "from": 2, "to": 2, "slice": slice},
-		{"sessionID": "543781490137", "stepType": "replace", "from": 3, "to": 3, "slice": slice},
-	}
-	file, err = note.ApplySteps(inst, file, fmt.Sprintf("%d", version), steps)
-	require.NoError(t, err)
+		file, err := inst.VFS().FileByID(noteID)
+		assert.NoError(t, err)
+		file, err = note.UpdateTitle(inst, file, "A very new title", "543781490137")
+		assert.NoError(t, err)
+		var res3 map[string]interface{}
+		err = c.ReadJSON(&res3)
+		assert.NoError(t, err)
+		assert.Equal(t, "UPDATED", res3["event"])
+		payload3, _ := res3["payload"].(map[string]interface{})
+		assert.Equal(t, noteID, payload3["id"])
+		assert.Equal(t, "io.cozy.notes.events", payload3["type"])
+		doc3, _ := payload3["doc"].(map[string]interface{})
+		assert.Equal(t, "io.cozy.notes.documents", doc3["doctype"])
+		assert.Equal(t, "A very new title", doc3["title"])
+		assert.Equal(t, "543781490137", doc3["sessionID"])
 
-	var res4 map[string]interface{}
-	err = c.ReadJSON(&res4)
-	assert.NoError(t, err)
-	assert.Equal(t, "UPDATED", res4["event"])
-	payload4, _ := res4["payload"].(map[string]interface{})
-	assert.Equal(t, noteID, payload4["id"])
-	assert.Equal(t, "io.cozy.notes.events", payload4["type"])
-	doc4, _ := payload4["doc"].(map[string]interface{})
+		slice := map[string]interface{}{
+			"content": []interface{}{
+				map[string]interface{}{"type": "text", "text": "X"},
+			},
+		}
+		steps := []note.Step{
+			{"sessionID": "543781490137", "stepType": "replace", "from": 2, "to": 2, "slice": slice},
+			{"sessionID": "543781490137", "stepType": "replace", "from": 3, "to": 3, "slice": slice},
+		}
+		file, err = note.ApplySteps(inst, file, fmt.Sprintf("%d", version), steps)
+		require.NoError(t, err)
 
-	var res5 map[string]interface{}
-	err = c.ReadJSON(&res5)
-	assert.NoError(t, err)
-	assert.Equal(t, "UPDATED", res5["event"])
-	payload5, _ := res5["payload"].(map[string]interface{})
-	assert.Equal(t, noteID, payload5["id"])
-	assert.Equal(t, "io.cozy.notes.events", payload5["type"])
-	doc5, _ := payload5["doc"].(map[string]interface{})
+		var res4 map[string]interface{}
+		err = c.ReadJSON(&res4)
+		assert.NoError(t, err)
+		assert.Equal(t, "UPDATED", res4["event"])
+		payload4, _ := res4["payload"].(map[string]interface{})
+		assert.Equal(t, noteID, payload4["id"])
+		assert.Equal(t, "io.cozy.notes.events", payload4["type"])
+		doc4, _ := payload4["doc"].(map[string]interface{})
 
-	// In some cases, the steps can be received in the bad order because of the
-	// concurrency between the goroutines in the realtime hub.
-	if doc4["version"].(float64) > doc5["version"].(float64) {
-		doc4, doc5 = doc5, doc4
-	}
+		var res5 map[string]interface{}
+		err = c.ReadJSON(&res5)
+		assert.NoError(t, err)
+		assert.Equal(t, "UPDATED", res5["event"])
+		payload5, _ := res5["payload"].(map[string]interface{})
+		assert.Equal(t, noteID, payload5["id"])
+		assert.Equal(t, "io.cozy.notes.events", payload5["type"])
+		doc5, _ := payload5["doc"].(map[string]interface{})
 
-	assert.Equal(t, "io.cozy.notes.steps", doc4["doctype"])
-	assert.Equal(t, "543781490137", doc4["sessionID"])
-	assert.Equal(t, "replace", doc4["stepType"])
-	assert.EqualValues(t, 2, doc4["from"])
-	assert.EqualValues(t, 2, doc4["to"])
-	vers4, _ := doc4["version"].(float64)
-	v4 := int(vers4)
-	assert.NotEqual(t, 0, v4)
-	assert.NotEqual(t, version, v4)
+		// In some cases, the steps can be received in the bad order because of the
+		// concurrency between the goroutines in the realtime hub.
+		if doc4["version"].(float64) > doc5["version"].(float64) {
+			doc4, doc5 = doc5, doc4
+		}
 
-	assert.Equal(t, "io.cozy.notes.steps", doc5["doctype"])
-	assert.Equal(t, "543781490137", doc5["sessionID"])
-	assert.Equal(t, "replace", doc5["stepType"])
-	assert.EqualValues(t, 3, doc5["from"])
-	assert.EqualValues(t, 3, doc5["to"])
-	vers5, _ := doc5["version"].(float64)
-	v5 := int(vers5)
-	assert.NotEqual(t, 0, v5)
-	assert.NotEqual(t, v4, v5)
-	assert.NotEqual(t, version, v5)
-	assert.EqualValues(t, file.Metadata["version"], v5)
-}
+		assert.Equal(t, "io.cozy.notes.steps", doc4["doctype"])
+		assert.Equal(t, "543781490137", doc4["sessionID"])
+		assert.Equal(t, "replace", doc4["stepType"])
+		assert.EqualValues(t, 2, doc4["from"])
+		assert.EqualValues(t, 2, doc4["to"])
+		vers4, _ := doc4["version"].(float64)
+		v4 := int(vers4)
+		assert.NotEqual(t, 0, v4)
+		assert.NotEqual(t, version, v4)
 
-func TestUploadImage(t *testing.T) {
-	for i := 0; i < 3; i++ {
-		u := fmt.Sprintf("/notes/%s/images?Name=wet.jpg", noteID)
+		assert.Equal(t, "io.cozy.notes.steps", doc5["doctype"])
+		assert.Equal(t, "543781490137", doc5["sessionID"])
+		assert.Equal(t, "replace", doc5["stepType"])
+		assert.EqualValues(t, 3, doc5["from"])
+		assert.EqualValues(t, 3, doc5["to"])
+		vers5, _ := doc5["version"].(float64)
+		v5 := int(vers5)
+		assert.NotEqual(t, 0, v5)
+		assert.NotEqual(t, v4, v5)
+		assert.NotEqual(t, version, v5)
+		assert.EqualValues(t, file.Metadata["version"], v5)
+	})
+
+	t.Run("UploadImage", func(t *testing.T) {
+		for i := 0; i < 3; i++ {
+			u := fmt.Sprintf("/notes/%s/images?Name=wet.jpg", noteID)
+			f, err := os.Open("../../tests/fixtures/wet-cozy_20160910__M4Dz.jpg")
+			assert.NoError(t, err)
+			defer f.Close()
+			req, err := http.NewRequest("POST", ts.URL+u, f)
+			assert.NoError(t, err)
+			req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+			req.Header.Add("Content-Type", "image/jpeg")
+			res, err := http.DefaultClient.Do(req)
+			assert.NoError(t, err)
+			assert.Equal(t, 201, res.StatusCode)
+			defer res.Body.Close()
+			var result map[string]interface{}
+			err = json.NewDecoder(res.Body).Decode(&result)
+			assert.NoError(t, err)
+			data, _ := result["data"].(map[string]interface{})
+			assert.Equal(t, consts.NotesImages, data["type"])
+			assert.NotEmpty(t, data["id"])
+			assert.NotEmpty(t, data["meta"])
+
+			attrs, _ := data["attributes"].(map[string]interface{})
+			if i == 0 {
+				assert.Equal(t, "wet.jpg", attrs["name"])
+			} else {
+				assert.Equal(t, fmt.Sprintf("wet (%d).jpg", i+1), attrs["name"])
+			}
+			assert.NotEmpty(t, attrs["cozyMetadata"])
+			assert.Equal(t, "image/jpeg", attrs["mime"])
+			assert.EqualValues(t, 440, attrs["width"])
+			assert.EqualValues(t, 294, attrs["height"])
+
+			links, _ := data["links"].(map[string]interface{})
+			assert.NotEmpty(t, links["self"])
+		}
+	})
+
+	t.Run("GetImage", func(t *testing.T) {
+		u := fmt.Sprintf("/notes/%s/images?Name=wet-cozy.jpg", noteID)
 		f, err := os.Open("../../tests/fixtures/wet-cozy_20160910__M4Dz.jpg")
 		assert.NoError(t, err)
 		defer f.Close()
@@ -698,155 +738,127 @@ func TestUploadImage(t *testing.T) {
 		assert.NotEmpty(t, data["meta"])
 
 		attrs, _ := data["attributes"].(map[string]interface{})
-		if i == 0 {
-			assert.Equal(t, "wet.jpg", attrs["name"])
-		} else {
-			assert.Equal(t, fmt.Sprintf("wet (%d).jpg", i+1), attrs["name"])
-		}
-		assert.NotEmpty(t, attrs["cozyMetadata"])
-		assert.Equal(t, "image/jpeg", attrs["mime"])
-		assert.EqualValues(t, 440, attrs["width"])
-		assert.EqualValues(t, 294, attrs["height"])
-
-		links, _ := data["links"].(map[string]interface{})
-		assert.NotEmpty(t, links["self"])
-	}
-}
-
-func TestGetImage(t *testing.T) {
-	u := fmt.Sprintf("/notes/%s/images?Name=wet-cozy.jpg", noteID)
-	f, err := os.Open("../../tests/fixtures/wet-cozy_20160910__M4Dz.jpg")
-	assert.NoError(t, err)
-	defer f.Close()
-	req, err := http.NewRequest("POST", ts.URL+u, f)
-	assert.NoError(t, err)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	req.Header.Add("Content-Type", "image/jpeg")
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 201, res.StatusCode)
-	defer res.Body.Close()
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	data, _ := result["data"].(map[string]interface{})
-	assert.Equal(t, consts.NotesImages, data["type"])
-	assert.NotEmpty(t, data["id"])
-	assert.NotEmpty(t, data["meta"])
-
-	attrs, _ := data["attributes"].(map[string]interface{})
-	assert.NotEmpty(t, attrs["name"])
-	assert.NotEmpty(t, attrs["cozyMetadata"])
-	assert.Equal(t, "image/jpeg", attrs["mime"])
-
-	links, _ := data["links"].(map[string]interface{})
-	link, _ := links["self"].(string)
-	assert.NotEmpty(t, link)
-
-	req, err = http.NewRequest("GET", ts.URL+link, nil)
-	assert.NoError(t, err)
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	defer res.Body.Close()
-
-	f2, err := os.Open("../../tests/fixtures/wet-cozy_20160910__M4Dz.jpg")
-	assert.NoError(t, err)
-	defer f2.Close()
-	expected, err := io.ReadAll(f2)
-	assert.NoError(t, err)
-	actual, err := io.ReadAll(res.Body)
-	assert.NoError(t, err)
-	assert.Equal(t, expected, actual)
-
-	req, err = http.NewRequest("GET", ts.URL+"/files/"+noteID, nil)
-	assert.NoError(t, err)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	defer res.Body.Close()
-	var result2 map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result2)
-	assert.NoError(t, err)
-	included, _ := result2["included"].([]interface{})
-	hasImage := false
-	for i := range included {
-		data, _ := included[i].(map[string]interface{})
-		if data["type"] == consts.FilesVersions {
-			continue
-		}
-		assert.Equal(t, consts.NotesImages, data["type"])
-		assert.NotEmpty(t, data["id"])
-		assert.NotEmpty(t, data["meta"])
-		attrs, _ := data["attributes"].(map[string]interface{})
 		assert.NotEmpty(t, attrs["name"])
 		assert.NotEmpty(t, attrs["cozyMetadata"])
 		assert.Equal(t, "image/jpeg", attrs["mime"])
-		links, _ := data["links"].(map[string]interface{})
-		assert.NotEmpty(t, links["self"])
-		hasImage = true
-	}
-	assert.True(t, hasImage)
-}
 
-func TestImportNotes(t *testing.T) {
-	buf := strings.NewReader(`
+		links, _ := data["links"].(map[string]interface{})
+		link, _ := links["self"].(string)
+		assert.NotEmpty(t, link)
+
+		req, err = http.NewRequest("GET", ts.URL+link, nil)
+		assert.NoError(t, err)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		defer res.Body.Close()
+
+		f2, err := os.Open("../../tests/fixtures/wet-cozy_20160910__M4Dz.jpg")
+		assert.NoError(t, err)
+		defer f2.Close()
+		expected, err := io.ReadAll(f2)
+		assert.NoError(t, err)
+		actual, err := io.ReadAll(res.Body)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, actual)
+
+		req, err = http.NewRequest("GET", ts.URL+"/files/"+noteID, nil)
+		assert.NoError(t, err)
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		defer res.Body.Close()
+		var result2 map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result2)
+		assert.NoError(t, err)
+		included, _ := result2["included"].([]interface{})
+		hasImage := false
+		for i := range included {
+			data, _ := included[i].(map[string]interface{})
+			if data["type"] == consts.FilesVersions {
+				continue
+			}
+			assert.Equal(t, consts.NotesImages, data["type"])
+			assert.NotEmpty(t, data["id"])
+			assert.NotEmpty(t, data["meta"])
+			attrs, _ := data["attributes"].(map[string]interface{})
+			assert.NotEmpty(t, attrs["name"])
+			assert.NotEmpty(t, attrs["cozyMetadata"])
+			assert.Equal(t, "image/jpeg", attrs["mime"])
+			links, _ := data["links"].(map[string]interface{})
+			assert.NotEmpty(t, links["self"])
+			hasImage = true
+		}
+		assert.True(t, hasImage)
+	})
+
+	t.Run("ImportNotes", func(t *testing.T) {
+		buf := strings.NewReader(`
 # Title
 
 Text with **bold** and [underlined]{.underlined}.
 `)
-	path := "/files/io.cozy.files.root-dir?Type=file&Name=An%20imported%20note.cozy-note"
-	req, err := http.NewRequest("POST", ts.URL+path, buf)
-	assert.NoError(t, err)
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
-	req.Header.Add("Content-Type", "text/plain")
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 201, res.StatusCode)
+		path := "/files/io.cozy.files.root-dir?Type=file&Name=An%20imported%20note.cozy-note"
+		req, err := http.NewRequest("POST", ts.URL+path, buf)
+		assert.NoError(t, err)
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
+		req.Header.Add("Content-Type", "text/plain")
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 201, res.StatusCode)
 
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	data, _ := result["data"].(map[string]interface{})
-	assert.Equal(t, "io.cozy.files", data["type"])
-	assert.Contains(t, data, "id")
-	fileID := data["id"].(string)
-	attrs, _ := data["attributes"].(map[string]interface{})
-	assert.Equal(t, "file", attrs["type"])
-	assert.Equal(t, "An imported note.cozy-note", attrs["name"])
-	assert.Equal(t, "text/vnd.cozy.note+markdown", attrs["mime"])
-	meta, _ := attrs["metadata"].(map[string]interface{})
-	assert.Equal(t, "An imported note", meta["title"])
-	assert.NotNil(t, meta["schema"])
-	assert.NotNil(t, meta["content"])
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		data, _ := result["data"].(map[string]interface{})
+		assert.Equal(t, "io.cozy.files", data["type"])
+		assert.Contains(t, data, "id")
+		fileID := data["id"].(string)
+		attrs, _ := data["attributes"].(map[string]interface{})
+		assert.Equal(t, "file", attrs["type"])
+		assert.Equal(t, "An imported note.cozy-note", attrs["name"])
+		assert.Equal(t, "text/vnd.cozy.note+markdown", attrs["mime"])
+		meta, _ := attrs["metadata"].(map[string]interface{})
+		assert.Equal(t, "An imported note", meta["title"])
+		assert.NotNil(t, meta["schema"])
+		assert.NotNil(t, meta["content"])
 
-	req, _ = http.NewRequest("GET", ts.URL+"/notes/"+fileID+"/open", nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var doc map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&doc)
-	assert.NoError(t, err)
-	data, _ = doc["data"].(map[string]interface{})
-	assert.Equal(t, fileID, data["id"])
-	attrs, _ = data["attributes"].(map[string]interface{})
-	assert.Equal(t, inst.Domain, attrs["instance"])
+		req, _ = http.NewRequest("GET", ts.URL+"/notes/"+fileID+"/open", nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var doc map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&doc)
+		assert.NoError(t, err)
+		data, _ = doc["data"].(map[string]interface{})
+		assert.Equal(t, fileID, data["id"])
+		attrs, _ = data["attributes"].(map[string]interface{})
+		assert.Equal(t, inst.Domain, attrs["instance"])
+	})
+
 }
 
-func TestMain(m *testing.M) {
-	config.UseTestFile()
-	testutils.NeedCouchdb()
-	setup := testutils.NewSetup(m, "notes_test")
-	inst = setup.GetTestInstance()
-	_, token = setup.GetTestClient(consts.Files)
-
-	ts = setup.GetTestServerMultipleRoutes(map[string]func(*echo.Group){
-		"/files":    files.Routes,
-		"/notes":    Routes,
-		"/realtime": webRealtime.Routes,
-	})
-	ts.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler
-	os.Exit(setup.Run())
+func assertInitialNote(t *testing.T, result map[string]interface{}) {
+	data, _ := result["data"].(map[string]interface{})
+	assert.Equal(t, "io.cozy.files", data["type"])
+	if noteID == "" {
+		assert.Contains(t, data, "id")
+		noteID = data["id"].(string)
+	} else {
+		assert.Equal(t, noteID, data["id"])
+	}
+	attrs := data["attributes"].(map[string]interface{})
+	assert.Equal(t, "file", attrs["type"])
+	assert.Equal(t, "A super note.cozy-note", attrs["name"])
+	assert.Equal(t, "text/vnd.cozy.note+markdown", attrs["mime"])
+	fcm, _ := attrs["cozyMetadata"].(map[string]interface{})
+	assert.Contains(t, fcm, "createdAt")
+	assert.Contains(t, fcm, "createdOn")
+	meta, _ := attrs["metadata"].(map[string]interface{})
+	assert.Equal(t, "A super note", meta["title"])
+	assert.EqualValues(t, 0, meta["version"])
+	assert.NotNil(t, meta["schema"])
+	assert.NotNil(t, meta["content"])
 }

--- a/web/notes/notes_test.go
+++ b/web/notes/notes_test.go
@@ -41,7 +41,8 @@ func TestNotes(t *testing.T) {
 
 	config.UseTestFile()
 	testutils.NeedCouchdb()
-	setup := testutils.NewSetup(m, "notes_test")
+	setup := testutils.NewSetup(nil, t.Name())
+	t.Cleanup(setup.Cleanup)
 	inst = setup.GetTestInstance()
 	_, token = setup.GetTestClient(consts.Files)
 

--- a/web/office/office_test.go
+++ b/web/office/office_test.go
@@ -44,7 +44,8 @@ func TestOffice(t *testing.T) {
 		"default": {OnlyOfficeURL: ooURL},
 	}
 	testutils.NeedCouchdb()
-	setup := testutils.NewSetup(m, "office_test")
+	setup := testutils.NewSetup(nil, t.Name())
+	t.Cleanup(setup.Cleanup)
 	inst = setup.GetTestInstance()
 	_, token = setup.GetTestClient(consts.Files)
 

--- a/web/office/office_test.go
+++ b/web/office/office_test.go
@@ -135,7 +135,6 @@ func TestOffice(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "version 2", string(buf))
 	})
-
 }
 
 func createFile() error {

--- a/web/office/office_test.go
+++ b/web/office/office_test.go
@@ -54,7 +54,6 @@ func TestOffice(t *testing.T) {
 
 	ts = setup.GetTestServer("/office", Routes)
 	ts.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler
-	os.Exit(setup.Run())
 
 	t.Run("OnlyOfficeLocal", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", ts.URL+"/office/"+fileID+"/open", nil)

--- a/web/office/office_test.go
+++ b/web/office/office_test.go
@@ -29,87 +29,15 @@ var token string
 var fileID string
 var key string
 
-func TestOnlyOfficeLocal(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/office/"+fileID+"/open", nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	require.Equal(t, 200, res.StatusCode)
-
-	var doc map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&doc)
-	assert.NoError(t, err)
-	data, _ := doc["data"].(map[string]interface{})
-	assert.Equal(t, consts.OfficeURL, data["type"])
-	assert.Equal(t, fileID, data["id"])
-	attrs, _ := data["attributes"].(map[string]interface{})
-	assert.Equal(t, fileID, attrs["document_id"])
-	assert.Equal(t, "nested", attrs["subdomain"])
-	assert.Contains(t, attrs["protocol"], "http")
-	assert.Equal(t, inst.Domain, attrs["instance"])
-	assert.NotEmpty(t, attrs["public_name"])
-	oo, _ := attrs["onlyoffice"].(map[string]interface{})
-	assert.NotEmpty(t, oo["url"])
-	assert.Equal(t, "word", oo["documentType"])
-	editor, _ := oo["editor"].(map[string]interface{})
-	assert.Equal(t, "edit", editor["mode"])
-	callbackURL, _ := editor["callbackUrl"].(string)
-	assert.True(t, strings.HasSuffix(callbackURL, "/office/callback"))
-	document, _ := oo["document"].(map[string]interface{})
-	key, _ = document["key"].(string)
-	assert.NotEmpty(t, key)
+type fakeServer struct {
+	count int
 }
 
-func TestSaveOnlyOffice(t *testing.T) {
-	// Force save
-	body := fmt.Sprintf(`{
-		"actions": [{"type": 0, "userid": "78e1e841"}],
-		"key": "%s",
-		"status": 6,
-		"url": "%s",
-		"users": ["6d5a81d0"]
-	}`, key, ooURL+"/dl")
-	req, _ := http.NewRequest("POST", ts.URL+"/office/callback", strings.NewReader(body))
-	req.Header.Add("Content-Type", "application/json")
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	require.Equal(t, 200, res.StatusCode)
+func TestOffice(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
 
-	var data map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&data)
-	assert.NoError(t, err)
-	assert.Equal(t, data["error"], 0.0)
-
-	doc, err := inst.VFS().FileByID(fileID)
-	assert.NoError(t, err)
-	file, err := inst.VFS().OpenFile(doc)
-	assert.NoError(t, err)
-	defer file.Close()
-	buf, err := io.ReadAll(file)
-	assert.NoError(t, err)
-	assert.Equal(t, "version 1", string(buf))
-
-	// Final save
-	body = strings.Replace(body, `"status": 6`, `"status": 2`, 1)
-	req, _ = http.NewRequest("POST", ts.URL+"/office/callback", strings.NewReader(body))
-	req.Header.Add("Content-Type", "application/json")
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	require.Equal(t, 200, res.StatusCode)
-
-	defer res.Body.Close()
-
-	doc, err = inst.VFS().FileByID(fileID)
-	assert.NoError(t, err)
-	file, err = inst.VFS().OpenFile(doc)
-	assert.NoError(t, err)
-	defer file.Close()
-	buf, err = io.ReadAll(file)
-	assert.NoError(t, err)
-	assert.Equal(t, "version 2", string(buf))
-}
-
-func TestMain(m *testing.M) {
 	config.UseTestFile()
 	ooURL = fakeOOServer()
 	config.GetConfig().Office = map[string]config.Office{
@@ -127,6 +55,87 @@ func TestMain(m *testing.M) {
 	ts = setup.GetTestServer("/office", Routes)
 	ts.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler
 	os.Exit(setup.Run())
+
+	t.Run("OnlyOfficeLocal", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/office/"+fileID+"/open", nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		require.Equal(t, 200, res.StatusCode)
+
+		var doc map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&doc)
+		assert.NoError(t, err)
+		data, _ := doc["data"].(map[string]interface{})
+		assert.Equal(t, consts.OfficeURL, data["type"])
+		assert.Equal(t, fileID, data["id"])
+		attrs, _ := data["attributes"].(map[string]interface{})
+		assert.Equal(t, fileID, attrs["document_id"])
+		assert.Equal(t, "nested", attrs["subdomain"])
+		assert.Contains(t, attrs["protocol"], "http")
+		assert.Equal(t, inst.Domain, attrs["instance"])
+		assert.NotEmpty(t, attrs["public_name"])
+		oo, _ := attrs["onlyoffice"].(map[string]interface{})
+		assert.NotEmpty(t, oo["url"])
+		assert.Equal(t, "word", oo["documentType"])
+		editor, _ := oo["editor"].(map[string]interface{})
+		assert.Equal(t, "edit", editor["mode"])
+		callbackURL, _ := editor["callbackUrl"].(string)
+		assert.True(t, strings.HasSuffix(callbackURL, "/office/callback"))
+		document, _ := oo["document"].(map[string]interface{})
+		key, _ = document["key"].(string)
+		assert.NotEmpty(t, key)
+	})
+
+	t.Run("SaveOnlyOffice", func(t *testing.T) {
+		// Force save
+		body := fmt.Sprintf(`{
+		"actions": [{"type": 0, "userid": "78e1e841"}],
+		"key": "%s",
+		"status": 6,
+		"url": "%s",
+		"users": ["6d5a81d0"]
+	}`, key, ooURL+"/dl")
+		req, _ := http.NewRequest("POST", ts.URL+"/office/callback", strings.NewReader(body))
+		req.Header.Add("Content-Type", "application/json")
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		require.Equal(t, 200, res.StatusCode)
+
+		var data map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&data)
+		assert.NoError(t, err)
+		assert.Equal(t, data["error"], 0.0)
+
+		doc, err := inst.VFS().FileByID(fileID)
+		assert.NoError(t, err)
+		file, err := inst.VFS().OpenFile(doc)
+		assert.NoError(t, err)
+		defer file.Close()
+		buf, err := io.ReadAll(file)
+		assert.NoError(t, err)
+		assert.Equal(t, "version 1", string(buf))
+
+		// Final save
+		body = strings.Replace(body, `"status": 6`, `"status": 2`, 1)
+		req, _ = http.NewRequest("POST", ts.URL+"/office/callback", strings.NewReader(body))
+		req.Header.Add("Content-Type", "application/json")
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		require.Equal(t, 200, res.StatusCode)
+
+		defer res.Body.Close()
+
+		doc, err = inst.VFS().FileByID(fileID)
+		assert.NoError(t, err)
+		file, err = inst.VFS().OpenFile(doc)
+		assert.NoError(t, err)
+		defer file.Close()
+		buf, err = io.ReadAll(file)
+		assert.NoError(t, err)
+		assert.Equal(t, "version 2", string(buf))
+	})
+
 }
 
 func createFile() error {
@@ -145,10 +154,6 @@ func createFile() error {
 	}
 	fileID = filedoc.ID()
 	return nil
-}
-
-type fakeServer struct {
-	count int
 }
 
 func (f *fakeServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/web/oidc/oidc_test.go
+++ b/web/oidc/oidc_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"regexp"
 	"testing"
 
@@ -86,7 +85,6 @@ func TestOidc(t *testing.T) {
 	if err != nil {
 		panic("Could not init dynamic FS")
 	}
-	os.Exit(testSetup.Run())
 
 	t.Run("StartWithOnboardingNotFinished", func(t *testing.T) {
 		// Should get a 200 with body "activate your cozy"

--- a/web/oidc/oidc_test.go
+++ b/web/oidc/oidc_test.go
@@ -33,7 +33,8 @@ func TestOidc(t *testing.T) {
 	config.UseTestFile()
 	config.GetConfig().Assets = "../../assets"
 	testutils.NeedCouchdb()
-	testSetup := testutils.NewSetup(m, "oidc_test")
+	setup := testutils.NewSetup(nil, t.Name())
+	t.Cleanup(setup.Cleanup)
 	render, _ := statik.NewDirRenderer("../../assets")
 	middlewares.BuildTemplates()
 
@@ -47,10 +48,10 @@ func TestOidc(t *testing.T) {
 	}
 	job.AddWorker(wl)
 
-	testInstance = testSetup.GetTestInstance(&lifecycle.Options{ContextName: "foocontext"})
+	testInstance = setup.GetTestInstance(&lifecycle.Options{ContextName: "foocontext"})
 
 	// Mocking API endpoint to validate token
-	ts = testSetup.GetTestServerMultipleRoutes(map[string]func(*echo.Group){
+	ts = setup.GetTestServerMultipleRoutes(map[string]func(*echo.Group){
 		"/oidc": Routes,
 		"/token": func(g *echo.Group) {
 			g.POST("/getToken", handleToken)

--- a/web/oidc/oidc_test.go
+++ b/web/oidc/oidc_test.go
@@ -26,173 +26,11 @@ import (
 var testInstance *instance.Instance
 var ts *httptest.Server
 
-func TestStartWithOnboardingNotFinished(t *testing.T) {
-	// Should get a 200 with body "activate your cozy"
-	req, err := http.NewRequest(http.MethodGet, ts.URL+"/oidc/start", nil)
-	req.Host = testInstance.Domain
-	assert.NoError(t, err)
-
-	// Preventing redirects
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	content, err := io.ReadAll(res.Body)
-	assert.NoError(t, err)
-	assert.Contains(t, string(content), "Onboarding Not activated")
-}
-
-func TestStartWithOnboardingFinished(t *testing.T) {
-	onboardingFinished := true
-	_ = lifecycle.Patch(testInstance, &lifecycle.Options{OnboardingFinished: &onboardingFinished})
-
-	// Should return a 303 redirect
-	req, err := http.NewRequest(http.MethodGet, ts.URL+"/oidc/start", nil)
-	req.Host = testInstance.Domain
-	assert.NoError(t, err)
-
-	// Preventing redirection to assert we are effectively redirected
-	c := &http.Client{CheckRedirect: noRedirect}
-	res, err := c.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 303, res.StatusCode)
-	location := res.Header["Location"][0]
-	redirected, err := url.Parse(location)
-	assert.NoError(t, err)
-	assert.Equal(t, "foobar.com", redirected.Host)
-	assert.Equal(t, "/authorize", redirected.Path)
-
-	values, err := url.ParseQuery(redirected.RawQuery)
-	assert.NoError(t, err)
-	assert.NotNil(t, values.Get("client_id"))
-	assert.NotNil(t, values.Get("nonce"))
-	assert.NotNil(t, values.Get("redirect_uri"))
-	assert.NotNil(t, values.Get("response_type"))
-	assert.NotNil(t, values.Get("state"))
-	assert.NotNil(t, values.Get("scope"))
-}
-
-func TestStateIsMandatoryForLogin(t *testing.T) {
-	onboardingFinished := true
-	_ = lifecycle.Patch(testInstance, &lifecycle.Options{OnboardingFinished: &onboardingFinished})
-
-	// Should return a 303 redirect
-	req, err := http.NewRequest(http.MethodGet, ts.URL+"/oidc/start", nil)
-	req.Host = testInstance.Domain
-	assert.NoError(t, err)
-
-	// Preventing redirection to assert we are effectively redirected
-	c := &http.Client{CheckRedirect: noRedirect}
-	res, err := c.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 303, res.StatusCode)
-	location := res.Header["Location"][0]
-	redirected, err := url.Parse(location)
-	assert.NoError(t, err)
-	assert.Equal(t, "foobar.com", redirected.Host)
-	assert.Equal(t, "/authorize", redirected.Path)
-
-	values, err := url.ParseQuery(redirected.RawQuery)
-	assert.NoError(t, err)
-	assert.NotNil(t, values.Get("client_id"))
-	assert.NotNil(t, values.Get("nonce"))
-	assert.NotNil(t, values.Get("redirect_uri"))
-	assert.NotNil(t, values.Get("response_type"))
-	assert.NotNil(t, values.Get("state"))
-	assert.NotNil(t, values.Get("scope"))
-
-	// Get the login page, assert we have an error if state is missing
-	stateID := values.Get("state")
-	values.Del("state")
-	v := values.Encode()
-	reqLogin, err := http.NewRequest(http.MethodGet, ts.URL+"/oidc/login?"+v, nil)
-	assert.NoError(t, err)
-	reqLogin.Host = testInstance.Domain
-	resLogin, err := c.Do(reqLogin)
-	assert.NoError(t, err)
-	assert.Equal(t, 404, resLogin.StatusCode)
-
-	// And the login page should work with the state
-	values.Add("state", stateID)
-	v = values.Encode()
-	reqLogin, err = http.NewRequest(http.MethodGet, ts.URL+"/oidc/login?"+v, nil)
-	assert.NoError(t, err)
-	reqLogin.Host = testInstance.Domain
-	resLogin, err = c.Do(reqLogin)
-	assert.NoError(t, err)
-	assert.Equal(t, 303, resLogin.StatusCode)
-	location = resLogin.Header["Location"][0]
-	assert.Equal(t, location, testInstance.DefaultRedirection().String())
-}
-
-func TestLoginWith2FA(t *testing.T) {
-	onboardingFinished := true
-	_ = lifecycle.Patch(testInstance, &lifecycle.Options{OnboardingFinished: &onboardingFinished, AuthMode: "two_factor_mail"})
-
-	// Should return a 303 redirect
-	req, err := http.NewRequest(http.MethodGet, ts.URL+"/oidc/start", nil)
-	req.Host = testInstance.Domain
-	assert.NoError(t, err)
-
-	// Preventing redirection to assert we are effectively redirected
-	c := &http.Client{CheckRedirect: noRedirect}
-	res, err := c.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 303, res.StatusCode)
-	location := res.Header["Location"][0]
-	redirected, err := url.Parse(location)
-	assert.NoError(t, err)
-	assert.Equal(t, "foobar.com", redirected.Host)
-	assert.Equal(t, "/authorize", redirected.Path)
-
-	values, err := url.ParseQuery(redirected.RawQuery)
-	assert.NoError(t, err)
-	assert.NotNil(t, values.Get("client_id"))
-	assert.NotNil(t, values.Get("nonce"))
-	assert.NotNil(t, values.Get("redirect_uri"))
-	assert.NotNil(t, values.Get("response_type"))
-	assert.NotNil(t, values.Get("state"))
-	assert.NotNil(t, values.Get("scope"))
-
-	// Get the login page, assert we have the 2FA activated
-	values.Add("token", "foo")
-	v := values.Encode()
-	reqLogin, err := http.NewRequest(http.MethodGet, ts.URL+"/oidc/login?"+v, nil)
-	assert.NoError(t, err)
-	reqLogin.Host = testInstance.Domain
-	resLogin, err := c.Do(reqLogin)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, resLogin.StatusCode)
-	content, err := io.ReadAll(resLogin.Body)
-	assert.NoError(t, err)
-	assert.Contains(t, string(content), `<form id="oidc-twofactor-form"`)
-	re := regexp.MustCompile(`name="access-token" value="(\w+)"`)
-	matches := re.FindStringSubmatch(string(content))
-	assert.Len(t, matches, 2)
-	accessToken := matches[1]
-
-	// Check that the user is redirected to the 2FA page
-	values = url.Values{
-		"access-token":         {accessToken},
-		"trusted-device-token": {""},
-		"redirect":             {""},
-		"confirm":              {""},
+func TestOidc(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
 	}
-	body := bytes.NewReader([]byte(values.Encode()))
-	req2FA, err := http.NewRequest(http.MethodPost, ts.URL+"/oidc/twofactor", body)
-	assert.NoError(t, err)
-	req2FA.Host = testInstance.Domain
-	res2FA, err := c.Do(req2FA)
-	assert.NoError(t, err)
-	assert.Equal(t, 303, res2FA.StatusCode)
 
-	locationLogin := res2FA.Header["Location"][0]
-	redirected, err = url.Parse(locationLogin)
-	assert.NoError(t, err)
-	assert.Equal(t, "/auth/twofactor", redirected.Path)
-	assert.NotNil(t, redirected.Query().Get("two_factor_token"))
-}
-
-func TestMain(m *testing.M) {
 	config.UseTestFile()
 	config.GetConfig().Assets = "../../assets"
 	testutils.NeedCouchdb()
@@ -249,6 +87,173 @@ func TestMain(m *testing.M) {
 		panic("Could not init dynamic FS")
 	}
 	os.Exit(testSetup.Run())
+
+	t.Run("StartWithOnboardingNotFinished", func(t *testing.T) {
+		// Should get a 200 with body "activate your cozy"
+		req, err := http.NewRequest(http.MethodGet, ts.URL+"/oidc/start", nil)
+		req.Host = testInstance.Domain
+		assert.NoError(t, err)
+
+		// Preventing redirects
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		content, err := io.ReadAll(res.Body)
+		assert.NoError(t, err)
+		assert.Contains(t, string(content), "Onboarding Not activated")
+	})
+
+	t.Run("StartWithOnboardingFinished", func(t *testing.T) {
+		onboardingFinished := true
+		_ = lifecycle.Patch(testInstance, &lifecycle.Options{OnboardingFinished: &onboardingFinished})
+
+		// Should return a 303 redirect
+		req, err := http.NewRequest(http.MethodGet, ts.URL+"/oidc/start", nil)
+		req.Host = testInstance.Domain
+		assert.NoError(t, err)
+
+		// Preventing redirection to assert we are effectively redirected
+		c := &http.Client{CheckRedirect: noRedirect}
+		res, err := c.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 303, res.StatusCode)
+		location := res.Header["Location"][0]
+		redirected, err := url.Parse(location)
+		assert.NoError(t, err)
+		assert.Equal(t, "foobar.com", redirected.Host)
+		assert.Equal(t, "/authorize", redirected.Path)
+
+		values, err := url.ParseQuery(redirected.RawQuery)
+		assert.NoError(t, err)
+		assert.NotNil(t, values.Get("client_id"))
+		assert.NotNil(t, values.Get("nonce"))
+		assert.NotNil(t, values.Get("redirect_uri"))
+		assert.NotNil(t, values.Get("response_type"))
+		assert.NotNil(t, values.Get("state"))
+		assert.NotNil(t, values.Get("scope"))
+	})
+
+	t.Run("StateIsMandatoryForLogin", func(t *testing.T) {
+		onboardingFinished := true
+		_ = lifecycle.Patch(testInstance, &lifecycle.Options{OnboardingFinished: &onboardingFinished})
+
+		// Should return a 303 redirect
+		req, err := http.NewRequest(http.MethodGet, ts.URL+"/oidc/start", nil)
+		req.Host = testInstance.Domain
+		assert.NoError(t, err)
+
+		// Preventing redirection to assert we are effectively redirected
+		c := &http.Client{CheckRedirect: noRedirect}
+		res, err := c.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 303, res.StatusCode)
+		location := res.Header["Location"][0]
+		redirected, err := url.Parse(location)
+		assert.NoError(t, err)
+		assert.Equal(t, "foobar.com", redirected.Host)
+		assert.Equal(t, "/authorize", redirected.Path)
+
+		values, err := url.ParseQuery(redirected.RawQuery)
+		assert.NoError(t, err)
+		assert.NotNil(t, values.Get("client_id"))
+		assert.NotNil(t, values.Get("nonce"))
+		assert.NotNil(t, values.Get("redirect_uri"))
+		assert.NotNil(t, values.Get("response_type"))
+		assert.NotNil(t, values.Get("state"))
+		assert.NotNil(t, values.Get("scope"))
+
+		// Get the login page, assert we have an error if state is missing
+		stateID := values.Get("state")
+		values.Del("state")
+		v := values.Encode()
+		reqLogin, err := http.NewRequest(http.MethodGet, ts.URL+"/oidc/login?"+v, nil)
+		assert.NoError(t, err)
+		reqLogin.Host = testInstance.Domain
+		resLogin, err := c.Do(reqLogin)
+		assert.NoError(t, err)
+		assert.Equal(t, 404, resLogin.StatusCode)
+
+		// And the login page should work with the state
+		values.Add("state", stateID)
+		v = values.Encode()
+		reqLogin, err = http.NewRequest(http.MethodGet, ts.URL+"/oidc/login?"+v, nil)
+		assert.NoError(t, err)
+		reqLogin.Host = testInstance.Domain
+		resLogin, err = c.Do(reqLogin)
+		assert.NoError(t, err)
+		assert.Equal(t, 303, resLogin.StatusCode)
+		location = resLogin.Header["Location"][0]
+		assert.Equal(t, location, testInstance.DefaultRedirection().String())
+	})
+
+	t.Run("LoginWith2FA", func(t *testing.T) {
+		onboardingFinished := true
+		_ = lifecycle.Patch(testInstance, &lifecycle.Options{OnboardingFinished: &onboardingFinished, AuthMode: "two_factor_mail"})
+
+		// Should return a 303 redirect
+		req, err := http.NewRequest(http.MethodGet, ts.URL+"/oidc/start", nil)
+		req.Host = testInstance.Domain
+		assert.NoError(t, err)
+
+		// Preventing redirection to assert we are effectively redirected
+		c := &http.Client{CheckRedirect: noRedirect}
+		res, err := c.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 303, res.StatusCode)
+		location := res.Header["Location"][0]
+		redirected, err := url.Parse(location)
+		assert.NoError(t, err)
+		assert.Equal(t, "foobar.com", redirected.Host)
+		assert.Equal(t, "/authorize", redirected.Path)
+
+		values, err := url.ParseQuery(redirected.RawQuery)
+		assert.NoError(t, err)
+		assert.NotNil(t, values.Get("client_id"))
+		assert.NotNil(t, values.Get("nonce"))
+		assert.NotNil(t, values.Get("redirect_uri"))
+		assert.NotNil(t, values.Get("response_type"))
+		assert.NotNil(t, values.Get("state"))
+		assert.NotNil(t, values.Get("scope"))
+
+		// Get the login page, assert we have the 2FA activated
+		values.Add("token", "foo")
+		v := values.Encode()
+		reqLogin, err := http.NewRequest(http.MethodGet, ts.URL+"/oidc/login?"+v, nil)
+		assert.NoError(t, err)
+		reqLogin.Host = testInstance.Domain
+		resLogin, err := c.Do(reqLogin)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, resLogin.StatusCode)
+		content, err := io.ReadAll(resLogin.Body)
+		assert.NoError(t, err)
+		assert.Contains(t, string(content), `<form id="oidc-twofactor-form"`)
+		re := regexp.MustCompile(`name="access-token" value="(\w+)"`)
+		matches := re.FindStringSubmatch(string(content))
+		assert.Len(t, matches, 2)
+		accessToken := matches[1]
+
+		// Check that the user is redirected to the 2FA page
+		values = url.Values{
+			"access-token":         {accessToken},
+			"trusted-device-token": {""},
+			"redirect":             {""},
+			"confirm":              {""},
+		}
+		body := bytes.NewReader([]byte(values.Encode()))
+		req2FA, err := http.NewRequest(http.MethodPost, ts.URL+"/oidc/twofactor", body)
+		assert.NoError(t, err)
+		req2FA.Host = testInstance.Domain
+		res2FA, err := c.Do(req2FA)
+		assert.NoError(t, err)
+		assert.Equal(t, 303, res2FA.StatusCode)
+
+		locationLogin := res2FA.Header["Location"][0]
+		redirected, err = url.Parse(locationLogin)
+		assert.NoError(t, err)
+		assert.Equal(t, "/auth/twofactor", redirected.Path)
+		assert.NotNil(t, redirected.Query().Get("two_factor_token"))
+	})
+
 }
 
 func noRedirect(*http.Request, []*http.Request) error {

--- a/web/oidc/oidc_test.go
+++ b/web/oidc/oidc_test.go
@@ -252,7 +252,6 @@ func TestOidc(t *testing.T) {
 		assert.Equal(t, "/auth/twofactor", redirected.Path)
 		assert.NotNil(t, redirected.Query().Get("two_factor_token"))
 	})
-
 }
 
 func noRedirect(*http.Request, []*http.Request) error {

--- a/web/permissions/permissions_test.go
+++ b/web/permissions/permissions_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -55,8 +54,6 @@ func TestPermissions(t *testing.T) {
 
 	ts = testSetup.GetTestServer("/permissions", Routes)
 	ts.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler
-
-	os.Exit(testSetup.Run())
 
 	t.Run("CreateShareSetByMobileRevokeByLinkedApp", func(t *testing.T) {
 		// Create OAuthLinkedClient

--- a/web/permissions/permissions_test.go
+++ b/web/permissions/permissions_test.go
@@ -894,7 +894,6 @@ func TestPermissions(t *testing.T) {
 		_, err = uninstaller.RunSync()
 		assert.NoError(t, err)
 	})
-
 }
 
 func createTestSubPermissions(tok string, codes string) (string, map[string]interface{}, error) {

--- a/web/permissions/permissions_test.go
+++ b/web/permissions/permissions_test.go
@@ -354,8 +354,7 @@ func TestPatchNoopFail(t *testing.T) {
 	    "attributes": { }
 	    }
 	  }
-	}
-`)
+	}`)
 
 	assert.Error(t, err)
 }
@@ -374,8 +373,7 @@ func TestBadPatchAddRuleForbidden(t *testing.T) {
 					}
 				}
 	    }
-	  }
-`)
+	  }`)
 
 	assert.Error(t, err)
 }
@@ -394,8 +392,7 @@ func TestPatchAddRule(t *testing.T) {
 					}
 				}
 	    }
-	  }
-`)
+	  }`)
 
 	data := out["data"].(map[string]interface{})
 	assert.Equal(t, id, data["id"])
@@ -420,8 +417,7 @@ func TestPatchRemoveRule(t *testing.T) {
 					}
 				}
 	    }
-	  }
-`)
+	  }`)
 
 	data := out["data"].(map[string]interface{})
 	assert.Equal(t, id, data["id"])
@@ -449,8 +445,7 @@ func TestPatchChangesCodes(t *testing.T) {
 					}
 				}
 			}
-		}
-`)
+		}`)
 	assert.Error(t, err)
 
 	out, err := doRequest("PATCH", ts.URL+"/permissions/"+id, token, `{
@@ -461,8 +456,7 @@ func TestPatchChangesCodes(t *testing.T) {
 					}
 				}
 	    }
-	  }
-`)
+	  }`)
 
 	require.NoError(t, err)
 
@@ -527,24 +521,25 @@ func TestRevokeByAnotherApp(t *testing.T) {
 }
 
 func createTestSubPermissions(tok string, codes string) (string, map[string]interface{}, error) {
-	out, err := doRequest("POST", ts.URL+"/permissions?codes="+codes, tok, `{
-"data": {
-	"type": "io.cozy.permissions",
-	"attributes": {
-		"permissions": {
-			"whatever": {
-				"type":   "io.cozy.files",
-				"verbs":  ["GET"],
-				"values": ["io.cozy.music"]
-			},
-			"otherrule": {
-				"type":   "io.cozy.files",
-				"verbs":  ["GET"],
-				"values":  ["some-other-dir"]
-		  }
-		}
-	}
-}
+	out, err := doRequest("POST", ts.URL+"/permissions?codes="+codes, tok, `
+  {
+    "data": {
+      "type": "io.cozy.permissions",
+      "attributes": {
+        "permissions": {
+          "whatever": {
+            "type":   "io.cozy.files",
+            "verbs":  ["GET"],
+            "values": ["io.cozy.music"]
+          },
+          "otherrule": {
+            "type":   "io.cozy.files",
+            "verbs":  ["GET"],
+            "values":  ["some-other-dir"]
+          }
+        }
+      }
+    }
 	}`)
 	if err != nil {
 		return "", nil, err
@@ -558,19 +553,20 @@ func createTestSubPermissions(tok string, codes string) (string, map[string]inte
 }
 
 func createTestTinyCode(tok string, codes string, ttl string) (string, map[string]interface{}, error) {
-	out, err := doRequest("POST", ts.URL+"/permissions?codes="+codes+"&tiny=true&ttl="+ttl, tok, `{
-"data": {
-	"type": "io.cozy.permissions",
-	"attributes": {
-		"permissions": {
-			"whatever": {
-				"type":   "io.cozy.files",
-				"verbs":  ["GET"],
-				"values": ["id.`+codes+`"]
-		  }
-		}
-	}
-}
+	out, err := doRequest("POST", ts.URL+"/permissions?codes="+codes+"&tiny=true&ttl="+ttl, tok, `
+  {
+    "data": {
+      "type": "io.cozy.permissions",
+      "attributes": {
+        "permissions": {
+          "whatever": {
+            "type":   "io.cozy.files",
+            "verbs":  ["GET"],
+            "values": ["id.`+codes+`"]
+          }
+        }
+      }
+    }
 	}`)
 	if err != nil {
 		return "", nil, err

--- a/web/permissions/permissions_test.go
+++ b/web/permissions/permissions_test.go
@@ -43,16 +43,17 @@ func TestPermissions(t *testing.T) {
 
 	config.UseTestFile()
 	testutils.NeedCouchdb()
-	testSetup := testutils.NewSetup(m, "permissions_test")
+	setup := testutils.NewSetup(nil, t.Name())
+	t.Cleanup(setup.Cleanup)
 
-	testInstance = testSetup.GetTestInstance()
+	testInstance = setup.GetTestInstance()
 	scopes := "io.cozy.contacts io.cozy.files:GET io.cozy.events"
-	client, tok := testSetup.GetTestClient(scopes)
+	client, tok := setup.GetTestClient(scopes)
 	clientVal = client
 	clientID = client.ClientID
 	token = tok
 
-	ts = testSetup.GetTestServer("/permissions", Routes)
+	ts = setup.GetTestServer("/permissions", Routes)
 	ts.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler
 
 	t.Run("CreateShareSetByMobileRevokeByLinkedApp", func(t *testing.T) {

--- a/web/realtime/realtime_test.go
+++ b/web/realtime/realtime_test.go
@@ -28,204 +28,11 @@ type testDoc struct {
 	doctype string
 }
 
-func (t *testDoc) ID() string      { return t.id }
-func (t *testDoc) DocType() string { return t.doctype }
-func (t *testDoc) MarshalJSON() ([]byte, error) {
-	j := `{"_id":"` + t.id + `", "_type":"` + t.doctype + `"}`
-	return []byte(j), nil
-}
+func TestRealtime(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
 
-func TestWSNoAuth(t *testing.T) {
-	u := strings.Replace(ts.URL+"/realtime/", "http", "ws", 1)
-	ws, _, err := websocket.DefaultDialer.Dial(u, nil)
-	assert.NoError(t, err)
-	defer ws.Close()
-
-	msg := `{"method": "SUBSCRIBE", "payload": { "type": "io.cozy.foos" }}`
-	err = ws.WriteMessage(websocket.TextMessage, []byte(msg))
-	assert.NoError(t, err)
-
-	var res map[string]interface{}
-	err = ws.ReadJSON(&res)
-	assert.NoError(t, err)
-	assert.Equal(t, "error", res["event"])
-	payload := res["payload"].(map[string]interface{})
-	assert.Equal(t, "405 Method Not Allowed", payload["status"])
-	assert.Equal(t, "method not allowed", payload["code"])
-	assert.Equal(t, "The SUBSCRIBE method is not supported", payload["title"])
-}
-
-func TestWSInvalidToken(t *testing.T) {
-	u := strings.Replace(ts.URL+"/realtime/", "http", "ws", 1)
-	ws, _, err := websocket.DefaultDialer.Dial(u, nil)
-	assert.NoError(t, err)
-	defer ws.Close()
-
-	auth := `{"method": "AUTH", "payload": "123456789"}`
-	err = ws.WriteMessage(websocket.TextMessage, []byte(auth))
-	assert.NoError(t, err)
-
-	var res map[string]interface{}
-	err = ws.ReadJSON(&res)
-	assert.NoError(t, err)
-	assert.Equal(t, "error", res["event"])
-	payload := res["payload"].(map[string]interface{})
-	assert.Equal(t, "401 Unauthorized", payload["status"])
-	assert.Equal(t, "unauthorized", payload["code"])
-	assert.Equal(t, "The authentication has failed", payload["title"])
-}
-
-func TestWSNoPermissionsForADoctype(t *testing.T) {
-	u := strings.Replace(ts.URL+"/realtime/", "http", "ws", 1)
-	ws, _, err := websocket.DefaultDialer.Dial(u, nil)
-	assert.NoError(t, err)
-	defer ws.Close()
-
-	auth := fmt.Sprintf(`{"method": "AUTH", "payload": "%s"}`, token)
-	err = ws.WriteMessage(websocket.TextMessage, []byte(auth))
-	assert.NoError(t, err)
-
-	msg := `{"method": "SUBSCRIBE", "payload": { "type": "io.cozy.contacts" }}`
-	err = ws.WriteMessage(websocket.TextMessage, []byte(msg))
-	assert.NoError(t, err)
-
-	var res map[string]interface{}
-	err = ws.ReadJSON(&res)
-	assert.NoError(t, err)
-	assert.Equal(t, "error", res["event"])
-	payload := res["payload"].(map[string]interface{})
-	assert.Equal(t, "403 Forbidden", payload["status"])
-	assert.Equal(t, "forbidden", payload["code"])
-	assert.Equal(t, "The application can't subscribe to io.cozy.contacts", payload["title"])
-}
-
-func TestWSSuccess(t *testing.T) {
-	u := strings.Replace(ts.URL+"/realtime/", "http", "ws", 1)
-	ws, _, err := websocket.DefaultDialer.Dial(u, nil)
-	require.NoError(t, err)
-
-	defer ws.Close()
-
-	auth := fmt.Sprintf(`{"method": "AUTH", "payload": "%s"}`, token)
-	err = ws.WriteMessage(websocket.TextMessage, []byte(auth))
-	require.NoError(t, err)
-
-	msg := `{"method": "SUBSCRIBE", "payload": { "type": "io.cozy.foos" }}`
-	err = ws.WriteMessage(websocket.TextMessage, []byte(msg))
-	require.NoError(t, err)
-
-	msg = `{"method": "SUBSCRIBE", "payload": { "type": "io.cozy.bars", "id": "bar-one" }}`
-	err = ws.WriteMessage(websocket.TextMessage, []byte(msg))
-	require.NoError(t, err)
-
-	msg = `{"method": "SUBSCRIBE", "payload": { "type": "io.cozy.bars", "id": "bar-two" }}`
-	err = ws.WriteMessage(websocket.TextMessage, []byte(msg))
-	require.NoError(t, err)
-
-	h := realtime.GetHub()
-	var res map[string]interface{}
-	time.Sleep(30 * time.Millisecond)
-
-	h.Publish(inst, realtime.EventUpdate, &testDoc{
-		doctype: "io.cozy.foos",
-		id:      "foo-one",
-	}, nil)
-	err = ws.ReadJSON(&res)
-	assert.NoError(t, err)
-	assert.Equal(t, "UPDATED", res["event"])
-	payload := res["payload"].(map[string]interface{})
-	assert.Equal(t, "io.cozy.foos", payload["type"])
-	assert.Equal(t, "foo-one", payload["id"])
-
-	h.Publish(inst, realtime.EventDelete, &testDoc{
-		doctype: "io.cozy.foos",
-		id:      "foo-two",
-	}, nil)
-	err = ws.ReadJSON(&res)
-	assert.NoError(t, err)
-	assert.Equal(t, "DELETED", res["event"])
-	payload = res["payload"].(map[string]interface{})
-	assert.Equal(t, "io.cozy.foos", payload["type"])
-	assert.Equal(t, "foo-two", payload["id"])
-
-	h.Publish(inst, realtime.EventCreate, &testDoc{
-		doctype: "io.cozy.bars",
-		id:      "bar-three",
-	}, nil)
-	// No event
-
-	h.Publish(inst, realtime.EventCreate, &testDoc{
-		doctype: "io.cozy.bars",
-		id:      "bar-one",
-	}, nil)
-	err = ws.ReadJSON(&res)
-	assert.NoError(t, err)
-	assert.Equal(t, "CREATED", res["event"])
-	payload = res["payload"].(map[string]interface{})
-	assert.Equal(t, "io.cozy.bars", payload["type"])
-	assert.Equal(t, "bar-one", payload["id"])
-
-	msg = `{"method": "UNSUBSCRIBE", "payload": { "type": "io.cozy.bars", "id": "bar-one" }}`
-	err = ws.WriteMessage(websocket.TextMessage, []byte(msg))
-	require.NoError(t, err)
-
-	time.Sleep(30 * time.Millisecond)
-
-	h.Publish(inst, realtime.EventUpdate, &testDoc{
-		doctype: "io.cozy.bars",
-		id:      "bar-one",
-	}, nil)
-	// No event
-
-	h.Publish(inst, realtime.EventUpdate, &testDoc{
-		doctype: "io.cozy.bars",
-		id:      "bar-two",
-	}, nil)
-	err = ws.ReadJSON(&res)
-	assert.NoError(t, err)
-	assert.Equal(t, "UPDATED", res["event"])
-	payload = res["payload"].(map[string]interface{})
-	assert.Equal(t, "io.cozy.bars", payload["type"])
-	assert.Equal(t, "bar-two", payload["id"])
-}
-
-func TestWSNotify(t *testing.T) {
-	u := strings.Replace(ts.URL+"/realtime/", "http", "ws", 1)
-	ws, _, err := websocket.DefaultDialer.Dial(u, nil)
-	require.NoError(t, err)
-
-	defer ws.Close()
-
-	auth := fmt.Sprintf(`{"method": "AUTH", "payload": "%s"}`, token)
-	err = ws.WriteMessage(websocket.TextMessage, []byte(auth))
-	require.NoError(t, err)
-
-	msg := `{"method": "SUBSCRIBE", "payload": { "type": "io.cozy.bazs", "id": "baz-one" }}`
-	err = ws.WriteMessage(websocket.TextMessage, []byte(msg))
-	require.NoError(t, err)
-
-	time.Sleep(30 * time.Millisecond)
-	body := `{"hello": "world"}`
-	req, _ := http.NewRequest("POST", ts.URL+"/realtime/io.cozy.bazs/baz-one", bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	require.Equal(t, http.StatusNoContent, res.StatusCode)
-
-	var resp map[string]interface{}
-	err = ws.ReadJSON(&resp)
-	require.NoError(t, err)
-
-	assert.Equal(t, "NOTIFIED", resp["event"])
-	payload := resp["payload"].(map[string]interface{})
-	assert.Equal(t, "io.cozy.bazs", payload["type"])
-	assert.Equal(t, "baz-one", payload["id"])
-	doc := payload["doc"].(map[string]interface{})
-	assert.Equal(t, "world", doc["hello"])
-}
-
-func TestMain(m *testing.M) {
 	config.UseTestFile()
 	testutils.NeedCouchdb()
 	setup := testutils.NewSetup(m, "realtime_test")
@@ -233,4 +40,202 @@ func TestMain(m *testing.M) {
 	_, token = setup.GetTestClient("io.cozy.foos io.cozy.bars io.cozy.bazs")
 	ts = setup.GetTestServer("/realtime", Routes)
 	os.Exit(setup.Run())
+
+	t.Run("WSNoAuth", func(t *testing.T) {
+		u := strings.Replace(ts.URL+"/realtime/", "http", "ws", 1)
+		ws, _, err := websocket.DefaultDialer.Dial(u, nil)
+		assert.NoError(t, err)
+		defer ws.Close()
+
+		msg := `{"method": "SUBSCRIBE", "payload": { "type": "io.cozy.foos" }}`
+		err = ws.WriteMessage(websocket.TextMessage, []byte(msg))
+		assert.NoError(t, err)
+
+		var res map[string]interface{}
+		err = ws.ReadJSON(&res)
+		assert.NoError(t, err)
+		assert.Equal(t, "error", res["event"])
+		payload := res["payload"].(map[string]interface{})
+		assert.Equal(t, "405 Method Not Allowed", payload["status"])
+		assert.Equal(t, "method not allowed", payload["code"])
+		assert.Equal(t, "The SUBSCRIBE method is not supported", payload["title"])
+	})
+
+	t.Run("WSInvalidToken", func(t *testing.T) {
+		u := strings.Replace(ts.URL+"/realtime/", "http", "ws", 1)
+		ws, _, err := websocket.DefaultDialer.Dial(u, nil)
+		assert.NoError(t, err)
+		defer ws.Close()
+
+		auth := `{"method": "AUTH", "payload": "123456789"}`
+		err = ws.WriteMessage(websocket.TextMessage, []byte(auth))
+		assert.NoError(t, err)
+
+		var res map[string]interface{}
+		err = ws.ReadJSON(&res)
+		assert.NoError(t, err)
+		assert.Equal(t, "error", res["event"])
+		payload := res["payload"].(map[string]interface{})
+		assert.Equal(t, "401 Unauthorized", payload["status"])
+		assert.Equal(t, "unauthorized", payload["code"])
+		assert.Equal(t, "The authentication has failed", payload["title"])
+	})
+
+	t.Run("WSNoPermissionsForADoctype", func(t *testing.T) {
+		u := strings.Replace(ts.URL+"/realtime/", "http", "ws", 1)
+		ws, _, err := websocket.DefaultDialer.Dial(u, nil)
+		assert.NoError(t, err)
+		defer ws.Close()
+
+		auth := fmt.Sprintf(`{"method": "AUTH", "payload": "%s"}`, token)
+		err = ws.WriteMessage(websocket.TextMessage, []byte(auth))
+		assert.NoError(t, err)
+
+		msg := `{"method": "SUBSCRIBE", "payload": { "type": "io.cozy.contacts" }}`
+		err = ws.WriteMessage(websocket.TextMessage, []byte(msg))
+		assert.NoError(t, err)
+
+		var res map[string]interface{}
+		err = ws.ReadJSON(&res)
+		assert.NoError(t, err)
+		assert.Equal(t, "error", res["event"])
+		payload := res["payload"].(map[string]interface{})
+		assert.Equal(t, "403 Forbidden", payload["status"])
+		assert.Equal(t, "forbidden", payload["code"])
+		assert.Equal(t, "The application can't subscribe to io.cozy.contacts", payload["title"])
+	})
+
+	t.Run("WSSuccess", func(t *testing.T) {
+		u := strings.Replace(ts.URL+"/realtime/", "http", "ws", 1)
+		ws, _, err := websocket.DefaultDialer.Dial(u, nil)
+		require.NoError(t, err)
+
+		defer ws.Close()
+
+		auth := fmt.Sprintf(`{"method": "AUTH", "payload": "%s"}`, token)
+		err = ws.WriteMessage(websocket.TextMessage, []byte(auth))
+		require.NoError(t, err)
+
+		msg := `{"method": "SUBSCRIBE", "payload": { "type": "io.cozy.foos" }}`
+		err = ws.WriteMessage(websocket.TextMessage, []byte(msg))
+		require.NoError(t, err)
+
+		msg = `{"method": "SUBSCRIBE", "payload": { "type": "io.cozy.bars", "id": "bar-one" }}`
+		err = ws.WriteMessage(websocket.TextMessage, []byte(msg))
+		require.NoError(t, err)
+
+		msg = `{"method": "SUBSCRIBE", "payload": { "type": "io.cozy.bars", "id": "bar-two" }}`
+		err = ws.WriteMessage(websocket.TextMessage, []byte(msg))
+		require.NoError(t, err)
+
+		h := realtime.GetHub()
+		var res map[string]interface{}
+		time.Sleep(30 * time.Millisecond)
+
+		h.Publish(inst, realtime.EventUpdate, &testDoc{
+			doctype: "io.cozy.foos",
+			id:      "foo-one",
+		}, nil)
+		err = ws.ReadJSON(&res)
+		assert.NoError(t, err)
+		assert.Equal(t, "UPDATED", res["event"])
+		payload := res["payload"].(map[string]interface{})
+		assert.Equal(t, "io.cozy.foos", payload["type"])
+		assert.Equal(t, "foo-one", payload["id"])
+
+		h.Publish(inst, realtime.EventDelete, &testDoc{
+			doctype: "io.cozy.foos",
+			id:      "foo-two",
+		}, nil)
+		err = ws.ReadJSON(&res)
+		assert.NoError(t, err)
+		assert.Equal(t, "DELETED", res["event"])
+		payload = res["payload"].(map[string]interface{})
+		assert.Equal(t, "io.cozy.foos", payload["type"])
+		assert.Equal(t, "foo-two", payload["id"])
+
+		h.Publish(inst, realtime.EventCreate, &testDoc{
+			doctype: "io.cozy.bars",
+			id:      "bar-three",
+		}, nil)
+		// No event
+
+		h.Publish(inst, realtime.EventCreate, &testDoc{
+			doctype: "io.cozy.bars",
+			id:      "bar-one",
+		}, nil)
+		err = ws.ReadJSON(&res)
+		assert.NoError(t, err)
+		assert.Equal(t, "CREATED", res["event"])
+		payload = res["payload"].(map[string]interface{})
+		assert.Equal(t, "io.cozy.bars", payload["type"])
+		assert.Equal(t, "bar-one", payload["id"])
+
+		msg = `{"method": "UNSUBSCRIBE", "payload": { "type": "io.cozy.bars", "id": "bar-one" }}`
+		err = ws.WriteMessage(websocket.TextMessage, []byte(msg))
+		require.NoError(t, err)
+
+		time.Sleep(30 * time.Millisecond)
+
+		h.Publish(inst, realtime.EventUpdate, &testDoc{
+			doctype: "io.cozy.bars",
+			id:      "bar-one",
+		}, nil)
+		// No event
+
+		h.Publish(inst, realtime.EventUpdate, &testDoc{
+			doctype: "io.cozy.bars",
+			id:      "bar-two",
+		}, nil)
+		err = ws.ReadJSON(&res)
+		assert.NoError(t, err)
+		assert.Equal(t, "UPDATED", res["event"])
+		payload = res["payload"].(map[string]interface{})
+		assert.Equal(t, "io.cozy.bars", payload["type"])
+		assert.Equal(t, "bar-two", payload["id"])
+	})
+
+	t.Run("WSNotify", func(t *testing.T) {
+		u := strings.Replace(ts.URL+"/realtime/", "http", "ws", 1)
+		ws, _, err := websocket.DefaultDialer.Dial(u, nil)
+		require.NoError(t, err)
+
+		defer ws.Close()
+
+		auth := fmt.Sprintf(`{"method": "AUTH", "payload": "%s"}`, token)
+		err = ws.WriteMessage(websocket.TextMessage, []byte(auth))
+		require.NoError(t, err)
+
+		msg := `{"method": "SUBSCRIBE", "payload": { "type": "io.cozy.bazs", "id": "baz-one" }}`
+		err = ws.WriteMessage(websocket.TextMessage, []byte(msg))
+		require.NoError(t, err)
+
+		time.Sleep(30 * time.Millisecond)
+		body := `{"hello": "world"}`
+		req, _ := http.NewRequest("POST", ts.URL+"/realtime/io.cozy.bazs/baz-one", bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		require.Equal(t, http.StatusNoContent, res.StatusCode)
+
+		var resp map[string]interface{}
+		err = ws.ReadJSON(&resp)
+		require.NoError(t, err)
+
+		assert.Equal(t, "NOTIFIED", resp["event"])
+		payload := resp["payload"].(map[string]interface{})
+		assert.Equal(t, "io.cozy.bazs", payload["type"])
+		assert.Equal(t, "baz-one", payload["id"])
+		doc := payload["doc"].(map[string]interface{})
+		assert.Equal(t, "world", doc["hello"])
+	})
+
+}
+
+func (t *testDoc) ID() string      { return t.id }
+func (t *testDoc) DocType() string { return t.doctype }
+func (t *testDoc) MarshalJSON() ([]byte, error) {
+	j := `{"_id":"` + t.id + `", "_type":"` + t.doctype + `"}`
+	return []byte(j), nil
 }

--- a/web/realtime/realtime_test.go
+++ b/web/realtime/realtime_test.go
@@ -229,7 +229,6 @@ func TestRealtime(t *testing.T) {
 		doc := payload["doc"].(map[string]interface{})
 		assert.Equal(t, "world", doc["hello"])
 	})
-
 }
 
 func (t *testDoc) ID() string      { return t.id }

--- a/web/realtime/realtime_test.go
+++ b/web/realtime/realtime_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -39,7 +38,6 @@ func TestRealtime(t *testing.T) {
 	inst = setup.GetTestInstance()
 	_, token = setup.GetTestClient("io.cozy.foos io.cozy.bars io.cozy.bazs")
 	ts = setup.GetTestServer("/realtime", Routes)
-	os.Exit(setup.Run())
 
 	t.Run("WSNoAuth", func(t *testing.T) {
 		u := strings.Replace(ts.URL+"/realtime/", "http", "ws", 1)

--- a/web/realtime/realtime_test.go
+++ b/web/realtime/realtime_test.go
@@ -34,7 +34,8 @@ func TestRealtime(t *testing.T) {
 
 	config.UseTestFile()
 	testutils.NeedCouchdb()
-	setup := testutils.NewSetup(m, "realtime_test")
+	setup := testutils.NewSetup(nil, t.Name())
+	t.Cleanup(setup.Cleanup)
 	inst = setup.GetTestInstance()
 	_, token = setup.GetTestClient("io.cozy.foos io.cozy.bars io.cozy.bazs")
 	ts = setup.GetTestServer("/realtime", Routes)

--- a/web/remote/remote_test.go
+++ b/web/remote/remote_test.go
@@ -65,7 +65,6 @@ func TestRemote(t *testing.T) {
 		meta, _ := logged["cozyMetadata"].(map[string]interface{})
 		assert.Equal(t, "answers", meta["createdByApp"])
 	})
-
 }
 
 func generateAppToken(inst *instance.Instance, slug, doctype string) string {

--- a/web/remote/remote_test.go
+++ b/web/remote/remote_test.go
@@ -20,39 +20,11 @@ var testInstance *instance.Instance
 var ts *httptest.Server
 var token string
 
-func TestRemoteGET(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/remote/org.wikidata.entity?entity=Q42&comment=foo", nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Host = testInstance.Domain
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	body, _ := io.ReadAll(res.Body)
-	assert.Equal(t, `{"entities":`, string(body[:12]))
-
-	var results []map[string]interface{}
-	allReq := &couchdb.AllDocsRequest{
-		Descending: true,
-		Limit:      1,
+func TestRemote(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
 	}
-	err = couchdb.GetAllDocs(testInstance, consts.RemoteRequests, allReq, &results)
-	assert.NoError(t, err)
-	assert.Len(t, results, 1)
-	logged := results[0]
-	assert.Equal(t, "org.wikidata.entity", logged["doctype"].(string))
-	assert.Equal(t, "GET", logged["verb"].(string))
-	assert.Equal(t, "https://www.wikidata.org/wiki/Special:EntityData/Q42.json", logged["url"].(string))
-	assert.Equal(t, float64(200), logged["response_code"].(float64))
-	assert.Equal(t, "application/json", logged["content_type"].(string))
-	assert.NotNil(t, logged["created_at"])
-	vars := logged["variables"].(map[string]interface{})
-	assert.Equal(t, "Q42", vars["entity"].(string))
-	assert.Equal(t, "foo", vars["comment"].(string))
-	meta, _ := logged["cozyMetadata"].(map[string]interface{})
-	assert.Equal(t, "answers", meta["createdByApp"])
-}
 
-func TestMain(m *testing.M) {
 	config.UseTestFile()
 	testutils.NeedCouchdb()
 	setup := testutils.NewSetup(m, "remote_test")
@@ -62,6 +34,39 @@ func TestMain(m *testing.M) {
 
 	ts = setup.GetTestServer("/remote", Routes)
 	os.Exit(setup.Run())
+
+	t.Run("RemoteGET", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/remote/org.wikidata.entity?entity=Q42&comment=foo", nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Host = testInstance.Domain
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		body, _ := io.ReadAll(res.Body)
+		assert.Equal(t, `{"entities":`, string(body[:12]))
+
+		var results []map[string]interface{}
+		allReq := &couchdb.AllDocsRequest{
+			Descending: true,
+			Limit:      1,
+		}
+		err = couchdb.GetAllDocs(testInstance, consts.RemoteRequests, allReq, &results)
+		assert.NoError(t, err)
+		assert.Len(t, results, 1)
+		logged := results[0]
+		assert.Equal(t, "org.wikidata.entity", logged["doctype"].(string))
+		assert.Equal(t, "GET", logged["verb"].(string))
+		assert.Equal(t, "https://www.wikidata.org/wiki/Special:EntityData/Q42.json", logged["url"].(string))
+		assert.Equal(t, float64(200), logged["response_code"].(float64))
+		assert.Equal(t, "application/json", logged["content_type"].(string))
+		assert.NotNil(t, logged["created_at"])
+		vars := logged["variables"].(map[string]interface{})
+		assert.Equal(t, "Q42", vars["entity"].(string))
+		assert.Equal(t, "foo", vars["comment"].(string))
+		meta, _ := logged["cozyMetadata"].(map[string]interface{})
+		assert.Equal(t, "answers", meta["createdByApp"])
+	})
+
 }
 
 func generateAppToken(inst *instance.Instance, slug, doctype string) string {

--- a/web/remote/remote_test.go
+++ b/web/remote/remote_test.go
@@ -4,7 +4,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/cozy/cozy-stack/model/instance"
@@ -33,7 +32,6 @@ func TestRemote(t *testing.T) {
 	token = generateAppToken(testInstance, "answers", "org.wikidata.entity")
 
 	ts = setup.GetTestServer("/remote", Routes)
-	os.Exit(setup.Run())
 
 	t.Run("RemoteGET", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", ts.URL+"/remote/org.wikidata.entity?entity=Q42&comment=foo", nil)

--- a/web/remote/remote_test.go
+++ b/web/remote/remote_test.go
@@ -26,7 +26,8 @@ func TestRemote(t *testing.T) {
 
 	config.UseTestFile()
 	testutils.NeedCouchdb()
-	setup := testutils.NewSetup(m, "remote_test")
+	setup := testutils.NewSetup(nil, t.Name())
+	t.Cleanup(setup.Cleanup)
 
 	testInstance = setup.GetTestInstance()
 	token = generateAppToken(testInstance, "answers", "org.wikidata.entity")

--- a/web/routing_test.go
+++ b/web/routing_test.go
@@ -24,7 +24,8 @@ func TestRouting(t *testing.T) {
 	config.UseTestFile()
 	config.GetConfig().Assets = "../assets"
 	testutils.NeedCouchdb()
-	setup := testutils.NewSetup(m, "routing_test")
+	setup := testutils.NewSetup(nil, t.Name())
+	t.Cleanup(setup.Cleanup)
 	inst := setup.GetTestInstance()
 	domain = inst.Domain
 	err := dynamic.InitDynamicAssetFS()

--- a/web/routing_test.go
+++ b/web/routing_test.go
@@ -3,7 +3,6 @@ package web
 import (
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/cozy/cozy-stack/pkg/assets/dynamic"
@@ -32,7 +31,6 @@ func TestRouting(t *testing.T) {
 	if err != nil {
 		panic("Could not init dynamic FS")
 	}
-	os.Exit(setup.Run())
 
 	t.Run("SetupAssets", func(t *testing.T) {
 		e := echo.New()

--- a/web/routing_test.go
+++ b/web/routing_test.go
@@ -17,123 +17,11 @@ import (
 
 var domain string
 
-func TestSetupAssets(t *testing.T) {
-	e := echo.New()
-	err := SetupAssets(e, "../assets")
-	require.NoError(t, err)
-
-	ts := httptest.NewServer(e)
-	defer ts.Close()
-
-	{
-		res, err := http.Get(ts.URL + "/assets/images/cozy.svg")
-		assert.NoError(t, err)
-		defer res.Body.Close()
-		assert.Equal(t, 200, res.StatusCode)
+func TestRouting(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
 	}
 
-	{
-		res, err := http.Head(ts.URL + "/assets/images/cozy.svg")
-		assert.NoError(t, err)
-		defer res.Body.Close()
-		assert.Equal(t, 200, res.StatusCode)
-	}
-}
-
-func TestSetupAssetsStatik(t *testing.T) {
-	e := echo.New()
-	err := SetupAssets(e, "")
-	require.NoError(t, err)
-
-	ts := httptest.NewServer(e)
-	defer ts.Close()
-
-	{
-		res, err := http.Get(ts.URL + "/assets/images/cozy.svg")
-		assert.NoError(t, err)
-		defer res.Body.Close()
-		assert.Equal(t, 200, res.StatusCode)
-		assert.NotContains(t, res.Header.Get("Cache-Control"), "max-age=")
-	}
-
-	{
-		res, err := http.Get(ts.URL + "/assets/images/cozy.badbeefbadbeef.svg")
-		assert.NoError(t, err)
-		defer res.Body.Close()
-		assert.Equal(t, 200, res.StatusCode)
-		assert.Contains(t, res.Header.Get("Cache-Control"), "max-age=")
-	}
-
-	{
-		res, err := http.Get(ts.URL + "/assets/images/cozy.immutable.svg")
-		assert.NoError(t, err)
-		defer res.Body.Close()
-		assert.Equal(t, 200, res.StatusCode)
-		assert.Contains(t, res.Header.Get("Cache-Control"), "max-age=")
-	}
-
-	{
-		res, err := http.Head(ts.URL + "/assets/images/cozy.svg")
-		assert.NoError(t, err)
-		defer res.Body.Close()
-		assert.Equal(t, 200, res.StatusCode)
-	}
-
-	{
-		res, err := http.Head(ts.URL + "/assets/images/cozy.badbeefbadbeef.svg")
-		assert.NoError(t, err)
-		defer res.Body.Close()
-		assert.Equal(t, 200, res.StatusCode)
-		assert.Contains(t, res.Header.Get("Cache-Control"), "max-age=")
-	}
-}
-
-func TestSetupRoutes(t *testing.T) {
-	e := echo.New()
-	err := SetupRoutes(e)
-	require.NoError(t, err)
-
-	ts := httptest.NewServer(e)
-	defer ts.Close()
-
-	res, err := http.Get(ts.URL + "/version")
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, 200, res.StatusCode)
-}
-
-func TestParseHost(t *testing.T) {
-	apis := echo.New()
-
-	apis.GET("/test", func(c echo.Context) error {
-		instance := middlewares.GetInstance(c)
-		assert.NotNil(t, instance, "the instance should have been set in the echo context")
-		return c.String(http.StatusOK, "OK")
-	}, middlewares.NeedInstance)
-
-	router, err := CreateSubdomainProxy(apis, func(c echo.Context) error {
-		slug := c.Get("slug").(string)
-		return c.String(200, "OK:"+slug)
-	})
-
-	require.NoError(t, err)
-
-	urls := map[string]string{
-		"https://" + domain + "/test":    "OK",
-		"https://foo." + domain + "/app": "OK:foo",
-		"https://bar." + domain + "/app": "OK:bar",
-	}
-
-	for u, k := range urls {
-		w := httptest.NewRecorder()
-		req := httptest.NewRequest("GET", u, nil)
-		router.ServeHTTP(w, req)
-		assert.Equal(t, http.StatusOK, w.Code)
-		assert.Equal(t, k, w.Body.String())
-	}
-}
-
-func TestMain(m *testing.M) {
 	config.UseTestFile()
 	config.GetConfig().Assets = "../assets"
 	testutils.NeedCouchdb()
@@ -145,4 +33,121 @@ func TestMain(m *testing.M) {
 		panic("Could not init dynamic FS")
 	}
 	os.Exit(setup.Run())
+
+	t.Run("SetupAssets", func(t *testing.T) {
+		e := echo.New()
+		err := SetupAssets(e, "../assets")
+		require.NoError(t, err)
+
+		ts := httptest.NewServer(e)
+		defer ts.Close()
+
+		{
+			res, err := http.Get(ts.URL + "/assets/images/cozy.svg")
+			assert.NoError(t, err)
+			defer res.Body.Close()
+			assert.Equal(t, 200, res.StatusCode)
+		}
+
+		{
+			res, err := http.Head(ts.URL + "/assets/images/cozy.svg")
+			assert.NoError(t, err)
+			defer res.Body.Close()
+			assert.Equal(t, 200, res.StatusCode)
+		}
+	})
+
+	t.Run("SetupAssetsStatik", func(t *testing.T) {
+		e := echo.New()
+		err := SetupAssets(e, "")
+		require.NoError(t, err)
+
+		ts := httptest.NewServer(e)
+		defer ts.Close()
+
+		{
+			res, err := http.Get(ts.URL + "/assets/images/cozy.svg")
+			assert.NoError(t, err)
+			defer res.Body.Close()
+			assert.Equal(t, 200, res.StatusCode)
+			assert.NotContains(t, res.Header.Get("Cache-Control"), "max-age=")
+		}
+
+		{
+			res, err := http.Get(ts.URL + "/assets/images/cozy.badbeefbadbeef.svg")
+			assert.NoError(t, err)
+			defer res.Body.Close()
+			assert.Equal(t, 200, res.StatusCode)
+			assert.Contains(t, res.Header.Get("Cache-Control"), "max-age=")
+		}
+
+		{
+			res, err := http.Get(ts.URL + "/assets/images/cozy.immutable.svg")
+			assert.NoError(t, err)
+			defer res.Body.Close()
+			assert.Equal(t, 200, res.StatusCode)
+			assert.Contains(t, res.Header.Get("Cache-Control"), "max-age=")
+		}
+
+		{
+			res, err := http.Head(ts.URL + "/assets/images/cozy.svg")
+			assert.NoError(t, err)
+			defer res.Body.Close()
+			assert.Equal(t, 200, res.StatusCode)
+		}
+
+		{
+			res, err := http.Head(ts.URL + "/assets/images/cozy.badbeefbadbeef.svg")
+			assert.NoError(t, err)
+			defer res.Body.Close()
+			assert.Equal(t, 200, res.StatusCode)
+			assert.Contains(t, res.Header.Get("Cache-Control"), "max-age=")
+		}
+	})
+
+	t.Run("SetupRoutes", func(t *testing.T) {
+		e := echo.New()
+		err := SetupRoutes(e)
+		require.NoError(t, err)
+
+		ts := httptest.NewServer(e)
+		defer ts.Close()
+
+		res, err := http.Get(ts.URL + "/version")
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, 200, res.StatusCode)
+	})
+
+	t.Run("ParseHost", func(t *testing.T) {
+		apis := echo.New()
+
+		apis.GET("/test", func(c echo.Context) error {
+			instance := middlewares.GetInstance(c)
+			assert.NotNil(t, instance, "the instance should have been set in the echo context")
+			return c.String(http.StatusOK, "OK")
+		}, middlewares.NeedInstance)
+
+		router, err := CreateSubdomainProxy(apis, func(c echo.Context) error {
+			slug := c.Get("slug").(string)
+			return c.String(200, "OK:"+slug)
+		})
+
+		require.NoError(t, err)
+
+		urls := map[string]string{
+			"https://" + domain + "/test":    "OK",
+			"https://foo." + domain + "/app": "OK:foo",
+			"https://bar." + domain + "/app": "OK:bar",
+		}
+
+		for u, k := range urls {
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", u, nil)
+			router.ServeHTTP(w, req)
+			assert.Equal(t, http.StatusOK, w.Code)
+			assert.Equal(t, k, w.Body.String())
+		}
+	})
+
 }

--- a/web/routing_test.go
+++ b/web/routing_test.go
@@ -148,5 +148,4 @@ func TestRouting(t *testing.T) {
 			assert.Equal(t, k, w.Body.String())
 		}
 	})
-
 }

--- a/web/settings/settings_test.go
+++ b/web/settings/settings_test.go
@@ -46,7 +46,8 @@ func TestSettings(t *testing.T) {
 
 	config.UseTestFile()
 	testutils.NeedCouchdb()
-	setup := testutils.NewSetup(m, "settings_test")
+	setup := testutils.NewSetup(nil, t.Name())
+	t.Cleanup(setup.Cleanup)
 	testInstance = setup.GetTestInstance(&lifecycle.Options{
 		Locale:      "en",
 		Timezone:    "Europe/Berlin",
@@ -70,7 +71,8 @@ func TestSettings(t *testing.T) {
 	})
 	tsB.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler
 
-	setupFlagship := testutils.NewSetup(m, "settings_flagship_test")
+	setupFlagship := testutils.NewSetup(nil, t.Name())
+	t.Cleanup(setup.Cleanup)
 	testInstanceFlagship = setupFlagship.GetTestInstance(&lifecycle.Options{
 		Locale:      "en",
 		Timezone:    "Europe/Berlin",

--- a/web/settings/settings_test.go
+++ b/web/settings/settings_test.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 	"time"
 
@@ -80,8 +79,6 @@ func TestSettings(t *testing.T) {
 	})
 	tsC = setupFlagship.GetTestServer("/settings", Routes)
 	tsC.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler
-
-	os.Exit(setup.Run())
 
 	t.Run("GetContext", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", ts.URL+"/settings/context", nil)

--- a/web/settings/settings_test.go
+++ b/web/settings/settings_test.go
@@ -37,939 +37,14 @@ var instanceRev string
 var token string
 var oauthClientID string
 
-func TestGetContext(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/settings/context", nil)
-	req.Header.Add("Accept", "application/vnd.api+json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, http.StatusOK, res.StatusCode)
-}
+// Fake middleware used to inject a false session to mislead the authentication
+// system
 
-func TestPatchWithGoodRev(t *testing.T) {
-	// We are going to patch an instance with newer values, and give the good rev
-	body := `{
-		"data": {
-			"type": "io.cozy.settings",
-			"id": "io.cozy.settings.instance",
-			"meta": {
-				"rev": "%s"
-			},
-			"attributes": {
-				"tz": "Europe/London",
-				"email": "alice@example.org",
-				"locale": "fr"
-			}
-		}
-	}`
-
-	doc1, err := testInstance.SettingsDocument()
-	assert.NoError(t, err)
-	body = fmt.Sprintf(body, doc1.Rev())
-	req, _ := http.NewRequest("PUT", ts.URL+"/settings/instance", bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/vnd.api+json")
-	req.Header.Add("Accept", "application/vnd.api+json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, http.StatusOK, res.StatusCode)
-}
-
-func TestPatchWithBadRev(t *testing.T) {
-	// We are going to patch an instance with newer values, but with a totally
-	// random rev
-	rev := "6-2d9b7ef014d10549c2b4e206672d3e44"
-	body := `{
-		"data": {
-			"type": "io.cozy.settings",
-			"id": "io.cozy.settings.instance",
-			"meta": {
-				"rev": "%s"
-			},
-			"attributes": {
-				"tz": "Europe/Berlin",
-				"email": "alice@example.com",
-				"locale": "en"
-			}
-		}
-	}`
-	body = fmt.Sprintf(body, rev)
-	req, _ := http.NewRequest("PUT", ts.URL+"/settings/instance", bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/vnd.api+json")
-	req.Header.Add("Accept", "application/vnd.api+json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, http.StatusConflict, res.StatusCode)
-}
-
-func TestPatchWithBadRevNoChanges(t *testing.T) {
-	// We are defining a random rev, but make no changes in the instance values
-	rev := "6-2d9b7ef014d10549c2b4e206672d3e44"
-	body := `{
-		"data": {
-			"type": "io.cozy.settings",
-			"id": "io.cozy.settings.instance",
-			"meta": {
-				"rev": "%s"
-			},
-			"attributes": {
-				"tz": "Europe/London",
-				"email": "alice@example.org",
-				"locale": "fr"
-			}
-		}
-	}`
-	body = fmt.Sprintf(body, rev)
-	req, _ := http.NewRequest("PUT", ts.URL+"/settings/instance", bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/vnd.api+json")
-	req.Header.Add("Accept", "application/vnd.api+json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, http.StatusOK, res.StatusCode)
-}
-
-func TestPatchWithBadRevAndChanges(t *testing.T) {
-	// We are defining a random rev, but make changes in the instance values
-	rev := "6-2d9b7ef014d10549c2b4e206672d3e44"
-	body := `{
-			"data": {
-				"type": "io.cozy.settings",
-				"id": "io.cozy.settings.instance",
-				"meta": {
-					"rev": "%s"
-				},
-				"attributes": {
-					"tz": "Europe/London",
-					"email": "alice@example.com",
-					"locale": "en"
-				}
-			}
-		}`
-	body = fmt.Sprintf(body, rev)
-	req, _ := http.NewRequest("PUT", ts.URL+"/settings/instance", bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/vnd.api+json")
-	req.Header.Add("Accept", "application/vnd.api+json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, http.StatusConflict, res.StatusCode)
-}
-
-func TestDiskUsage(t *testing.T) {
-	res, err := http.Get(ts.URL + "/settings/disk-usage")
-	assert.NoError(t, err)
-	assert.Equal(t, 401, res.StatusCode)
-
-	req, err := http.NewRequest(http.MethodGet, ts.URL+"/settings/disk-usage?include=trash", nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	assert.NoError(t, err)
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	data, ok := result["data"].(map[string]interface{})
-	assert.True(t, ok)
-	assert.Equal(t, "io.cozy.settings", data["type"].(string))
-	assert.Equal(t, "io.cozy.settings.disk-usage", data["id"].(string))
-	attrs, ok := data["attributes"].(map[string]interface{})
-	assert.True(t, ok)
-	used, ok := attrs["used"].(string)
-	assert.True(t, ok)
-	assert.Equal(t, "0", used)
-	files, ok := attrs["files"].(string)
-	assert.True(t, ok)
-	assert.Equal(t, "0", files)
-	versions, ok := attrs["versions"].(string)
-	assert.True(t, ok)
-	assert.Equal(t, "0", versions)
-	trash, ok := attrs["trash"].(string)
-	assert.True(t, ok)
-	assert.Equal(t, "0", trash)
-}
-
-func TestRegisterPassphraseWrongToken(t *testing.T) {
-	args, _ := json.Marshal(&echo.Map{
-		"passphrase":     "MyFirstPassphrase",
-		"iterations":     5000,
-		"register_token": "BADBEEF",
-	})
-	res1, err := http.Post(ts.URL+"/settings/passphrase", "application/json", bytes.NewReader(args))
-	assert.NoError(t, err)
-	defer res1.Body.Close()
-	assert.Equal(t, "400 Bad Request", res1.Status)
-
-	args, _ = json.Marshal(&echo.Map{
-		"passphrase":     "MyFirstPassphrase",
-		"iterations":     5000,
-		"register_token": "XYZ",
-	})
-	res2, err := http.Post(ts.URL+"/settings/passphrase", "application/json", bytes.NewReader(args))
-	assert.NoError(t, err)
-	defer res2.Body.Close()
-	assert.Equal(t, "400 Bad Request", res2.Status)
-}
-
-func TestRegisterPassphraseCorrectToken(t *testing.T) {
-	args, _ := json.Marshal(&echo.Map{
-		"passphrase":     "MyFirstPassphrase",
-		"iterations":     5000,
-		"register_token": hex.EncodeToString(testInstance.RegisterToken),
-		"key":            "xxx",
-	})
-	res, err := http.Post(ts.URL+"/settings/passphrase", "application/json", bytes.NewReader(args))
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, 200, res.StatusCode)
-	cookies := res.Cookies()
-	assert.Len(t, cookies, 1)
-	assert.Equal(t, cookies[0].Name, session.CookieName(testInstance))
-	assert.NotEmpty(t, cookies[0].Value)
-}
-
-func TestRegisterPassphraseForFlagshipApp(t *testing.T) {
-	oauthClient := &oauth.Client{
-		RedirectURIs:    []string{"http:/localhost:4000/oauth/callback"},
-		ClientName:      "Cozy-desktop on my-new-laptop",
-		ClientKind:      "desktop",
-		ClientURI:       "https://docs.cozy.io/en/mobile/desktop.html",
-		LogoURI:         "https://docs.cozy.io/assets/images/cozy-logo-docs.svg",
-		PolicyURI:       "https://cozy.io/policy",
-		SoftwareID:      "/github.com/cozy-labs/cozy-desktop",
-		SoftwareVersion: "0.16.0",
-	}
-	require.Nil(t, oauthClient.Create(testInstanceFlagship))
-	client, err := oauth.FindClient(testInstanceFlagship, oauthClient.ClientID)
-	require.NoError(t, err)
-	require.NoError(t, client.SetFlagship(testInstanceFlagship))
-
-	args, _ := json.Marshal(&echo.Map{
-		"passphrase":     "MyFirstPassphrase",
-		"iterations":     5000,
-		"register_token": hex.EncodeToString(testInstanceFlagship.RegisterToken),
-		"key":            "xxx-key-xxx",
-		"public_key":     "xxx-public-key-xxx",
-		"private_key":    "xxx-private-key-xxx",
-		"client_id":      client.CouchID,
-		"client_secret":  client.ClientSecret,
-	})
-	res, err := http.Post(tsC.URL+"/settings/passphrase/flagship", "application/json", bytes.NewReader(args))
-	require.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, 200, res.StatusCode)
-	var resbody map[string]interface{}
-	require.NoError(t, json.NewDecoder(res.Body).Decode(&resbody))
-	assert.NotNil(t, resbody["access_token"])
-	assert.NotNil(t, resbody["refresh_token"])
-	assert.Equal(t, "*", resbody["scope"])
-	assert.Equal(t, "bearer", resbody["token_type"])
-}
-
-func TestUpdatePassphraseWithWrongPassphrase(t *testing.T) {
-	args, _ := json.Marshal(&echo.Map{
-		"new_passphrase":     "MyPassphrase",
-		"current_passphrase": "BADBEEF",
-		"iterations":         5000,
-	})
-	req, _ := http.NewRequest("PUT", ts.URL+"/settings/passphrase", bytes.NewReader(args))
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "400 Bad Request", res.Status)
-}
-
-func TestUpdatePassphraseSuccess(t *testing.T) {
-	args, _ := json.Marshal(&echo.Map{
-		"new_passphrase":     "MyUpdatedPassphrase",
-		"current_passphrase": "MyFirstPassphrase",
-		"iterations":         5000,
-	})
-	req, _ := http.NewRequest("PUT", ts.URL+"/settings/passphrase", bytes.NewReader(args))
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "204 No Content", res.Status)
-	cookies := res.Cookies()
-	assert.Len(t, cookies, 1)
-	assert.Equal(t, cookies[0].Name, session.CookieName(testInstance))
-	assert.NotEmpty(t, cookies[0].Value)
-}
-
-func TestUpdatePassphraseWithForce(t *testing.T) {
-	args, _ := json.Marshal(&echo.Map{
-		"new_passphrase": "MyPassphrase",
-		"iterations":     5000,
-		"force":          true,
-	})
-	req, _ := http.NewRequest("PUT", ts.URL+"/settings/passphrase", bytes.NewReader(args))
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "400 Bad Request", res.Status)
-
-	cfg := config.GetConfig().Authentication
-	cfg["test-context"] = map[string]interface{}{
-		"disable_password_authentication": true,
-	}
-	defer delete(cfg, "test-context")
-
-	req, _ = http.NewRequest("PUT", ts.URL+"/settings/passphrase?Force=true", bytes.NewReader(args))
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "204 No Content", res.Status)
-}
-
-func TestCheckPassphrase(t *testing.T) {
-	args, _ := json.Marshal(&echo.Map{
-		"passphrase": "Invalid Passphrase",
-	})
-	req, _ := http.NewRequest("POST", ts.URL+"/settings/passphrase/check", bytes.NewReader(args))
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, 403, res.StatusCode)
-
-	args, _ = json.Marshal(&echo.Map{
-		"passphrase": "MyPassphrase",
-	})
-	req, _ = http.NewRequest("POST", ts.URL+"/settings/passphrase/check", bytes.NewReader(args))
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "204 No Content", res.Status)
-}
-
-func TestGetHint(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/settings/hint", nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "404 Not Found", res.Status)
-
-	setting, err := settings.Get(testInstance)
-	assert.NoError(t, err)
-	setting.PassphraseHint = "my hint"
-	err = couchdb.UpdateDoc(testInstance, setting)
-	assert.NoError(t, err)
-
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "204 No Content", res.Status)
-}
-
-func TestUpdateHint(t *testing.T) {
-	args, _ := json.Marshal(&echo.Map{
-		"hint": "my updated hint",
-	})
-	req, _ := http.NewRequest("PUT", ts.URL+"/settings/hint", bytes.NewReader(args))
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "204 No Content", res.Status)
-
-	setting, err := settings.Get(testInstance)
-	assert.NoError(t, err)
-	assert.Equal(t, "my updated hint", setting.PassphraseHint)
-}
-
-func TestGetPassphraseParameters(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/settings/passphrase", nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, 200, res.StatusCode)
-
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	data, ok := result["data"].(map[string]interface{})
-	assert.True(t, ok)
-	assert.Equal(t, "io.cozy.settings", data["type"])
-	assert.Equal(t, "io.cozy.settings.passphrase", data["id"])
-	attrs, ok := data["attributes"].(map[string]interface{})
-	assert.True(t, ok)
-	assert.Equal(t, "me@"+testInstance.Domain, attrs["salt"])
-	assert.Equal(t, float64(0), attrs["kdf"])
-	assert.Equal(t, float64(5000), attrs["iterations"])
-}
-
-func TestGetCapabilities(t *testing.T) {
-	res, err := http.Get(ts.URL + "/settings/instance")
-	assert.NoError(t, err)
-	assert.Equal(t, 401, res.StatusCode)
-
-	req, err := http.NewRequest(http.MethodGet, ts.URL+"/settings/capabilities", nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	assert.NoError(t, err)
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	data, ok := result["data"].(map[string]interface{})
-	assert.True(t, ok)
-	assert.Equal(t, "io.cozy.settings", data["type"].(string))
-	assert.Equal(t, "io.cozy.settings.capabilities", data["id"].(string))
-	attrs, ok := data["attributes"].(map[string]interface{})
-	assert.True(t, ok)
-	versioning, ok := attrs["file_versioning"].(bool)
-	assert.True(t, ok)
-	assert.True(t, versioning)
-	pass, ok := attrs["can_auth_with_password"].(bool)
-	assert.True(t, ok)
-	assert.True(t, pass)
-	oidc, ok := attrs["can_auth_with_oidc"].(bool)
-	assert.True(t, ok)
-	assert.False(t, oidc)
-}
-
-func TestGetInstance(t *testing.T) {
-	res, err := http.Get(ts.URL + "/settings/instance")
-	assert.NoError(t, err)
-	assert.Equal(t, 401, res.StatusCode)
-
-	testInstance.RegisterToken = []byte("test")
-	res, err = http.Get(ts.URL + "/settings/instance?registerToken=74657374")
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	testInstance.RegisterToken = []byte{}
-
-	req, err := http.NewRequest(http.MethodGet, ts.URL+"/settings/instance", nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	assert.NoError(t, err)
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	data, ok := result["data"].(map[string]interface{})
-	assert.True(t, ok)
-	assert.Equal(t, "io.cozy.settings", data["type"].(string))
-	assert.Equal(t, "io.cozy.settings.instance", data["id"].(string))
-	meta, ok := data["meta"].(map[string]interface{})
-	assert.True(t, ok)
-	instanceRev = meta["rev"].(string)
-	assert.NotEmpty(t, instanceRev)
-	attrs, ok := data["attributes"].(map[string]interface{})
-	assert.True(t, ok)
-	email, ok := attrs["email"].(string)
-	assert.True(t, ok)
-	assert.Equal(t, "alice@example.org", email)
-	tz, ok := attrs["tz"].(string)
-	assert.True(t, ok)
-	assert.Equal(t, "Europe/London", tz)
-	locale, ok := attrs["locale"].(string)
-	assert.True(t, ok)
-	assert.Equal(t, "en", locale)
-}
-
-func TestUpdateInstance(t *testing.T) {
-	var newRev string
-
-	checkResult := func(res *http.Response) {
-		assert.Equal(t, 200, res.StatusCode)
-		var result map[string]interface{}
-		err := json.NewDecoder(res.Body).Decode(&result)
-		assert.NoError(t, err)
-		data, ok := result["data"].(map[string]interface{})
-		assert.True(t, ok)
-		assert.Equal(t, "io.cozy.settings", data["type"].(string))
-		assert.Equal(t, "io.cozy.settings.instance", data["id"].(string))
-		meta, ok := data["meta"].(map[string]interface{})
-		assert.True(t, ok)
-		rev := meta["rev"].(string)
-		assert.NotEmpty(t, rev)
-		assert.NotEqual(t, instanceRev, rev)
-		newRev = rev
-		attrs, ok := data["attributes"].(map[string]interface{})
-		assert.True(t, ok)
-		email, ok := attrs["email"].(string)
-		assert.True(t, ok)
-		assert.Equal(t, "alice@example.net", email)
-		tz, ok := attrs["tz"].(string)
-		assert.True(t, ok)
-		assert.Equal(t, "Europe/Paris", tz)
-		locale, ok := attrs["locale"].(string)
-		assert.True(t, ok)
-		assert.Equal(t, "fr", locale)
+func TestSettings(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
 	}
 
-	body := `{
-		"data": {
-			"type": "io.cozy.settings",
-			"id": "io.cozy.settings.instance",
-			"meta": {
-				"rev": "%s"
-			},
-			"attributes": {
-				"tz": "Europe/Paris",
-				"email": "alice@example.net",
-				"locale": "fr"
-			}
-		}
-	}`
-	body = fmt.Sprintf(body, instanceRev)
-	req, _ := http.NewRequest("PUT", ts.URL+"/settings/instance", bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/vnd.api+json")
-	req.Header.Add("Accept", "application/vnd.api+json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	checkResult(res)
-
-	req, _ = http.NewRequest("GET", ts.URL+"/settings/instance", nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	checkResult(res)
-
-	instanceRev = newRev
-}
-
-func TestUpdatePassphraseWithTwoFactorAuth(t *testing.T) {
-	body := `{
-		"auth_mode": "two_factor_mail"
-	}`
-	req, _ := http.NewRequest("PUT", ts.URL+"/settings/instance/auth_mode", bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Accept", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	if !assert.Equal(t, "204 No Content", res.Status) {
-		return
-	}
-
-	mailPassCode, err := testInstance.GenerateMailConfirmationCode()
-	assert.NoError(t, err)
-	body = `{
-		"auth_mode": "two_factor_mail",
-		"two_factor_activation_code": "%s"
-	}`
-	body = fmt.Sprintf(body, mailPassCode)
-	req, _ = http.NewRequest("PUT", ts.URL+"/settings/instance/auth_mode", bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Accept", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	if !assert.Equal(t, "204 No Content", res.Status) {
-		return
-	}
-
-	args, _ := json.Marshal(&echo.Map{
-		"current_passphrase": "MyPassphrase",
-	})
-	req, _ = http.NewRequest("PUT", ts.URL+"/settings/passphrase", bytes.NewReader(args))
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "200 OK", res.Status)
-
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-
-	{
-		twoFactorToken, ok := result["two_factor_token"].(string)
-		assert.True(t, ok)
-		assert.NotEmpty(t, twoFactorToken)
-	}
-
-	twoFactorToken, twoFactorPasscode, err := testInstance.GenerateTwoFactorSecrets()
-	assert.NoError(t, err)
-
-	args, _ = json.Marshal(&echo.Map{
-		"new_passphrase":      "MyLastPassphrase",
-		"two_factor_token":    twoFactorToken,
-		"two_factor_passcode": twoFactorPasscode,
-	})
-	req, _ = http.NewRequest("PUT", ts.URL+"/settings/passphrase", bytes.NewReader(args))
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	defer res.Body.Close()
-	assert.Equal(t, "204 No Content", res.Status)
-}
-
-func TestListClients(t *testing.T) {
-	res, err := http.Get(ts.URL + "/settings/clients")
-	assert.NoError(t, err)
-	assert.Equal(t, 401, res.StatusCode)
-
-	client := &oauth.Client{
-		RedirectURIs:    []string{"http:/localhost:4000/oauth/callback"},
-		ClientName:      "Cozy-desktop on my-new-laptop",
-		ClientKind:      "desktop",
-		ClientURI:       "https://docs.cozy.io/en/mobile/desktop.html",
-		LogoURI:         "https://docs.cozy.io/assets/images/cozy-logo-docs.svg",
-		PolicyURI:       "https://cozy.io/policy",
-		SoftwareID:      "/github.com/cozy-labs/cozy-desktop",
-		SoftwareVersion: "0.16.0",
-	}
-	regErr := client.Create(testInstance)
-	assert.Nil(t, regErr)
-	oauthClientID = client.ClientID
-
-	req, err := http.NewRequest(http.MethodGet, ts.URL+"/settings/clients", nil)
-	assert.NoError(t, err)
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	data := result["data"].([]interface{})
-	assert.Len(t, data, 2)
-	obj := data[1].(map[string]interface{})
-	assert.Equal(t, "io.cozy.oauth.clients", obj["type"].(string))
-	assert.Equal(t, client.ClientID, obj["id"].(string))
-	links := obj["links"].(map[string]interface{})
-	self := links["self"].(string)
-	assert.Equal(t, "/settings/clients/"+client.ClientID, self)
-	attrs := obj["attributes"].(map[string]interface{})
-	redirectURIs := attrs["redirect_uris"].([]interface{})
-	assert.Len(t, redirectURIs, 1)
-	assert.Equal(t, client.RedirectURIs[0], redirectURIs[0].(string))
-	assert.Equal(t, client.ClientName, attrs["client_name"].(string))
-	assert.Equal(t, client.ClientKind, attrs["client_kind"].(string))
-	assert.Equal(t, client.ClientURI, attrs["client_uri"].(string))
-	assert.Equal(t, client.LogoURI, attrs["logo_uri"].(string))
-	assert.Equal(t, client.PolicyURI, attrs["policy_uri"].(string))
-	assert.Equal(t, client.SoftwareID, attrs["software_id"].(string))
-	assert.Equal(t, client.SoftwareVersion, attrs["software_version"].(string))
-	assert.Nil(t, attrs["client_secret"])
-}
-
-func TestRevokeClient(t *testing.T) {
-	req, err := http.NewRequest(http.MethodDelete, ts.URL+"/settings/clients/"+oauthClientID, nil)
-	assert.NoError(t, err)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 401, res.StatusCode)
-
-	req, err = http.NewRequest(http.MethodDelete, ts.URL+"/settings/clients/"+oauthClientID, nil)
-	assert.NoError(t, err)
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 204, res.StatusCode)
-
-	req, err = http.NewRequest(http.MethodGet, ts.URL+"/settings/clients", nil)
-	assert.NoError(t, err)
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	data := result["data"].([]interface{})
-	assert.Len(t, data, 1)
-}
-
-func TestRedirectOnboardingSecret(t *testing.T) {
-	url := tsB.URL + "/settings/onboarded"
-
-	// Disable redirections
-	client := &http.Client{
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
-		}}
-	// Without onboarding
-	res, err := client.Get(url)
-	assert.NoError(t, err)
-	assert.Equal(t, res.StatusCode, http.StatusSeeOther)
-	loc, _ := res.Location()
-	assert.Equal(t, loc.String(), testInstance.OnboardedRedirection().String())
-
-	// With onboarding
-	deeplink := "cozydrive://testinstance.com"
-	oauthClient := &oauth.Client{
-		RedirectURIs:     []string{deeplink},
-		ClientName:       "CozyTest",
-		SoftwareID:       "/github.com/cozy-labs/cozy-desktop",
-		OnboardingSecret: "foobar",
-		OnboardingApp:    "test",
-	}
-
-	oauthClient.Create(testInstance)
-	res, err = client.Get(url)
-	assert.NoError(t, err)
-	assert.Equal(t, res.StatusCode, http.StatusSeeOther)
-
-	loc, _ = res.Location()
-	assert.NotEqual(t, loc.String(), testInstance.OnboardedRedirection().String())
-	assert.Contains(t, loc.String(), "/auth/authorize")
-
-	values := loc.Query()
-	assert.Equal(t, values.Get("redirect_uri"), deeplink)
-}
-
-func TestPatchInstanceSameParams(t *testing.T) {
-	doc1, err := testInstance.SettingsDocument()
-	assert.NoError(t, err)
-
-	body := `{
-			"data": {
-				"type": "io.cozy.settings",
-				"id": "io.cozy.settings.instance",
-				"meta": {
-					"rev": "%s"
-				},
-				"attributes": {
-					"tz": "Europe/Paris",
-					"email": "alice@example.net",
-					"locale": "fr"
-				}
-			}
-		}`
-	body = fmt.Sprintf(body, doc1.Rev())
-	req, _ := http.NewRequest("PUT", ts.URL+"/settings/instance", bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/vnd.api+json")
-	req.Header.Add("Accept", "application/vnd.api+json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	content, err := io.ReadAll(res.Body)
-	assert.NoError(t, err)
-	assert.NotEmpty(t, content)
-
-	doc2, err := testInstance.SettingsDocument()
-	assert.NoError(t, err)
-	// Assert no changes
-	assert.Equal(t, doc1.Rev(), doc2.Rev())
-}
-
-func TestPatchInstanceChangeParams(t *testing.T) {
-	doc, err := testInstance.SettingsDocument()
-	assert.NoError(t, err)
-
-	body := `{
-			"data": {
-				"type": "io.cozy.settings",
-				"id": "io.cozy.settings.instance",
-				"meta": {
-					"rev": "%s"
-				},
-				"attributes": {
-					"tz": "Antarctica/McMurdo",
-					"email": "alice@expat.eu",
-					"locale": "de"
-				}
-			}
-		}`
-	body = fmt.Sprintf(body, doc.Rev())
-	req, _ := http.NewRequest("PUT", ts.URL+"/settings/instance", bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/vnd.api+json")
-	req.Header.Add("Accept", "application/vnd.api+json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	content, err := io.ReadAll(res.Body)
-	assert.NoError(t, err)
-	assert.NotEmpty(t, content)
-
-	doc, err = testInstance.SettingsDocument()
-	assert.NoError(t, err)
-
-	assert.Equal(t, "Antarctica/McMurdo", doc.M["tz"].(string))
-	assert.Equal(t, "alice@expat.eu", doc.M["email"].(string))
-}
-
-func TestPatchInstanceAddParam(t *testing.T) {
-	doc1, err := testInstance.SettingsDocument()
-	assert.NoError(t, err)
-
-	body := `{
-			"data": {
-				"type": "io.cozy.settings",
-				"id": "io.cozy.settings.instance",
-				"meta": {
-					"rev": "%s"
-				},
-				"attributes": {
-					"tz": "Europe/Berlin",
-					"email": "alice@example.com",
-					"how_old_are_you": "42"
-				}
-			}
-		}`
-	body = fmt.Sprintf(body, doc1.Rev())
-	req, _ := http.NewRequest("PUT", ts.URL+"/settings/instance", bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/vnd.api+json")
-	req.Header.Add("Accept", "application/vnd.api+json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	content, err := io.ReadAll(res.Body)
-	assert.NoError(t, err)
-	assert.NotEmpty(t, content)
-
-	doc2, err := testInstance.SettingsDocument()
-	assert.NoError(t, err)
-	assert.NotEqual(t, doc1.Rev(), doc2.Rev())
-	assert.Equal(t, "42", doc2.M["how_old_are_you"].(string))
-	assert.Equal(t, "Europe/Berlin", doc2.M["tz"].(string))
-	assert.Equal(t, "alice@example.com", doc2.M["email"].(string))
-}
-
-func TestPatchInstanceRemoveParams(t *testing.T) {
-	doc1, err := testInstance.SettingsDocument()
-	assert.NoError(t, err)
-
-	body := `{
-			"data": {
-				"type": "io.cozy.settings",
-				"id": "io.cozy.settings.instance",
-				"meta": {
-					"rev": "%s"
-				},
-				"attributes": {
-					"tz": "Europe/Berlin"
-				}
-			}
-		}`
-	body = fmt.Sprintf(body, doc1.Rev())
-	req, _ := http.NewRequest("PUT", ts.URL+"/settings/instance", bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/vnd.api+json")
-	req.Header.Add("Accept", "application/vnd.api+json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	content, err := io.ReadAll(res.Body)
-	assert.NoError(t, err)
-	assert.NotEmpty(t, content)
-
-	doc2, err := testInstance.SettingsDocument()
-	assert.NoError(t, err)
-	assert.NotEqual(t, doc1.Rev(), doc2.Rev())
-	assert.Equal(t, "Europe/Berlin", doc2.M["tz"].(string))
-	_, ok := doc2.M["email"]
-	assert.False(t, ok)
-}
-
-func TestFeatureFlags(t *testing.T) {
-	_ = couchdb.DeleteDB(prefixer.GlobalPrefixer, consts.Settings)
-	defer func() { _ = couchdb.DeleteDB(prefixer.GlobalPrefixer, consts.Settings) }()
-
-	req, err := http.NewRequest(http.MethodGet, ts.URL+"/settings/flags", nil)
-	assert.NoError(t, err)
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
-	data, _ := result["data"].(map[string]interface{})
-	assert.Equal(t, "io.cozy.settings", data["type"])
-	assert.Equal(t, "io.cozy.settings.flags", data["id"])
-	attrs, ok := data["attributes"].(map[string]interface{})
-	assert.True(t, ok)
-	assert.Len(t, attrs, 0)
-
-	testInstance.FeatureFlags = map[string]interface{}{
-		"from_instance_flag":   true,
-		"from_multiple_source": "instance_flag",
-		"json_object":          map[string]interface{}{"foo": "bar"},
-	}
-	testInstance.FeatureSets = []string{"set1", "set2"}
-	err = testInstance.Update()
-	assert.NoError(t, err)
-	cache := config.GetConfig().CacheStorage
-	cacheKey := fmt.Sprintf("flags:%s:%v", testInstance.ContextName, testInstance.FeatureSets)
-	buf, err := json.Marshal(map[string]interface{}{
-		"from_feature_sets":    true,
-		"from_multiple_source": "manager",
-	})
-	assert.NoError(t, err)
-	cache.Set(cacheKey, buf, 5*time.Second)
-	ctxFlags := couchdb.JSONDoc{Type: consts.Settings}
-	ctxFlags.M = map[string]interface{}{
-		"ratio_0": []map[string]interface{}{
-			{"ratio": 0, "value": "context"},
-		},
-		"ratio_1": []map[string]interface{}{
-			{"ratio": 1, "value": "context"},
-		},
-		"ratio_0.000001": []map[string]interface{}{
-			{"ratio": 0.000001, "value": "context"},
-		},
-		"ratio_0.999999": []map[string]interface{}{
-			{"ratio": 0.999999, "value": "context"},
-		},
-	}
-	id := fmt.Sprintf("%s.%s", consts.ContextFlagsSettingsID, testInstance.ContextName)
-	ctxFlags.SetID(id)
-	err = couchdb.CreateNamedDocWithDB(prefixer.GlobalPrefixer, &ctxFlags)
-	assert.NoError(t, err)
-	defFlags := couchdb.JSONDoc{Type: consts.Settings}
-	defFlags.M = map[string]interface{}{
-		"ratio_0":              "defaults",
-		"ratio_1":              "defaults",
-		"ratio_0.000001":       "defaults",
-		"ratio_0.999999":       "defaults",
-		"from_multiple_source": "defaults",
-		"from_defaults":        true,
-	}
-	defFlags.SetID(consts.DefaultFlagsSettingsID)
-	err = couchdb.CreateNamedDocWithDB(prefixer.GlobalPrefixer, &defFlags)
-	assert.NoError(t, err)
-
-	res2, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res2.StatusCode)
-	var result2 map[string]interface{}
-	err = json.NewDecoder(res2.Body).Decode(&result2)
-	assert.NoError(t, err)
-	data2, _ := result2["data"].(map[string]interface{})
-	assert.Equal(t, "io.cozy.settings", data2["type"])
-	assert.Equal(t, "io.cozy.settings.flags", data2["id"])
-	attrs2, _ := data2["attributes"].(map[string]interface{})
-	assert.Equal(t, true, attrs2["from_instance_flag"])
-	assert.Equal(t, true, attrs2["from_feature_sets"])
-	assert.Equal(t, true, attrs2["from_defaults"])
-	assert.EqualValues(t, testInstance.FeatureFlags["json_object"], attrs2["json_object"])
-	assert.Equal(t, "instance_flag", attrs2["from_multiple_source"])
-	assert.Equal(t, "defaults", attrs2["ratio_0"])
-	assert.Equal(t, "defaults", attrs2["ratio_0.000001"])
-	assert.Equal(t, "context", attrs2["ratio_0.999999"])
-	assert.Equal(t, "context", attrs2["ratio_1"])
-}
-
-func TestMain(m *testing.M) {
 	config.UseTestFile()
 	testutils.NeedCouchdb()
 	setup := testutils.NewSetup(m, "settings_test")
@@ -1007,10 +82,941 @@ func TestMain(m *testing.M) {
 	tsC.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler
 
 	os.Exit(setup.Run())
+
+	t.Run("GetContext", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/settings/context", nil)
+		req.Header.Add("Accept", "application/vnd.api+json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+	})
+
+	t.Run("PatchWithGoodRev", func(t *testing.T) {
+		// We are going to patch an instance with newer values, and give the good rev
+		body := `{
+		"data": {
+			"type": "io.cozy.settings",
+			"id": "io.cozy.settings.instance",
+			"meta": {
+				"rev": "%s"
+			},
+			"attributes": {
+				"tz": "Europe/London",
+				"email": "alice@example.org",
+				"locale": "fr"
+			}
+		}
+	}`
+
+		doc1, err := testInstance.SettingsDocument()
+		assert.NoError(t, err)
+		body = fmt.Sprintf(body, doc1.Rev())
+		req, _ := http.NewRequest("PUT", ts.URL+"/settings/instance", bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/vnd.api+json")
+		req.Header.Add("Accept", "application/vnd.api+json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+	})
+
+	t.Run("PatchWithBadRev", func(t *testing.T) {
+		// We are going to patch an instance with newer values, but with a totally
+		// random rev
+		rev := "6-2d9b7ef014d10549c2b4e206672d3e44"
+		body := `{
+		"data": {
+			"type": "io.cozy.settings",
+			"id": "io.cozy.settings.instance",
+			"meta": {
+				"rev": "%s"
+			},
+			"attributes": {
+				"tz": "Europe/Berlin",
+				"email": "alice@example.com",
+				"locale": "en"
+			}
+		}
+	}`
+		body = fmt.Sprintf(body, rev)
+		req, _ := http.NewRequest("PUT", ts.URL+"/settings/instance", bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/vnd.api+json")
+		req.Header.Add("Accept", "application/vnd.api+json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusConflict, res.StatusCode)
+	})
+
+	t.Run("PatchWithBadRevNoChanges", func(t *testing.T) {
+		// We are defining a random rev, but make no changes in the instance values
+		rev := "6-2d9b7ef014d10549c2b4e206672d3e44"
+		body := `{
+		"data": {
+			"type": "io.cozy.settings",
+			"id": "io.cozy.settings.instance",
+			"meta": {
+				"rev": "%s"
+			},
+			"attributes": {
+				"tz": "Europe/London",
+				"email": "alice@example.org",
+				"locale": "fr"
+			}
+		}
+	}`
+		body = fmt.Sprintf(body, rev)
+		req, _ := http.NewRequest("PUT", ts.URL+"/settings/instance", bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/vnd.api+json")
+		req.Header.Add("Accept", "application/vnd.api+json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+	})
+
+	t.Run("PatchWithBadRevAndChanges", func(t *testing.T) {
+		// We are defining a random rev, but make changes in the instance values
+		rev := "6-2d9b7ef014d10549c2b4e206672d3e44"
+		body := `{
+			"data": {
+				"type": "io.cozy.settings",
+				"id": "io.cozy.settings.instance",
+				"meta": {
+					"rev": "%s"
+				},
+				"attributes": {
+					"tz": "Europe/London",
+					"email": "alice@example.com",
+					"locale": "en"
+				}
+			}
+		}`
+		body = fmt.Sprintf(body, rev)
+		req, _ := http.NewRequest("PUT", ts.URL+"/settings/instance", bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/vnd.api+json")
+		req.Header.Add("Accept", "application/vnd.api+json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusConflict, res.StatusCode)
+	})
+
+	t.Run("DiskUsage", func(t *testing.T) {
+		res, err := http.Get(ts.URL + "/settings/disk-usage")
+		assert.NoError(t, err)
+		assert.Equal(t, 401, res.StatusCode)
+
+		req, err := http.NewRequest(http.MethodGet, ts.URL+"/settings/disk-usage?include=trash", nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		assert.NoError(t, err)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		data, ok := result["data"].(map[string]interface{})
+		assert.True(t, ok)
+		assert.Equal(t, "io.cozy.settings", data["type"].(string))
+		assert.Equal(t, "io.cozy.settings.disk-usage", data["id"].(string))
+		attrs, ok := data["attributes"].(map[string]interface{})
+		assert.True(t, ok)
+		used, ok := attrs["used"].(string)
+		assert.True(t, ok)
+		assert.Equal(t, "0", used)
+		files, ok := attrs["files"].(string)
+		assert.True(t, ok)
+		assert.Equal(t, "0", files)
+		versions, ok := attrs["versions"].(string)
+		assert.True(t, ok)
+		assert.Equal(t, "0", versions)
+		trash, ok := attrs["trash"].(string)
+		assert.True(t, ok)
+		assert.Equal(t, "0", trash)
+	})
+
+	t.Run("RegisterPassphraseWrongToken", func(t *testing.T) {
+		args, _ := json.Marshal(&echo.Map{
+			"passphrase":     "MyFirstPassphrase",
+			"iterations":     5000,
+			"register_token": "BADBEEF",
+		})
+		res1, err := http.Post(ts.URL+"/settings/passphrase", "application/json", bytes.NewReader(args))
+		assert.NoError(t, err)
+		defer res1.Body.Close()
+		assert.Equal(t, "400 Bad Request", res1.Status)
+
+		args, _ = json.Marshal(&echo.Map{
+			"passphrase":     "MyFirstPassphrase",
+			"iterations":     5000,
+			"register_token": "XYZ",
+		})
+		res2, err := http.Post(ts.URL+"/settings/passphrase", "application/json", bytes.NewReader(args))
+		assert.NoError(t, err)
+		defer res2.Body.Close()
+		assert.Equal(t, "400 Bad Request", res2.Status)
+	})
+
+	t.Run("RegisterPassphraseCorrectToken", func(t *testing.T) {
+		args, _ := json.Marshal(&echo.Map{
+			"passphrase":     "MyFirstPassphrase",
+			"iterations":     5000,
+			"register_token": hex.EncodeToString(testInstance.RegisterToken),
+			"key":            "xxx",
+		})
+		res, err := http.Post(ts.URL+"/settings/passphrase", "application/json", bytes.NewReader(args))
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, 200, res.StatusCode)
+		cookies := res.Cookies()
+		assert.Len(t, cookies, 1)
+		assert.Equal(t, cookies[0].Name, session.CookieName(testInstance))
+		assert.NotEmpty(t, cookies[0].Value)
+	})
+
+	t.Run("RegisterPassphraseForFlagshipApp", func(t *testing.T) {
+		oauthClient := &oauth.Client{
+			RedirectURIs:    []string{"http:/localhost:4000/oauth/callback"},
+			ClientName:      "Cozy-desktop on my-new-laptop",
+			ClientKind:      "desktop",
+			ClientURI:       "https://docs.cozy.io/en/mobile/desktop.html",
+			LogoURI:         "https://docs.cozy.io/assets/images/cozy-logo-docs.svg",
+			PolicyURI:       "https://cozy.io/policy",
+			SoftwareID:      "/github.com/cozy-labs/cozy-desktop",
+			SoftwareVersion: "0.16.0",
+		}
+		require.Nil(t, oauthClient.Create(testInstanceFlagship))
+		client, err := oauth.FindClient(testInstanceFlagship, oauthClient.ClientID)
+		require.NoError(t, err)
+		require.NoError(t, client.SetFlagship(testInstanceFlagship))
+
+		args, _ := json.Marshal(&echo.Map{
+			"passphrase":     "MyFirstPassphrase",
+			"iterations":     5000,
+			"register_token": hex.EncodeToString(testInstanceFlagship.RegisterToken),
+			"key":            "xxx-key-xxx",
+			"public_key":     "xxx-public-key-xxx",
+			"private_key":    "xxx-private-key-xxx",
+			"client_id":      client.CouchID,
+			"client_secret":  client.ClientSecret,
+		})
+		res, err := http.Post(tsC.URL+"/settings/passphrase/flagship", "application/json", bytes.NewReader(args))
+		require.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, 200, res.StatusCode)
+		var resbody map[string]interface{}
+		require.NoError(t, json.NewDecoder(res.Body).Decode(&resbody))
+		assert.NotNil(t, resbody["access_token"])
+		assert.NotNil(t, resbody["refresh_token"])
+		assert.Equal(t, "*", resbody["scope"])
+		assert.Equal(t, "bearer", resbody["token_type"])
+	})
+
+	t.Run("UpdatePassphraseWithWrongPassphrase", func(t *testing.T) {
+		args, _ := json.Marshal(&echo.Map{
+			"new_passphrase":     "MyPassphrase",
+			"current_passphrase": "BADBEEF",
+			"iterations":         5000,
+		})
+		req, _ := http.NewRequest("PUT", ts.URL+"/settings/passphrase", bytes.NewReader(args))
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, "400 Bad Request", res.Status)
+	})
+
+	t.Run("UpdatePassphraseSuccess", func(t *testing.T) {
+		args, _ := json.Marshal(&echo.Map{
+			"new_passphrase":     "MyUpdatedPassphrase",
+			"current_passphrase": "MyFirstPassphrase",
+			"iterations":         5000,
+		})
+		req, _ := http.NewRequest("PUT", ts.URL+"/settings/passphrase", bytes.NewReader(args))
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, "204 No Content", res.Status)
+		cookies := res.Cookies()
+		assert.Len(t, cookies, 1)
+		assert.Equal(t, cookies[0].Name, session.CookieName(testInstance))
+		assert.NotEmpty(t, cookies[0].Value)
+	})
+
+	t.Run("UpdatePassphraseWithForce", func(t *testing.T) {
+		args, _ := json.Marshal(&echo.Map{
+			"new_passphrase": "MyPassphrase",
+			"iterations":     5000,
+			"force":          true,
+		})
+		req, _ := http.NewRequest("PUT", ts.URL+"/settings/passphrase", bytes.NewReader(args))
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, "400 Bad Request", res.Status)
+
+		cfg := config.GetConfig().Authentication
+		cfg["test-context"] = map[string]interface{}{
+			"disable_password_authentication": true,
+		}
+		defer delete(cfg, "test-context")
+
+		req, _ = http.NewRequest("PUT", ts.URL+"/settings/passphrase?Force=true", bytes.NewReader(args))
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, "204 No Content", res.Status)
+	})
+
+	t.Run("CheckPassphrase", func(t *testing.T) {
+		args, _ := json.Marshal(&echo.Map{
+			"passphrase": "Invalid Passphrase",
+		})
+		req, _ := http.NewRequest("POST", ts.URL+"/settings/passphrase/check", bytes.NewReader(args))
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, 403, res.StatusCode)
+
+		args, _ = json.Marshal(&echo.Map{
+			"passphrase": "MyPassphrase",
+		})
+		req, _ = http.NewRequest("POST", ts.URL+"/settings/passphrase/check", bytes.NewReader(args))
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, "204 No Content", res.Status)
+	})
+
+	t.Run("GetHint", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/settings/hint", nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, "404 Not Found", res.Status)
+
+		setting, err := settings.Get(testInstance)
+		assert.NoError(t, err)
+		setting.PassphraseHint = "my hint"
+		err = couchdb.UpdateDoc(testInstance, setting)
+		assert.NoError(t, err)
+
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, "204 No Content", res.Status)
+	})
+
+	t.Run("UpdateHint", func(t *testing.T) {
+		args, _ := json.Marshal(&echo.Map{
+			"hint": "my updated hint",
+		})
+		req, _ := http.NewRequest("PUT", ts.URL+"/settings/hint", bytes.NewReader(args))
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, "204 No Content", res.Status)
+
+		setting, err := settings.Get(testInstance)
+		assert.NoError(t, err)
+		assert.Equal(t, "my updated hint", setting.PassphraseHint)
+	})
+
+	t.Run("GetPassphraseParameters", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/settings/passphrase", nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, 200, res.StatusCode)
+
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		data, ok := result["data"].(map[string]interface{})
+		assert.True(t, ok)
+		assert.Equal(t, "io.cozy.settings", data["type"])
+		assert.Equal(t, "io.cozy.settings.passphrase", data["id"])
+		attrs, ok := data["attributes"].(map[string]interface{})
+		assert.True(t, ok)
+		assert.Equal(t, "me@"+testInstance.Domain, attrs["salt"])
+		assert.Equal(t, float64(0), attrs["kdf"])
+		assert.Equal(t, float64(5000), attrs["iterations"])
+	})
+
+	t.Run("GetCapabilities", func(t *testing.T) {
+		res, err := http.Get(ts.URL + "/settings/instance")
+		assert.NoError(t, err)
+		assert.Equal(t, 401, res.StatusCode)
+
+		req, err := http.NewRequest(http.MethodGet, ts.URL+"/settings/capabilities", nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		assert.NoError(t, err)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		data, ok := result["data"].(map[string]interface{})
+		assert.True(t, ok)
+		assert.Equal(t, "io.cozy.settings", data["type"].(string))
+		assert.Equal(t, "io.cozy.settings.capabilities", data["id"].(string))
+		attrs, ok := data["attributes"].(map[string]interface{})
+		assert.True(t, ok)
+		versioning, ok := attrs["file_versioning"].(bool)
+		assert.True(t, ok)
+		assert.True(t, versioning)
+		pass, ok := attrs["can_auth_with_password"].(bool)
+		assert.True(t, ok)
+		assert.True(t, pass)
+		oidc, ok := attrs["can_auth_with_oidc"].(bool)
+		assert.True(t, ok)
+		assert.False(t, oidc)
+	})
+
+	t.Run("GetInstance", func(t *testing.T) {
+		res, err := http.Get(ts.URL + "/settings/instance")
+		assert.NoError(t, err)
+		assert.Equal(t, 401, res.StatusCode)
+
+		testInstance.RegisterToken = []byte("test")
+		res, err = http.Get(ts.URL + "/settings/instance?registerToken=74657374")
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		testInstance.RegisterToken = []byte{}
+
+		req, err := http.NewRequest(http.MethodGet, ts.URL+"/settings/instance", nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		assert.NoError(t, err)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		data, ok := result["data"].(map[string]interface{})
+		assert.True(t, ok)
+		assert.Equal(t, "io.cozy.settings", data["type"].(string))
+		assert.Equal(t, "io.cozy.settings.instance", data["id"].(string))
+		meta, ok := data["meta"].(map[string]interface{})
+		assert.True(t, ok)
+		instanceRev = meta["rev"].(string)
+		assert.NotEmpty(t, instanceRev)
+		attrs, ok := data["attributes"].(map[string]interface{})
+		assert.True(t, ok)
+		email, ok := attrs["email"].(string)
+		assert.True(t, ok)
+		assert.Equal(t, "alice@example.org", email)
+		tz, ok := attrs["tz"].(string)
+		assert.True(t, ok)
+		assert.Equal(t, "Europe/London", tz)
+		locale, ok := attrs["locale"].(string)
+		assert.True(t, ok)
+		assert.Equal(t, "en", locale)
+	})
+
+	t.Run("UpdateInstance", func(t *testing.T) {
+		var newRev string
+
+		checkResult := func(res *http.Response) {
+			assert.Equal(t, 200, res.StatusCode)
+			var result map[string]interface{}
+			err := json.NewDecoder(res.Body).Decode(&result)
+			assert.NoError(t, err)
+			data, ok := result["data"].(map[string]interface{})
+			assert.True(t, ok)
+			assert.Equal(t, "io.cozy.settings", data["type"].(string))
+			assert.Equal(t, "io.cozy.settings.instance", data["id"].(string))
+			meta, ok := data["meta"].(map[string]interface{})
+			assert.True(t, ok)
+			rev := meta["rev"].(string)
+			assert.NotEmpty(t, rev)
+			assert.NotEqual(t, instanceRev, rev)
+			newRev = rev
+			attrs, ok := data["attributes"].(map[string]interface{})
+			assert.True(t, ok)
+			email, ok := attrs["email"].(string)
+			assert.True(t, ok)
+			assert.Equal(t, "alice@example.net", email)
+			tz, ok := attrs["tz"].(string)
+			assert.True(t, ok)
+			assert.Equal(t, "Europe/Paris", tz)
+			locale, ok := attrs["locale"].(string)
+			assert.True(t, ok)
+			assert.Equal(t, "fr", locale)
+		}
+
+		body := `{
+		"data": {
+			"type": "io.cozy.settings",
+			"id": "io.cozy.settings.instance",
+			"meta": {
+				"rev": "%s"
+			},
+			"attributes": {
+				"tz": "Europe/Paris",
+				"email": "alice@example.net",
+				"locale": "fr"
+			}
+		}
+	}`
+		body = fmt.Sprintf(body, instanceRev)
+		req, _ := http.NewRequest("PUT", ts.URL+"/settings/instance", bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/vnd.api+json")
+		req.Header.Add("Accept", "application/vnd.api+json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		checkResult(res)
+
+		req, _ = http.NewRequest("GET", ts.URL+"/settings/instance", nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		checkResult(res)
+
+		instanceRev = newRev
+	})
+
+	t.Run("UpdatePassphraseWithTwoFactorAuth", func(t *testing.T) {
+		body := `{
+		"auth_mode": "two_factor_mail"
+	}`
+		req, _ := http.NewRequest("PUT", ts.URL+"/settings/instance/auth_mode", bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("Accept", "application/json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		if !assert.Equal(t, "204 No Content", res.Status) {
+			return
+		}
+
+		mailPassCode, err := testInstance.GenerateMailConfirmationCode()
+		assert.NoError(t, err)
+		body = `{
+		"auth_mode": "two_factor_mail",
+		"two_factor_activation_code": "%s"
+	}`
+		body = fmt.Sprintf(body, mailPassCode)
+		req, _ = http.NewRequest("PUT", ts.URL+"/settings/instance/auth_mode", bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("Accept", "application/json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		if !assert.Equal(t, "204 No Content", res.Status) {
+			return
+		}
+
+		args, _ := json.Marshal(&echo.Map{
+			"current_passphrase": "MyPassphrase",
+		})
+		req, _ = http.NewRequest("PUT", ts.URL+"/settings/passphrase", bytes.NewReader(args))
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, "200 OK", res.Status)
+
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+
+		{
+			twoFactorToken, ok := result["two_factor_token"].(string)
+			assert.True(t, ok)
+			assert.NotEmpty(t, twoFactorToken)
+		}
+
+		twoFactorToken, twoFactorPasscode, err := testInstance.GenerateTwoFactorSecrets()
+		assert.NoError(t, err)
+
+		args, _ = json.Marshal(&echo.Map{
+			"new_passphrase":      "MyLastPassphrase",
+			"two_factor_token":    twoFactorToken,
+			"two_factor_passcode": twoFactorPasscode,
+		})
+		req, _ = http.NewRequest("PUT", ts.URL+"/settings/passphrase", bytes.NewReader(args))
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, "204 No Content", res.Status)
+	})
+
+	t.Run("ListClients", func(t *testing.T) {
+		res, err := http.Get(ts.URL + "/settings/clients")
+		assert.NoError(t, err)
+		assert.Equal(t, 401, res.StatusCode)
+
+		client := &oauth.Client{
+			RedirectURIs:    []string{"http:/localhost:4000/oauth/callback"},
+			ClientName:      "Cozy-desktop on my-new-laptop",
+			ClientKind:      "desktop",
+			ClientURI:       "https://docs.cozy.io/en/mobile/desktop.html",
+			LogoURI:         "https://docs.cozy.io/assets/images/cozy-logo-docs.svg",
+			PolicyURI:       "https://cozy.io/policy",
+			SoftwareID:      "/github.com/cozy-labs/cozy-desktop",
+			SoftwareVersion: "0.16.0",
+		}
+		regErr := client.Create(testInstance)
+		assert.Nil(t, regErr)
+		oauthClientID = client.ClientID
+
+		req, err := http.NewRequest(http.MethodGet, ts.URL+"/settings/clients", nil)
+		assert.NoError(t, err)
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		data := result["data"].([]interface{})
+		assert.Len(t, data, 2)
+		obj := data[1].(map[string]interface{})
+		assert.Equal(t, "io.cozy.oauth.clients", obj["type"].(string))
+		assert.Equal(t, client.ClientID, obj["id"].(string))
+		links := obj["links"].(map[string]interface{})
+		self := links["self"].(string)
+		assert.Equal(t, "/settings/clients/"+client.ClientID, self)
+		attrs := obj["attributes"].(map[string]interface{})
+		redirectURIs := attrs["redirect_uris"].([]interface{})
+		assert.Len(t, redirectURIs, 1)
+		assert.Equal(t, client.RedirectURIs[0], redirectURIs[0].(string))
+		assert.Equal(t, client.ClientName, attrs["client_name"].(string))
+		assert.Equal(t, client.ClientKind, attrs["client_kind"].(string))
+		assert.Equal(t, client.ClientURI, attrs["client_uri"].(string))
+		assert.Equal(t, client.LogoURI, attrs["logo_uri"].(string))
+		assert.Equal(t, client.PolicyURI, attrs["policy_uri"].(string))
+		assert.Equal(t, client.SoftwareID, attrs["software_id"].(string))
+		assert.Equal(t, client.SoftwareVersion, attrs["software_version"].(string))
+		assert.Nil(t, attrs["client_secret"])
+	})
+
+	t.Run("RevokeClient", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodDelete, ts.URL+"/settings/clients/"+oauthClientID, nil)
+		assert.NoError(t, err)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 401, res.StatusCode)
+
+		req, err = http.NewRequest(http.MethodDelete, ts.URL+"/settings/clients/"+oauthClientID, nil)
+		assert.NoError(t, err)
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 204, res.StatusCode)
+
+		req, err = http.NewRequest(http.MethodGet, ts.URL+"/settings/clients", nil)
+		assert.NoError(t, err)
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		data := result["data"].([]interface{})
+		assert.Len(t, data, 1)
+	})
+
+	t.Run("RedirectOnboardingSecret", func(t *testing.T) {
+		url := tsB.URL + "/settings/onboarded"
+
+		// Disable redirections
+		client := &http.Client{
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse
+			}}
+		// Without onboarding
+		res, err := client.Get(url)
+		assert.NoError(t, err)
+		assert.Equal(t, res.StatusCode, http.StatusSeeOther)
+		loc, _ := res.Location()
+		assert.Equal(t, loc.String(), testInstance.OnboardedRedirection().String())
+
+		// With onboarding
+		deeplink := "cozydrive://testinstance.com"
+		oauthClient := &oauth.Client{
+			RedirectURIs:     []string{deeplink},
+			ClientName:       "CozyTest",
+			SoftwareID:       "/github.com/cozy-labs/cozy-desktop",
+			OnboardingSecret: "foobar",
+			OnboardingApp:    "test",
+		}
+
+		oauthClient.Create(testInstance)
+		res, err = client.Get(url)
+		assert.NoError(t, err)
+		assert.Equal(t, res.StatusCode, http.StatusSeeOther)
+
+		loc, _ = res.Location()
+		assert.NotEqual(t, loc.String(), testInstance.OnboardedRedirection().String())
+		assert.Contains(t, loc.String(), "/auth/authorize")
+
+		values := loc.Query()
+		assert.Equal(t, values.Get("redirect_uri"), deeplink)
+	})
+
+	t.Run("PatchInstanceSameParams", func(t *testing.T) {
+		doc1, err := testInstance.SettingsDocument()
+		assert.NoError(t, err)
+
+		body := `{
+			"data": {
+				"type": "io.cozy.settings",
+				"id": "io.cozy.settings.instance",
+				"meta": {
+					"rev": "%s"
+				},
+				"attributes": {
+					"tz": "Europe/Paris",
+					"email": "alice@example.net",
+					"locale": "fr"
+				}
+			}
+		}`
+		body = fmt.Sprintf(body, doc1.Rev())
+		req, _ := http.NewRequest("PUT", ts.URL+"/settings/instance", bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/vnd.api+json")
+		req.Header.Add("Accept", "application/vnd.api+json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		content, err := io.ReadAll(res.Body)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, content)
+
+		doc2, err := testInstance.SettingsDocument()
+		assert.NoError(t, err)
+		// Assert no changes
+		assert.Equal(t, doc1.Rev(), doc2.Rev())
+	})
+
+	t.Run("PatchInstanceChangeParams", func(t *testing.T) {
+		doc, err := testInstance.SettingsDocument()
+		assert.NoError(t, err)
+
+		body := `{
+			"data": {
+				"type": "io.cozy.settings",
+				"id": "io.cozy.settings.instance",
+				"meta": {
+					"rev": "%s"
+				},
+				"attributes": {
+					"tz": "Antarctica/McMurdo",
+					"email": "alice@expat.eu",
+					"locale": "de"
+				}
+			}
+		}`
+		body = fmt.Sprintf(body, doc.Rev())
+		req, _ := http.NewRequest("PUT", ts.URL+"/settings/instance", bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/vnd.api+json")
+		req.Header.Add("Accept", "application/vnd.api+json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		content, err := io.ReadAll(res.Body)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, content)
+
+		doc, err = testInstance.SettingsDocument()
+		assert.NoError(t, err)
+
+		assert.Equal(t, "Antarctica/McMurdo", doc.M["tz"].(string))
+		assert.Equal(t, "alice@expat.eu", doc.M["email"].(string))
+	})
+
+	t.Run("PatchInstanceAddParam", func(t *testing.T) {
+		doc1, err := testInstance.SettingsDocument()
+		assert.NoError(t, err)
+
+		body := `{
+			"data": {
+				"type": "io.cozy.settings",
+				"id": "io.cozy.settings.instance",
+				"meta": {
+					"rev": "%s"
+				},
+				"attributes": {
+					"tz": "Europe/Berlin",
+					"email": "alice@example.com",
+					"how_old_are_you": "42"
+				}
+			}
+		}`
+		body = fmt.Sprintf(body, doc1.Rev())
+		req, _ := http.NewRequest("PUT", ts.URL+"/settings/instance", bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/vnd.api+json")
+		req.Header.Add("Accept", "application/vnd.api+json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		content, err := io.ReadAll(res.Body)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, content)
+
+		doc2, err := testInstance.SettingsDocument()
+		assert.NoError(t, err)
+		assert.NotEqual(t, doc1.Rev(), doc2.Rev())
+		assert.Equal(t, "42", doc2.M["how_old_are_you"].(string))
+		assert.Equal(t, "Europe/Berlin", doc2.M["tz"].(string))
+		assert.Equal(t, "alice@example.com", doc2.M["email"].(string))
+	})
+
+	t.Run("PatchInstanceRemoveParams", func(t *testing.T) {
+		doc1, err := testInstance.SettingsDocument()
+		assert.NoError(t, err)
+
+		body := `{
+			"data": {
+				"type": "io.cozy.settings",
+				"id": "io.cozy.settings.instance",
+				"meta": {
+					"rev": "%s"
+				},
+				"attributes": {
+					"tz": "Europe/Berlin"
+				}
+			}
+		}`
+		body = fmt.Sprintf(body, doc1.Rev())
+		req, _ := http.NewRequest("PUT", ts.URL+"/settings/instance", bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/vnd.api+json")
+		req.Header.Add("Accept", "application/vnd.api+json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		content, err := io.ReadAll(res.Body)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, content)
+
+		doc2, err := testInstance.SettingsDocument()
+		assert.NoError(t, err)
+		assert.NotEqual(t, doc1.Rev(), doc2.Rev())
+		assert.Equal(t, "Europe/Berlin", doc2.M["tz"].(string))
+		_, ok := doc2.M["email"]
+		assert.False(t, ok)
+	})
+
+	t.Run("FeatureFlags", func(t *testing.T) {
+		_ = couchdb.DeleteDB(prefixer.GlobalPrefixer, consts.Settings)
+		defer func() { _ = couchdb.DeleteDB(prefixer.GlobalPrefixer, consts.Settings) }()
+
+		req, err := http.NewRequest(http.MethodGet, ts.URL+"/settings/flags", nil)
+		assert.NoError(t, err)
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
+		data, _ := result["data"].(map[string]interface{})
+		assert.Equal(t, "io.cozy.settings", data["type"])
+		assert.Equal(t, "io.cozy.settings.flags", data["id"])
+		attrs, ok := data["attributes"].(map[string]interface{})
+		assert.True(t, ok)
+		assert.Len(t, attrs, 0)
+
+		testInstance.FeatureFlags = map[string]interface{}{
+			"from_instance_flag":   true,
+			"from_multiple_source": "instance_flag",
+			"json_object":          map[string]interface{}{"foo": "bar"},
+		}
+		testInstance.FeatureSets = []string{"set1", "set2"}
+		err = testInstance.Update()
+		assert.NoError(t, err)
+		cache := config.GetConfig().CacheStorage
+		cacheKey := fmt.Sprintf("flags:%s:%v", testInstance.ContextName, testInstance.FeatureSets)
+		buf, err := json.Marshal(map[string]interface{}{
+			"from_feature_sets":    true,
+			"from_multiple_source": "manager",
+		})
+		assert.NoError(t, err)
+		cache.Set(cacheKey, buf, 5*time.Second)
+		ctxFlags := couchdb.JSONDoc{Type: consts.Settings}
+		ctxFlags.M = map[string]interface{}{
+			"ratio_0": []map[string]interface{}{
+				{"ratio": 0, "value": "context"},
+			},
+			"ratio_1": []map[string]interface{}{
+				{"ratio": 1, "value": "context"},
+			},
+			"ratio_0.000001": []map[string]interface{}{
+				{"ratio": 0.000001, "value": "context"},
+			},
+			"ratio_0.999999": []map[string]interface{}{
+				{"ratio": 0.999999, "value": "context"},
+			},
+		}
+		id := fmt.Sprintf("%s.%s", consts.ContextFlagsSettingsID, testInstance.ContextName)
+		ctxFlags.SetID(id)
+		err = couchdb.CreateNamedDocWithDB(prefixer.GlobalPrefixer, &ctxFlags)
+		assert.NoError(t, err)
+		defFlags := couchdb.JSONDoc{Type: consts.Settings}
+		defFlags.M = map[string]interface{}{
+			"ratio_0":              "defaults",
+			"ratio_1":              "defaults",
+			"ratio_0.000001":       "defaults",
+			"ratio_0.999999":       "defaults",
+			"from_multiple_source": "defaults",
+			"from_defaults":        true,
+		}
+		defFlags.SetID(consts.DefaultFlagsSettingsID)
+		err = couchdb.CreateNamedDocWithDB(prefixer.GlobalPrefixer, &defFlags)
+		assert.NoError(t, err)
+
+		res2, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res2.StatusCode)
+		var result2 map[string]interface{}
+		err = json.NewDecoder(res2.Body).Decode(&result2)
+		assert.NoError(t, err)
+		data2, _ := result2["data"].(map[string]interface{})
+		assert.Equal(t, "io.cozy.settings", data2["type"])
+		assert.Equal(t, "io.cozy.settings.flags", data2["id"])
+		attrs2, _ := data2["attributes"].(map[string]interface{})
+		assert.Equal(t, true, attrs2["from_instance_flag"])
+		assert.Equal(t, true, attrs2["from_feature_sets"])
+		assert.Equal(t, true, attrs2["from_defaults"])
+		assert.EqualValues(t, testInstance.FeatureFlags["json_object"], attrs2["json_object"])
+		assert.Equal(t, "instance_flag", attrs2["from_multiple_source"])
+		assert.Equal(t, "defaults", attrs2["ratio_0"])
+		assert.Equal(t, "defaults", attrs2["ratio_0.000001"])
+		assert.Equal(t, "context", attrs2["ratio_0.999999"])
+		assert.Equal(t, "context", attrs2["ratio_1"])
+	})
+
 }
 
-// Fake middleware used to inject a false session to mislead the authentication
-// system
 func fakeAuthentication(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		instance := c.Get("instance").(*instance.Instance)

--- a/web/settings/settings_test.go
+++ b/web/settings/settings_test.go
@@ -1013,7 +1013,6 @@ func TestSettings(t *testing.T) {
 		assert.Equal(t, "context", attrs2["ratio_0.999999"])
 		assert.Equal(t, "context", attrs2["ratio_1"])
 	})
-
 }
 
 func fakeAuthentication(next echo.HandlerFunc) echo.HandlerFunc {

--- a/web/sharings/replicator_test.go
+++ b/web/sharings/replicator_test.go
@@ -447,7 +447,6 @@ func TestReplicator(t *testing.T) {
 		assert.NotEmpty(t, attrs["created_at"])
 		assert.NotEmpty(t, attrs["updated_at"])
 	})
-
 }
 
 func uuidv4() string {

--- a/web/sharings/replicator_test.go
+++ b/web/sharings/replicator_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/tests/testutils"
 	"github.com/cozy/cozy-stack/web"
-	"github.com/cozy/cozy-stack/web/auth"
 	"github.com/cozy/cozy-stack/web/errors"
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/cozy/cozy-stack/web/permissions"
@@ -83,27 +82,6 @@ func TestReplicator(t *testing.T) {
 		Jar:           jar,
 	}
 
-	// Prepare Bob's instance
-	bobSetup := testutils.NewSetup(nil, t.Name()+"_bob")
-	bobInstance = bobSetup.GetTestInstance(&lifecycle.Options{
-		Email:         "bob@example.net",
-		PublicName:    "Bob",
-		Passphrase:    "MyPassphrase",
-		KdfIterations: 5000,
-		Key:           "xxx",
-	})
-	bobAppToken = generateAppToken(bobInstance, "testapp", iocozytests)
-	edwardContact = createContact(bobInstance, "Edward", "edward@example.net")
-	tsB = bobSetup.GetTestServerMultipleRoutes(map[string]func(*echo.Group){
-		"/auth": func(g *echo.Group) {
-			g.Use(middlewares.LoadSession)
-			auth.Routes(g)
-		},
-		"/sharings": sharings.Routes,
-	})
-	tsB.Config.Handler.(*echo.Echo).Renderer = render
-	tsB.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler
-
 	// Prepare another instance for the replicator tests
 	replSetup := testutils.NewSetup(nil, t.Name()+"_replicator")
 	replInstance = replSetup.GetTestInstance()
@@ -116,7 +94,6 @@ func TestReplicator(t *testing.T) {
 		panic("Could not init dynamic FS")
 	}
 	setup.AddCleanup(func() error {
-		bobSetup.Cleanup()
 		replSetup.Cleanup()
 		return nil
 	})

--- a/web/sharings/replicator_test.go
+++ b/web/sharings/replicator_test.go
@@ -31,41 +31,341 @@ var xorKey []byte
 const replDoctype = "io.cozy.replicator.tests"
 
 // It's not really a test, more a setup for the replicator tests
-func TestCreateSharingForReplicatorTest(t *testing.T) {
-	rule := sharing.Rule{
-		Title:    "tests",
-		DocType:  replDoctype,
-		Selector: "foo",
-		Values:   []string{"bar", "baz"},
-		Add:      "sync",
-		Update:   "sync",
-		Remove:   "sync",
-	}
-	s := sharing.Sharing{
-		Description: "replicator tests",
-		Rules:       []sharing.Rule{rule},
-	}
-	assert.NoError(t, s.BeOwner(replInstance, ""))
-	s.Members = append(s.Members, sharing.Member{
-		Status:   sharing.MemberStatusReady,
-		Name:     "J. Doe",
-		Email:    "j.doe@example.net",
-		Instance: "https://j.example.net/",
-	})
-	s.Credentials = append(s.Credentials, sharing.Credentials{})
-	_, err := s.Create(replInstance)
-	assert.NoError(t, err)
-	replSharingID = s.SID
 
-	cli, err := sharing.CreateOAuthClient(replInstance, &s.Members[1])
-	assert.NoError(t, err)
-	s.Credentials[0].Client = sharing.ConvertOAuthClient(cli)
-	token, err := sharing.CreateAccessToken(replInstance, cli, s.SID, permission.ALL)
-	assert.NoError(t, err)
-	s.Credentials[0].AccessToken = token
-	assert.NoError(t, couchdb.UpdateDoc(replInstance, &s))
-	replAccessToken = token.AccessToken
-	assert.NoError(t, couchdb.CreateDB(replInstance, replDoctype))
+// It's not really a test, more a setup for the io.cozy.files tests
+
+func TestReplicator(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	t.Run("CreateSharingForReplicatorTest", func(t *testing.T) {
+		rule := sharing.Rule{
+			Title:    "tests",
+			DocType:  replDoctype,
+			Selector: "foo",
+			Values:   []string{"bar", "baz"},
+			Add:      "sync",
+			Update:   "sync",
+			Remove:   "sync",
+		}
+		s := sharing.Sharing{
+			Description: "replicator tests",
+			Rules:       []sharing.Rule{rule},
+		}
+		assert.NoError(t, s.BeOwner(replInstance, ""))
+		s.Members = append(s.Members, sharing.Member{
+			Status:   sharing.MemberStatusReady,
+			Name:     "J. Doe",
+			Email:    "j.doe@example.net",
+			Instance: "https://j.example.net/",
+		})
+		s.Credentials = append(s.Credentials, sharing.Credentials{})
+		_, err := s.Create(replInstance)
+		assert.NoError(t, err)
+		replSharingID = s.SID
+
+		cli, err := sharing.CreateOAuthClient(replInstance, &s.Members[1])
+		assert.NoError(t, err)
+		s.Credentials[0].Client = sharing.ConvertOAuthClient(cli)
+		token, err := sharing.CreateAccessToken(replInstance, cli, s.SID, permission.ALL)
+		assert.NoError(t, err)
+		s.Credentials[0].AccessToken = token
+		assert.NoError(t, couchdb.UpdateDoc(replInstance, &s))
+		replAccessToken = token.AccessToken
+		assert.NoError(t, couchdb.CreateDB(replInstance, replDoctype))
+	})
+
+	t.Run("Permissions", func(t *testing.T) {
+		assert.NotNil(t, replSharingID)
+		assert.NotNil(t, replAccessToken)
+
+		id := replDoctype + "/" + uuidv4()
+		createShared(t, id, []string{"111111111"})
+
+		body, _ := json.Marshal(sharing.Changed{
+			"id": []string{"1-111111111"},
+		})
+		u := tsR.URL + "/sharings/" + replSharingID + "/_revs_diff"
+
+		r := bytes.NewReader(body)
+		req, err := http.NewRequest(http.MethodPost, u, r)
+		assert.NoError(t, err)
+		req.Header.Add(echo.HeaderAccept, "application/json")
+		req.Header.Add(echo.HeaderContentType, "application/json")
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusUnauthorized, res.StatusCode)
+		defer res.Body.Close()
+
+		r = bytes.NewReader(body)
+		req, err = http.NewRequest(http.MethodPost, u, r)
+		assert.NoError(t, err)
+		req.Header.Add(echo.HeaderAccept, "application/json")
+		req.Header.Add(echo.HeaderContentType, "application/json")
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+replAccessToken)
+		res, err = http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+		defer res.Body.Close()
+	})
+
+	t.Run("RevsDiff", func(t *testing.T) {
+		assert.NotEmpty(t, replSharingID)
+		assert.NotEmpty(t, replAccessToken)
+
+		sid1 := replDoctype + "/" + uuidv4()
+		createShared(t, sid1, []string{"1a", "1a", "1a"})
+		sid2 := replDoctype + "/" + uuidv4()
+		createShared(t, sid2, []string{"2a", "2a", "2a"})
+		sid3 := replDoctype + "/" + uuidv4()
+		createShared(t, sid3, []string{"3a", "3a", "3a"})
+		sid4 := replDoctype + "/" + uuidv4()
+		createShared(t, sid4, []string{"4a", "4a", "4a"})
+		sid5 := replDoctype + "/" + uuidv4()
+		createShared(t, sid5, []string{"5a", "5a", "5a"})
+		sid6 := replDoctype + "/" + uuidv4()
+
+		body, _ := json.Marshal(sharing.Changed{
+			sid1: []string{"3-1a"},
+			sid2: []string{"2-2a"},
+			sid3: []string{"5-3b"},
+			sid4: []string{"2-4b", "2-4c", "4-4d"},
+			sid6: []string{"1-6b"},
+		})
+		r := bytes.NewReader(body)
+		u := tsR.URL + "/sharings/" + replSharingID + "/_revs_diff"
+		req, err := http.NewRequest(http.MethodPost, u, r)
+		assert.NoError(t, err)
+		req.Header.Add(echo.HeaderAccept, "application/json")
+		req.Header.Add(echo.HeaderContentType, "application/json")
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+replAccessToken)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+		defer res.Body.Close()
+
+		missings := make(sharing.Missings)
+		err = json.NewDecoder(res.Body).Decode(&missings)
+		assert.NoError(t, err)
+
+		// sid1 is the same on both sides
+		assert.NotContains(t, missings, sid1)
+
+		// sid2 was updated on the target
+		assert.NotContains(t, missings, sid2)
+
+		// sid3 was updated on the source
+		assert.Contains(t, missings, sid3)
+		assert.Equal(t, missings[sid3].Missing, []string{"5-3b"})
+
+		// sid4 is a conflict
+		assert.Contains(t, missings, sid4)
+		assert.Equal(t, missings[sid4].Missing, []string{"2-4b", "2-4c", "4-4d"})
+
+		// sid5 has been created on the target
+		assert.NotContains(t, missings, sid5)
+
+		// sid6 has been created on the source
+		assert.Contains(t, missings, sid6)
+		assert.Equal(t, missings[sid6].Missing, []string{"1-6b"})
+	})
+
+	t.Run("BulkDocs", func(t *testing.T) {
+		assert.NotEmpty(t, replSharingID)
+		assert.NotEmpty(t, replAccessToken)
+
+		id1 := uuidv4()
+		sid1 := replDoctype + "/" + id1
+		createShared(t, sid1, []string{"aaa", "bbb"})
+		id2 := uuidv4()
+		sid2 := replDoctype + "/" + id2
+
+		body, _ := json.Marshal(sharing.DocsByDoctype{
+			replDoctype: {
+				{
+					"_id":  id1,
+					"_rev": "3-ccc",
+					"_revisions": map[string]interface{}{
+						"start": 3,
+						"ids":   []string{"ccc", "bbb"},
+					},
+					"this": "is document " + id1 + " at revision 3-ccc",
+					"foo":  "bar",
+				},
+				{
+					"_id":  id2,
+					"_rev": "3-fff",
+					"_revisions": map[string]interface{}{
+						"start": 3,
+						"ids":   []string{"fff", "eee", "dd"},
+					},
+					"this": "is document " + id2 + " at revision 3-fff",
+					"foo":  "baz",
+				},
+			},
+		})
+		r := bytes.NewReader(body)
+		u := tsR.URL + "/sharings/" + replSharingID + "/_bulk_docs"
+		req, err := http.NewRequest(http.MethodPost, u, r)
+		assert.NoError(t, err)
+		req.Header.Add(echo.HeaderAccept, "application/json")
+		req.Header.Add(echo.HeaderContentType, "application/json")
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+replAccessToken)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+		defer res.Body.Close()
+
+		assertSharedDoc(t, sid1, "3-ccc")
+		assertSharedDoc(t, sid2, "3-fff")
+	})
+
+	t.Run("CreateSharingForUploadFileTest", func(t *testing.T) {
+		dirID = uuidv4()
+		ruleOne := sharing.Rule{
+			Title:    "file one",
+			DocType:  "io.cozy.files",
+			Selector: "",
+			Values:   []string{dirID},
+			Add:      "sync",
+			Update:   "sync",
+			Remove:   "sync",
+		}
+		s := sharing.Sharing{
+			Description: "upload files tests",
+			Rules:       []sharing.Rule{ruleOne},
+		}
+		assert.NoError(t, s.BeOwner(replInstance, ""))
+		s.Members = append(s.Members, sharing.Member{
+			Status:   sharing.MemberStatusReady,
+			Name:     "J. Doe",
+			Email:    "j.doe@example.net",
+			Instance: "https://j.example.net/",
+		})
+		s.Credentials = append(s.Credentials, sharing.Credentials{})
+		_, err := s.Create(replInstance)
+		assert.NoError(t, err)
+		fileSharingID = s.SID
+
+		xorKey = sharing.MakeXorKey()
+		s.Credentials[0].XorKey = xorKey
+		cli, err := sharing.CreateOAuthClient(aliceInstance, &s.Members[0])
+		assert.NoError(t, err)
+		s.Credentials[0].Client = sharing.ConvertOAuthClient(cli)
+		token, err := sharing.CreateAccessToken(aliceInstance, cli, s.SID, permission.ALL)
+		assert.NoError(t, err)
+		s.Credentials[0].AccessToken = token
+		cli2, err := sharing.CreateOAuthClient(replInstance, &s.Members[1])
+		assert.NoError(t, err)
+		s.Credentials[0].InboundClientID = cli2.ClientID
+		token2, err := sharing.CreateAccessToken(replInstance, cli2, s.SID, permission.ALL)
+		assert.NoError(t, err)
+		fileAccessToken = token2.AccessToken
+		assert.NoError(t, couchdb.UpdateDoc(replInstance, &s))
+	})
+
+	t.Run("UploadNewFile", func(t *testing.T) {
+		assert.NotEmpty(t, fileSharingID)
+		assert.NotEmpty(t, fileAccessToken)
+
+		fileOneID := uuidv4()
+		body, _ := json.Marshal(map[string]interface{}{
+			"_id":  fileOneID,
+			"_rev": "1-5f9ba207fefdc250e35f7cd866c84cc6",
+			"_revisions": map[string]interface{}{
+				"start": 1,
+				"ids":   []string{"5f9ba207fefdc250e35f7cd866c84cc6"},
+			},
+			"type":       "file",
+			"name":       "hello.txt",
+			"created_at": "2018-04-23T18:11:42.343937292+02:00",
+			"updated_at": "2018-04-23T18:11:42.343937292+02:00",
+			"size":       "6",
+			"md5sum":     "WReFt5RgHiErJg4lklY2/Q==",
+			"mime":       "text/plain",
+			"class":      "text",
+			"executable": false,
+			"trashed":    false,
+			"tags":       []string{},
+		})
+		r := bytes.NewReader(body)
+		u := tsR.URL + "/sharings/" + fileSharingID + "/io.cozy.files/" + fileOneID + "/metadata"
+		req, err := http.NewRequest(http.MethodPut, u, r)
+		assert.NoError(t, err)
+		req.Header.Add(echo.HeaderAccept, "application/json")
+		req.Header.Add(echo.HeaderContentType, "application/json")
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+fileAccessToken)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+		defer res.Body.Close()
+		var key map[string]string
+		assert.NoError(t, json.NewDecoder(res.Body).Decode(&key))
+		assert.NotEmpty(t, key["key"])
+
+		r2 := strings.NewReader("world\n")
+		u2 := tsR.URL + "/sharings/" + fileSharingID + "/io.cozy.files/" + key["key"]
+		req2, err := http.NewRequest(http.MethodPut, u2, r2)
+		assert.NoError(t, err)
+		req2.Header.Add(echo.HeaderContentType, "text/plain")
+		req2.Header.Add(echo.HeaderAuthorization, "Bearer "+fileAccessToken)
+		res2, err := http.DefaultClient.Do(req2)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusNoContent, res2.StatusCode)
+		defer res.Body.Close()
+	})
+
+	t.Run("GetFolder", func(t *testing.T) {
+		assert.NotEmpty(t, fileSharingID)
+		assert.NotEmpty(t, fileAccessToken)
+
+		fs := replInstance.VFS()
+		folder, err := vfs.NewDirDoc(fs, "zorglub", dirID, nil)
+		assert.NoError(t, err)
+		assert.NoError(t, fs.CreateDir(folder))
+		msg := sharing.TrackMessage{
+			SharingID: fileSharingID,
+			RuleIndex: 0,
+			DocType:   consts.Files,
+		}
+		evt := sharing.TrackEvent{
+			Verb: "CREATED",
+			Doc: couchdb.JSONDoc{
+				Type: consts.Files,
+				M: map[string]interface{}{
+					"type":   folder.Type,
+					"_id":    folder.DocID,
+					"_rev":   folder.DocRev,
+					"name":   folder.DocName,
+					"path":   folder.Fullpath,
+					"dir_id": dirID,
+				},
+			},
+		}
+		assert.NoError(t, sharing.UpdateShared(replInstance, msg, evt))
+
+		xoredID := sharing.XorID(folder.DocID, xorKey)
+		u := tsR.URL + "/sharings/" + fileSharingID + "/io.cozy.files/" + xoredID
+		req, err := http.NewRequest(http.MethodGet, u, nil)
+		assert.NoError(t, err)
+		req.Header.Add(echo.HeaderAccept, "application/json")
+		req.Header.Add(echo.HeaderAuthorization, "Bearer "+fileAccessToken)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+		defer res.Body.Close()
+		var attrs map[string]interface{}
+		assert.NoError(t, json.NewDecoder(res.Body).Decode(&attrs))
+		assert.Equal(t, xoredID, attrs["_id"])
+		assert.Equal(t, folder.DocRev, attrs["_rev"])
+		assert.Equal(t, "directory", attrs["type"])
+		assert.Equal(t, "zorglub", attrs["name"])
+		assert.Empty(t, attrs["dir_id"])
+		assert.NotEmpty(t, attrs["created_at"])
+		assert.NotEmpty(t, attrs["updated_at"])
+	})
+
 }
 
 func uuidv4() string {
@@ -114,101 +414,6 @@ func createShared(t *testing.T, sid string, revisions []string) *sharing.SharedR
 	return &ref
 }
 
-func TestPermissions(t *testing.T) {
-	assert.NotNil(t, replSharingID)
-	assert.NotNil(t, replAccessToken)
-
-	id := replDoctype + "/" + uuidv4()
-	createShared(t, id, []string{"111111111"})
-
-	body, _ := json.Marshal(sharing.Changed{
-		"id": []string{"1-111111111"},
-	})
-	u := tsR.URL + "/sharings/" + replSharingID + "/_revs_diff"
-
-	r := bytes.NewReader(body)
-	req, err := http.NewRequest(http.MethodPost, u, r)
-	assert.NoError(t, err)
-	req.Header.Add(echo.HeaderAccept, "application/json")
-	req.Header.Add(echo.HeaderContentType, "application/json")
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, http.StatusUnauthorized, res.StatusCode)
-	defer res.Body.Close()
-
-	r = bytes.NewReader(body)
-	req, err = http.NewRequest(http.MethodPost, u, r)
-	assert.NoError(t, err)
-	req.Header.Add(echo.HeaderAccept, "application/json")
-	req.Header.Add(echo.HeaderContentType, "application/json")
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+replAccessToken)
-	res, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, http.StatusOK, res.StatusCode)
-	defer res.Body.Close()
-}
-
-func TestRevsDiff(t *testing.T) {
-	assert.NotEmpty(t, replSharingID)
-	assert.NotEmpty(t, replAccessToken)
-
-	sid1 := replDoctype + "/" + uuidv4()
-	createShared(t, sid1, []string{"1a", "1a", "1a"})
-	sid2 := replDoctype + "/" + uuidv4()
-	createShared(t, sid2, []string{"2a", "2a", "2a"})
-	sid3 := replDoctype + "/" + uuidv4()
-	createShared(t, sid3, []string{"3a", "3a", "3a"})
-	sid4 := replDoctype + "/" + uuidv4()
-	createShared(t, sid4, []string{"4a", "4a", "4a"})
-	sid5 := replDoctype + "/" + uuidv4()
-	createShared(t, sid5, []string{"5a", "5a", "5a"})
-	sid6 := replDoctype + "/" + uuidv4()
-
-	body, _ := json.Marshal(sharing.Changed{
-		sid1: []string{"3-1a"},
-		sid2: []string{"2-2a"},
-		sid3: []string{"5-3b"},
-		sid4: []string{"2-4b", "2-4c", "4-4d"},
-		sid6: []string{"1-6b"},
-	})
-	r := bytes.NewReader(body)
-	u := tsR.URL + "/sharings/" + replSharingID + "/_revs_diff"
-	req, err := http.NewRequest(http.MethodPost, u, r)
-	assert.NoError(t, err)
-	req.Header.Add(echo.HeaderAccept, "application/json")
-	req.Header.Add(echo.HeaderContentType, "application/json")
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+replAccessToken)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, http.StatusOK, res.StatusCode)
-	defer res.Body.Close()
-
-	missings := make(sharing.Missings)
-	err = json.NewDecoder(res.Body).Decode(&missings)
-	assert.NoError(t, err)
-
-	// sid1 is the same on both sides
-	assert.NotContains(t, missings, sid1)
-
-	// sid2 was updated on the target
-	assert.NotContains(t, missings, sid2)
-
-	// sid3 was updated on the source
-	assert.Contains(t, missings, sid3)
-	assert.Equal(t, missings[sid3].Missing, []string{"5-3b"})
-
-	// sid4 is a conflict
-	assert.Contains(t, missings, sid4)
-	assert.Equal(t, missings[sid4].Missing, []string{"2-4b", "2-4c", "4-4d"})
-
-	// sid5 has been created on the target
-	assert.NotContains(t, missings, sid5)
-
-	// sid6 has been created on the source
-	assert.Contains(t, missings, sid6)
-	assert.Equal(t, missings[sid6].Missing, []string{"1-6b"})
-}
-
 func assertSharedDoc(t *testing.T, sid, rev string) {
 	parts := strings.SplitN(sid, "/", 2)
 	doctype := parts[0]
@@ -218,200 +423,4 @@ func assertSharedDoc(t *testing.T, sid, rev string) {
 	assert.Equal(t, doc.ID(), id)
 	assert.Equal(t, doc.Rev(), rev)
 	assert.Equal(t, doc.M["this"], "is document "+id+" at revision "+rev)
-}
-
-func TestBulkDocs(t *testing.T) {
-	assert.NotEmpty(t, replSharingID)
-	assert.NotEmpty(t, replAccessToken)
-
-	id1 := uuidv4()
-	sid1 := replDoctype + "/" + id1
-	createShared(t, sid1, []string{"aaa", "bbb"})
-	id2 := uuidv4()
-	sid2 := replDoctype + "/" + id2
-
-	body, _ := json.Marshal(sharing.DocsByDoctype{
-		replDoctype: {
-			{
-				"_id":  id1,
-				"_rev": "3-ccc",
-				"_revisions": map[string]interface{}{
-					"start": 3,
-					"ids":   []string{"ccc", "bbb"},
-				},
-				"this": "is document " + id1 + " at revision 3-ccc",
-				"foo":  "bar",
-			},
-			{
-				"_id":  id2,
-				"_rev": "3-fff",
-				"_revisions": map[string]interface{}{
-					"start": 3,
-					"ids":   []string{"fff", "eee", "dd"},
-				},
-				"this": "is document " + id2 + " at revision 3-fff",
-				"foo":  "baz",
-			},
-		},
-	})
-	r := bytes.NewReader(body)
-	u := tsR.URL + "/sharings/" + replSharingID + "/_bulk_docs"
-	req, err := http.NewRequest(http.MethodPost, u, r)
-	assert.NoError(t, err)
-	req.Header.Add(echo.HeaderAccept, "application/json")
-	req.Header.Add(echo.HeaderContentType, "application/json")
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+replAccessToken)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, http.StatusOK, res.StatusCode)
-	defer res.Body.Close()
-
-	assertSharedDoc(t, sid1, "3-ccc")
-	assertSharedDoc(t, sid2, "3-fff")
-}
-
-// It's not really a test, more a setup for the io.cozy.files tests
-func TestCreateSharingForUploadFileTest(t *testing.T) {
-	dirID = uuidv4()
-	ruleOne := sharing.Rule{
-		Title:    "file one",
-		DocType:  "io.cozy.files",
-		Selector: "",
-		Values:   []string{dirID},
-		Add:      "sync",
-		Update:   "sync",
-		Remove:   "sync",
-	}
-	s := sharing.Sharing{
-		Description: "upload files tests",
-		Rules:       []sharing.Rule{ruleOne},
-	}
-	assert.NoError(t, s.BeOwner(replInstance, ""))
-	s.Members = append(s.Members, sharing.Member{
-		Status:   sharing.MemberStatusReady,
-		Name:     "J. Doe",
-		Email:    "j.doe@example.net",
-		Instance: "https://j.example.net/",
-	})
-	s.Credentials = append(s.Credentials, sharing.Credentials{})
-	_, err := s.Create(replInstance)
-	assert.NoError(t, err)
-	fileSharingID = s.SID
-
-	xorKey = sharing.MakeXorKey()
-	s.Credentials[0].XorKey = xorKey
-	cli, err := sharing.CreateOAuthClient(aliceInstance, &s.Members[0])
-	assert.NoError(t, err)
-	s.Credentials[0].Client = sharing.ConvertOAuthClient(cli)
-	token, err := sharing.CreateAccessToken(aliceInstance, cli, s.SID, permission.ALL)
-	assert.NoError(t, err)
-	s.Credentials[0].AccessToken = token
-	cli2, err := sharing.CreateOAuthClient(replInstance, &s.Members[1])
-	assert.NoError(t, err)
-	s.Credentials[0].InboundClientID = cli2.ClientID
-	token2, err := sharing.CreateAccessToken(replInstance, cli2, s.SID, permission.ALL)
-	assert.NoError(t, err)
-	fileAccessToken = token2.AccessToken
-	assert.NoError(t, couchdb.UpdateDoc(replInstance, &s))
-}
-
-func TestUploadNewFile(t *testing.T) {
-	assert.NotEmpty(t, fileSharingID)
-	assert.NotEmpty(t, fileAccessToken)
-
-	fileOneID := uuidv4()
-	body, _ := json.Marshal(map[string]interface{}{
-		"_id":  fileOneID,
-		"_rev": "1-5f9ba207fefdc250e35f7cd866c84cc6",
-		"_revisions": map[string]interface{}{
-			"start": 1,
-			"ids":   []string{"5f9ba207fefdc250e35f7cd866c84cc6"},
-		},
-		"type":       "file",
-		"name":       "hello.txt",
-		"created_at": "2018-04-23T18:11:42.343937292+02:00",
-		"updated_at": "2018-04-23T18:11:42.343937292+02:00",
-		"size":       "6",
-		"md5sum":     "WReFt5RgHiErJg4lklY2/Q==",
-		"mime":       "text/plain",
-		"class":      "text",
-		"executable": false,
-		"trashed":    false,
-		"tags":       []string{},
-	})
-	r := bytes.NewReader(body)
-	u := tsR.URL + "/sharings/" + fileSharingID + "/io.cozy.files/" + fileOneID + "/metadata"
-	req, err := http.NewRequest(http.MethodPut, u, r)
-	assert.NoError(t, err)
-	req.Header.Add(echo.HeaderAccept, "application/json")
-	req.Header.Add(echo.HeaderContentType, "application/json")
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+fileAccessToken)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, http.StatusOK, res.StatusCode)
-	defer res.Body.Close()
-	var key map[string]string
-	assert.NoError(t, json.NewDecoder(res.Body).Decode(&key))
-	assert.NotEmpty(t, key["key"])
-
-	r2 := strings.NewReader("world\n")
-	u2 := tsR.URL + "/sharings/" + fileSharingID + "/io.cozy.files/" + key["key"]
-	req2, err := http.NewRequest(http.MethodPut, u2, r2)
-	assert.NoError(t, err)
-	req2.Header.Add(echo.HeaderContentType, "text/plain")
-	req2.Header.Add(echo.HeaderAuthorization, "Bearer "+fileAccessToken)
-	res2, err := http.DefaultClient.Do(req2)
-	assert.NoError(t, err)
-	assert.Equal(t, http.StatusNoContent, res2.StatusCode)
-	defer res.Body.Close()
-}
-
-func TestGetFolder(t *testing.T) {
-	assert.NotEmpty(t, fileSharingID)
-	assert.NotEmpty(t, fileAccessToken)
-
-	fs := replInstance.VFS()
-	folder, err := vfs.NewDirDoc(fs, "zorglub", dirID, nil)
-	assert.NoError(t, err)
-	assert.NoError(t, fs.CreateDir(folder))
-	msg := sharing.TrackMessage{
-		SharingID: fileSharingID,
-		RuleIndex: 0,
-		DocType:   consts.Files,
-	}
-	evt := sharing.TrackEvent{
-		Verb: "CREATED",
-		Doc: couchdb.JSONDoc{
-			Type: consts.Files,
-			M: map[string]interface{}{
-				"type":   folder.Type,
-				"_id":    folder.DocID,
-				"_rev":   folder.DocRev,
-				"name":   folder.DocName,
-				"path":   folder.Fullpath,
-				"dir_id": dirID,
-			},
-		},
-	}
-	assert.NoError(t, sharing.UpdateShared(replInstance, msg, evt))
-
-	xoredID := sharing.XorID(folder.DocID, xorKey)
-	u := tsR.URL + "/sharings/" + fileSharingID + "/io.cozy.files/" + xoredID
-	req, err := http.NewRequest(http.MethodGet, u, nil)
-	assert.NoError(t, err)
-	req.Header.Add(echo.HeaderAccept, "application/json")
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+fileAccessToken)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, http.StatusOK, res.StatusCode)
-	defer res.Body.Close()
-	var attrs map[string]interface{}
-	assert.NoError(t, json.NewDecoder(res.Body).Decode(&attrs))
-	assert.Equal(t, xoredID, attrs["_id"])
-	assert.Equal(t, folder.DocRev, attrs["_rev"])
-	assert.Equal(t, "directory", attrs["type"])
-	assert.Equal(t, "zorglub", attrs["name"])
-	assert.Empty(t, attrs["dir_id"])
-	assert.NotEmpty(t, attrs["created_at"])
-	assert.NotEmpty(t, attrs["updated_at"])
 }

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -70,7 +70,8 @@ func TestSharings(t *testing.T) {
 	middlewares.BuildTemplates()
 
 	// Prepare Alice's instance
-	setup := testutils.NewSetup(m, "sharing_test_alice")
+	setup := testutils.NewSetup(nil, t.Name())
+	t.Cleanup(setup.Cleanup)
 	aliceInstance = setup.GetTestInstance(&lifecycle.Options{
 		Email:      "alice@example.net",
 		PublicName: "Alice",
@@ -94,7 +95,8 @@ func TestSharings(t *testing.T) {
 	}
 
 	// Prepare Bob's instance
-	bobSetup := testutils.NewSetup(m, "sharing_test_bob")
+	setup := testutils.NewSetup(nil, t.Name())
+	t.Cleanup(setup.Cleanup)
 	bobInstance = bobSetup.GetTestInstance(&lifecycle.Options{
 		Email:         "bob@example.net",
 		PublicName:    "Bob",
@@ -115,7 +117,8 @@ func TestSharings(t *testing.T) {
 	tsB.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler
 
 	// Prepare another instance for the replicator tests
-	replSetup := testutils.NewSetup(m, "sharing_test_replicator")
+	setup := testutils.NewSetup(nil, t.Name())
+	t.Cleanup(setup.Cleanup)
 	replInstance = replSetup.GetTestInstance()
 	tsR = replSetup.GetTestServerMultipleRoutes(map[string]func(*echo.Group){
 		"/sharings": sharings.Routes,

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -70,7 +70,7 @@ func TestSharings(t *testing.T) {
 	middlewares.BuildTemplates()
 
 	// Prepare Alice's instance
-	setup := testutils.NewSetup(nil, t.Name())
+	setup := testutils.NewSetup(nil, t.Name()+"_alice")
 	t.Cleanup(setup.Cleanup)
 	aliceInstance = setup.GetTestInstance(&lifecycle.Options{
 		Email:      "alice@example.net",
@@ -95,8 +95,8 @@ func TestSharings(t *testing.T) {
 	}
 
 	// Prepare Bob's instance
-	setup := testutils.NewSetup(nil, t.Name())
-	t.Cleanup(setup.Cleanup)
+	bobSetup := testutils.NewSetup(nil, t.Name()+"_bob")
+	t.Cleanup(bobSetup.Cleanup)
 	bobInstance = bobSetup.GetTestInstance(&lifecycle.Options{
 		Email:         "bob@example.net",
 		PublicName:    "Bob",
@@ -117,8 +117,8 @@ func TestSharings(t *testing.T) {
 	tsB.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler
 
 	// Prepare another instance for the replicator tests
-	setup := testutils.NewSetup(nil, t.Name())
-	t.Cleanup(setup.Cleanup)
+	replSetup := testutils.NewSetup(nil, t.Name()+"_replicator")
+	t.Cleanup(replSetup.Cleanup)
 	replInstance = replSetup.GetTestInstance()
 	tsR = replSetup.GetTestServerMultipleRoutes(map[string]func(*echo.Group){
 		"/sharings": sharings.Routes,

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -116,21 +116,12 @@ func TestSharings(t *testing.T) {
 	tsB.Config.Handler.(*echo.Echo).Renderer = render
 	tsB.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler
 
-	// Prepare another instance for the replicator tests
-	replSetup := testutils.NewSetup(nil, t.Name()+"_replicator")
-	t.Cleanup(replSetup.Cleanup)
-	replInstance = replSetup.GetTestInstance()
-	tsR = replSetup.GetTestServerMultipleRoutes(map[string]func(*echo.Group){
-		"/sharings": sharings.Routes,
-	})
-
 	err := dynamic.InitDynamicAssetFS()
 	if err != nil {
 		panic("Could not init dynamic FS")
 	}
 	setup.AddCleanup(func() error {
 		bobSetup.Cleanup()
-		replSetup.Cleanup()
 		return nil
 	})
 

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -835,7 +835,6 @@ func TestSharings(t *testing.T) {
 		host = sharings.ClearAppInURL("https://my-cozy.example.net/")
 		assert.Equal(t, "https://my-cozy.example.net/", host)
 	})
-
 }
 
 func assertSharingByAliceToBobAndDave(t *testing.T, members []interface{}) {

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -131,7 +130,6 @@ func TestSharings(t *testing.T) {
 		replSetup.Cleanup()
 		return nil
 	})
-	os.Exit(setup.Run())
 
 	t.Run("CreateSharingSuccess", func(t *testing.T) {
 		bobContact := createBobContact()

--- a/web/shortcuts/shortcuts_test.go
+++ b/web/shortcuts/shortcuts_test.go
@@ -25,8 +25,23 @@ var shortcutID string
 
 const targetURL = "https://alice-photos.cozy.example/#/photos/629fb233be550a21174ac8e19f0043af"
 
-func TestCreateShortcut(t *testing.T) {
-	body := `
+func TestShortcuts(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	config.UseTestFile()
+	testutils.NeedCouchdb()
+	setup := testutils.NewSetup(m, "shortcuts_test")
+	inst = setup.GetTestInstance()
+	_, token = setup.GetTestClient(consts.Files)
+
+	ts = setup.GetTestServer("/shortcuts", Routes)
+	ts.Config.Handler.(*echo.Echo).HTTPErrorHandler = weberrors.ErrorHandler
+	os.Exit(setup.Run())
+
+	t.Run("CreateShortcut", func(t *testing.T) {
+		body := `
 {
   "data": {
     "type": "io.cozy.files.shortcuts",
@@ -46,81 +61,71 @@ func TestCreateShortcut(t *testing.T) {
     }
   }
 }`
-	req, _ := http.NewRequest("POST", ts.URL+"/shortcuts", bytes.NewBufferString(body))
-	req.Header.Add("Content-Type", "application/vnd.api+json")
-	req.Header.Add("Authorization", "Bearer "+token)
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 201, res.StatusCode)
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
+		req, _ := http.NewRequest("POST", ts.URL+"/shortcuts", bytes.NewBufferString(body))
+		req.Header.Add("Content-Type", "application/vnd.api+json")
+		req.Header.Add("Authorization", "Bearer "+token)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 201, res.StatusCode)
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
 
-	data, _ := result["data"].(map[string]interface{})
-	assert.Equal(t, "io.cozy.files", data["type"])
-	assert.Contains(t, data, "id")
-	shortcutID = data["id"].(string)
-	attrs := data["attributes"].(map[string]interface{})
-	assert.Equal(t, "file", attrs["type"])
-	assert.Equal(t, "sunset.jpg.url", attrs["name"])
-	assert.Equal(t, "application/internet-shortcut", attrs["mime"])
-	fcm, _ := attrs["cozyMetadata"].(map[string]interface{})
-	assert.Contains(t, fcm, "createdAt")
-	assert.Contains(t, fcm, "createdOn")
-	meta, _ := attrs["metadata"].(map[string]interface{})
-	target, _ := meta["target"].(map[string]interface{})
-	assert.Equal(t, "photos", target["app"])
-	assert.Equal(t, "io.cozy.files", target["_type"])
-	assert.Equal(t, "image/jpg", target["mime"])
-}
+		data, _ := result["data"].(map[string]interface{})
+		assert.Equal(t, "io.cozy.files", data["type"])
+		assert.Contains(t, data, "id")
+		shortcutID = data["id"].(string)
+		attrs := data["attributes"].(map[string]interface{})
+		assert.Equal(t, "file", attrs["type"])
+		assert.Equal(t, "sunset.jpg.url", attrs["name"])
+		assert.Equal(t, "application/internet-shortcut", attrs["mime"])
+		fcm, _ := attrs["cozyMetadata"].(map[string]interface{})
+		assert.Contains(t, fcm, "createdAt")
+		assert.Contains(t, fcm, "createdOn")
+		meta, _ := attrs["metadata"].(map[string]interface{})
+		target, _ := meta["target"].(map[string]interface{})
+		assert.Equal(t, "photos", target["app"])
+		assert.Equal(t, "io.cozy.files", target["_type"])
+		assert.Equal(t, "image/jpg", target["mime"])
+	})
 
-func TestGetShortcut(t *testing.T) {
-	req, _ := http.NewRequest("GET", ts.URL+"/shortcuts/"+shortcutID, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Add("Accept", "application/vnd.api+json")
-	res, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode)
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	assert.NoError(t, err)
+	t.Run("GetShortcut", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", ts.URL+"/shortcuts/"+shortcutID, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Add("Accept", "application/vnd.api+json")
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		assert.NoError(t, err)
 
-	data, _ := result["data"].(map[string]interface{})
-	assert.Equal(t, "io.cozy.files.shortcuts", data["type"])
-	assert.Equal(t, shortcutID, data["id"])
-	shortcutID = data["id"].(string)
-	attrs := data["attributes"].(map[string]interface{})
-	assert.Equal(t, "sunset.jpg.url", attrs["name"])
-	assert.Equal(t, "io.cozy.files.root-dir", attrs["dir_id"])
-	assert.Equal(t, targetURL, attrs["url"])
-	meta := attrs["metadata"].(map[string]interface{})
-	target := meta["target"].(map[string]interface{})
-	assert.Equal(t, "photos", target["app"])
-	assert.Equal(t, "io.cozy.files", target["_type"])
-	assert.Equal(t, "image/jpg", target["mime"])
+		data, _ := result["data"].(map[string]interface{})
+		assert.Equal(t, "io.cozy.files.shortcuts", data["type"])
+		assert.Equal(t, shortcutID, data["id"])
+		shortcutID = data["id"].(string)
+		attrs := data["attributes"].(map[string]interface{})
+		assert.Equal(t, "sunset.jpg.url", attrs["name"])
+		assert.Equal(t, "io.cozy.files.root-dir", attrs["dir_id"])
+		assert.Equal(t, targetURL, attrs["url"])
+		meta := attrs["metadata"].(map[string]interface{})
+		target := meta["target"].(map[string]interface{})
+		assert.Equal(t, "photos", target["app"])
+		assert.Equal(t, "io.cozy.files", target["_type"])
+		assert.Equal(t, "image/jpg", target["mime"])
 
-	client := http.Client{
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			return errors.New("Do not follow the redirections")
-		},
-	}
-	req, _ = http.NewRequest("GET", ts.URL+"/shortcuts/"+shortcutID, nil)
-	req.Header.Add("Authorization", "Bearer "+token)
-	req.Header.Add("Accept", "text/html")
-	res, err = client.Do(req)
-	assert.Contains(t, err.Error(), "Do not follow the redirections")
-	assert.Equal(t, 303, res.StatusCode)
-	assert.Equal(t, targetURL, res.Header.Get("Location"))
-}
+		client := http.Client{
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return errors.New("Do not follow the redirections")
+			},
+		}
+		req, _ = http.NewRequest("GET", ts.URL+"/shortcuts/"+shortcutID, nil)
+		req.Header.Add("Authorization", "Bearer "+token)
+		req.Header.Add("Accept", "text/html")
+		res, err = client.Do(req)
+		assert.Contains(t, err.Error(), "Do not follow the redirections")
+		assert.Equal(t, 303, res.StatusCode)
+		assert.Equal(t, targetURL, res.Header.Get("Location"))
+	})
 
-func TestMain(m *testing.M) {
-	config.UseTestFile()
-	testutils.NeedCouchdb()
-	setup := testutils.NewSetup(m, "shortcuts_test")
-	inst = setup.GetTestInstance()
-	_, token = setup.GetTestClient(consts.Files)
-
-	ts = setup.GetTestServer("/shortcuts", Routes)
-	ts.Config.Handler.(*echo.Echo).HTTPErrorHandler = weberrors.ErrorHandler
-	os.Exit(setup.Run())
 }

--- a/web/shortcuts/shortcuts_test.go
+++ b/web/shortcuts/shortcuts_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/cozy/cozy-stack/model/instance"
@@ -38,7 +37,6 @@ func TestShortcuts(t *testing.T) {
 
 	ts = setup.GetTestServer("/shortcuts", Routes)
 	ts.Config.Handler.(*echo.Echo).HTTPErrorHandler = weberrors.ErrorHandler
-	os.Exit(setup.Run())
 
 	t.Run("CreateShortcut", func(t *testing.T) {
 		body := `

--- a/web/shortcuts/shortcuts_test.go
+++ b/web/shortcuts/shortcuts_test.go
@@ -31,7 +31,8 @@ func TestShortcuts(t *testing.T) {
 
 	config.UseTestFile()
 	testutils.NeedCouchdb()
-	setup := testutils.NewSetup(m, "shortcuts_test")
+	setup := testutils.NewSetup(nil, t.Name())
+	t.Cleanup(setup.Cleanup)
 	inst = setup.GetTestInstance()
 	_, token = setup.GetTestClient(consts.Files)
 

--- a/web/shortcuts/shortcuts_test.go
+++ b/web/shortcuts/shortcuts_test.go
@@ -126,5 +126,4 @@ func TestShortcuts(t *testing.T) {
 		assert.Equal(t, 303, res.StatusCode)
 		assert.Equal(t, targetURL, res.Header.Get("Location"))
 	})
-
 }

--- a/web/status/status_test.go
+++ b/web/status/status_test.go
@@ -30,7 +30,6 @@ func TestStatus(t *testing.T) {
 
 		testRequest(t, ts.URL+"/status")
 	})
-
 }
 
 func testRequest(t *testing.T, url string) {

--- a/web/status/status_test.go
+++ b/web/status/status_test.go
@@ -14,6 +14,27 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestStatus(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	config.UseTestFile()
+	os.Exit(m.Run())
+
+	t.Run("Routes", func(t *testing.T) {
+		handler := echo.New()
+		handler.HTTPErrorHandler = errors.ErrorHandler
+		Routes(handler.Group("/status"))
+
+		ts := httptest.NewServer(handler)
+		defer ts.Close()
+
+		testRequest(t, ts.URL+"/status")
+	})
+
+}
+
 func testRequest(t *testing.T, url string) {
 	res, err := http.Get(url)
 	assert.NoError(t, err)
@@ -31,20 +52,4 @@ func testRequest(t *testing.T, url string) {
 	assert.Equal(t, "OK", data["status"])
 	assert.Equal(t, "OK", data["message"])
 	assert.Contains(t, data, "latency")
-}
-
-func TestRoutes(t *testing.T) {
-	handler := echo.New()
-	handler.HTTPErrorHandler = errors.ErrorHandler
-	Routes(handler.Group("/status"))
-
-	ts := httptest.NewServer(handler)
-	defer ts.Close()
-
-	testRequest(t, ts.URL+"/status")
-}
-
-func TestMain(m *testing.M) {
-	config.UseTestFile()
-	os.Exit(m.Run())
 }

--- a/web/status/status_test.go
+++ b/web/status/status_test.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/cozy/cozy-stack/pkg/config/config"
@@ -20,7 +19,6 @@ func TestStatus(t *testing.T) {
 	}
 
 	config.UseTestFile()
-	os.Exit(m.Run())
 
 	t.Run("Routes", func(t *testing.T) {
 		handler := echo.New()


### PR DESCRIPTION
This migration is an application of [the ADR 0002](https://github.com/cozy/cozy-stack/blob/master/docs/architecture/decisions/0002-refactor-tests-using-the-subtest-pattern.md).

It's advised to review the PR commit by commit and skipping the commit `Run the script migrate-test-init.sh on /web`. This commit is really big and have been completly generated by a script that you can review inside `./scripts`.