### PR TITLE
Add some cache to the CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,18 +48,13 @@ jobs:
           EOF
           DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --force-yes couchdb=${{ matrix.couchdb-version }}*
           echo "COZY_COUCHDB_URL=http://admin:password@localhost:5984/" >> $GITHUB_ENV
-      - name: Install Go
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Setup Go
         uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Install
-        run: |
-          git config --global user.email "github@spam.cozycloud.cc"
-          git config --global user.name "github actions"
-          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-          go install
+          cache: true
       - name: Lint
         if: ${{ matrix.lint }}
         run: |


### PR DESCRIPTION
This cache option follow the official github documentation: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go#caching-dependencies