### PR TITLE
Improve check sharings command for no_database

### DIFF
--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -1176,7 +1176,9 @@ func findParentFileSharingID(inst *instance.Instance, sharing *Sharing) (string,
 	for _, id := range sharingRule.Values {
 		var sharingRoot couchdb.JSONDoc
 		if err := couchdb.GetDoc(inst, consts.Files, id, &sharingRoot); err != nil {
-			return "", err
+			// We can ignore the error here, it will reported as
+			// missing_matching_docs_for_member later.
+			return "", nil
 		}
 		sharingRoots = append(sharingRoots, sharingRoot)
 	}

--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -1176,8 +1176,9 @@ func findParentFileSharingID(inst *instance.Instance, sharing *Sharing) (string,
 	for _, id := range sharingRule.Values {
 		var sharingRoot couchdb.JSONDoc
 		if err := couchdb.GetDoc(inst, consts.Files, id, &sharingRoot); err != nil {
-			// We can ignore the error here, it will reported as
-			// missing_matching_docs_for_member later.
+			// We can ignore the error here. It will be reported as
+			// missing_matching_docs_for_owner or missing_matching_docs_for_member
+			// later.
 			return "", nil
 		}
 		sharingRoots = append(sharingRoots, sharingRoot)


### PR DESCRIPTION
Some instances were having a no_database error on the check sharings command, because the sharing root of an active sharing is missing. It would be better to categorize this error as
missing_matching_docs_for_member.