### PR TITLE
Use the same tests for all the `/pkg/limits` implems

### DIFF
--- a/pkg/limits/rate_limiting_test.go
+++ b/pkg/limits/rate_limiting_test.go
@@ -1,119 +1,86 @@
 package limits
 
 import (
-	"context"
 	"testing"
 
 	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/redis/go-redis/v9"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-const redisURL = "redis://localhost:6379/0"
-
-var testInstance = prefixer.NewPrefixer(0, "cozy.example.net", "cozy-example-net")
-
 func TestRate(t *testing.T) {
-	if testing.Short() {
-		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	var testInstance = prefixer.NewPrefixer(0, "cozy.example.net", "cozy-example-limits")
+
+	rOpt, err := redis.ParseURL("redis://localhost:6379/0")
+	require.NoError(t, err)
+
+	redisClient := redis.NewClient(rOpt)
+
+	tests := []struct {
+		Name      string
+		Client    Counter
+		NeedRedis bool
+	}{
+		{
+			Name:      "InMemory",
+			Client:    NewInMemory(),
+			NeedRedis: false,
+		},
+		{
+			Name:      "Redis",
+			Client:    NewRedis(redisClient),
+			NeedRedis: true,
+		},
 	}
 
-	t.Run("LoginRateNotExceededMem", func(t *testing.T) {
-		globalCounter = NewInMemory()
-		assert.NoError(t, CheckRateLimit(testInstance, AuthType))
-	})
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			if test.NeedRedis && testing.Short() {
+				t.Skip("a redis is required for this test: test skipped due to the use of --short flag")
+			}
 
-	t.Run("LoginRateExceededMem", func(t *testing.T) {
-		globalCounter = NewInMemory()
-		for i := 1; i <= 1000; i++ {
-			assert.NoError(t, CheckRateLimit(testInstance, AuthType))
-		}
-		err := CheckRateLimit(testInstance, AuthType)
-		assert.Error(t, err)
-	})
+			globalCounter = test.Client
 
-	t.Run("LoginRateNotExceededRedis", func(t *testing.T) {
-		opts, _ := redis.ParseURL(redisURL)
-		client := redis.NewClient(opts)
-		client.Del(context.Background(), "auth:"+testInstance.DomainName())
-		globalCounter = NewRedis(client)
-		assert.NoError(t, CheckRateLimit(testInstance, AuthType))
-	})
+			t.Run("LoginRateNotExceeded", func(t *testing.T) {
+				require.NoError(t, CheckRateLimit(testInstance, AuthType))
+			})
 
-	t.Run("LoginRateExceededRedis", func(t *testing.T) {
-		opts, _ := redis.ParseURL(redisURL)
-		client := redis.NewClient(opts)
-		globalCounter = NewRedis(client)
-		client.Del(context.Background(), "auth:"+testInstance.DomainName())
-		for i := 1; i <= 1000; i++ {
-			assert.NoError(t, CheckRateLimit(testInstance, AuthType))
-		}
-		assert.Error(t, CheckRateLimit(testInstance, AuthType))
-	})
+			t.Run("LoginRateExceeded", func(t *testing.T) {
+				// Take into account the call above
+				for i := 1; i < 1000; i++ {
+					require.NoError(t, CheckRateLimit(testInstance, AuthType))
+				}
+				err := CheckRateLimit(testInstance, AuthType)
+				require.Error(t, err)
+			})
 
-	t.Run("2FAGenerationNotExceededMem", func(t *testing.T) {
-		globalCounter = NewInMemory()
-		assert.NoError(t, CheckRateLimit(testInstance, TwoFactorGenerationType))
-	})
+			t.Run("2FAGenerationNotExceeded", func(t *testing.T) {
+				require.NoError(t, CheckRateLimit(testInstance, TwoFactorGenerationType))
+			})
 
-	t.Run("2FAGenerationExceededMem", func(t *testing.T) {
-		globalCounter = NewInMemory()
-		for i := 1; i <= 20; i++ {
-			assert.NoError(t, CheckRateLimit(testInstance, TwoFactorGenerationType))
-		}
-		err := CheckRateLimit(testInstance, TwoFactorGenerationType)
-		assert.Error(t, err)
-	})
+			t.Run("2FAGenerationExceeded", func(t *testing.T) {
+				// Take into account the call above
+				for i := 1; i < 20; i++ {
+					require.NoError(t, CheckRateLimit(testInstance, TwoFactorGenerationType))
+				}
 
-	t.Run("2FAGenerationNotExceededRedis", func(t *testing.T) {
-		opts, _ := redis.ParseURL(redisURL)
-		client := redis.NewClient(opts)
-		client.Del(context.Background(), "two-factor-generation:"+testInstance.DomainName())
-		globalCounter = NewRedis(client)
-		assert.NoError(t, CheckRateLimit(testInstance, TwoFactorGenerationType))
-	})
+				err := CheckRateLimit(testInstance, TwoFactorGenerationType)
+				require.Error(t, err)
+			})
 
-	t.Run("2FAGenerationExceededRedis", func(t *testing.T) {
-		opts, _ := redis.ParseURL(redisURL)
-		client := redis.NewClient(opts)
-		globalCounter = NewRedis(client)
-		client.Del(context.Background(), "two-factor-generation:"+testInstance.DomainName())
-		for i := 1; i <= 20; i++ {
-			assert.NoError(t, CheckRateLimit(testInstance, TwoFactorGenerationType))
-		}
-		assert.Error(t, CheckRateLimit(testInstance, TwoFactorGenerationType))
-	})
+			t.Run("2FARateExceededNotExceeded", func(t *testing.T) {
+				require.NoError(t, CheckRateLimit(testInstance, TwoFactorType))
+			})
 
-	t.Run("2FARateExceededNotExceededMem", func(t *testing.T) {
-		globalCounter = NewInMemory()
-		assert.NoError(t, CheckRateLimit(testInstance, TwoFactorType))
-	})
+			t.Run("2FARateExceeded", func(t *testing.T) {
+				// Take into account the call above
+				for i := 1; i < 10; i++ {
+					require.NoError(t, CheckRateLimit(testInstance, TwoFactorType))
+				}
 
-	t.Run("2FARateExceededMem", func(t *testing.T) {
-		globalCounter = NewInMemory()
-		for i := 1; i <= 10; i++ {
-			assert.NoError(t, CheckRateLimit(testInstance, TwoFactorType))
-		}
-		err := CheckRateLimit(testInstance, TwoFactorType)
-		assert.Error(t, err)
-	})
-
-	t.Run("2FANotExceededRedis", func(t *testing.T) {
-		opts, _ := redis.ParseURL(redisURL)
-		client := redis.NewClient(opts)
-		client.Del(context.Background(), "two-factor:"+testInstance.DomainName())
-		globalCounter = NewRedis(client)
-		assert.NoError(t, CheckRateLimit(testInstance, TwoFactorType))
-	})
-
-	t.Run("2FAExceededRedis", func(t *testing.T) {
-		opts, _ := redis.ParseURL(redisURL)
-		client := redis.NewClient(opts)
-		globalCounter = NewRedis(client)
-		client.Del(context.Background(), "two-factor:"+testInstance.DomainName())
-		for i := 1; i <= 10; i++ {
-			assert.NoError(t, CheckRateLimit(testInstance, TwoFactorType))
-		}
-		assert.Error(t, CheckRateLimit(testInstance, TwoFactorType))
-	})
+				err := CheckRateLimit(testInstance, TwoFactorType)
+				require.Error(t, err)
+			})
+		})
+	}
 }


### PR DESCRIPTION
This ensure use that both the implementation have the exact same behavior. It will also make easier the new tests and the new implems.