### PR TITLE
Fix false positive for invalid_instance_for_member

### DIFF
--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -1356,7 +1356,7 @@ func (s *Sharing) checkSharingMembers() (checks []map[string]interface{}, validM
 	}
 
 	for _, m := range s.Members {
-		if m.Status == MemberStatusOwner {
+		if m.Status != MemberStatusReady {
 			continue
 		}
 
@@ -1370,7 +1370,7 @@ func (s *Sharing) checkSharingMembers() (checks []map[string]interface{}, validM
 			continue
 		}
 
-		domain := u.Hostname()
+		domain := strings.ToLower(u.Hostname())
 		if u.Port() != "" {
 			domain += ":" + u.Port()
 		}


### PR DESCRIPTION
The cozy-stack check sharings command was returning false invalid_instance_for_member errors, because it was trying to look at instance for members that haven't accepted the sharing, and thus the instance field was blank and cannot be parsed.

We also put the domain in lower case, as the domain is case insensitive, and stored as lower case in CouchDB.