### PR TITLE
Add the `context.Context` arg support for the `pkg/couchdb` package

### DIFF
--- a/model/account/accounts.go
+++ b/model/account/accounts.go
@@ -1,6 +1,7 @@
 package account
 
 import (
+	"context"
 	"encoding/json"
 	"net/url"
 	"time"
@@ -324,7 +325,7 @@ func createSoftDeletedAccount(db prefixer.Prefixer, old couchdb.Doc) {
 	if err := createNamedDocWithDB(db, cloned); err != nil {
 		logger.WithDomain(db.DomainName()).Errorf("Failed to soft-delete account: %s", err)
 	}
-	if err := couchdb.Compact(db, consts.Accounts); err != nil {
+	if err := couchdb.Compact(context.TODO(), db, consts.Accounts); err != nil {
 		logger.WithDomain(db.DomainName()).Infof("Failed to compact accounts: %s", err)
 	}
 }

--- a/model/app/installer_webapp_test.go
+++ b/model/app/installer_webapp_test.go
@@ -980,7 +980,7 @@ func TestInstallerWebApp(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Contains(t, man.Version(), "1.0.0")
 
-		t1, err := couchdb.CountAllDocs(instance, consts.Triggers)
+		t1, err := couchdb.CountAllDocs(context.TODO(), instance, consts.Triggers)
 		assert.NoError(t, err)
 
 		// Update the app, but with new perms. The app should stay on the same
@@ -996,7 +996,7 @@ func TestInstallerWebApp(t *testing.T) {
 
 		man, err = inst2.RunSync()
 		assert.NoError(t, err)
-		t2, err := couchdb.CountAllDocs(instance, consts.Triggers)
+		t2, err := couchdb.CountAllDocs(context.TODO(), instance, consts.Triggers)
 		assert.NoError(t, err)
 
 		assert.Contains(t, man.Version(), "1.0.0")

--- a/model/app/konnector.go
+++ b/model/app/konnector.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/url"
@@ -416,7 +417,7 @@ func ListKonnectorsWithPagination(db prefixer.Prefixer, limit int, startKey stri
 		Limit:    limit + 1, // Also get the following document for the next key
 		StartKey: startKey,
 	}
-	err := couchdb.GetAllDocs(db, consts.Konnectors, req, &docs)
+	err := couchdb.GetAllDocs(context.TODO(), db, consts.Konnectors, req, &docs)
 	if err != nil {
 		return nil, "", err
 	}

--- a/model/app/maintenance.go
+++ b/model/app/maintenance.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/cozy/cozy-stack/pkg/consts"
@@ -66,7 +67,7 @@ func GetMaintenanceOptions(slug string) (map[string]interface{}, error) {
 // (not from apps registry).
 func ListMaintenance() ([]map[string]interface{}, error) {
 	list := []map[string]interface{}{}
-	err := couchdb.ForeachDocs(prefixer.GlobalPrefixer, consts.KonnectorsMaintenance, func(id string, raw json.RawMessage) error {
+	err := couchdb.ForeachDocs(context.TODO(), prefixer.GlobalPrefixer, consts.KonnectorsMaintenance, func(id string, raw json.RawMessage) error {
 		var opts map[string]interface{}
 		if err := json.Unmarshal(raw, &opts); err != nil {
 			return err

--- a/model/app/webapp.go
+++ b/model/app/webapp.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -624,7 +625,7 @@ func ListWebappsWithPagination(db prefixer.Prefixer, limit int, startKey string)
 		Limit:    limit + 1, // Also get the following document for the next key
 		StartKey: startKey,
 	}
-	err := couchdb.GetAllDocs(db, consts.Apps, req, &docs)
+	err := couchdb.GetAllDocs(context.TODO(), db, consts.Apps, req, &docs)
 	if err != nil {
 		return nil, "", err
 	}

--- a/model/bi/webhook.go
+++ b/model/bi/webhook.go
@@ -1,6 +1,7 @@
 package bi
 
 import (
+	"context"
 	"crypto/subtle"
 	"encoding/json"
 	"errors"
@@ -69,7 +70,7 @@ type WebhookCall struct {
 // a io.cozy.trigger, and launch a job for them if needed.
 func (c *WebhookCall) Fire() error {
 	var accounts []*account.Account
-	if err := couchdb.GetAllDocs(c.Instance, consts.Accounts, nil, &accounts); err != nil {
+	if err := couchdb.GetAllDocs(context.TODO(), c.Instance, consts.Accounts, nil, &accounts); err != nil {
 		return err
 	}
 	c.accounts = accounts

--- a/model/bitwarden/cipher.go
+++ b/model/bitwarden/cipher.go
@@ -181,7 +181,7 @@ func DeleteUnrecoverableCiphers(inst *instance.Instance) error {
 		}
 		return err
 	}
-	return couchdb.BulkDeleteDocs(inst, consts.BitwardenCiphers, ciphers)
+	return couchdb.BulkDeleteDocs(context.TODO(), inst, consts.BitwardenCiphers, ciphers)
 }
 
 var _ couchdb.Doc = &Cipher{}

--- a/model/bitwarden/cipher.go
+++ b/model/bitwarden/cipher.go
@@ -1,6 +1,7 @@
 package bitwarden
 
 import (
+	"context"
 	"encoding/json"
 	"strconv"
 	"time"
@@ -164,7 +165,7 @@ func FindCiphersInFolder(inst *instance.Instance, folderID string) ([]*Cipher, e
 // lost, as there are no ways to recover those encrypted ciphers.
 func DeleteUnrecoverableCiphers(inst *instance.Instance) error {
 	var ciphers []couchdb.Doc
-	err := couchdb.ForeachDocs(inst, consts.BitwardenCiphers, func(_ string, data json.RawMessage) error {
+	err := couchdb.ForeachDocs(context.TODO(), inst, consts.BitwardenCiphers, func(_ string, data json.RawMessage) error {
 		var c Cipher
 		if err := json.Unmarshal(data, &c); err != nil {
 			return err

--- a/model/bitwarden/cipher_test.go
+++ b/model/bitwarden/cipher_test.go
@@ -1,6 +1,7 @@
 package bitwarden
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -59,7 +60,7 @@ func TestCipher(t *testing.T) {
 
 		assert.NoError(t, DeleteUnrecoverableCiphers(inst))
 		var ciphers []*Cipher
-		err = couchdb.GetAllDocs(inst, consts.BitwardenCiphers, nil, &ciphers)
+		err = couchdb.GetAllDocs(context.TODO(), inst, consts.BitwardenCiphers, nil, &ciphers)
 		assert.NoError(t, err)
 		assert.Len(t, ciphers, 3)
 		for _, c := range ciphers {

--- a/model/bitwarden/organization.go
+++ b/model/bitwarden/organization.go
@@ -109,7 +109,7 @@ func (o *Organization) Delete(inst *instance.Instance) error {
 	for i := range ciphers {
 		docs[i] = ciphers[i].Clone()
 	}
-	if err := couchdb.BulkDeleteDocs(inst, consts.BitwardenCiphers, docs); err != nil {
+	if err := couchdb.BulkDeleteDocs(context.TODO(), inst, consts.BitwardenCiphers, docs); err != nil {
 		return err
 	}
 

--- a/model/bitwarden/organization.go
+++ b/model/bitwarden/organization.go
@@ -1,6 +1,7 @@
 package bitwarden
 
 import (
+	"context"
 	"errors"
 
 	"github.com/cozy/cozy-stack/model/bitwarden/settings"
@@ -177,7 +178,7 @@ func GetCozyOrganization(inst *instance.Instance, setting *settings.Settings) (*
 func FindAllOrganizations(inst *instance.Instance, setting *settings.Settings) ([]*Organization, error) {
 	var orgs []*Organization
 	req := &couchdb.AllDocsRequest{}
-	if err := couchdb.GetAllDocs(inst, consts.BitwardenOrganizations, req, &orgs); err != nil {
+	if err := couchdb.GetAllDocs(context.TODO(), inst, consts.BitwardenOrganizations, req, &orgs); err != nil {
 		if couchdb.IsNoDatabaseError(err) {
 			_ = couchdb.CreateDB(inst, consts.BitwardenOrganizations)
 		} else {

--- a/model/instance/instance.go
+++ b/model/instance/instance.go
@@ -581,7 +581,7 @@ func List() ([]*Instance, error) {
 
 // ForeachInstances execute the given callback for each instances.
 func ForeachInstances(fn func(*Instance) error) error {
-	return couchdb.ForeachDocsWithCustomPagination(prefixer.GlobalPrefixer, consts.Instances, 10000, func(_ string, data json.RawMessage) error {
+	return couchdb.ForeachDocsWithCustomPagination(context.TODO(), prefixer.GlobalPrefixer, consts.Instances, 10000, func(_ string, data json.RawMessage) error {
 		var doc *Instance
 		if err := json.Unmarshal(data, &doc); err != nil {
 			return err

--- a/model/instance/instance.go
+++ b/model/instance/instance.go
@@ -1,6 +1,7 @@
 package instance
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -599,7 +600,7 @@ func PaginatedList(limit int, startKey string, skip int) ([]*Instance, string, e
 		StartKey: startKey,
 		Skip:     skip,
 	}
-	err := couchdb.GetAllDocs(prefixer.GlobalPrefixer, consts.Instances, req, &docs)
+	err := couchdb.GetAllDocs(context.TODO(), prefixer.GlobalPrefixer, consts.Instances, req, &docs)
 	if err != nil {
 		return nil, "", err
 	}

--- a/model/instance/lifecycle/destroy.go
+++ b/model/instance/lifecycle/destroy.go
@@ -1,6 +1,7 @@
 package lifecycle
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 	"time"
@@ -125,7 +126,7 @@ func destroyWithoutHooks(domain string) error {
 
 func deleteAccounts(inst *instance.Instance) error {
 	var accounts []*account.Account
-	if err := couchdb.GetAllDocs(inst, consts.Accounts, nil, &accounts); err != nil {
+	if err := couchdb.GetAllDocs(context.TODO(), inst, consts.Accounts, nil, &accounts); err != nil {
 		if couchdb.IsNoDatabaseError(err) {
 			return nil
 		}

--- a/model/job/broker.go
+++ b/model/job/broker.go
@@ -389,7 +389,7 @@ func GetAllJobs(db prefixer.Prefixer) ([]*Job, error) {
 			StartKey: startkey,
 		}
 
-		err := couchdb.GetAllDocs(db, consts.Jobs, req, &jobs)
+		err := couchdb.GetAllDocs(context.TODO(), db, consts.Jobs, req, &jobs)
 		if err != nil {
 			return nil, err
 		}

--- a/model/job/mem_scheduler.go
+++ b/model/job/mem_scheduler.go
@@ -65,12 +65,12 @@ func (s *memScheduler) StartScheduler(b Broker) error {
 	}
 
 	var ts []*TriggerInfos
-	err := couchdb.ForeachDocs(prefixer.GlobalPrefixer, consts.Instances, func(_ string, data json.RawMessage) error {
+	err := couchdb.ForeachDocs(context.TODO(), prefixer.GlobalPrefixer, consts.Instances, func(_ string, data json.RawMessage) error {
 		db := &instance.Instance{}
 		if err := json.Unmarshal(data, db); err != nil {
 			return err
 		}
-		err := couchdb.ForeachDocs(db, consts.Triggers, func(_ string, data json.RawMessage) error {
+		err := couchdb.ForeachDocs(context.TODO(), db, consts.Triggers, func(_ string, data json.RawMessage) error {
 			var t *TriggerInfos
 			if err := json.Unmarshal(data, &t); err != nil {
 				return err

--- a/model/job/redis_scheduler.go
+++ b/model/job/redis_scheduler.go
@@ -481,7 +481,7 @@ func (s *redisScheduler) deleteTrigger(t Trigger) error {
 // GetAllTriggers returns all the triggers for a domain, from couch.
 func (s *redisScheduler) GetAllTriggers(db prefixer.Prefixer) ([]Trigger, error) {
 	var infos []*TriggerInfos
-	err := couchdb.ForeachDocs(db, consts.Triggers, func(_ string, data json.RawMessage) error {
+	err := couchdb.ForeachDocs(context.TODO(), db, consts.Triggers, func(_ string, data json.RawMessage) error {
 		var t *TriggerInfos
 		if err := json.Unmarshal(data, &t); err != nil {
 			return err

--- a/model/move/cursor.go
+++ b/model/move/cursor.go
@@ -1,6 +1,7 @@
 package move
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -91,7 +92,7 @@ func listFilesFromCursor(inst *instance.Instance, exportDoc *ExportDoc, start Cu
 	}
 	for {
 		var results []*vfs.FileDoc
-		if err := couchdb.GetAllDocs(inst, consts.Files, &req, &results); err != nil {
+		if err := couchdb.GetAllDocs(context.TODO(), inst, consts.Files, &req, &results); err != nil {
 			return nil, err
 		}
 		if len(results) == 0 {
@@ -139,7 +140,7 @@ func listVersionsFromCursor(inst *instance.Instance, exportDoc *ExportDoc, start
 	}
 	for {
 		var results []*vfs.Version
-		if err := couchdb.GetAllDocs(inst, consts.FilesVersions, &req, &results); err != nil {
+		if err := couchdb.GetAllDocs(context.TODO(), inst, consts.FilesVersions, &req, &results); err != nil {
 			return nil, err
 		}
 		if len(results) == 0 {

--- a/model/move/export.go
+++ b/model/move/export.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"archive/zip"
 	"compress/gzip"
+	"context"
 	"encoding/json"
 	"io"
 	"net/url"
@@ -385,7 +386,7 @@ func exportFiles(i *instance.Instance, exportDoc *ExportDoc, tw *tar.Writer) (in
 	}
 
 	versions := make(map[string]int64)
-	err = couchdb.ForeachDocs(i, consts.FilesVersions, func(id string, raw json.RawMessage) error {
+	err = couchdb.ForeachDocs(context.TODO(), i, consts.FilesVersions, func(id string, raw json.RawMessage) error {
 		var doc vfs.Version
 		if err := json.Unmarshal(raw, &doc); err != nil {
 			return err
@@ -425,7 +426,7 @@ func exportDocuments(in *instance.Instance, doc *ExportDoc, now time.Time, tw *t
 			continue
 		}
 		dir := url.PathEscape(doctype)
-		err := couchdb.ForeachDocs(in, doctype, func(id string, doc json.RawMessage) error {
+		err := couchdb.ForeachDocs(context.TODO(), in, doctype, func(id string, doc json.RawMessage) error {
 			n, err := writeMarshaledDoc(dir, id, doc, now, tw)
 			if err == nil {
 				size += n

--- a/model/move/export_test.go
+++ b/model/move/export_test.go
@@ -1,6 +1,7 @@
 package move
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"path"
@@ -51,7 +52,7 @@ func TestExport(t *testing.T) {
 		assert.NoError(t, err)
 		populateTree(t, fs, root, nbFiles)
 
-		nbVersions, err := couchdb.CountNormalDocs(inst, consts.FilesVersions)
+		nbVersions, err := couchdb.CountNormalDocs(context.TODO(), inst, consts.FilesVersions)
 		assert.NoError(t, err)
 
 		// /* Uncomment this section for debug */

--- a/model/move/importer.go
+++ b/model/move/importer.go
@@ -2,6 +2,7 @@ package move
 
 import (
 	"archive/zip"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -229,11 +230,11 @@ func (im *importer) flush() error {
 	}
 
 	olds := make([]interface{}, len(im.docs))
-	if err := couchdb.BulkUpdateDocs(im.inst, im.doctype, im.docs, olds); err != nil {
+	if err := couchdb.BulkUpdateDocs(context.TODO(), im.inst, im.doctype, im.docs, olds); err != nil {
 		// XXX CouchDB can be overloaded sometimes when importing lots of documents.
 		// Let's wait a bit and retry...
 		time.Sleep(10 * time.Minute)
-		if err = couchdb.BulkUpdateDocs(im.inst, im.doctype, im.docs, olds); err != nil {
+		if err = couchdb.BulkUpdateDocs(context.TODO(), im.inst, im.doctype, im.docs, olds); err != nil {
 			return err
 		}
 	}
@@ -286,7 +287,7 @@ func (im *importer) importAccount(zf *zip.File) error {
 	if err := couchdb.EnsureDBExist(im.inst, consts.Accounts); err != nil {
 		return err
 	}
-	return couchdb.BulkUpdateDocs(im.inst, consts.Accounts, docs, olds)
+	return couchdb.BulkUpdateDocs(context.TODO(), im.inst, consts.Accounts, docs, olds)
 }
 
 func (im *importer) readTrigger(zf *zip.File) (*job.TriggerInfos, error) {

--- a/model/move/sharing.go
+++ b/model/move/sharing.go
@@ -2,6 +2,7 @@ package move
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -30,7 +31,7 @@ func NotifySharings(inst *instance.Instance) error {
 
 	var sharings []*sharing.Sharing
 	req := couchdb.AllDocsRequest{Limit: 1000}
-	if err := couchdb.GetAllDocs(inst, consts.Sharings, &req, &sharings); err != nil {
+	if err := couchdb.GetAllDocs(context.TODO(), inst, consts.Sharings, &req, &sharings); err != nil {
 		return err
 	}
 

--- a/model/note/delete.go
+++ b/model/note/delete.go
@@ -1,6 +1,8 @@
 package note
 
 import (
+	"context"
+
 	"github.com/cozy/cozy-stack/model/instance"
 	"github.com/cozy/cozy-stack/model/vfs"
 	"github.com/cozy/cozy-stack/pkg/consts"
@@ -36,7 +38,7 @@ func deleteNote(db prefixer.Prefixer, noteID string) {
 			for i := range steps {
 				docs = append(docs, &steps[i])
 			}
-			_ = couchdb.BulkDeleteDocs(db, consts.NotesSteps, docs)
+			_ = couchdb.BulkDeleteDocs(context.TODO(), db, consts.NotesSteps, docs)
 		}
 	}()
 }

--- a/model/note/image.go
+++ b/model/note/image.go
@@ -1,6 +1,7 @@
 package note
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"path"
@@ -205,7 +206,7 @@ func getImages(db prefixer.Prefixer, fileID string) ([]*Image, error) {
 		StartKey: startkey(fileID),
 		EndKey:   endkey(fileID),
 	}
-	if err := couchdb.GetAllDocs(db, consts.NotesImages, &req, &images); err != nil {
+	if err := couchdb.GetAllDocs(context.TODO(), db, consts.NotesImages, &req, &images); err != nil {
 		return nil, err
 	}
 	return images, nil

--- a/model/note/step.go
+++ b/model/note/step.go
@@ -248,7 +248,7 @@ func purgeOldSteps(inst *instance.Instance, fileID string) {
 	if len(docs) == 0 {
 		return
 	}
-	if err := couchdb.BulkDeleteDocs(inst, consts.NotesSteps, docs); err != nil {
+	if err := couchdb.BulkDeleteDocs(context.TODO(), inst, consts.NotesSteps, docs); err != nil {
 		inst.Logger().WithNamespace("notes").
 			Warnf("Cannot purge old steps for file %s: %s", fileID, err)
 	}
@@ -275,7 +275,7 @@ func purgeAllSteps(inst *instance.Instance, fileID string) {
 		return
 	}
 
-	if err := couchdb.BulkDeleteDocs(inst, consts.NotesSteps, docs); err != nil {
+	if err := couchdb.BulkDeleteDocs(context.TODO(), inst, consts.NotesSteps, docs); err != nil {
 		inst.Logger().WithNamespace("notes").
 			Warnf("Cannot purge all steps for file %s: %s", fileID, err)
 	}

--- a/model/note/step.go
+++ b/model/note/step.go
@@ -256,7 +256,7 @@ func purgeOldSteps(inst *instance.Instance, fileID string) {
 
 func purgeAllSteps(inst *instance.Instance, fileID string) {
 	var docs []couchdb.Doc
-	err := couchdb.ForeachDocsWithCustomPagination(inst, consts.NotesSteps, 1000, func(_ string, raw json.RawMessage) error {
+	err := couchdb.ForeachDocsWithCustomPagination(context.TODO(), inst, consts.NotesSteps, 1000, func(_ string, raw json.RawMessage) error {
 		var doc Step
 		if err := json.Unmarshal(raw, &doc); err != nil {
 			return err

--- a/model/note/step.go
+++ b/model/note/step.go
@@ -216,7 +216,7 @@ func saveSteps(inst *instance.Instance, steps []Step) error {
 	for i, s := range steps {
 		news[i] = s
 	}
-	return couchdb.BulkUpdateDocs(inst, consts.NotesSteps, news, olds)
+	return couchdb.BulkUpdateDocs(context.TODO(), inst, consts.NotesSteps, news, olds)
 }
 
 func purgeOldSteps(inst *instance.Instance, fileID string) {

--- a/model/note/step.go
+++ b/model/note/step.go
@@ -1,6 +1,7 @@
 package note
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -119,7 +120,7 @@ func getSteps(db prefixer.Prefixer, fileID string, version int64) ([]Step, error
 		StartKey: stepID(fileID, version),
 		EndKey:   endkey(fileID),
 	}
-	if err := couchdb.GetAllDocs(db, consts.NotesSteps, &req, &steps); err != nil {
+	if err := couchdb.GetAllDocs(context.TODO(), db, consts.NotesSteps, &req, &steps); err != nil {
 		return nil, err
 	}
 
@@ -225,7 +226,7 @@ func purgeOldSteps(inst *instance.Instance, fileID string) {
 		StartKey: stepID(fileID, 0),
 		EndKey:   endkey(fileID),
 	}
-	if err := couchdb.GetAllDocs(inst, consts.NotesSteps, &req, &steps); err != nil {
+	if err := couchdb.GetAllDocs(context.TODO(), inst, consts.NotesSteps, &req, &steps); err != nil {
 		if !couchdb.IsNoDatabaseError(err) {
 			inst.Logger().WithNamespace("notes").
 				Warnf("Cannot purge old steps for file %s: %s", fileID, err)

--- a/model/session/login_history.go
+++ b/model/session/login_history.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"context"
 	"net"
 	"net/http"
 	"net/url"
@@ -180,7 +181,7 @@ func sendLoginNotification(i *instance.Instance, l *LoginEntry) error {
 	// even called when this is the case, but sometimes the user can create
 	// their Cozy from the manager with an OIDC flow, with no confirmation mail
 	// no password choosing, and we need this trick for them.
-	nb, _ := couchdb.CountNormalDocs(i, consts.SessionsLogins)
+	nb, _ := couchdb.CountNormalDocs(context.TODO(), i, consts.SessionsLogins)
 	if nb == 1 {
 		return nil
 	}

--- a/model/session/session.go
+++ b/model/session/session.go
@@ -218,7 +218,7 @@ func GetAll(inst *instance.Instance) ([]*Session, error) {
 		}
 	}
 	if len(expired) > 0 {
-		if err := couchdb.BulkDeleteDocs(inst, consts.Sessions, expired); err != nil {
+		if err := couchdb.BulkDeleteDocs(context.TODO(), inst, consts.Sessions, expired); err != nil {
 			inst.Logger().WithNamespace("sessions").
 				Infof("Error while deleting expired sessions: %s", err)
 		}

--- a/model/session/session.go
+++ b/model/session/session.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -203,7 +204,7 @@ func GetAll(inst *instance.Instance) ([]*Session, error) {
 	req := couchdb.AllDocsRequest{
 		Limit: 50000,
 	}
-	if err := couchdb.GetAllDocs(inst, consts.Sessions, &req, &sessions); err != nil {
+	if err := couchdb.GetAllDocs(context.TODO(), inst, consts.Sessions, &req, &sessions); err != nil {
 		return nil, err
 	}
 	var expired []couchdb.Doc

--- a/model/session/session.go
+++ b/model/session/session.go
@@ -276,7 +276,7 @@ func (s *Session) ToCookie() (*http.Cookie, error) {
 // DeleteOthers will remove all sessions except the one given in parameter.
 func DeleteOthers(i *instance.Instance, selfSessionID string) error {
 	var sessions []*Session
-	err := couchdb.ForeachDocs(i, consts.Sessions, func(_ string, data json.RawMessage) error {
+	err := couchdb.ForeachDocs(context.TODO(), i, consts.Sessions, func(_ string, data json.RawMessage) error {
 		var s Session
 		if err := json.Unmarshal(data, &s); err != nil {
 			return err

--- a/model/sharing/indexer.go
+++ b/model/sharing/indexer.go
@@ -1,6 +1,7 @@
 package sharing
 
 import (
+	"context"
 	"encoding/hex"
 	"fmt"
 
@@ -269,7 +270,7 @@ func (s *sharingIndexer) bulkForceUpdateDoc(olddoc, doc *vfs.FileDoc) error {
 	doc.SetRev(s.bulkRevs.Rev)
 	s.setDirOrFileRevisions(nil, olddoc, docs[0])
 
-	return couchdb.BulkForceUpdateDocs(s.db, consts.Files, docs)
+	return couchdb.BulkForceUpdateDocs(context.TODO(), s.db, consts.Files, docs)
 }
 
 // DeleteFileDoc is used when uploading a new file fails (invalid md5sum for example)
@@ -317,7 +318,7 @@ func (s *sharingIndexer) UpdateDirDoc(olddoc, doc *vfs.DirDoc) error {
 	doc.SetRev(s.bulkRevs.Rev)
 	s.setDirOrFileRevisions(olddoc, nil, docs[0])
 
-	if err := couchdb.BulkForceUpdateDocs(s.db, consts.Files, docs); err != nil {
+	if err := couchdb.BulkForceUpdateDocs(context.TODO(), s.db, consts.Files, docs); err != nil {
 		return err
 	}
 

--- a/model/sharing/replicator.go
+++ b/model/sharing/replicator.go
@@ -351,7 +351,7 @@ var errRevokeSharing = errors.New("Sharing must be revoked")
 // callChangesFeed fetches the last changes from the changes feed
 // http://docs.couchdb.org/en/stable/api/database/changes.html
 func (s *Sharing) callChangesFeed(inst *instance.Instance, since string) (*changesResponse, error) {
-	response, err := couchdb.GetChanges(inst, &couchdb.ChangesRequest{
+	response, err := couchdb.GetChanges(context.TODO(), inst, &couchdb.ChangesRequest{
 		DocType:     consts.Shared,
 		IncludeDocs: true,
 		Since:       since,

--- a/model/sharing/replicator.go
+++ b/model/sharing/replicator.go
@@ -499,7 +499,7 @@ func (s *Sharing) ComputeRevsDiff(inst *instance.Instance, changed Changed) (*Mi
 	}
 	results := make([]SharedRef, 0, len(changed))
 	req := couchdb.AllDocsRequest{Keys: ids}
-	err := couchdb.GetAllDocs(inst, consts.Shared, &req, &results)
+	err := couchdb.GetAllDocs(context.TODO(), inst, consts.Shared, &req, &results)
 	if err != nil {
 		return nil, err
 	}
@@ -727,7 +727,7 @@ func partitionDocsPayload(inst *instance.Instance, doctype string, docs DocsList
 	}
 	results := make([]interface{}, 0, len(docs))
 	req := couchdb.AllDocsRequest{Keys: ids}
-	if err = couchdb.GetAllDocs(inst, doctype, &req, &results); err != nil {
+	if err = couchdb.GetAllDocs(context.TODO(), inst, doctype, &req, &results); err != nil {
 		return nil, nil, err
 	}
 	for i, doc := range docs {

--- a/model/sharing/replicator.go
+++ b/model/sharing/replicator.go
@@ -243,7 +243,7 @@ func (s *Sharing) UpdateLastSequenceNumber(inst *instance.Instance, m *Member, w
 		}
 	}
 	result["last_seq"] = seq
-	return couchdb.PutLocal(inst, consts.Shared, id+"/"+worker, result)
+	return couchdb.PutLocal(context.TODO(), inst, consts.Shared, id+"/"+worker, result)
 }
 
 // ClearLastSequenceNumbers removes the last sequence numbers for a member

--- a/model/sharing/replicator.go
+++ b/model/sharing/replicator.go
@@ -678,7 +678,7 @@ func (s *Sharing) ApplyBulkDocs(inst *instance.Instance, payload DocsByDoctype) 
 			}
 		}
 		if len(okDocs) > 0 {
-			if err = couchdb.BulkForceUpdateDocs(inst, doctype, okDocs); err != nil {
+			if err = couchdb.BulkForceUpdateDocs(context.TODO(), inst, doctype, okDocs); err != nil {
 				return err
 			}
 			for _, doc := range okDocs {

--- a/model/sharing/replicator.go
+++ b/model/sharing/replicator.go
@@ -211,7 +211,7 @@ func (s *Sharing) getLastSeqNumber(inst *instance.Instance, m *Member, worker st
 	if err != nil {
 		return "", err
 	}
-	result, err := couchdb.GetLocal(inst, consts.Shared, id+"/"+worker)
+	result, err := couchdb.GetLocal(context.TODO(), inst, consts.Shared, id+"/"+worker)
 	if couchdb.IsNotFoundError(err) {
 		return "", nil
 	}
@@ -229,7 +229,7 @@ func (s *Sharing) UpdateLastSequenceNumber(inst *instance.Instance, m *Member, w
 	if err != nil {
 		return err
 	}
-	result, err := couchdb.GetLocal(inst, consts.Shared, id+"/"+worker)
+	result, err := couchdb.GetLocal(context.TODO(), inst, consts.Shared, id+"/"+worker)
 	if err != nil {
 		if !couchdb.IsNotFoundError(err) {
 			return err

--- a/model/sharing/replicator.go
+++ b/model/sharing/replicator.go
@@ -565,7 +565,7 @@ func (s *Sharing) getMissingDocs(inst *instance.Instance, missings *Missings, ch
 	}
 
 	for doctype, query := range queries {
-		results, err := couchdb.BulkGetDocs(inst, doctype, query)
+		results, err := couchdb.BulkGetDocs(context.TODO(), inst, doctype, query)
 		if err != nil {
 			return nil, err
 		}

--- a/model/sharing/replicator.go
+++ b/model/sharing/replicator.go
@@ -262,7 +262,7 @@ func (s *Sharing) clearLastSequenceNumber(inst *instance.Instance, m *Member, wo
 	if err != nil {
 		return err
 	}
-	err = couchdb.DeleteLocal(inst, consts.Shared, id+"/"+worker)
+	err = couchdb.DeleteLocal(context.TODO(), inst, consts.Shared, id+"/"+worker)
 	if couchdb.IsNotFoundError(err) {
 		return nil
 	}

--- a/model/sharing/replicator.go
+++ b/model/sharing/replicator.go
@@ -708,7 +708,7 @@ func (s *Sharing) ApplyBulkDocs(inst *instance.Instance, payload DocsByDoctype) 
 		refsToUpdate[i] = ref
 	}
 	olds := make([]interface{}, len(refsToUpdate))
-	return couchdb.BulkUpdateDocs(inst, consts.Shared, refsToUpdate, olds)
+	return couchdb.BulkUpdateDocs(context.TODO(), inst, consts.Shared, refsToUpdate, olds)
 }
 
 // partitionDocsPayload returns two slices: the first with documents that are new,

--- a/model/sharing/replicator_test.go
+++ b/model/sharing/replicator_test.go
@@ -1,6 +1,7 @@
 package sharing
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -758,10 +759,10 @@ func getSharedRef(t *testing.T, inst *instance.Instance, doctype, id string) *Sh
 }
 
 func assertNbSharedRef(t *testing.T, inst *instance.Instance, expected int) {
-	nb, err := couchdb.CountAllDocs(inst, consts.Shared)
+	nb, err := couchdb.CountAllDocs(context.TODO(), inst, consts.Shared)
 	if err != nil {
 		time.Sleep(1 * time.Second)
-		nb, err = couchdb.CountAllDocs(inst, consts.Shared)
+		nb, err = couchdb.CountAllDocs(context.TODO(), inst, consts.Shared)
 	}
 	assert.NoError(t, err)
 	assert.Equal(t, expected, nb)

--- a/model/sharing/reupload.go
+++ b/model/sharing/reupload.go
@@ -1,6 +1,7 @@
 package sharing
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 
@@ -27,7 +28,7 @@ func AskReupload(inst *instance.Instance) error {
 		Limit: 100,
 	}
 	var sharings []*Sharing
-	err := couchdb.GetAllDocs(inst, consts.Sharings, req, &sharings)
+	err := couchdb.GetAllDocs(context.TODO(), inst, consts.Sharings, req, &sharings)
 	if err != nil {
 		return err
 	}

--- a/model/sharing/setup.go
+++ b/model/sharing/setup.go
@@ -235,7 +235,7 @@ func (s *Sharing) InitialCopy(inst *instance.Instance, rule Rule, r int) error {
 		return nil
 	}
 	olds := make([]interface{}, len(refs))
-	return couchdb.BulkUpdateDocs(inst, consts.Shared, refs, olds)
+	return couchdb.BulkUpdateDocs(context.TODO(), inst, consts.Shared, refs, olds)
 }
 
 // FindMatchingDocs finds the documents that match the given rule

--- a/model/sharing/setup.go
+++ b/model/sharing/setup.go
@@ -1,6 +1,7 @@
 package sharing
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"runtime"
@@ -265,7 +266,7 @@ func FindMatchingDocs(inst *instance.Instance, rule Rule) ([]couchdb.JSONDoc, er
 			req := &couchdb.AllDocsRequest{
 				Keys: rule.Values,
 			}
-			if err := couchdb.GetAllDocs(inst, rule.DocType, req, &docs); err != nil {
+			if err := couchdb.GetAllDocs(context.TODO(), inst, rule.DocType, req, &docs); err != nil {
 				return nil, err
 			}
 		}

--- a/model/sharing/shared.go
+++ b/model/sharing/shared.go
@@ -310,7 +310,7 @@ func updateRemovedForFiles(inst *instance.Instance, sharingID, dirID string, rul
 		return nil
 	}
 	olds := make([]interface{}, len(docs))
-	return couchdb.BulkUpdateDocs(inst, consts.Shared, docs, olds)
+	return couchdb.BulkUpdateDocs(context.TODO(), inst, consts.Shared, docs, olds)
 }
 
 // UpdateShared updates the io.cozy.shared database when a document is

--- a/model/sharing/shared.go
+++ b/model/sharing/shared.go
@@ -1,6 +1,7 @@
 package sharing
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 
@@ -108,7 +109,7 @@ func (s *SharedRef) Fetch(field string) []string {
 func FindReferences(inst *instance.Instance, ids []string) ([]*SharedRef, error) {
 	var refs []*SharedRef
 	req := &couchdb.AllDocsRequest{Keys: ids}
-	if err := couchdb.GetAllDocs(inst, consts.Shared, req, &refs); err != nil {
+	if err := couchdb.GetAllDocs(context.TODO(), inst, consts.Shared, req, &refs); err != nil {
 		return nil, err
 	}
 	return refs, nil

--- a/model/sharing/shared.go
+++ b/model/sharing/shared.go
@@ -547,7 +547,7 @@ func extractDocReferenceFromID(id string) *couchdb.DocReference {
 // revision tree for inconsistencies.
 func CheckShared(inst *instance.Instance) ([]*CheckSharedError, error) {
 	checks := []*CheckSharedError{}
-	err := couchdb.ForeachDocs(inst, consts.Shared, func(id string, data json.RawMessage) error {
+	err := couchdb.ForeachDocs(context.TODO(), inst, consts.Shared, func(id string, data json.RawMessage) error {
 		s := &SharedRef{}
 		if err := json.Unmarshal(data, s); err != nil {
 			checks = append(checks, &CheckSharedError{Type: "invalid_json", ID: id})

--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -2,6 +2,7 @@ package sharing
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -698,7 +699,7 @@ func FindSharings(db prefixer.Prefixer, sharingIDs []string) ([]*Sharing, error)
 		Keys: sharingIDs,
 	}
 	var res []*Sharing
-	err := couchdb.GetAllDocs(db, consts.Sharings, req, &res)
+	err := couchdb.GetAllDocs(context.TODO(), db, consts.Sharings, req, &res)
 	if err != nil {
 		return nil, err
 	}
@@ -741,7 +742,7 @@ func findIntentForRedirect(inst *instance.Instance, webapp *app.WebappManifest, 
 		}
 	}
 	var mans []app.WebappManifest
-	err := couchdb.GetAllDocs(inst, consts.Apps, &couchdb.AllDocsRequest{}, &mans)
+	err := couchdb.GetAllDocs(context.TODO(), inst, consts.Apps, &couchdb.AllDocsRequest{}, &mans)
 	if err != nil {
 		return nil, ""
 	}

--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -1036,7 +1036,7 @@ func (s *Sharing) sendPublicKeyToOwner(inst *instance.Instance, publicKey string
 // triggers and members/credentials.
 func CheckSharings(inst *instance.Instance, skipFSConsistency bool) ([]map[string]interface{}, error) {
 	checks := []map[string]interface{}{}
-	err := couchdb.ForeachDocs(inst, consts.Sharings, func(_ string, data json.RawMessage) error {
+	err := couchdb.ForeachDocs(context.TODO(), inst, consts.Sharings, func(_ string, data json.RawMessage) error {
 		s := &Sharing{}
 		if err := json.Unmarshal(data, s); err != nil {
 			return err

--- a/model/sharing/upload.go
+++ b/model/sharing/upload.go
@@ -176,7 +176,7 @@ func (s *Sharing) UploadTo(inst *instance.Instance, m *Member, lastTry bool) (bo
 // and the sequence number where it is in the changes feed.
 func (s *Sharing) findNextFileToUpload(inst *instance.Instance, since string) (map[string]interface{}, int, string, error) {
 	for {
-		response, err := couchdb.GetChanges(inst, &couchdb.ChangesRequest{
+		response, err := couchdb.GetChanges(context.TODO(), inst, &couchdb.ChangesRequest{
 			DocType:     consts.Shared,
 			IncludeDocs: true,
 			Since:       since,

--- a/model/sharing/upload.go
+++ b/model/sharing/upload.go
@@ -2,6 +2,7 @@ package sharing
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -214,7 +215,7 @@ func (s *Sharing) findNextFileToUpload(inst *instance.Instance, since string) (m
 		docID := strings.SplitN(r.DocID, "/", 2)[1]
 		ir := couchdb.IDRev{ID: docID, Rev: rev}
 		query := []couchdb.IDRev{ir}
-		results, err := couchdb.BulkGetDocs(inst, consts.Files, query)
+		results, err := couchdb.BulkGetDocs(context.TODO(), inst, consts.Files, query)
 		if err != nil {
 			return nil, 0, since, err
 		}

--- a/model/vfs/couchdb_indexer.go
+++ b/model/vfs/couchdb_indexer.go
@@ -1,6 +1,7 @@
 package vfs
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path"
@@ -697,7 +698,7 @@ func (c *couchdbIndexer) DeleteVersion(v *Version) error {
 
 func (c *couchdbIndexer) AllVersions() ([]*Version, error) {
 	var versions []*Version
-	err := couchdb.ForeachDocs(c.db, consts.FilesVersions, func(_id string, doc json.RawMessage) error {
+	err := couchdb.ForeachDocs(context.TODO(), c.db, consts.FilesVersions, func(_id string, doc json.RawMessage) error {
 		var v Version
 		if err := json.Unmarshal(doc, &v); err != nil {
 			return err
@@ -895,7 +896,7 @@ func (c *couchdbIndexer) CheckTreeIntegrity(tree *Tree, accumulate func(*FsckLog
 		}
 	}
 
-	return couchdb.ForeachDocs(c.db, consts.FilesVersions, func(_ string, data json.RawMessage) error {
+	return couchdb.ForeachDocs(context.TODO(), c.db, consts.FilesVersions, func(_ string, data json.RawMessage) error {
 		v := &Version{}
 		if erru := json.Unmarshal(data, v); erru != nil {
 			return erru
@@ -931,7 +932,7 @@ func (c *couchdbIndexer) BuildTree(eaches ...func(*TreeFile)) (t *Tree, err erro
 		each = func(*TreeFile) {}
 	}
 
-	err = couchdb.ForeachDocs(c.db, consts.Files, func(_ string, data json.RawMessage) error {
+	err = couchdb.ForeachDocs(context.TODO(), c.db, consts.Files, func(_ string, data json.RawMessage) error {
 		var f *TreeFile
 		if erru := json.Unmarshal(data, &f); erru != nil {
 			return erru

--- a/model/vfs/couchdb_indexer.go
+++ b/model/vfs/couchdb_indexer.go
@@ -337,10 +337,10 @@ func (c *couchdbIndexer) BatchDelete(docs []couchdb.Doc) error {
 		}
 		toDelete := remaining[:n]
 		remaining = remaining[n:]
-		if err := couchdb.BulkDeleteDocs(c.db, consts.Files, toDelete); err != nil {
+		if err := couchdb.BulkDeleteDocs(context.TODO(), c.db, consts.Files, toDelete); err != nil {
 			// If it fails once, try again
 			time.Sleep(1 * time.Second)
-			if err := couchdb.BulkDeleteDocs(c.db, consts.Files, toDelete); err != nil {
+			if err := couchdb.BulkDeleteDocs(context.TODO(), c.db, consts.Files, toDelete); err != nil {
 				return err
 			}
 		}
@@ -721,9 +721,9 @@ func (c *couchdbIndexer) BatchDeleteVersions(versions []*Version) error {
 		}
 		toDelete := remaining[:n]
 		remaining = remaining[n:]
-		if err := couchdb.BulkDeleteDocs(c.db, consts.FilesVersions, toDelete); err != nil {
+		if err := couchdb.BulkDeleteDocs(context.TODO(), c.db, consts.FilesVersions, toDelete); err != nil {
 			// If it fails once, try again
-			if err := couchdb.BulkDeleteDocs(c.db, consts.FilesVersions, toDelete); err != nil {
+			if err := couchdb.BulkDeleteDocs(context.TODO(), c.db, consts.FilesVersions, toDelete); err != nil {
 				return err
 			}
 		}

--- a/model/vfs/couchdb_indexer.go
+++ b/model/vfs/couchdb_indexer.go
@@ -410,7 +410,7 @@ func (c *couchdbIndexer) MoveDir(oldpath, newpath string) error {
 			child.Fullpath = path.Join(newpath, child.Fullpath[len(oldpath)+1:])
 			docs = append(docs, child)
 		}
-		if err = couchdb.BulkUpdateDocs(c.db, consts.Files, docs, olddocs); err != nil {
+		if err = couchdb.BulkUpdateDocs(context.TODO(), c.db, consts.Files, docs, olddocs); err != nil {
 			return err
 		}
 		if len(children) < limit {
@@ -685,7 +685,7 @@ func (c *couchdbIndexer) setTrashedForFilesInsideDir(doc *DirDoc, trashed bool) 
 }
 
 func (c *couchdbIndexer) BatchUpdate(docs, oldDocs []interface{}) error {
-	return couchdb.BulkUpdateDocs(c.db, consts.Files, docs, oldDocs)
+	return couchdb.BulkUpdateDocs(context.TODO(), c.db, consts.Files, docs, oldDocs)
 }
 
 func (c *couchdbIndexer) CreateVersion(v *Version) error {

--- a/model/vfs/version.go
+++ b/model/vfs/version.go
@@ -1,6 +1,7 @@
 package vfs
 
 import (
+	"context"
 	"sort"
 	"time"
 
@@ -148,7 +149,7 @@ func VersionsFor(db prefixer.Prefixer, fileID string) ([]*Version, error) {
 		StartKey: fileID + "/",
 		EndKey:   fileID + "0", // 0 is the next character after / in ascii
 	}
-	if err := couchdb.GetAllDocs(db, consts.FilesVersions, req, &versions); err != nil {
+	if err := couchdb.GetAllDocs(context.TODO(), db, consts.FilesVersions, req, &versions); err != nil {
 		return nil, err
 	}
 	return versions, nil

--- a/model/vfs/vfsafero/fsck.go
+++ b/model/vfs/vfsafero/fsck.go
@@ -2,6 +2,7 @@ package vfsafero
 
 import (
 	"bytes"
+	"context"
 	"crypto/md5"
 	"encoding/json"
 	"errors"
@@ -56,7 +57,7 @@ func (afs *aferoVFS) checkFiles(
 	failFast bool,
 ) error {
 	versions := make(map[string]*vfs.Version, 1024)
-	err := couchdb.ForeachDocs(afs, consts.FilesVersions, func(_ string, data json.RawMessage) error {
+	err := couchdb.ForeachDocs(context.TODO(), afs, consts.FilesVersions, func(_ string, data json.RawMessage) error {
 		v := &vfs.Version{}
 		if erru := json.Unmarshal(data, v); erru != nil {
 			return erru

--- a/model/vfs/vfsswift/fsck_v3.go
+++ b/model/vfs/vfsswift/fsck_v3.go
@@ -52,7 +52,7 @@ func (sfs *swiftVFSV3) checkFiles(
 	failFast bool,
 ) error {
 	versions := make(map[string]*vfs.Version, 1024)
-	err := couchdb.ForeachDocs(sfs, consts.FilesVersions, func(_ string, data json.RawMessage) error {
+	err := couchdb.ForeachDocs(context.TODO(), sfs, consts.FilesVersions, func(_ string, data json.RawMessage) error {
 		v := &vfs.Version{}
 		if erru := json.Unmarshal(data, v); erru != nil {
 			return erru
@@ -65,7 +65,7 @@ func (sfs *swiftVFSV3) checkFiles(
 	}
 
 	images := make(map[string]struct{})
-	err = couchdb.ForeachDocs(sfs, consts.NotesImages, func(_ string, data json.RawMessage) error {
+	err = couchdb.ForeachDocs(context.TODO(), sfs, consts.NotesImages, func(_ string, data json.RawMessage) error {
 		img := make(map[string]interface{})
 		if erru := json.Unmarshal(data, &img); erru != nil {
 			return erru

--- a/pkg/couchdb/bulk.go
+++ b/pkg/couchdb/bulk.go
@@ -134,7 +134,7 @@ func GetAllDocs(ctx context.Context, db prefixer.Prefixer, doctype string, req *
 	return json.Unmarshal(data, results)
 }
 
-func MakeAllDocsRequest(db prefixer.Prefixer, doctype string, params *AllDocsRequest) (io.ReadCloser, error) {
+func MakeAllDocsRequest(ctx context.Context, db prefixer.Prefixer, doctype string, params *AllDocsRequest) (io.ReadCloser, error) {
 	if len(params.Keys) > 0 {
 		return nil, errors.New("keys is not supported by MakeAllDocsRequest")
 	}
@@ -163,7 +163,7 @@ func MakeAllDocsRequest(db prefixer.Prefixer, doctype string, params *AllDocsReq
 	}
 
 	start := time.Now()
-	resp, err := config.CouchClient().Do(req)
+	resp, err := config.CouchClient().Do(req.WithContext(ctx))
 	elapsed := time.Since(start)
 	// Possible err = mostly connection failure
 	if err != nil {

--- a/pkg/couchdb/bulk.go
+++ b/pkg/couchdb/bulk.go
@@ -185,13 +185,13 @@ func MakeAllDocsRequest(ctx context.Context, db prefixer.Prefixer, doctype strin
 // ForeachDocs traverse all the documents from the given database with the
 // specified doctype and calls a function for each document.
 func ForeachDocs(db prefixer.Prefixer, doctype string, fn func(id string, doc json.RawMessage) error) error {
-	return ForeachDocsWithCustomPagination(db, doctype, 100, fn)
+	return ForeachDocsWithCustomPagination(context.TODO(), db, doctype, 100, fn)
 }
 
 // ForeachDocsWithCustomPagination traverse all the documents from the given
 // database, and calls a function for each document. The documents are fetched
 // from CouchDB with a pagination with a custom number of items per page.
-func ForeachDocsWithCustomPagination(db prefixer.Prefixer, doctype string, limit int, fn func(id string, doc json.RawMessage) error) error {
+func ForeachDocsWithCustomPagination(ctx context.Context, db prefixer.Prefixer, doctype string, limit int, fn func(id string, doc json.RawMessage) error) error {
 	var startKey string
 	for {
 		skip := 0
@@ -211,7 +211,7 @@ func ForeachDocsWithCustomPagination(db prefixer.Prefixer, doctype string, limit
 
 		var res AllDocsResponse
 		url := "_all_docs?" + v.Encode()
-		err = makeRequest(context.TODO(), db, doctype, http.MethodGet, url, nil, &res)
+		err = makeRequest(ctx, db, doctype, http.MethodGet, url, nil, &res)
 		if err != nil {
 			return err
 		}

--- a/pkg/couchdb/bulk.go
+++ b/pkg/couchdb/bulk.go
@@ -71,9 +71,9 @@ func CountAllDocs(ctx context.Context, db prefixer.Prefixer, doctype string) (in
 
 // CountNormalDocs returns the number of documents of the given doctype,
 // and excludes the design docs from the count.
-func CountNormalDocs(db prefixer.Prefixer, doctype string) (int, error) {
+func CountNormalDocs(ctx context.Context, db prefixer.Prefixer, doctype string) (int, error) {
 	var designRes ViewResponse
-	err := makeRequest(context.TODO(), db, doctype, http.MethodGet, "_design_docs", nil, &designRes)
+	err := makeRequest(ctx, db, doctype, http.MethodGet, "_design_docs", nil, &designRes)
 	if err != nil {
 		return 0, err
 	}
@@ -83,7 +83,7 @@ func CountNormalDocs(db prefixer.Prefixer, doctype string) (int, error) {
 	// - is the total number of design documents on CouchDB 2.3+
 	// See https://github.com/apache/couchdb/issues/1603
 	if total == len(designRes.Rows) {
-		if total, err = CountAllDocs(context.TODO(), db, doctype); err != nil {
+		if total, err = CountAllDocs(ctx, db, doctype); err != nil {
 			return 0, err
 		}
 	}

--- a/pkg/couchdb/bulk.go
+++ b/pkg/couchdb/bulk.go
@@ -184,8 +184,8 @@ func MakeAllDocsRequest(ctx context.Context, db prefixer.Prefixer, doctype strin
 
 // ForeachDocs traverse all the documents from the given database with the
 // specified doctype and calls a function for each document.
-func ForeachDocs(db prefixer.Prefixer, doctype string, fn func(id string, doc json.RawMessage) error) error {
-	return ForeachDocsWithCustomPagination(context.TODO(), db, doctype, 100, fn)
+func ForeachDocs(ctx context.Context, db prefixer.Prefixer, doctype string, fn func(id string, doc json.RawMessage) error) error {
+	return ForeachDocsWithCustomPagination(ctx, db, doctype, 100, fn)
 }
 
 // ForeachDocsWithCustomPagination traverse all the documents from the given

--- a/pkg/couchdb/bulk.go
+++ b/pkg/couchdb/bulk.go
@@ -358,7 +358,7 @@ func BulkDeleteDocs(ctx context.Context, db prefixer.Prefixer, doctype string, d
 
 // BulkForceUpdateDocs is used to update several docs in one call, and to force
 // the revisions history. It is used by replications.
-func BulkForceUpdateDocs(db prefixer.Prefixer, doctype string, docs []map[string]interface{}) error {
+func BulkForceUpdateDocs(ctx context.Context, db prefixer.Prefixer, doctype string, docs []map[string]interface{}) error {
 	if len(docs) == 0 {
 		return nil
 	}
@@ -371,5 +371,5 @@ func BulkForceUpdateDocs(db prefixer.Prefixer, doctype string, docs []map[string
 	}
 	// XXX CouchDB returns just an empty array when new_edits is false, so we
 	// ignore the response
-	return makeRequest(context.TODO(), db, doctype, http.MethodPost, "_bulk_docs", body, nil)
+	return makeRequest(ctx, db, doctype, http.MethodPost, "_bulk_docs", body, nil)
 }

--- a/pkg/couchdb/bulk.go
+++ b/pkg/couchdb/bulk.go
@@ -331,7 +331,7 @@ func bulkUpdateDocs(ctx context.Context, db prefixer.Prefixer, doctype string, d
 }
 
 // BulkDeleteDocs is used to delete serveral documents in one call.
-func BulkDeleteDocs(db prefixer.Prefixer, doctype string, docs []Doc) error {
+func BulkDeleteDocs(ctx context.Context, db prefixer.Prefixer, doctype string, docs []Doc) error {
 	if len(docs) == 0 {
 		return nil
 	}
@@ -346,7 +346,7 @@ func BulkDeleteDocs(db prefixer.Prefixer, doctype string, docs []Doc) error {
 		))
 	}
 	var res []UpdateResponse
-	if err := makeRequest(context.TODO(), db, doctype, http.MethodPost, "_bulk_docs", body, &res); err != nil {
+	if err := makeRequest(ctx, db, doctype, http.MethodPost, "_bulk_docs", body, &res); err != nil {
 		return err
 	}
 	for i, doc := range docs {

--- a/pkg/couchdb/bulk.go
+++ b/pkg/couchdb/bulk.go
@@ -92,7 +92,7 @@ func CountNormalDocs(ctx context.Context, db prefixer.Prefixer, doctype string) 
 
 // GetAllDocs returns all documents of a specified doctype. It filters
 // out the possible _design document.
-func GetAllDocs(db prefixer.Prefixer, doctype string, req *AllDocsRequest, results interface{}) (err error) {
+func GetAllDocs(ctx context.Context, db prefixer.Prefixer, doctype string, req *AllDocsRequest, results interface{}) (err error) {
 	var v url.Values
 	if req != nil {
 		v, err = req.Values()
@@ -106,7 +106,7 @@ func GetAllDocs(db prefixer.Prefixer, doctype string, req *AllDocsRequest, resul
 	var response AllDocsResponse
 	if req == nil || len(req.Keys) == 0 {
 		url := "_all_docs?" + v.Encode()
-		err = makeRequest(context.TODO(), db, doctype, http.MethodGet, url, nil, &response)
+		err = makeRequest(ctx, db, doctype, http.MethodGet, url, nil, &response)
 	} else {
 		v.Del("keys")
 		url := "_all_docs?" + v.Encode()
@@ -115,7 +115,7 @@ func GetAllDocs(db prefixer.Prefixer, doctype string, req *AllDocsRequest, resul
 		}{
 			Keys: req.Keys,
 		}
-		err = makeRequest(context.TODO(), db, doctype, http.MethodPost, url, body, &response)
+		err = makeRequest(ctx, db, doctype, http.MethodPost, url, body, &response)
 	}
 	if err != nil {
 		return err

--- a/pkg/couchdb/bulk.go
+++ b/pkg/couchdb/bulk.go
@@ -234,7 +234,7 @@ func ForeachDocsWithCustomPagination(ctx context.Context, db prefixer.Prefixer, 
 }
 
 // BulkGetDocs returns the documents with the given id at the given revision
-func BulkGetDocs(db prefixer.Prefixer, doctype string, payload []IDRev) ([]map[string]interface{}, error) {
+func BulkGetDocs(ctx context.Context, db prefixer.Prefixer, doctype string, payload []IDRev) ([]map[string]interface{}, error) {
 	path := "_bulk_get?revs=true"
 	body := struct {
 		Docs []IDRev `json:"docs"`
@@ -242,7 +242,7 @@ func BulkGetDocs(db prefixer.Prefixer, doctype string, payload []IDRev) ([]map[s
 		Docs: payload,
 	}
 	var response BulkGetResponse
-	err := makeRequest(context.TODO(), db, doctype, http.MethodPost, path, body, &response)
+	err := makeRequest(ctx, db, doctype, http.MethodPost, path, body, &response)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/couchdb/bulk.go
+++ b/pkg/couchdb/bulk.go
@@ -59,10 +59,10 @@ type BulkGetResponse struct {
 }
 
 // CountAllDocs returns the number of documents of the given doctype.
-func CountAllDocs(db prefixer.Prefixer, doctype string) (int, error) {
+func CountAllDocs(ctx context.Context, db prefixer.Prefixer, doctype string) (int, error) {
 	var response AllDocsResponse
 	url := "_all_docs?limit=0"
-	err := makeRequest(context.TODO(), db, doctype, http.MethodGet, url, nil, &response)
+	err := makeRequest(ctx, db, doctype, http.MethodGet, url, nil, &response)
 	if err != nil {
 		return 0, err
 	}
@@ -83,7 +83,7 @@ func CountNormalDocs(db prefixer.Prefixer, doctype string) (int, error) {
 	// - is the total number of design documents on CouchDB 2.3+
 	// See https://github.com/apache/couchdb/issues/1603
 	if total == len(designRes.Rows) {
-		if total, err = CountAllDocs(db, doctype); err != nil {
+		if total, err = CountAllDocs(context.TODO(), db, doctype); err != nil {
 			return 0, err
 		}
 	}

--- a/pkg/couchdb/bulk.go
+++ b/pkg/couchdb/bulk.go
@@ -1,6 +1,7 @@
 package couchdb
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -61,7 +62,7 @@ type BulkGetResponse struct {
 func CountAllDocs(db prefixer.Prefixer, doctype string) (int, error) {
 	var response AllDocsResponse
 	url := "_all_docs?limit=0"
-	err := makeRequest(db, doctype, http.MethodGet, url, nil, &response)
+	err := makeRequest(context.TODO(), db, doctype, http.MethodGet, url, nil, &response)
 	if err != nil {
 		return 0, err
 	}
@@ -72,7 +73,7 @@ func CountAllDocs(db prefixer.Prefixer, doctype string) (int, error) {
 // and excludes the design docs from the count.
 func CountNormalDocs(db prefixer.Prefixer, doctype string) (int, error) {
 	var designRes ViewResponse
-	err := makeRequest(db, doctype, http.MethodGet, "_design_docs", nil, &designRes)
+	err := makeRequest(context.TODO(), db, doctype, http.MethodGet, "_design_docs", nil, &designRes)
 	if err != nil {
 		return 0, err
 	}
@@ -105,7 +106,7 @@ func GetAllDocs(db prefixer.Prefixer, doctype string, req *AllDocsRequest, resul
 	var response AllDocsResponse
 	if req == nil || len(req.Keys) == 0 {
 		url := "_all_docs?" + v.Encode()
-		err = makeRequest(db, doctype, http.MethodGet, url, nil, &response)
+		err = makeRequest(context.TODO(), db, doctype, http.MethodGet, url, nil, &response)
 	} else {
 		v.Del("keys")
 		url := "_all_docs?" + v.Encode()
@@ -114,7 +115,7 @@ func GetAllDocs(db prefixer.Prefixer, doctype string, req *AllDocsRequest, resul
 		}{
 			Keys: req.Keys,
 		}
-		err = makeRequest(db, doctype, http.MethodPost, url, body, &response)
+		err = makeRequest(context.TODO(), db, doctype, http.MethodPost, url, body, &response)
 	}
 	if err != nil {
 		return err
@@ -210,7 +211,7 @@ func ForeachDocsWithCustomPagination(db prefixer.Prefixer, doctype string, limit
 
 		var res AllDocsResponse
 		url := "_all_docs?" + v.Encode()
-		err = makeRequest(db, doctype, http.MethodGet, url, nil, &res)
+		err = makeRequest(context.TODO(), db, doctype, http.MethodGet, url, nil, &res)
 		if err != nil {
 			return err
 		}
@@ -241,7 +242,7 @@ func BulkGetDocs(db prefixer.Prefixer, doctype string, payload []IDRev) ([]map[s
 		Docs: payload,
 	}
 	var response BulkGetResponse
-	err := makeRequest(db, doctype, http.MethodPost, path, body, &response)
+	err := makeRequest(context.TODO(), db, doctype, http.MethodPost, path, body, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -297,7 +298,7 @@ func bulkUpdateDocs(db prefixer.Prefixer, doctype string, docs, olddocs []interf
 		Docs: docs,
 	}
 	var res []UpdateResponse
-	if err := makeRequest(db, doctype, http.MethodPost, "_bulk_docs", body, &res); err != nil {
+	if err := makeRequest(context.TODO(), db, doctype, http.MethodPost, "_bulk_docs", body, &res); err != nil {
 		return err
 	}
 	if len(res) != len(docs) {
@@ -345,7 +346,7 @@ func BulkDeleteDocs(db prefixer.Prefixer, doctype string, docs []Doc) error {
 		))
 	}
 	var res []UpdateResponse
-	if err := makeRequest(db, doctype, http.MethodPost, "_bulk_docs", body, &res); err != nil {
+	if err := makeRequest(context.TODO(), db, doctype, http.MethodPost, "_bulk_docs", body, &res); err != nil {
 		return err
 	}
 	for i, doc := range docs {
@@ -370,5 +371,5 @@ func BulkForceUpdateDocs(db prefixer.Prefixer, doctype string, docs []map[string
 	}
 	// XXX CouchDB returns just an empty array when new_edits is false, so we
 	// ignore the response
-	return makeRequest(db, doctype, http.MethodPost, "_bulk_docs", body, nil)
+	return makeRequest(context.TODO(), db, doctype, http.MethodPost, "_bulk_docs", body, nil)
 }

--- a/pkg/couchdb/changes.go
+++ b/pkg/couchdb/changes.go
@@ -142,7 +142,7 @@ type Change struct {
 }
 
 // GetChanges returns a list of changes in couchdb
-func GetChanges(db prefixer.Prefixer, req *ChangesRequest) (*ChangesResponse, error) {
+func GetChanges(ctx context.Context, db prefixer.Prefixer, req *ChangesRequest) (*ChangesResponse, error) {
 	if req.DocType == "" {
 		return nil, errors.New("Empty doctype in GetChanges")
 	}
@@ -154,7 +154,7 @@ func GetChanges(db prefixer.Prefixer, req *ChangesRequest) (*ChangesResponse, er
 
 	var response ChangesResponse
 	url := "_changes?" + v.Encode()
-	err = makeRequest(context.TODO(), db, req.DocType, http.MethodGet, url, nil, &response)
+	err = makeRequest(ctx, db, req.DocType, http.MethodGet, url, nil, &response)
 
 	if err != nil {
 		return nil, err

--- a/pkg/couchdb/changes.go
+++ b/pkg/couchdb/changes.go
@@ -1,6 +1,7 @@
 package couchdb
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -153,7 +154,7 @@ func GetChanges(db prefixer.Prefixer, req *ChangesRequest) (*ChangesResponse, er
 
 	var response ChangesResponse
 	url := "_changes?" + v.Encode()
-	err = makeRequest(db, req.DocType, http.MethodGet, url, nil, &response)
+	err = makeRequest(context.TODO(), db, req.DocType, http.MethodGet, url, nil, &response)
 
 	if err != nil {
 		return nil, err
@@ -182,7 +183,7 @@ func PostChanges(db prefixer.Prefixer, req *ChangesRequest, body io.ReadCloser) 
 
 	var response ChangesResponse
 	url := "_changes?" + v.Encode()
-	err = makeRequest(db, req.DocType, http.MethodPost, url, payload, &response)
+	err = makeRequest(context.TODO(), db, req.DocType, http.MethodPost, url, payload, &response)
 
 	if err != nil {
 		return nil, err

--- a/pkg/couchdb/changes.go
+++ b/pkg/couchdb/changes.go
@@ -163,7 +163,7 @@ func GetChanges(ctx context.Context, db prefixer.Prefixer, req *ChangesRequest) 
 }
 
 // PostChanges returns a list of changes in couchdb
-func PostChanges(db prefixer.Prefixer, req *ChangesRequest, body io.ReadCloser) (*ChangesResponse, error) {
+func PostChanges(ctx context.Context, db prefixer.Prefixer, req *ChangesRequest, body io.ReadCloser) (*ChangesResponse, error) {
 	var payload json.RawMessage
 	if err := json.NewDecoder(body).Decode(&payload); err != nil {
 		return nil, err
@@ -183,7 +183,7 @@ func PostChanges(db prefixer.Prefixer, req *ChangesRequest, body io.ReadCloser) 
 
 	var response ChangesResponse
 	url := "_changes?" + v.Encode()
-	err = makeRequest(context.TODO(), db, req.DocType, http.MethodPost, url, payload, &response)
+	err = makeRequest(ctx, db, req.DocType, http.MethodPost, url, payload, &response)
 
 	if err != nil {
 		return nil, err

--- a/pkg/couchdb/couchdb.go
+++ b/pkg/couchdb/couchdb.go
@@ -972,7 +972,7 @@ func NormalDocs(db prefixer.Prefixer, doctype string, skip, limit int, bookmark 
 	if bookmark == "" && len(res.Rows) < limit {
 		res.Total = skip + len(res.Rows)
 	} else {
-		total, err := CountNormalDocs(db, doctype)
+		total, err := CountNormalDocs(context.TODO(), db, doctype)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/couchdb/couchdb.go
+++ b/pkg/couchdb/couchdb.go
@@ -354,10 +354,10 @@ func makeRequest(ctx context.Context, db prefixer.Prefixer, doctype, method, pat
 }
 
 // Compact asks CouchDB to compact a database.
-func Compact(db prefixer.Prefixer, doctype string) error {
+func Compact(ctx context.Context, db prefixer.Prefixer, doctype string) error {
 	// CouchDB requires a Content-Type: application/json header
 	body := map[string]interface{}{}
-	return makeRequest(context.TODO(), db, doctype, http.MethodPost, "_compact", body, nil)
+	return makeRequest(ctx, db, doctype, http.MethodPost, "_compact", body, nil)
 }
 
 // UUID requests a Universally Unique Identifier (UUID) from CouchDB.

--- a/pkg/couchdb/couchdb_test.go
+++ b/pkg/couchdb/couchdb_test.go
@@ -37,6 +37,8 @@ func TestCouchdb(t *testing.T) {
 		t.Skip("a couchdb is required for this test: test skipped due to the use of --short flag")
 	}
 
+	ctx := context.Background()
+
 	config.UseTestFile()
 
 	if _, err := CheckStatus(context.Background()); err != nil {
@@ -130,7 +132,7 @@ func TestCouchdb(t *testing.T) {
 		assert.NoError(t, CreateDoc(TestPrefix, doc2))
 
 		var results []*testDoc
-		err := GetAllDocs(TestPrefix, TestDoctype, &AllDocsRequest{Limit: 2}, &results)
+		err := GetAllDocs(ctx, TestPrefix, TestDoctype, &AllDocsRequest{Limit: 2}, &results)
 		if assert.NoError(t, err) {
 			assert.Len(t, results, 2)
 			assert.Equal(t, results[0].Test, "all_1")
@@ -168,7 +170,7 @@ func TestCouchdb(t *testing.T) {
 		assert.NoError(t, CreateDoc(TestPrefix, doc2))
 
 		var results []*testDoc
-		err := GetAllDocs(TestPrefix, TestDoctype, &AllDocsRequest{Limit: 2}, &results)
+		err := GetAllDocs(ctx, TestPrefix, TestDoctype, &AllDocsRequest{Limit: 2}, &results)
 		assert.NoError(t, err)
 		results[0].Test = "after_1"
 		results[1].Test = "after_2"
@@ -181,7 +183,7 @@ func TestCouchdb(t *testing.T) {
 		err = BulkUpdateDocs(TestPrefix, results[0].DocType(), docs, olddocs)
 		assert.NoError(t, err)
 
-		err = GetAllDocs(TestPrefix, TestDoctype, &AllDocsRequest{Limit: 2}, &results)
+		err = GetAllDocs(ctx, TestPrefix, TestDoctype, &AllDocsRequest{Limit: 2}, &results)
 		if assert.NoError(t, err) {
 			assert.Len(t, results, 2)
 			assert.Equal(t, results[0].Test, "after_1")

--- a/pkg/couchdb/couchdb_test.go
+++ b/pkg/couchdb/couchdb_test.go
@@ -464,7 +464,7 @@ func TestCouchdb(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "baz", out["bar"])
 
-		err = DeleteLocal(TestPrefix, TestDoctype, id)
+		err = DeleteLocal(ctx, TestPrefix, TestDoctype, id)
 		assert.NoError(t, err)
 
 		_, err = GetLocal(ctx, TestPrefix, TestDoctype, id)

--- a/pkg/couchdb/couchdb_test.go
+++ b/pkg/couchdb/couchdb_test.go
@@ -456,7 +456,7 @@ func TestCouchdb(t *testing.T) {
 		assert.True(t, IsNotFoundError(err))
 
 		doc := map[string]interface{}{"bar": "baz"}
-		err = PutLocal(TestPrefix, TestDoctype, id, doc)
+		err = PutLocal(ctx, TestPrefix, TestDoctype, id, doc)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, doc["_rev"])
 

--- a/pkg/couchdb/couchdb_test.go
+++ b/pkg/couchdb/couchdb_test.go
@@ -262,7 +262,7 @@ func TestCouchdb(t *testing.T) {
 		request := &ChangesRequest{
 			DocType: TestDoctype,
 		}
-		response, err := GetChanges(TestPrefix, request)
+		response, err := GetChanges(ctx, TestPrefix, request)
 		seqnoAfterCreates := response.LastSeq
 		assert.NoError(t, err)
 		assert.Len(t, response.Results, 0)
@@ -279,7 +279,7 @@ func TestCouchdb(t *testing.T) {
 			Since:   seqnoAfterCreates,
 		}
 
-		response, err = GetChanges(TestPrefix, request)
+		response, err = GetChanges(ctx, TestPrefix, request)
 		assert.NoError(t, err)
 		assert.Len(t, response.Results, 3)
 
@@ -289,7 +289,7 @@ func TestCouchdb(t *testing.T) {
 			Limit:   2,
 		}
 
-		response, err = GetChanges(TestPrefix, request)
+		response, err = GetChanges(ctx, TestPrefix, request)
 		assert.NoError(t, err)
 		assert.Len(t, response.Results, 2)
 
@@ -302,7 +302,7 @@ func TestCouchdb(t *testing.T) {
 			DocType: TestDoctype,
 			Since:   seqnoAfterCreates,
 		}
-		response, err = GetChanges(TestPrefix, request)
+		response, err = GetChanges(ctx, TestPrefix, request)
 		assert.NoError(t, err)
 		assert.Len(t, response.Results, 2)
 	})

--- a/pkg/couchdb/couchdb_test.go
+++ b/pkg/couchdb/couchdb_test.go
@@ -452,7 +452,7 @@ func TestCouchdb(t *testing.T) {
 
 	t.Run("LocalDocuments", func(t *testing.T) {
 		id := "foo"
-		_, err := GetLocal(TestPrefix, TestDoctype, id)
+		_, err := GetLocal(ctx, TestPrefix, TestDoctype, id)
 		assert.True(t, IsNotFoundError(err))
 
 		doc := map[string]interface{}{"bar": "baz"}
@@ -460,14 +460,14 @@ func TestCouchdb(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotEmpty(t, doc["_rev"])
 
-		out, err := GetLocal(TestPrefix, TestDoctype, id)
+		out, err := GetLocal(ctx, TestPrefix, TestDoctype, id)
 		assert.NoError(t, err)
 		assert.Equal(t, "baz", out["bar"])
 
 		err = DeleteLocal(TestPrefix, TestDoctype, id)
 		assert.NoError(t, err)
 
-		_, err = GetLocal(TestPrefix, TestDoctype, id)
+		_, err = GetLocal(ctx, TestPrefix, TestDoctype, id)
 		assert.True(t, IsNotFoundError(err))
 	})
 }

--- a/pkg/couchdb/couchdb_test.go
+++ b/pkg/couchdb/couchdb_test.go
@@ -180,7 +180,7 @@ func TestCouchdb(t *testing.T) {
 		for i, doc := range results {
 			docs[i] = doc
 		}
-		err = BulkUpdateDocs(TestPrefix, results[0].DocType(), docs, olddocs)
+		err = BulkUpdateDocs(ctx, TestPrefix, results[0].DocType(), docs, olddocs)
 		assert.NoError(t, err)
 
 		err = GetAllDocs(ctx, TestPrefix, TestDoctype, &AllDocsRequest{Limit: 2}, &results)

--- a/pkg/couchdb/local.go
+++ b/pkg/couchdb/local.go
@@ -1,6 +1,7 @@
 package couchdb
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 
@@ -12,7 +13,7 @@ import (
 func GetLocal(db prefixer.Prefixer, doctype, id string) (map[string]interface{}, error) {
 	var out map[string]interface{}
 	u := "_local/" + url.PathEscape(id)
-	if err := makeRequest(db, doctype, http.MethodGet, u, nil, &out); err != nil {
+	if err := makeRequest(context.TODO(), db, doctype, http.MethodGet, u, nil, &out); err != nil {
 		return nil, err
 	}
 	return out, nil
@@ -23,7 +24,7 @@ func GetLocal(db prefixer.Prefixer, doctype, id string) (map[string]interface{},
 func PutLocal(db prefixer.Prefixer, doctype, id string, doc map[string]interface{}) error {
 	u := "_local/" + url.PathEscape(id)
 	var out UpdateResponse
-	if err := makeRequest(db, doctype, http.MethodPut, u, doc, &out); err != nil {
+	if err := makeRequest(context.TODO(), db, doctype, http.MethodPut, u, doc, &out); err != nil {
 		return err
 	}
 	doc["_rev"] = out.Rev
@@ -33,5 +34,5 @@ func PutLocal(db prefixer.Prefixer, doctype, id string, doc map[string]interface
 // DeleteLocal will delete a local document in CouchDB.
 func DeleteLocal(db prefixer.Prefixer, doctype, id string) error {
 	u := "_local/" + url.PathEscape(id)
-	return makeRequest(db, doctype, http.MethodDelete, u, nil, nil)
+	return makeRequest(context.TODO(), db, doctype, http.MethodDelete, u, nil, nil)
 }

--- a/pkg/couchdb/local.go
+++ b/pkg/couchdb/local.go
@@ -32,7 +32,7 @@ func PutLocal(ctx context.Context, db prefixer.Prefixer, doctype, id string, doc
 }
 
 // DeleteLocal will delete a local document in CouchDB.
-func DeleteLocal(db prefixer.Prefixer, doctype, id string) error {
+func DeleteLocal(ctx context.Context, db prefixer.Prefixer, doctype, id string) error {
 	u := "_local/" + url.PathEscape(id)
-	return makeRequest(context.TODO(), db, doctype, http.MethodDelete, u, nil, nil)
+	return makeRequest(ctx, db, doctype, http.MethodDelete, u, nil, nil)
 }

--- a/pkg/couchdb/local.go
+++ b/pkg/couchdb/local.go
@@ -21,10 +21,10 @@ func GetLocal(ctx context.Context, db prefixer.Prefixer, doctype, id string) (ma
 
 // PutLocal will put a local document in CouchDB.
 // Note that you should put the last revision in `doc` to avoid conflicts.
-func PutLocal(db prefixer.Prefixer, doctype, id string, doc map[string]interface{}) error {
+func PutLocal(ctx context.Context, db prefixer.Prefixer, doctype, id string, doc map[string]interface{}) error {
 	u := "_local/" + url.PathEscape(id)
 	var out UpdateResponse
-	if err := makeRequest(context.TODO(), db, doctype, http.MethodPut, u, doc, &out); err != nil {
+	if err := makeRequest(ctx, db, doctype, http.MethodPut, u, doc, &out); err != nil {
 		return err
 	}
 	doc["_rev"] = out.Rev

--- a/pkg/couchdb/local.go
+++ b/pkg/couchdb/local.go
@@ -10,10 +10,10 @@ import (
 
 // GetLocal fetch a local document from CouchDB
 // http://docs.couchdb.org/en/stable/api/local.html#get--db-_local-docid
-func GetLocal(db prefixer.Prefixer, doctype, id string) (map[string]interface{}, error) {
+func GetLocal(ctx context.Context, db prefixer.Prefixer, doctype, id string) (map[string]interface{}, error) {
 	var out map[string]interface{}
 	u := "_local/" + url.PathEscape(id)
-	if err := makeRequest(context.TODO(), db, doctype, http.MethodGet, u, nil, &out); err != nil {
+	if err := makeRequest(ctx, db, doctype, http.MethodGet, u, nil, &out); err != nil {
 		return nil, err
 	}
 	return out, nil

--- a/pkg/metrics/inner_data.go
+++ b/pkg/metrics/inner_data.go
@@ -1,6 +1,8 @@
 package metrics
 
 import (
+	"context"
+
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/prefixer"
@@ -18,7 +20,7 @@ func (i *innerDataCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (i *innerDataCollector) Collect(ch chan<- prometheus.Metric) {
-	if count, err := couchdb.CountAllDocs(prefixer.GlobalPrefixer, consts.Instances); err == nil {
+	if count, err := couchdb.CountAllDocs(context.TODO(), prefixer.GlobalPrefixer, consts.Instances); err == nil {
 		ch <- prometheus.MustNewConstMetric(
 			i.instancesCountDesc,
 			prometheus.CounterValue,

--- a/web/accounts/oauth.go
+++ b/web/accounts/oauth.go
@@ -1,6 +1,7 @@
 package accounts
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -193,7 +194,7 @@ func redirect(c echo.Context) error {
 func findAccountWithSameConnectionID(inst *instance.Instance, connectionID string) (*account.Account, error) {
 	var accounts []*account.Account
 	req := &couchdb.AllDocsRequest{Limit: 1000}
-	err := couchdb.GetAllDocs(inst, consts.Accounts, req, &accounts)
+	err := couchdb.GetAllDocs(context.TODO(), inst, consts.Accounts, req, &accounts)
 	if err != nil {
 		return nil, err
 	}

--- a/web/auth/auth_test.go
+++ b/web/auth/auth_test.go
@@ -5,6 +5,7 @@ package auth_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -278,7 +279,7 @@ func TestAuth(t *testing.T) {
 			assert.NotEmpty(t, cookies[1].Value)
 
 			var results []*session.LoginEntry
-			err = couchdb.GetAllDocs(
+			err = couchdb.GetAllDocs(context.TODO(),
 				testInstance,
 				consts.SessionsLogins,
 				&couchdb.AllDocsRequest{Limit: 100},
@@ -970,7 +971,7 @@ func TestAuth(t *testing.T) {
 		if assert.Equal(t, "302 Found", res.Status) {
 			var results []oauth.AccessCode
 			req := &couchdb.AllDocsRequest{}
-			err = couchdb.GetAllDocs(testInstance, consts.OAuthAccessCodes, req, &results)
+			err = couchdb.GetAllDocs(context.TODO(), testInstance, consts.OAuthAccessCodes, req, &results)
 			assert.NoError(t, err)
 			if assert.Len(t, results, 1) {
 				code = results[0].Code
@@ -1094,7 +1095,7 @@ func TestAuth(t *testing.T) {
 
 		var results []oauth.AccessCode
 		reqDocs := &couchdb.AllDocsRequest{}
-		err = couchdb.GetAllDocs(testInstance, consts.OAuthAccessCodes, reqDocs, &results)
+		err = couchdb.GetAllDocs(context.TODO(), testInstance, consts.OAuthAccessCodes, reqDocs, &results)
 		assert.NoError(t, err)
 		for _, result := range results {
 			if result.ClientID == linkedClientID {
@@ -1331,7 +1332,7 @@ func TestAuth(t *testing.T) {
 		require.Equal(t, "302 Found", res.Status)
 		var results []oauth.AccessCode
 		allReq := &couchdb.AllDocsRequest{}
-		err = couchdb.GetAllDocs(testInstance, consts.OAuthAccessCodes, allReq, &results)
+		err = couchdb.GetAllDocs(context.TODO(), testInstance, consts.OAuthAccessCodes, allReq, &results)
 		assert.NoError(t, err)
 		var code string
 		for _, result := range results {

--- a/web/bitwarden/bitwarden_test.go
+++ b/web/bitwarden/bitwarden_test.go
@@ -2,6 +2,7 @@ package bitwarden
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -579,7 +580,7 @@ func TestBitwarden(t *testing.T) {
 	t.Run("BulkDeleteCiphers", func(t *testing.T) {
 		// Setup
 		nbCiphersToDelete := 5
-		nbCiphers, err := couchdb.CountAllDocs(inst, consts.BitwardenCiphers)
+		nbCiphers, err := couchdb.CountAllDocs(context.TODO(), inst, consts.BitwardenCiphers)
 		assert.NoError(t, err)
 
 		var ids []string
@@ -611,7 +612,7 @@ func TestBitwarden(t *testing.T) {
 			ids = append(ids, result["Id"].(string))
 		}
 
-		nb, err := couchdb.CountAllDocs(inst, consts.BitwardenCiphers)
+		nb, err := couchdb.CountAllDocs(context.TODO(), inst, consts.BitwardenCiphers)
 		assert.NoError(t, err)
 		assert.Equal(t, nbCiphers+nbCiphersToDelete, nb)
 
@@ -669,7 +670,7 @@ func TestBitwarden(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 200, res.StatusCode)
 
-		nb, err = couchdb.CountAllDocs(inst, consts.BitwardenCiphers)
+		nb, err = couchdb.CountAllDocs(context.TODO(), inst, consts.BitwardenCiphers)
 		assert.NoError(t, err)
 		assert.Equal(t, nbCiphers, nb)
 	})
@@ -779,9 +780,9 @@ func TestBitwarden(t *testing.T) {
 	})
 
 	t.Run("ImportCiphers", func(t *testing.T) {
-		nbCiphers, err := couchdb.CountAllDocs(inst, consts.BitwardenCiphers)
+		nbCiphers, err := couchdb.CountAllDocs(context.TODO(), inst, consts.BitwardenCiphers)
 		assert.NoError(t, err)
-		nbFolders, err := couchdb.CountAllDocs(inst, consts.BitwardenFolders)
+		nbFolders, err := couchdb.CountAllDocs(context.TODO(), inst, consts.BitwardenFolders)
 		assert.NoError(t, err)
 		body := `
 {
@@ -822,10 +823,10 @@ func TestBitwarden(t *testing.T) {
 		res, err := http.DefaultClient.Do(req)
 		assert.NoError(t, err)
 		assert.Equal(t, 200, res.StatusCode)
-		nb, err := couchdb.CountAllDocs(inst, consts.BitwardenCiphers)
+		nb, err := couchdb.CountAllDocs(context.TODO(), inst, consts.BitwardenCiphers)
 		assert.NoError(t, err)
 		assert.Equal(t, nbCiphers+2, nb)
-		nb, err = couchdb.CountAllDocs(inst, consts.BitwardenFolders)
+		nb, err = couchdb.CountAllDocs(context.TODO(), inst, consts.BitwardenFolders)
 		assert.NoError(t, err)
 		assert.Equal(t, nbFolders+1, nb)
 	})

--- a/web/bitwarden/ciphers.go
+++ b/web/bitwarden/ciphers.go
@@ -673,7 +673,7 @@ func BulkDeleteCiphers(c echo.Context) error {
 	for i := range ciphers {
 		docs[i] = ciphers[i].Clone()
 	}
-	if err := couchdb.BulkDeleteDocs(inst, consts.BitwardenCiphers, docs); err != nil {
+	if err := couchdb.BulkDeleteDocs(context.TODO(), inst, consts.BitwardenCiphers, docs); err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{
 			"error": err.Error(),
 		})

--- a/web/bitwarden/ciphers.go
+++ b/web/bitwarden/ciphers.go
@@ -1,6 +1,7 @@
 package bitwarden
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -247,7 +248,7 @@ func ListCiphers(c echo.Context) error {
 
 	var ciphers []*bitwarden.Cipher
 	req := &couchdb.AllDocsRequest{}
-	if err := couchdb.GetAllDocs(inst, consts.BitwardenCiphers, req, &ciphers); err != nil {
+	if err := couchdb.GetAllDocs(context.TODO(), inst, consts.BitwardenCiphers, req, &ciphers); err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{
 			"error": err.Error(),
 		})
@@ -663,7 +664,7 @@ func BulkDeleteCiphers(c echo.Context) error {
 
 	var ciphers []bitwarden.Cipher
 	keys := couchdb.AllDocsRequest{Keys: req.IDs}
-	if err := couchdb.GetAllDocs(inst, consts.BitwardenCiphers, &keys, &ciphers); err != nil {
+	if err := couchdb.GetAllDocs(context.TODO(), inst, consts.BitwardenCiphers, &keys, &ciphers); err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{
 			"error": err.Error(),
 		})
@@ -705,7 +706,7 @@ func BulkSoftDeleteCiphers(c echo.Context) error {
 
 	var ciphers []bitwarden.Cipher
 	keys := couchdb.AllDocsRequest{Keys: req.IDs}
-	if err := couchdb.GetAllDocs(inst, consts.BitwardenCiphers, &keys, &ciphers); err != nil {
+	if err := couchdb.GetAllDocs(context.TODO(), inst, consts.BitwardenCiphers, &keys, &ciphers); err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{
 			"error": err.Error(),
 		})
@@ -752,7 +753,7 @@ func BulkRestoreCiphers(c echo.Context) error {
 
 	var ciphers []bitwarden.Cipher
 	keys := couchdb.AllDocsRequest{Keys: req.IDs}
-	if err := couchdb.GetAllDocs(inst, consts.BitwardenCiphers, &keys, &ciphers); err != nil {
+	if err := couchdb.GetAllDocs(context.TODO(), inst, consts.BitwardenCiphers, &keys, &ciphers); err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{
 			"error": err.Error(),
 		})

--- a/web/bitwarden/ciphers.go
+++ b/web/bitwarden/ciphers.go
@@ -720,7 +720,7 @@ func BulkSoftDeleteCiphers(c echo.Context) error {
 		cipher.DeletedDate = &cipher.Metadata.UpdatedAt
 		docs[i] = cipher
 	}
-	if err := couchdb.BulkUpdateDocs(inst, consts.BitwardenCiphers, docs, olds); err != nil {
+	if err := couchdb.BulkUpdateDocs(context.TODO(), inst, consts.BitwardenCiphers, docs, olds); err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{
 			"error": err.Error(),
 		})
@@ -767,7 +767,7 @@ func BulkRestoreCiphers(c echo.Context) error {
 		cipher.DeletedDate = nil
 		docs[i] = cipher
 	}
-	if err := couchdb.BulkUpdateDocs(inst, consts.BitwardenCiphers, docs, olds); err != nil {
+	if err := couchdb.BulkUpdateDocs(context.TODO(), inst, consts.BitwardenCiphers, docs, olds); err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{
 			"error": err.Error(),
 		})
@@ -909,7 +909,7 @@ func ImportCiphers(c echo.Context) error {
 	for i, folder := range req.Folders {
 		folders[i] = folder.toFolder()
 	}
-	if err := couchdb.BulkUpdateDocs(inst, consts.BitwardenFolders, folders, olds); err != nil {
+	if err := couchdb.BulkUpdateDocs(context.TODO(), inst, consts.BitwardenFolders, folders, olds); err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{
 			"error": err.Error(),
 		})
@@ -932,7 +932,7 @@ func ImportCiphers(c echo.Context) error {
 		}
 		ciphers[i] = cipher
 	}
-	if err := couchdb.BulkUpdateDocs(inst, consts.BitwardenCiphers, ciphers, olds); err != nil {
+	if err := couchdb.BulkUpdateDocs(context.TODO(), inst, consts.BitwardenCiphers, ciphers, olds); err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{
 			"error": err.Error(),
 		})

--- a/web/bitwarden/folders.go
+++ b/web/bitwarden/folders.go
@@ -1,6 +1,7 @@
 package bitwarden
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"time"
@@ -67,7 +68,7 @@ func ListFolders(c echo.Context) error {
 
 	var folders []*bitwarden.Folder
 	req := &couchdb.AllDocsRequest{}
-	if err := couchdb.GetAllDocs(inst, consts.BitwardenFolders, req, &folders); err != nil {
+	if err := couchdb.GetAllDocs(context.TODO(), inst, consts.BitwardenFolders, req, &folders); err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{
 			"error": err.Error(),
 		})

--- a/web/bitwarden/folders.go
+++ b/web/bitwarden/folders.go
@@ -246,7 +246,7 @@ func DeleteFolder(c echo.Context) error {
 		doc.FolderID = ""
 		docs[i] = ciphers[i]
 	}
-	if err := couchdb.BulkUpdateDocs(inst, consts.BitwardenCiphers, docs, olds); err != nil {
+	if err := couchdb.BulkUpdateDocs(context.TODO(), inst, consts.BitwardenCiphers, docs, olds); err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{
 			"error": err.Error(),
 		})

--- a/web/bitwarden/sync.go
+++ b/web/bitwarden/sync.go
@@ -1,6 +1,7 @@
 package bitwarden
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/cozy/cozy-stack/model/bitwarden"
@@ -133,7 +134,7 @@ func Sync(c echo.Context) error {
 
 	var ciphers []*bitwarden.Cipher
 	req := &couchdb.AllDocsRequest{}
-	if err := couchdb.GetAllDocs(inst, consts.BitwardenCiphers, req, &ciphers); err != nil {
+	if err := couchdb.GetAllDocs(context.TODO(), inst, consts.BitwardenCiphers, req, &ciphers); err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{
 			"error": err.Error(),
 		})
@@ -141,7 +142,7 @@ func Sync(c echo.Context) error {
 
 	var folders []*bitwarden.Folder
 	req = &couchdb.AllDocsRequest{}
-	if err := couchdb.GetAllDocs(inst, consts.BitwardenFolders, req, &folders); err != nil {
+	if err := couchdb.GetAllDocs(context.TODO(), inst, consts.BitwardenFolders, req, &folders); err != nil {
 		if couchdb.IsNoDatabaseError(err) {
 			_ = couchdb.CreateDB(inst, consts.BitwardenFolders)
 		} else {

--- a/web/data/data.go
+++ b/web/data/data.go
@@ -383,6 +383,8 @@ func findDocuments(c echo.Context) error {
 }
 
 func allDocs(c echo.Context) error {
+	ctx := c.Request().Context()
+
 	doctype := c.Param("doctype")
 	if err := permission.CheckReadable(doctype); err != nil {
 		return err
@@ -406,7 +408,7 @@ func allDocs(c echo.Context) error {
 		StartKey:   c.QueryParam("startkey"),
 		EndKey:     c.QueryParam("endkey"),
 	}
-	body, err := couchdb.MakeAllDocsRequest(inst, doctype, req)
+	body, err := couchdb.MakeAllDocsRequest(ctx, inst, doctype, req)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": err})
 	}

--- a/web/data/replication.go
+++ b/web/data/replication.go
@@ -240,7 +240,7 @@ func changesFeed(c echo.Context) error {
 	if filter == "" {
 		results, err = couchdb.GetChanges(context.TODO(), instance, couchReq)
 	} else {
-		results, err = couchdb.PostChanges(instance, couchReq, c.Request().Body)
+		results, err = couchdb.PostChanges(context.TODO(), instance, couchReq, c.Request().Body)
 	}
 	if err != nil {
 		return err

--- a/web/data/replication.go
+++ b/web/data/replication.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"context"
 	"log"
 	"net/http"
 	"strconv"
@@ -237,7 +238,7 @@ func changesFeed(c echo.Context) error {
 
 	var results *couchdb.ChangesResponse
 	if filter == "" {
-		results, err = couchdb.GetChanges(instance, couchReq)
+		results, err = couchdb.GetChanges(context.TODO(), instance, couchReq)
 	} else {
 		results, err = couchdb.PostChanges(instance, couchReq, c.Request().Body)
 	}

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -5,6 +5,7 @@ package files
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -1640,7 +1641,7 @@ func ChangesFeed(c echo.Context) error {
 		IncludeDocs: includeDocs,
 		Filter:      "_selector",
 	}
-	results, err := couchdb.PostChanges(inst, couchReq, filter)
+	results, err := couchdb.PostChanges(context.TODO(), inst, couchReq, filter)
 	mu.Unlock()
 	if err != nil {
 		return err

--- a/web/files/notsynchronized.go
+++ b/web/files/notsynchronized.go
@@ -1,6 +1,7 @@
 package files
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -191,7 +192,7 @@ func AddBulkNotSynchronizedOn(c echo.Context) error {
 	}
 
 	// Use bulk update for better performances
-	err = couchdb.BulkUpdateDocs(instance, consts.Files, docs, oldDocs)
+	err = couchdb.BulkUpdateDocs(context.TODO(), instance, consts.Files, docs, oldDocs)
 	if err != nil {
 		return WrapVfsError(err)
 	}
@@ -241,7 +242,7 @@ func RemoveBulkNotSynchronizedOn(c echo.Context) error {
 	}
 
 	// Use bulk update for better performances
-	err = couchdb.BulkUpdateDocs(instance, consts.Files, docs, oldDocs)
+	err = couchdb.BulkUpdateDocs(context.TODO(), instance, consts.Files, docs, oldDocs)
 	if err != nil {
 		return WrapVfsError(err)
 	}

--- a/web/files/references.go
+++ b/web/files/references.go
@@ -1,6 +1,7 @@
 package files
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -213,7 +214,7 @@ func AddReferencesHandler(c echo.Context) error {
 	}
 	// Use bulk update for better performances
 	defer lockVFS(instance)()
-	err = couchdb.BulkUpdateDocs(instance, consts.Files, docs, oldDocs)
+	err = couchdb.BulkUpdateDocs(context.TODO(), instance, consts.Files, docs, oldDocs)
 	if err != nil {
 		return WrapVfsError(err)
 	}
@@ -271,7 +272,7 @@ func RemoveReferencesHandler(c echo.Context) error {
 	}
 	// Use bulk update for better performances
 	defer lockVFS(instance)()
-	err = couchdb.BulkUpdateDocs(instance, consts.Files, docs, oldDocs)
+	err = couchdb.BulkUpdateDocs(context.TODO(), instance, consts.Files, docs, oldDocs)
 	if err != nil {
 		return WrapVfsError(err)
 	}

--- a/web/instances/checks.go
+++ b/web/instances/checks.go
@@ -2,6 +2,7 @@ package instances
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"strconv"
@@ -99,7 +100,7 @@ func checkTriggers(c echo.Context) error {
 		Message    json.RawMessage `json:"message"`
 	}
 	var triggers []*TriggerInfo
-	err = couchdb.ForeachDocs(inst, consts.Triggers, func(_ string, data json.RawMessage) error {
+	err = couchdb.ForeachDocs(context.TODO(), inst, consts.Triggers, func(_ string, data json.RawMessage) error {
 		var t *TriggerInfo
 		if err := json.Unmarshal(data, &t); err != nil {
 			return err

--- a/web/instances/fixers.go
+++ b/web/instances/fixers.go
@@ -3,6 +3,7 @@ package instances
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -212,13 +213,13 @@ func orphanAccountFixer(c echo.Context) error {
 	}
 
 	var accounts []*account.Account
-	err = couchdb.GetAllDocs(inst, consts.Accounts, nil, &accounts)
+	err = couchdb.GetAllDocs(context.TODO(), inst, consts.Accounts, nil, &accounts)
 	if err != nil || len(accounts) == 0 {
 		return err
 	}
 
 	var konnectors []*couchdb.JSONDoc
-	err = couchdb.GetAllDocs(inst, consts.Konnectors, nil, &konnectors)
+	err = couchdb.GetAllDocs(context.TODO(), inst, consts.Konnectors, nil, &konnectors)
 	if err != nil {
 		return err
 	}

--- a/web/instances/instances.go
+++ b/web/instances/instances.go
@@ -1,6 +1,7 @@
 package instances
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -249,7 +250,7 @@ func listHandler(c echo.Context) error {
 }
 
 func countHandler(c echo.Context) error {
-	count, err := couchdb.CountNormalDocs(prefixer.GlobalPrefixer, consts.Instances)
+	count, err := couchdb.CountNormalDocs(context.TODO(), prefixer.GlobalPrefixer, consts.Instances)
 	if couchdb.IsNoDatabaseError(err) {
 		count = 0
 	} else if err != nil {

--- a/web/jobs/jobs.go
+++ b/web/jobs/jobs.go
@@ -1,6 +1,7 @@
 package jobs
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -660,7 +661,7 @@ func cleanJobs(c echo.Context) error {
 	}
 	var ups []*job.Job
 	now := time.Now()
-	err := couchdb.ForeachDocs(instance, consts.Jobs, func(_ string, data json.RawMessage) error {
+	err := couchdb.ForeachDocs(context.TODO(), instance, consts.Jobs, func(_ string, data json.RawMessage) error {
 		var j *job.Job
 		if err := json.Unmarshal(data, &j); err != nil {
 			return err

--- a/web/jobs/jobs.go
+++ b/web/jobs/jobs.go
@@ -778,7 +778,7 @@ func purgeJobs(c echo.Context) error {
 			end = len(jobsToDelete)
 		}
 
-		err = couchdb.BulkDeleteDocs(instance, consts.Jobs, jobsToDelete[i:end])
+		err = couchdb.BulkDeleteDocs(context.TODO(), instance, consts.Jobs, jobsToDelete[i:end])
 		if err != nil {
 			return err
 		}

--- a/web/oauth/clients.go
+++ b/web/oauth/clients.go
@@ -36,7 +36,7 @@ func deleteClients(c echo.Context) error {
 	}
 
 	if len(clients) > 0 {
-		if err := couchdb.BulkDeleteDocs(inst, consts.OAuthClients, clients); err != nil {
+		if err := couchdb.BulkDeleteDocs(context.TODO(), inst, consts.OAuthClients, clients); err != nil {
 			return err
 		}
 	}

--- a/web/oauth/clients.go
+++ b/web/oauth/clients.go
@@ -1,6 +1,7 @@
 package oauth
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 
@@ -20,7 +21,7 @@ func deleteClients(c echo.Context) error {
 
 	kind := c.QueryParam("Kind")
 	var clients []couchdb.Doc
-	err = couchdb.ForeachDocs(inst, consts.OAuthClients, func(id string, doc json.RawMessage) error {
+	err = couchdb.ForeachDocs(context.TODO(), inst, consts.OAuthClients, func(id string, doc json.RawMessage) error {
 		client := &oauth.Client{}
 		if err := json.Unmarshal(doc, client); err != nil {
 			return err

--- a/web/remote/remote_test.go
+++ b/web/remote/remote_test.go
@@ -1,6 +1,7 @@
 package remote
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -48,7 +49,7 @@ func TestRemote(t *testing.T) {
 			Descending: true,
 			Limit:      1,
 		}
-		err = couchdb.GetAllDocs(testInstance, consts.RemoteRequests, allReq, &results)
+		err = couchdb.GetAllDocs(context.TODO(), testInstance, consts.RemoteRequests, allReq, &results)
 		assert.NoError(t, err)
 		assert.Len(t, results, 1)
 		logged := results[0]

--- a/web/sharings/replicator_test.go
+++ b/web/sharings/replicator_test.go
@@ -2,6 +2,7 @@ package sharings_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -441,7 +442,7 @@ func createShared(t *testing.T, sid string, revisions []string) *sharing.SharedR
 			"this": "is document " + id + " at revision " + rev,
 		},
 	}
-	err := couchdb.BulkForceUpdateDocs(replInstance, doctype, docs)
+	err := couchdb.BulkForceUpdateDocs(context.TODO(), replInstance, doctype, docs)
 	assert.NoError(t, err)
 	var tree *sharing.RevsTree
 	for i, r := range revisions {

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -2,6 +2,7 @@ package sharings_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -904,7 +905,7 @@ func assertInvitationMailWasSent(t *testing.T) string {
 func assertSharingRequestHasBeenCreated(t *testing.T) {
 	var results []*sharing.Sharing
 	req := couchdb.AllDocsRequest{}
-	err := couchdb.GetAllDocs(bobInstance, consts.Sharings, &req, &results)
+	err := couchdb.GetAllDocs(context.TODO(), bobInstance, consts.Sharings, &req, &results)
 	assert.NoError(t, err)
 	assert.Len(t, results, 1)
 	s := results[0]
@@ -992,7 +993,7 @@ func bobLogin(t *testing.T) {
 func fakeAliceInstance(t *testing.T) {
 	var results []*sharing.Sharing
 	req := couchdb.AllDocsRequest{}
-	err := couchdb.GetAllDocs(bobInstance, consts.Sharings, &req, &results)
+	err := couchdb.GetAllDocs(context.TODO(), bobInstance, consts.Sharings, &req, &results)
 	assert.NoError(t, err)
 	assert.Len(t, results, 1)
 	s := results[0]
@@ -1017,7 +1018,7 @@ func assertAuthorizePageShowsTheSharing(t *testing.T, body string) {
 func assertCredentialsHasBeenExchanged(t *testing.T) {
 	var resultsA []map[string]interface{}
 	req := couchdb.AllDocsRequest{}
-	err := couchdb.GetAllDocs(bobInstance, consts.OAuthClients, &req, &resultsA)
+	err := couchdb.GetAllDocs(context.TODO(), bobInstance, consts.OAuthClients, &req, &resultsA)
 	assert.NoError(t, err)
 	assert.True(t, len(resultsA) > 0)
 	clientA := resultsA[len(resultsA)-1]
@@ -1026,7 +1027,7 @@ func assertCredentialsHasBeenExchanged(t *testing.T) {
 	assert.Equal(t, clientA["client_name"], "Sharing Alice")
 
 	var resultsB []map[string]interface{}
-	err = couchdb.GetAllDocs(aliceInstance, consts.OAuthClients, &req, &resultsB)
+	err = couchdb.GetAllDocs(context.TODO(), aliceInstance, consts.OAuthClients, &req, &resultsB)
 	assert.NoError(t, err)
 	assert.True(t, len(resultsB) > 0)
 	clientB := resultsB[len(resultsB)-1]
@@ -1035,7 +1036,7 @@ func assertCredentialsHasBeenExchanged(t *testing.T) {
 	assert.Equal(t, clientB["client_name"], "Sharing Bob")
 
 	var sharingsA []*sharing.Sharing
-	err = couchdb.GetAllDocs(aliceInstance, consts.Sharings, &req, &sharingsA)
+	err = couchdb.GetAllDocs(context.TODO(), aliceInstance, consts.Sharings, &req, &sharingsA)
 	assert.NoError(t, err)
 	assert.True(t, len(sharingsA) > 0)
 	assert.Len(t, sharingsA[0].Credentials, 2)
@@ -1052,7 +1053,7 @@ func assertCredentialsHasBeenExchanged(t *testing.T) {
 	assert.Equal(t, sharingsA[0].Members[2].Status, "pending")
 
 	var sharingsB []*sharing.Sharing
-	err = couchdb.GetAllDocs(bobInstance, consts.Sharings, &req, &sharingsB)
+	err = couchdb.GetAllDocs(context.TODO(), bobInstance, consts.Sharings, &req, &sharingsB)
 	assert.NoError(t, err)
 	assert.True(t, len(sharingsB) > 0)
 	assert.Len(t, sharingsB[0].Credentials, 1)

--- a/worker/exec/konnector.go
+++ b/worker/exec/konnector.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"archive/tar"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -81,7 +82,7 @@ func (m *KonnectorMessage) updateFolderToSave(inst *instance.Instance, dir strin
 	d["folder_to_save"] = dir
 	m.data, _ = json.Marshal(d)
 
-	_ = couchdb.ForeachDocs(inst, consts.Triggers, func(_ string, data json.RawMessage) error {
+	_ = couchdb.ForeachDocs(context.TODO(), inst, consts.Triggers, func(_ string, data json.RawMessage) error {
 		var infos *job.TriggerInfos
 		if err := json.Unmarshal(data, &infos); err != nil {
 			return err

--- a/worker/updates/updates.go
+++ b/worker/updates/updates.go
@@ -1,6 +1,7 @@
 package updates
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
@@ -106,7 +107,7 @@ func UpdateAll(ctx *job.WorkerContext, opts *Options) error {
 	insc := make(chan *app.Installer)
 	errc := make(chan *updateError)
 
-	totalInstances, err := couchdb.CountAllDocs(prefixer.GlobalPrefixer, consts.Instances)
+	totalInstances, err := couchdb.CountAllDocs(context.TODO(), prefixer.GlobalPrefixer, consts.Instances)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
A `context.TODO()` have been used as a placeholder for all the calls,
even if there is a real context available.

This is due to the fact that the call migration is done programatically
(with `sed`) without taking into account each call environment. This
should be fixed in a following step.