### PR TITLE
Enable the exitAfterDefer lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -62,8 +62,5 @@ linters-settings:
   gocritic:
     disabled-checks:
       - appendAssign
-        # TODO: Remove all the defer from the `TestMain` functions or refactor
-        # the tests and avoid the use of `TestMain` with `os.Exit`
-      - exitAfterDefer 
       - ifElseChain
       - argOrder


### PR DESCRIPTION
This lint was not deactivated due to the use of the `TestMain` functions. Now we can enable it again and be sure that the tests are correctly cleanup.