### PR TITLE
Fix the export/import integration test

### DIFF
--- a/tests/integration/tests/export_import.rb
+++ b/tests/integration/tests/export_import.rb
@@ -7,8 +7,8 @@ describe "Export and import" do
     Helpers.scenario "export_import"
     Helpers.start_mailhog
 
-    source = Instance.create name: "source"
-    target = Instance.create name: "target"
+    source = Instance.create name: "exportsource"
+    target = Instance.create name: "exporttarget"
     source.install_app "photos"
 
     # Create a file with an old version


### PR DESCRIPTION
When running the export/import integration test, we are looking at an email with the export link. For that, we are querying MailHog with the instance email source+test@localhost. But, it can return us an email for konnsource+test@localhost from another integration tests. The first email address is included in the second address, and MailHog matches on that. The fix consists of having a more specific email address for the instances of the export/import test.