### PR TITLE
Remove the global `instance.Instance` variable inside the tests

### DIFF
--- a/model/intent/intents_test.go
+++ b/model/intent/intents_test.go
@@ -14,8 +14,6 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-var ins *instance.Instance
-
 func TestIntents(t *testing.T) {
 	if testing.Short() {
 		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
@@ -23,7 +21,7 @@ func TestIntents(t *testing.T) {
 
 	config.UseTestFile()
 
-	ins = &instance.Instance{Domain: "cozy.example.net"}
+	ins := &instance.Instance{Domain: "cozy.example.net"}
 
 	err := couchdb.ResetDB(ins, consts.Apps)
 	require.NoError(t, err)

--- a/model/move/export_test.go
+++ b/model/move/export_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cozy/cozy-stack/model/instance"
 	"github.com/cozy/cozy-stack/model/vfs"
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
@@ -15,8 +14,6 @@ import (
 	"github.com/cozy/cozy-stack/tests/testutils"
 	"github.com/stretchr/testify/assert"
 )
-
-var inst *instance.Instance
 
 type Stats struct {
 	TotalSize int64
@@ -34,7 +31,7 @@ func TestExport(t *testing.T) {
 	rand.Seed(seed)
 	config.UseTestFile()
 	setup := testutils.NewSetup(t, t.Name())
-	inst = setup.GetTestInstance()
+	inst := setup.GetTestInstance()
 
 	t.Run("ExportFiles", func(t *testing.T) {
 		fs := inst.VFS()

--- a/model/oauth/client_test.go
+++ b/model/oauth/client_test.go
@@ -15,8 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var testInstance *instance.Instance
-
 var c = &oauth.Client{
 	CouchID: "my-client-id",
 }
@@ -28,7 +26,7 @@ func TestClient(t *testing.T) {
 
 	config.UseTestFile()
 	setup := testutils.NewSetup(t, t.Name())
-	testInstance = setup.GetTestInstance()
+	testInstance := setup.GetTestInstance()
 
 	t.Run("CreateJWT", func(t *testing.T) {
 		tokenString, err := c.CreateJWT(testInstance, "test", "foo:read")

--- a/web/middlewares/user_agent_test.go
+++ b/web/middlewares/user_agent_test.go
@@ -17,8 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var ins *instance.Instance
-
 type stupidRenderer struct{}
 
 func TestUser(t *testing.T) {
@@ -45,7 +43,7 @@ func TestUser(t *testing.T) {
 		req.Header.Set(echo.HeaderAccept, "text/html")
 		req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:96.0) Gecko/20100101 Firefox/96.0") // Firefox
 
-		ins = &instance.Instance{Domain: "cozy.local", Locale: "en"}
+		ins := &instance.Instance{Domain: "cozy.local", Locale: "en"}
 
 		rec := httptest.NewRecorder()
 		c := e.NewContext(req, rec)

--- a/web/remote/remote_test.go
+++ b/web/remote/remote_test.go
@@ -1,7 +1,6 @@
 package remote
 
 import (
-	"net/http/httptest"
 	"testing"
 
 	"github.com/cozy/cozy-stack/model/instance"
@@ -14,10 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var testInstance *instance.Instance
-var ts *httptest.Server
-var token string
-
 func TestRemote(t *testing.T) {
 	if testing.Short() {
 		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
@@ -27,10 +22,10 @@ func TestRemote(t *testing.T) {
 	testutils.NeedCouchdb(t)
 	setup := testutils.NewSetup(t, t.Name())
 
-	testInstance = setup.GetTestInstance()
-	token = generateAppToken(testInstance, "answers", "org.wikidata.entity")
+	testInstance := setup.GetTestInstance()
+	token := generateAppToken(testInstance, "answers", "org.wikidata.entity")
 
-	ts = setup.GetTestServer("/remote", Routes)
+	ts := setup.GetTestServer("/remote", Routes)
 	t.Cleanup(ts.Close)
 
 	t.Run("RemoteGET", func(t *testing.T) {


### PR DESCRIPTION
The tests seems to encounter some issues where two tests are using the same global variable creating randoms side effects. 

This review propose to avoid this kind of issue by moving as much variable inside the tests scope. This is also a requirement for running tests in parallel. This is not possible yet but it could be a great improvement in the future.

Bonus side effect: It allow us to detect unused variables and remove them.