### PR TITLE
Remove upper case in errors following go code review comments

### DIFF
--- a/client/apps.go
+++ b/client/apps.go
@@ -256,7 +256,7 @@ func makeAppsPath(appType, path string) string {
 	case consts.Konnectors:
 		return "/konnectors/" + path
 	}
-	panic(fmt.Errorf("Unknown application type %s", appType))
+	panic(fmt.Errorf("unknown application type %s", appType))
 }
 
 func readAppManifestStream(res *http.Response) (*AppManifest, error) {
@@ -271,14 +271,14 @@ func readAppManifestStream(res *http.Response) (*AppManifest, error) {
 		if evt.Name == "error" {
 			var stringError string
 			if err := json.Unmarshal(evt.Data, &stringError); err != nil {
-				return nil, fmt.Errorf("Could not parse error from event-stream: %s", err.Error())
+				return nil, fmt.Errorf("could not parse error from event-stream: %s", err.Error())
 			}
 			return nil, errors.New(stringError)
 		}
 		lastevt = evt
 	}
 	if lastevt == nil {
-		return nil, errors.New("No application data was sent")
+		return nil, errors.New("no application data was sent")
 	}
 	app := &AppManifest{}
 	if err := readJSONAPI(bytes.NewReader(lastevt.Data), &app); err != nil {

--- a/client/auth/auth.go
+++ b/client/auth/auth.go
@@ -189,7 +189,7 @@ func (r *Request) Authenticate() error {
 	}
 	query := receivedURL.Query()
 	if state != query.Get("state") {
-		return errors.New("Non matching states")
+		return errors.New("non matching states")
 	}
 	token, err = r.GetAccessToken(client, query.Get("code"))
 	if err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -13,7 +13,7 @@ import (
 )
 
 // ErrWrongPassphrase is used when the passphrase is wrong
-var ErrWrongPassphrase = errors.New("Unauthorized: wrong passphrase")
+var ErrWrongPassphrase = errors.New("unauthorized: wrong passphrase")
 
 // jsonAPIErrors is a group of errors. It is the error type returned by the
 // API.

--- a/client/files.go
+++ b/client/files.go
@@ -439,7 +439,7 @@ func readFile(res *http.Response) (*File, error) {
 		return nil, err
 	}
 	if file.Attrs.Type != FileType {
-		return nil, fmt.Errorf("Not a file")
+		return nil, fmt.Errorf("not a file")
 	}
 	return file, nil
 }
@@ -450,7 +450,7 @@ func readDir(res *http.Response) (*Dir, error) {
 		return nil, err
 	}
 	if dir.Attrs.Type != DirType {
-		return nil, fmt.Errorf("Not a directory")
+		return nil, fmt.Errorf("not a directory")
 	}
 	return dir, nil
 }

