### PR TITLE
feat: map CozyFonts() to the apiOpenParams object

### DIFF
--- a/web/apps/apps.go
+++ b/web/apps/apps.go
@@ -746,6 +746,7 @@ func (o *apiOpenParams) MarshalJSON() ([]byte, error) {
 	data["Flags"], _ = o.params.Flags()
 	data["Capabilities"], _ = o.params.Capabilities()
 	data["CozyBar"], _ = o.params.CozyBar()
+	data["CozyFonts"] = o.params.CozyFonts()
 	data["CozyClientJS"], _ = o.params.CozyClientJS()
 	data["ThemeCSS"] = o.params.ThemeCSS()
 	data["Favicon"] = o.params.Favicon()


### PR DESCRIPTION
It appears it was forgotten in an earlier commit