### PR TITLE
Fix goroutine leak in realtime

### DIFF
--- a/pkg/realtime/mem_realtime.go
+++ b/pkg/realtime/mem_realtime.go
@@ -162,11 +162,13 @@ func (h *memHub) unwatch(sub *Subscriber, key, id string) {
 }
 
 func (h *memHub) close(sub *Subscriber) {
-	h.Lock()
+	h.RLock()
 	list := h.bySubscribers[sub]
-	h.Unlock()
+	h.RUnlock()
+	keys := make([]string, len(list))
+	copy(keys, list)
 
-	for _, key := range list {
+	for _, key := range keys {
 		h.unsubscribe(sub, key)
 	}
 }


### PR DESCRIPTION
When a realtime websocket is closed, the Subscriber calls close on the realtime hub. It iterates on the sucscribed keys, and removes them. But the list of keys was modified during the loop, which can make some topics to be kept, and their goroutines won't be stopped.