### PR TITLE
Add an InMemory implementation for the dynamic assets

### DIFF
--- a/pkg/assets/dynamic/fs.go
+++ b/pkg/assets/dynamic/fs.go
@@ -30,16 +30,21 @@ func InitDynamicAssetFS() error {
 	scheme := config.FsURL().Scheme
 
 	switch scheme {
-	case config.SchemeFile, config.SchemeMem:
+	case config.SchemeMem:
+		assetFS = NewInMemoryFS()
+
+	case config.SchemeFile:
 		assetFS, err = NewOsFS()
 		if err != nil {
 			return err
 		}
+
 	case config.SchemeSwift, config.SchemeSwiftSecure:
 		assetFS, err = NewSwiftFS()
 		if err != nil {
 			return err
 		}
+
 	default:
 		return fmt.Errorf("Invalid scheme %s for dynamic assets FS", scheme)
 	}

--- a/pkg/assets/dynamic/impl_afero.go
+++ b/pkg/assets/dynamic/impl_afero.go
@@ -32,6 +32,14 @@ type AferoFS struct {
 	folder *url.URL
 }
 
+// NewInMemoryFS instantiate a new [AferoFS] with the in-memeory driver.
+//
+// This implementation loose every data after being clean up so it should
+// be only used for the tests.
+func NewInMemoryFS() *AferoFS {
+	return &AferoFS{fs: afero.NewMemMapFs()}
+}
+
 // NewOsFS instantiate a new [AferoFS] with the OsFS driver.
 func NewOsFS() (*AferoFS, error) {
 	tmp := config.FsURL().String()

--- a/pkg/assets/dynamic/impl_afero.go
+++ b/pkg/assets/dynamic/impl_afero.go
@@ -16,21 +16,24 @@ import (
 )
 
 // DynamicAssetsFolderName is the folder name for dynamic assets
-const DynamicAssetsFolderName = "dyn-assets"
+const DynamicAssetsFolderName = "dyn-asets"
 
-// OsFS is the OS implementation of [AssetsFS].
+// AferoFS is a wrapper around the [spf13/afero] filesystem.
 //
-// It saves the assets directly on the host OS filesyteme.
+// It can be setup with two differents drivers:
+//   - [NewInMemory] use the in-memory driver. It should be
+//     used only for the tests as nothing is persisted.
+//   - [NewOsFS] use the OsFs driver. It will save the assets
+//     on the host filesystem.
 //
-// Technically this is a wrapper around https://github.com/spf13/afero
-// which handle all the heavy works around the OS compatibility.
-type OsFS struct {
+// [spf13/afero]: https://github.com/spf13/afero
+type AferoFS struct {
 	fs     afero.Fs
 	folder *url.URL
 }
 
-// NewOsFS instantiate a new OsFS.
-func NewOsFS() (*OsFS, error) {
+// NewOsFS instantiate a new [AferoFS] with the OsFS driver.
+func NewOsFS() (*AferoFS, error) {
 	tmp := config.FsURL().String()
 	folder, err := url.Parse(tmp)
 	folder.Path = filepath.Join(folder.Path, DynamicAssetsFolderName)
@@ -39,29 +42,29 @@ func NewOsFS() (*OsFS, error) {
 		return nil, err
 	}
 
-	aferoFS := &OsFS{fs: afero.NewOsFs(), folder: folder}
+	aferoFS := &AferoFS{fs: afero.NewOsFs(), folder: folder}
 	if err := aferoFS.fs.MkdirAll(aferoFS.folder.Path, 0755); err != nil && !os.IsExist(err) {
 		return nil, err
 	}
 	return aferoFS, nil
 }
 
-func (a *OsFS) GetAssetFolderName(context, name string) string {
+func (a *AferoFS) GetAssetFolderName(context, name string) string {
 	return filepath.Join(a.folder.Path, context, name)
 }
 
-func (a *OsFS) Remove(context, name string) error {
+func (a *AferoFS) Remove(context, name string) error {
 	filePath := a.GetAssetFolderName(context, name)
 	return a.fs.Remove(filePath)
 }
 
-func (a *OsFS) CheckStatus(_ context.Context) (time.Duration, error) {
+func (a *AferoFS) CheckStatus(_ context.Context) (time.Duration, error) {
 	before := time.Now()
 	_, err := a.fs.Stat("/")
 	return time.Since(before), err
 }
 
-func (a *OsFS) List() (map[string][]*model.Asset, error) {
+func (a *AferoFS) List() (map[string][]*model.Asset, error) {
 	objs := map[string][]*model.Asset{}
 
 	// List contexts
@@ -91,7 +94,7 @@ func (a *OsFS) List() (map[string][]*model.Asset, error) {
 	return objs, nil
 }
 
-func (a *OsFS) Get(context, name string) ([]byte, error) {
+func (a *AferoFS) Get(context, name string) ([]byte, error) {
 	filePath := a.GetAssetFolderName(context, name)
 
 	f, err := a.fs.Open(filePath)
@@ -108,7 +111,7 @@ func (a *OsFS) Get(context, name string) ([]byte, error) {
 	return buf.Bytes(), f.Close()
 }
 
-func (a *OsFS) Add(context, name string, asset *model.Asset) error {
+func (a *AferoFS) Add(context, name string, asset *model.Asset) error {
 	filePath := a.GetAssetFolderName(context, name)
 
 	// Creates the asset folder


### PR DESCRIPTION
This new implementation will bring several advantages:
- The tests will be quicker as the assets will be in RAM
- Each test can popup it's own in-memory FS without any conflict, allowing parallel tests
- The tests will not push files on the host filesystem like the `/pkg/assets/dynamic/dyn-assets` folder