### PR TITLE
fix: Skip sharing checks for inactive members

### DIFF
--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -1126,6 +1126,10 @@ func CheckSharings(inst *instance.Instance, skipFSConsistency bool) ([]map[strin
 					continue
 				}
 
+				if !ms.Active {
+					continue
+				}
+
 				parentSharingID, err := findParentFileSharingID(m, ms)
 				if err != nil {
 					return err


### PR DESCRIPTION
There's no point in checking an inactive sharing member's files and
folders' consistency with those of the sharing owner as the
synchronization is not active anymore.

Besides, no skipping them would mean returning
`invalid_number_of_credentials` errors while this is a perfectly
normal situation.