### PR TITLE
Add a fullname to a sharing contacts when missing

### DIFF
--- a/model/contact/contacts.go
+++ b/model/contact/contacts.go
@@ -139,6 +139,14 @@ func (c *Contact) PrimaryCozyURL() string {
 	return url
 }
 
+// FillFullnameIfMissing can be used to add a fullname if there was none.
+func (c *Contact) FillFullnameIfMissing(fullname string) {
+	name, ok := c.Get("fullname").(string)
+	if !ok || len(name) == 0 {
+		c.M["fullname"] = fullname
+	}
+}
+
 // AddCozyURL adds a cozy URL to this contact (unless the contact has already
 // this cozy URL) and saves the contact.
 func (c *Contact) AddCozyURL(db prefixer.Prefixer, cozyURL string) error {

--- a/model/sharing/member.go
+++ b/model/sharing/member.go
@@ -417,7 +417,7 @@ func (s *Sharing) DelegateDiscovery(inst *instance.Instance, state, cozyURL stri
 	if err = json.NewDecoder(res.Body).Decode(&success); err != nil {
 		return "", err
 	}
-	PersistInstanceURL(inst, success["email"], cozyURL)
+	PersistInstanceURL(inst, success["email"], cozyURL, success["public_name"])
 	return success["redirect"], nil
 }
 
@@ -441,8 +441,8 @@ func (s *Sharing) UpdateRecipients(inst *instance.Instance, members []Member) er
 }
 
 // PersistInstanceURL updates the io.cozy.contacts document with the Cozy
-// instance URL
-func PersistInstanceURL(inst *instance.Instance, email, cozyURL string) {
+// instance URL, and fills the fullname if it was missing.
+func PersistInstanceURL(inst *instance.Instance, email, cozyURL, name string) {
 	if email == "" || cozyURL == "" {
 		return
 	}
@@ -450,6 +450,7 @@ func PersistInstanceURL(inst *instance.Instance, email, cozyURL string) {
 	if err != nil {
 		return
 	}
+	c.FillFullnameIfMissing(name)
 	if err := c.AddCozyURL(inst, cozyURL); err != nil {
 		inst.Logger().WithNamespace("sharing").
 			Warnf("Error on saving contact: %s", err)

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -581,7 +581,7 @@ func PostDiscovery(c echo.Context) error {
 		if err != nil {
 			return wrapErrors(err)
 		}
-		sharing.PersistInstanceURL(inst, member.Email, member.Instance)
+		sharing.PersistInstanceURL(inst, member.Email, member.Instance, member.Name)
 	} else {
 		redirectURL, err = s.DelegateDiscovery(inst, state, cozyURL)
 		if err != nil {


### PR DESCRIPTION
1. Alice sends a sharing invitation to bob@example.org
2. Bob accepts the sharing
3. On Alice's Cozy, the io.cozy.contacts for bob@example.org is updated to add the public name of Bob's Cozy if there was no fullname