### PR TITLE
`testutils` package refactoring

### DIFF
--- a/model/app/webapp_test.go
+++ b/model/app/webapp_test.go
@@ -21,7 +21,7 @@ func TestWebapp(t *testing.T) {
 
 	config.UseTestFile()
 	testutils.NeedCouchdb(t)
-	setup := testutils.NewSetup(nil, t.Name())
+	setup := testutils.NewSetup(t, t.Name())
 	t.Cleanup(setup.Cleanup)
 
 	_, err := stack.Start()

--- a/model/app/webapp_test.go
+++ b/model/app/webapp_test.go
@@ -21,13 +21,9 @@ func TestWebapp(t *testing.T) {
 
 	config.UseTestFile()
 	testutils.NeedCouchdb(t)
-	setup := testutils.NewSetup(t, t.Name())
-	t.Cleanup(setup.Cleanup)
 
 	_, err := stack.Start()
-	if err != nil {
-		require.NoError(t, err, "Error while starting job system")
-	}
+	require.NoError(t, err, "Error while starting job system")
 
 	t.Run("ListWebappsWithPagination", func(t *testing.T) {
 		of := true

--- a/model/job/redis_scheduler_test.go
+++ b/model/job/redis_scheduler_test.go
@@ -53,7 +53,6 @@ func TestRedisScheduler(t *testing.T) {
 
 	testutils.NeedCouchdb(t)
 	setup := testutils.NewSetup(t, t.Name())
-	t.Cleanup(setup.Cleanup)
 	testInstance = setup.GetTestInstance()
 
 	setup.AddCleanup(func() error {

--- a/model/job/redis_scheduler_test.go
+++ b/model/job/redis_scheduler_test.go
@@ -52,7 +52,7 @@ func TestRedisScheduler(t *testing.T) {
 	}
 
 	testutils.NeedCouchdb(t)
-	setup := testutils.NewSetup(nil, t.Name())
+	setup := testutils.NewSetup(t, t.Name())
 	t.Cleanup(setup.Cleanup)
 	testInstance = setup.GetTestInstance()
 

--- a/model/job/redis_scheduler_test.go
+++ b/model/job/redis_scheduler_test.go
@@ -55,11 +55,11 @@ func TestRedisScheduler(t *testing.T) {
 	setup := testutils.NewSetup(t, t.Name())
 	testInstance = setup.GetTestInstance()
 
-	setup.AddCleanup(func() error {
+	t.Cleanup(func() {
 		cfg.Jobs.RedisConfig = was
 		opts, _ := redis.ParseURL(redisURL)
 		client := redis.NewClient(opts)
-		return client.Del(context.Background(), jobs.TriggersKey, jobs.SchedKey).Err()
+		_ = client.Del(context.Background(), jobs.TriggersKey, jobs.SchedKey)
 	})
 
 	t.Run("RedisSchedulerWithTimeTriggers", func(t *testing.T) {

--- a/model/job/redis_scheduler_test.go
+++ b/model/job/redis_scheduler_test.go
@@ -2,7 +2,6 @@ package job_test
 
 import (
 	"context"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -63,8 +62,6 @@ func TestRedisScheduler(t *testing.T) {
 		client := redis.NewClient(opts)
 		return client.Del(context.Background(), jobs.TriggersKey, jobs.SchedKey).Err()
 	})
-
-	os.Exit(setup.Run())
 
 	t.Run("RedisSchedulerWithTimeTriggers", func(t *testing.T) {
 		var wAt sync.WaitGroup

--- a/model/move/export_test.go
+++ b/model/move/export_test.go
@@ -34,7 +34,7 @@ func TestExport(t *testing.T) {
 	fmt.Printf("seed = %d\n", seed)
 	rand.Seed(seed)
 	config.UseTestFile()
-	setup := testutils.NewSetup(nil, t.Name())
+	setup := testutils.NewSetup(t, t.Name())
 	t.Cleanup(setup.Cleanup)
 	inst = setup.GetTestInstance()
 

--- a/model/move/export_test.go
+++ b/model/move/export_test.go
@@ -35,7 +35,6 @@ func TestExport(t *testing.T) {
 	rand.Seed(seed)
 	config.UseTestFile()
 	setup := testutils.NewSetup(t, t.Name())
-	t.Cleanup(setup.Cleanup)
 	inst = setup.GetTestInstance()
 
 	t.Run("ExportFiles", func(t *testing.T) {

--- a/model/move/export_test.go
+++ b/model/move/export_test.go
@@ -3,7 +3,6 @@ package move
 import (
 	"fmt"
 	"math/rand"
-	"os"
 	"path"
 	"testing"
 	"time"
@@ -38,7 +37,6 @@ func TestExport(t *testing.T) {
 	setup := testutils.NewSetup(nil, t.Name())
 	t.Cleanup(setup.Cleanup)
 	inst = setup.GetTestInstance()
-	os.Exit(setup.Run())
 
 	t.Run("ExportFiles", func(t *testing.T) {
 		fs := inst.VFS()

--- a/model/oauth/client_test.go
+++ b/model/oauth/client_test.go
@@ -27,7 +27,7 @@ func TestClient(t *testing.T) {
 	}
 
 	config.UseTestFile()
-	setup := testutils.NewSetup(nil, t.Name())
+	setup := testutils.NewSetup(t, t.Name())
 	t.Cleanup(setup.Cleanup)
 	t.Cleanup(setup.Cleanup)
 	testInstance = setup.GetTestInstance()

--- a/model/oauth/client_test.go
+++ b/model/oauth/client_test.go
@@ -28,8 +28,6 @@ func TestClient(t *testing.T) {
 
 	config.UseTestFile()
 	setup := testutils.NewSetup(t, t.Name())
-	t.Cleanup(setup.Cleanup)
-	t.Cleanup(setup.Cleanup)
 	testInstance = setup.GetTestInstance()
 
 	t.Run("CreateJWT", func(t *testing.T) {

--- a/model/sharing/files_test.go
+++ b/model/sharing/files_test.go
@@ -17,7 +17,7 @@ func TestFiles(t *testing.T) {
 
 	config.UseTestFile()
 	testutils.NeedCouchdb(t)
-	setup := testutils.NewSetup(nil, t.Name())
+	setup := testutils.NewSetup(t, t.Name())
 	t.Cleanup(setup.Cleanup)
 	inst := setup.GetTestInstance()
 

--- a/model/sharing/files_test.go
+++ b/model/sharing/files_test.go
@@ -18,7 +18,6 @@ func TestFiles(t *testing.T) {
 	config.UseTestFile()
 	testutils.NeedCouchdb(t)
 	setup := testutils.NewSetup(t, t.Name())
-	t.Cleanup(setup.Cleanup)
 	inst := setup.GetTestInstance()
 
 	t.Run("MakeXorKey", func(t *testing.T) {

--- a/model/sharing/replicator_test.go
+++ b/model/sharing/replicator_test.go
@@ -28,7 +28,6 @@ func TestReplicator(t *testing.T) {
 	config.UseTestFile()
 	testutils.NeedCouchdb(t)
 	setup := testutils.NewSetup(t, t.Name())
-	t.Cleanup(setup.Cleanup)
 	inst := setup.GetTestInstance()
 
 	t.Run("SequenceNumber", func(t *testing.T) {

--- a/model/sharing/replicator_test.go
+++ b/model/sharing/replicator_test.go
@@ -27,7 +27,7 @@ func TestReplicator(t *testing.T) {
 
 	config.UseTestFile()
 	testutils.NeedCouchdb(t)
-	setup := testutils.NewSetup(nil, t.Name())
+	setup := testutils.NewSetup(t, t.Name())
 	t.Cleanup(setup.Cleanup)
 	inst := setup.GetTestInstance()
 

--- a/model/sharing/revisions_test.go
+++ b/model/sharing/revisions_test.go
@@ -241,7 +241,6 @@ func TestAddMissingRevsToChain(t *testing.T) {
 	config.UseTestFile()
 	testutils.NeedCouchdb(t)
 	setup := testutils.NewSetup(t, t.Name())
-	t.Cleanup(setup.Cleanup)
 	inst := setup.GetTestInstance()
 
 	doc := &couchdb.JSONDoc{

--- a/model/sharing/revisions_test.go
+++ b/model/sharing/revisions_test.go
@@ -240,7 +240,7 @@ func TestAddMissingRevsToChain(t *testing.T) {
 
 	config.UseTestFile()
 	testutils.NeedCouchdb(t)
-	setup := testutils.NewSetup(nil, t.Name())
+	setup := testutils.NewSetup(t, t.Name())
 	t.Cleanup(setup.Cleanup)
 	inst := setup.GetTestInstance()
 

--- a/tests/testutils/test_utils.go
+++ b/tests/testutils/test_utils.go
@@ -83,6 +83,8 @@ func NewSetup(t testing.TB, name string) *TestSetup {
 		cleanup: func() {},
 	}
 
+	t.Cleanup(setup.cleanup)
+
 	return &setup
 }
 
@@ -90,11 +92,6 @@ func NewSetup(t testing.TB, name string) *TestSetup {
 func (c *TestSetup) CleanupAndDie(msg ...interface{}) {
 	c.cleanup()
 	Fatal(msg...)
-}
-
-// Cleanup cleanup the TestSetup
-func (c *TestSetup) Cleanup() {
-	c.cleanup()
 }
 
 // SetupSwiftTest can be used to start an in-memory Swift server for tests.

--- a/tests/testutils/test_utils.go
+++ b/tests/testutils/test_utils.go
@@ -249,13 +249,6 @@ func (c *TestSetup) GetTestServerMultipleRoutes(mpr map[string]func(*echo.Group)
 	return ts
 }
 
-// Run runs the underlying testing.M and cleanup
-func (c *TestSetup) Run() int {
-	value := c.testingM.Run()
-	c.cleanup()
-	return value
-}
-
 // CookieJar is a http.CookieJar which always returns all cookies.
 // NOTE golang stdlib uses cookies for the URL (ie the testserver),
 // not for the host (ie the instance), so we do it manually

--- a/tests/testutils/test_utils.go
+++ b/tests/testutils/test_utils.go
@@ -9,7 +9,6 @@ import (
 	"net/http/cookiejar"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"path"
 	"testing"
 	"time"
@@ -123,16 +122,6 @@ func (c *TestSetup) AddCleanup(f func() error) {
 		}
 		next()
 	}
-}
-
-// GetTmpDirectory creates a temporary directory
-// The directory will be removed on container cleanup
-func (c *TestSetup) GetTmpDirectory() string {
-	tempdir, err := os.MkdirTemp("", "cozy-stack")
-	require.NoError(c.t, err, "Could not create temporary directory.")
-
-	c.AddCleanup(func() error { return os.RemoveAll(tempdir) })
-	return tempdir
 }
 
 // GetTestInstance creates an instance with a random host

--- a/tests/testutils/test_utils.go
+++ b/tests/testutils/test_utils.go
@@ -36,12 +36,6 @@ import (
 // This flag avoid starting the stack twice.
 var stackStarted bool
 
-// Fatal prints a message and immediately exit the process
-func Fatal(msg ...interface{}) {
-	fmt.Println(msg...)
-	os.Exit(1)
-}
-
 // NeedCouchdb kill the process if there is no couchdb running
 func NeedCouchdb(t *testing.T) {
 	if _, err := couchdb.CheckStatus(); err != nil {

--- a/tests/testutils/test_utils.go
+++ b/tests/testutils/test_utils.go
@@ -65,23 +65,24 @@ func TODO(t *testing.T, date string, args ...interface{}) {
 // setting up instance, client, VFSContext, testserver
 // and cleaning up after itself
 type TestSetup struct {
-	testingM *testing.M
-	name     string
-	host     string
-	inst     *instance.Instance
-	ts       *httptest.Server
-	cleanup  func()
+	t       testing.TB
+	name    string
+	host    string
+	inst    *instance.Instance
+	ts      *httptest.Server
+	cleanup func()
 }
 
 // NewSetup returns a new TestSetup
 // name is used to prevent bug when tests are run in parallel
-func NewSetup(testingM *testing.M, name string) *TestSetup {
+func NewSetup(t testing.TB, name string) *TestSetup {
 	setup := TestSetup{
-		name:     name,
-		testingM: testingM,
-		host:     name + "_" + utils.RandomString(10) + ".cozy.local",
-		cleanup:  func() {},
+		name:    name,
+		t:       t,
+		host:    name + "_" + utils.RandomString(10) + ".cozy.local",
+		cleanup: func() {},
 	}
+
 	return &setup
 }
 

--- a/web/accounts/oauth_test.go
+++ b/web/accounts/oauth_test.go
@@ -39,7 +39,6 @@ func TestOauth(t *testing.T) {
 	testutils.NeedCouchdb(t)
 
 	setup := testutils.NewSetup(t, t.Name())
-	t.Cleanup(setup.Cleanup)
 	ts = setup.GetTestServer("/accounts", Routes, func(r *echo.Echo) *echo.Echo {
 		r.POST("/login", func(c echo.Context) error {
 			sess, _ := session.New(testInstance, session.LongRun)

--- a/web/accounts/oauth_test.go
+++ b/web/accounts/oauth_test.go
@@ -38,7 +38,7 @@ func TestOauth(t *testing.T) {
 	build.BuildMode = build.ModeDev
 	testutils.NeedCouchdb(t)
 
-	setup := testutils.NewSetup(nil, t.Name())
+	setup := testutils.NewSetup(t, t.Name())
 	t.Cleanup(setup.Cleanup)
 	ts = setup.GetTestServer("/accounts", Routes, func(r *echo.Echo) *echo.Echo {
 		r.POST("/login", func(c echo.Context) error {

--- a/web/accounts/oauth_test.go
+++ b/web/accounts/oauth_test.go
@@ -53,9 +53,7 @@ func TestOauth(t *testing.T) {
 		Domain: strings.Replace(ts.URL, "http://127.0.0.1", "cozy.localhost", 1),
 	})
 	_ = couchdb.ResetDB(prefixer.SecretsPrefixer, consts.AccountTypes)
-	setup.AddCleanup(func() error {
-		return couchdb.DeleteDB(prefixer.SecretsPrefixer, consts.AccountTypes)
-	})
+	t.Cleanup(func() { _ = couchdb.DeleteDB(prefixer.SecretsPrefixer, consts.AccountTypes) })
 
 	// Login
 	jar = setup.GetCookieJar()

--- a/web/apps/apps_test.go
+++ b/web/apps/apps_test.go
@@ -59,7 +59,7 @@ func TestApps(t *testing.T) {
 	config.UseTestFile()
 	config.GetConfig().Assets = "../../assets"
 	testutils.NeedCouchdb(t)
-	setup := testutils.NewSetup(nil, t.Name())
+	setup := testutils.NewSetup(t, t.Name())
 	t.Cleanup(setup.Cleanup)
 	require.NoError(t, setup.SetupSwiftTest(), "Could not init Swift test")
 

--- a/web/apps/apps_test.go
+++ b/web/apps/apps_test.go
@@ -63,7 +63,7 @@ func TestApps(t *testing.T) {
 	require.NoError(t, setup.SetupSwiftTest(), "Could not init Swift test")
 
 	require.NoError(t, dynamic.InitDynamicAssetFS(), "Could not init dynamic FS")
-	tempdir := setup.GetTmpDirectory()
+	tempdir := t.TempDir()
 
 	cfg := config.GetConfig()
 	cfg.Fs.URL = &url.URL{

--- a/web/apps/apps_test.go
+++ b/web/apps/apps_test.go
@@ -87,14 +87,10 @@ func TestApps(t *testing.T) {
 	_ = testInstance.Update()
 
 	slug, err := setup.InstallMiniApp()
-	if err != nil {
-		setup.CleanupAndDie("Could not install mini app.", err)
-	}
+	require.NoError(t, err, "Could not install mini app")
 
 	_, err = setup.InstallMiniKonnector()
-	if err != nil {
-		setup.CleanupAndDie("Could not install mini konnector.", err)
-	}
+	require.NoError(t, err, "Could not install mini konnector")
 
 	ts = setup.GetTestServer("/apps", webApps.WebappsRoutes, func(r *echo.Echo) *echo.Echo {
 		r.POST("/login", func(c echo.Context) error {
@@ -105,9 +101,7 @@ func TestApps(t *testing.T) {
 		})
 		r.POST("/auth/session_code", auth.CreateSessionCode)
 		router, err := web.CreateSubdomainProxy(r, webApps.Serve)
-		if err != nil {
-			setup.CleanupAndDie("Cant start subdoman proxy", err)
-		}
+		require.NoError(t, err, "Cant start subdoman proxy")
 		return router
 	})
 

--- a/web/apps/apps_test.go
+++ b/web/apps/apps_test.go
@@ -60,7 +60,6 @@ func TestApps(t *testing.T) {
 	config.GetConfig().Assets = "../../assets"
 	testutils.NeedCouchdb(t)
 	setup := testutils.NewSetup(t, t.Name())
-	t.Cleanup(setup.Cleanup)
 	require.NoError(t, setup.SetupSwiftTest(), "Could not init Swift test")
 
 	require.NoError(t, dynamic.InitDynamicAssetFS(), "Could not init dynamic FS")

--- a/web/auth/auth_test.go
+++ b/web/auth/auth_test.go
@@ -97,9 +97,7 @@ func TestAuth(t *testing.T) {
 
 	ts = setup.GetTestServer("/test", fakeAPI, func(r *echo.Echo) *echo.Echo {
 		handler, err := web.CreateSubdomainProxy(r, apps.Serve)
-		if err != nil {
-			setup.CleanupAndDie("Cant start subdomain proxy", err)
-		}
+		require.NoError(t, err, "Cant start subdomain proxy")
 		return handler
 	})
 	ts.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler
@@ -107,9 +105,7 @@ func TestAuth(t *testing.T) {
 	require.NoError(t, dynamic.InitDynamicAssetFS(), "Could not init dynamic FS")
 
 	konnSlug, err := setup.InstallMiniKonnector()
-	if err != nil {
-		setup.CleanupAndDie("Could not install mini konnector.", err)
-	}
+	require.NoError(t, err, "Could not install mini konnector.")
 
 	t.Run("InstanceBlocked", func(t *testing.T) {
 		// Block the instance

--- a/web/auth/auth_test.go
+++ b/web/auth/auth_test.go
@@ -80,7 +80,6 @@ func TestAuth(t *testing.T) {
 	_ = web.LoadSupportedLocales()
 	testutils.NeedCouchdb(t)
 	setup := testutils.NewSetup(t, t.Name())
-	t.Cleanup(setup.Cleanup)
 
 	testInstance = setup.GetTestInstance(&lifecycle.Options{
 		Domain:        domain,

--- a/web/auth/auth_test.go
+++ b/web/auth/auth_test.go
@@ -79,7 +79,7 @@ func TestAuth(t *testing.T) {
 
 	_ = web.LoadSupportedLocales()
 	testutils.NeedCouchdb(t)
-	setup := testutils.NewSetup(nil, t.Name())
+	setup := testutils.NewSetup(t, t.Name())
 	t.Cleanup(setup.Cleanup)
 
 	testInstance = setup.GetTestInstance(&lifecycle.Options{

--- a/web/bitwarden/bitwarden_test.go
+++ b/web/bitwarden/bitwarden_test.go
@@ -39,7 +39,6 @@ func TestBitwarden(t *testing.T) {
 	config.UseTestFile()
 	testutils.NeedCouchdb(t)
 	setup := testutils.NewSetup(t, t.Name())
-	t.Cleanup(setup.Cleanup)
 	inst = setup.GetTestInstance(&lifecycle.Options{
 		Domain:     "bitwarden.example.net",
 		Passphrase: "cozy",

--- a/web/bitwarden/bitwarden_test.go
+++ b/web/bitwarden/bitwarden_test.go
@@ -38,7 +38,7 @@ func TestBitwarden(t *testing.T) {
 
 	config.UseTestFile()
 	testutils.NeedCouchdb(t)
-	setup := testutils.NewSetup(nil, t.Name())
+	setup := testutils.NewSetup(t, t.Name())
 	t.Cleanup(setup.Cleanup)
 	inst = setup.GetTestInstance(&lifecycle.Options{
 		Domain:     "bitwarden.example.net",

--- a/web/contacts/contacts_test.go
+++ b/web/contacts/contacts_test.go
@@ -28,7 +28,6 @@ func TestContacts(t *testing.T) {
 	config.UseTestFile()
 	testutils.NeedCouchdb(t)
 	setup := testutils.NewSetup(t, t.Name())
-	t.Cleanup(setup.Cleanup)
 	testInstance = setup.GetTestInstance(&lifecycle.Options{
 		Email:      "alice@example.com",
 		PublicName: "Alice",

--- a/web/contacts/contacts_test.go
+++ b/web/contacts/contacts_test.go
@@ -27,7 +27,7 @@ func TestContacts(t *testing.T) {
 
 	config.UseTestFile()
 	testutils.NeedCouchdb(t)
-	setup := testutils.NewSetup(nil, t.Name())
+	setup := testutils.NewSetup(t, t.Name())
 	t.Cleanup(setup.Cleanup)
 	testInstance = setup.GetTestInstance(&lifecycle.Options{
 		Email:      "alice@example.com",

--- a/web/data/data_test.go
+++ b/web/data/data_test.go
@@ -63,7 +63,6 @@ func TestData(t *testing.T) {
 	config.UseTestFile()
 	testutils.NeedCouchdb(t)
 	setup := testutils.NewSetup(t, t.Name())
-	t.Cleanup(setup.Cleanup)
 	testInstance = setup.GetTestInstance()
 	scope := "io.cozy.doctypes io.cozy.files io.cozy.events " +
 		"io.cozy.anothertype io.cozy.nottype"

--- a/web/data/data_test.go
+++ b/web/data/data_test.go
@@ -62,7 +62,7 @@ func TestData(t *testing.T) {
 
 	config.UseTestFile()
 	testutils.NeedCouchdb(t)
-	setup := testutils.NewSetup(nil, t.Name())
+	setup := testutils.NewSetup(t, t.Name())
 	t.Cleanup(setup.Cleanup)
 	testInstance = setup.GetTestInstance()
 	scope := "io.cozy.doctypes io.cozy.files io.cozy.events " +

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -62,7 +62,7 @@ func TestFiles(t *testing.T) {
 	require.NoError(t, loadLocale(), "Could not load default locale translations")
 
 	testutils.NeedCouchdb(t)
-	setup := testutils.NewSetup(nil, t.Name())
+	setup := testutils.NewSetup(t, t.Name())
 	t.Cleanup(setup.Cleanup)
 
 	tempdir, err := os.MkdirTemp("", "cozy-stack")

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -63,16 +63,11 @@ func TestFiles(t *testing.T) {
 
 	testutils.NeedCouchdb(t)
 	setup := testutils.NewSetup(t, t.Name())
-	tempdir, err := os.MkdirTemp("", "cozy-stack")
-	if err != nil {
-		require.NoError(t, err, "Could not create temporary directory")
-	}
-	setup.AddCleanup(func() error { return os.RemoveAll(tempdir) })
 
 	config.GetConfig().Fs.URL = &url.URL{
 		Scheme: "file",
 		Host:   "localhost",
-		Path:   tempdir,
+		Path:   t.TempDir(),
 	}
 
 	testInstance = setup.GetTestInstance()

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -63,8 +63,6 @@ func TestFiles(t *testing.T) {
 
 	testutils.NeedCouchdb(t)
 	setup := testutils.NewSetup(t, t.Name())
-	t.Cleanup(setup.Cleanup)
-
 	tempdir, err := os.MkdirTemp("", "cozy-stack")
 	if err != nil {
 		require.NoError(t, err, "Could not create temporary directory")

--- a/web/intents/intents_test.go
+++ b/web/intents/intents_test.go
@@ -39,7 +39,6 @@ func TestIntents(t *testing.T) {
 	config.UseTestFile()
 	testutils.NeedCouchdb(t)
 	setup := testutils.NewSetup(t, t.Name())
-	t.Cleanup(setup.Cleanup)
 	ins = setup.GetTestInstance(&lifecycle.Options{
 		Domain: "cozy.example.net",
 	})

--- a/web/intents/intents_test.go
+++ b/web/intents/intents_test.go
@@ -38,7 +38,7 @@ func TestIntents(t *testing.T) {
 
 	config.UseTestFile()
 	testutils.NeedCouchdb(t)
-	setup := testutils.NewSetup(nil, t.Name())
+	setup := testutils.NewSetup(t, t.Name())
 	t.Cleanup(setup.Cleanup)
 	ins = setup.GetTestInstance(&lifecycle.Options{
 		Domain: "cozy.example.net",

--- a/web/jobs/jobs_test.go
+++ b/web/jobs/jobs_test.go
@@ -49,7 +49,7 @@ func TestJobs(t *testing.T) {
 
 	config.UseTestFile()
 	testutils.NeedCouchdb(t)
-	setup := testutils.NewSetup(nil, t.Name())
+	setup := testutils.NewSetup(t, t.Name())
 	t.Cleanup(setup.Cleanup)
 
 	job.AddWorker(&job.WorkerConfig{

--- a/web/jobs/jobs_test.go
+++ b/web/jobs/jobs_test.go
@@ -50,7 +50,6 @@ func TestJobs(t *testing.T) {
 	config.UseTestFile()
 	testutils.NeedCouchdb(t)
 	setup := testutils.NewSetup(t, t.Name())
-	t.Cleanup(setup.Cleanup)
 
 	job.AddWorker(&job.WorkerConfig{
 		WorkerType:  "print",

--- a/web/middlewares/setup_test.go
+++ b/web/middlewares/setup_test.go
@@ -18,7 +18,7 @@ func TestSetup(t *testing.T) {
 
 	config.UseTestFile()
 	config.GetConfig().Assets = "../../assets"
-	setup := testutils.NewSetup(nil, t.Name())
+	setup := testutils.NewSetup(t, t.Name())
 	t.Cleanup(setup.Cleanup)
 
 	require.NoError(t, setup.SetupSwiftTest(), "Could not init Swift test")

--- a/web/middlewares/setup_test.go
+++ b/web/middlewares/setup_test.go
@@ -19,7 +19,6 @@ func TestSetup(t *testing.T) {
 	config.UseTestFile()
 	config.GetConfig().Assets = "../../assets"
 	setup := testutils.NewSetup(t, t.Name())
-	t.Cleanup(setup.Cleanup)
 
 	require.NoError(t, setup.SetupSwiftTest(), "Could not init Swift test")
 	require.NoError(t, dynamic.InitDynamicAssetFS(), "Could not init dynamic FS")

--- a/web/notes/notes_test.go
+++ b/web/notes/notes_test.go
@@ -42,7 +42,6 @@ func TestNotes(t *testing.T) {
 	config.UseTestFile()
 	testutils.NeedCouchdb(t)
 	setup := testutils.NewSetup(t, t.Name())
-	t.Cleanup(setup.Cleanup)
 	inst = setup.GetTestInstance()
 	_, token = setup.GetTestClient(consts.Files)
 

--- a/web/notes/notes_test.go
+++ b/web/notes/notes_test.go
@@ -41,7 +41,7 @@ func TestNotes(t *testing.T) {
 
 	config.UseTestFile()
 	testutils.NeedCouchdb(t)
-	setup := testutils.NewSetup(nil, t.Name())
+	setup := testutils.NewSetup(t, t.Name())
 	t.Cleanup(setup.Cleanup)
 	inst = setup.GetTestInstance()
 	_, token = setup.GetTestClient(consts.Files)

--- a/web/office/office_test.go
+++ b/web/office/office_test.go
@@ -43,7 +43,7 @@ func TestOffice(t *testing.T) {
 		"default": {OnlyOfficeURL: ooURL},
 	}
 	testutils.NeedCouchdb(t)
-	setup := testutils.NewSetup(nil, t.Name())
+	setup := testutils.NewSetup(t, t.Name())
 	t.Cleanup(setup.Cleanup)
 	inst = setup.GetTestInstance()
 	_, token = setup.GetTestClient(consts.Files)

--- a/web/office/office_test.go
+++ b/web/office/office_test.go
@@ -44,7 +44,6 @@ func TestOffice(t *testing.T) {
 	}
 	testutils.NeedCouchdb(t)
 	setup := testutils.NewSetup(t, t.Name())
-	t.Cleanup(setup.Cleanup)
 	inst = setup.GetTestInstance()
 	_, token = setup.GetTestClient(consts.Files)
 

--- a/web/oidc/oidc_test.go
+++ b/web/oidc/oidc_test.go
@@ -34,7 +34,7 @@ func TestOidc(t *testing.T) {
 	config.UseTestFile()
 	config.GetConfig().Assets = "../../assets"
 	testutils.NeedCouchdb(t)
-	setup := testutils.NewSetup(nil, t.Name())
+	setup := testutils.NewSetup(t, t.Name())
 	t.Cleanup(setup.Cleanup)
 	render, _ := statik.NewDirRenderer("../../assets")
 	middlewares.BuildTemplates()

--- a/web/oidc/oidc_test.go
+++ b/web/oidc/oidc_test.go
@@ -35,7 +35,6 @@ func TestOidc(t *testing.T) {
 	config.GetConfig().Assets = "../../assets"
 	testutils.NeedCouchdb(t)
 	setup := testutils.NewSetup(t, t.Name())
-	t.Cleanup(setup.Cleanup)
 	render, _ := statik.NewDirRenderer("../../assets")
 	middlewares.BuildTemplates()
 

--- a/web/permissions/permissions_test.go
+++ b/web/permissions/permissions_test.go
@@ -44,7 +44,6 @@ func TestPermissions(t *testing.T) {
 	config.UseTestFile()
 	testutils.NeedCouchdb(t)
 	setup := testutils.NewSetup(t, t.Name())
-	t.Cleanup(setup.Cleanup)
 
 	testInstance = setup.GetTestInstance()
 	scopes := "io.cozy.contacts io.cozy.files:GET io.cozy.events"

--- a/web/permissions/permissions_test.go
+++ b/web/permissions/permissions_test.go
@@ -43,7 +43,7 @@ func TestPermissions(t *testing.T) {
 
 	config.UseTestFile()
 	testutils.NeedCouchdb(t)
-	setup := testutils.NewSetup(nil, t.Name())
+	setup := testutils.NewSetup(t, t.Name())
 	t.Cleanup(setup.Cleanup)
 
 	testInstance = setup.GetTestInstance()

--- a/web/realtime/realtime_test.go
+++ b/web/realtime/realtime_test.go
@@ -34,7 +34,7 @@ func TestRealtime(t *testing.T) {
 
 	config.UseTestFile()
 	testutils.NeedCouchdb(t)
-	setup := testutils.NewSetup(nil, t.Name())
+	setup := testutils.NewSetup(t, t.Name())
 	t.Cleanup(setup.Cleanup)
 	inst = setup.GetTestInstance()
 	_, token = setup.GetTestClient("io.cozy.foos io.cozy.bars io.cozy.bazs")

--- a/web/realtime/realtime_test.go
+++ b/web/realtime/realtime_test.go
@@ -35,7 +35,6 @@ func TestRealtime(t *testing.T) {
 	config.UseTestFile()
 	testutils.NeedCouchdb(t)
 	setup := testutils.NewSetup(t, t.Name())
-	t.Cleanup(setup.Cleanup)
 	inst = setup.GetTestInstance()
 	_, token = setup.GetTestClient("io.cozy.foos io.cozy.bars io.cozy.bazs")
 	ts = setup.GetTestServer("/realtime", Routes)

--- a/web/remote/remote_test.go
+++ b/web/remote/remote_test.go
@@ -27,7 +27,6 @@ func TestRemote(t *testing.T) {
 	config.UseTestFile()
 	testutils.NeedCouchdb(t)
 	setup := testutils.NewSetup(t, t.Name())
-	t.Cleanup(setup.Cleanup)
 
 	testInstance = setup.GetTestInstance()
 	token = generateAppToken(testInstance, "answers", "org.wikidata.entity")

--- a/web/remote/remote_test.go
+++ b/web/remote/remote_test.go
@@ -26,7 +26,7 @@ func TestRemote(t *testing.T) {
 
 	config.UseTestFile()
 	testutils.NeedCouchdb(t)
-	setup := testutils.NewSetup(nil, t.Name())
+	setup := testutils.NewSetup(t, t.Name())
 	t.Cleanup(setup.Cleanup)
 
 	testInstance = setup.GetTestInstance()

--- a/web/routing_test.go
+++ b/web/routing_test.go
@@ -24,7 +24,7 @@ func TestRouting(t *testing.T) {
 	config.UseTestFile()
 	config.GetConfig().Assets = "../assets"
 	testutils.NeedCouchdb(t)
-	setup := testutils.NewSetup(nil, t.Name())
+	setup := testutils.NewSetup(t, t.Name())
 	t.Cleanup(setup.Cleanup)
 	inst := setup.GetTestInstance()
 	domain = inst.Domain

--- a/web/routing_test.go
+++ b/web/routing_test.go
@@ -25,7 +25,6 @@ func TestRouting(t *testing.T) {
 	config.GetConfig().Assets = "../assets"
 	testutils.NeedCouchdb(t)
 	setup := testutils.NewSetup(t, t.Name())
-	t.Cleanup(setup.Cleanup)
 	inst := setup.GetTestInstance()
 	domain = inst.Domain
 	require.NoError(t, dynamic.InitDynamicAssetFS(), "Could not init dynamic FS")

--- a/web/settings/settings_test.go
+++ b/web/settings/settings_test.go
@@ -47,7 +47,6 @@ func TestSettings(t *testing.T) {
 	config.UseTestFile()
 	testutils.NeedCouchdb(t)
 	setup := testutils.NewSetup(t, t.Name())
-	t.Cleanup(setup.Cleanup)
 	testInstance = setup.GetTestInstance(&lifecycle.Options{
 		Locale:      "en",
 		Timezone:    "Europe/Berlin",
@@ -72,7 +71,6 @@ func TestSettings(t *testing.T) {
 	tsB.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler
 
 	setupFlagship := testutils.NewSetup(t, t.Name())
-	t.Cleanup(setup.Cleanup)
 	testInstanceFlagship = setupFlagship.GetTestInstance(&lifecycle.Options{
 		Locale:      "en",
 		Timezone:    "Europe/Berlin",

--- a/web/settings/settings_test.go
+++ b/web/settings/settings_test.go
@@ -46,7 +46,7 @@ func TestSettings(t *testing.T) {
 
 	config.UseTestFile()
 	testutils.NeedCouchdb(t)
-	setup := testutils.NewSetup(nil, t.Name())
+	setup := testutils.NewSetup(t, t.Name())
 	t.Cleanup(setup.Cleanup)
 	testInstance = setup.GetTestInstance(&lifecycle.Options{
 		Locale:      "en",
@@ -71,7 +71,7 @@ func TestSettings(t *testing.T) {
 	})
 	tsB.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler
 
-	setupFlagship := testutils.NewSetup(nil, t.Name())
+	setupFlagship := testutils.NewSetup(t, t.Name())
 	t.Cleanup(setup.Cleanup)
 	testInstanceFlagship = setupFlagship.GetTestInstance(&lifecycle.Options{
 		Locale:      "en",

--- a/web/sharings/replicator_test.go
+++ b/web/sharings/replicator_test.go
@@ -60,7 +60,7 @@ func TestReplicator(t *testing.T) {
 	middlewares.BuildTemplates()
 
 	// Prepare Alice's instance
-	setup := testutils.NewSetup(nil, t.Name()+"_alice")
+	setup := testutils.NewSetup(t, t.Name()+"_alice")
 	aliceInstance = setup.GetTestInstance(&lifecycle.Options{
 		Email:      "alice@example.net",
 		PublicName: "Alice",
@@ -84,7 +84,7 @@ func TestReplicator(t *testing.T) {
 	}
 
 	// Prepare another instance for the replicator tests
-	replSetup := testutils.NewSetup(nil, t.Name()+"_replicator")
+	replSetup := testutils.NewSetup(t, t.Name()+"_replicator")
 	replInstance = replSetup.GetTestInstance()
 	tsR = replSetup.GetTestServerMultipleRoutes(map[string]func(*echo.Group){
 		"/sharings": sharings.Routes,

--- a/web/sharings/replicator_test.go
+++ b/web/sharings/replicator_test.go
@@ -91,12 +91,6 @@ func TestReplicator(t *testing.T) {
 	})
 
 	require.NoError(t, dynamic.InitDynamicAssetFS(), "Could not init dynamic FS")
-
-	setup.AddCleanup(func() error {
-		replSetup.Cleanup()
-		return nil
-	})
-
 	t.Run("CreateSharingForReplicatorTest", func(t *testing.T) {
 		rule := sharing.Rule{
 			Title:    "tests",

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -71,7 +71,7 @@ func TestSharings(t *testing.T) {
 	middlewares.BuildTemplates()
 
 	// Prepare Alice's instance
-	setup := testutils.NewSetup(nil, t.Name()+"_alice")
+	setup := testutils.NewSetup(t, t.Name()+"_alice")
 	t.Cleanup(setup.Cleanup)
 	aliceInstance = setup.GetTestInstance(&lifecycle.Options{
 		Email:      "alice@example.net",
@@ -96,7 +96,7 @@ func TestSharings(t *testing.T) {
 	}
 
 	// Prepare Bob's instance
-	bobSetup := testutils.NewSetup(nil, t.Name()+"_bob")
+	bobSetup := testutils.NewSetup(t, t.Name()+"_bob")
 	t.Cleanup(bobSetup.Cleanup)
 	bobInstance = bobSetup.GetTestInstance(&lifecycle.Options{
 		Email:         "bob@example.net",

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -72,7 +72,6 @@ func TestSharings(t *testing.T) {
 
 	// Prepare Alice's instance
 	setup := testutils.NewSetup(t, t.Name()+"_alice")
-	t.Cleanup(setup.Cleanup)
 	aliceInstance = setup.GetTestInstance(&lifecycle.Options{
 		Email:      "alice@example.net",
 		PublicName: "Alice",
@@ -97,7 +96,6 @@ func TestSharings(t *testing.T) {
 
 	// Prepare Bob's instance
 	bobSetup := testutils.NewSetup(t, t.Name()+"_bob")
-	t.Cleanup(bobSetup.Cleanup)
 	bobInstance = bobSetup.GetTestInstance(&lifecycle.Options{
 		Email:         "bob@example.net",
 		PublicName:    "Bob",
@@ -118,11 +116,6 @@ func TestSharings(t *testing.T) {
 	tsB.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler
 
 	require.NoError(t, dynamic.InitDynamicAssetFS(), "Could not init dynamic FS")
-
-	setup.AddCleanup(func() error {
-		bobSetup.Cleanup()
-		return nil
-	})
 
 	t.Run("CreateSharingSuccess", func(t *testing.T) {
 		bobContact := createBobContact()

--- a/web/shortcuts/shortcuts_test.go
+++ b/web/shortcuts/shortcuts_test.go
@@ -32,7 +32,6 @@ func TestShortcuts(t *testing.T) {
 	config.UseTestFile()
 	testutils.NeedCouchdb(t)
 	setup := testutils.NewSetup(t, t.Name())
-	t.Cleanup(setup.Cleanup)
 	inst = setup.GetTestInstance()
 	_, token = setup.GetTestClient(consts.Files)
 

--- a/web/shortcuts/shortcuts_test.go
+++ b/web/shortcuts/shortcuts_test.go
@@ -31,7 +31,7 @@ func TestShortcuts(t *testing.T) {
 
 	config.UseTestFile()
 	testutils.NeedCouchdb(t)
-	setup := testutils.NewSetup(nil, t.Name())
+	setup := testutils.NewSetup(t, t.Name())
 	t.Cleanup(setup.Cleanup)
 	inst = setup.GetTestInstance()
 	_, token = setup.GetTestClient(consts.Files)

--- a/worker/archive/unzip_test.go
+++ b/worker/archive/unzip_test.go
@@ -20,7 +20,6 @@ func Test_archive(t *testing.T) {
 
 	config.UseTestFile()
 	setup := testutils.NewSetup(t, t.Name())
-	t.Cleanup(setup.Cleanup)
 
 	inst := setup.GetTestInstance()
 

--- a/worker/archive/unzip_test.go
+++ b/worker/archive/unzip_test.go
@@ -19,7 +19,7 @@ func Test_archive(t *testing.T) {
 	}
 
 	config.UseTestFile()
-	setup := testutils.NewSetup(nil, t.Name())
+	setup := testutils.NewSetup(t, t.Name())
 	t.Cleanup(setup.Cleanup)
 
 	inst := setup.GetTestInstance()

--- a/worker/exec/konnector_test.go
+++ b/worker/exec/konnector_test.go
@@ -32,7 +32,6 @@ func TestExecKonnector(t *testing.T) {
 	config.UseTestFile()
 
 	setup := testutils.NewSetup(t, t.Name())
-	t.Cleanup(setup.Cleanup)
 
 	inst := setup.GetTestInstance()
 

--- a/worker/exec/konnector_test.go
+++ b/worker/exec/konnector_test.go
@@ -31,7 +31,7 @@ func TestExecKonnector(t *testing.T) {
 
 	config.UseTestFile()
 
-	setup := testutils.NewSetup(nil, t.Name())
+	setup := testutils.NewSetup(t, t.Name())
 	t.Cleanup(setup.Cleanup)
 
 	inst := setup.GetTestInstance()

--- a/worker/mails/mail_test.go
+++ b/worker/mails/mail_test.go
@@ -37,7 +37,7 @@ func TestMails(t *testing.T) {
 
 	config.UseTestFile()
 
-	setup := testutils.NewSetup(nil, t.Name())
+	setup := testutils.NewSetup(t, t.Name())
 	t.Cleanup(setup.Cleanup)
 
 	inst := setup.GetTestInstance(&lifecycle.Options{Email: "me@me"})

--- a/worker/mails/mail_test.go
+++ b/worker/mails/mail_test.go
@@ -38,7 +38,6 @@ func TestMails(t *testing.T) {
 	config.UseTestFile()
 
 	setup := testutils.NewSetup(t, t.Name())
-	t.Cleanup(setup.Cleanup)
 
 	inst := setup.GetTestInstance(&lifecycle.Options{Email: "me@me"})
 


### PR DESCRIPTION
This package refactoring come after the tests migration to the subtest pattern instead of the use of `TestMain`.

Now we can leverage the use of the `testing.T` type.