### PR TITLE
feat: Add mail_not_sent sharings check

### DIFF
--- a/docs/admin.md
+++ b/docs/admin.md
@@ -721,10 +721,10 @@ missing owner document in `ownerDoc`.
 ===
 
 Other error types include `missing_trigger_on_active_sharing`,
-`trigger_on_inactive_sharing`, `not_enough_members`, `invalid_member_status`,
-`invalid_instance_for_member`, `missing_instance_for_member`,
-`missing_oauth_client`, `missing_access_token`, `invalid_number_of_credentials`
-and `missing_inbound_client_id`.
+`trigger_on_inactive_sharing`, `not_enough_members`, `mail_not_sent`,
+`invalid_member_status`, `invalid_instance_for_member`,
+`missing_instance_for_member`, `missing_oauth_client`, `missing_access_token`,
+`invalid_number_of_credentials` and `missing_inbound_client_id`.
 
 When checking for files and folders inconsistencies, sharings will be skipped
 when inactive, not initialized, read-only or not about `io.cozy.files`

--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -1359,6 +1359,15 @@ func (s *Sharing) checkSharingMembers() (checks []map[string]interface{}, validM
 	}
 
 	for _, m := range s.Members {
+		if m.Status == MemberStatusMailNotSent {
+			checks = append(checks, map[string]interface{}{
+				"id":     s.SID,
+				"type":   "mail_not_sent",
+				"member": m.Instance,
+			})
+			continue
+		}
+
 		if m.Status != MemberStatusReady {
 			continue
 		}


### PR DESCRIPTION
Members of a sharing who don't have received the invitation e-mail and
are thus not ready to share are excluded of the tree consistency
checks but it would be nice to be notified via a dedicated check as
this is not a normal situation.