### PR TITLE
Fix removing sharing reference on directory

### DIFF
--- a/model/vfs/couchdb_indexer.go
+++ b/model/vfs/couchdb_indexer.go
@@ -404,7 +404,7 @@ func (c *couchdbIndexer) MoveDir(oldpath, newpath string) error {
 			}
 			cloned := child.Clone()
 			if isTrashed {
-				c.checkTrashedDirIsShared(cloned.(*DirDoc))
+				c.checkTrashedDirIsShared(child)
 			}
 			olddocs = append(olddocs, cloned)
 			child.Fullpath = path.Join(newpath, child.Fullpath[len(oldpath)+1:])


### PR DESCRIPTION
Scenario of what was happening before this commit:

 1. Alice shares a directory "Holidays 2023" to Bob
 2. Bob accepts the sharing "Holidays 2023"
 3. Bob moves this directory inside "Photos"
 4. Bob moves the "Photos" directory to the trash
 5. When moved to the trash, the "Holidays 2023" sharing is revoked
 6. When seeing the mistake, Bob restores the "Photos" directory
 7. Bob edits a note inside "Holidays 2023"
 8. Bob understands that the directory is no longer shared
 9. He asks Alice to share again the directory, Alice agrees
10. Bob accepts the sharing
11. The same directory is reused for the sharing
12. And conflicts happen...

The error is on step 5: the reference to the sharing was not removed from the "Holidays 2023" directory when the sharing is revoked. This commit fixes this issue.