### PR TITLE
Use `t.TempDir()` instead of `os.TempDir()` in tests

### DIFF
--- a/pkg/assets/dynamic/dynamic_test.go
+++ b/pkg/assets/dynamic/dynamic_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"log"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -18,20 +17,18 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAddCustomAsset(t *testing.T) {
 	var err error
 
-	tmpfile, err := os.OpenFile(filepath.Join(os.TempDir(), "foo.js"), os.O_CREATE, 0600)
-	if err != nil {
-		t.Error(err)
-	}
-	defer tmpfile.Close()
+	tmpfile, err := os.OpenFile(filepath.Join(t.TempDir(), "foo.js"), os.O_CREATE, 0600)
+	require.NoError(t, err)
 
 	h := sha256.New()
 	if _, err := io.Copy(h, tmpfile); err != nil {
-		log.Fatal(err)
+		require.NoError(t, err)
 	}
 	sum := h.Sum(nil)
 
@@ -66,7 +63,7 @@ func TestRemoveCustomAsset(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Adding the asset
-	tmpfile, err := os.OpenFile(filepath.Join(os.TempDir(), "foo2.js"), os.O_CREATE, 0600)
+	tmpfile, err := os.OpenFile(filepath.Join(t.TempDir(), "foo2.js"), os.O_CREATE, 0600)
 	assert.NoError(t, err)
 	asset.URL = fmt.Sprintf("file://%s", tmpfile.Name())
 

--- a/pkg/config/config/config_test.go
+++ b/pkg/config/config/config_test.go
@@ -21,12 +21,9 @@ func TestUseViper(t *testing.T) {
 }
 
 func TestSetup(t *testing.T) {
-	tmpdir := os.TempDir()
+	tmpdir := t.TempDir()
 	tmpfile, err := os.OpenFile(filepath.Join(tmpdir, "cozy.yaml"), os.O_RDWR|os.O_CREATE|os.O_EXCL, 0600)
 	require.NoError(t, err)
-
-	defer tmpfile.Close()
-	defer os.Remove(tmpfile.Name())
 
 	t.Setenv("OS_USERNAME", "os_username_val")
 	t.Setenv("OS_PASSWORD", "os_password_val")

--- a/pkg/hooks/hooks_test.go
+++ b/pkg/hooks/hooks_test.go
@@ -12,9 +12,8 @@ import (
 )
 
 func TestExecuteSuccess(t *testing.T) {
-	tmp := fmt.Sprintf("%s/foo-%d", os.TempDir(), time.Now().Unix())
+	tmp := fmt.Sprintf("%s/foo-%d", t.TempDir(), time.Now().Unix())
 	args := []string{tmp, "bar"}
-	defer os.Remove(tmp)
 	executed := false
 	fn := func() error { executed = true; return nil }
 	err := Execute("success", args, fn)
@@ -34,9 +33,8 @@ func TestExecutePreFails(t *testing.T) {
 }
 
 func TestExecuteFunctionFails(t *testing.T) {
-	tmp := fmt.Sprintf("%s/foo-%d", os.TempDir(), time.Now().Unix())
+	tmp := fmt.Sprintf("%s/foo-%d", t.TempDir(), time.Now().Unix())
 	args := []string{tmp, "bar"}
-	defer os.Remove(tmp)
 	executed := false
 	e := errors.New("fn fails")
 	fn := func() error { executed = true; return e }
@@ -49,9 +47,8 @@ func TestExecuteFunctionFails(t *testing.T) {
 }
 
 func TestRunHooks(t *testing.T) {
-	tmp := fmt.Sprintf("%s/foo-%d", os.TempDir(), time.Now().Unix())
+	tmp := fmt.Sprintf("%s/foo-%d", t.TempDir(), time.Now().Unix())
 	args := []string{tmp, "bar"}
-	defer os.Remove(tmp)
 	err := runHook("pre", "success", args)
 	assert.NoError(t, err)
 	content, err := os.ReadFile(tmp)

--- a/web/apps/apps_test.go
+++ b/web/apps/apps_test.go
@@ -179,7 +179,7 @@ func TestApps(t *testing.T) {
 			_ = assets.Remove(asset.Name, asset.Context)
 		}
 		// Create and insert an asset in foo context
-		tmpdir := os.TempDir()
+		tmpdir := t.TempDir()
 		_, err := os.OpenFile(filepath.Join(tmpdir, "custom_favicon.png"), os.O_RDWR|os.O_CREATE, 0600)
 		assert.NoError(t, err)
 

--- a/worker/exec/konnector_test.go
+++ b/worker/exec/konnector_test.go
@@ -162,7 +162,7 @@ echo "{\"type\": \"manifest\", \"message\": \"$(ls ${1}/manifest.konnector)\" }"
 			assert.Equal(t, "manifest", doc2.M["type"])
 
 			msg2 := doc2.M["message"].(string)
-			assert.True(t, strings.HasPrefix(msg2, os.TempDir()))
+			assert.True(t, strings.HasPrefix(msg2, t.TempDir()))
 			assert.True(t, strings.HasSuffix(msg2, "/manifest.konnector"))
 
 			msg1 := doc1.M["message"].(string)


### PR DESCRIPTION
t.TempDir will automatically remove the folder at the end of the test.