### PR TITLE
Fix adding the fullname to a sharing contact

### DIFF
--- a/model/contact/contacts.go
+++ b/model/contact/contacts.go
@@ -139,10 +139,12 @@ func (c *Contact) PrimaryCozyURL() string {
 	return url
 }
 
-// AddNameIfMissing can be used to add a name if there was none.
-func (c *Contact) AddNameIfMissing(db prefixer.Prefixer, name string) error {
+// AddNameIfMissing can be used to add a name if there was none. We need the
+// email address to ignore it if the displayName was updated with it by a
+// service of the contacts application.
+func (c *Contact) AddNameIfMissing(db prefixer.Prefixer, name, email string) error {
 	was, ok := c.Get("displayName").(string)
-	if ok && len(was) > 0 {
+	if ok && len(was) > 0 && was != email {
 		return nil
 	}
 	was, ok = c.Get("fullname").(string)

--- a/model/sharing/oauth.go
+++ b/model/sharing/oauth.go
@@ -438,7 +438,7 @@ func (s *Sharing) ProcessAnswer(inst *instance.Instance, creds *APICredentials) 
 			// Update the contact to fill the name if missing
 			if email := s.Members[i+1].Email; email != "" {
 				if c, err := contact.FindByEmail(inst, email); err == nil {
-					if err := c.AddNameIfMissing(inst, s.Members[i+1].PublicName); err != nil {
+					if err := c.AddNameIfMissing(inst, s.Members[i+1].PublicName, email); err != nil {
 						inst.Logger().WithNamespace("sharing").
 							Warnf("Error on saving contact: %s", err)
 					}


### PR DESCRIPTION
The contacts application may fill the displayName of a contact with their email address. We need to ignore this case when filling the fullname for a sharing contact with just the email address known.