### PR TITLE
fix: Handle missing port in sharing instance check

### DIFF
--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -1349,7 +1349,7 @@ func (s *Sharing) checkSharingMembers() (checks []map[string]interface{}, validM
 			continue
 		}
 
-		u, err := url.Parse(m.Instance)
+		u, err := url.ParseRequestURI(m.Instance)
 		if err != nil {
 			checks = append(checks, map[string]interface{}{
 				"id":     s.SID,
@@ -1359,11 +1359,9 @@ func (s *Sharing) checkSharingMembers() (checks []map[string]interface{}, validM
 			continue
 		}
 
-		var domain string
-		if (strings.HasPrefix(m.Instance, "http:") && u.Port() != "80") || (strings.HasPrefix(m.Instance, "https:") && u.Port() != "443") {
-			domain = u.Hostname() + ":" + u.Port()
-		} else {
-			domain = u.Hostname()
+		domain := u.Hostname()
+		if u.Port() != "" {
+			domain += ":" + u.Port()
 		}
 
 		member, err := instance.Get(domain)


### PR DESCRIPTION
To check if a sharing member's instance can be found in CouchDB, we
first need to parse the member's URL instance to retrieve its domain.
However, when the Cozy is reachable using a specific port, that port
is part of the instance's domain (i.e. in the form of
`<domain>:<port>`).

We assumed that a missing port in an `http` URL would give port value
of `80` once parsed (and `443` for a `https` URL) but that's not the
case.
Therefore, in these situations, the instance's domain used for the
CouchDB request would have the form `<domain>:` and the instance would
never be found.