### PR TITLE
Cache refacto

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1,12 +1,8 @@
 package cache
 
 import (
-	"bytes"
-	"compress/gzip"
 	"context"
 	"io"
-	"strings"
-	"sync"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -33,164 +29,15 @@ type cacheEntry struct {
 	expiredAt time.Time
 }
 
-// GenericCache is a `GenericCache` implementation handle as well a Redis backend
-// or a in-memory one.
-//
-// The backend selection is done based on the `New.client` argument. If a client is
-// given, the redis backend is chosed, if nil is provided the inmemory backend would
-// be chosen.
-type GenericCache struct {
-	client redis.UniversalClient
-	m      *sync.Map
-	ctx    context.Context
-}
-
-// New instantiate a GenericCache Client.
+// New instantiate a Cache Client.
 //
 // The backend selection is done based on the `client` argument. If a client is
-// given, the redis backend is chosed, if nil is provided the inmemory backend would
+// given, the redis backend is chosen, if nil is provided the inmemory backend would
 // be chosen.
-func New(client redis.UniversalClient) GenericCache {
-	ctx := context.Background()
-	if client != nil {
-		return GenericCache{client, nil, ctx}
+func New(client redis.UniversalClient) Cache {
+	if client == nil {
+		return NewInMemory()
 	}
-	m := sync.Map{}
-	return GenericCache{nil, &m, ctx}
-}
 
-// CheckStatus checks that the cache is ready, or returns an error.
-func (c GenericCache) CheckStatus(ctx context.Context) (time.Duration, error) {
-	if c.client == nil {
-		return 0, nil
-	}
-	before := time.Now()
-	if err := c.client.Ping(ctx).Err(); err != nil {
-		return 0, err
-	}
-	return time.Since(before), nil
-}
-
-// Get fetch the cached asset at the given key, and returns true only if the
-// asset was found.
-func (c GenericCache) Get(key string) ([]byte, bool) {
-	if c.client == nil {
-		if value, ok := c.m.Load(key); ok {
-			entry := value.(cacheEntry)
-			if time.Now().Before(entry.expiredAt) {
-				return entry.payload, true
-			}
-			c.Clear(key)
-		}
-	} else {
-		cmd := c.client.Get(c.ctx, key)
-		if b, err := cmd.Bytes(); err == nil {
-			return b, true
-		}
-	}
-	return nil, false
-}
-
-// MultiGet can be used to fetch several keys at once.
-func (c GenericCache) MultiGet(keys []string) [][]byte {
-	results := make([][]byte, len(keys))
-	if c.client == nil {
-		for i, key := range keys {
-			results[i], _ = c.Get(key)
-		}
-	} else {
-		cmd := c.client.MGet(c.ctx, keys...)
-		for i, val := range cmd.Val() {
-			if buf, ok := val.(string); ok {
-				results[i] = []byte(buf)
-			}
-		}
-	}
-	return results
-}
-
-// Keys returns the list of keys with the given prefix.
-// Note: it can be slow and should be used carefully.
-func (c GenericCache) Keys(prefix string) []string {
-	if c.client != nil {
-		cmd := c.client.Keys(c.ctx, prefix+"*")
-		return cmd.Val()
-	}
-	results := make([]string, 0)
-	c.m.Range(func(key, _ interface{}) bool {
-		k := key.(string)
-		if strings.HasPrefix(k, prefix) {
-			results = append(results, k)
-		}
-		return true
-	})
-	return results
-}
-
-// Clear removes a key from the cache
-func (c GenericCache) Clear(key string) {
-	if c.client == nil {
-		c.m.Delete(key)
-	} else {
-		c.client.Del(c.ctx, key)
-	}
-}
-
-// Set stores an asset to the given key.
-func (c GenericCache) Set(key string, data []byte, expiration time.Duration) {
-	if c.client == nil {
-		c.m.Store(key, cacheEntry{
-			payload:   data,
-			expiredAt: time.Now().Add(expiration),
-		})
-	} else {
-		c.client.Set(c.ctx, key, data, expiration)
-	}
-}
-
-// SetNX stores the data in the cache only if the key doesn't exist yet.
-func (c GenericCache) SetNX(key string, data []byte, expiration time.Duration) {
-	if c.client == nil {
-		c.m.LoadOrStore(key, cacheEntry{
-			payload:   data,
-			expiredAt: time.Now().Add(expiration),
-		})
-	} else {
-		c.client.SetNX(c.ctx, key, data, expiration)
-	}
-}
-
-// GetCompressed works like Get but expect a compressed asset that is
-// uncompressed.
-func (c GenericCache) GetCompressed(key string) (io.Reader, bool) {
-	if r, ok := c.Get(key); ok {
-		if gr, err := gzip.NewReader(bytes.NewReader(r)); err == nil {
-			return gr, true
-		}
-	}
-	return nil, false
-}
-
-// SetCompressed works like Set but compress the asset data before storing it.
-func (c GenericCache) SetCompressed(key string, data []byte, expiration time.Duration) {
-	dataCompressed := new(bytes.Buffer)
-	gw := gzip.NewWriter(dataCompressed)
-	defer gw.Close()
-	if _, err := io.Copy(gw, bytes.NewReader(data)); err != nil {
-		return
-	}
-	c.Set(key, dataCompressed.Bytes(), expiration)
-}
-
-// RefreshTTL can be used to update the TTL of an existing entry in the cache.
-func (c GenericCache) RefreshTTL(key string, expiration time.Duration) {
-	if c.client == nil {
-		if value, ok := c.m.Load(key); ok {
-			entry := value.(cacheEntry)
-			entry.expiredAt = time.Now().Add(expiration)
-			c.m.Store(key, entry)
-		}
-	} else {
-		c.client.Expire(c.ctx, key, expiration)
-	}
+	return NewRedis(client)
 }

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -19,8 +19,9 @@ func TestRedisCache(t *testing.T) {
 	opts, err := redis.ParseURL(redisURL)
 	require.NoError(t, err)
 
-	redisClient := New(redis.NewClient(opts))
-	inMemoryClient := New(nil)
+	redisClient := NewRedis(redis.NewClient(opts))
+	genericCacheWithClient := New(redis.NewClient(opts))
+	genericCacheWithoutClient := New(nil)
 
 	tests := []struct {
 		name        string
@@ -28,13 +29,18 @@ func TestRedisCache(t *testing.T) {
 		RequireInte bool
 	}{
 		{
-			name:        "RedisClient",
-			client:      &redisClient,
+			name:        "GenericCacheWithClient",
+			client:      &genericCacheWithClient,
 			RequireInte: true,
 		},
 		{
-			name:        "InMemoryClient",
-			client:      &inMemoryClient,
+			name:        "RedisClient",
+			client:      redisClient,
+			RequireInte: true,
+		},
+		{
+			name:        "GenericCacheWithoutClient",
+			client:      &genericCacheWithoutClient,
 			RequireInte: false,
 		},
 	}

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -10,10 +10,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func GenericCacheImplementsCache(t *testing.T) {
+	require.Implements(t, (*Cache)(nil), new(GenericCache))
+}
+
 func TestRedisCache(t *testing.T) {
 	redisURL := "redis://localhost:6379/0"
 	opts, err := redis.ParseURL(redisURL)
 	require.NoError(t, err)
+
+	redisClient := New(redis.NewClient(opts))
+	inMemoryClient := New(nil)
 
 	tests := []struct {
 		name        string
@@ -22,12 +29,12 @@ func TestRedisCache(t *testing.T) {
 	}{
 		{
 			name:        "RedisClient",
-			client:      New(redis.NewClient(opts)),
+			client:      &redisClient,
 			RequireInte: true,
 		},
 		{
 			name:        "InMemoryClient",
-			client:      New(nil),
+			client:      &inMemoryClient,
 			RequireInte: false,
 		},
 	}

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -7,55 +7,92 @@ import (
 
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestCache(t *testing.T) {
-	if testing.Short() {
-		t.Skip("a redis is required for this test: test skipped due to the use of --short flag")
+func TestRedisCache(t *testing.T) {
+	redisURL := "redis://localhost:6379/0"
+	opts, err := redis.ParseURL(redisURL)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		client      Cache
+		RequireInte bool
+	}{
+		{
+			name:        "RedisClient",
+			client:      New(redis.NewClient(opts)),
+			RequireInte: true,
+		},
+		{
+			name:        "InMemoryClient",
+			client:      New(nil),
+			RequireInte: false,
+		},
 	}
 
-	t.Run("CacheInMemory", func(t *testing.T) {
-		key := "foo"
-		val := []byte("bar")
-		c := New(nil)
-		c.Set(key, val, 10*time.Millisecond)
-		actual, ok := c.Get(key)
-		assert.True(t, ok)
-		assert.Equal(t, val, actual)
-		time.Sleep(11 * time.Millisecond)
-		_, ok = c.Get(key)
-		assert.False(t, ok)
-	})
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if testing.Short() && test.RequireInte {
+				t.Skip("a redis is required for this test: test skipped due to the use of --short flag")
+			}
 
-	t.Run("MultiGet", func(t *testing.T) {
-		redisURL := "redis://localhost:6379/0"
-		opts, _ := redis.ParseURL(redisURL)
-		client := redis.NewClient(opts)
-		c := New(client)
-		c.Set("one", []byte("1"), 10*time.Millisecond)
-		c.Set("two", []byte("2"), 10*time.Millisecond)
-		bufs := c.MultiGet([]string{"one", "two", "three"})
-		assert.Len(t, bufs, 3)
-		assert.Equal(t, []byte("1"), bufs[0])
-		assert.Equal(t, []byte("2"), bufs[1])
-		assert.Nil(t, bufs[2])
-	})
+			c := test.client
 
-	t.Run("Keys", func(t *testing.T) {
-		test := func(client redis.UniversalClient) {
-			c := New(client)
-			c.Set("foo:one", []byte("1"), 10*time.Millisecond)
-			c.Set("foo:two", []byte("2"), 10*time.Millisecond)
-			c.Set("bar:baz", []byte("3"), 10*time.Millisecond)
-			keys := c.Keys("foo:")
-			sort.Strings(keys)
-			assert.Equal(t, []string{"foo:one", "foo:two"}, keys)
-		}
+			t.Run("SET/GET/EXPIRE", func(t *testing.T) {
+				key := "foo"
+				val := []byte("bar")
 
-		redisURL := "redis://localhost:6379/0"
-		opts, _ := redis.ParseURL(redisURL)
-		client := redis.NewClient(opts)
-		test(client)
-		test(nil) // In-memory
-	})
+				// Set a key/value pair with a 10 ms expiration
+				c.Set(key, val, 10*time.Millisecond)
+
+				// Fetch the pair
+				actual, ok := c.Get(key)
+				assert.True(t, ok)
+				assert.Equal(t, val, actual)
+
+				// Wait the pair expiration
+				time.Sleep(11 * time.Millisecond)
+
+				// Check that the pair is no more available
+				_, ok = c.Get(key)
+				assert.False(t, ok)
+			})
+
+			t.Run("Keys", func(t *testing.T) {
+				c.Set("foo:one", []byte("1"), 10*time.Millisecond)
+				c.Set("foo:two", []byte("2"), 10*time.Millisecond)
+				c.Set("bar:baz", []byte("3"), 10*time.Millisecond)
+				keys := c.Keys("foo:")
+				sort.Strings(keys)
+				assert.Equal(t, []string{"foo:one", "foo:two"}, keys)
+			})
+
+			t.Run("MultiGet", func(t *testing.T) {
+				// Set two values
+				c.Set("one", []byte("1"), 10*time.Millisecond)
+				c.Set("two", []byte("2"), 10*time.Millisecond)
+
+				// Get the two
+				bufs := c.MultiGet([]string{"one", "two", "three"})
+
+				assert.Len(t, bufs, 3)
+				assert.Equal(t, []byte("1"), bufs[0])
+				assert.Equal(t, []byte("2"), bufs[1])
+				assert.Nil(t, bufs[2])
+			})
+
+			t.Run("Keys", func(t *testing.T) {
+				// Set three values
+				c.Set("foo:one", []byte("1"), 10*time.Millisecond)
+				c.Set("foo:two", []byte("2"), 10*time.Millisecond)
+				c.Set("bar:baz", []byte("3"), 10*time.Millisecond)
+
+				keys := c.Keys("foo:")
+				sort.Strings(keys)
+				assert.Equal(t, []string{"foo:one", "foo:two"}, keys)
+			})
+		})
+	}
 }

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -20,6 +20,7 @@ func TestRedisCache(t *testing.T) {
 	require.NoError(t, err)
 
 	redisClient := NewRedis(redis.NewClient(opts))
+	inMemoryClient := NewInMemory()
 	genericCacheWithClient := New(redis.NewClient(opts))
 	genericCacheWithoutClient := New(nil)
 
@@ -37,6 +38,11 @@ func TestRedisCache(t *testing.T) {
 			name:        "RedisClient",
 			client:      redisClient,
 			RequireInte: true,
+		},
+		{
+			name:        "InMemoryClient",
+			client:      inMemoryClient,
+			RequireInte: false,
 		},
 		{
 			name:        "GenericCacheWithoutClient",

--- a/pkg/cache/impl_inmemory.go
+++ b/pkg/cache/impl_inmemory.go
@@ -1,0 +1,126 @@
+package cache
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"strings"
+	"sync"
+	"time"
+)
+
+// InMemory implementation of the Cache client.
+type InMemory struct {
+	m *sync.Map
+}
+
+// NewRedis instantiate a new in-memory Cache Client.
+func NewInMemory() *InMemory {
+	return &InMemory{m: new(sync.Map)}
+}
+
+// CheckStatus checks that the cache is ready, or returns an error.
+func (c *InMemory) CheckStatus(ctx context.Context) (time.Duration, error) {
+	return 0, nil
+}
+
+// Get fetch the cached asset at the given key, and returns true only if the
+// asset was found.
+func (c *InMemory) Get(key string) ([]byte, bool) {
+	value, ok := c.m.Load(key)
+	if !ok {
+		return nil, false
+	}
+
+	entry := value.(cacheEntry)
+	if time.Now().After(entry.expiredAt) {
+		// The value is expired. Clean it and return not found
+		c.Clear(key)
+		return nil, false
+	}
+
+	return entry.payload, true
+}
+
+// MultiGet can be used to fetch several keys at once.
+func (c *InMemory) MultiGet(keys []string) [][]byte {
+	results := make([][]byte, len(keys))
+
+	for i, key := range keys {
+		results[i], _ = c.Get(key)
+	}
+
+	return results
+}
+
+// Keys returns the list of keys with the given prefix.
+func (c *InMemory) Keys(prefix string) []string {
+	results := make([]string, 0)
+
+	c.m.Range(func(key, _ interface{}) bool {
+		k := key.(string)
+		if strings.HasPrefix(k, prefix) {
+			results = append(results, k)
+		}
+
+		return true
+	})
+
+	return results
+}
+
+// Clear removes a key from the cache
+func (c *InMemory) Clear(key string) {
+	c.m.Delete(key)
+}
+
+// Set stores an asset to the given key.
+func (c *InMemory) Set(key string, data []byte, expiration time.Duration) {
+	c.m.Store(key, cacheEntry{
+		payload:   data,
+		expiredAt: time.Now().Add(expiration),
+	})
+}
+
+// SetNX stores the data in the cache only if the key doesn't exist yet.
+func (c *InMemory) SetNX(key string, data []byte, expiration time.Duration) {
+	c.m.LoadOrStore(key, cacheEntry{
+		payload:   data,
+		expiredAt: time.Now().Add(expiration),
+	})
+}
+
+// GetCompressed works like Get but expect a compressed asset that is
+// uncompressed.
+func (c *InMemory) GetCompressed(key string) (io.Reader, bool) {
+	if r, ok := c.Get(key); ok {
+		if gr, err := gzip.NewReader(bytes.NewReader(r)); err == nil {
+			return gr, true
+		}
+	}
+	return nil, false
+}
+
+// SetCompressed works like Set but compress the asset data before storing it.
+func (c *InMemory) SetCompressed(key string, data []byte, expiration time.Duration) {
+	dataCompressed := new(bytes.Buffer)
+	gw := gzip.NewWriter(dataCompressed)
+	defer gw.Close()
+	if _, err := io.Copy(gw, bytes.NewReader(data)); err != nil {
+		return
+	}
+	c.Set(key, dataCompressed.Bytes(), expiration)
+}
+
+// RefreshTTL can be used to update the TTL of an existing entry in the cache.
+func (c *InMemory) RefreshTTL(key string, expiration time.Duration) {
+	value, ok := c.m.Load(key)
+	if !ok {
+		return
+	}
+
+	entry := value.(cacheEntry)
+	entry.expiredAt = time.Now().Add(expiration)
+	c.m.Store(key, entry)
+}

--- a/pkg/cache/impl_redis.go
+++ b/pkg/cache/impl_redis.go
@@ -1,0 +1,116 @@
+package cache
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// Redis implementation of the cache client.
+type Redis struct {
+	client redis.UniversalClient
+}
+
+// NewRedis instantiate a new Redis Cache Client.
+func NewRedis(client redis.UniversalClient) *Redis {
+	return &Redis{client}
+}
+
+// CheckStatus checks that the cache is ready, or returns an error.
+func (c *Redis) CheckStatus(ctx context.Context) (time.Duration, error) {
+	before := time.Now()
+	if err := c.client.Ping(ctx).Err(); err != nil {
+		return 0, err
+	}
+	return time.Since(before), nil
+}
+
+// Get fetch the cached asset at the given key, and returns true only if the
+// asset was found.
+func (c *Redis) Get(key string) ([]byte, bool) {
+	cmd := c.client.Get(context.TODO(), key)
+	b, err := cmd.Bytes()
+	if err != nil {
+		return nil, false
+	}
+
+	return b, true
+}
+
+// MultiGet can be used to fetch several keys at once.
+func (c *Redis) MultiGet(keys []string) [][]byte {
+	results := make([][]byte, len(keys))
+
+	cmd := c.client.MGet(context.TODO(), keys...)
+
+	for i, val := range cmd.Val() {
+		if buf, ok := val.(string); ok {
+			results[i] = []byte(buf)
+		}
+	}
+
+	return results
+}
+
+// Keys returns the list of keys with the given prefix.
+//
+// Note: it can be slow and should be used carefully.
+func (c *Redis) Keys(prefix string) []string {
+	cmd := c.client.Keys(context.TODO(), prefix+"*")
+
+	return cmd.Val()
+}
+
+// Clear removes a key from the cache
+func (c *Redis) Clear(key string) {
+	c.client.Del(context.TODO(), key)
+}
+
+// Set stores an asset to the given key.
+func (c *Redis) Set(key string, data []byte, expiration time.Duration) {
+	c.client.Set(context.TODO(), key, data, expiration)
+}
+
+// SetNX stores the data in the cache only if the key doesn't exist yet.
+func (c *Redis) SetNX(key string, data []byte, expiration time.Duration) {
+	c.client.SetNX(context.TODO(), key, data, expiration)
+}
+
+// GetCompressed works like Get but expect a compressed asset that is
+// uncompressed.
+func (c *Redis) GetCompressed(key string) (io.Reader, bool) {
+	r, ok := c.Get(key)
+	if !ok {
+		return nil, false
+	}
+
+	gr, err := gzip.NewReader(bytes.NewReader(r))
+	if err != nil {
+		return nil, false
+	}
+
+	return gr, true
+}
+
+// SetCompressed works like Set but compress the asset data before storing it.
+func (c *Redis) SetCompressed(key string, data []byte, expiration time.Duration) {
+	dataCompressed := new(bytes.Buffer)
+
+	gw := gzip.NewWriter(dataCompressed)
+	defer gw.Close()
+
+	if _, err := io.Copy(gw, bytes.NewReader(data)); err != nil {
+		return
+	}
+
+	c.Set(key, dataCompressed.Bytes(), expiration)
+}
+
+// RefreshTTL can be used to update the TTL of an existing entry in the cache.
+func (c *Redis) RefreshTTL(key string, expiration time.Duration) {
+	c.client.Expire(context.TODO(), key, expiration)
+}


### PR DESCRIPTION
The `/pkg/cache/cache.go.Cache` struct seems to contains two separate
behavior based on the presence (or not) of a redis client.

If the redis client is present we are using the redis client, if not
we are using an in-memory implementation.

The goal of the next commits is to separate those two logic in two
separate implementations in order to increase the readability.