### PR TITLE
Optimize counting the number of files in a sharing

### DIFF
--- a/model/sharing/indexer.go
+++ b/model/sharing/indexer.go
@@ -143,8 +143,8 @@ func (s *sharingIndexer) TrashUsage() (int64, error) {
 	return s.indexer.TrashUsage()
 }
 
-func (s *sharingIndexer) DirSize(doc *vfs.DirDoc) (int64, error) {
-	return s.indexer.DirSize(doc)
+func (s *sharingIndexer) DirSizeAndCount(doc *vfs.DirDoc) (int64, int64, error) {
+	return s.indexer.DirSizeAndCount(doc)
 }
 
 func (s *sharingIndexer) CreateFileDoc(doc *vfs.FileDoc) error {

--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -59,7 +59,7 @@ type Sharing struct {
 	PreviewPath string    `json:"preview_path,omitempty"`
 	CreatedAt   time.Time `json:"created_at"`
 	UpdatedAt   time.Time `json:"updated_at"`
-	NbFiles     int       `json:"initial_number_of_files_to_sync,omitempty"`
+	NbFiles     int64     `json:"initial_number_of_files_to_sync,omitempty"`
 	Initial     bool      `json:"initial_sync,omitempty"`
 	ShortcutID  string    `json:"shortcut_id,omitempty"`
 	MovedFrom   string    `json:"moved_from,omitempty"`

--- a/model/sharing/upload.go
+++ b/model/sharing/upload.go
@@ -626,7 +626,7 @@ func (s *Sharing) UploadNewFile(inst *instance.Instance, target *FileDocWithRevi
 // countReceivedFiles counts the number of files received during the initial
 // sync, and pushs an event to the real-time system with this count
 func (s *Sharing) countReceivedFiles(inst *instance.Instance) {
-	count := 0
+	var count int64
 	req := &couchdb.ViewRequest{
 		Key:         s.SID,
 		IncludeDocs: true,

--- a/model/vfs/couchdb_indexer.go
+++ b/model/vfs/couchdb_indexer.go
@@ -84,7 +84,11 @@ func (c *couchdbIndexer) FilesUsage() (int64, error) {
 		return 0, nil
 	}
 	// Reduce of _sum should give us a number value
-	used, ok := doc.Rows[0].Value.(float64)
+	stats, ok := doc.Rows[0].Value.(map[string]interface{})
+	if !ok {
+		return 0, ErrWrongCouchdbState
+	}
+	used, ok := stats["sum"].(float64)
 	if !ok {
 		return 0, ErrWrongCouchdbState
 	}
@@ -147,7 +151,10 @@ func (c *couchdbIndexer) prepareFileDoc(doc *FileDoc) error {
 	return nil
 }
 
-func (c *couchdbIndexer) DirSize(doc *DirDoc) (int64, error) {
+// DirSizeAndCount returns the size taken by the directory and the files inside
+// it (including in the children directories), and also the number of files
+// inside it.
+func (c *couchdbIndexer) DirSizeAndCount(doc *DirDoc) (int64, int64, error) {
 	start := doc.Fullpath + "/"
 	stop := doc.Fullpath + "0" // 0 is the next ascii character after /
 	if doc.DocID == consts.RootDirID {
@@ -170,7 +177,7 @@ func (c *couchdbIndexer) DirSize(doc *DirDoc) (int64, error) {
 	var children []couchdb.JSONDoc
 	err := couchdb.FindDocs(c.db, consts.Files, req, &children)
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 	keys := make([]interface{}, len(children)+1)
 	keys[0] = doc.DocID
@@ -186,22 +193,31 @@ func (c *couchdbIndexer) DirSize(doc *DirDoc) (int64, error) {
 		Reduce: true,
 	}, &resp)
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 	if len(resp.Rows) == 0 {
-		return 0, nil
+		return 0, 0, nil
 	}
 
-	// Reduce of _sum should give us a number value
-	var size int64
+	// Reduce of _stats should give us `sum` and `count` fields with number values
+	var size, count int64
 	for _, row := range resp.Rows {
-		value, ok := row.Value.(float64)
+		stats, ok := row.Value.(map[string]interface{})
 		if !ok {
-			return 0, ErrWrongCouchdbState
+			return 0, 0, ErrWrongCouchdbState
+		}
+		value, ok := stats["sum"].(float64)
+		if !ok {
+			return 0, 0, ErrWrongCouchdbState
 		}
 		size += int64(value)
+		value, ok = stats["count"].(float64)
+		if !ok {
+			return 0, 0, ErrWrongCouchdbState
+		}
+		count += int64(value)
 	}
-	return size, nil
+	return size, count, nil
 }
 
 func (c *couchdbIndexer) CreateFileDoc(doc *FileDoc) error {

--- a/model/vfs/vfs.go
+++ b/model/vfs/vfs.go
@@ -168,8 +168,8 @@ type Indexer interface {
 	// TrashUsage computes the total size of the files contained in the trash.
 	TrashUsage() (int64, error)
 	// DirSize returns the size of a directory, including files in
-	// subdirectories.
-	DirSize(doc *DirDoc) (int64, error)
+	// subdirectories, and the number of files.
+	DirSizeAndCount(doc *DirDoc) (int64, int64, error)
 
 	// CreateFileDoc creates and add in the index a new file document.
 	CreateFileDoc(doc *FileDoc) error

--- a/pkg/couchdb/index.go
+++ b/pkg/couchdb/index.go
@@ -11,7 +11,7 @@ import (
 
 // IndexViewsVersion is the version of current definition of views & indexes.
 // This number should be incremented when this file changes.
-const IndexViewsVersion int = 33
+const IndexViewsVersion int = 34
 
 // Indexes is the index list required by an instance to run properly.
 var Indexes = []*mango.Index{
@@ -69,7 +69,7 @@ function(doc) {
   }
 }
 `,
-	Reduce: "_sum",
+	Reduce: "_stats",
 }
 
 // OldVersionsDiskUsageView is the view used for computing the disk usage for

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -812,7 +812,7 @@ func GetDirSize(c echo.Context) error {
 		return err
 	}
 
-	size, err := fs.DirSize(dir)
+	size, _, err := fs.DirSizeAndCount(dir)
 	if err != nil {
 		return WrapVfsError(err)
 	}


### PR DESCRIPTION
When the stack sends a request for creating a sharing, it includes the number of files in the sharing. Counting the number of files may have been slow because we were walking the VFS to count the files. We have optimized it by reusing a CouchDB view.