### PR TITLE
Fix for thumbnails handling

### DIFF
--- a/model/vfs/vfsswift/thumbs_v2_v3.go
+++ b/model/vfs/vfsswift/thumbs_v2_v3.go
@@ -142,6 +142,14 @@ func (t *thumbsV2) ServeThumbContent(w http.ResponseWriter, req *http.Request, i
 
 	ctype := o["Content-Type"]
 	if ctype == echo.MIMEOctetStream {
+		// We have some old images where the thumbnail has not been correctly
+		// saved in Swift. We should delete the thumbnail to allow another try.
+		if l, err := f.Length(t.ctx); err == nil && l > 0 {
+			_ = t.RemoveThumbs(img, vfs.ThumbnailFormatNames)
+			return os.ErrNotExist
+		}
+		// Image magick has failed to generate a thumbnail, and retrying would
+		// be useless.
 		return os.ErrInvalid
 	}
 


### PR DESCRIPTION
We had some old thumbnails that were incorrectly saved in Swift. When encountering one of them, we will delete it and retry generating a new one.