### PR TITLE
Fix invitation mail for sharing

### DIFF
--- a/model/sharing/invitation.go
+++ b/model/sharing/invitation.go
@@ -177,7 +177,7 @@ func (m *Member) SendMail(inst *instance.Instance, s *Sharing, sharer, descripti
 	}
 	sharerMail, _ := inst.SettingsEMail()
 	var action string
-	if s.ReadOnlyRules() {
+	if s.ReadOnlyRules() || m.ReadOnly {
 		action = inst.Translate("Mail Sharing Request Action Read")
 	} else {
 		action = inst.Translate("Mail Sharing Request Action Write")


### PR DESCRIPTION
When a sharing has read-write rules, but a member is read-only, the invitation mail for this member should not tell them that they will be able to edit the shared content, only to read it.