### PR TITLE
Move the rate limiters implementations in their own files

### DIFF
--- a/pkg/limits/impl_inmemory.go
+++ b/pkg/limits/impl_inmemory.go
@@ -1,0 +1,58 @@
+package limits
+
+import (
+	"sync"
+	"time"
+)
+
+var counterCleanInterval = 1 * time.Second
+
+type memRef struct {
+	val int64
+	exp time.Time
+}
+
+// InMemory implementation ofr [Counter].
+type InMemory struct {
+	mu   sync.Mutex
+	vals map[string]*memRef
+}
+
+// NewInMemory returns a in-memory counter.
+func NewInMemory() *InMemory {
+	counter := &InMemory{vals: make(map[string]*memRef)}
+
+	go counter.cleaner()
+
+	return counter
+}
+
+func (i *InMemory) cleaner() {
+	for range time.Tick(counterCleanInterval) {
+		now := time.Now()
+		for k, v := range i.vals {
+			if now.After(v.exp) {
+				delete(i.vals, k)
+			}
+		}
+	}
+}
+
+func (i *InMemory) Increment(key string, timeLimit time.Duration) (int64, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	if _, ok := i.vals[key]; !ok {
+		i.vals[key] = &memRef{
+			val: 0,
+			exp: time.Now().Add(timeLimit),
+		}
+	}
+	i.vals[key].val++
+	return i.vals[key].val, nil
+}
+
+func (i *InMemory) Reset(key string) error {
+	delete(i.vals, key)
+	return nil
+}

--- a/pkg/limits/impl_redis.go
+++ b/pkg/limits/impl_redis.go
@@ -1,0 +1,47 @@
+package limits
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// Redis implementation of [Counter].
+//
+// This implementation is safe to use in multi-instances installation.
+type Redis struct {
+	Client redis.UniversalClient
+	ctx    context.Context
+}
+
+// NewRedis returns a counter that can be mutualized between several
+// cozy-stack processes by using redis.
+func NewRedis(client redis.UniversalClient) Counter {
+	return &Redis{client, context.Background()}
+}
+
+// incrWithTTL is a lua script for redis to increment a counter and sets a TTL
+// if it doesn't have one.
+const incrWithTTL = `
+local n = redis.call("INCR", KEYS[1])
+if redis.call("TTL", KEYS[1]) == -1 then
+  redis.call("EXPIRE", KEYS[1], KEYS[2])
+end
+return n
+`
+
+func (r *Redis) Increment(key string, timeLimit time.Duration) (int64, error) {
+	ttl := strconv.FormatInt(int64(timeLimit/time.Second), 10)
+	count, err := r.Client.Eval(r.ctx, incrWithTTL, []string{key, ttl}).Result()
+	if err != nil {
+		return 0, err
+	}
+	return count.(int64), nil
+}
+
+func (r *Redis) Reset(key string) error {
+	_, err := r.Client.Del(r.ctx, key).Result()
+	return err
+}

