### PR TITLE
fix: Return member with interact permissions

### DIFF
--- a/web/permissions/permissions.go
+++ b/web/permissions/permissions.go
@@ -85,7 +85,7 @@ func displayPermissions(c echo.Context) error {
 
 	// Include the sharing member (when relevant)
 	var included []jsonapi.Object
-	if doc.Type == permission.TypeSharePreview {
+	if doc.Type == permission.TypeSharePreview || doc.Type == permission.TypeShareInteract {
 		inst := middlewares.GetInstance(c)
 		sharingID := strings.TrimPrefix(doc.SourceID, consts.Sharings+"/")
 		if s, err := sharing.FindSharing(inst, sharingID); err == nil {


### PR DESCRIPTION
When returning permissions from an interact sharecode, we'll return
the associated sharing member in the `included` part of the response
like we already do with preview sharecodes.