--- a/client/instances.go
+++ b/client/instances.go
@@ -146,7 +146,7 @@ func (ac *AdminClient) GetInstance(domain string) (*Instance, error) {
 // and locale.
 func (ac *AdminClient) CreateInstance(opts *InstanceOptions) (*Instance, error) {
 	if !validDomain(opts.Domain) {
-		return nil, fmt.Errorf("Invalid domain: %s", opts.Domain)
+		return nil, fmt.Errorf("invalid domain: %s", opts.Domain)
 	}
 	q := url.Values{
 		"Domain":        {opts.Domain},
@@ -220,7 +220,7 @@ func (ac *AdminClient) ListInstances() ([]*Instance, error) {
 func (ac *AdminClient) ModifyInstance(opts *InstanceOptions) (*Instance, error) {
 	domain := opts.Domain
 	if !validDomain(domain) {
-		return nil, fmt.Errorf("Invalid domain: %s", domain)
+		return nil, fmt.Errorf("invalid domain: %s", domain)
 	}
 	q := url.Values{
 		"Locale":      {opts.Locale},
@@ -265,7 +265,7 @@ func (ac *AdminClient) ModifyInstance(opts *InstanceOptions) (*Instance, error) 
 // DestroyInstance is used to delete an instance and all its data.
 func (ac *AdminClient) DestroyInstance(domain string) error {
 	if !validDomain(domain) {
-		return fmt.Errorf("Invalid domain: %s", domain)
+		return fmt.Errorf("invalid domain: %s", domain)
 	}
 	_, err := ac.Req(&request.Options{
 		Method:     "DELETE",
@@ -278,7 +278,7 @@ func (ac *AdminClient) DestroyInstance(domain string) error {
 // GetDebug is used to known if an instance has its logger in debug mode.
 func (ac *AdminClient) GetDebug(domain string) (bool, error) {
 	if !validDomain(domain) {
-		return false, fmt.Errorf("Invalid domain: %s", domain)
+		return false, fmt.Errorf("invalid domain: %s", domain)
 	}
 	_, err := ac.Req(&request.Options{
 		Method:     "GET",
@@ -299,7 +299,7 @@ func (ac *AdminClient) GetDebug(domain string) (bool, error) {
 // EnableDebug sets the logger of an instance in debug mode.
 func (ac *AdminClient) EnableDebug(domain string, ttl time.Duration) error {
 	if !validDomain(domain) {
-		return fmt.Errorf("Invalid domain: %s", domain)
+		return fmt.Errorf("invalid domain: %s", domain)
 	}
 	_, err := ac.Req(&request.Options{
 		Method:     "POST",
@@ -315,7 +315,7 @@ func (ac *AdminClient) EnableDebug(domain string, ttl time.Duration) error {
 // CleanSessions delete the databases for io.cozy.sessions and io.cozy.sessions.logins
 func (ac *AdminClient) CleanSessions(domain string) error {
 	if !validDomain(domain) {
-		return fmt.Errorf("Invalid domain: %s", domain)
+		return fmt.Errorf("invalid domain: %s", domain)
 	}
 	_, err := ac.Req(&request.Options{
 		Method:     "DELETE",
@@ -328,7 +328,7 @@ func (ac *AdminClient) CleanSessions(domain string) error {
 // DisableDebug disables the debug mode for the logger of an instance.
 func (ac *AdminClient) DisableDebug(domain string) error {
 	if !validDomain(domain) {
-		return fmt.Errorf("Invalid domain: %s", domain)
+		return fmt.Errorf("invalid domain: %s", domain)
 	}
 	_, err := ac.Req(&request.Options{
 		Method:     "DELETE",
@@ -464,7 +464,7 @@ func (ac *AdminClient) Updates(opts *UpdatesOptions) error {
 // Export launch the creation of a tarball to export data from an instance.
 func (ac *AdminClient) Export(opts *ExportOptions) error {
 	if !validDomain(opts.Domain) {
-		return fmt.Errorf("Invalid domain: %s", opts.Domain)
+		return fmt.Errorf("invalid domain: %s", opts.Domain)
 	}
 
 	downloadArchives := opts.LocalPath != ""
@@ -510,7 +510,7 @@ func (ac *AdminClient) Export(opts *ExportOptions) error {
 					continue
 				}
 				if exportDoc.State == move.ExportStateError {
-					return fmt.Errorf("Failed to export instance: %s", exportDoc.Error)
+					return fmt.Errorf("failed to export instance: %s", exportDoc.Error)
 				}
 				if exportDoc.State != move.ExportStateDone {
 					continue
@@ -572,7 +572,7 @@ func (ac *AdminClient) Export(opts *ExportOptions) error {
 // Import launch the import of a tarball with data to put in an instance.
 func (ac *AdminClient) Import(domain string, opts *ImportOptions) error {
 	if !validDomain(domain) {
-		return fmt.Errorf("Invalid domain: %s", domain)
+		return fmt.Errorf("invalid domain: %s", domain)
 	}
 	q := url.Values{
 		"manifest_url": {opts.ManifestURL},

--- a/cmd/apps.go
+++ b/cmd/apps.go
@@ -237,14 +237,14 @@ var runKonnectorsCmd = &cobra.Command{
 		}
 
 		if len(triggers) == 0 {
-			return fmt.Errorf("Could not find a konnector %q: "+
+			return fmt.Errorf("could not find a konnector %q: "+
 				"it may be installed but it is not activated (no related trigger)", slug)
 		}
 
 		var trigger *localTrigger
 		if len(triggers) > 1 || flagKonnectorAccountID != "" {
 			if flagKonnectorAccountID == "" {
-				return errors.New("Found multiple konnectors with different accounts: use the --account-id flag")
+				return errors.New("found multiple konnectors with different accounts: use the --account-id flag")
 			}
 			for _, t := range triggers {
 				if t.accountID == flagKonnectorAccountID {
@@ -253,7 +253,7 @@ var runKonnectorsCmd = &cobra.Command{
 				}
 			}
 			if trigger == nil {
-				return fmt.Errorf("Could not find konnector linked to account with id %q",
+				return fmt.Errorf("could not find konnector linked to account with id %q",
 					flagKonnectorAccountID)
 			}
 		} else {
@@ -650,7 +650,7 @@ func foreachDomains(predicate func(*client.Instance) error) error {
 		}
 	}
 	if hasErr {
-		return errors.New("At least one error occurred while executing this command")
+		return errors.New("at least one error occurred while executing this command")
 	}
 	return nil
 }

--- a/cmd/assets.go
+++ b/cmd/assets.go
@@ -38,7 +38,7 @@ https://example.mycozy.cloud/assets/foo/bar/baz.js (and not on
 
 func addAsset(cmd *cobra.Command, args []string) error {
 	if flagContext == "" {
-		return fmt.Errorf("You must provide a context")
+		return fmt.Errorf("you must provide a context")
 	}
 
 	assetOption := modelAsset.AssetOption{

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -39,7 +39,7 @@ following line to the .bash_profile
 			includeDescription := true
 			return RootCmd.GenFishCompletion(os.Stdout, includeDescription)
 		}
-		return errors.New("Unsupported shell")
+		return errors.New("unsupported shell")
 	},
 }
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -66,7 +66,7 @@ The environment variable 'COZY_ADMIN_PASSPHRASE' can be used to pass the passphr
 				return err
 			}
 			if !bytes.Equal(pass1, pass2) {
-				return fmt.Errorf("Passphrase missmatch")
+				return fmt.Errorf("passphrase missmatch")
 			}
 
 			passphrase = pass1
@@ -243,12 +243,12 @@ var decryptCredentialsCmd = &cobra.Command{
 
 		credentialsEncrypted, err := base64.StdEncoding.DecodeString(args[1])
 		if err != nil {
-			return fmt.Errorf("Cipher text is not properly base64 encoded: %s", err)
+			return fmt.Errorf("cipher text is not properly base64 encoded: %s", err)
 		}
 
 		login, password, err := account.DecryptCredentialsWithKey(credsDecryptor, credentialsEncrypted)
 		if err != nil {
-			return fmt.Errorf("Could not decrypt cipher text: %s", err)
+			return fmt.Errorf("could not decrypt cipher text: %s", err)
 		}
 
 		fmt.Printf(`Decrypted credentials:

--- a/cmd/files.go
+++ b/cmd/files.go
@@ -21,7 +21,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var errFilesExec = errors.New("Bad usage of files exec")
+var errFilesExec = errors.New("bad usage of files exec")
 
 const filesExecUsage = `Available commands:
 
@@ -480,7 +480,7 @@ func importFiles(c *client.Client, from, to string, match *regexp.Regexp) error 
 			if f.IsDir() {
 				return nil
 			}
-			return fmt.Errorf("Not a directory: %s", localname)
+			return fmt.Errorf("not a directory: %s", localname)
 		}
 
 		distname := path.Join(to, strings.TrimPrefix(localname, from))

--- a/cmd/instances.go
+++ b/cmd/instances.go
@@ -157,7 +157,7 @@ be used as the error message.
 	Example: "$ cozy-stack instances add --passphrase cozy --apps drive,photos,settings,home,store cozy.localhost:8080",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if reason := os.Getenv("COZY_DISABLE_INSTANCES_ADD_RM"); reason != "" {
-			return fmt.Errorf("Sorry, instances add is disabled: %s", reason)
+			return fmt.Errorf("sorry, instances add is disabled: %s", reason)
 		}
 		if len(args) == 0 {
 			return cmd.Usage()
@@ -334,7 +334,7 @@ var updateInstancePassphraseCmd = &cobra.Command{
 		case http.StatusNoContent:
 			fmt.Println("Passphrase has been changed for instance ", domain)
 		case http.StatusBadRequest:
-			return fmt.Errorf("Bad current passphrase for instance %s", domain)
+			return fmt.Errorf("bad current passphrase for instance %s", domain)
 		case http.StatusInternalServerError:
 			return fmt.Errorf("%s", err)
 		}
@@ -357,7 +357,7 @@ instance of the given domain. Set the quota to 0 to remove the quota.
 		}
 		parsed, err := humanize.ParseBytes(args[1])
 		if err != nil {
-			return fmt.Errorf("Could not parse disk-quota: %s", err)
+			return fmt.Errorf("could not parse disk-quota: %s", err)
 		}
 		diskQuota := int64(parsed)
 		if diskQuota == 0 {
@@ -607,7 +607,7 @@ and all its data.
 	Aliases: []string{"rm", "delete", "remove"},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if reason := os.Getenv("COZY_DISABLE_INSTANCES_ADD_RM"); reason != "" {
-			return fmt.Errorf("Sorry, instances add is disabled: %s", reason)
+			return fmt.Errorf("sorry, instances add is disabled: %s", reason)
 		}
 		if len(args) == 0 {
 			return cmd.Usage()
@@ -647,7 +647,7 @@ Type again the domain to confirm: `, action, domain)
 
 	str = strings.ToLower(strings.TrimSpace(str))
 	if str != domain {
-		return errors.New("Aborted")
+		return errors.New("aborted")
 	}
 
 	fmt.Println()
@@ -745,7 +745,7 @@ var oauthTokenInstanceCmd = &cobra.Command{
 			return cmd.Usage()
 		}
 		if args[1] == "" {
-			return errors.New("Missing clientID")
+			return errors.New("missing clientID")
 		}
 		if strings.Contains(args[2], ",") {
 			fmt.Fprintf(os.Stderr, "Warning: the delimiter for the scopes is a space!\n")
@@ -926,7 +926,7 @@ var importCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ac := newAdminClient()
 		if len(args) < 1 {
-			return errors.New("The URL to the exported data is missing")
+			return errors.New("the URL to the exported data is missing")
 		}
 
 		if !flagForce {
@@ -950,7 +950,7 @@ var showSwiftPrefixInstanceCmd = &cobra.Command{
 
 		ac := newAdminClient()
 		if len(args) < 1 {
-			return errors.New("The domain is missing")
+			return errors.New("the domain is missing")
 		}
 
 		req := &request.Options{
@@ -1004,7 +1004,7 @@ var instanceAppVersionCmd = &cobra.Command{
 			return err
 		}
 		if len(out.Instances) == 0 {
-			return fmt.Errorf("No instances have application \"%s\" in version \"%s\"", args[0], args[1])
+			return fmt.Errorf("no instances have application \"%s\" in version \"%s\"", args[0], args[1])
 		}
 
 		json, err := json.MarshalIndent(out.Instances, "", "  ")

--- a/cmd/jobs.go
+++ b/cmd/jobs.go
@@ -38,7 +38,7 @@ var jobsRunCmd = &cobra.Command{
 			return errMissingDomain
 		}
 		if flagJobJSONArg == "" {
-			return errors.New("The JSON argument is missing")
+			return errors.New("the JSON argument is missing")
 		}
 		c := newClient(flagDomain, "io.cozy.jobs", "io.cozy.jobs.logs")
 		o := &client.JobOptions{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,7 +29,7 @@ var flagDomain string
 
 var cfgFile string
 
-var errMissingDomain = errors.New("Missing --domain flag, or COZY_DOMAIN env variable")
+var errMissingDomain = errors.New("missing --domain flag, or COZY_DOMAIN env variable")
 
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -53,7 +53,7 @@ example), you can use the --appdir flag like this:
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if !flagAllowRoot && os.Getuid() == 0 {
 			errPrintfln("Use --allow-root if you really want to start with the root user")
-			return errors.New("Starting cozy-stack serve as root not allowed")
+			return errors.New("starting cozy-stack serve as root not allowed")
 		}
 
 		if flagDevMode {
@@ -71,7 +71,7 @@ example), you can use the --appdir flag like this:
 				case 2:
 					apps[parts[0]] = parts[1]
 				default:
-					return errors.New("Invalid appdir value")
+					return errors.New("invalid appdir value")
 				}
 			}
 		}

--- a/model/account/type.go
+++ b/model/account/type.go
@@ -202,7 +202,7 @@ func (at *AccountType) MakeOauthStartURL(i *instance.Instance, state string, par
 			vv.Add("id_connection", id)
 		}
 	default:
-		return "", errors.New("Wrong account type")
+		return "", errors.New("wrong account type")
 	}
 
 	vv.Add("state", state)
@@ -292,7 +292,7 @@ func (at *AccountType) RequestAccessToken(i *instance.Instance, accessCode, stat
 		return nil, err
 	}
 	if out.Error != "" {
-		return nil, fmt.Errorf("OauthError(%s) %s", out.Error, out.ErrorDescription)
+		return nil, fmt.Errorf("oauthError(%s) %s", out.Error, out.ErrorDescription)
 	}
 
 	var ExpiresAt time.Time
@@ -371,7 +371,7 @@ func (at *AccountType) RefreshAccount(a Account) error {
 	}
 
 	if out.Error != "" {
-		return fmt.Errorf("OauthError(%s) %s", out.Error, out.ErrorDescription)
+		return fmt.Errorf("oauthError(%s) %s", out.Error, out.ErrorDescription)
 	}
 
 	if out.AccessToken != "" {
@@ -396,7 +396,7 @@ func (at *AccountType) MakeManageURL(i *instance.Instance, state string, params 
 	case BIWebauth, BIWebauthAndSecret, BIWebview, BIWebviewAndSecret:
 		// OK
 	default:
-		return "", errors.New("Wrong account type")
+		return "", errors.New("wrong account type")
 	}
 
 	u, err := url.Parse(at.ManageEndpoint)
@@ -420,7 +420,7 @@ func (at *AccountType) MakeReconnectURL(i *instance.Instance, state string, para
 	case BIWebauth, BIWebauthAndSecret, BIWebview, BIWebviewAndSecret:
 		// OK
 	default:
-		return "", errors.New("Wrong account type")
+		return "", errors.New("wrong account type")
 	}
 
 	u, err := url.Parse(at.ReconnectEndpoint)

--- a/model/app/errors.go
+++ b/model/app/errors.go
@@ -4,34 +4,34 @@ import "errors"
 
 var (
 	// ErrInvalidSlugName is used when the given slug name is not valid
-	ErrInvalidSlugName = errors.New("Invalid slug name")
+	ErrInvalidSlugName = errors.New("invalid slug name")
 	// ErrAlreadyExists is used when an application with the specified slug name
 	// is already installed.
-	ErrAlreadyExists = errors.New("Application with same slug already exists")
+	ErrAlreadyExists = errors.New("application with same slug already exists")
 	// ErrNotFound is used when no application with specified slug name is
 	// installed.
 	// Used by Cloudery, don't modify it
-	ErrNotFound = errors.New("Application is not installed")
+	ErrNotFound = errors.New("application is not installed")
 	// ErrNotSupportedSource is used when the source transport or
 	// protocol is not supported
-	ErrNotSupportedSource = errors.New("Invalid or not supported source scheme")
+	ErrNotSupportedSource = errors.New("invalid or not supported source scheme")
 	// ErrManifestNotReachable is used when the manifest of the
 	// application is not reachable
-	ErrManifestNotReachable = errors.New("Application manifest is not reachable")
+	ErrManifestNotReachable = errors.New("application manifest is not reachable")
 	// ErrSourceNotReachable is used when the given source for
 	// application is not reachable
-	ErrSourceNotReachable = errors.New("Application source is not reachable")
+	ErrSourceNotReachable = errors.New("application source is not reachable")
 	// ErrBadManifest when the manifest is not valid or malformed
-	ErrBadManifest = errors.New("Application manifest is invalid or malformed")
+	ErrBadManifest = errors.New("application manifest is invalid or malformed")
 	// ErrBadState is used when trying to use the application while in a
 	// state that is not appropriate for the given operation.
-	ErrBadState = errors.New("Application is not in valid state to perform this operation")
+	ErrBadState = errors.New("application is not in valid state to perform this operation")
 	// ErrMissingSource is used when installing an application, but there is no
 	// source URL
-	ErrMissingSource = errors.New("The source URL for the app is missing")
+	ErrMissingSource = errors.New("the source URL for the app is missing")
 	// ErrBadChecksum is used when the application checksum does not match the
 	// specified one.
-	ErrBadChecksum = errors.New("Application checksum does not match")
+	ErrBadChecksum = errors.New("application checksum does not match")
 	// ErrLinkedAppExists is used when an OAuth client is linked to this app
-	ErrLinkedAppExists = errors.New("A linked OAuth client exists for this app")
+	ErrLinkedAppExists = errors.New("a linked OAuth client exists for this app")
 )

--- a/model/app/fetcher_git.go
+++ b/model/app/fetcher_git.go
@@ -315,7 +315,7 @@ func resolveGithubURL(src *url.URL, filename string) (string, error) {
 		return "", &url.Error{
 			Op:  "parsepath",
 			URL: src.String(),
-			Err: errors.New("Could not parse url git path"),
+			Err: errors.New("could not parse url git path"),
 		}
 	}
 
@@ -332,7 +332,7 @@ func resolveGitlabURL(src *url.URL, filename string) (string, error) {
 		return "", &url.Error{
 			Op:  "parsepath",
 			URL: src.String(),
-			Err: errors.New("Could not parse url git path"),
+			Err: errors.New("could not parse url git path"),
 		}
 	}
 

--- a/model/app/installer.go
+++ b/model/app/installer.go
@@ -592,7 +592,7 @@ func (i *Installer) ReadManifest(state State) (Manifest, error) {
 	appTypesMismatch := i.man.AppType() != newManifestAppType
 
 	if !appTypesEmpty && appTypesMismatch {
-		return nil, fmt.Errorf("Manifest types are not the sames. Expected %d, got %d. Are you sure of %s type ? (konnector/webapp)", i.man.AppType(), newManifestAppType, i.man.Slug())
+		return nil, fmt.Errorf("manifest types are not the sames. Expected %d, got %d. Are you sure of %s type ? (konnector/webapp)", i.man.AppType(), newManifestAppType, i.man.Slug())
 	}
 	return newManifest, nil
 }

--- a/model/app/webapp.go
+++ b/model/app/webapp.go
@@ -563,7 +563,7 @@ func loadManifestFromDir(slug string) (*WebappManifest, error) {
 	manFile, err := fs.Open(WebappManifestName)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("Could not find the manifest in your app directory %s", dir)
+			return nil, fmt.Errorf("could not find the manifest in your app directory %s", dir)
 		}
 		return nil, err
 	}
@@ -572,7 +572,7 @@ func loadManifestFromDir(slug string) (*WebappManifest, error) {
 	}
 	man, err := app.ReadManifest(manFile, slug, "file://localhost"+dir)
 	if err != nil {
-		return nil, fmt.Errorf("Could not parse the manifest: %s", err.Error())
+		return nil, fmt.Errorf("could not parse the manifest: %s", err.Error())
 	}
 	app = man.(*WebappManifest)
 	app.FromAppsDir = true

--- a/model/bitwarden/icon.go
+++ b/model/bitwarden/icon.go
@@ -38,7 +38,7 @@ func GetIcon(domain string) (*Icon, error) {
 	key := "bw-icons:" + domain
 	if data, ok := cache.Get(key); ok {
 		if len(data) == 0 {
-			return nil, errors.New("No icon")
+			return nil, errors.New("no icon")
 		}
 		icon := &Icon{}
 		if err := json.Unmarshal(data, icon); err != nil {
@@ -60,17 +60,17 @@ func GetIcon(domain string) (*Icon, error) {
 
 func validateDomain(domain string) error {
 	if domain == "" || len(domain) > 255 || strings.Contains(domain, "..") {
-		return errors.New("Unauthorized domain")
+		return errors.New("unauthorized domain")
 	}
 
 	for _, c := range domain {
 		if c == ' ' || !strconv.IsPrint(c) {
-			return errors.New("Invalid domain")
+			return errors.New("invalid domain")
 		}
 	}
 
 	if _, _, err := net.ParseCIDR(domain + "/24"); err == nil {
-		return errors.New("IP address are not authorized")
+		return errors.New("iP address are not authorized")
 	}
 
 	return nil
@@ -100,12 +100,12 @@ func getPage(domain string) (io.ReadCloser, error) {
 	}
 	if res.StatusCode != http.StatusOK {
 		res.Body.Close()
-		return nil, errors.New("Not status OK")
+		return nil, errors.New("not status OK")
 	}
 	ct := strings.ToLower(res.Header.Get(echo.HeaderContentType))
 	if !strings.Contains(ct, echo.MIMETextHTML) {
 		res.Body.Close()
-		return nil, errors.New("Not html")
+		return nil, errors.New("not html")
 	}
 	return res.Body, nil
 }
@@ -233,24 +233,24 @@ func downloadIcon(u string) (*Icon, error) {
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return nil, errors.New("Not status OK")
+		return nil, errors.New("not status OK")
 	}
 	b, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}
 	if len(b) == 0 {
-		return nil, errors.New("Empty icon")
+		return nil, errors.New("empty icon")
 	}
 	if len(b) > maxSize {
-		return nil, errors.New("Max size exceeded")
+		return nil, errors.New("max size exceeded")
 	}
 	ico := Icon{
 		Mime: res.Header.Get(echo.HeaderContentType),
 		Body: b,
 	}
 	if strings.Split(ico.Mime, "/")[0] != "image" {
-		return nil, errors.New("Invalid mime-type")
+		return nil, errors.New("invalid mime-type")
 	}
 	return &ico, nil
 }

--- a/model/bitwarden/organization.go
+++ b/model/bitwarden/organization.go
@@ -119,7 +119,7 @@ func (o *Organization) Delete(inst *instance.Instance) error {
 // for the konnectors running on the Cozy server.
 func GetCozyOrganization(inst *instance.Instance, setting *settings.Settings) (*Organization, error) {
 	if setting == nil || setting.PublicKey == "" {
-		return nil, errors.New("No public key")
+		return nil, errors.New("no public key")
 	}
 	orgKey, err := setting.OrganizationKey()
 	if err != nil {

--- a/model/bitwarden/settings/settings.go
+++ b/model/bitwarden/settings/settings.go
@@ -17,7 +17,7 @@ import (
 const DocTypeVersion = "1"
 
 // ErrMissingOrgKey is used when the organization key does not exist
-var ErrMissingOrgKey = errors.New("No organization key")
+var ErrMissingOrgKey = errors.New("no organization key")
 
 // Settings is the struct that holds the birwarden settings
 type Settings struct {
@@ -128,7 +128,7 @@ func (s *Settings) OrganizationKey() ([]byte, error) {
 	}
 	b64, ok := decrypted.(string)
 	if !ok {
-		return nil, errors.New("Invalid key")
+		return nil, errors.New("invalid key")
 	}
 	return base64.StdEncoding.DecodeString(b64)
 }

--- a/model/contact/errors.go
+++ b/model/contact/errors.go
@@ -5,7 +5,7 @@ import "errors"
 var (
 	// ErrNoMailAddress is returned when trying to access the email address of
 	// a contact that has no known email address.
-	ErrNoMailAddress = errors.New("The contact has no email address")
+	ErrNoMailAddress = errors.New("the contact has no email address")
 	// ErrNotFound is returned when no contact has been found for a query
-	ErrNotFound = errors.New("No contact has been found")
+	ErrNotFound = errors.New("no contact has been found")
 )

--- a/model/feature/flag.go
+++ b/model/feature/flag.go
@@ -143,7 +143,7 @@ func (f *Flags) addManager(inst *instance.Instance) error {
 
 var (
 	cacheDuration      = 12 * time.Hour
-	errInvalidResponse = errors.New("Invalid response from the manager")
+	errInvalidResponse = errors.New("invalid response from the manager")
 )
 
 func getFlagsFromManager(inst *instance.Instance) (map[string]interface{}, error) {

--- a/model/instance/errors.go
+++ b/model/instance/errors.go
@@ -4,31 +4,31 @@ import "errors"
 
 var (
 	// ErrNotFound is used when the seeked instance was not found
-	ErrNotFound = errors.New("Instance not found")
+	ErrNotFound = errors.New("instance not found")
 	// ErrExists is used the instance already exists
-	ErrExists = errors.New("Instance already exists")
+	ErrExists = errors.New("instance already exists")
 	// ErrIllegalDomain is used when the domain named contains illegal characters
-	ErrIllegalDomain = errors.New("Domain name contains illegal characters")
+	ErrIllegalDomain = errors.New("domain name contains illegal characters")
 	// ErrMissingToken is returned by RegisterPassphrase if token is empty
-	ErrMissingToken = errors.New("Empty register token")
+	ErrMissingToken = errors.New("empty register token")
 	// ErrInvalidToken is returned by RegisterPassphrase if token is invalid
-	ErrInvalidToken = errors.New("Invalid register token")
+	ErrInvalidToken = errors.New("invalid register token")
 	// ErrMissingPassphrase is returned when the new passphrase is missing
-	ErrMissingPassphrase = errors.New("Missing new passphrase")
+	ErrMissingPassphrase = errors.New("missing new passphrase")
 	// ErrInvalidPassphrase is returned when the passphrase is invalid
-	ErrInvalidPassphrase = errors.New("Invalid passphrase")
+	ErrInvalidPassphrase = errors.New("invalid passphrase")
 	// ErrInvalidTwoFactor is returned when the two-factor authentication
 	// verification is invalid.
-	ErrInvalidTwoFactor = errors.New("Invalid two-factor parameters")
+	ErrInvalidTwoFactor = errors.New("invalid two-factor parameters")
 	// ErrResetAlreadyRequested is returned when a passphrase reset token is already set and valid
-	ErrResetAlreadyRequested = errors.New("The passphrase reset has already been requested")
+	ErrResetAlreadyRequested = errors.New("the passphrase reset has already been requested")
 	// ErrUnknownAuthMode is returned when an unknown authentication mode is
 	// used.
-	ErrUnknownAuthMode = errors.New("Unknown authentication mode")
+	ErrUnknownAuthMode = errors.New("unknown authentication mode")
 	// ErrBadTOSVersion is returned when a malformed TOS version is provided.
-	ErrBadTOSVersion = errors.New("Bad format for TOS version")
+	ErrBadTOSVersion = errors.New("bad format for TOS version")
 	// ErrInvalidSwiftLayout is returned when the Swift layout is unknown.
-	ErrInvalidSwiftLayout = errors.New("Invalid Swift layout")
+	ErrInvalidSwiftLayout = errors.New("invalid Swift layout")
 	// ErrDeletionAlreadyRequested is returned when a deletion has already been requested.
-	ErrDeletionAlreadyRequested = errors.New("The deletion has already been requested")
+	ErrDeletionAlreadyRequested = errors.New("the deletion has already been requested")
 )

--- a/model/instance/lifecycle/create.go
+++ b/model/instance/lifecycle/create.go
@@ -146,7 +146,7 @@ func CreateWithoutHooks(opts *Options) (*instance.Instance, error) {
 	case config.SchemeSwift, config.SchemeSwiftSecure:
 		switch opts.SwiftLayout {
 		case 0:
-			return nil, errors.New("Swift layout v1 disabled for instance creation")
+			return nil, errors.New("swift layout v1 disabled for instance creation")
 		case 1, 2:
 			i.SwiftLayout = opts.SwiftLayout
 		default:

--- a/model/instance/lifecycle/passphrase.go
+++ b/model/instance/lifecycle/passphrase.go
@@ -18,7 +18,7 @@ import (
 // ErrHintSameAsPassword is used when trying to set an hint that is the same as
 // the password, which would defeat security (e.g. the hint is not encrypted in
 // CouchDB).
-var ErrHintSameAsPassword = errors.New("The hint cannot be the same as the password")
+var ErrHintSameAsPassword = errors.New("the hint cannot be the same as the password")
 
 // PassParameters are the parameters for setting a new passphrase
 type PassParameters struct {

--- a/model/intent/intents.go
+++ b/model/intent/intents.go
@@ -191,12 +191,12 @@ func (in *Intent) FillAvailableWebapps(inst *instance.Instance) error {
 			webappMan := app.WebappManifest{}
 			v, err := registry.GetLatestVersion(webapp, "stable", registries)
 			if err != nil {
-				errorsChan <- fmt.Errorf("Could not get last version for %s: %s", webapp, err)
+				errorsChan <- fmt.Errorf("could not get last version for %s: %s", webapp, err)
 				return
 			}
 			err = json.NewDecoder(bytes.NewReader(v.Manifest)).Decode(&webappMan)
 			if err != nil {
-				errorsChan <- fmt.Errorf("Could not get decode manifest for %s: %s", webapp, err)
+				errorsChan <- fmt.Errorf("could not get decode manifest for %s: %s", webapp, err)
 				return
 			}
 

--- a/model/job/broker.go
+++ b/model/job/broker.go
@@ -282,7 +282,7 @@ func (j *Job) WaitUntilDone(db prefixer.Prefixer) error {
 			case Done:
 				return nil
 			case Errored:
-				return errors.New("The konnector failed on account deletion")
+				return errors.New("the konnector failed on account deletion")
 			}
 		case <-timeout:
 			return nil

--- a/model/job/errors.go
+++ b/model/job/errors.go
@@ -25,14 +25,14 @@ var (
 	ErrAbort = errors.New("jobs: abort")
 
 	// ErrUnknownTrigger is used when the trigger type is not recognized
-	ErrUnknownTrigger = errors.New("Unknown trigger type")
+	ErrUnknownTrigger = errors.New("unknown trigger type")
 	// ErrNotFoundTrigger is used when the trigger was not found
-	ErrNotFoundTrigger = errors.New("Trigger with specified ID does not exist")
+	ErrNotFoundTrigger = errors.New("trigger with specified ID does not exist")
 	// ErrMalformedTrigger is used to indicate the trigger is unparsable
 	ErrMalformedTrigger = echo.NewHTTPError(http.StatusBadRequest, "Trigger unparsable")
 	// ErrNotCronTrigger is used when a @cron trigger is expected, but it is
 	// not the case
-	ErrNotCronTrigger = errors.New("Invalid type for trigger (@cron expected)")
+	ErrNotCronTrigger = errors.New("invalid type for trigger (@cron expected)")
 )
 
 // ErrBadTrigger is an error conveying the information of a trigger that is not

--- a/model/job/rate_limiting.go
+++ b/model/job/rate_limiting.go
@@ -32,6 +32,6 @@ func GetCounterTypeFromWorkerType(workerType string) (limits.CounterType, error)
 	case "client":
 		return limits.JobClientType, nil
 	default:
-		return -1, errors.New("CounterType was not found")
+		return -1, errors.New("counterType was not found")
 	}
 }

--- a/model/job/redis_scheduler.go
+++ b/model/job/redis_scheduler.go
@@ -272,7 +272,7 @@ func (s *redisScheduler) PollScheduler(now int64) error {
 		}
 		results, ok := res.([]interface{})
 		if !ok {
-			return errors.New("Unexpected response from redis")
+			return errors.New("unexpected response from redis")
 		}
 		if len(results) < 2 {
 			return nil
@@ -280,7 +280,7 @@ func (s *redisScheduler) PollScheduler(now int64) error {
 		parts := strings.SplitN(results[0].(string), "/", 2)
 		if len(parts) != 2 {
 			s.client.ZRem(s.ctx, SchedKey, results[0])
-			return fmt.Errorf("Invalid key %s", res)
+			return fmt.Errorf("invalid key %s", res)
 		}
 
 		triggerID := parts[1]
@@ -357,7 +357,7 @@ func (s *redisScheduler) PollScheduler(now int64) error {
 				return err
 			}
 		default:
-			return errors.New("Not implemented yet")
+			return errors.New("not implemented yet")
 		}
 	}
 }
@@ -388,7 +388,7 @@ func (s *redisScheduler) addToRedis(t Trigger, prev time.Time) error {
 	case *WebhookTrigger, *ClientTrigger:
 		return nil
 	default:
-		return errors.New("Not implemented yet")
+		return errors.New("not implemented yet")
 	}
 	pipe := s.client.Pipeline()
 	err := pipe.ZAdd(s.ctx, TriggersKey, redis.Z{

--- a/model/job/trigger_event.go
+++ b/model/job/trigger_event.go
@@ -179,7 +179,7 @@ type DumpFilePather struct{}
 // FilePath only returns an error saying to not call this method
 func (d DumpFilePather) FilePath(doc *vfs.FileDoc) (string, error) {
 	logger.WithNamespace("event-trigger").Warn("FilePath method of DumpFilePather has been called")
-	return "", errors.New("DumpFilePather FilePath should not have been called")
+	return "", errors.New("dumpFilePather FilePath should not have been called")
 }
 
 var dumpFilePather = DumpFilePather{}

--- a/model/job/worker.go
+++ b/model/job/worker.go
@@ -235,7 +235,7 @@ func (w *Worker) Start(jobs chan *Job) error {
 	w.closed = make(chan struct{})
 	if w.Conf.WorkerInit != nil {
 		if err := w.Conf.WorkerInit(); err != nil {
-			return fmt.Errorf("Could not start worker %s: %s", w.Type, err)
+			return fmt.Errorf("could not start worker %s: %s", w.Type, err)
 		}
 	}
 	for i := 0; i < w.Conf.Concurrency; i++ {

--- a/model/job/workers_list.go
+++ b/model/job/workers_list.go
@@ -100,7 +100,7 @@ func AddWorker(conf *WorkerConfig) {
 	}
 	for _, w := range workersList {
 		if w.WorkerType == conf.WorkerType {
-			panic(fmt.Errorf("A worker with of type %q is already defined", conf.WorkerType))
+			panic(fmt.Errorf("a worker with of type %q is already defined", conf.WorkerType))
 		}
 	}
 	workersList = append(workersList, conf)

--- a/model/move/doc.go
+++ b/model/move/doc.go
@@ -185,7 +185,7 @@ func (e *ExportDoc) NotifyTarget(inst *instance.Instance, to *MoveToOptions, tok
 	}
 	defer res.Body.Close()
 	if res.StatusCode != 200 {
-		return fmt.Errorf("Cannot notify target: %d", res.StatusCode)
+		return fmt.Errorf("cannot notify target: %d", res.StatusCode)
 	}
 	return nil
 }

--- a/model/move/import.go
+++ b/model/move/import.go
@@ -98,7 +98,7 @@ func transformSettingsURLToManifestURL(settingsURL string) (string, error) {
 		u.Host = strings.Join(parts, ".")
 	}
 	if !strings.HasPrefix(u.Fragment, "/exports/") {
-		return "", fmt.Errorf("Fragment is not in the expected format")
+		return "", fmt.Errorf("fragment is not in the expected format")
 	}
 	mac := strings.TrimPrefix(u.Fragment, "/exports/")
 	u.Fragment = ""
@@ -239,7 +239,7 @@ func SendImportDoneMail(inst *instance.Instance, status Status, notInstalled []s
 			TemplateName: "import_error",
 		}
 	default:
-		return fmt.Errorf("Unknown import status: %v", status)
+		return fmt.Errorf("unknown import status: %v", status)
 	}
 
 	msg, err := job.NewMessage(&email)

--- a/model/move/importer.go
+++ b/model/move/importer.go
@@ -388,7 +388,7 @@ func (im *importer) importFile(zdoc, zcontent *zip.File) error {
 	}
 
 	if zcontent == nil {
-		return errors.New("No content for file")
+		return errors.New("no content for file")
 	}
 	fileDoc.SetRev("")
 	// Do not trust carbon copy and electronic safe flags on import

--- a/model/move/request.go
+++ b/model/move/request.go
@@ -91,15 +91,15 @@ func CreateRequest(inst *instance.Instance, params url.Values) (*Request, error)
 	if code == "" {
 		source.ClientID = params.Get("client_id")
 		if source.ClientID == "" {
-			return nil, errors.New("No client_id")
+			return nil, errors.New("no client_id")
 		}
 		source.ClientSecret = params.Get("client_secret")
 		if source.ClientSecret == "" {
-			return nil, errors.New("No client_secret")
+			return nil, errors.New("no client_secret")
 		}
 		source.Token = params.Get("token")
 		if source.Token == "" {
-			return nil, errors.New("No code or token")
+			return nil, errors.New("no code or token")
 		}
 		if err := checkSourceToken(inst, source); err != nil {
 			return nil, err
@@ -125,22 +125,22 @@ func CreateRequest(inst *instance.Instance, params url.Values) (*Request, error)
 	var target RequestCredentials
 	cozyURL := params.Get("target_url")
 	if cozyURL == "" {
-		return nil, errors.New("No target_url")
+		return nil, errors.New("no target_url")
 	}
 	if inst.HasDomain(cozyURL) {
-		return nil, errors.New("Invalid target_url")
+		return nil, errors.New("invalid target_url")
 	}
 	target.Token = params.Get("target_token")
 	if target.Token == "" {
-		return nil, errors.New("No target_token")
+		return nil, errors.New("no target_token")
 	}
 	target.ClientID = params.Get("target_client_id")
 	if target.ClientID == "" {
-		return nil, errors.New("No target_client_id")
+		return nil, errors.New("no target_client_id")
 	}
 	target.ClientSecret = params.Get("target_client_secret")
 	if target.ClientSecret == "" {
-		return nil, errors.New("No target_client_secret")
+		return nil, errors.New("no target_client_secret")
 	}
 
 	// If the user has clicked on the "Ignore this step" button in cozy-move at
@@ -219,18 +219,18 @@ func StartMove(inst *instance.Instance, secret string) (*Request, error) {
 		return nil, err
 	}
 	if req == nil {
-		return nil, errors.New("Invalid secret")
+		return nil, errors.New("invalid secret")
 	}
 
 	u := req.ImportingURL() + "?source=" + inst.ContextualDomain()
 	r, err := http.NewRequest("POST", u, nil)
 	if err != nil {
-		return nil, errors.New("Cannot reach the other Cozy")
+		return nil, errors.New("cannot reach the other Cozy")
 	}
 	r.Header.Add(echo.HeaderAuthorization, "Bearer "+req.TargetCreds.Token)
 	_, err = safehttp.ClientWithKeepAlive.Do(r)
 	if err != nil {
-		return nil, errors.New("Cannot reach the other Cozy")
+		return nil, errors.New("cannot reach the other Cozy")
 	}
 
 	doc, err := inst.SettingsDocument()

--- a/model/note/errors.go
+++ b/model/note/errors.go
@@ -4,20 +4,20 @@ import "errors"
 
 var (
 	// ErrInvalidSchema is used when the schema cannot be read by prosemirror.
-	ErrInvalidSchema = errors.New("Invalid schema for prosemirror")
+	ErrInvalidSchema = errors.New("invalid schema for prosemirror")
 	// ErrInvalidFile is used when a file doesn't have the metadata to be used
 	// as a note.
-	ErrInvalidFile = errors.New("Invalid file, not a note")
+	ErrInvalidFile = errors.New("invalid file, not a note")
 	// ErrNoSteps is used when steps are expected, but there are none.
-	ErrNoSteps = errors.New("No steps")
+	ErrNoSteps = errors.New("no steps")
 	// ErrInvalidSteps is used when prosemirror can't instantiate the steps.
-	ErrInvalidSteps = errors.New("Invalid steps")
+	ErrInvalidSteps = errors.New("invalid steps")
 	// ErrCannotApply is used when trying to apply some steps, but it fails
 	// because of a conflict. The client can try to rebase the steps.
-	ErrCannotApply = errors.New("Cannot apply the steps")
+	ErrCannotApply = errors.New("cannot apply the steps")
 	// ErrTooOld is used when the steps just after the given revision are no
 	// longer available.
-	ErrTooOld = errors.New("The revision is too old")
+	ErrTooOld = errors.New("the revision is too old")
 	// ErrMissingSessionID is used when a telepointer has no identifier.
-	ErrMissingSessionID = errors.New("The session id is missing")
+	ErrMissingSessionID = errors.New("the session id is missing")
 )

--- a/model/notification/center/errors.go
+++ b/model/notification/center/errors.go
@@ -4,12 +4,12 @@ import "errors"
 
 var (
 	// ErrBadNotification is used when the notification request is not valid.
-	ErrBadNotification = errors.New("Notification is not valid")
+	ErrBadNotification = errors.New("notification is not valid")
 	// ErrUnauthorized is used when the notification creator is not authorized to do so.
-	ErrUnauthorized = errors.New("Not authorized to send notification")
+	ErrUnauthorized = errors.New("not authorized to send notification")
 	// ErrNoCategory is used when no category is declared for this application
-	ErrNoCategory = errors.New("No category for this app")
+	ErrNoCategory = errors.New("no category for this app")
 	// ErrCategoryNotFound is used when sending a notification from an unknown
 	// category.
-	ErrCategoryNotFound = errors.New("Notification category does not exist")
+	ErrCategoryNotFound = errors.New("notification category does not exist")
 )

--- a/model/notification/center/notification_center.go
+++ b/model/notification/center/notification_center.go
@@ -235,7 +235,7 @@ func makePush(inst *instance.Instance, p *notification.Properties, n *notificati
 			log.Errorf("Error while sending sms: %s", err)
 			errm = multierror.Append(errm, err)
 		default:
-			err := fmt.Errorf("Unknown channel for notification: %s", channel)
+			err := fmt.Errorf("unknown channel for notification: %s", channel)
 			errm = multierror.Append(errm, err)
 		}
 	}
@@ -269,7 +269,7 @@ func sendPush(inst *instance.Instance,
 	at string,
 ) error {
 	if !hasNotifiableDevice(inst) {
-		return errors.New("No device with push notification")
+		return errors.New("no device with push notification")
 	}
 	email := buildMailMessage(p, n)
 	push := PushMessage{

--- a/model/oauth/client.go
+++ b/model/oauth/client.go
@@ -236,7 +236,7 @@ func FindClientBySoftwareID(i *instance.Instance, softwareID string) (*Client, e
 	if len(results) == 1 {
 		return results[0], nil
 	}
-	return nil, fmt.Errorf("Could not find client with software_id %s", softwareID)
+	return nil, fmt.Errorf("could not find client with software_id %s", softwareID)
 }
 
 // FindClientByOnBoardingSecret loads a client from the database with an OnboardingSecret
@@ -255,7 +255,7 @@ func FindClientByOnBoardingSecret(i *instance.Instance, onboardingSecret string)
 	if len(results) == 1 {
 		return results[0], nil
 	}
-	return nil, fmt.Errorf("Could not find client with onboarding_secret %s", onboardingSecret)
+	return nil, fmt.Errorf("could not find client with onboarding_secret %s", onboardingSecret)
 }
 
 // FindOnboardingClient loads a client from the database with an OnboardingSecret
@@ -274,7 +274,7 @@ func FindOnboardingClient(i *instance.Instance) (*Client, error) {
 	if len(results) == 1 {
 		return results[0], nil
 	}
-	return nil, fmt.Errorf("Could not find client with an onboarding_secret")
+	return nil, fmt.Errorf("could not find client with an onboarding_secret")
 }
 
 // ClientRegistrationError is a Client Registration Error Response, as described

--- a/model/office/errors.go
+++ b/model/office/errors.go
@@ -5,10 +5,10 @@ import "errors"
 var (
 	// ErrNoServer is used when no OnlyOnffice server is configured for the
 	// current context
-	ErrNoServer = errors.New("No OnlyOnffice server is configured")
+	ErrNoServer = errors.New("no OnlyOnffice server is configured")
 	// ErrInvalidFile is used when a file is not an office document
-	ErrInvalidFile = errors.New("Invalid file, not an office document")
+	ErrInvalidFile = errors.New("invalid file, not an office document")
 	// ErrInternalServerError is used when something goes wrong (like no
 	// connection to redis)
-	ErrInternalServerError = errors.New("Internal server error")
+	ErrInternalServerError = errors.New("internal server error")
 )

--- a/model/permission/permissions.go
+++ b/model/permission/permissions.go
@@ -353,14 +353,14 @@ func GetTokenAndPermissionsFromShortcode(db prefixer.Prefixer, shortcode string)
 		}
 	}
 
-	return "", nil, fmt.Errorf("Cannot find token for shortcode %s", res.Rows[0].Key)
+	return "", nil, fmt.Errorf("cannot find token for shortcode %s", res.Rows[0].Key)
 }
 
 // CreateWebappSet creates a Permission doc for an app
 func CreateWebappSet(db prefixer.Prefixer, slug string, set Set, version string) (*Permission, error) {
 	existing, _ := GetForWebapp(db, slug)
 	if existing != nil {
-		return nil, fmt.Errorf("There is already a permission doc for %v", slug)
+		return nil, fmt.Errorf("there is already a permission doc for %v", slug)
 	}
 	// Add metadata
 	md, err := metadata.NewWithApp(slug, version, DocTypeVersion)
@@ -374,7 +374,7 @@ func CreateWebappSet(db prefixer.Prefixer, slug string, set Set, version string)
 func CreateKonnectorSet(db prefixer.Prefixer, slug string, set Set, version string) (*Permission, error) {
 	existing, _ := GetForKonnector(db, slug)
 	if existing != nil {
-		return nil, fmt.Errorf("There is already a permission doc for %v", slug)
+		return nil, fmt.Errorf("there is already a permission doc for %v", slug)
 	}
 	// Add metadata
 	md, err := metadata.NewWithApp(slug, version, DocTypeVersion)

--- a/model/permission/rule.go
+++ b/model/permission/rule.go
@@ -157,7 +157,7 @@ func (r Rule) TranslationKey() string {
 // Rule1 name & description are kept
 func (r Rule) Merge(r2 Rule) (*Rule, error) {
 	if r.Type != r2.Type {
-		return nil, fmt.Errorf("Cannot merge these rules, type is different")
+		return nil, fmt.Errorf("cannot merge these rules, type is different")
 	}
 
 	newRule := &r

--- a/model/session/delegated.go
+++ b/model/session/delegated.go
@@ -31,12 +31,12 @@ func CheckDelegatedJWT(instance *instance.Instance, token string) error {
 	}
 	delegatedTypes, ok := authenticationConfig[context]
 	if !ok {
-		return errors.New("No delegated authentication defined for this context")
+		return errors.New("no delegated authentication defined for this context")
 	}
 
 	JWTSecret, ok := delegatedTypes.(map[string]interface{})["jwt_secret"]
 	if !ok {
-		return errors.New("JWT delegated type is not defined for this context")
+		return errors.New("jWT delegated type is not defined for this context")
 	}
 
 	claims := ExternalClaims{}
@@ -50,11 +50,11 @@ func CheckDelegatedJWT(instance *instance.Instance, token string) error {
 	}
 
 	if claims.RegisteredClaims.ExpiresAt != nil && claims.RegisteredClaims.ExpiresAt.Before(time.Now()) {
-		return errors.New("Token has expired")
+		return errors.New("token has expired")
 	}
 
 	if claims.Name != instance.Domain {
-		return errors.New("Issuer is not valid")
+		return errors.New("issuer is not valid")
 	}
 
 	return nil

--- a/model/session/session.go
+++ b/model/session/session.go
@@ -25,11 +25,11 @@ const defaultCookieName = "cozysessid"
 
 var (
 	// ErrNoCookie is returned by GetSession if there is no cookie
-	ErrNoCookie = errors.New("No session cookie")
+	ErrNoCookie = errors.New("no session cookie")
 	// ErrExpired is returned when the session has expired
-	ErrExpired = errors.New("Session expired")
+	ErrExpired = errors.New("session expired")
 	// ErrInvalidID is returned by GetSession if the cookie contains wrong ID
-	ErrInvalidID = errors.New("Session cookie has wrong ID")
+	ErrInvalidID = errors.New("session cookie has wrong ID")
 )
 
 // A Session is an instance opened in a browser

--- a/model/sharing/error.go
+++ b/model/sharing/error.go
@@ -4,51 +4,51 @@ import "errors"
 
 var (
 	// ErrNoRules is used when a sharing is created without a rule
-	ErrNoRules = errors.New("A sharing must have rules")
+	ErrNoRules = errors.New("a sharing must have rules")
 	// ErrNoRecipients is used when a sharing is created without a recipient
-	ErrNoRecipients = errors.New("A sharing must have recipients")
+	ErrNoRecipients = errors.New("a sharing must have recipients")
 	// ErrTooManyMembers is used when a sharing has too many members
-	ErrTooManyMembers = errors.New("There are too many members for this sharing")
+	ErrTooManyMembers = errors.New("there are too many members for this sharing")
 	// ErrInvalidURL is used for invalid URL of a Cozy instance
-	ErrInvalidURL = errors.New("The Cozy URL is invalid")
+	ErrInvalidURL = errors.New("the Cozy URL is invalid")
 	// ErrInvalidRule is used when a rule is invalid when the sharing is
 	// created
-	ErrInvalidRule = errors.New("A rule is invalid")
+	ErrInvalidRule = errors.New("a rule is invalid")
 	// ErrInvalidSharing is used when an action cannot be made on a sharing,
 	// because this sharing is not the expected state
-	ErrInvalidSharing = errors.New("Sharing is not in the expected state")
+	ErrInvalidSharing = errors.New("sharing is not in the expected state")
 	// ErrMemberNotFound is used when trying to find a member, but there is no
 	// member with the expected value for the criterion
-	ErrMemberNotFound = errors.New("The member was not found")
+	ErrMemberNotFound = errors.New("the member was not found")
 	// ErrInvitationNotSent is used when the invitation shortcut or mail failed
 	// to be sent
-	ErrInvitationNotSent = errors.New("The invitation cannot be sent")
+	ErrInvitationNotSent = errors.New("the invitation cannot be sent")
 	// ErrRequestFailed is used when a cozy tries to create a sharing request
 	// on another cozy, but it failed
-	ErrRequestFailed = errors.New("The sharing request failed")
+	ErrRequestFailed = errors.New("the sharing request failed")
 	// ErrNoOAuthClient is used when the owner of the Cozy has not yet
 	// registered to the recipient as an OAuth client.
-	ErrNoOAuthClient = errors.New("No OAuth client was found")
+	ErrNoOAuthClient = errors.New("no OAuth client was found")
 	// ErrInternalServerError is used for CouchDB errors
-	ErrInternalServerError = errors.New("Internal Server Error")
+	ErrInternalServerError = errors.New("internal Server Error")
 	// ErrClientError is used when an OAuth client has made a request, and the
 	// response was a 4xx error
-	ErrClientError = errors.New("OAuth client request was in error")
+	ErrClientError = errors.New("oAuth client request was in error")
 	// ErrMissingID is used when _id is missing on a doc for a bulk operation
-	ErrMissingID = errors.New("An identifier is missing")
+	ErrMissingID = errors.New("an identifier is missing")
 	// ErrMissingRev is used when _rev is missing on a doc for a bulk operation
-	ErrMissingRev = errors.New("A revision is missing")
+	ErrMissingRev = errors.New("a revision is missing")
 	// ErrMissingFileMetadata is used when uploading a file and the key is not
 	// in the cache (so no metadata and the upload can't succeed)
-	ErrMissingFileMetadata = errors.New("The metadata for this file were not found")
+	ErrMissingFileMetadata = errors.New("the metadata for this file were not found")
 	// ErrFolderNotFound is used when informations about a folder is asked,
 	// but this folder was not found
-	ErrFolderNotFound = errors.New("This folder was not found")
+	ErrFolderNotFound = errors.New("this folder was not found")
 	// ErrSafety is used when an operation is aborted due to the safety principal
-	ErrSafety = errors.New("Operation aborted")
+	ErrSafety = errors.New("operation aborted")
 	// ErrAlreadyAccepted is used when someone tries to accept twice a sharing
 	// on the same cozy instance
-	ErrAlreadyAccepted = errors.New("Sharing already accepted by this recipient")
+	ErrAlreadyAccepted = errors.New("sharing already accepted by this recipient")
 	// ErrCannotOpenFile is used when opening a file fails
-	ErrCannotOpenFile = errors.New("The file cannot be opened")
+	ErrCannotOpenFile = errors.New("the file cannot be opened")
 )

--- a/model/sharing/replicator.go
+++ b/model/sharing/replicator.go
@@ -346,7 +346,7 @@ type changesResponse struct {
 // It means that a document fetched from the changes that has been removed, and
 // the sharing rule for it has the revoke action. So, the caller should check
 // for this error, and it is the case, it should revoke the sharing.
-var errRevokeSharing = errors.New("Sharing must be revoked")
+var errRevokeSharing = errors.New("sharing must be revoked")
 
 // callChangesFeed fetches the last changes from the changes feed
 // http://docs.couchdb.org/en/stable/api/database/changes.html

--- a/model/sharing/revisions.go
+++ b/model/sharing/revisions.go
@@ -332,7 +332,7 @@ func addMissingRevsToChain(db prefixer.Prefixer, ref *SharedRef, chain []string)
 	}
 	revisions := revsMapToStruct(doc.M["_revisions"])
 	if len(revisions.IDs) < chainLowestGen-1 {
-		return nil, fmt.Errorf("Cannot add the missing revs to io.cozy.shared %s", docRef.ID)
+		return nil, fmt.Errorf("cannot add the missing revs to io.cozy.shared %s", docRef.ID)
 	}
 	var oldRevs []string
 	for i := refHighestGen + 1; i < chainLowestGen; i++ {

--- a/model/stack/main.go
+++ b/model/stack/main.go
@@ -80,7 +80,7 @@ security features. Please do not use this binary as your production server.
 		if err == nil {
 			break
 		}
-		err = fmt.Errorf("Could not reach Couchdb database: %s", err.Error())
+		err = fmt.Errorf("could not reach Couchdb database: %s", err.Error())
 		if i < attempts-1 {
 			logrus.Warnf("%s, retrying in %v", err, attemptsSpacing)
 			time.Sleep(attemptsSpacing)

--- a/model/vfs/archive.go
+++ b/model/vfs/archive.go
@@ -129,7 +129,7 @@ func (a *Archive) Serve(fs VFS, w http.ResponseWriter) error {
 			}
 			name, err = filepath.Rel(base, name)
 			if err != nil {
-				return fmt.Errorf("Invalid filepath <%s>: %s", name, err)
+				return fmt.Errorf("invalid filepath <%s>: %s", name, err)
 			}
 			if dir != nil {
 				_, err = zw.Create(a.Name + "/" + name + "/")
@@ -142,11 +142,11 @@ func (a *Archive) Serve(fs VFS, w http.ResponseWriter) error {
 			}
 			ze, err := zw.CreateHeader(header)
 			if err != nil {
-				return fmt.Errorf("Can't create zip entry <%s>: %s", name, err)
+				return fmt.Errorf("can't create zip entry <%s>: %s", name, err)
 			}
 			f, err := fs.OpenFile(file)
 			if err != nil {
-				return fmt.Errorf("Can't open file <%s>: %s", name, err)
+				return fmt.Errorf("can't open file <%s>: %s", name, err)
 			}
 			defer f.Close()
 			_, err = io.Copy(ze, f)

--- a/model/vfs/errors.go
+++ b/model/vfs/errors.go
@@ -5,47 +5,47 @@ import "errors"
 var (
 	// ErrParentDoesNotExist is used when the parent directory does not
 	// exist
-	ErrParentDoesNotExist = errors.New("Parent directory with given DirID does not exist")
+	ErrParentDoesNotExist = errors.New("parent directory with given DirID does not exist")
 	// ErrForbiddenDocMove is used when trying to move a document in an
 	// illicit destination
-	ErrForbiddenDocMove = errors.New("Forbidden document move")
+	ErrForbiddenDocMove = errors.New("forbidden document move")
 	// ErrIllegalFilename is used when the given filename is not allowed
-	ErrIllegalFilename = errors.New("Invalid filename: empty or contains an illegal character")
+	ErrIllegalFilename = errors.New("invalid filename: empty or contains an illegal character")
 	// ErrIllegalPath is used when the path has too many levels
-	ErrIllegalPath = errors.New("Invalid path: too many levels")
+	ErrIllegalPath = errors.New("invalid path: too many levels")
 	// ErrIllegalMime is used when the mime-type of a file is invalid
-	ErrIllegalMime = errors.New("Invalid Content-Type")
+	ErrIllegalMime = errors.New("invalid Content-Type")
 	// ErrIllegalTime is used when a time given (creation or
 	// modification) is not allowed
-	ErrIllegalTime = errors.New("Invalid time given")
+	ErrIllegalTime = errors.New("invalid time given")
 	// ErrInvalidHash is used when the given hash does not match the
 	// calculated one
-	ErrInvalidHash = errors.New("Invalid hash")
+	ErrInvalidHash = errors.New("invalid hash")
 	// ErrContentLengthMismatch is used when the content-length does not
 	// match the calculated one
-	ErrContentLengthMismatch = errors.New("Content length does not match")
+	ErrContentLengthMismatch = errors.New("content length does not match")
 	// ErrConflict is used when the access to a file or directory is in
 	// conflict with another
-	ErrConflict = errors.New("Conflict access to same file or directory")
+	ErrConflict = errors.New("conflict access to same file or directory")
 	// ErrFileInTrash is used when the file is already in the trash
-	ErrFileInTrash = errors.New("File or directory is already in the trash")
+	ErrFileInTrash = errors.New("file or directory is already in the trash")
 	// ErrFileNotInTrash is used when the file is not in the trash
-	ErrFileNotInTrash = errors.New("File or directory is not in the trash")
+	ErrFileNotInTrash = errors.New("file or directory is not in the trash")
 	// ErrParentInTrash is used when trying to upload a file to a directory
 	// that is trashed
-	ErrParentInTrash = errors.New("Parent directory is in the trash")
+	ErrParentInTrash = errors.New("parent directory is in the trash")
 	// ErrNonAbsolutePath is used when the given path is not absolute
 	// while it is required to be
-	ErrNonAbsolutePath = errors.New("Path should be absolute")
+	ErrNonAbsolutePath = errors.New("path should be absolute")
 	// ErrDirNotEmpty is used to inform that the directory is not
 	// empty
-	ErrDirNotEmpty = errors.New("Directory is not empty")
+	ErrDirNotEmpty = errors.New("directory is not empty")
 	// ErrWrongCouchdbState is given when couchdb gives us an unexpected value
-	ErrWrongCouchdbState = errors.New("Wrong couchdb reduce value")
+	ErrWrongCouchdbState = errors.New("wrong couchdb reduce value")
 	// ErrFileTooBig is used when there is no more space left on the filesystem
-	ErrFileTooBig = errors.New("The file is too big and exceeds the disk quota")
+	ErrFileTooBig = errors.New("the file is too big and exceeds the disk quota")
 	// ErrFsckFailFast is used when the FSCK is stopped by the fail-fast option
-	ErrFsckFailFast = errors.New("FSCK has been stopped on first failure")
+	ErrFsckFailFast = errors.New("fSCK has been stopped on first failure")
 	// ErrWrongToken is used when a key is not found on the store
-	ErrWrongToken = errors.New("Wrong download token")
+	ErrWrongToken = errors.New("wrong download token")
 )

--- a/model/vfs/metadata.go
+++ b/model/vfs/metadata.go
@@ -323,7 +323,7 @@ func exifDateTimeInLocation(x *exif.Exif, loc *time.Location) (time.Time, error)
 		}
 	}
 	if tag.Format() != tiff.StringVal {
-		return time.Time{}, errors.New("DateTime[Original] not in string format")
+		return time.Time{}, errors.New("dateTime[Original] not in string format")
 	}
 	const exifTimeLayout = "2006:01:02 15:04:05"
 	dateStr := strings.TrimRight(string(tag.Val), "\x00")

--- a/model/vfs/vfs.go
+++ b/model/vfs/vfs.go
@@ -306,7 +306,7 @@ type Prefixer interface {
 
 // ErrIteratorDone is returned by the Next() method of the iterator when
 // the iterator is actually done.
-var ErrIteratorDone = errors.New("No more element in the iterator")
+var ErrIteratorDone = errors.New("no more element in the iterator")
 
 // IteratorOptions contains the options of the iterator.
 type IteratorOptions struct {

--- a/model/vfs/vfs_test.go
+++ b/model/vfs/vfs_test.go
@@ -367,11 +367,11 @@ func TestVfs(t *testing.T) {
 					}
 
 					if dir != nil && !assert.Equal(t, dir.Fullpath, name) {
-						return fmt.Errorf("Bad fullpath")
+						return fmt.Errorf("bad fullpath")
 					}
 
 					if file != nil && !assert.True(t, strings.HasSuffix(name, file.DocName)) {
-						return fmt.Errorf("Bad fullpath")
+						return fmt.Errorf("bad fullpath")
 					}
 
 					walked[name] = nil
@@ -792,7 +792,7 @@ func recFetchTree(fs vfs.VFS, parent *vfs.DirDoc, name string) (H, error) {
 		}
 		if d != nil {
 			if path.Join(name, d.DocName) != d.Fullpath {
-				return nil, fmt.Errorf("Bad fullpath: %s instead of %s", d.Fullpath, path.Join(name, d.DocName))
+				return nil, fmt.Errorf("bad fullpath: %s instead of %s", d.Fullpath, path.Join(name, d.DocName))
 			}
 			children, err := recFetchTree(fs, d, d.Fullpath)
 			if err != nil {

--- a/model/vfs/vfsafero/impl.go
+++ b/model/vfs/vfsafero/impl.go
@@ -485,7 +485,7 @@ func (afs *aferoVFS) OpenFile(doc *vfs.FileDoc) (vfs.File, error) {
 }
 
 func (afs *aferoVFS) EnsureErased(journal vfs.TrashJournal) error {
-	return errors.New("EnsureErased is only for Swift")
+	return errors.New("ensureErased is only for Swift")
 }
 
 func (afs *aferoVFS) OpenFileVersion(doc *vfs.FileDoc, version *vfs.Version) (vfs.File, error) {

--- a/model/vfs/vfsswift/impl_v1.go
+++ b/model/vfs/vfsswift/impl_v1.go
@@ -419,7 +419,7 @@ func (sfs *swiftVFS) destroyFileVersions(objName string) error {
 }
 
 func (sfs *swiftVFS) EnsureErased(journal vfs.TrashJournal) error {
-	return errors.New("EnsureErased is not available for Swift layout v1")
+	return errors.New("ensureErased is not available for Swift layout v1")
 }
 
 func (sfs *swiftVFS) OpenFile(doc *vfs.FileDoc) (vfs.File, error) {

--- a/pkg/appfs/server.go
+++ b/pkg/appfs/server.go
@@ -295,7 +295,7 @@ func (s *aferoServer) Open(slug, version, shasum, file string) (io.ReadCloser, e
 	case brotlied:
 		return newBrotliReadCloser(f)
 	default:
-		panic(fmt.Errorf("Unknown compression type: %v", compression))
+		panic(fmt.Errorf("unknown compression type: %v", compression))
 	}
 }
 
@@ -374,7 +374,7 @@ func (s *aferoServer) serveFileContent(w http.ResponseWriter, req *http.Request,
 			content = bytes.NewReader(b)
 		}
 	default:
-		panic(fmt.Errorf("Unknown compression type: %v", compression))
+		panic(fmt.Errorf("unknown compression type: %v", compression))
 	}
 
 	contentType := mime.TypeByExtension(path.Ext(filepath))

--- a/pkg/assets/dynamic/dynamic.go
+++ b/pkg/assets/dynamic/dynamic.go
@@ -22,7 +22,7 @@ import (
 
 // ErrDynAssetNotFound is the error returned when a dynamic asset cannot be
 // found.
-var ErrDynAssetNotFound = errors.New("Dynamic asset was not found")
+var ErrDynAssetNotFound = errors.New("dynamic asset was not found")
 
 var assetsClient = &http.Client{
 	Timeout: 30 * time.Second,

--- a/pkg/assets/dynamic/fs.go
+++ b/pkg/assets/dynamic/fs.go
@@ -65,7 +65,7 @@ func InitDynamicAssetFS() error {
 			return err
 		}
 	default:
-		return fmt.Errorf("Invalid scheme %s for dynamic assets FS", scheme)
+		return fmt.Errorf("invalid scheme %s for dynamic assets FS", scheme)
 	}
 
 	return nil
@@ -92,7 +92,7 @@ func newswiftFS() (*swiftFS, error) {
 	swiftFS := &swiftFS{swiftConn: config.GetSwiftConnection(), ctx: ctx}
 	err := swiftFS.swiftConn.ContainerCreate(ctx, DynamicAssetsContainerName, nil)
 	if err != nil {
-		return nil, fmt.Errorf("Cannot create container for dynamic assets: %s", err)
+		return nil, fmt.Errorf("cannot create container for dynamic assets: %s", err)
 	}
 
 	return swiftFS, nil

--- a/pkg/config/config/config.go
+++ b/pkg/config/config/config.go
@@ -430,7 +430,7 @@ func Setup(cfgFile string) (err error) {
 		tmpl = tmpl.Option("missingkey=zero")
 		tmpl, err = tmpl.Funcs(numericFuncsMap).ParseFiles(cfgFile)
 		if err != nil {
-			return fmt.Errorf("Unable to open and parse configuration file "+
+			return fmt.Errorf("unable to open and parse configuration file "+
 				"template %s: %s", cfgFile, err)
 		}
 
@@ -444,7 +444,7 @@ func Setup(cfgFile string) (err error) {
 		}
 		err = tmpl.ExecuteTemplate(dest, tmplName, ctxt)
 		if err != nil {
-			return fmt.Errorf("Template error for config files %s: %s", cfgFile, err)
+			return fmt.Errorf("template error for config files %s: %s", cfgFile, err)
 		}
 
 		cfgFile = regexp.MustCompile(`\.local$`).ReplaceAllString(cfgFile, "")
@@ -499,10 +499,10 @@ func UseViper(v *viper.Viper) error {
 	if fsURL.Scheme == "file" {
 		fsPath := fsURL.Path
 		if fsPath != "" && !path.IsAbs(fsPath) {
-			return fmt.Errorf("Filesystem path should be absolute, was: %q", fsPath)
+			return fmt.Errorf("filesystem path should be absolute, was: %q", fsPath)
 		}
 		if fsPath == "/" {
-			return fmt.Errorf("Filesystem path should not be root, was: %q", fsPath)
+			return fmt.Errorf("filesystem path should not be root, was: %q", fsPath)
 		}
 	}
 
@@ -1021,11 +1021,11 @@ func makeOffice(v *viper.Viper) (map[string]Office, error) {
 	for k, v := range v.GetStringMap("office") {
 		ctx, ok := v.(map[string]interface{})
 		if !ok {
-			return nil, errors.New("Bad format in the office section of the configuration file")
+			return nil, errors.New("bad format in the office section of the configuration file")
 		}
 		url, ok := ctx["onlyoffice_url"].(string)
 		if !ok {
-			return nil, errors.New("Bad format in the office section of the configuration file")
+			return nil, errors.New("bad format in the office section of the configuration file")
 		}
 		inbox, _ := ctx["onlyoffice_inbox_secret"].(string)
 		outbox, _ := ctx["onlyoffice_outbox_secret"].(string)
@@ -1129,7 +1129,7 @@ func FindConfigFile(name string) (string, error) {
 			return filename, nil
 		}
 	}
-	return "", fmt.Errorf("Could not find config file %q", name)
+	return "", fmt.Errorf("could not find config file %q", name)
 }
 
 // findConfigFiles search in the Paths directories for the first existing directory,

--- a/pkg/couchdb/bulk.go
+++ b/pkg/couchdb/bulk.go
@@ -301,7 +301,7 @@ func bulkUpdateDocs(db prefixer.Prefixer, doctype string, docs, olddocs []interf
 		return err
 	}
 	if len(res) != len(docs) {
-		return errors.New("BulkUpdateDoc receive an unexpected number of responses")
+		return errors.New("bulkUpdateDoc receive an unexpected number of responses")
 	}
 	for i, doc := range docs {
 		if d, ok := doc.(Doc); ok {

--- a/pkg/couchdb/changes.go
+++ b/pkg/couchdb/changes.go
@@ -33,7 +33,7 @@ func ValidChangesMode(feed string) (ChangesFeedMode, error) {
 		return ChangesModeNormal, nil
 	}
 
-	err := fmt.Errorf("Unsuported feed value '%s'", feed)
+	err := fmt.Errorf("unsuported feed value '%s'", feed)
 	return ChangesModeNormal, err
 }
 
@@ -46,7 +46,7 @@ func ValidChangesStyle(style string) (ChangesFeedStyle, error) {
 	if style == string(ChangesStyleAllDocs) {
 		return ChangesStyleAllDocs, nil
 	}
-	err := fmt.Errorf("Unsuported style value '%s'", style)
+	err := fmt.Errorf("unsuported style value '%s'", style)
 	return ChangesStyleMainOnly, err
 }
 
@@ -57,7 +57,7 @@ func StaticChangesFilter(filter string) (string, error) {
 	case "", "_doc_ids", "_selector", "_design":
 		return filter, nil
 	default:
-		return "", fmt.Errorf("Unsuported filter value '%s'", filter)
+		return "", fmt.Errorf("unsuported filter value '%s'", filter)
 	}
 }
 
@@ -143,7 +143,7 @@ type Change struct {
 // GetChanges returns a list of changes in couchdb
 func GetChanges(db prefixer.Prefixer, req *ChangesRequest) (*ChangesResponse, error) {
 	if req.DocType == "" {
-		return nil, errors.New("Empty doctype in GetChanges")
+		return nil, errors.New("empty doctype in GetChanges")
 	}
 
 	v, err := query.Values(req)
@@ -172,7 +172,7 @@ func PostChanges(db prefixer.Prefixer, req *ChangesRequest, body io.ReadCloser) 
 	}
 
 	if req.DocType == "" {
-		return nil, errors.New("Empty doctype in GetChanges")
+		return nil, errors.New("empty doctype in GetChanges")
 	}
 
 	v, err := query.Values(req)

--- a/pkg/couchdb/couchdb.go
+++ b/pkg/couchdb/couchdb.go
@@ -413,7 +413,7 @@ func GetDoc(db prefixer.Prefixer, doctype, id string, out Doc) error {
 		return err
 	}
 	if id == "" {
-		return fmt.Errorf("Missing ID for GetDoc")
+		return fmt.Errorf("missing ID for GetDoc")
 	}
 	return makeRequest(db, doctype, http.MethodGet, url.PathEscape(id), nil, out)
 }
@@ -427,7 +427,7 @@ func GetDocRev(db prefixer.Prefixer, doctype, id, rev string, out Doc) error {
 		return err
 	}
 	if id == "" {
-		return fmt.Errorf("Missing ID for GetDoc")
+		return fmt.Errorf("missing ID for GetDoc")
 	}
 	url := url.PathEscape(id) + "?rev=" + url.QueryEscape(rev)
 	return makeRequest(db, doctype, http.MethodGet, url, nil, out)
@@ -443,7 +443,7 @@ func GetDocWithRevs(db prefixer.Prefixer, doctype, id string, out Doc) error {
 		return err
 	}
 	if id == "" {
-		return fmt.Errorf("Missing ID for GetDoc")
+		return fmt.Errorf("missing ID for GetDoc")
 	}
 	url := url.PathEscape(id) + "?revs=true"
 	return makeRequest(db, doctype, http.MethodGet, url, nil, out)
@@ -492,7 +492,7 @@ func DeleteDB(db prefixer.Prefixer, doctype string) error {
 func DeleteAllDBs(db prefixer.Prefixer) error {
 	dbprefix := db.DBPrefix()
 	if dbprefix == "" {
-		return fmt.Errorf("You need to provide a valid database")
+		return fmt.Errorf("you need to provide a valid database")
 	}
 
 	dbsList, err := allDbs(db)
@@ -532,7 +532,7 @@ func DeleteDoc(db prefixer.Prefixer, doc Doc) error {
 		return err
 	}
 	if id == "" {
-		return fmt.Errorf("Missing ID for DeleteDoc")
+		return fmt.Errorf("missing ID for DeleteDoc")
 	}
 	old := doc.Clone()
 
@@ -582,7 +582,7 @@ func UpdateDoc(db prefixer.Prefixer, doc Doc) error {
 	}
 	doctype := doc.DocType()
 	if id == "" || doc.Rev() == "" || doctype == "" {
-		return fmt.Errorf("UpdateDoc doc argument should have doctype, id and rev")
+		return fmt.Errorf("updateDoc doc argument should have doctype, id and rev")
 	}
 
 	url := url.PathEscape(id)
@@ -612,7 +612,7 @@ func UpdateDocWithOld(db prefixer.Prefixer, doc, oldDoc Doc) error {
 	}
 	doctype := doc.DocType()
 	if id == "" || doc.Rev() == "" || doctype == "" {
-		return fmt.Errorf("UpdateDoc doc argument should have doctype, id and rev")
+		return fmt.Errorf("updateDoc doc argument should have doctype, id and rev")
 	}
 
 	url := url.PathEscape(id)
@@ -637,7 +637,7 @@ func CreateNamedDoc(db prefixer.Prefixer, doc Doc) error {
 	}
 	doctype := doc.DocType()
 	if doc.Rev() != "" || id == "" || doctype == "" {
-		return fmt.Errorf("CreateNamedDoc should have type and id but no rev")
+		return fmt.Errorf("createNamedDoc should have type and id but no rev")
 	}
 	var res UpdateResponse
 	err = makeRequest(db, doctype, http.MethodPut, url.PathEscape(id), doc, &res)
@@ -718,7 +718,7 @@ func CreateDoc(db prefixer.Prefixer, doc Doc) error {
 	if err != nil {
 		return err
 	} else if !res.Ok {
-		return fmt.Errorf("CouchDB replied with 200 ok=false")
+		return fmt.Errorf("couchDB replied with 200 ok=false")
 	}
 
 	doc.SetID(res.ID)

--- a/pkg/couchdb/status.go
+++ b/pkg/couchdb/status.go
@@ -34,7 +34,7 @@ func CheckStatus(ctx context.Context) (time.Duration, error) {
 	}
 	defer res.Body.Close()
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
-		return 0, fmt.Errorf("Invalid responde code: %d", res.StatusCode)
+		return 0, fmt.Errorf("invalid responde code: %d", res.StatusCode)
 	}
 	return latency, nil
 }

--- a/pkg/crypto/jwt.go
+++ b/pkg/crypto/jwt.go
@@ -59,7 +59,7 @@ func NewJWT(secret []byte, claims jwt.Claims) (string, error) {
 func ParseJWT(tokenString string, keyFunc jwt.Keyfunc, claims jwt.Claims) error {
 	token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
-			return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
 		return keyFunc(token)
 	})
@@ -67,7 +67,7 @@ func ParseJWT(tokenString string, keyFunc jwt.Keyfunc, claims jwt.Claims) error 
 		return err
 	}
 	if !token.Valid {
-		return errors.New("Invalid JSON Web Token")
+		return errors.New("invalid JSON Web Token")
 	}
 	return nil
 }

--- a/pkg/crypto/rsa.go
+++ b/pkg/crypto/rsa.go
@@ -43,7 +43,7 @@ func EncryptWithRSA(key string, payload []byte) (string, error) {
 	}
 	pub, ok := pubKey.(*rsa.PublicKey)
 	if !ok {
-		return "", errors.New("Invalid public key")
+		return "", errors.New("invalid public key")
 	}
 
 	hash := sha1.New()

--- a/pkg/crypto/scrypt.go
+++ b/pkg/crypto/scrypt.go
@@ -33,7 +33,7 @@ const defaultSaltLen = 16
 
 // Errors
 var (
-	ErrInvalidHash                 = errors.New("Invalid hash format")
+	ErrInvalidHash                 = errors.New("invalid hash format")
 	ErrMismatchedHashAndPassphrase = errors.New("hash and password are different")
 	ErrNoUpdateNeeded              = errors.New("hash already has correct parameters")
 )

--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -11,7 +11,7 @@ import (
 )
 
 // ErrHookFailed is used when an hook script exits with a non-zero status
-var ErrHookFailed = errors.New("Hook exited with non-zero status")
+var ErrHookFailed = errors.New("hook exited with non-zero status")
 
 // Execute runs a pre-hook, then calls te function, and finally run the
 // post-hook.

--- a/pkg/jsonapi/jsonapi_test.go
+++ b/pkg/jsonapi/jsonapi_test.go
@@ -36,7 +36,7 @@ func TestJsonapi(t *testing.T) {
 			return c.JSON(200, fmt.Sprintf("key %d %s %s", c3.Limit, c3.NextKey, c3.NextDocID))
 		}
 
-		return fmt.Errorf("Wrong cursor type")
+		return fmt.Errorf("wrong cursor type")
 	})
 
 	ts := httptest.NewServer(router)

--- a/pkg/limits/rate_limiting.go
+++ b/pkg/limits/rate_limiting.go
@@ -17,11 +17,11 @@ type CounterType int
 
 // ErrRateLimitReached is the error returned when we were under the limit
 // before the check, and reach the limit.
-var ErrRateLimitReached = errors.New("Rate limit reached")
+var ErrRateLimitReached = errors.New("rate limit reached")
 
 // ErrRateLimitExceeded is the error returned when the limit was already
 // reached before the check.
-var ErrRateLimitExceeded = errors.New("Rate limit exceeded")
+var ErrRateLimitExceeded = errors.New("rate limit exceeded")
 
 const (
 	// AuthType is used for counting the number of login attempts.

--- a/pkg/logger/syslog_stub.go
+++ b/pkg/logger/syslog_stub.go
@@ -10,5 +10,5 @@ import (
 )
 
 func syslogHook() (logrus.Hook, error) {
-	return nil, errors.New("Syslog is not available on Windows")
+	return nil, errors.New("syslog is not available on Windows")
 }

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -10,7 +10,7 @@ const MetadataVersion = 1
 
 // ErrSlugEmpty is returned when an UpdatedByApp entry is created with and empty
 // slug
-var ErrSlugEmpty = errors.New("Slug cannot be empty")
+var ErrSlugEmpty = errors.New("slug cannot be empty")
 
 // UpdatedByAppEntry represents a modification made by an application to the
 // document

--- a/pkg/shortcut/shortcut.go
+++ b/pkg/shortcut/shortcut.go
@@ -10,7 +10,7 @@ import (
 )
 
 // ErrInvalidShortcut is the error when a .url file cannot be parsed.
-var ErrInvalidShortcut = errors.New("The file is not in the expected format")
+var ErrInvalidShortcut = errors.New("the file is not in the expected format")
 
 // Result is the result of the parsing of a .url file.
 type Result struct {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -134,7 +134,7 @@ func FileExists(name string) (bool, error) {
 		return false, err
 	}
 	if infos.IsDir() {
-		return false, fmt.Errorf("Path %s is a directory", name)
+		return false, fmt.Errorf("path %s is a directory", name)
 	}
 	return true, nil
 }
@@ -150,7 +150,7 @@ func DirExists(name string) (bool, error) {
 		return false, err
 	}
 	if !infos.IsDir() {
-		return false, fmt.Errorf("Path %s is not a directory", name)
+		return false, fmt.Errorf("path %s is not a directory", name)
 	}
 	return true, nil
 }

--- a/web/auth/oauth.go
+++ b/web/auth/oauth.go
@@ -946,7 +946,7 @@ func secretExchange(c echo.Context) error {
 	}
 
 	if e.Secret == "" {
-		return jsonapi.BadRequest(errors.New("Missing secret"))
+		return jsonapi.BadRequest(errors.New("missing secret"))
 	}
 
 	doc, err := oauth.FindClientByOnBoardingSecret(instance, e.Secret)
@@ -955,7 +955,7 @@ func secretExchange(c echo.Context) error {
 	}
 
 	if doc.OnboardingSecret == "" || doc.OnboardingSecret != e.Secret {
-		return jsonapi.InvalidAttribute("secret", errors.New("Invalid secret"))
+		return jsonapi.InvalidAttribute("secret", errors.New("invalid secret"))
 	}
 
 	doc.TransformIDAndRev()

--- a/web/auth/rate_limiting.go
+++ b/web/auth/rate_limiting.go
@@ -11,7 +11,7 @@ import (
 // LoginRateExceeded blocks the instance after too many failed attempts to
 // login
 func LoginRateExceeded(i *instance.Instance) error {
-	err := fmt.Errorf("Instance was blocked because of too many login failed attempts")
+	err := fmt.Errorf("instance was blocked because of too many login failed attempts")
 	i.Logger().WithNamespace("rate_limiting").Warn(err.Error())
 	return lifecycle.Block(i, instance.BlockedLoginFailed.Code)
 }
@@ -32,7 +32,7 @@ func TwoFactorRateExceeded(i *instance.Instance) error {
 // TwoFactorGenerationExceeded checks if there was too many attempts to
 // regenerate a 2FA code within an hour
 func TwoFactorGenerationExceeded(i *instance.Instance) error {
-	err := fmt.Errorf("Instance was blocked because of too many 2FA passcode generations")
+	err := fmt.Errorf("instance was blocked because of too many 2FA passcode generations")
 	i.Logger().WithNamespace("rate_limiting").Warn(err.Error())
 
 	return lifecycle.Block(i, instance.BlockedLoginFailed.Code)

--- a/web/dev.go
+++ b/web/dev.go
@@ -57,7 +57,7 @@ func devMailsHandler(c echo.Context) error {
 	}
 	if part == nil {
 		return echo.NewHTTPError(http.StatusNotFound,
-			fmt.Errorf("Could not find template %q with content-type %q", name, contentType))
+			fmt.Errorf("could not find template %q with content-type %q", name, contentType))
 	}
 
 	// Remove all CSP policies to display HTML email. this is a dev-only

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -57,7 +57,7 @@ const TagSeparator = ","
 
 // ErrDocTypeInvalid is used when the document type sent is not
 // recognized
-var ErrDocTypeInvalid = errors.New("Invalid document type")
+var ErrDocTypeInvalid = errors.New("invalid document type")
 
 // CreationHandler handle all POST requests on /files/:file-id
 // aiming at creating a new document in the FS. Given the Type
@@ -2056,7 +2056,7 @@ func CheckIfMatch(c echo.Context, rev string) error {
 
 func checkIfMatch(rev, wantedRev string) error {
 	if wantedRev != "" && rev != wantedRev {
-		return jsonapi.PreconditionFailed("If-Match", fmt.Errorf("Revision does not match"))
+		return jsonapi.PreconditionFailed("If-Match", fmt.Errorf("revision does not match"))
 	}
 	return nil
 }
@@ -2076,12 +2076,12 @@ func parseMD5Hash(md5B64 string) ([]byte, error) {
 	// out of these boundaries we know we don't have a good hash and we
 	// can bail immediately.
 	if len(md5B64) < 22 || len(md5B64) > 24 {
-		return nil, fmt.Errorf("Given Content-MD5 is invalid")
+		return nil, fmt.Errorf("given Content-MD5 is invalid")
 	}
 
 	md5Sum, err := base64.StdEncoding.DecodeString(md5B64)
 	if err != nil || len(md5Sum) != 16 {
-		return nil, fmt.Errorf("Given Content-MD5 is invalid")
+		return nil, fmt.Errorf("given Content-MD5 is invalid")
 	}
 
 	return md5Sum, nil

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -3511,7 +3511,7 @@ func loadLocale() error {
 		pofile := path.Join("../..", assetsPath, "locales", locale+".po")
 		po, err := os.ReadFile(pofile)
 		if err != nil {
-			return fmt.Errorf("Can't load the po file for %s", locale)
+			return fmt.Errorf("can't load the po file for %s", locale)
 		}
 		i18n.LoadLocale(locale, "", po)
 	}

--- a/web/files/notsynchronized.go
+++ b/web/files/notsynchronized.go
@@ -182,7 +182,7 @@ func AddBulkNotSynchronizedOn(c echo.Context) error {
 			return WrapVfsError(err)
 		}
 		if dir == nil {
-			return jsonapi.BadRequest(errors.New("Cannot add not_synchronized_on on files"))
+			return jsonapi.BadRequest(errors.New("cannot add not_synchronized_on on files"))
 		}
 		oldDocs[i] = dir.Clone()
 		dir.AddNotSynchronizedOn(docRef)
@@ -232,7 +232,7 @@ func RemoveBulkNotSynchronizedOn(c echo.Context) error {
 			return WrapVfsError(err)
 		}
 		if dir == nil {
-			return jsonapi.BadRequest(errors.New("Cannot add not_synchronized_on on files"))
+			return jsonapi.BadRequest(errors.New("cannot add not_synchronized_on on files"))
 		}
 		oldDocs[i] = dir.Clone()
 		dir.RemoveNotSynchronizedOn(docRef)

--- a/web/files/references.go
+++ b/web/files/references.go
@@ -90,7 +90,7 @@ func ListReferencesHandler(c echo.Context) error {
 	case "datetime", "-datetime":
 		view = couchdb.ReferencedBySortedByDatetimeView
 	default:
-		return jsonapi.BadRequest(errors.New("Invalid sort parameter"))
+		return jsonapi.BadRequest(errors.New("invalid sort parameter"))
 	}
 
 	req := &couchdb.ViewRequest{

--- a/web/instances/debug.go
+++ b/web/instances/debug.go
@@ -14,7 +14,7 @@ func getDebug(c echo.Context) error {
 	domain := c.Param("domain")
 	until := logger.DebugExpiration(domain)
 	if until == nil {
-		return jsonapi.NotFound(errors.New("Debug is disabled on this domain"))
+		return jsonapi.NotFound(errors.New("debug is disabled on this domain"))
 	}
 	res := map[string]interface{}{domain: true, "until": until}
 	return c.JSON(http.StatusOK, res)

--- a/web/instances/feature.go
+++ b/web/instances/feature.go
@@ -88,7 +88,7 @@ func getContextFromConfig(context string) (interface{}, error) {
 		return ctx, nil
 	}
 
-	return nil, fmt.Errorf("Unable to get context %q from config", context)
+	return nil, fmt.Errorf("unable to get context %q from config", context)
 }
 
 func getFeatureConfig(c echo.Context) error {

--- a/web/instances/fixers.go
+++ b/web/instances/fixers.go
@@ -46,7 +46,7 @@ func contentMismatchFixer(c echo.Context) error {
 	domain := c.Param("domain")
 	inst, err := lifecycle.GetInstance(domain)
 	if err != nil {
-		return fmt.Errorf("Cannot find instance %s", domain)
+		return fmt.Errorf("cannot find instance %s", domain)
 	}
 
 	body := struct {

--- a/web/instances/instances.go
+++ b/web/instances/instances.go
@@ -106,11 +106,11 @@ func createHandler(c echo.Context) error {
 			return wrapError(err)
 		}
 		if iter < crypto.MinPBKDF2Iterations && iter != 0 {
-			err := errors.New("The KdfIterations number is too low")
+			err := errors.New("the KdfIterations number is too low")
 			return jsonapi.InvalidParameter("KdfIterations", err)
 		}
 		if iter > crypto.MaxPBKDF2Iterations {
-			err := errors.New("The KdfIterations number is too high")
+			err := errors.New("the KdfIterations number is too high")
 			return jsonapi.InvalidParameter("KdfIterations", err)
 		}
 		opts.KdfIterations = iter
@@ -312,7 +312,7 @@ func setAuthMode(c echo.Context) error {
 
 	authModeString, ok := m["auth_mode"]
 	if !ok {
-		return jsonapi.BadRequest(errors.New("Missing auth_mode key"))
+		return jsonapi.BadRequest(errors.New("missing auth_mode key"))
 	}
 
 	authMode, err := instance.StringToAuthMode(authModeString.(string))

--- a/web/intents/intents.go
+++ b/web/intents/intents.go
@@ -72,10 +72,10 @@ func createIntent(c echo.Context) error {
 		return jsonapi.BadRequest(err)
 	}
 	if intent.Action == "" {
-		return jsonapi.InvalidParameter("action", errors.New("Action is missing"))
+		return jsonapi.InvalidParameter("action", errors.New("action is missing"))
 	}
 	if intent.Type == "" {
-		return jsonapi.InvalidParameter("type", errors.New("Type is missing"))
+		return jsonapi.InvalidParameter("type", errors.New("type is missing"))
 	}
 	intent.Client = pdoc.SourceID
 	intent.SetID("")

--- a/web/jobs/jobs.go
+++ b/web/jobs/jobs.go
@@ -403,7 +403,7 @@ func patchTrigger(c echo.Context) error {
 		return wrapJobsError(err)
 	}
 	if req.Arguments == "" {
-		return jsonapi.BadRequest(errors.New("Only arguments can be patched"))
+		return jsonapi.BadRequest(errors.New("only arguments can be patched"))
 	}
 
 	if err := sched.UpdateCron(inst, t, req.Arguments); err != nil {
@@ -511,7 +511,7 @@ func fireWebhook(c echo.Context) error {
 	}
 	webhook, ok := t.(*job.WebhookTrigger)
 	if !ok {
-		return jsonapi.InvalidAttribute("Type", errors.New("Not a webhook"))
+		return jsonapi.InvalidAttribute("Type", errors.New("not a webhook"))
 	}
 
 	payload, err := io.ReadAll(c.Request().Body)
@@ -644,7 +644,7 @@ func patchJob(c echo.Context) error {
 		err = j.Ack()
 		log.Info("Konnector success")
 	default:
-		err = jsonapi.InvalidAttribute("State", errors.New("State must be done or errored"))
+		err = jsonapi.InvalidAttribute("State", errors.New("state must be done or errored"))
 	}
 	if err != nil {
 		return wrapJobsError(err)

--- a/web/middlewares/permissions.go
+++ b/web/middlewares/permissions.go
@@ -76,7 +76,7 @@ type linkedAppScope struct {
 
 func parseLinkedAppScope(scope string) (*linkedAppScope, error) {
 	if !strings.HasPrefix(scope, "@") {
-		return nil, fmt.Errorf("Scope %s is not a linked-app", scope)
+		return nil, fmt.Errorf("scope %s is not a linked-app", scope)
 	}
 	splitted := strings.Split(strings.TrimPrefix(scope, "@"), "/")
 

--- a/web/notes/notes.go
+++ b/web/notes/notes.go
@@ -357,7 +357,7 @@ func UploadImage(c echo.Context) error {
 	// Check that the uploaded file is an image
 	contentType := c.Request().Header.Get(echo.HeaderContentType)
 	if !strings.HasPrefix(contentType, "image/") {
-		err := errors.New("Only images are accepted")
+		err := errors.New("only images are accepted")
 		return jsonapi.InvalidParameter(echo.HeaderContentType, err)
 	}
 
@@ -366,7 +366,7 @@ func UploadImage(c echo.Context) error {
 	if quota > 0 {
 		size := c.Request().ContentLength
 		if size <= 0 {
-			err := errors.New("The Content-Length header is mandatory")
+			err := errors.New("the Content-Length header is mandatory")
 			return jsonapi.InvalidParameter(echo.HeaderContentLength, err)
 		}
 		if size > note.MaxImageWeight {
@@ -374,7 +374,7 @@ func UploadImage(c echo.Context) error {
 		}
 		used, err := inst.VFS().FilesUsage()
 		if err != nil {
-			return jsonapi.InternalServerError(errors.New("Cannot check quota"))
+			return jsonapi.InternalServerError(errors.New("cannot check quota"))
 		}
 		if used+size > quota {
 			return jsonapi.Errorf(http.StatusRequestEntityTooLarge, "%s", vfs.ErrFileTooBig)
@@ -386,7 +386,7 @@ func UploadImage(c echo.Context) error {
 	upload, err := note.NewImageUpload(inst, doc, name, contentType)
 	if err != nil {
 		inst.Logger().WithNamespace("notes").Infof("Image upload has failed: %s", err)
-		return jsonapi.BadRequest(errors.New("Upload has failed"))
+		return jsonapi.BadRequest(errors.New("upload has failed"))
 	}
 
 	// Manage the content upload
@@ -396,7 +396,7 @@ func UploadImage(c echo.Context) error {
 	}
 	if err != nil {
 		inst.Logger().WithNamespace("notes").Infof("Image upload has failed: %s", err)
-		return jsonapi.BadRequest(errors.New("Upload has failed"))
+		return jsonapi.BadRequest(errors.New("upload has failed"))
 	}
 
 	image := files.NewNoteImage(inst, upload.Image)

--- a/web/oidc/oidc.go
+++ b/web/oidc/oidc.go
@@ -321,7 +321,7 @@ type Config struct {
 func getConfig(context string) (*Config, error) {
 	oidc, ok := config.GetOIDC(context)
 	if !ok {
-		return nil, errors.New("No OIDC is configured for this context")
+		return nil, errors.New("no OIDC is configured for this context")
 	}
 
 	// Optional fields
@@ -334,35 +334,35 @@ func getConfig(context string) (*Config, error) {
 	// Mandatory fields
 	clientID, ok := oidc["client_id"].(string)
 	if !ok {
-		return nil, errors.New("The client_id is missing for this context")
+		return nil, errors.New("the client_id is missing for this context")
 	}
 	clientSecret, ok := oidc["client_secret"].(string)
 	if !ok {
-		return nil, errors.New("The client_secret is missing for this context")
+		return nil, errors.New("the client_secret is missing for this context")
 	}
 	scope, ok := oidc["scope"].(string)
 	if !ok {
-		return nil, errors.New("The scope is missing for this context")
+		return nil, errors.New("the scope is missing for this context")
 	}
 	redirectURI, ok := oidc["redirect_uri"].(string)
 	if !ok {
-		return nil, errors.New("The redirect_uri is missing for this context")
+		return nil, errors.New("the redirect_uri is missing for this context")
 	}
 	authorizeURL, ok := oidc["authorize_url"].(string)
 	if !ok {
-		return nil, errors.New("The authorize_url is missing for this context")
+		return nil, errors.New("the authorize_url is missing for this context")
 	}
 	tokenURL, ok := oidc["token_url"].(string)
 	if !ok {
-		return nil, errors.New("The token_url is missing for this context")
+		return nil, errors.New("the token_url is missing for this context")
 	}
 	userInfoURL, ok := oidc["userinfo_url"].(string)
 	if !ok {
-		return nil, errors.New("The userinfo_url is missing for this context")
+		return nil, errors.New("the userinfo_url is missing for this context")
 	}
 	userInfoField, ok := oidc["userinfo_instance_field"].(string)
 	if !ok && !allowCustomInstance {
-		return nil, errors.New("The userinfo_instance_field is missing for this context")
+		return nil, errors.New("the userinfo_instance_field is missing for this context")
 	}
 
 	config := &Config{
@@ -433,7 +433,7 @@ func getToken(conf *Config, code string) (string, error) {
 		_, _ = io.Copy(io.Discard, res.Body)
 		logger.WithNamespace("oidc").
 			Infof("Invalid status code %d for %s", res.StatusCode, conf.TokenURL)
-		return "", fmt.Errorf("OIDC service responded with %d", res.StatusCode)
+		return "", fmt.Errorf("oIDC service responded with %d", res.StatusCode)
 	}
 	resBody, err := io.ReadAll(res.Body)
 	if err != nil {
@@ -471,7 +471,7 @@ func checkDomainFromUserInfo(conf *Config, inst *instance.Instance, token string
 		sub, ok := params["sub"].(string)
 		if !ok || sub == "" || sub != inst.OIDCID {
 			inst.Logger().WithNamespace("oidc").Errorf("Invalid sub: %s != %s", sub, inst.OIDCID)
-			return errors.New("Error The authentication has failed")
+			return errors.New("error The authentication has failed")
 		}
 		return nil
 	}
@@ -482,7 +482,7 @@ func checkDomainFromUserInfo(conf *Config, inst *instance.Instance, token string
 	}
 	if domain != inst.Domain {
 		logger.WithNamespace("oidc").Errorf("Invalid domains: %s != %s", domain, inst.Domain)
-		return errors.New("Error The authentication has failed")
+		return errors.New("error The authentication has failed")
 	}
 	return nil
 }
@@ -504,14 +504,14 @@ func getUserInfo(conf *Config, token string) (map[string]interface{}, error) {
 		_, _ = io.Copy(io.Discard, res.Body)
 		logger.WithNamespace("oidc").
 			Infof("Invalid status code %d for %s", res.StatusCode, conf.UserInfoURL)
-		return nil, fmt.Errorf("OIDC service responded with %d", res.StatusCode)
+		return nil, fmt.Errorf("oIDC service responded with %d", res.StatusCode)
 	}
 
 	var params map[string]interface{}
 	err = json.NewDecoder(res.Body).Decode(&params)
 	if err != nil {
 		logger.WithNamespace("oidc").Errorf("Error on getDomainFromUserInfo: %s", err)
-		return nil, errors.New("Invalid response from the identity provider")
+		return nil, errors.New("invalid response from the identity provider")
 	}
 	return params, nil
 }
@@ -519,7 +519,7 @@ func getUserInfo(conf *Config, token string) (map[string]interface{}, error) {
 func extractDomain(conf *Config, params map[string]interface{}) (string, error) {
 	domain, ok := params[conf.UserInfoField].(string)
 	if !ok {
-		return "", errors.New("Error The authentication has failed")
+		return "", errors.New("error The authentication has failed")
 	}
 	domain = strings.ReplaceAll(domain, "-", "") // We don't want - in cozy instance
 	domain = strings.ToLower(domain)             // The domain is case insensitive
@@ -548,7 +548,7 @@ func checkIDToken(conf *Config, inst *instance.Instance, idToken string) error {
 	claims := token.Claims.(jwt.MapClaims)
 	if claims["sub"] == "" || claims["sub"] != inst.OIDCID {
 		inst.Logger().WithNamespace("oidc").Errorf("Invalid sub: %s != %s", claims["sub"], inst.OIDCID)
-		return errors.New("Error The authentication has failed")
+		return errors.New("error The authentication has failed")
 	}
 
 	return nil
@@ -620,7 +620,7 @@ func getKeysFromHTTP(keyURL string) ([]byte, error) {
 // ChooseKeyForIDToken can be used to check an id_token as a JWT.
 func ChooseKeyForIDToken(keys []*jwKey, token *jwt.Token) (interface{}, error) {
 	if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
-		return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
+		return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 	}
 
 	var key *jwKey
@@ -634,7 +634,7 @@ func ChooseKeyForIDToken(keys []*jwKey, token *jwt.Token) (interface{}, error) {
 		key = k
 	}
 	if key == nil {
-		return nil, errors.New("Key not found")
+		return nil, errors.New("key not found")
 	}
 	return loadKey(key)
 }

--- a/web/server.go
+++ b/web/server.go
@@ -43,7 +43,7 @@ func LoadSupportedLocales() error {
 			pofile := path.Join(assetsPath, "locales", locale+".po")
 			po, err := os.ReadFile(pofile)
 			if err != nil {
-				return fmt.Errorf("Can't load the po file for %s", locale)
+				return fmt.Errorf("can't load the po file for %s", locale)
 			}
 			i18n.LoadLocale(locale, "", po)
 		}
@@ -53,7 +53,7 @@ func LoadSupportedLocales() error {
 	for _, locale := range consts.SupportedLocales {
 		f, err := assets.Open("/locales/"+locale+".po", config.DefaultInstanceContext)
 		if err != nil {
-			return fmt.Errorf("Can't load the po file for %s", locale)
+			return fmt.Errorf("can't load the po file for %s", locale)
 		}
 		po, err := io.ReadAll(f)
 		if err != nil {
@@ -100,7 +100,7 @@ func checkExists(filepath string) error {
 		return err
 	}
 	if !exists {
-		return fmt.Errorf("Directory %s should contain a %s file",
+		return fmt.Errorf("directory %s should contain a %s file",
 			path.Dir(filepath), path.Base(filepath))
 	}
 	return nil

--- a/web/settings/passphrase.go
+++ b/web/settings/passphrase.go
@@ -94,11 +94,11 @@ func registerPassphrase(c echo.Context) error {
 	}
 
 	if args.Iterations < crypto.MinPBKDF2Iterations && args.Iterations != 0 {
-		err := errors.New("The KdfIterations number is too low")
+		err := errors.New("the KdfIterations number is too low")
 		return jsonapi.InvalidParameter("KdfIterations", err)
 	}
 	if args.Iterations > crypto.MaxPBKDF2Iterations {
-		err := errors.New("The KdfIterations number is too high")
+		err := errors.New("the KdfIterations number is too high")
 		return jsonapi.InvalidParameter("KdfIterations", err)
 	}
 
@@ -150,11 +150,11 @@ func registerPassphraseFlagship(c echo.Context) error {
 	}
 
 	if args.Iterations < crypto.MinPBKDF2Iterations {
-		err := errors.New("The KdfIterations number is too low")
+		err := errors.New("the KdfIterations number is too low")
 		return jsonapi.InvalidParameter("KdfIterations", err)
 	}
 	if args.Iterations > crypto.MaxPBKDF2Iterations {
-		err := errors.New("The KdfIterations number is too high")
+		err := errors.New("the KdfIterations number is too high")
 		return jsonapi.InvalidParameter("KdfIterations", err)
 	}
 
@@ -281,7 +281,7 @@ func updatePassphrase(c echo.Context) error {
 		}
 
 		if !canForce {
-			err = fmt.Errorf("Bitwarden extension has already been installed on this Cozy, cannot force update the passphrase.")
+			err = fmt.Errorf("bitwarden extension has already been installed on this Cozy, cannot force update the passphrase.")
 			return jsonapi.BadRequest(err)
 		}
 
@@ -321,11 +321,11 @@ func updatePassphrase(c echo.Context) error {
 	}
 
 	if args.Iterations < crypto.MinPBKDF2Iterations && args.Iterations != 0 {
-		err := errors.New("The KdfIterations number is too low")
+		err := errors.New("the KdfIterations number is too low")
 		return jsonapi.InvalidParameter("KdfIterations", err)
 	}
 	if args.Iterations > crypto.MaxPBKDF2Iterations {
-		err := errors.New("The KdfIterations number is too high")
+		err := errors.New("the KdfIterations number is too high")
 		return jsonapi.InvalidParameter("KdfIterations", err)
 	}
 
@@ -388,7 +388,7 @@ func getHint(c echo.Context) error {
 	}
 
 	if setting.PassphraseHint == "" {
-		return jsonapi.NotFound(errors.New("No hint"))
+		return jsonapi.NotFound(errors.New("no hint"))
 	}
 
 	return c.NoContent(http.StatusNoContent)

--- a/web/sharings/readonly.go
+++ b/web/sharings/readonly.go
@@ -31,7 +31,7 @@ func AddReadOnly(c echo.Context) error {
 		return jsonapi.InvalidParameter("index", err)
 	}
 	if index == 0 || index >= len(s.Members) {
-		return jsonapi.InvalidParameter("index", errors.New("Invalid index"))
+		return jsonapi.InvalidParameter("index", errors.New("invalid index"))
 	}
 	if s.Owner {
 		if err = s.AddReadOnlyFlag(inst, index); err != nil {
@@ -85,7 +85,7 @@ func RemoveReadOnly(c echo.Context) error {
 		return jsonapi.InvalidParameter("index", err)
 	}
 	if index == 0 || index >= len(s.Members) {
-		return jsonapi.InvalidParameter("index", errors.New("Invalid index"))
+		return jsonapi.InvalidParameter("index", errors.New("invalid index"))
 	}
 	if s.Owner {
 		if err = s.RemoveReadOnlyFlag(inst, index); err != nil {

--- a/web/sharings/replicator.go
+++ b/web/sharings/replicator.go
@@ -104,7 +104,7 @@ func SyncFile(c echo.Context) error {
 		return wrapErrors(err)
 	}
 	if c.Param("id") != fileDoc.DocID {
-		err = errors.New("The identifiers in the URL and in the doc are not the same")
+		err = errors.New("the identifiers in the URL and in the doc are not the same")
 		return jsonapi.InvalidAttribute("id", err)
 	}
 	key, err := s.SyncFile(inst, &fileDoc)

--- a/web/sharings/revoke.go
+++ b/web/sharings/revoke.go
@@ -46,7 +46,7 @@ func RevokeRecipient(c echo.Context) error {
 		return jsonapi.InvalidParameter("index", err)
 	}
 	if index == 0 || index >= len(s.Members) {
-		return jsonapi.InvalidParameter("index", errors.New("Invalid index"))
+		return jsonapi.InvalidParameter("index", errors.New("invalid index"))
 	}
 	if err = s.RevokeRecipient(inst, index); err != nil {
 		return wrapErrors(err)

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -741,7 +741,7 @@ func Routes(router *echo.Group) {
 func extractSlugFromSourceID(sourceID string) (string, error) {
 	parts := strings.SplitN(sourceID, "/", 2)
 	if len(parts) < 2 {
-		return "", jsonapi.BadRequest(errors.New("Invalid request"))
+		return "", jsonapi.BadRequest(errors.New("invalid request"))
 	}
 	slug := parts[1]
 	return slug, nil

--- a/web/shortcuts/shortcuts.go
+++ b/web/shortcuts/shortcuts.go
@@ -72,10 +72,10 @@ func FromJSONAPI(c echo.Context) (*vfs.FileDoc, []byte, error) {
 		return nil, nil, err
 	}
 	if doc.URL == "" {
-		return nil, nil, jsonapi.InvalidAttribute("url", errors.New("No URL"))
+		return nil, nil, jsonapi.InvalidAttribute("url", errors.New("no URL"))
 	}
 	if doc.Name == "" {
-		return nil, nil, jsonapi.InvalidAttribute("name", errors.New("No name"))
+		return nil, nil, jsonapi.InvalidAttribute("name", errors.New("no name"))
 	}
 	if !strings.HasSuffix(doc.Name, ".url") {
 		doc.Name += ".url"
@@ -161,7 +161,7 @@ func Get(c echo.Context) error {
 		return wrapError(err)
 	}
 	if link.URL == "" {
-		return jsonapi.BadRequest(errors.New("No URL found"))
+		return jsonapi.BadRequest(errors.New("no URL found"))
 	}
 
 	if meta, ok := file.Metadata["sharing"].(map[string]interface{}); ok && meta["status"] != "seen" {

--- a/web/statik/handler.go
+++ b/web/statik/handler.go
@@ -110,7 +110,7 @@ func NewDirRenderer(assetsPath string) (AssetRenderer, error) {
 	var err error
 	t, err = t.Funcs(middlewares.FuncsMap).ParseFiles(list...)
 	if err != nil {
-		return nil, fmt.Errorf("Can't load the assets from %q: %s", assetsPath, err)
+		return nil, fmt.Errorf("can't load the assets from %q: %s", assetsPath, err)
 	}
 
 	return &renderer{t: t, Handler: h}, nil
@@ -137,7 +137,7 @@ func NewRenderer() (AssetRenderer, error) {
 		tmpl := t.New(name).Funcs(middlewares.FuncsMap)
 		f, err := assets.Open("/templates/"+name, config.DefaultInstanceContext)
 		if err != nil {
-			return nil, fmt.Errorf("Can't load asset %q: %s", name, err)
+			return nil, fmt.Errorf("can't load asset %q: %s", name, err)
 		}
 		b, err := io.ReadAll(f)
 		if err != nil {

--- a/web/swift/swift.go
+++ b/web/swift/swift.go
@@ -220,6 +220,6 @@ func swiftContainer(i *instance.Instance) string {
 	case 2:
 		return "cozy-v3-" + i.DBPrefix()
 	default:
-		panic(errors.New("Unknown Swift layout"))
+		panic(errors.New("unknown Swift layout"))
 	}
 }

--- a/worker/exec/konnector.go
+++ b/worker/exec/konnector.go
@@ -226,7 +226,7 @@ func (w *konnectorWorker) PrepareWorkDir(ctx *job.WorkerContext, i *instance.Ins
 	}
 
 	if man.State() != app.Ready {
-		return "", cleanDir, errors.New("Konnector is not ready")
+		return "", cleanDir, errors.New("konnector is not ready")
 	}
 
 	var workDir string
@@ -589,7 +589,7 @@ func (w *konnectorWorker) ScanOutput(ctx *job.WorkerContext, i *instance.Instanc
 		NoRetry bool   `json:"no_retry"`
 	}
 	if err := json.Unmarshal(line, &msg); err != nil {
-		return fmt.Errorf("Could not parse stdout as JSON: %q", string(line))
+		return fmt.Errorf("could not parse stdout as JSON: %q", string(line))
 	}
 
 	// Truncate very long messages

--- a/worker/exec/service.go
+++ b/worker/exec/service.go
@@ -70,7 +70,7 @@ func (w *serviceWorker) PrepareWorkDir(ctx *job.WorkerContext, i *instance.Insta
 	}
 
 	if man.State() != app.Ready {
-		err = errors.New("Application is not ready")
+		err = errors.New("application is not ready")
 		return
 	}
 
@@ -88,7 +88,7 @@ func (w *serviceWorker) PrepareWorkDir(ctx *job.WorkerContext, i *instance.Insta
 		}
 	}
 	if !ok {
-		err = job.ErrBadTrigger{Err: fmt.Errorf("Service %q was not found", name)}
+		err = job.ErrBadTrigger{Err: fmt.Errorf("service %q was not found", name)}
 		return
 	}
 	// Check if the trigger is orphan
@@ -98,17 +98,17 @@ func (w *serviceWorker) PrepareWorkDir(ctx *job.WorkerContext, i *instance.Insta
 			var tInfos job.TriggerInfos
 			err = couchdb.GetDoc(i, consts.Triggers, triggerID, &tInfos)
 			if err != nil {
-				err = job.ErrBadTrigger{Err: fmt.Errorf("Trigger %q not found", triggerID)}
+				err = job.ErrBadTrigger{Err: fmt.Errorf("trigger %q not found", triggerID)}
 				return
 			}
 			var msg ServiceOptions
 			err = json.Unmarshal(tInfos.Message, &msg)
 			if err != nil {
-				err = job.ErrBadTrigger{Err: fmt.Errorf("Trigger %q has bad message structure", triggerID)}
+				err = job.ErrBadTrigger{Err: fmt.Errorf("trigger %q has bad message structure", triggerID)}
 				return
 			}
 			if msg.Name != name {
-				err = job.ErrBadTrigger{Err: fmt.Errorf("Trigger %q is orphan", triggerID)}
+				err = job.ErrBadTrigger{Err: fmt.Errorf("trigger %q is orphan", triggerID)}
 				return
 			}
 		}
@@ -209,7 +209,7 @@ func (w *serviceWorker) ScanOutput(ctx *job.WorkerContext, i *instance.Instance,
 		Message string `json:"message"`
 	}
 	if err := json.Unmarshal(line, &msg); err != nil {
-		return fmt.Errorf("Could not parse stdout as JSON: %q", string(line))
+		return fmt.Errorf("could not parse stdout as JSON: %q", string(line))
 	}
 
 	// Truncate very long messages

--- a/worker/mails/mail.go
+++ b/worker/mails/mail.go
@@ -107,7 +107,7 @@ func SendMail(ctx *job.WorkerContext) error {
 			return err
 		}
 	default:
-		return fmt.Errorf("Mail sent with unknown mode %s", opts.Mode)
+		return fmt.Errorf("mail sent with unknown mode %s", opts.Mode)
 	}
 	if opts.TemplateName != "" && opts.Locale == "" {
 		opts.Locale = ctx.Instance.Locale
@@ -125,7 +125,7 @@ func addressFromInstance(i *instance.Instance) (*mail.Address, error) {
 	}
 	email, ok := doc.M["email"].(string)
 	if !ok {
-		return nil, fmt.Errorf("Domain %s has no email in its settings", i.Domain)
+		return nil, fmt.Errorf("domain %s has no email in its settings", i.Domain)
 	}
 	publicName, _ := doc.M["public_name"].(string)
 	return &mail.Address{
@@ -136,13 +136,13 @@ func addressFromInstance(i *instance.Instance) (*mail.Address, error) {
 
 func doSendMail(ctx *job.WorkerContext, opts *mail.Options, domain string) error {
 	if opts.TemplateName == "" && opts.Subject == "" {
-		return errors.New("Missing mail subject")
+		return errors.New("missing mail subject")
 	}
 	if len(opts.To) == 0 {
-		return errors.New("Missing mail recipient")
+		return errors.New("missing mail recipient")
 	}
 	if opts.From == nil {
-		return errors.New("Missing mail sender")
+		return errors.New("missing mail sender")
 	}
 	email := gomail.NewMessage()
 	dialerOptions := opts.Dialer
@@ -226,7 +226,7 @@ func doSendMail(ctx *job.WorkerContext, opts *mail.Options, domain string) error
 func addPart(mail *gomail.Message, part *mail.Part) error {
 	contentType := part.Type
 	if contentType != "text/plain" && contentType != "text/html" {
-		return fmt.Errorf("Unknown body content-type %s", contentType)
+		return fmt.Errorf("unknown body content-type %s", contentType)
 	}
 	mail.AddAlternative(contentType, part.Body)
 	return nil

--- a/worker/mails/mail_templates.go
+++ b/worker/mails/mail_templates.go
@@ -62,7 +62,7 @@ type subjectEntry struct {
 func (m MailTemplater) Execute(ctx *job.WorkerContext, name, layout, locale string, recipientName string, data map[string]interface{}) (string, []*mail.Part, error) {
 	entry, ok := m[name]
 	if !ok {
-		err := fmt.Errorf("Could not find email named %q", name)
+		err := fmt.Errorf("could not find email named %q", name)
 		return "", nil, err
 	}
 

--- a/worker/migrations/migrations.go
+++ b/worker/migrations/migrations.go
@@ -280,7 +280,7 @@ func migrateToSwiftV3(domain string) error {
 	dstContainer := swiftV3ContainerPrefix + inst.DBPrefix()
 	if _, _, err = c.Container(ctx, dstContainer); !errors.Is(err, swift.ContainerNotFound) {
 		log.Errorf("Destination container %s already exists or something went wrong. Migration canceled.", dstContainer)
-		return errors.New("Destination container busy")
+		return errors.New("destination container busy")
 	}
 	if err = c.ContainerCreate(ctx, dstContainer, nil); err != nil {
 		return err
@@ -345,7 +345,7 @@ func copyTheFilesToSwiftV3(inst *instance.Instance, ctx context.Context, c *swif
 		srcName := getSrcName(inst, f)
 		dstName := getDstName(inst, f)
 		if srcName == "" || dstName == "" {
-			return fmt.Errorf("Unexpected copy: %q -> %q", srcName, dstName)
+			return fmt.Errorf("unexpected copy: %q -> %q", srcName, dstName)
 		}
 
 		if err := sem.Acquire(ctx, 1); err != nil {

--- a/worker/sms/sms.go
+++ b/worker/sms/sms.go
@@ -60,7 +60,7 @@ func sendSMS(ctx *job.WorkerContext, msg *center.SMS) error {
 		log := ctx.Logger()
 		return sendSenAPI(cfg, msg, number, log)
 	default:
-		return errors.New("Unknown provider for sending SMS")
+		return errors.New("unknown provider for sending SMS")
 	}
 }
 
@@ -98,7 +98,7 @@ func sendSenAPI(cfg *config.SMS, msg *center.SMS, number string, log *logger.Ent
 		}
 		log.WithField("status_code", res.StatusCode).Warnf("Cannot send SMS")
 	}
-	return fmt.Errorf("Unexpected status code: %d", res.StatusCode)
+	return fmt.Errorf("unexpected status code: %d", res.StatusCode)
 }
 
 func getMyselfPhoneNumber(inst *instance.Instance) (string, error) {
@@ -108,7 +108,7 @@ func getMyselfPhoneNumber(inst *instance.Instance) (string, error) {
 	}
 	number := myself.PrimaryPhoneNumber()
 	if number == "" {
-		return "", errors.New("No phone number in the myself contact document")
+		return "", errors.New("no phone number in the myself contact document")
 	}
 	return number, nil
 }
@@ -116,7 +116,7 @@ func getMyselfPhoneNumber(inst *instance.Instance) (string, error) {
 func getConfig(inst *instance.Instance) (*config.SMS, error) {
 	cfg, ok := config.GetConfig().Notifications.Contexts[inst.ContextName]
 	if !ok {
-		return nil, errors.New("SMS not configured on this context")
+		return nil, errors.New("sMS not configured on this context")
 	}
 	return &cfg, nil
 }

--- a/worker/trash/trash.go
+++ b/worker/trash/trash.go
@@ -94,7 +94,7 @@ func WorkerCleanOldTrashed(ctx *job.WorkerContext) error {
 		} else if d != nil {
 			err = fs.DestroyDirAndContent(d, push)
 		} else {
-			err = fmt.Errorf("Invalid type for %v", item)
+			err = fmt.Errorf("invalid type for %v", item)
 		}
 		if err != nil {
 			errm = multierror.Append(errm, err)

--- a/worker/updates/updates.go
+++ b/worker/updates/updates.go
@@ -176,7 +176,7 @@ func UpdateAll(ctx *job.WorkerContext, opts *Options) error {
 	}
 
 	if errors > 0 {
-		return fmt.Errorf("At least one error has happened during the updates: "+
+		return fmt.Errorf("at least one error has happened during the updates: "+
 			"%d errors for %d updates", errors, totals)
 	}
 	return nil
@@ -228,7 +228,7 @@ func UpdateInstance(ctx *job.WorkerContext, inst *instance.Instance, opts *Optio
 	}
 
 	if errors > 0 {
-		return fmt.Errorf("At least one error has happened during the updates: "+
+		return fmt.Errorf("at least one error has happened during the updates: "+
 			"%d errors for %d updates", errors, totals)
 	}
 	return nil


### PR DESCRIPTION
This review apply the advices found at:
https://github.com/golang/go/wiki/CodeReviewComments#error-strings

This review have been generated with by the following command:

```bash
sed -i 's/errors.New("\([A-Z]\)/errors.New("\L\1/g' **/*.go
sed -i 's/fmt.Errorf("\([A-Z]\)/fmt.Errorf("\L\1/g' **/*.go
````