### PR TITLE
Fix adding name to contacts on sharings

### DIFF
--- a/model/contact/contacts.go
+++ b/model/contact/contacts.go
@@ -139,12 +139,19 @@ func (c *Contact) PrimaryCozyURL() string {
 	return url
 }
 
-// FillFullnameIfMissing can be used to add a fullname if there was none.
-func (c *Contact) FillFullnameIfMissing(fullname string) {
-	name, ok := c.Get("fullname").(string)
-	if !ok || len(name) == 0 {
-		c.M["fullname"] = fullname
+// AddNameIfMissing can be used to add a name if there was none.
+func (c *Contact) AddNameIfMissing(db prefixer.Prefixer, name string) error {
+	was, ok := c.Get("displayName").(string)
+	if ok && len(was) > 0 {
+		return nil
 	}
+	was, ok = c.Get("fullname").(string)
+	if ok && len(was) > 0 {
+		return nil
+	}
+	c.M["displayName"] = name
+	c.M["fullname"] = name
+	return couchdb.UpdateDoc(db, c)
 }
 
 // AddCozyURL adds a cozy URL to this contact (unless the contact has already

--- a/model/sharing/member.go
+++ b/model/sharing/member.go
@@ -417,7 +417,7 @@ func (s *Sharing) DelegateDiscovery(inst *instance.Instance, state, cozyURL stri
 	if err = json.NewDecoder(res.Body).Decode(&success); err != nil {
 		return "", err
 	}
-	PersistInstanceURL(inst, success["email"], cozyURL, success["public_name"])
+	PersistInstanceURL(inst, success["email"], cozyURL)
 	return success["redirect"], nil
 }
 
@@ -442,7 +442,7 @@ func (s *Sharing) UpdateRecipients(inst *instance.Instance, members []Member) er
 
 // PersistInstanceURL updates the io.cozy.contacts document with the Cozy
 // instance URL, and fills the fullname if it was missing.
-func PersistInstanceURL(inst *instance.Instance, email, cozyURL, name string) {
+func PersistInstanceURL(inst *instance.Instance, email, cozyURL string) {
 	if email == "" || cozyURL == "" {
 		return
 	}
@@ -450,7 +450,6 @@ func PersistInstanceURL(inst *instance.Instance, email, cozyURL, name string) {
 	if err != nil {
 		return
 	}
-	c.FillFullnameIfMissing(name)
 	if err := c.AddCozyURL(inst, cozyURL); err != nil {
 		inst.Logger().WithNamespace("sharing").
 			Warnf("Error on saving contact: %s", err)

--- a/model/sharing/oauth.go
+++ b/model/sharing/oauth.go
@@ -435,6 +435,16 @@ func (s *Sharing) ProcessAnswer(inst *instance.Instance, creds *APICredentials) 
 			}
 			ac.Credentials.AccessToken = token
 
+			// Update the contact to fill the name if missing
+			if email := s.Members[i+1].Email; email != "" {
+				if c, err := contact.FindByEmail(inst, email); err == nil {
+					if err := c.AddNameIfMissing(inst, s.Members[i+1].PublicName); err != nil {
+						inst.Logger().WithNamespace("sharing").
+							Warnf("Error on saving contact: %s", err)
+					}
+				}
+			}
+
 			s.Active = true
 			if err := couchdb.UpdateDoc(inst, s); err != nil {
 				if !couchdb.IsConflictError(err) {

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -581,7 +581,7 @@ func PostDiscovery(c echo.Context) error {
 		if err != nil {
 			return wrapErrors(err)
 		}
-		sharing.PersistInstanceURL(inst, member.Email, member.Instance, member.Name)
+		sharing.PersistInstanceURL(inst, member.Email, member.Instance)
 	} else {
 		redirectURL, err = s.DelegateDiscovery(inst, state, cozyURL)
 		if err != nil {


### PR DESCRIPTION
We need to fill both the fullname and the displayName, as it is what the contacts app expects.