### PR TITLE
Add a previously remove `time.Sleep` in `/web/files` tests

### DIFF
--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -3095,6 +3095,10 @@ func TestFiles(t *testing.T) {
 		large := links.Value("large").String().NotEmpty().Raw()
 		medium := links.Value("medium").String().NotEmpty().Raw()
 		small := links.Value("small").String().NotEmpty().Raw()
+
+		// Wait for tiny thumbnail generation
+		time.Sleep(time.Second)
+
 		tiny := links.Value("tiny").String().NotEmpty().Raw()
 
 		// Large, medium, and small are not generated automatically


### PR DESCRIPTION
Without this sleep the `tiny` thumbnail don't have the time to be generated

Historique: https://github.com/cozy/cozy-stack/blob/3df818ac10a1f07a42317c13edb54ef5343b111d/web/files/files_test.go#L3111