--- a/pkg/limits/rate_limiting_test.go
+++ b/pkg/limits/rate_limiting_test.go
@@ -19,12 +19,12 @@ func TestRate(t *testing.T) {
 	}
 
 	t.Run("LoginRateNotExceededMem", func(t *testing.T) {
-		globalCounter = NewMemCounter()
+		globalCounter = NewInMemory()
 		assert.NoError(t, CheckRateLimit(testInstance, AuthType))
 	})
 
 	t.Run("LoginRateExceededMem", func(t *testing.T) {
-		globalCounter = NewMemCounter()
+		globalCounter = NewInMemory()
 		for i := 1; i <= 1000; i++ {
 			assert.NoError(t, CheckRateLimit(testInstance, AuthType))
 		}
@@ -52,12 +52,12 @@ func TestRate(t *testing.T) {
 	})
 
 	t.Run("2FAGenerationNotExceededMem", func(t *testing.T) {
-		globalCounter = NewMemCounter()
+		globalCounter = NewInMemory()
 		assert.NoError(t, CheckRateLimit(testInstance, TwoFactorGenerationType))
 	})
 
 	t.Run("2FAGenerationExceededMem", func(t *testing.T) {
-		globalCounter = NewMemCounter()
+		globalCounter = NewInMemory()
 		for i := 1; i <= 20; i++ {
 			assert.NoError(t, CheckRateLimit(testInstance, TwoFactorGenerationType))
 		}
@@ -85,12 +85,12 @@ func TestRate(t *testing.T) {
 	})
 
 	t.Run("2FARateExceededNotExceededMem", func(t *testing.T) {
-		globalCounter = NewMemCounter()
+		globalCounter = NewInMemory()
 		assert.NoError(t, CheckRateLimit(testInstance, TwoFactorType))
 	})
 
 	t.Run("2FARateExceededMem", func(t *testing.T) {
-		globalCounter = NewMemCounter()
+		globalCounter = NewInMemory()
 		for i := 1; i <= 10; i++ {
 			assert.NoError(t, CheckRateLimit(testInstance, TwoFactorType))
 		}

--- a/pkg/limits/rate_limiting_test.go
+++ b/pkg/limits/rate_limiting_test.go
@@ -36,14 +36,14 @@ func TestRate(t *testing.T) {
 		opts, _ := redis.ParseURL(redisURL)
 		client := redis.NewClient(opts)
 		client.Del(context.Background(), "auth:"+testInstance.DomainName())
-		globalCounter = NewRedisCounter(client)
+		globalCounter = NewRedis(client)
 		assert.NoError(t, CheckRateLimit(testInstance, AuthType))
 	})
 
 	t.Run("LoginRateExceededRedis", func(t *testing.T) {
 		opts, _ := redis.ParseURL(redisURL)
 		client := redis.NewClient(opts)
-		globalCounter = NewRedisCounter(client)
+		globalCounter = NewRedis(client)
 		client.Del(context.Background(), "auth:"+testInstance.DomainName())
 		for i := 1; i <= 1000; i++ {
 			assert.NoError(t, CheckRateLimit(testInstance, AuthType))
@@ -69,14 +69,14 @@ func TestRate(t *testing.T) {
 		opts, _ := redis.ParseURL(redisURL)
 		client := redis.NewClient(opts)
 		client.Del(context.Background(), "two-factor-generation:"+testInstance.DomainName())
-		globalCounter = NewRedisCounter(client)
+		globalCounter = NewRedis(client)
 		assert.NoError(t, CheckRateLimit(testInstance, TwoFactorGenerationType))
 	})
 
 	t.Run("2FAGenerationExceededRedis", func(t *testing.T) {
 		opts, _ := redis.ParseURL(redisURL)
 		client := redis.NewClient(opts)
-		globalCounter = NewRedisCounter(client)
+		globalCounter = NewRedis(client)
 		client.Del(context.Background(), "two-factor-generation:"+testInstance.DomainName())
 		for i := 1; i <= 20; i++ {
 			assert.NoError(t, CheckRateLimit(testInstance, TwoFactorGenerationType))
@@ -102,14 +102,14 @@ func TestRate(t *testing.T) {
 		opts, _ := redis.ParseURL(redisURL)
 		client := redis.NewClient(opts)
 		client.Del(context.Background(), "two-factor:"+testInstance.DomainName())
-		globalCounter = NewRedisCounter(client)
+		globalCounter = NewRedis(client)
 		assert.NoError(t, CheckRateLimit(testInstance, TwoFactorType))
 	})
 
 	t.Run("2FAExceededRedis", func(t *testing.T) {
 		opts, _ := redis.ParseURL(redisURL)
 		client := redis.NewClient(opts)
-		globalCounter = NewRedisCounter(client)
+		globalCounter = NewRedis(client)
 		client.Del(context.Background(), "two-factor:"+testInstance.DomainName())
 		for i := 1; i <= 10; i++ {
 			assert.NoError(t, CheckRateLimit(testInstance, TwoFactorType))


### PR DESCRIPTION
This will permit to quickly see what implementation is available and facilitate the navigation inside an implementation