### PR TITLE
Refactor the `vfs` test inits

### DIFF
--- a/model/vfs/permissions_test.go
+++ b/model/vfs/permissions_test.go
@@ -21,13 +21,8 @@ func TestPermissions(t *testing.T) {
 	config.UseTestFile()
 	testutils.NeedCouchdb(t)
 
-	aferoFS, aferoRollback, err := makeAferoFS()
-	t.Cleanup(aferoRollback)
-	require.NoError(t, err)
-
-	swiftFS, swiftRollback, err := makeSwiftFS(2)
-	t.Cleanup(swiftRollback)
-	require.NoError(t, err)
+	aferoFS := makeAferoFS(t)
+	swiftFS := makeSwiftFS(t, 2)
 
 	var tests = []struct {
 		name string


### PR DESCRIPTION
This allow to remove the last use of `os.MkdirTemp` inside the tests