### PR TITLE
Fix downgrading app

### DIFF
--- a/model/app/fetcher_registry.go
+++ b/model/app/fetcher_registry.go
@@ -47,6 +47,10 @@ func (f *registryFetcher) FetchManifest(src *url.URL) (io.ReadCloser, error) {
 	return io.NopCloser(bytes.NewBuffer(version.Manifest)), nil
 }
 
+func (f *registryFetcher) appVersion() string {
+	return f.version.Version
+}
+
 func (f *registryFetcher) Fetch(src *url.URL, fs appfs.Copier, man Manifest) error {
 	v := f.version
 	shasum, err := hex.DecodeString(v.Sha256)

--- a/model/app/installer.go
+++ b/model/app/installer.go
@@ -387,6 +387,10 @@ func (i *Installer) update() error {
 		return err
 	}
 
+	if fetcher, ok := i.fetcher.(*registryFetcher); ok {
+		newManifest.SetVersion(fetcher.appVersion())
+	}
+
 	// Fast path for registry:// and http:// sources: we do not need to go
 	// further in the case where the fetched manifest has the same version has
 	// the one in database.


### PR DESCRIPTION
When an app is installed on version x.y.z from the stable canal of the apps registry, and the stack is asked to update it to the version x.y.z-dev.shasum from the dev canal of the apps registry, the downgrade was failing because the manifest sent to the apps registry was for the x.y.z version, without the shasum. The stack is now forcing the version for this case.