### PR TITLE
Improve sharing logs

### DIFF
--- a/model/sharing/indexer.go
+++ b/model/sharing/indexer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cozy/cozy-stack/model/vfs"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/couchdb/revision"
 	"github.com/cozy/cozy-stack/pkg/crypto"
 	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/cozy/cozy-stack/pkg/prefixer"
@@ -66,7 +67,7 @@ func (s *sharingIndexer) IncrementRevision() {
 // have to create a new revision that will be propagated to the other cozy.
 func (s *sharingIndexer) WillResolveConflict(rev string, chain []string) {
 	last := chain[len(chain)-1]
-	if RevGeneration(last) == RevGeneration(rev) {
+	if revision.Generation(last) == revision.Generation(rev) {
 		s.bulkRevs = nil
 		return
 	}

--- a/model/sharing/replicator.go
+++ b/model/sharing/replicator.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cozy/cozy-stack/model/job"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/couchdb/revision"
 	"github.com/cozy/cozy-stack/pkg/lock"
 	"github.com/cozy/cozy-stack/pkg/realtime"
 	"github.com/cozy/cozy-stack/pkg/safehttp"
@@ -237,7 +238,7 @@ func (s *Sharing) UpdateLastSequenceNumber(inst *instance.Instance, m *Member, w
 		result = make(map[string]interface{})
 	} else {
 		if prev, ok := result["last_seq"].(string); ok {
-			if RevGeneration(seq) <= RevGeneration(prev) {
+			if revision.Generation(seq) <= revision.Generation(prev) {
 				return nil
 			}
 		}

--- a/model/sharing/replicator_test.go
+++ b/model/sharing/replicator_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/couchdb/revision"
 	"github.com/cozy/cozy-stack/tests/testutils"
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
@@ -55,7 +56,7 @@ func TestReplicator(t *testing.T) {
 		feed, err := s.callChangesFeed(inst, seq)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, feed.Seq)
-		assert.Equal(t, nb, RevGeneration(feed.Seq))
+		assert.Equal(t, nb, revision.Generation(feed.Seq))
 		err = s.UpdateLastSequenceNumber(inst, m, "replicator", feed.Seq)
 		assert.NoError(t, err)
 
@@ -248,7 +249,7 @@ func TestReplicator(t *testing.T) {
 		feed, err := s.callChangesFeed(inst, "")
 		assert.NoError(t, err)
 		assert.NotEmpty(t, feed.Seq)
-		assert.Equal(t, 3, RevGeneration(feed.Seq))
+		assert.Equal(t, 3, revision.Generation(feed.Seq))
 		changes := &feed.Changes
 		assert.Equal(t, []string{"1-aaa", "2-ccc"}, changes.Changed[ref1.SID])
 		assert.Equal(t, []string{"3-bbb"}, changes.Changed[ref2.SID])
@@ -269,7 +270,7 @@ func TestReplicator(t *testing.T) {
 		feed3, err := s.callChangesFeed(inst, feed.Seq)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, feed3.Seq)
-		assert.Equal(t, 4, RevGeneration(feed3.Seq))
+		assert.Equal(t, 4, revision.Generation(feed3.Seq))
 		changes = &feed3.Changes
 		assert.Equal(t, []string{"1-aaa", "2-ccc", "3-ddd"}, changes.Changed[ref1.SID])
 		assert.NotContains(t, changes.Changed, ref2.SID)

--- a/model/sharing/revisions_test.go
+++ b/model/sharing/revisions_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/couchdb/revision"
 	"github.com/cozy/cozy-stack/tests/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -192,12 +193,6 @@ func TestRevsTreeInsertChainStartingBefore(t *testing.T) {
 	assert.Len(t, sub.Branches, 0)
 }
 
-func TestRevGeneration(t *testing.T) {
-	assert.Equal(t, 1, RevGeneration("1-aaa"))
-	assert.Equal(t, 3, RevGeneration("3-123"))
-	assert.Equal(t, 10, RevGeneration("10-1f2"))
-}
-
 func TestRevsStructToChain(t *testing.T) {
 	input := RevsStruct{
 		Start: 3,
@@ -282,7 +277,7 @@ func TestIndexerIncrementRevisions(t *testing.T) {
 	}
 	indexer.IncrementRevision()
 	assert.Equal(t, 4, indexer.bulkRevs.Revisions.Start)
-	gen := RevGeneration(indexer.bulkRevs.Rev)
+	gen := revision.Generation(indexer.bulkRevs.Rev)
 	assert.Equal(t, 4, gen)
 	assert.Len(t, indexer.bulkRevs.Revisions.IDs, 3)
 	rev := fmt.Sprintf("%d-%s", gen, indexer.bulkRevs.Revisions.IDs[0])
@@ -366,7 +361,7 @@ func TestIndexerCreateBogusPrevRev(t *testing.T) {
 	}
 	indexer.CreateBogusPrevRev()
 	assert.Equal(t, 3, indexer.bulkRevs.Revisions.Start)
-	gen := RevGeneration(indexer.bulkRevs.Rev)
+	gen := revision.Generation(indexer.bulkRevs.Rev)
 	assert.Equal(t, 3, gen)
 	assert.Len(t, indexer.bulkRevs.Revisions.IDs, 2)
 	rev := fmt.Sprintf("%d-%s", gen, indexer.bulkRevs.Revisions.IDs[0])

--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
+	"github.com/cozy/cozy-stack/pkg/couchdb/revision"
 	"github.com/cozy/cozy-stack/pkg/crypto"
 	"github.com/cozy/cozy-stack/pkg/jsonapi"
 	"github.com/cozy/cozy-stack/pkg/metadata"
@@ -1532,7 +1533,7 @@ func (s *Sharing) checkSharingTreesConsistency(inst *instance.Instance, ownerDoc
 
 		if ownerDoc, found := ownerDocsById[ownerID]; found {
 			if ownerDoc.Rev() != memberDoc.Rev() {
-				if RevGeneration(ownerDoc.Rev()) < RevGeneration(memberDoc.Rev()) && ms.ReadOnly() {
+				if revision.Generation(ownerDoc.Rev()) < revision.Generation(memberDoc.Rev()) && ms.ReadOnly() {
 					checks = append(checks, map[string]interface{}{
 						"id":     s.SID,
 						"type":   "read_only_member",
@@ -1543,14 +1544,14 @@ func (s *Sharing) checkSharingTreesConsistency(inst *instance.Instance, ownerDoc
 					// assume the sharing synchronization is still in progress and
 					// that would explain the difference between the 2 revisions.
 					// In this case, we do nothing.
-				} else if RevGeneration(ownerDoc.Rev()) > RevGeneration(memberDoc.Rev()) && isFileTooBigForInstance(m, ownerDoc) {
+				} else if revision.Generation(ownerDoc.Rev()) > revision.Generation(memberDoc.Rev()) && isFileTooBigForInstance(m, ownerDoc) {
 					checks = append(checks, map[string]interface{}{
 						"id":       s.SID,
 						"type":     "disk_quota_exceeded",
 						"instance": m.Domain,
 						"file":     ownerDoc,
 					})
-				} else if RevGeneration(ownerDoc.Rev()) < RevGeneration(memberDoc.Rev()) && isFileTooBigForInstance(inst, memberDoc) {
+				} else if revision.Generation(ownerDoc.Rev()) < revision.Generation(memberDoc.Rev()) && isFileTooBigForInstance(inst, memberDoc) {
 					checks = append(checks, map[string]interface{}{
 						"id":       s.SID,
 						"type":     "disk_quota_exceeded",

--- a/pkg/couchdb/revision/rev.go
+++ b/pkg/couchdb/revision/rev.go
@@ -1,0 +1,17 @@
+package revision
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Generation returns the number before the hyphen, called the generation of a
+// revision.
+func Generation(rev string) int {
+	parts := strings.SplitN(rev, "-", 2)
+	gen, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0
+	}
+	return gen
+}

--- a/pkg/couchdb/revision/rev_test.go
+++ b/pkg/couchdb/revision/rev_test.go
@@ -1,0 +1,13 @@
+package revision
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGeneration(t *testing.T) {
+	assert.Equal(t, 1, Generation("1-aaa"))
+	assert.Equal(t, 3, Generation("3-123"))
+	assert.Equal(t, 10, Generation("10-1f2"))
+}

--- a/web/sharings/replicator_test.go
+++ b/web/sharings/replicator_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/couchdb/revision"
 	"github.com/cozy/cozy-stack/tests/testutils"
 	"github.com/cozy/cozy-stack/web"
 	"github.com/cozy/cozy-stack/web/errors"
@@ -398,7 +399,7 @@ func createShared(t *testing.T, sid string, revisions []string, replInstance *in
 	parts := strings.SplitN(sid, "/", 2)
 	doctype := parts[0]
 	id := parts[1]
-	start := sharing.RevGeneration(rev)
+	start := revision.Generation(rev)
 	docs := []map[string]interface{}{
 		{
 			"_id":  id,


### PR DESCRIPTION
Adding some logs for bulk operations can be helpful for debugging sharing issues.