### PR TITLE
Move some error checks to the 1.13 format by using `errors.Is`

### DIFF
--- a/client/auth/storage.go
+++ b/client/auth/storage.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -59,7 +60,7 @@ func (s *FileStorage) Load(domain string) (client *Client, token *AccessToken, e
 	}()
 	f, err := os.Open(filename)
 	if err != nil {
-		if os.IsNotExist(err) || err == io.EOF {
+		if os.IsNotExist(err) || errors.Is(err, io.EOF) {
 			err = nil
 		}
 		return nil, nil, err

--- a/client/files.go
+++ b/client/files.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -372,7 +373,7 @@ func walk(c *Client, name string, doc *DirOrFile, walkFn WalkFn) error {
 
 	err := walkFn(name, doc, nil)
 	if err != nil {
-		if isDir && err == filepath.SkipDir {
+		if isDir && errors.Is(err, filepath.SkipDir) {
 			return nil
 		}
 		return err
@@ -405,7 +406,7 @@ func walk(c *Client, name string, doc *DirOrFile, walkFn WalkFn) error {
 		for _, d := range included {
 			fullpath := path.Join(name, d.Attrs.Name)
 			err = walk(c, fullpath, d, walkFn)
-			if err != nil && err != filepath.SkipDir {
+			if err != nil && !errors.Is(err, filepath.SkipDir) {
 				return err
 			}
 		}

--- a/client/realtime.go
+++ b/client/realtime.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/url"
@@ -137,7 +138,7 @@ func (r *RealtimeChannel) pump() {
 		}
 		r.ch <- &msg
 	}
-	if err != io.EOF && atomic.LoadUint32(&r.closed) == 0 {
+	if !errors.Is(err, io.EOF) && atomic.LoadUint32(&r.closed) == 0 {
 		r.ch <- &RealtimeServerMessage{
 			Event:   "error",
 			Payload: RealtimeServerPayload{Title: err.Error()},

--- a/client/request/request.go
+++ b/client/request/request.go
@@ -217,7 +217,7 @@ func ReadSSE(r io.ReadCloser, ch chan *SSEEvent) {
 	for {
 		var bs []byte
 		bs, err = rb.ReadBytes('\n')
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			err = nil
 			return
 		}

--- a/cmd/files.go
+++ b/cmd/files.go
@@ -75,7 +75,7 @@ var execFilesCmd = &cobra.Command{
 		c := newClient(flagDomain, consts.Files)
 		command := args[0]
 		err := execCommand(c, command, os.Stdout)
-		if err == errFilesExec {
+		if errors.Is(err, errFilesExec) {
 			return cmd.Usage()
 		}
 		return err

--- a/model/app/fetcher_git.go
+++ b/model/app/fetcher_git.go
@@ -124,7 +124,7 @@ func (g *gitFetcher) doFetchManifestFromGitArchive(src *url.URL, branch string, 
 	g.log.Infof("Fetching manifest %s", strings.Join(cmd.Args, " "))
 	stdout, err := cmd.Output()
 	if err != nil {
-		if err == exec.ErrNotFound {
+		if errors.Is(err, exec.ErrNotFound) {
 			return nil, ErrNotSupportedSource
 		}
 		return nil, ErrManifestNotReachable
@@ -133,7 +133,7 @@ func (g *gitFetcher) doFetchManifestFromGitArchive(src *url.URL, branch string, 
 	r := tar.NewReader(bytes.NewReader(stdout))
 	for {
 		h, err := r.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {
@@ -177,7 +177,7 @@ func (g *gitFetcher) Fetch(src *url.URL, fs appfs.Copier, man Manifest) (err err
 	// If the scheme uses ssh, we have to use the git command.
 	if isGitSSHScheme(src.Scheme) {
 		err = g.fetchWithGit(gitFs, gitDir, src, fs, man)
-		if err == exec.ErrNotFound {
+		if errors.Is(err, exec.ErrNotFound) {
 			return ErrNotSupportedSource
 		}
 		return err
@@ -226,7 +226,7 @@ func (g *gitFetcher) doFetchWithGit(
 		srcStr, fmt.Sprintf("refs/heads/%s", branch))
 	lsRemote, err := cmd.Output()
 	if err != nil {
-		if err != exec.ErrNotFound {
+		if !errors.Is(err, exec.ErrNotFound) {
 			g.log.Errorf("ls-remote error of %s: %s",
 				strings.Join(cmd.Args, " "), err.Error())
 		}
@@ -269,7 +269,7 @@ func (g *gitFetcher) doFetchWithGit(
 	g.log.Infof("Clone with git: %s", strings.Join(cmd.Args, " "))
 	stdoutStderr, err := cmd.CombinedOutput()
 	if err != nil {
-		if err != exec.ErrNotFound {
+		if !errors.Is(err, exec.ErrNotFound) {
 			g.log.Errorf("Clone error of %s %s: %s", srcStr, stdoutStderr,
 				err.Error())
 		}

--- a/model/app/fetcher_http.go
+++ b/model/app/fetcher_http.go
@@ -6,6 +6,7 @@ import (
 	"compress/gzip"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"hash"
 	"io"
 	"net/http"
@@ -78,7 +79,7 @@ func (f *httpFetcher) FetchManifest(src *url.URL) (r io.ReadCloser, err error) {
 	tarReader := tar.NewReader(reader)
 	for {
 		hdr, err := tarReader.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return nil, ErrManifestNotReachable
 		}
 		if err != nil {
@@ -188,7 +189,7 @@ func fetchHTTP(src *url.URL, shasum []byte, fs appfs.Copier, man Manifest, prefi
 	tarReader := tar.NewReader(reader)
 	for {
 		hdr, err := tarReader.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/model/app/installer.go
+++ b/model/app/installer.go
@@ -3,6 +3,7 @@ package app
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -199,7 +200,7 @@ func initManifest(db prefixer.Prefixer, opts *InstallerOptions) (man Manifest, e
 		if err == nil {
 			return nil, ErrAlreadyExists
 		}
-		if err != ErrNotFound {
+		if !errors.Is(err, ErrNotFound) {
 			return nil, err
 		}
 		switch opts.Type {

--- a/model/app/webapp.go
+++ b/model/app/webapp.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -412,7 +413,7 @@ func diffServices(db prefixer.Prefixer, slug string, oldServices, newServices Se
 	sched := job.System()
 	for _, service := range deleted {
 		if service.TriggerID != "" {
-			if err := sched.DeleteTrigger(db, service.TriggerID); err != nil && err != job.ErrNotFoundTrigger {
+			if err := sched.DeleteTrigger(db, service.TriggerID); err != nil && !errors.Is(err, job.ErrNotFoundTrigger) {
 				return err
 			}
 		}

--- a/model/bitwarden/cipher_test.go
+++ b/model/bitwarden/cipher_test.go
@@ -1,6 +1,7 @@
 package bitwarden
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"testing"
@@ -31,7 +32,7 @@ func TestCipher(t *testing.T) {
 	t.Run("DeleteUnrecoverableCiphers", func(t *testing.T) {
 		domain := "cozy.example.net"
 		err := lifecycle.Destroy(domain)
-		if err != instance.ErrNotFound {
+		if !errors.Is(err, instance.ErrNotFound) {
 			assert.NoError(t, err)
 		}
 		inst, err := lifecycle.Create(&lifecycle.Options{

--- a/model/instance/lifecycle/create.go
+++ b/model/instance/lifecycle/create.go
@@ -99,7 +99,7 @@ func CreateWithoutHooks(opts *Options) (*instance.Instance, error) {
 	opts.trace("check if instance already exist", func() {
 		_, err = instance.GetFromCouch(domain)
 	})
-	if err != instance.ErrNotFound {
+	if !errors.Is(err, instance.ErrNotFound) {
 		if err == nil {
 			err = instance.ErrExists
 		}

--- a/model/instance/lifecycle/destroy.go
+++ b/model/instance/lifecycle/destroy.go
@@ -1,6 +1,7 @@
 package lifecycle
 
 import (
+	"errors"
 	"net/http"
 	"net/url"
 	"time"
@@ -141,7 +142,7 @@ func deleteAccounts(inst *instance.Instance) error {
 			continue
 		}
 		man, err := app.GetKonnectorBySlug(inst, slug)
-		if err == app.ErrNotFound {
+		if errors.Is(err, app.ErrNotFound) {
 			copier := app.Copier(consts.KonnectorType, inst)
 			installer, erri := app.NewInstaller(inst, copier,
 				&app.InstallerOptions{

--- a/model/instance/lifecycle/helpers.go
+++ b/model/instance/lifecycle/helpers.go
@@ -2,6 +2,7 @@ package lifecycle
 
 import (
 	"context"
+	"errors"
 	"os"
 	"strings"
 
@@ -133,7 +134,7 @@ func checkAliases(inst *instance.Instance, aliases []string) ([]string, error) {
 			return nil, instance.ErrExists
 		}
 		other, err := instance.GetFromCouch(alias)
-		if err != instance.ErrNotFound {
+		if !errors.Is(err, instance.ErrNotFound) {
 			if err != nil {
 				return nil, err
 			}

--- a/model/job/mem_broker.go
+++ b/model/job/mem_broker.go
@@ -3,6 +3,7 @@ package job
 import (
 	"container/list"
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -191,7 +192,7 @@ func (b *memBroker) PushJob(db prefixer.Prefixer, req *JobRequest) (*Job, error)
 	ct, err := GetCounterTypeFromWorkerType(req.WorkerType)
 	if err == nil {
 		err := limits.CheckRateLimit(db, ct)
-		if err == limits.ErrRateLimitReached {
+		if errors.Is(err, limits.ErrRateLimitReached) {
 			joblog.WithFields(logrus.Fields{
 				"worker_type": req.WorkerType,
 				"instance":    db.DomainName(),

--- a/model/job/redis_broker.go
+++ b/model/job/redis_broker.go
@@ -2,6 +2,7 @@ package job
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"strconv"
@@ -211,7 +212,7 @@ func (b *redisBroker) PushJob(db prefixer.Prefixer, req *JobRequest) (*Job, erro
 	ct, err := GetCounterTypeFromWorkerType(req.WorkerType)
 	if err == nil {
 		err := limits.CheckRateLimit(db, ct)
-		if err == limits.ErrRateLimitReached {
+		if errors.Is(err, limits.ErrRateLimitReached) {
 			joblog.WithFields(logrus.Fields{
 				"worker_type": req.WorkerType,
 				"instance":    db.DomainName(),

--- a/model/job/redis_scheduler.go
+++ b/model/job/redis_scheduler.go
@@ -292,7 +292,7 @@ func (s *redisScheduler) PollScheduler(now int64) error {
 		}
 		t, err := s.GetTrigger(prefixer.NewPrefixer(cluster, "", prefix), triggerID)
 		if err != nil {
-			if err == ErrNotFoundTrigger || err == ErrMalformedTrigger {
+			if errors.Is(err, ErrNotFoundTrigger) || errors.Is(err, ErrMalformedTrigger) {
 				s.client.ZRem(s.ctx, SchedKey, results[0])
 			}
 			return err
@@ -340,7 +340,7 @@ func (s *redisScheduler) PollScheduler(now int64) error {
 			if _, err = s.broker.PushJob(t, job); err != nil {
 				// Remove the cron trigger from redis if it is invalid, as it
 				// may block other cron triggers
-				if err == ErrUnknownWorker || limits.IsLimitReachedOrExceeded(err) {
+				if errors.Is(err, ErrUnknownWorker) || limits.IsLimitReachedOrExceeded(err) {
 					s.client.ZRem(s.ctx, SchedKey, results[0])
 					continue
 				}

--- a/model/job/worker.go
+++ b/model/job/worker.go
@@ -467,7 +467,7 @@ func (t *task) run() (err error) {
 				// Forcing the timeout counter to 0 if it has not been initialized
 				metrics.WorkerExecTimeoutsCounter.WithLabelValues(t.w.Type, slug)
 
-				if err == context.DeadlineExceeded { // This is a timeout
+				if errors.Is(err, context.DeadlineExceeded) { // This is a timeout
 					metrics.WorkerExecTimeoutsCounter.WithLabelValues(t.w.Type, slug).Inc()
 				}
 			}

--- a/model/move/archiver.go
+++ b/model/move/archiver.go
@@ -2,6 +2,7 @@ package move
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -100,7 +101,7 @@ type switfArchiver struct {
 }
 
 func (a *switfArchiver) init() error {
-	if _, _, err := a.c.Container(a.ctx, a.container); err == swift.ContainerNotFound {
+	if _, _, err := a.c.Container(a.ctx, a.container); errors.Is(err, swift.ContainerNotFound) {
 		if err = a.c.ContainerCreate(a.ctx, a.container, nil); err != nil {
 			return err
 		}

--- a/model/move/export.go
+++ b/model/move/export.go
@@ -5,6 +5,7 @@ import (
 	"archive/zip"
 	"compress/gzip"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/url"
 	"path"
@@ -120,7 +121,7 @@ func copyJSONData(zw *zip.Writer, inst *instance.Instance, exportDoc *ExportDoc,
 
 	for {
 		header, err := tr.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/model/move/importer.go
+++ b/model/move/importer.go
@@ -272,7 +272,7 @@ func (im *importer) importAccount(zf *zip.File) error {
 	// on deletion.
 	slug, _ := doc["account_type"].(string)
 	man, err := app.GetKonnectorBySlug(im.inst, slug)
-	if err == app.ErrNotFound {
+	if errors.Is(err, app.ErrNotFound) {
 		im.installApp(consts.Konnectors + "/" + slug)
 		man, err = app.GetKonnectorBySlug(im.inst, slug)
 	}
@@ -368,7 +368,7 @@ func (im *importer) installApp(id string) {
 	if err == nil {
 		_, err = installer.RunSync()
 	}
-	if err != nil && err != app.ErrAlreadyExists {
+	if err != nil && !errors.Is(err, app.ErrAlreadyExists) {
 		im.servicesInError[slug] = true
 	}
 }

--- a/model/move/store.go
+++ b/model/move/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"sync"
 	"time"
 
@@ -144,7 +145,7 @@ type redisStore struct {
 func (s *redisStore) GetRequest(db prefixer.Prefixer, secret string) (*Request, error) {
 	key := requestKey(db, secret)
 	b, err := s.c.Get(s.ctx, key).Bytes()
-	if err == redis.Nil {
+	if errors.Is(err, redis.Nil) {
 		return nil, nil
 	}
 	if err != nil {

--- a/model/note/image.go
+++ b/model/note/image.go
@@ -1,6 +1,7 @@
 package note
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"path"
@@ -98,7 +99,7 @@ func NewImageUpload(inst *instance.Instance, note *vfs.FileDoc, name, mime strin
 // Write implements the io.Writer interface (used by io.Copy).
 func (u *ImageUpload) Write(p []byte) (int, error) {
 	if u.meta != nil {
-		if _, err := (*u.meta).Write(p); err != nil && err != io.ErrClosedPipe {
+		if _, err := (*u.meta).Write(p); err != nil && !errors.Is(err, io.ErrClosedPipe) {
 			(*u.meta).Abort(err)
 			u.meta = nil
 		}

--- a/model/note/import.go
+++ b/model/note/import.go
@@ -3,6 +3,7 @@ package note
 import (
 	"archive/tar"
 	"bytes"
+	"errors"
 	"io"
 	"path"
 	"strconv"
@@ -70,7 +71,7 @@ func importReader(inst *instance.Instance, doc *vfs.FileDoc, reader io.Reader, s
 	buf := &bytes.Buffer{}
 	var hasImages bool
 	if _, err := io.CopyN(buf, reader, 512); err != nil {
-		if err != io.EOF {
+		if !errors.Is(err, io.EOF) {
 			return nil, err
 		}
 		hasImages = false

--- a/model/note/note.go
+++ b/model/note/note.go
@@ -6,6 +6,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -382,7 +383,7 @@ func writeFile(inst *instance.Instance, doc *Document, oldDoc *vfs.FileDoc) (fil
 		file, err = fs.CreateFile(fileDoc, oldDoc)
 		if err == nil {
 			break
-		} else if err != os.ErrExist {
+		} else if !errors.Is(err, os.ErrExist) {
 			return
 		}
 		filename := strings.TrimSuffix(path.Base(basename), path.Ext(basename))
@@ -554,7 +555,7 @@ func get(inst *instance.Instance, file *vfs.FileDoc) (*Document, error) {
 	}
 	version, _ := versionFromMetadata(file)
 	steps, err := getSteps(inst, file.ID(), version)
-	if err != nil && err != ErrTooOld && !couchdb.IsNoDatabaseError(err) {
+	if err != nil && !errors.Is(err, ErrTooOld) && !couchdb.IsNoDatabaseError(err) {
 		return nil, err
 	}
 	doc, err := fromMetadata(file)

--- a/model/office/store.go
+++ b/model/office/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"sync"
 	"time"
 
@@ -164,7 +165,7 @@ func (s *redisStore) AddDoc(db prefixer.Prefixer, payload conflictDetector) (str
 func (s *redisStore) GetDoc(db prefixer.Prefixer, secret string) (*conflictDetector, error) {
 	key := docKey(db, secret)
 	b, err := s.c.Get(s.ctx, key).Bytes()
-	if err == redis.Nil {
+	if errors.Is(err, redis.Nil) {
 		return nil, nil
 	}
 	if err != nil {

--- a/model/permission/set.go
+++ b/model/permission/set.go
@@ -3,6 +3,7 @@ package permission
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"reflect"
 	"strconv"
@@ -116,7 +117,7 @@ func extractJSONKeys(j []byte) ([]string, error) {
 	depth := 0
 	for {
 		t, err := dec.Token()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/model/sharing/oauth.go
+++ b/model/sharing/oauth.go
@@ -187,7 +187,7 @@ func (s *Sharing) RegisterCozyURL(inst *instance.Instance, m *Member, cozyURL st
 	}
 	if err = m.CreateSharingRequest(inst, s, creds, u); err != nil {
 		inst.Logger().WithNamespace("sharing").Warnf("Error on sharing request: %s", err)
-		if err == ErrAlreadyAccepted {
+		if errors.Is(err, ErrAlreadyAccepted) {
 			return err
 		}
 		return ErrRequestFailed

--- a/model/sharing/replicator.go
+++ b/model/sharing/replicator.go
@@ -161,7 +161,7 @@ func (s *Sharing) ReplicateTo(inst *instance.Instance, m *Member, initial bool) 
 
 	feed, err := s.callChangesFeed(inst, lastSeq)
 	if err != nil {
-		if err == errRevokeSharing {
+		if errors.Is(err, errRevokeSharing) {
 			if s.Owner {
 				return false, s.Revoke(inst)
 			} else {

--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -3,6 +3,7 @@ package sharing
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -565,7 +566,7 @@ func (s *Sharing) RemoveTriggers(inst *instance.Instance) error {
 func removeSharingTrigger(inst *instance.Instance, triggerID string) error {
 	if triggerID != "" {
 		err := job.System().DeleteTrigger(inst, triggerID)
-		if err != nil && err != job.ErrNotFoundTrigger {
+		if err != nil && !errors.Is(err, job.ErrNotFoundTrigger) {
 			return err
 		}
 	}
@@ -1672,7 +1673,7 @@ func isFileTooBigForInstance(inst *instance.Instance, doc couchdb.JSONDoc) bool 
 	}
 
 	_, _, _, err = vfs.CheckAvailableDiskSpace(inst.VFS(), file)
-	return err == vfs.ErrFileTooBig
+	return errors.Is(err, vfs.ErrFileTooBig)
 }
 
 // wasUpdatedRecently returns true if the given document's latest update, given

--- a/model/sharing/upload_store.go
+++ b/model/sharing/upload_store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"sync"
 	"time"
 
@@ -104,7 +105,7 @@ type redisStore struct {
 
 func (s *redisStore) Get(db prefixer.Prefixer, key string) (*FileDocWithRevisions, error) {
 	b, err := s.c.Get(s.ctx, db.DBPrefix()+":"+key).Bytes()
-	if err == redis.Nil {
+	if errors.Is(err, redis.Nil) {
 		return nil, nil
 	}
 	if err != nil {

--- a/model/vfs/couchdb_indexer.go
+++ b/model/vfs/couchdb_indexer.go
@@ -2,6 +2,7 @@ package vfs
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path"
 	"strings"
@@ -827,7 +828,7 @@ func (c *couchdbIndexer) CheckIndexIntegrity(accumulate func(*FsckLog), failFast
 	if err != nil {
 		return err
 	}
-	if err := c.CheckTreeIntegrity(tree, accumulate, failFast); err != nil && err != ErrFsckFailFast {
+	if err := c.CheckTreeIntegrity(tree, accumulate, failFast); err != nil && !errors.Is(err, ErrFsckFailFast) {
 		return err
 	}
 	return nil
@@ -835,7 +836,7 @@ func (c *couchdbIndexer) CheckIndexIntegrity(accumulate func(*FsckLog), failFast
 
 func (c *couchdbIndexer) CheckTreeIntegrity(tree *Tree, accumulate func(*FsckLog), failFast bool) error {
 	if err := c.checkNoConflicts(accumulate, failFast); err != nil {
-		if err == ErrFsckFailFast {
+		if errors.Is(err, ErrFsckFailFast) {
 			return nil
 		}
 		return err

--- a/model/vfs/directory.go
+++ b/model/vfs/directory.go
@@ -1,6 +1,7 @@
 package vfs
 
 import (
+	"errors"
 	"os"
 	"path"
 	"path/filepath"
@@ -109,7 +110,7 @@ func (d *DirDoc) Sys() interface{} { return nil }
 func (d *DirDoc) IsEmpty(fs VFS) (bool, error) {
 	iter := fs.DirIterator(d, &IteratorOptions{ByFetch: 1})
 	_, _, err := iter.Next()
-	if err == ErrIteratorDone {
+	if errors.Is(err, ErrIteratorDone) {
 		return true, nil
 	}
 	return false, err

--- a/model/vfs/metadata_test.go
+++ b/model/vfs/metadata_test.go
@@ -1,6 +1,7 @@
 package vfs_test
 
 import (
+	"errors"
 	"io"
 	"os"
 	"testing"
@@ -29,7 +30,7 @@ func TestMetadata(t *testing.T) {
 		assert.NoError(t, err)
 		defer f.Close()
 		_, err = io.Copy(*extractor, f)
-		assert.True(t, err == nil || err == io.ErrClosedPipe)
+		assert.True(t, err == nil || errors.Is(err, io.ErrClosedPipe))
 		err = (*extractor).Close()
 		assert.NoError(t, err)
 		meta := (*extractor).Result()

--- a/model/vfs/store.go
+++ b/model/vfs/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"sync"
 	"time"
 
@@ -318,7 +319,7 @@ func (s *redisStore) AddMetadata(db prefixer.Prefixer, metadata *Metadata) (stri
 
 func (s *redisStore) GetFile(db prefixer.Prefixer, key string) (string, error) {
 	f, err := s.c.Get(s.ctx, db.DBPrefix()+":"+key).Result()
-	if err == redis.Nil {
+	if errors.Is(err, redis.Nil) {
 		return "", ErrWrongToken
 	}
 	if err != nil {
@@ -329,7 +330,7 @@ func (s *redisStore) GetFile(db prefixer.Prefixer, key string) (string, error) {
 
 func (s *redisStore) GetThumb(db prefixer.Prefixer, key string) (string, error) {
 	f, err := s.c.Get(s.ctx, db.DBPrefix()+":"+key).Result()
-	if err == redis.Nil {
+	if errors.Is(err, redis.Nil) {
 		return "", ErrWrongToken
 	}
 	if err != nil {
@@ -340,7 +341,7 @@ func (s *redisStore) GetThumb(db prefixer.Prefixer, key string) (string, error) 
 
 func (s *redisStore) GetVersion(db prefixer.Prefixer, key string) (string, error) {
 	f, err := s.c.Get(s.ctx, db.DBPrefix()+":"+key).Result()
-	if err == redis.Nil {
+	if errors.Is(err, redis.Nil) {
 		return "", ErrWrongToken
 	}
 	if err != nil {
@@ -351,7 +352,7 @@ func (s *redisStore) GetVersion(db prefixer.Prefixer, key string) (string, error
 
 func (s *redisStore) GetArchive(db prefixer.Prefixer, key string) (*Archive, error) {
 	b, err := s.c.Get(s.ctx, db.DBPrefix()+":"+key).Bytes()
-	if err == redis.Nil {
+	if errors.Is(err, redis.Nil) {
 		return nil, ErrWrongToken
 	}
 	if err != nil {
@@ -366,7 +367,7 @@ func (s *redisStore) GetArchive(db prefixer.Prefixer, key string) (*Archive, err
 
 func (s *redisStore) GetMetadata(db prefixer.Prefixer, key string) (*Metadata, error) {
 	b, err := s.c.Get(s.ctx, db.DBPrefix()+":"+key).Bytes()
-	if err == redis.Nil {
+	if errors.Is(err, redis.Nil) {
 		return nil, ErrWrongToken
 	}
 	if err != nil {

--- a/model/vfs/vfs.go
+++ b/model/vfs/vfs.go
@@ -630,7 +630,7 @@ func walk(fs Indexer, name string, dir *DirDoc, file *FileDoc, walkFn WalkFn, co
 	}
 	err := walkFn(name, dir, file, nil)
 	if err != nil {
-		if dir != nil && err == ErrSkipDir {
+		if dir != nil && errors.Is(err, ErrSkipDir) {
 			return nil
 		}
 		return err
@@ -641,7 +641,7 @@ func walk(fs Indexer, name string, dir *DirDoc, file *FileDoc, walkFn WalkFn, co
 	iter := fs.DirIterator(dir, nil)
 	for {
 		d, f, err := iter.Next()
-		if err == ErrIteratorDone {
+		if errors.Is(err, ErrIteratorDone) {
 			break
 		}
 		if err != nil {

--- a/model/vfs/vfs_test.go
+++ b/model/vfs/vfs_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http/httptest"
@@ -783,7 +784,7 @@ func recFetchTree(fs vfs.VFS, parent *vfs.DirDoc, name string) (H, error) {
 	iter := fs.DirIterator(parent, nil)
 	for {
 		d, f, err := iter.Next()
-		if err == vfs.ErrIteratorDone {
+		if errors.Is(err, vfs.ErrIteratorDone) {
 			break
 		}
 		if err != nil {

--- a/model/vfs/vfsafero/fsck.go
+++ b/model/vfs/vfsafero/fsck.go
@@ -29,7 +29,7 @@ func (afs *aferoVFS) Fsck(accumulate func(log *vfs.FsckLog), failFast bool) erro
 		return err
 	}
 	if err = afs.CheckTreeIntegrity(tree, accumulate, failFast); err != nil {
-		if err == vfs.ErrFsckFailFast {
+		if errors.Is(err, vfs.ErrFsckFailFast) {
 			return nil
 		}
 		return err
@@ -160,7 +160,7 @@ func (afs *aferoVFS) checkFiles(
 		return nil
 	})
 	if err != nil {
-		if err == errFailFast {
+		if errors.Is(err, errFailFast) {
 			return nil
 		}
 		return err

--- a/model/vfs/vfsafero/impl.go
+++ b/model/vfs/vfsafero/impl.go
@@ -310,7 +310,7 @@ func (afs *aferoVFS) DissociateFile(src, dst *vfs.FileDoc) error {
 	// Move the source file to the destination
 	needRename := true
 	from, err := afs.Indexer.FilePath(src)
-	if err == vfs.ErrParentDoesNotExist {
+	if errors.Is(err, vfs.ErrParentDoesNotExist) {
 		needRename = false // The parent directory has already been dissociated
 	} else if err != nil {
 		return err
@@ -742,7 +742,7 @@ func (f *aferoFileCreation) Seek(offset int64, whence int) (int64, error) {
 
 func (f *aferoFileCreation) Write(p []byte) (int, error) {
 	if f.meta != nil {
-		if _, err := (*f.meta).Write(p); err != nil && err != io.ErrClosedPipe {
+		if _, err := (*f.meta).Write(p); err != nil && !errors.Is(err, io.ErrClosedPipe) {
 			(*f.meta).Abort(err)
 			f.meta = nil
 		}

--- a/model/vfs/vfsswift/fsck_v1.go
+++ b/model/vfs/vfsswift/fsck_v1.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	"errors"
 	"path"
 	"strings"
 
@@ -23,7 +24,7 @@ func (sfs *swiftVFS) Fsck(accumulate func(log *vfs.FsckLog), failFast bool) erro
 		return err
 	}
 	if err = sfs.CheckTreeIntegrity(tree, accumulate, failFast); err != nil {
-		if err == vfs.ErrFsckFailFast {
+		if errors.Is(err, vfs.ErrFsckFailFast) {
 			return nil
 		}
 		return err
@@ -123,7 +124,7 @@ func (sfs *swiftVFS) checkFiles(
 		return objs, err
 	})
 	if err != nil {
-		if err == errFailFast {
+		if errors.Is(err, errFailFast) {
 			return nil
 		}
 		return err

--- a/model/vfs/vfsswift/fsck_v2.go
+++ b/model/vfs/vfsswift/fsck_v2.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	"errors"
 	"path"
 
 	"github.com/cozy/cozy-stack/model/vfs"
@@ -22,7 +23,7 @@ func (sfs *swiftVFSV2) Fsck(accumulate func(log *vfs.FsckLog), failFast bool) er
 		return err
 	}
 	if err = sfs.CheckTreeIntegrity(tree, accumulate, failFast); err != nil {
-		if err == vfs.ErrFsckFailFast {
+		if errors.Is(err, vfs.ErrFsckFailFast) {
 			return nil
 		}
 		return err
@@ -93,7 +94,7 @@ func (sfs *swiftVFSV2) checkFiles(
 		return objs, err
 	})
 	if err != nil {
-		if err == errFailFast {
+		if errors.Is(err, errFailFast) {
 			return nil
 		}
 		return err
@@ -107,7 +108,7 @@ func (sfs *swiftVFSV2) checkFiles(
 			IsFile:  true,
 			FileDoc: f,
 		})
-		if err == errFailFast {
+		if errors.Is(err, errFailFast) {
 			return nil
 		}
 	}

--- a/model/vfs/vfsswift/fsck_v3.go
+++ b/model/vfs/vfsswift/fsck_v3.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"path"
 	"strings"
 
@@ -25,7 +26,7 @@ func (sfs *swiftVFSV3) Fsck(accumulate func(log *vfs.FsckLog), failFast bool) er
 		return err
 	}
 	if err = sfs.CheckTreeIntegrity(tree, accumulate, failFast); err != nil {
-		if err == vfs.ErrFsckFailFast {
+		if errors.Is(err, vfs.ErrFsckFailFast) {
 			return nil
 		}
 		return err
@@ -180,7 +181,7 @@ func (sfs *swiftVFSV3) checkFiles(
 		return objs, nil
 	})
 	if err != nil {
-		if err == errFailFast {
+		if errors.Is(err, errFailFast) {
 			return nil
 		}
 		return err

--- a/model/vfs/vfsswift/swift.go
+++ b/model/vfs/vfsswift/swift.go
@@ -24,7 +24,7 @@ var errFailFast = errors.New("fail fast")
 // deletes it.
 func DeleteContainer(ctx context.Context, c *swift.Connection, container string) error {
 	_, _, err := c.Container(ctx, container)
-	if err == swift.ContainerNotFound {
+	if errors.Is(err, swift.ContainerNotFound) {
 		return nil
 	}
 	if err != nil {
@@ -48,7 +48,7 @@ func DeleteContainer(ctx context.Context, c *swift.Connection, container string)
 	// container to work-around this limitation.
 	return utils.RetryWithExpBackoff(5, 2*time.Second, func() error {
 		err = c.ContainerDelete(ctx, container)
-		if err == swift.ContainerNotFound {
+		if errors.Is(err, swift.ContainerNotFound) {
 			return nil
 		}
 		return err

--- a/model/vfs/vfsswift/thumbs_v1.go
+++ b/model/vfs/vfsswift/thumbs_v1.go
@@ -2,6 +2,7 @@ package vfsswift
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -49,7 +50,7 @@ func (t *thumbs) CreateThumb(img *vfs.FileDoc, format string) (vfs.ThumbFiler, e
 func (t *thumbs) ThumbExists(img *vfs.FileDoc, format string) (bool, error) {
 	name := t.makeName(img.ID(), format)
 	infos, _, err := t.c.Object(t.ctx, t.container, name)
-	if err == swift.ObjectNotFound {
+	if errors.Is(err, swift.ObjectNotFound) {
 		return false, nil
 	}
 	if err != nil {
@@ -103,7 +104,7 @@ func (t *thumbs) CreateNoteThumb(id, mime, format string) (vfs.ThumbFiler, error
 func (t *thumbs) OpenNoteThumb(id, format string) (io.ReadCloser, error) {
 	name := t.makeName(id, format)
 	obj, _, err := t.c.ObjectOpen(t.ctx, t.container, name, false, nil)
-	if err == swift.ObjectNotFound {
+	if errors.Is(err, swift.ObjectNotFound) {
 		return nil, os.ErrNotExist
 	}
 	if err != nil {
@@ -145,7 +146,7 @@ func (t *thumbs) makeName(imgID string, format string) string {
 }
 
 func wrapSwiftErr(err error) error {
-	if err == swift.ObjectNotFound || err == swift.ContainerNotFound {
+	if errors.Is(err, swift.ObjectNotFound) || errors.Is(err, swift.ContainerNotFound) {
 		return os.ErrNotExist
 	}
 	return err

--- a/model/vfs/vfsswift/thumbs_v2_v3.go
+++ b/model/vfs/vfsswift/thumbs_v2_v3.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -103,7 +104,7 @@ func (t *thumbsV2) CreateThumb(img *vfs.FileDoc, format string) (vfs.ThumbFiler,
 func (t *thumbsV2) ThumbExists(img *vfs.FileDoc, format string) (bool, error) {
 	name := t.makeName(img.ID(), format)
 	infos, headers, err := t.c.Object(t.ctx, t.container, name)
-	if err == swift.ObjectNotFound {
+	if errors.Is(err, swift.ObjectNotFound) {
 		return false, nil
 	}
 	if err != nil {
@@ -174,7 +175,7 @@ func (t *thumbsV2) CreateNoteThumb(id, mime, format string) (vfs.ThumbFiler, err
 func (t *thumbsV2) OpenNoteThumb(id, format string) (io.ReadCloser, error) {
 	name := t.makeName(id, format)
 	obj, _, err := t.c.ObjectOpen(t.ctx, t.container, name, false, nil)
-	if err == swift.ObjectNotFound {
+	if errors.Is(err, swift.ObjectNotFound) {
 		return nil, os.ErrNotExist
 	}
 	if err != nil {

--- a/pkg/appfs/copier.go
+++ b/pkg/appfs/copier.go
@@ -2,6 +2,7 @@ package appfs
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"path"
@@ -63,7 +64,7 @@ func (f *swiftCopier) Exist(slug, version, shasum string) (bool, error) {
 	if err == nil {
 		return true, nil
 	}
-	if err != swift.ObjectNotFound {
+	if !errors.Is(err, swift.ObjectNotFound) {
 		return false, err
 	}
 	return false, nil
@@ -75,7 +76,7 @@ func (f *swiftCopier) Start(slug, version, shasum string) (bool, error) {
 		return exist, err
 	}
 
-	if _, _, err = f.c.Container(f.ctx, f.container); err == swift.ContainerNotFound {
+	if _, _, err = f.c.Container(f.ctx, f.container); errors.Is(err, swift.ContainerNotFound) {
 		if err = f.c.ContainerCreate(f.ctx, f.container, nil); err != nil {
 			return false, err
 		}

--- a/pkg/appfs/server.go
+++ b/pkg/appfs/server.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/md5"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -438,7 +439,7 @@ func containerName(appsType consts.AppType) string {
 }
 
 func wrapSwiftErr(err error) error {
-	if err == swift.ObjectNotFound || err == swift.ContainerNotFound {
+	if errors.Is(err, swift.ObjectNotFound) || errors.Is(err, swift.ContainerNotFound) {
 		return os.ErrNotExist
 	}
 	return err

--- a/pkg/assets/asset.go
+++ b/pkg/assets/asset.go
@@ -3,6 +3,7 @@ package assets
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -30,7 +31,7 @@ func Get(name, context string) (*model.Asset, bool) {
 	if err == nil {
 		return dynAsset, true
 	}
-	if err != dynamic.ErrDynAssetNotFound {
+	if !errors.Is(err, dynamic.ErrDynAssetNotFound) {
 		logger.WithNamespace("asset").Errorf("Error while retreiving dynamic asset: %s", err)
 	}
 

--- a/pkg/assets/dynamic/dynamic.go
+++ b/pkg/assets/dynamic/dynamic.go
@@ -52,7 +52,7 @@ func GetAsset(context, name string) (*model.Asset, error) {
 	// Re-constructing the asset struct from the dyn FS content
 	content, err := assetFS.Get(context, name)
 	if err != nil {
-		if err == swift.ObjectNotFound || os.IsNotExist(err) {
+		if errors.Is(err, swift.ObjectNotFound) || os.IsNotExist(err) {
 			return nil, ErrDynAssetNotFound
 		}
 		return nil, err

--- a/pkg/limits/rate_limiting.go
+++ b/pkg/limits/rate_limiting.go
@@ -363,7 +363,7 @@ func ResetCounter(p prefixer.Prefixer, ct CounterType) {
 // IsLimitReachedOrExceeded return true if the limit has been reached or
 // exceeded, false otherwise.
 func IsLimitReachedOrExceeded(err error) bool {
-	return err == ErrRateLimitReached || err == ErrRateLimitExceeded
+	return errors.Is(err, ErrRateLimitReached) || errors.Is(err, ErrRateLimitExceeded)
 }
 
 // GetMaximumLimit returns the limit of a CounterType

--- a/pkg/previewfs/cache.go
+++ b/pkg/previewfs/cache.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -112,7 +113,7 @@ func (s swiftCache) SetIcon(md5sum []byte, buffer *bytes.Buffer) error {
 		return err
 	}
 	err = writeClose(f, buffer)
-	if err == swift.ContainerNotFound || err == swift.ObjectNotFound {
+	if errors.Is(err, swift.ContainerNotFound) || errors.Is(err, swift.ObjectNotFound) {
 		_ = s.c.ContainerCreate(s.ctx, containerName, nil)
 		f, err = s.c.ObjectCreate(s.ctx, containerName, objectName, true, "", "image/jpg", headers)
 		if err == nil {
@@ -140,7 +141,7 @@ func (s swiftCache) SetPreview(md5sum []byte, buffer *bytes.Buffer) error {
 		return err
 	}
 	err = writeClose(f, buffer)
-	if err == swift.ContainerNotFound || err == swift.ObjectNotFound {
+	if errors.Is(err, swift.ContainerNotFound) || errors.Is(err, swift.ObjectNotFound) {
 		_ = s.c.ContainerCreate(s.ctx, containerName, nil)
 		f, err = s.c.ObjectCreate(s.ctx, containerName, objectName, true, "", "image/jpg", headers)
 		if err == nil {

--- a/tests/testutils/test_utils.go
+++ b/tests/testutils/test_utils.go
@@ -3,6 +3,7 @@ package testutils
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -133,7 +134,7 @@ func (c *TestSetup) GetTestInstance(opts ...*lifecycle.Options) *instance.Instan
 		c.host = opts[0].Domain
 	}
 	err = lifecycle.Destroy(c.host)
-	if err != nil && err != instance.ErrNotFound {
+	if err != nil && !errors.Is(err, instance.ErrNotFound) {
 		require.NoError(c.t, err, "Error while destroying instance")
 	}
 

--- a/web/apps/apps.go
+++ b/web/apps/apps.go
@@ -639,7 +639,7 @@ func iconHandler(appType consts.AppType) echo.HandlerFunc {
 		version := c.Param("version")
 		a, err := app.GetBySlug(instance, slug, appType)
 		if err != nil {
-			if err == app.ErrNotFound {
+			if errors.Is(err, app.ErrNotFound) {
 				return jsonapi.NotFound(err)
 			}
 			return err

--- a/web/apps/apps_test.go
+++ b/web/apps/apps_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -345,7 +346,7 @@ func TestApps(t *testing.T) {
 		indexFound := false
 		for {
 			header, err := tr.Next()
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			require.NoError(t, err)
@@ -372,7 +373,7 @@ func TestApps(t *testing.T) {
 		iconFound := false
 		for {
 			header, err := tr.Next()
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			require.NoError(t, err)

--- a/web/apps/serve.go
+++ b/web/apps/serve.go
@@ -3,6 +3,7 @@ package apps
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"html/template"
 	"io"
 	"net/http"
@@ -48,7 +49,7 @@ func Serve(c echo.Context) error {
 
 	webapp, err := app.GetWebappBySlug(i, slug)
 	if err != nil {
-		if err == app.ErrNotFound {
+		if errors.Is(err, app.ErrNotFound) {
 			return handleAppNotFound(c, i, slug)
 		}
 		return err

--- a/web/auth/oauth.go
+++ b/web/auth/oauth.go
@@ -341,7 +341,7 @@ func authorize(c echo.Context) error {
 			Slug:       slug,
 			Registries: instance.Registries(),
 		})
-		if err != app.ErrAlreadyExists {
+		if !errors.Is(err, app.ErrAlreadyExists) {
 			if err != nil {
 				return err
 			}

--- a/web/auth/store.go
+++ b/web/auth/store.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"sync"
 	"time"
 
@@ -107,7 +108,7 @@ func (s *redisStore) AddCode(db prefixer.Prefixer) (string, error) {
 func (s *redisStore) GetCode(db prefixer.Prefixer, code string) (bool, error) {
 	key := confirmKey(db, code)
 	n, err := s.c.Exists(s.ctx, key).Result()
-	if err == redis.Nil || n == 0 {
+	if errors.Is(err, redis.Nil) || n == 0 {
 		return false, nil
 	}
 	if err != nil {

--- a/web/bitwarden/bitwarden.go
+++ b/web/bitwarden/bitwarden.go
@@ -3,6 +3,7 @@ package bitwarden
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -300,7 +301,7 @@ func getInitialCredentials(c echo.Context) error {
 	}
 	key := setting.Key
 
-	if _, err := setting.OrganizationKey(); err == settings.ErrMissingOrgKey {
+	if _, err := setting.OrganizationKey(); errors.Is(err, settings.ErrMissingOrgKey) {
 		// The organization key should exist at this moment as it is created at the
 		// instance creation or at the login-hashed migration.
 		log.Warnf("Organization key does not exist")

--- a/web/contacts/contacts.go
+++ b/web/contacts/contacts.go
@@ -3,6 +3,7 @@ package contacts
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 
 	"github.com/cozy/cozy-stack/model/contact"
@@ -27,7 +28,7 @@ func (m *apiMyself) Included() []jsonapi.Object             { return []jsonapi.O
 func MyselfHandler(c echo.Context) error {
 	inst := middlewares.GetInstance(c)
 	myself, err := contact.GetMyself(inst)
-	if err == contact.ErrNotFound {
+	if errors.Is(err, contact.ErrNotFound) {
 		var settings *couchdb.JSONDoc
 		settings, err = inst.SettingsDocument()
 		if err == nil {

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -129,7 +129,7 @@ func createFileHandler(c echo.Context, fs vfs.VFS) (*file, error) {
 		inst.Logger().WithNamespace("files").
 			Warnf("Error on uploading file (copy): %s (%d bytes written - expected %d)", err, n, doc.ByteSize)
 	}
-	if cerr := file.Close(); cerr != nil && (err == nil || err == io.ErrUnexpectedEOF) {
+	if cerr := file.Close(); cerr != nil && (err == nil || errors.Is(err, io.ErrUnexpectedEOF)) {
 		err = cerr
 		inst.Logger().WithNamespace("files").
 			Warnf("Error on uploading file (close): %s", err)
@@ -1015,7 +1015,7 @@ func ThumbnailHandler(c echo.Context) error {
 	format := c.Param("format")
 	err = fs.ServeThumbContent(c.Response(), c.Request(), doc, format)
 	if err != nil {
-		if err != os.ErrInvalid {
+		if !errors.Is(err, os.ErrInvalid) {
 			msg, _ := job.NewMessage(thumbnail.ImageMessage{
 				File:   doc,
 				Format: format,

--- a/web/instances/fixers.go
+++ b/web/instances/fixers.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -346,7 +347,7 @@ func serviceTriggersFixer(c echo.Context) error {
 
 	for slug, triggers := range byApps {
 		manifest, err := app.GetWebappBySlug(inst, slug)
-		if err == app.ErrNotFound {
+		if errors.Is(err, app.ErrNotFound) {
 			// The app has been uninstalled, but some duplicate triggers has
 			// been left
 			toDelete = append(toDelete, triggers...)
@@ -363,7 +364,7 @@ func serviceTriggersFixer(c echo.Context) error {
 			}
 			if service.TriggerID != "" {
 				_, err := jobsSystem.GetTrigger(inst, service.TriggerID)
-				if err == job.ErrNotFoundTrigger {
+				if errors.Is(err, job.ErrNotFoundTrigger) {
 					triggerID, err := app.CreateServiceTrigger(inst, slug, service)
 					if err != nil {
 						return err

--- a/web/jobs/jobs.go
+++ b/web/jobs/jobs.go
@@ -831,7 +831,7 @@ func wrapJobsError(err error) error {
 func checkReservedWorker(worker string) error {
 	reserved, err := job.System().WorkerIsReserved(worker)
 	if err != nil {
-		if err == job.ErrUnknownWorker {
+		if errors.Is(err, job.ErrUnknownWorker) {
 			return echo.NewHTTPError(http.StatusNotFound)
 		}
 		return err

--- a/web/middlewares/recover.go
+++ b/web/middlewares/recover.go
@@ -1,6 +1,7 @@
 package middlewares
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"runtime"
@@ -48,7 +49,7 @@ func RecoverWithConfig(config RecoverConfig) echo.MiddlewareFunc {
 					// We don't want to log panic with ErrAbortHandler, as it
 					// is just noise (http.Server does that too).
 					// See https://golang.org/pkg/net/http/#ErrAbortHandler
-					if err != http.ErrAbortHandler {
+					if !errors.Is(err, http.ErrAbortHandler) {
 						stack := make([]byte, config.StackSize)
 						length := runtime.Stack(stack, false)
 						log := logger.WithDomain(c.Request().Host).WithField("panic", true)

--- a/web/notes/notes.go
+++ b/web/notes/notes.go
@@ -145,7 +145,7 @@ func GetSteps(c echo.Context) error {
 		return jsonapi.InvalidParameter("Version", err)
 	}
 	steps, err := note.GetSteps(inst, file.DocID, rev)
-	if err == note.ErrTooOld {
+	if errors.Is(err, note.ErrTooOld) {
 		file, err = note.GetFile(inst, file)
 		if err != nil {
 			return wrapError(err)
@@ -391,7 +391,7 @@ func UploadImage(c echo.Context) error {
 
 	// Manage the content upload
 	_, err = io.Copy(upload, c.Request().Body)
-	if cerr := upload.Close(); cerr != nil && (err == nil || err == io.ErrUnexpectedEOF) {
+	if cerr := upload.Close(); cerr != nil && (err == nil || errors.Is(err, io.ErrUnexpectedEOF)) {
 		err = cerr
 	}
 	if err != nil {

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -572,7 +572,7 @@ func PostDiscovery(c echo.Context) error {
 			if c.Request().Header.Get(echo.HeaderAccept) == echo.MIMEApplicationJSON {
 				return c.JSON(http.StatusBadRequest, echo.Map{"error": err.Error()})
 			}
-			if err == sharing.ErrAlreadyAccepted {
+			if errors.Is(err, sharing.ErrAlreadyAccepted) {
 				return renderAlreadyAccepted(c, inst, cozyURL)
 			}
 			return renderDiscoveryForm(c, inst, http.StatusBadRequest, sharingID, state, sharecode, member)
@@ -585,7 +585,7 @@ func PostDiscovery(c echo.Context) error {
 	} else {
 		redirectURL, err = s.DelegateDiscovery(inst, state, cozyURL)
 		if err != nil {
-			if err == sharing.ErrInvalidURL {
+			if errors.Is(err, sharing.ErrInvalidURL) {
 				if c.Request().Header.Get(echo.HeaderAccept) == echo.MIMEApplicationJSON {
 					return c.JSON(http.StatusBadRequest, echo.Map{"error": err.Error()})
 				}

--- a/worker/exec/konnector.go
+++ b/worker/exec/konnector.go
@@ -203,7 +203,7 @@ func (w *konnectorWorker) PrepareWorkDir(ctx *job.WorkerContext, i *instance.Ins
 
 	w.man, err = app.GetKonnectorBySlugAndUpdate(i, slug,
 		app.Copier(consts.KonnectorType, i), i.Registries())
-	if err == app.ErrNotFound {
+	if errors.Is(err, app.ErrNotFound) {
 		return "", cleanDir, job.ErrBadTrigger{Err: err}
 	} else if err != nil {
 		return "", cleanDir, err
@@ -478,7 +478,7 @@ func extractTar(workFS afero.Fs, tarFile io.ReadCloser) error {
 	for {
 		var hdr *tar.Header
 		hdr, err := tr.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return nil
 		}
 		if err != nil {

--- a/worker/exec/konnector_test.go
+++ b/worker/exec/konnector_test.go
@@ -1,6 +1,7 @@
 package exec
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -133,7 +134,7 @@ echo "{\"type\": \"manifest\", \"message\": \"$(ls ${1}/manifest.konnector)\" }"
 				SourceURL: "git://github.com/konnectors/cozy-konnector-trainline.git",
 			},
 		)
-		if err != app.ErrAlreadyExists {
+		if !errors.Is(err, app.ErrAlreadyExists) {
 			require.NoError(t, err)
 
 			_, err = installer.RunSync()
@@ -237,7 +238,7 @@ echo "{\"type\": \"params\", \"message\": ${SECRET} }"
 				SourceURL: "git://github.com/konnectors/cozy-konnector-trainline.git",
 			},
 		)
-		if err != app.ErrAlreadyExists {
+		if !errors.Is(err, app.ErrAlreadyExists) {
 			require.NoError(t, err)
 
 			_, err = installer.RunSync()
@@ -307,7 +308,7 @@ echo "{\"type\": \"toto\", \"message\": \"COZY_URL=${COZY_URL}\"}"
 				SourceURL: "git://github.com/konnectors/cozy-konnector-trainline.git",
 			},
 		)
-		if err != app.ErrAlreadyExists {
+		if !errors.Is(err, app.ErrAlreadyExists) {
 			require.NoError(t, err)
 
 			_, err = installer.RunSync()

--- a/worker/exec/service.go
+++ b/worker/exec/service.go
@@ -54,7 +54,7 @@ func (w *serviceWorker) PrepareWorkDir(ctx *job.WorkerContext, i *instance.Insta
 	man, err := app.GetWebappBySlugAndUpdate(i, slug,
 		app.Copier(consts.WebappType, i), i.Registries())
 	if err != nil {
-		if err == app.ErrNotFound {
+		if errors.Is(err, app.ErrNotFound) {
 			err = job.ErrBadTrigger{Err: err}
 		}
 		return

--- a/worker/migrations/migrations.go
+++ b/worker/migrations/migrations.go
@@ -122,7 +122,7 @@ func removeUnwantedFolders(domain string) error {
 
 	var errf error
 	removeDir := func(dir *vfs.DirDoc, err error) {
-		if err == os.ErrNotExist {
+		if errors.Is(err, os.ErrNotExist) {
 			return
 		} else if err != nil {
 			errf = multierror.Append(errf, err)
@@ -278,7 +278,7 @@ func migrateToSwiftV3(domain string) error {
 
 	ctx := context.Background()
 	dstContainer := swiftV3ContainerPrefix + inst.DBPrefix()
-	if _, _, err = c.Container(ctx, dstContainer); err != swift.ContainerNotFound {
+	if _, _, err = c.Container(ctx, dstContainer); !errors.Is(err, swift.ContainerNotFound) {
 		log.Errorf("Destination container %s already exists or something went wrong. Migration canceled.", dstContainer)
 		return errors.New("Destination container busy")
 	}


### PR DESCRIPTION
More informations about the 1.13 error format and how to use it can be found at https://go.dev/blog/go1.13-errors

This commit have been generated by the following commands:
```
sed -i 's/err == \([a-z]*\)\.\([a-zA-Z]*\)/errors.Is(err, \1.\2)/g' **/*.go
sed -i 's/err != \([a-z]*\)\.\([a-zA-Z]*\)/!errors.Is(err, \1.\2)/g' **/*.go

sed -i 's/err == \([a-zA-Z]*\)/errors.Is(err, \1)/g' **/*.go
sed -i 's/errors\.Is(err, nil)/err == nil/g' **/*.go

sed -i 's/err != \([a-zA-Z]*\)/!errors.Is(err, \1)/g' **/*.go
sed -i 's/!errors\.Is(err, nil)/err != nil/g' **/*.go
```