### PR TITLE
feat: Add --path flag to admin export command

### DIFF
--- a/client/admin_client.go
+++ b/client/admin_client.go
@@ -1,0 +1,46 @@
+package client
+
+import (
+	"time"
+
+	"github.com/cozy/cozy-stack/client/request"
+	"github.com/cozy/cozy-stack/pkg/config/config"
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/tlsclient"
+)
+
+type AdminClient struct {
+	Client
+}
+
+func (ac *AdminClient) NewInstanceClient(domain string, scopes ...string) (*Client, error) {
+	token, err := ac.GetToken(&TokenOptions{
+		Domain:   domain,
+		Subject:  "CLI",
+		Audience: consts.CLIAudience,
+		Scope:    scopes,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	httpClient, clientURL, err := tlsclient.NewHTTPClient(tlsclient.HTTPEndpoint{
+		Host:      config.GetConfig().Host,
+		Port:      config.GetConfig().Port,
+		Timeout:   5 * time.Minute,
+		EnvPrefix: "COZY_HOST",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	c := &Client{
+		Scheme:     clientURL.Scheme,
+		Addr:       clientURL.Host,
+		Domain:     domain,
+		Client:     httpClient,
+		Authorizer: &request.BearerAuthorizer{Token: token},
+	}
+
+	return c, nil
+}

--- a/client/apps.go
+++ b/client/apps.go
@@ -203,12 +203,12 @@ func (c *Client) UninstallApp(opts *AppOptions) (*AppManifest, error) {
 }
 
 // ListMaintenances returns a list of konnectors in maintenance
-func (c *Client) ListMaintenances(context string) ([]interface{}, error) {
+func (ac *AdminClient) ListMaintenances(context string) ([]interface{}, error) {
 	queries := url.Values{}
 	if context != "" {
 		queries.Add("Context", context)
 	}
-	res, err := c.Req(&request.Options{
+	res, err := ac.Req(&request.Options{
 		Method:  "GET",
 		Path:    "/konnectors/maintenance",
 		Queries: queries,
@@ -224,13 +224,13 @@ func (c *Client) ListMaintenances(context string) ([]interface{}, error) {
 }
 
 // ActivateMaintenance is used to activate the maintenance for a konnector
-func (c *Client) ActivateMaintenance(slug string, opts map[string]interface{}) error {
+func (ac *AdminClient) ActivateMaintenance(slug string, opts map[string]interface{}) error {
 	data := map[string]interface{}{"attributes": opts}
 	body, err := writeJSONAPI(data)
 	if err != nil {
 		return err
 	}
-	_, err = c.Req(&request.Options{
+	_, err = ac.Req(&request.Options{
 		Method:     "PUT",
 		Path:       "/konnectors/maintenance/" + slug,
 		Body:       body,
@@ -240,8 +240,8 @@ func (c *Client) ActivateMaintenance(slug string, opts map[string]interface{}) e
 }
 
 // DeactivateMaintenance is used to deactivate the maintenance for a konnector
-func (c *Client) DeactivateMaintenance(slug string) error {
-	_, err := c.Req(&request.Options{
+func (ac *AdminClient) DeactivateMaintenance(slug string) error {
+	_, err := ac.Req(&request.Options{
 		Method:     "DELETE",
 		Path:       "/konnectors/maintenance/" + slug,
 		NoResponse: true,

--- a/client/instances.go
+++ b/client/instances.go
@@ -118,8 +118,8 @@ func (i *Instance) DBPrefix() string {
 }
 
 // GetInstance returns the instance associated with the specified domain.
-func (c *Client) GetInstance(domain string) (*Instance, error) {
-	res, err := c.Req(&request.Options{
+func (ac *AdminClient) GetInstance(domain string) (*Instance, error) {
+	res, err := ac.Req(&request.Options{
 		Method: "GET",
 		Path:   "/instances/" + domain,
 	})
@@ -131,7 +131,7 @@ func (c *Client) GetInstance(domain string) (*Instance, error) {
 
 // CreateInstance is used to create a new cozy instance of the specified domain
 // and locale.
-func (c *Client) CreateInstance(opts *InstanceOptions) (*Instance, error) {
+func (ac *AdminClient) CreateInstance(opts *InstanceOptions) (*Instance, error) {
 	if !validDomain(opts.Domain) {
 		return nil, fmt.Errorf("Invalid domain: %s", opts.Domain)
 	}
@@ -159,7 +159,7 @@ func (c *Client) CreateInstance(opts *InstanceOptions) (*Instance, error) {
 	if opts.Trace != nil && *opts.Trace {
 		q.Add("Trace", "true")
 	}
-	res, err := c.Req(&request.Options{
+	res, err := ac.Req(&request.Options{
 		Method:  "POST",
 		Path:    "/instances",
 		Queries: q,
@@ -171,8 +171,8 @@ func (c *Client) CreateInstance(opts *InstanceOptions) (*Instance, error) {
 }
 
 // CountInstances returns the number of instances.
-func (c *Client) CountInstances() (int, error) {
-	res, err := c.Req(&request.Options{
+func (ac *AdminClient) CountInstances() (int, error) {
+	res, err := ac.Req(&request.Options{
 		Method: "GET",
 		Path:   "/instances/count",
 	})
@@ -188,8 +188,8 @@ func (c *Client) CountInstances() (int, error) {
 }
 
 // ListInstances returns the list of instances recorded on the stack.
-func (c *Client) ListInstances() ([]*Instance, error) {
-	res, err := c.Req(&request.Options{
+func (ac *AdminClient) ListInstances() ([]*Instance, error) {
+	res, err := ac.Req(&request.Options{
 		Method: "GET",
 		Path:   "/instances",
 	})
@@ -204,7 +204,7 @@ func (c *Client) ListInstances() ([]*Instance, error) {
 }
 
 // ModifyInstance is used to update an instance.
-func (c *Client) ModifyInstance(opts *InstanceOptions) (*Instance, error) {
+func (ac *AdminClient) ModifyInstance(opts *InstanceOptions) (*Instance, error) {
 	domain := opts.Domain
 	if !validDomain(domain) {
 		return nil, fmt.Errorf("Invalid domain: %s", domain)
@@ -238,7 +238,7 @@ func (c *Client) ModifyInstance(opts *InstanceOptions) (*Instance, error) {
 	if opts.OnboardingFinished != nil {
 		q.Add("OnboardingFinished", strconv.FormatBool(*opts.OnboardingFinished))
 	}
-	res, err := c.Req(&request.Options{
+	res, err := ac.Req(&request.Options{
 		Method:  "PATCH",
 		Path:    "/instances/" + domain,
 		Queries: q,
@@ -250,11 +250,11 @@ func (c *Client) ModifyInstance(opts *InstanceOptions) (*Instance, error) {
 }
 
 // DestroyInstance is used to delete an instance and all its data.
-func (c *Client) DestroyInstance(domain string) error {
+func (ac *AdminClient) DestroyInstance(domain string) error {
 	if !validDomain(domain) {
 		return fmt.Errorf("Invalid domain: %s", domain)
 	}
-	_, err := c.Req(&request.Options{
+	_, err := ac.Req(&request.Options{
 		Method:     "DELETE",
 		Path:       "/instances/" + domain,
 		NoResponse: true,
@@ -263,11 +263,11 @@ func (c *Client) DestroyInstance(domain string) error {
 }
 
 // GetDebug is used to known if an instance has its logger in debug mode.
-func (c *Client) GetDebug(domain string) (bool, error) {
+func (ac *AdminClient) GetDebug(domain string) (bool, error) {
 	if !validDomain(domain) {
 		return false, fmt.Errorf("Invalid domain: %s", domain)
 	}
-	_, err := c.Req(&request.Options{
+	_, err := ac.Req(&request.Options{
 		Method:     "GET",
 		Path:       "/instances/" + domain + "/debug",
 		NoResponse: true,
@@ -284,11 +284,11 @@ func (c *Client) GetDebug(domain string) (bool, error) {
 }
 
 // EnableDebug sets the logger of an instance in debug mode.
-func (c *Client) EnableDebug(domain string, ttl time.Duration) error {
+func (ac *AdminClient) EnableDebug(domain string, ttl time.Duration) error {
 	if !validDomain(domain) {
 		return fmt.Errorf("Invalid domain: %s", domain)
 	}
-	_, err := c.Req(&request.Options{
+	_, err := ac.Req(&request.Options{
 		Method:     "POST",
 		Path:       "/instances/" + domain + "/debug",
 		NoResponse: true,
@@ -300,11 +300,11 @@ func (c *Client) EnableDebug(domain string, ttl time.Duration) error {
 }
 
 // CleanSessions delete the databases for io.cozy.sessions and io.cozy.sessions.logins
-func (c *Client) CleanSessions(domain string) error {
+func (ac *AdminClient) CleanSessions(domain string) error {
 	if !validDomain(domain) {
 		return fmt.Errorf("Invalid domain: %s", domain)
 	}
-	_, err := c.Req(&request.Options{
+	_, err := ac.Req(&request.Options{
 		Method:     "DELETE",
 		Path:       "/instances/" + domain + "/sessions",
 		NoResponse: true,
@@ -313,11 +313,11 @@ func (c *Client) CleanSessions(domain string) error {
 }
 
 // DisableDebug disables the debug mode for the logger of an instance.
-func (c *Client) DisableDebug(domain string) error {
+func (ac *AdminClient) DisableDebug(domain string) error {
 	if !validDomain(domain) {
 		return fmt.Errorf("Invalid domain: %s", domain)
 	}
-	_, err := c.Req(&request.Options{
+	_, err := ac.Req(&request.Options{
 		Method:     "DELETE",
 		Path:       "/instances/" + domain + "/debug",
 		NoResponse: true,
@@ -326,7 +326,7 @@ func (c *Client) DisableDebug(domain string) error {
 }
 
 // GetToken is used to generate a token with the specified options.
-func (c *Client) GetToken(opts *TokenOptions) (string, error) {
+func (ac *AdminClient) GetToken(opts *TokenOptions) (string, error) {
 	q := url.Values{
 		"Domain":   {opts.Domain},
 		"Subject":  {opts.Subject},
@@ -336,7 +336,7 @@ func (c *Client) GetToken(opts *TokenOptions) (string, error) {
 	if opts.Expire != nil {
 		q.Add("Expire", opts.Expire.String())
 	}
-	res, err := c.Req(&request.Options{
+	res, err := ac.Req(&request.Options{
 		Method:  "POST",
 		Path:    "/instances/token",
 		Queries: q,
@@ -354,7 +354,7 @@ func (c *Client) GetToken(opts *TokenOptions) (string, error) {
 
 // RegisterOAuthClient register a new OAuth client associated to the specified
 // instance.
-func (c *Client) RegisterOAuthClient(opts *OAuthClientOptions) (map[string]interface{}, error) {
+func (ac *AdminClient) RegisterOAuthClient(opts *OAuthClientOptions) (map[string]interface{}, error) {
 	q := url.Values{
 		"Domain":                {opts.Domain},
 		"RedirectURI":           {opts.RedirectURI},
@@ -366,7 +366,7 @@ func (c *Client) RegisterOAuthClient(opts *OAuthClientOptions) (map[string]inter
 		"OnboardingPermissions": {opts.OnboardingPermissions},
 		"OnboardingState":       {opts.OnboardingState},
 	}
-	res, err := c.Req(&request.Options{
+	res, err := ac.Req(&request.Options{
 		Method:  "POST",
 		Path:    "/instances/oauth_client",
 		Queries: q,
@@ -384,7 +384,7 @@ func (c *Client) RegisterOAuthClient(opts *OAuthClientOptions) (map[string]inter
 
 // Updates launch the updating process of the applications. When no Domain is
 // specified, the updates are launched for all the existing instances.
-func (c *Client) Updates(opts *UpdatesOptions) error {
+func (ac *AdminClient) Updates(opts *UpdatesOptions) error {
 	q := url.Values{
 		"Domain":             {opts.Domain},
 		"DomainsWithContext": {opts.DomainsWithContext},
@@ -392,7 +392,7 @@ func (c *Client) Updates(opts *UpdatesOptions) error {
 		"ForceRegistry":      {strconv.FormatBool(opts.ForceRegistry)},
 		"OnlyRegistry":       {strconv.FormatBool(opts.OnlyRegistry)},
 	}
-	channel, err := c.RealtimeClient(RealtimeOptions{
+	channel, err := ac.RealtimeClient(RealtimeOptions{
 		DocTypes: []string{"io.cozy.jobs", "io.cozy.jobs.logs"},
 	})
 	if err != nil {
@@ -404,7 +404,7 @@ func (c *Client) Updates(opts *UpdatesOptions) error {
 		}
 		channel.Close()
 	}()
-	res, err := c.Req(&request.Options{
+	res, err := ac.Req(&request.Options{
 		Method:  "POST",
 		Path:    "/instances/updates",
 		Queries: q,
@@ -453,11 +453,11 @@ func (c *Client) Updates(opts *UpdatesOptions) error {
 }
 
 // Export launch the creation of a tarball to export data from an instance.
-func (c *Client) Export(domain string) error {
+func (ac *AdminClient) Export(domain string) error {
 	if !validDomain(domain) {
 		return fmt.Errorf("Invalid domain: %s", domain)
 	}
-	_, err := c.Req(&request.Options{
+	_, err := ac.Req(&request.Options{
 		Method:     "POST",
 		Path:       "/instances/" + url.PathEscape(domain) + "/export",
 		NoResponse: true,
@@ -466,14 +466,14 @@ func (c *Client) Export(domain string) error {
 }
 
 // Import launch the import of a tarball with data to put in an instance.
-func (c *Client) Import(domain string, opts *ImportOptions) error {
+func (ac *AdminClient) Import(domain string, opts *ImportOptions) error {
 	if !validDomain(domain) {
 		return fmt.Errorf("Invalid domain: %s", domain)
 	}
 	q := url.Values{
 		"manifest_url": {opts.ManifestURL},
 	}
-	_, err := c.Req(&request.Options{
+	_, err := ac.Req(&request.Options{
 		Method:     "POST",
 		Path:       "/instances/" + url.PathEscape(domain) + "/import",
 		Queries:    q,
@@ -483,8 +483,8 @@ func (c *Client) Import(domain string, opts *ImportOptions) error {
 }
 
 // RebuildRedis puts the triggers in redis.
-func (c *Client) RebuildRedis() error {
-	_, err := c.Req(&request.Options{
+func (ac *AdminClient) RebuildRedis() error {
+	_, err := ac.Req(&request.Options{
 		Method:     "POST",
 		Path:       "/instances/redis",
 		NoResponse: true,
@@ -493,7 +493,7 @@ func (c *Client) RebuildRedis() error {
 }
 
 // DiskUsage returns the information about disk usage and quota
-func (c *Client) DiskUsage(domain string, includeTrash bool) (map[string]interface{}, error) {
+func (ac *AdminClient) DiskUsage(domain string, includeTrash bool) (map[string]interface{}, error) {
 	var q map[string][]string
 	if includeTrash {
 		q = url.Values{
@@ -501,7 +501,7 @@ func (c *Client) DiskUsage(domain string, includeTrash bool) (map[string]interfa
 		}
 	}
 
-	res, err := c.Req(&request.Options{
+	res, err := ac.Req(&request.Options{
 		Method:  "GET",
 		Path:    "/instances/" + url.PathEscape(domain) + "/disk-usage",
 		Queries: q,

--- a/client/tools.go
+++ b/client/tools.go
@@ -7,8 +7,8 @@ import (
 )
 
 // ProfileHeap returns a sampling of memory allocations as pprof format.
-func (c *Client) ProfileHeap() (io.ReadCloser, error) {
-	res, err := c.Req(&request.Options{
+func (ac *AdminClient) ProfileHeap() (io.ReadCloser, error) {
+	res, err := ac.Req(&request.Options{
 		Method: "GET",
 		Path:   "/tools/pprof/heap",
 	})

--- a/cmd/apps.go
+++ b/cmd/apps.go
@@ -279,8 +279,8 @@ var listMaintenancesCmd = &cobra.Command{
 	Use:   "ls-maintenances",
 	Short: `List the konnectors in maintenance`,
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
-		c := newAdminClient()
-		list, err := c.ListMaintenances(flagKonnectorContext)
+		ac := newAdminClient()
+		list, err := ac.ListMaintenances(flagKonnectorContext)
 		if err != nil {
 			return err
 		}
@@ -325,8 +325,8 @@ var activateMaintenanceKonnectorsCmd = &cobra.Command{
 			"flag_disallow_manual_exec": flagKonnectorsDisallowManualExec,
 			"messages":                  messages,
 		}
-		c := newAdminClient()
-		return c.ActivateMaintenance(args[0], opts)
+		ac := newAdminClient()
+		return ac.ActivateMaintenance(args[0], opts)
 	},
 }
 
@@ -337,8 +337,8 @@ var deactivateMaintenanceKonnectorsCmd = &cobra.Command{
 		if len(args) != 1 {
 			return cmd.Help()
 		}
-		c := newAdminClient()
-		return c.DeactivateMaintenance(args[0])
+		ac := newAdminClient()
+		return ac.DeactivateMaintenance(args[0])
 	},
 }
 
@@ -634,8 +634,8 @@ func lsApps(cmd *cobra.Command, args []string, appType string) error {
 }
 
 func foreachDomains(predicate func(*client.Instance) error) error {
-	c := newAdminClient()
-	list, err := c.ListInstances()
+	ac := newAdminClient()
+	list, err := ac.ListInstances()
 	if err != nil {
 		return nil
 	}

--- a/cmd/assets.go
+++ b/cmd/assets.go
@@ -54,13 +54,13 @@ func addAsset(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	c := newAdminClient()
+	ac := newAdminClient()
 	req := &request.Options{
 		Method: "POST",
 		Path:   "instances/assets",
 		Body:   bytes.NewReader(marshaledAssets),
 	}
-	res, err := c.Req(req)
+	res, err := ac.Req(req)
 	if err != nil {
 		return err
 	}
@@ -83,12 +83,12 @@ func rmAsset(cmd *cobra.Command, args []string) error {
 		return cmd.Usage()
 	}
 
-	c := newAdminClient()
+	ac := newAdminClient()
 	req := &request.Options{
 		Method: "DELETE",
 		Path:   fmt.Sprintf("instances/assets/%s/%s", args[0], args[1]),
 	}
-	res, err := c.Req(req)
+	res, err := ac.Req(req)
 	if err != nil {
 		return err
 	}
@@ -106,12 +106,12 @@ var lsAssetsCmd = &cobra.Command{
 }
 
 func lsAssets(cmd *cobra.Command, args []string) error {
-	c := newAdminClient()
+	ac := newAdminClient()
 	req := &request.Options{
 		Method: "GET",
 		Path:   "instances/assets",
 	}
-	res, err := c.Req(req)
+	res, err := ac.Req(req)
 	if err != nil {
 		return err
 	}

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -57,8 +57,8 @@ func fsck(domain string) error {
 		flagCheckFSFilesConsistensy = false
 	}
 
-	c := newAdminClient()
-	res, err := c.Req(&request.Options{
+	ac := newAdminClient()
+	res, err := ac.Req(&request.Options{
 		Method: "GET",
 		Path:   "/instances/" + url.PathEscape(domain) + "/fsck",
 		Queries: url.Values{
@@ -101,8 +101,8 @@ triggers of the same type, for the same worker, and with the same arguments.
 		}
 		domain := args[0]
 
-		c := newAdminClient()
-		res, err := c.Req(&request.Options{
+		ac := newAdminClient()
+		res, err := ac.Req(&request.Options{
 			Method: "POST",
 			Path:   "/instances/" + url.PathEscape(domain) + "/checks/triggers",
 		})
@@ -141,8 +141,8 @@ generation smaller than their generation.
 		}
 		domain := args[0]
 
-		c := newAdminClient()
-		res, err := c.Req(&request.Options{
+		ac := newAdminClient()
+		res, err := ac.Req(&request.Options{
 			Method: "POST",
 			Path:   "/instances/" + url.PathEscape(domain) + "/checks/shared",
 		})
@@ -191,8 +191,8 @@ check via the flags.
 		}
 		domain := args[0]
 
-		c := newAdminClient()
-		res, err := c.Req(&request.Options{
+		ac := newAdminClient()
+		res, err := ac.Req(&request.Options{
 			Method: "POST",
 			Path:   "/instances/" + url.PathEscape(domain) + "/checks/sharings",
 			Queries: url.Values{

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -330,12 +330,12 @@ var showContextCmd = &cobra.Command{
 		if len(args) < 1 {
 			return cmd.Usage()
 		}
-		c := newAdminClient()
+		ac := newAdminClient()
 		req := &request.Options{
 			Method: "GET",
 			Path:   "instances/contexts/" + args[0],
 		}
-		res, err := c.Req(req)
+		res, err := ac.Req(req)
 		if err != nil {
 			return err
 		}
@@ -365,12 +365,12 @@ var listContextsCmd = &cobra.Command{
 	Long:    "List contexts currently used by the stack",
 	Example: "$ cozy-stack config ls-contexts",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		c := newAdminClient()
+		ac := newAdminClient()
 		req := &request.Options{
 			Method: "GET",
 			Path:   "instances/contexts",
 		}
-		res, err := c.Req(req)
+		res, err := ac.Req(req)
 		if err != nil {
 			return err
 		}

--- a/cmd/feature.go
+++ b/cmd/feature.go
@@ -90,7 +90,7 @@ If you give a null value, the flag will be removed.
 			errPrintfln("%s", errMissingDomain)
 			return cmd.Usage()
 		}
-		c := newAdminClient()
+		ac := newAdminClient()
 		req := request.Options{
 			Method: "GET",
 			Path:   fmt.Sprintf("/instances/%s/feature/flags", flagDomain),
@@ -99,7 +99,7 @@ If you give a null value, the flag will be removed.
 			req.Method = "PATCH"
 			req.Body = strings.NewReader(args[0])
 		}
-		res, err := c.Req(&req)
+		res, err := ac.Req(&req)
 		if err != nil {
 			return err
 		}
@@ -132,7 +132,7 @@ All the sets can be removed by setting an empty list ('').
 			errPrintfln("%s", errMissingDomain)
 			return cmd.Usage()
 		}
-		c := newAdminClient()
+		ac := newAdminClient()
 		req := request.Options{
 			Method: "GET",
 			Path:   fmt.Sprintf("/instances/%s/feature/sets", flagDomain),
@@ -149,7 +149,7 @@ All the sets can be removed by setting an empty list ('').
 			req.Method = "PUT"
 			req.Body = bytes.NewReader(buf)
 		}
-		res, err := c.Req(&req)
+		res, err := ac.Req(&req)
 		if err != nil {
 			return err
 		}
@@ -181,7 +181,7 @@ To remove a flag, set it to an empty array (or null).
 		if flagContext == "" {
 			return cmd.Usage()
 		}
-		c := newAdminClient()
+		ac := newAdminClient()
 		req := request.Options{
 			Method: "GET",
 			Path:   fmt.Sprintf("/instances/feature/contexts/%s", flagContext),
@@ -190,7 +190,7 @@ To remove a flag, set it to an empty array (or null).
 			req.Method = "PATCH"
 			req.Body = strings.NewReader(args[0])
 		}
-		res, err := c.Req(&req)
+		res, err := ac.Req(&req)
 		if err != nil {
 			return err
 		}
@@ -219,12 +219,12 @@ These flags are read only and can only be updated by changing configuration and 
 		if flagContext == "" {
 			return cmd.Usage()
 		}
-		c := newAdminClient()
+		ac := newAdminClient()
 		req := request.Options{
 			Method: "GET",
 			Path:   fmt.Sprintf("/instances/feature/config/%s", flagContext),
 		}
-		res, err := c.Req(&req)
+		res, err := ac.Req(&req)
 		if err != nil {
 			return err
 		}
@@ -252,7 +252,7 @@ If you give a null value, the flag will be removed.
 `,
 	Example: `$ cozy-stack feature defaults '{"add_this_flag": true, "remove_this_flag": null}'`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		c := newAdminClient()
+		ac := newAdminClient()
 		req := request.Options{
 			Method: "GET",
 			Path:   "/instances/feature/defaults",
@@ -261,7 +261,7 @@ If you give a null value, the flag will be removed.
 			req.Method = "PATCH"
 			req.Body = strings.NewReader(args[0])
 		}
-		res, err := c.Req(&req)
+		res, err := ac.Req(&req)
 		if err != nil {
 			return err
 		}

--- a/cmd/files.go
+++ b/cmd/files.go
@@ -116,8 +116,8 @@ var usageFilesCmd = &cobra.Command{
 			errPrintfln("%s", errMissingDomain)
 			return cmd.Usage()
 		}
-		c := newAdminClient()
-		info, err := c.DiskUsage(flagDomain, flagIncludeTrash)
+		ac := newAdminClient()
+		info, err := ac.DiskUsage(flagDomain, flagIncludeTrash)
 		if err != nil {
 			return err
 		}

--- a/cmd/fix.go
+++ b/cmd/fix.go
@@ -100,8 +100,8 @@ var redisFixer = &cobra.Command{
 	Use:   "redis",
 	Short: "Rebuild scheduling data strucutures in redis",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		c := newAdminClient()
-		return c.RebuildRedis()
+		ac := newAdminClient()
+		return ac.RebuildRedis()
 	},
 }
 
@@ -138,8 +138,8 @@ var contactEmailsFixer = &cobra.Command{
 	Use:   "contact-emails",
 	Short: "Detect and try to fix invalid emails on contacts",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		c := newAdminClient()
-		instances, err := c.ListInstances()
+		ac := newAdminClient()
+		instances, err := ac.ListInstances()
 		if err != nil {
 			return err
 		}

--- a/cmd/instances.go
+++ b/cmd/instances.go
@@ -61,6 +61,7 @@ var flagOnboardingSecret string
 var flagOnboardingApp string
 var flagOnboardingPermissions string
 var flagOnboardingState string
+var flagPath string
 
 // instanceCmdGroup represents the instances command
 var instanceCmdGroup = &cobra.Command{
@@ -911,7 +912,10 @@ var exportCmd = &cobra.Command{
 	Long:  `Export the files, documents, and settings`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ac := newAdminClient()
-		return ac.Export(flagDomain)
+		return ac.Export(&client.ExportOptions{
+			Domain:    flagDomain,
+			LocalPath: flagPath,
+		})
 	},
 }
 
@@ -1160,6 +1164,7 @@ func init() {
 	updateCmd.Flags().BoolVar(&flagForceRegistry, "force-registry", false, "Force to update all applications sources from git to the registry")
 	updateCmd.Flags().BoolVar(&flagOnlyRegistry, "only-registry", false, "Only update applications installed from the registry")
 	exportCmd.Flags().StringVar(&flagDomain, "domain", "", "Specify the domain name of the instance")
+	exportCmd.Flags().StringVar(&flagPath, "path", "", "Specify the local path where to store the export archive")
 	importCmd.Flags().StringVar(&flagDomain, "domain", "", "Specify the domain name of the instance")
 	importCmd.Flags().BoolVar(&flagForce, "force", false, "Force the import without asking for confirmation")
 	_ = exportCmd.MarkFlagRequired("domain")

--- a/cmd/instances.go
+++ b/cmd/instances.go
@@ -95,8 +95,8 @@ given domain.
 			return cmd.Usage()
 		}
 		domain := args[0]
-		c := newAdminClient()
-		in, err := c.GetInstance(domain)
+		ac := newAdminClient()
+		in, err := ac.GetInstance(domain)
 		if err != nil {
 			return err
 		}
@@ -124,8 +124,8 @@ It will also show the couch_cluster if it is not the default one.
 			return cmd.Usage()
 		}
 		domain := args[0]
-		c := newAdminClient()
-		in, err := c.GetInstance(domain)
+		ac := newAdminClient()
+		in, err := ac.GetInstance(domain)
 		if err != nil {
 			return err
 		}
@@ -175,8 +175,8 @@ be used as the error message.
 		}
 
 		domain := args[0]
-		c := newAdminClient()
-		in, err := c.CreateInstance(&client.InstanceOptions{
+		ac := newAdminClient()
+		in, err := ac.CreateInstance(&client.InstanceOptions{
 			Domain:        domain,
 			DomainAliases: flagDomainAliases,
 			Locale:        flagLocale,
@@ -254,7 +254,7 @@ settings for a specified domain.
 		}
 
 		domain := args[0]
-		c := newAdminClient()
+		ac := newAdminClient()
 		opts := &client.InstanceOptions{
 			Domain:         domain,
 			DomainAliases:  flagDomainAliases,
@@ -280,7 +280,7 @@ settings for a specified domain.
 		if flagOnboardingFinished {
 			opts.OnboardingFinished = &flagOnboardingFinished
 		}
-		in, err := c.ModifyInstance(opts)
+		in, err := ac.ModifyInstance(opts)
 		if err != nil {
 			errPrintfln(
 				"Failed to modify instance for domain %s", domain)
@@ -363,8 +363,8 @@ instance of the given domain. Set the quota to 0 to remove the quota.
 			diskQuota = -1
 		}
 		domain := args[0]
-		c := newAdminClient()
-		_, err = c.ModifyInstance(&client.InstanceOptions{
+		ac := newAdminClient()
+		_, err = ac.ModifyInstance(&client.InstanceOptions{
 			Domain:    domain,
 			DiskQuota: diskQuota,
 		})
@@ -403,17 +403,17 @@ specific domain.
 			return cmd.Usage()
 		}
 
-		c := newAdminClient()
+		ac := newAdminClient()
 		var err error
 		var debug bool
 		switch action {
 		case "get":
-			debug, err = c.GetDebug(domain)
+			debug, err = ac.GetDebug(domain)
 		case "enable":
-			err = c.EnableDebug(domain, flagTTL)
+			err = ac.EnableDebug(domain, flagTTL)
 			debug = true
 		case "disable":
-			err = c.DisableDebug(domain)
+			err = ac.DisableDebug(domain)
 			debug = false
 		}
 		if debug {
@@ -430,8 +430,8 @@ var countInstanceCmd = &cobra.Command{
 	Short:   "Count the instances",
 	Example: "$ cozy-stack instances count",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		c := newAdminClient()
-		count, err := c.CountInstances()
+		ac := newAdminClient()
+		count, err := ac.CountInstances()
 		if err != nil {
 			return err
 		}
@@ -467,8 +467,8 @@ by this server.
 			fmt.Println("db_prefix")
 			return nil
 		}
-		c := newAdminClient()
-		list, err := c.ListInstances()
+		ac := newAdminClient()
+		list, err := ac.ListInstances()
 		if err != nil {
 			return err
 		}
@@ -620,8 +620,8 @@ and all its data.
 			}
 		}
 
-		c := newAdminClient()
-		err := c.DestroyInstance(domain)
+		ac := newAdminClient()
+		err := ac.DestroyInstance(domain)
 		if err != nil {
 			errPrintfln(
 				"An error occurred while destroying instance for domain %s", domain)
@@ -684,8 +684,8 @@ func appOrKonnectorTokenInstance(cmd *cobra.Command, args []string, appType stri
 	if len(args) < 2 {
 		return cmd.Usage()
 	}
-	c := newAdminClient()
-	token, err := c.GetToken(&client.TokenOptions{
+	ac := newAdminClient()
+	token, err := ac.GetToken(&client.TokenOptions{
 		Domain:   args[0],
 		Subject:  args[1],
 		Audience: appType,
@@ -721,8 +721,8 @@ var cliTokenInstanceCmd = &cobra.Command{
 		if len(args) < 2 {
 			return cmd.Usage()
 		}
-		c := newAdminClient()
-		token, err := c.GetToken(&client.TokenOptions{
+		ac := newAdminClient()
+		token, err := ac.GetToken(&client.TokenOptions{
 			Domain:   args[0],
 			Scope:    args[1:],
 			Audience: consts.CLIAudience,
@@ -749,8 +749,8 @@ var oauthTokenInstanceCmd = &cobra.Command{
 		if strings.Contains(args[2], ",") {
 			fmt.Fprintf(os.Stderr, "Warning: the delimiter for the scopes is a space!\n")
 		}
-		c := newAdminClient()
-		token, err := c.GetToken(&client.TokenOptions{
+		ac := newAdminClient()
+		token, err := ac.GetToken(&client.TokenOptions{
 			Domain:   args[0],
 			Subject:  args[1],
 			Audience: consts.AccessTokenAudience,
@@ -776,8 +776,8 @@ var oauthRefreshTokenInstanceCmd = &cobra.Command{
 		if strings.Contains(args[2], ",") {
 			fmt.Fprintf(os.Stderr, "Warning: the delimiter for the scopes is a space!\n")
 		}
-		c := newAdminClient()
-		token, err := c.GetToken(&client.TokenOptions{
+		ac := newAdminClient()
+		token, err := ac.GetToken(&client.TokenOptions{
 			Domain:   args[0],
 			Subject:  args[1],
 			Audience: consts.RefreshTokenAudience,
@@ -799,8 +799,8 @@ var oauthClientInstanceCmd = &cobra.Command{
 		if len(args) < 4 {
 			return cmd.Usage()
 		}
-		c := newAdminClient()
-		oauthClient, err := c.RegisterOAuthClient(&client.OAuthClientOptions{
+		ac := newAdminClient()
+		oauthClient, err := ac.RegisterOAuthClient(&client.OAuthClientOptions{
 			Domain:                args[0],
 			RedirectURI:           args[1],
 			ClientName:            args[2],
@@ -834,7 +834,7 @@ var findOauthClientCmd = &cobra.Command{
 			return cmd.Usage()
 		}
 		var v interface{}
-		c := newAdminClient()
+		ac := newAdminClient()
 
 		q := url.Values{
 			"domain":      {args[0]},
@@ -846,7 +846,7 @@ var findOauthClientCmd = &cobra.Command{
 			Path:    "instances/oauth_client",
 			Queries: q,
 		}
-		res, err := c.Req(req)
+		res, err := ac.Req(req)
 		if err != nil {
 			return err
 		}
@@ -873,7 +873,7 @@ The slugs arguments can be used to select which applications should be
 updated.`,
 	Aliases: []string{"updates"},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		c := newAdminClient()
+		ac := newAdminClient()
 		if flagAllDomains {
 			logs := make(chan *client.JobLog)
 			go func() {
@@ -885,7 +885,7 @@ updated.`,
 					fmt.Printf(" %s\n", log.Message)
 				}
 			}()
-			return c.Updates(&client.UpdatesOptions{
+			return ac.Updates(&client.UpdatesOptions{
 				Slugs:         args,
 				ForceRegistry: flagForceRegistry,
 				OnlyRegistry:  flagOnlyRegistry,
@@ -895,7 +895,7 @@ updated.`,
 		if flagDomain == "" {
 			return errMissingDomain
 		}
-		return c.Updates(&client.UpdatesOptions{
+		return ac.Updates(&client.UpdatesOptions{
 			Domain:             flagDomain,
 			DomainsWithContext: flagContextName,
 			Slugs:              args,
@@ -910,8 +910,8 @@ var exportCmd = &cobra.Command{
 	Short: "Export an instance",
 	Long:  `Export the files, documents, and settings`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		c := newAdminClient()
-		return c.Export(flagDomain)
+		ac := newAdminClient()
+		return ac.Export(flagDomain)
 	},
 }
 
@@ -920,7 +920,7 @@ var importCmd = &cobra.Command{
 	Short: "Import data from an export link",
 	Long:  "This command will reset the Cozy instance and import data from an export link",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		c := newAdminClient()
+		ac := newAdminClient()
 		if len(args) < 1 {
 			return errors.New("The URL to the exported data is missing")
 		}
@@ -931,7 +931,7 @@ var importCmd = &cobra.Command{
 			}
 		}
 
-		return c.Import(flagDomain, &client.ImportOptions{
+		return ac.Import(flagDomain, &client.ImportOptions{
 			ManifestURL: args[0],
 		})
 	},
@@ -944,7 +944,7 @@ var showSwiftPrefixInstanceCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var v map[string]string
 
-		c := newAdminClient()
+		ac := newAdminClient()
 		if len(args) < 1 {
 			return errors.New("The domain is missing")
 		}
@@ -953,7 +953,7 @@ var showSwiftPrefixInstanceCmd = &cobra.Command{
 			Method: "GET",
 			Path:   "instances/" + args[0] + "/swift-prefix",
 		}
-		res, err := c.Req(req)
+		res, err := ac.Req(req)
 		if err != nil {
 			return err
 		}
@@ -980,9 +980,9 @@ var instanceAppVersionCmd = &cobra.Command{
 			return cmd.Usage()
 		}
 
-		c := newAdminClient()
+		ac := newAdminClient()
 		path := fmt.Sprintf("/instances/with-app-version/%s/%s", args[0], args[1])
-		res, err := c.Req(&request.Options{
+		res, err := ac.Req(&request.Options{
 			Method: "GET",
 			Path:   path,
 		})
@@ -1026,7 +1026,7 @@ var setAuthModeCmd = &cobra.Command{
 		}
 
 		domain := args[0]
-		c := newAdminClient()
+		ac := newAdminClient()
 
 		body := struct {
 			AuthMode string `json:"auth_mode"`
@@ -1039,7 +1039,7 @@ var setAuthModeCmd = &cobra.Command{
 			return err
 		}
 
-		res, err := c.Req(&request.Options{
+		res, err := ac.Req(&request.Options{
 			Method: "POST",
 			Path:   "/instances/" + url.PathEscape(domain) + "/auth-mode",
 			Body:   bytes.NewReader(reqBody),
@@ -1072,8 +1072,8 @@ var cleanSessionsCmd = &cobra.Command{
 			return cmd.Usage()
 		}
 		domain := args[0]
-		c := newAdminClient()
-		return c.CleanSessions(domain)
+		ac := newAdminClient()
+		return ac.CleanSessions(domain)
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,8 +56,8 @@ func newClientSafe(domain string, scopes ...string) (*client.Client, error) {
 	// For the CLI client, we rely on the admin APIs to generate a CLI token.
 	// We may want in the future rely on OAuth to handle the permissions with
 	// more granularity.
-	c := newAdminClient()
-	token, err := c.GetToken(&client.TokenOptions{
+	ac := newAdminClient()
+	token, err := ac.GetToken(&client.TokenOptions{
 		Domain:   domain,
 		Subject:  "CLI",
 		Audience: consts.CLIAudience,
@@ -95,7 +95,7 @@ func newClient(domain string, scopes ...string) *client.Client {
 	return client
 }
 
-func newAdminClient() *client.Client {
+func newAdminClient() *client.AdminClient {
 	pass := []byte(os.Getenv("COZY_ADMIN_PASSWORD"))
 	if !build.IsDevRelease() {
 		if len(pass) == 0 {
@@ -116,12 +116,14 @@ func newAdminClient() *client.Client {
 	})
 	checkNoErr(err)
 
-	return &client.Client{
-		Scheme:     adminURL.Scheme,
-		Addr:       adminURL.Host,
-		Domain:     adminURL.Host,
-		Client:     httpClient,
-		Authorizer: &request.BasicAuthorizer{Password: string(pass)},
+	return &client.AdminClient{
+		Client: client.Client{
+			Scheme:     adminURL.Scheme,
+			Addr:       adminURL.Host,
+			Domain:     adminURL.Host,
+			Client:     httpClient,
+			Authorizer: &request.BasicAuthorizer{Password: string(pass)},
+		},
 	}
 }
 

--- a/cmd/swift.go
+++ b/cmd/swift.go
@@ -29,10 +29,10 @@ var lsLayoutsCmd = &cobra.Command{
 	Short:   `Count layouts by types (v1, v2a, v2b, v3a, v3b)`,
 	Example: "$ cozy-stack swift ls-layouts",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		c := newAdminClient()
+		ac := newAdminClient()
 		values := url.Values{}
 		values.Add("show_domains", strconv.FormatBool(flagShowDomains))
-		res, err := c.Req(&request.Options{
+		res, err := ac.Req(&request.Options{
 			Method:  "GET",
 			Path:    "/swift/layouts",
 			Queries: values,
@@ -64,9 +64,9 @@ var swiftGetCmd = &cobra.Command{
 			return cmd.Usage()
 		}
 
-		c := newAdminClient()
+		ac := newAdminClient()
 		path := fmt.Sprintf("/swift/vfs/%s", url.PathEscape(args[1]))
-		res, err := c.Req(&request.Options{
+		res, err := ac.Req(&request.Options{
 			Method: "GET",
 			Path:   path,
 			Domain: args[0],
@@ -93,7 +93,7 @@ expected on the standard input.`,
 			return cmd.Usage()
 		}
 
-		c := newAdminClient()
+		ac := newAdminClient()
 		buf := new(bytes.Buffer)
 
 		_, err := io.Copy(buf, os.Stdin)
@@ -101,7 +101,7 @@ expected on the standard input.`,
 			return err
 		}
 
-		_, err = c.Req(&request.Options{
+		_, err = ac.Req(&request.Options{
 			Method: "PUT",
 			Path:   fmt.Sprintf("/swift/vfs/%s", url.PathEscape(args[1])),
 			Body:   bytes.NewReader(buf.Bytes()),
@@ -127,9 +127,9 @@ var swiftDeleteCmd = &cobra.Command{
 			return cmd.Usage()
 		}
 
-		c := newAdminClient()
+		ac := newAdminClient()
 		path := fmt.Sprintf("/swift/vfs/%s", url.PathEscape(args[1]))
-		_, err := c.Req(&request.Options{
+		_, err := ac.Req(&request.Options{
 			Method: "DELETE",
 			Path:   path,
 			Domain: args[0],
@@ -151,8 +151,8 @@ var swiftLsCmd = &cobra.Command{
 			ObjectNameList []string `json:"objects_names"`
 		}
 
-		c := newAdminClient()
-		res, err := c.Req(&request.Options{
+		ac := newAdminClient()
+		res, err := ac.Req(&request.Options{
 			Method: "GET",
 			Path:   "/swift/vfs",
 			Domain: args[0],

--- a/cmd/tools.go
+++ b/cmd/tools.go
@@ -40,8 +40,8 @@ See https://go.dev/doc/diagnostics#profiling.
 `,
 	Example: "$ cozy-stack tools heap > heap.pprof && go tool pprof heap.pprof",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		c := newAdminClient()
-		heap, err := c.ProfileHeap()
+		ac := newAdminClient()
+		heap, err := ac.ProfileHeap()
 		if err != nil {
 			return err
 		}
@@ -66,9 +66,9 @@ owner's instance.
 		if len(args) != 3 {
 			return cmd.Usage()
 		}
-		c := newAdminClient()
+		ac := newAdminClient()
 		path := fmt.Sprintf("/instances/%s/sharings/%s/unxor/%s", args[0], args[1], args[2])
-		res, err := c.Req(&request.Options{
+		res, err := ac.Req(&request.Options{
 			Method: "GET",
 			Path:   path,
 		})

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -283,6 +283,92 @@ Delete the accounts which are not linked to a konnector
 POST /instances/alice.cozy.localhost/fixers/orphan-account HTTP/1.1
 ```
 
+### POST /instances/:domain/export
+
+Starts an export for the given instance. The CouchDB documents will be saved in 
+an intermediary archive while the files won't be added until the data is 
+actually downloaded.
+
+The response contains the details of the scheduled export job.
+
+#### Query-String
+
+| Parameter | Description                                                                                 |
+| --------- | ------------------------------------------------------------------------------------------- |
+| admin-req | Boolean indicating when the request is made by an admin and the user should not be notified |
+
+The admin-req parameter is optional: by default, the instance's owner will be 
+notified via e-mail, whether the export is successful or not. If it's 
+successful, the e-mail will contain a link to the Settings app allowing the user
+to download the data archives.
+When this parameter is `true`, no e-mails will be sent and the admin will be 
+able to get the export document via realtime events.
+
+#### Request
+
+```http
+POST /instances/alice.cozy.localhost/export?admin-req=true HTTP/1.1
+```
+
+#### Response
+
+```http
+HTTP/1.1 204 Accepted
+Content-Type: application/json
+```
+
+```json
+{
+  "_id": "123123",
+  "_rev": "1-58d2b368da0a1b336bcd18ced210a8a1",
+  "domain": "alice.cozy.localhost",
+   "prefix": "cozyfdd8fd8eb825ad98821b11871abf58c9",
+   "worker": "export",
+   "message": {
+     "parts_size": 0,
+     "max_age": 0,
+     "contextual_domain": "alice.cozy.localhost",
+     "admin_req": true
+   },
+   "event": null,
+   "state": "queued",
+   "queued_at": "2023-02-01T11:50:59.286530525+01:00",
+   "started_at": "0001-01-01T00:00:00Z",
+   "finished_at": "0001-01-01T00:00:00Z"
+}
+```
+
+### GET /instances/:domain/exports/:export-id/data
+
+This endpoint will return an archive containing the metadata and files of the
+user, as part of a multi-part response.
+
+Only the first part of the archive contains the metadata.
+
+#### Query-String
+
+| Parameter | Description                                                         |
+| --------- | ------------------------------------------------------------------- |
+| cursor    | String reprentation of the export cursor to start the download from |
+
+The cursor parameter is optional but any given cursor should be one of the 
+defined `parts_cursors` in the export document.
+To get all the parts, this endpoint must be called one time with no cursors, and
+one time for each cursor in `parts_cursors`.
+
+#### Request
+
+```http
+GET /instances/alice.cozy.localhost/exports/123123/data?cursor=io.cozy.files%2Fa27b3bae83160774a74525de670d5d8e HTTP/1.1
+```
+
+#### Response
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/zip
+Content-Disposition: attachment; filename="alice.cozy.localhost - part001.zip"
+```
 
 ## Contexts
 

--- a/model/move/doc.go
+++ b/model/move/doc.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/jsonapi"
 	"github.com/cozy/cozy-stack/pkg/mail"
 	"github.com/cozy/cozy-stack/pkg/prefixer"
+	"github.com/cozy/cozy-stack/pkg/realtime"
 	"github.com/cozy/cozy-stack/pkg/safehttp"
 	"github.com/labstack/echo/v4"
 )
@@ -187,6 +188,10 @@ func (e *ExportDoc) NotifyTarget(inst *instance.Instance, to *MoveToOptions, tok
 		return fmt.Errorf("Cannot notify target: %d", res.StatusCode)
 	}
 	return nil
+}
+
+func (e *ExportDoc) NotifyRealtime() {
+	realtime.GetHub().Publish(prefixer.GlobalPrefixer, realtime.EventCreate, e.Clone(), nil)
 }
 
 // GenerateLink generates a link to download the export with a MAC.

--- a/model/move/export.go
+++ b/model/move/export.go
@@ -31,6 +31,7 @@ type ExportOptions struct {
 	TokenSource      string         `json:"token_source,omitempty"`
 	IgnoreVault      bool           `json:"ignore_vault,omitempty"`
 	MoveTo           *MoveToOptions `json:"move_to,omitempty"`
+	AdminReq         bool           `json:"admin_req,omitempty"`
 }
 
 // MoveToOptions is used when the export must be sent to another Cozy.
@@ -385,13 +386,13 @@ func exportFiles(i *instance.Instance, exportDoc *ExportDoc, tw *tar.Writer) (in
 		return 0, err
 	}
 
-	versions := make(map[string]int64)
+	versionsizes := make(map[string]int64)
 	err = couchdb.ForeachDocs(i, consts.FilesVersions, func(id string, raw json.RawMessage) error {
 		var doc vfs.Version
 		if err := json.Unmarshal(raw, &doc); err != nil {
 			return err
 		}
-		versions[id] = doc.ByteSize
+		versionsizes[id] = doc.ByteSize
 		return nil
 	})
 	if err != nil {
@@ -402,7 +403,7 @@ func exportFiles(i *instance.Instance, exportDoc *ExportDoc, tw *tar.Writer) (in
 	var cursors []string
 	cursors, remaining = splitFiles(exportDoc.PartsSize, remaining, filesizes, consts.Files)
 	exportDoc.PartsCursors = cursors
-	cursors, _ = splitFiles(exportDoc.PartsSize, remaining, versions, consts.FilesVersions)
+	cursors, _ = splitFiles(exportDoc.PartsSize, remaining, versionsizes, consts.FilesVersions)
 	if len(cursors) > 0 {
 		exportDoc.PartsCursors = append(exportDoc.PartsCursors, cursors...)
 	}

--- a/web/instances/instances.go
+++ b/web/instances/instances.go
@@ -634,6 +634,7 @@ func Routes(router *echo.Group) {
 	router.POST("/oauth_client", registerClient)
 	router.GET("/:domain/last-activity", lastActivity)
 	router.POST("/:domain/export", exporter)
+	router.GET("/:domain/exports/:export-id/data", dataExporter)
 	router.POST("/:domain/import", importer)
 	router.GET("/:domain/disk-usage", diskUsage)
 	router.GET("/:domain/prefix", showPrefix)

--- a/web/instances/move.go
+++ b/web/instances/move.go
@@ -1,45 +1,94 @@
 package instances
 
 import (
+	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/cozy/cozy-stack/model/instance/lifecycle"
 	"github.com/cozy/cozy-stack/model/job"
 	"github.com/cozy/cozy-stack/model/move"
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/labstack/echo/v4"
 )
 
 func exporter(c echo.Context) error {
 	domain := c.Param("domain")
+	adminReq, err := strconv.ParseBool(c.QueryParam("admin-req"))
+	if err != nil {
+		return wrapError(err)
+	}
+
 	inst, err := lifecycle.GetInstance(domain)
 	if err != nil {
-		return err
+		return wrapError(err)
 	}
 
 	options := move.ExportOptions{
 		ContextualDomain: domain,
+		AdminReq:         adminReq,
 	}
 	msg, err := job.NewMessage(options)
 	if err != nil {
-		return err
+		return wrapError(err)
 	}
 
-	_, err = job.System().PushJob(inst, &job.JobRequest{
+	j, err := job.System().PushJob(inst, &job.JobRequest{
 		WorkerType: "export",
 		Message:    msg,
 	})
 	if err != nil {
-		return err
+		return wrapError(err)
 	}
 
-	return c.NoContent(http.StatusNoContent)
+	return c.JSON(http.StatusAccepted, j)
+}
+
+func dataExporter(c echo.Context) error {
+	domain := c.Param("domain")
+	exportID := c.Param("export-id")
+
+	inst, err := lifecycle.GetInstance(domain)
+	if err != nil {
+		return wrapError(err)
+	}
+
+	var exportDoc move.ExportDoc
+	if err := couchdb.GetDoc(prefixer.GlobalPrefixer, consts.Exports, exportID, &exportDoc); err != nil {
+		if couchdb.IsNotFoundError(err) || couchdb.IsNoDatabaseError(err) {
+			return wrapError(move.ErrExportNotFound)
+		}
+		return wrapError(err)
+	}
+	if exportDoc.HasExpired() {
+		return wrapError(move.ErrExportExpired)
+	}
+
+	cursor, err := move.ParseCursor(&exportDoc, c.QueryParam("cursor"))
+	if err != nil {
+		return wrapError(err)
+	}
+
+	w := c.Response()
+	w.Header().Set(echo.HeaderContentType, "application/zip")
+	filename := domain + ".zip"
+	if len(exportDoc.PartsCursors) > 0 {
+		filename = fmt.Sprintf("%s - part%03d.zip", domain, cursor.Number)
+	}
+	w.Header().Set(echo.HeaderContentDisposition, fmt.Sprintf(`attachment; filename="%s"`, filename))
+	w.WriteHeader(http.StatusOK)
+
+	archiver := move.SystemArchiver()
+	return move.ExportCopyData(w, inst, &exportDoc, archiver, cursor)
 }
 
 func importer(c echo.Context) error {
 	domain := c.Param("domain")
 	inst, err := lifecycle.GetInstance(domain)
 	if err != nil {
-		return err
+		return wrapError(err)
 	}
 
 	options := move.ImportOptions{
@@ -47,7 +96,7 @@ func importer(c echo.Context) error {
 	}
 	msg, err := job.NewMessage(options)
 	if err != nil {
-		return err
+		return wrapError(err)
 	}
 
 	_, err = job.System().PushJob(inst, &job.JobRequest{
@@ -55,7 +104,7 @@ func importer(c echo.Context) error {
 		Message:    msg,
 	})
 	if err != nil {
-		return err
+		return wrapError(err)
 	}
 
 	return c.NoContent(http.StatusNoContent)


### PR DESCRIPTION
This new flag accepts a local directory path so that an admin can
make an export of the given instance.

When passing this flag, the cli will download all the export's
archives from the Cozy and save them with their archive name or, if
that name is missing from the download response, as
`<instance domain> - part<00n>.zip` in the directory pointed by the
flag.
If a file with the same name already exists, it is overwritten.

The command returns when all the archives have been downloaded.