### PR TITLE
Move the implems inside `/pkd/assets/dynamic` into their own files.

### DIFF
--- a/pkg/assets/dynamic/fs.go
+++ b/pkg/assets/dynamic/fs.go
@@ -4,15 +4,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
-	"net/url"
-	"os"
 	"path"
-	"path/filepath"
 	"strings"
 	"time"
 
-	"github.com/cozy/afero"
 	"github.com/cozy/cozy-stack/pkg/assets/model"
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/ncw/swift/v2"
@@ -39,15 +34,6 @@ type swiftFS struct {
 	ctx       context.Context
 }
 
-type aferoFS struct {
-	fs     afero.Fs
-	folder *url.URL
-}
-
-func (a *aferoFS) GetAssetFolderName(context, name string) string {
-	return filepath.Join(a.folder.Path, context, name)
-}
-
 // InitDynamicAssetFS initializes the dynamic asset FS.
 func InitDynamicAssetFS() error {
 	var err error
@@ -71,22 +57,6 @@ func InitDynamicAssetFS() error {
 	return nil
 }
 
-func newOsFS() (*aferoFS, error) {
-	tmp := config.FsURL().String()
-	folder, err := url.Parse(tmp)
-	folder.Path = filepath.Join(folder.Path, DynamicAssetsFolderName)
-
-	if err != nil {
-		return nil, err
-	}
-
-	aferoFS := &aferoFS{fs: afero.NewOsFs(), folder: folder}
-	if err := aferoFS.fs.MkdirAll(aferoFS.folder.Path, 0755); err != nil && !os.IsExist(err) {
-		return nil, err
-	}
-	return aferoFS, nil
-}
-
 func newswiftFS() (*swiftFS, error) {
 	ctx := context.Background()
 	swiftFS := &swiftFS{swiftConn: config.GetSwiftConnection(), ctx: ctx}
@@ -96,87 +66,6 @@ func newswiftFS() (*swiftFS, error) {
 	}
 
 	return swiftFS, nil
-}
-
-func (a *aferoFS) Add(context, name string, asset *model.Asset) error {
-	filePath := a.GetAssetFolderName(context, name)
-
-	// Creates the asset folder
-	err := a.fs.MkdirAll(filepath.Dir(filePath), 0755)
-	if err != nil {
-		return err
-	}
-
-	// Writing the file
-	f, err := a.fs.OpenFile(filePath, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0600)
-	if err != nil {
-		return err
-	}
-
-	_, err = f.Write(asset.GetData())
-	if err != nil {
-		return err
-	}
-
-	return f.Close()
-}
-
-func (a *aferoFS) Get(context, name string) ([]byte, error) {
-	filePath := a.GetAssetFolderName(context, name)
-
-	f, err := a.fs.Open(filePath)
-	if err != nil {
-		return nil, err
-	}
-
-	buf := new(bytes.Buffer)
-
-	_, err = io.Copy(buf, f)
-	if err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), f.Close()
-}
-
-func (a *aferoFS) Remove(context, name string) error {
-	filePath := a.GetAssetFolderName(context, name)
-	return a.fs.Remove(filePath)
-}
-
-func (a *aferoFS) CheckStatus(_ context.Context) (time.Duration, error) {
-	before := time.Now()
-	_, err := a.fs.Stat("/")
-	return time.Since(before), err
-}
-
-func (a *aferoFS) List() (map[string][]*model.Asset, error) {
-	objs := map[string][]*model.Asset{}
-
-	// List contexts
-	entries, err := os.ReadDir(a.folder.Path)
-	if err != nil {
-		return nil, err
-	}
-	for _, context := range entries {
-		ctxName := context.Name()
-		ctxPath := filepath.Join(a.folder.Path, ctxName)
-
-		err := filepath.Walk(ctxPath, func(path string, info os.FileInfo, err error) error {
-			if !info.IsDir() {
-				assetName := strings.Replace(path, ctxPath, "", 1)
-				asset, err := GetAsset(ctxName, assetName)
-				if err != nil {
-					return err
-				}
-				objs[ctxName] = append(objs[ctxName], asset)
-			}
-			return nil
-		})
-		if err != nil {
-			return nil, err
-		}
-	}
-	return objs, nil
 }
 
 func (s *swiftFS) Add(context, name string, asset *model.Asset) error {

--- a/pkg/assets/dynamic/fs.go
+++ b/pkg/assets/dynamic/fs.go
@@ -41,7 +41,7 @@ func InitDynamicAssetFS() error {
 
 	switch scheme {
 	case config.SchemeFile, config.SchemeMem:
-		assetFS, err = newOsFS()
+		assetFS, err = NewOsFS()
 		if err != nil {
 			return err
 		}

--- a/pkg/assets/dynamic/fs.go
+++ b/pkg/assets/dynamic/fs.go
@@ -11,12 +11,6 @@ import (
 
 var assetFS AssetsFS
 
-// DynamicAssetsContainerName is the Swift container name for dynamic assets
-const DynamicAssetsContainerName = "__dyn-assets__"
-
-// DynamicAssetsFolderName is the folder name for dynamic assets
-const DynamicAssetsFolderName = "dyn-assets"
-
 // AssetsFS is the interface implemented by all the implementations handling assets.
 //
 // At the moment there two separate implementations:

--- a/pkg/assets/dynamic/fs.go
+++ b/pkg/assets/dynamic/fs.go
@@ -1,16 +1,12 @@
 package dynamic
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"path"
-	"strings"
 	"time"
 
 	"github.com/cozy/cozy-stack/pkg/assets/model"
 	"github.com/cozy/cozy-stack/pkg/config/config"
-	"github.com/ncw/swift/v2"
 )
 
 var assetFS assetsFS
@@ -27,11 +23,6 @@ type assetsFS interface {
 	Remove(string, string) error
 	List() (map[string][]*model.Asset, error)
 	CheckStatus(ctx context.Context) (time.Duration, error)
-}
-
-type swiftFS struct {
-	swiftConn *swift.Connection
-	ctx       context.Context
 }
 
 // InitDynamicAssetFS initializes the dynamic asset FS.
@@ -55,87 +46,4 @@ func InitDynamicAssetFS() error {
 	}
 
 	return nil
-}
-
-func newswiftFS() (*swiftFS, error) {
-	ctx := context.Background()
-	swiftFS := &swiftFS{swiftConn: config.GetSwiftConnection(), ctx: ctx}
-	err := swiftFS.swiftConn.ContainerCreate(ctx, DynamicAssetsContainerName, nil)
-	if err != nil {
-		return nil, fmt.Errorf("Cannot create container for dynamic assets: %s", err)
-	}
-
-	return swiftFS, nil
-}
-
-func (s *swiftFS) Add(context, name string, asset *model.Asset) error {
-	objectName := path.Join(asset.Context, asset.Name)
-	swiftConn := s.swiftConn
-	f, err := swiftConn.ObjectCreate(s.ctx, DynamicAssetsContainerName, objectName, true, "", "", nil)
-	if err != nil {
-		return err
-	}
-
-	// Writing the asset content to Swift
-	_, err = f.Write(asset.GetData())
-	if err != nil {
-		return err
-	}
-	return f.Close()
-}
-
-func (s *swiftFS) Get(context, name string) ([]byte, error) {
-	objectName := path.Join(context, name)
-	assetContent := new(bytes.Buffer)
-
-	_, err := s.swiftConn.ObjectGet(s.ctx, DynamicAssetsContainerName, objectName, assetContent, true, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return assetContent.Bytes(), nil
-}
-
-func (s *swiftFS) Remove(context, name string) error {
-	objectName := path.Join(context, name)
-
-	return s.swiftConn.ObjectDelete(s.ctx, DynamicAssetsContainerName, objectName)
-}
-
-func (s *swiftFS) List() (map[string][]*model.Asset, error) {
-	objs := map[string][]*model.Asset{}
-
-	objNames, err := s.swiftConn.ObjectNamesAll(s.ctx, DynamicAssetsContainerName, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, obj := range objNames {
-		splitted := strings.SplitN(obj, "/", 2)
-		ctx := splitted[0]
-		assetName := model.NormalizeAssetName(splitted[1])
-
-		a, err := GetAsset(ctx, assetName)
-		if err != nil {
-			return nil, err
-		}
-
-		objs[ctx] = append(objs[ctx], a)
-	}
-
-	return objs, nil
-}
-
-func (s *swiftFS) CheckStatus(ctx context.Context) (time.Duration, error) {
-	before := time.Now()
-	var err error
-	if config.GetConfig().Fs.CanQueryInfo {
-		_, err = s.swiftConn.QueryInfo(ctx)
-	} else {
-		_, _, err = s.swiftConn.Container(ctx, DynamicAssetsContainerName)
-	}
-	if err != nil {
-		return 0, err
-	}
-	return time.Since(before), nil
 }

--- a/pkg/assets/dynamic/fs.go
+++ b/pkg/assets/dynamic/fs.go
@@ -37,7 +37,7 @@ func InitDynamicAssetFS() error {
 			return err
 		}
 	case config.SchemeSwift, config.SchemeSwiftSecure:
-		assetFS, err = newswiftFS()
+		assetFS, err = NewSwiftFS()
 		if err != nil {
 			return err
 		}

--- a/pkg/assets/dynamic/fs.go
+++ b/pkg/assets/dynamic/fs.go
@@ -9,7 +9,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/config/config"
 )
 
-var assetFS assetsFS
+var assetFS AssetsFS
 
 // DynamicAssetsContainerName is the Swift container name for dynamic assets
 const DynamicAssetsContainerName = "__dyn-assets__"
@@ -17,7 +17,12 @@ const DynamicAssetsContainerName = "__dyn-assets__"
 // DynamicAssetsFolderName is the folder name for dynamic assets
 const DynamicAssetsFolderName = "dyn-assets"
 
-type assetsFS interface {
+// AssetsFS is the interface implemented by all the implementations handling assets.
+//
+// At the moment there two separate implementations:
+// - [SwiftFS] allowing to manage assets via an OpenStack Swift API.
+// - [OsFS] allowing to manage assets directly via the host Operating System.
+type AssetsFS interface {
 	Add(string, string, *model.Asset) error
 	Get(string, string) ([]byte, error)
 	Remove(string, string) error

--- a/pkg/assets/dynamic/impl_os.go
+++ b/pkg/assets/dynamic/impl_os.go
@@ -1,0 +1,122 @@
+package dynamic
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/cozy/afero"
+	"github.com/cozy/cozy-stack/pkg/assets/model"
+	"github.com/cozy/cozy-stack/pkg/config/config"
+)
+
+type aferoFS struct {
+	fs     afero.Fs
+	folder *url.URL
+}
+
+func newOsFS() (*aferoFS, error) {
+	tmp := config.FsURL().String()
+	folder, err := url.Parse(tmp)
+	folder.Path = filepath.Join(folder.Path, DynamicAssetsFolderName)
+
+	if err != nil {
+		return nil, err
+	}
+
+	aferoFS := &aferoFS{fs: afero.NewOsFs(), folder: folder}
+	if err := aferoFS.fs.MkdirAll(aferoFS.folder.Path, 0755); err != nil && !os.IsExist(err) {
+		return nil, err
+	}
+	return aferoFS, nil
+}
+
+func (a *aferoFS) GetAssetFolderName(context, name string) string {
+	return filepath.Join(a.folder.Path, context, name)
+}
+
+func (a *aferoFS) Remove(context, name string) error {
+	filePath := a.GetAssetFolderName(context, name)
+	return a.fs.Remove(filePath)
+}
+
+func (a *aferoFS) CheckStatus(_ context.Context) (time.Duration, error) {
+	before := time.Now()
+	_, err := a.fs.Stat("/")
+	return time.Since(before), err
+}
+
+func (a *aferoFS) List() (map[string][]*model.Asset, error) {
+	objs := map[string][]*model.Asset{}
+
+	// List contexts
+	entries, err := os.ReadDir(a.folder.Path)
+	if err != nil {
+		return nil, err
+	}
+	for _, context := range entries {
+		ctxName := context.Name()
+		ctxPath := filepath.Join(a.folder.Path, ctxName)
+
+		err := filepath.Walk(ctxPath, func(path string, info os.FileInfo, err error) error {
+			if !info.IsDir() {
+				assetName := strings.Replace(path, ctxPath, "", 1)
+				asset, err := GetAsset(ctxName, assetName)
+				if err != nil {
+					return err
+				}
+				objs[ctxName] = append(objs[ctxName], asset)
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	return objs, nil
+}
+
+func (a *aferoFS) Get(context, name string) ([]byte, error) {
+	filePath := a.GetAssetFolderName(context, name)
+
+	f, err := a.fs.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	buf := new(bytes.Buffer)
+
+	_, err = io.Copy(buf, f)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), f.Close()
+}
+
+func (a *aferoFS) Add(context, name string, asset *model.Asset) error {
+	filePath := a.GetAssetFolderName(context, name)
+
+	// Creates the asset folder
+	err := a.fs.MkdirAll(filepath.Dir(filePath), 0755)
+	if err != nil {
+		return err
+	}
+
+	// Writing the file
+	f, err := a.fs.OpenFile(filePath, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0600)
+	if err != nil {
+		return err
+	}
+
+	_, err = f.Write(asset.GetData())
+	if err != nil {
+		return err
+	}
+
+	return f.Close()
+}

--- a/pkg/assets/dynamic/impl_os.go
+++ b/pkg/assets/dynamic/impl_os.go
@@ -15,7 +15,10 @@ import (
 	"github.com/cozy/cozy-stack/pkg/config/config"
 )
 
-// OsFS is the OS implementation of AssetsFS.
+// DynamicAssetsFolderName is the folder name for dynamic assets
+const DynamicAssetsFolderName = "dyn-assets"
+
+// OsFS is the OS implementation of [AssetsFS].
 //
 // It saves the assets directly on the host OS filesyteme.
 //

--- a/pkg/assets/dynamic/impl_swift.go
+++ b/pkg/assets/dynamic/impl_swift.go
@@ -1,0 +1,102 @@
+package dynamic
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/cozy/cozy-stack/pkg/assets/model"
+	"github.com/cozy/cozy-stack/pkg/config/config"
+	"github.com/ncw/swift/v2"
+)
+
+type swiftFS struct {
+	swiftConn *swift.Connection
+	ctx       context.Context
+}
+
+func newswiftFS() (*swiftFS, error) {
+	ctx := context.Background()
+	swiftFS := &swiftFS{swiftConn: config.GetSwiftConnection(), ctx: ctx}
+	err := swiftFS.swiftConn.ContainerCreate(ctx, DynamicAssetsContainerName, nil)
+	if err != nil {
+		return nil, fmt.Errorf("Cannot create container for dynamic assets: %s", err)
+	}
+
+	return swiftFS, nil
+}
+
+func (s *swiftFS) Add(context, name string, asset *model.Asset) error {
+	objectName := path.Join(asset.Context, asset.Name)
+	swiftConn := s.swiftConn
+	f, err := swiftConn.ObjectCreate(s.ctx, DynamicAssetsContainerName, objectName, true, "", "", nil)
+	if err != nil {
+		return err
+	}
+
+	// Writing the asset content to Swift
+	_, err = f.Write(asset.GetData())
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}
+
+func (s *swiftFS) Get(context, name string) ([]byte, error) {
+	objectName := path.Join(context, name)
+	assetContent := new(bytes.Buffer)
+
+	_, err := s.swiftConn.ObjectGet(s.ctx, DynamicAssetsContainerName, objectName, assetContent, true, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return assetContent.Bytes(), nil
+}
+
+func (s *swiftFS) Remove(context, name string) error {
+	objectName := path.Join(context, name)
+
+	return s.swiftConn.ObjectDelete(s.ctx, DynamicAssetsContainerName, objectName)
+}
+
+func (s *swiftFS) List() (map[string][]*model.Asset, error) {
+	objs := map[string][]*model.Asset{}
+
+	objNames, err := s.swiftConn.ObjectNamesAll(s.ctx, DynamicAssetsContainerName, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, obj := range objNames {
+		splitted := strings.SplitN(obj, "/", 2)
+		ctx := splitted[0]
+		assetName := model.NormalizeAssetName(splitted[1])
+
+		a, err := GetAsset(ctx, assetName)
+		if err != nil {
+			return nil, err
+		}
+
+		objs[ctx] = append(objs[ctx], a)
+	}
+
+	return objs, nil
+}
+
+func (s *swiftFS) CheckStatus(ctx context.Context) (time.Duration, error) {
+	before := time.Now()
+	var err error
+	if config.GetConfig().Fs.CanQueryInfo {
+		_, err = s.swiftConn.QueryInfo(ctx)
+	} else {
+		_, _, err = s.swiftConn.Container(ctx, DynamicAssetsContainerName)
+	}
+	if err != nil {
+		return 0, err
+	}
+	return time.Since(before), nil
+}

--- a/pkg/assets/dynamic/impl_swift.go
+++ b/pkg/assets/dynamic/impl_swift.go
@@ -13,6 +13,9 @@ import (
 	"github.com/ncw/swift/v2"
 )
 
+// DynamicAssetsContainerName is the Swift container name for dynamic assets
+const DynamicAssetsContainerName = "__dyn-assets__"
+
 // SwiftFS is the Swift implementation of [AssetsFS].
 //
 // It save and fetch assets into/from any OpenStack Swift compatible API.


### PR DESCRIPTION
By moving each `assetFS` implementation into their own file, it became a lot easier to see what implementations is available by looking the file tree.

Now the `fs.go` file contains only the interface and initialization function.