### PR TITLE
Add {{.CozyFonts}} helper

### DIFF
--- a/docs/apps.md
+++ b/docs/apps.md
@@ -665,6 +665,7 @@ Content-Type: application/vnd.api+json
       "Capabilities": "{ \"file_versioning\": true }",
       "CozyBar": "...",
       "CozyClientJS": "...",
+      "CozyFonts": "...",
       "DefaultWallpaper": "...",
       "Domain": "cozy.example.net",
       "Favicon": "...",

--- a/docs/client-app-dev.md
+++ b/docs/client-app-dev.md
@@ -176,6 +176,8 @@ There are also some helpers to inject asset tags or URLs:
 -   `{{.CozyBar}}` will be replaced by the JavaScript to inject the cozy-bar.
 -   `{{.CozyClientJS}}` will be replaced by the JavaScript to inject the
     cozy-client-js.
+-   `{{.CozyFonts}}` will be replaced by the `fonts.css` used to inject the
+    web fonts (Lato and Lato bold by default).
 -   `{{.ThemeCSS}}` will be replaced by the `theme.css`. It is empty by default,
     but can be overrided by using `contexts`. See
     [contexts](https://docs.cozy.io/en/cozy-stack/assets/#contexts) and [dynamic

--- a/web/apps/serve.go
+++ b/web/apps/serve.go
@@ -532,6 +532,10 @@ func (s serveParams) CozyClientJS() (template.HTML, error) {
 	return cozyclientjs(s.instance)
 }
 
+func (s serveParams) CozyFonts() template.HTML {
+	return middlewares.CozyFonts(s.instance)
+}
+
 func (s serveParams) ThemeCSS() template.HTML {
 	return middlewares.ThemeCSS(s.instance)
 }

--- a/web/middlewares/assets.go
+++ b/web/middlewares/assets.go
@@ -13,11 +13,15 @@ import (
 // It is filled in web/statik but declared here to avoid circular imports.
 var FuncsMap template.FuncMap
 
+var fontsTemplate *template.Template
 var themeTemplate *template.Template
 var faviconTemplate *template.Template
 
 // BuildTemplates ensure that the cozy-ui can be injected in templates
 func BuildTemplates() {
+	fontsTemplate = template.Must(template.New("fonts").Funcs(FuncsMap).Parse(`` +
+		`<link rel="stylesheet" type="text/css" href="{{asset .Domain "/fonts/fonts.css" .ContextName}}">`,
+	))
 	themeTemplate = template.Must(template.New("theme").Funcs(FuncsMap).Parse(`` +
 		`<link rel="stylesheet" type="text/css" href="{{asset .Domain "/styles/theme.css" .ContextName}}">`,
 	))
@@ -31,6 +35,20 @@ func BuildTemplates() {
 	<link rel="apple-touch-icon" sizes="180x180" href="{{asset .Domain "/apple-touch-icon.png" .ContextName}}"/>
 	<link rel="manifest" href="{{asset .Domain "/manifest.webmanifest"}}">
 		`))
+}
+
+// CozyFonts returns an HTML template for inserting the HTML tag for the loading
+// the CSS file for web fonts (lato and lato-bold).
+func CozyFonts(i *instance.Instance) template.HTML {
+	buf := new(bytes.Buffer)
+	err := fontsTemplate.Execute(buf, echo.Map{
+		"Domain":      i.ContextualDomain(),
+		"ContextName": i.ContextName,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return template.HTML(buf.String())
 }
 
 // ThemeCSS returns an HTML template for inserting the HTML tag for the custom


### PR DESCRIPTION
This helper can be used by front applications in their html template to insert an HTML tag for loading the fonts.css file, and thus the Lato and Lato bold font. The fonts.css can also be overloaded by context via dynamic assets, and be used to load other web fonts.