### PR TITLE
Add a lint job for go files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
           # Recommended version
           - go-version: '1.20.x'
             couchdb-version: '3.3.1'
-            lint: true
           # More exotic version
           - go-version: '1.18.x'
             couchdb-version: '3.2.2'
@@ -55,10 +54,6 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
           cache: true
-      - name: Lint
-        if: ${{ matrix.lint }}
-        run: |
-          make jslint
       - name: Unit tests
         run: |
           make unit-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Lint
         if: ${{ matrix.lint }}
         run: |
-          make lint jslint
+          make jslint
       - name: Unit tests
         run: |
           make unit-tests

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -1,0 +1,26 @@
+name: Lint go
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '**.go'
+  pull_request:
+    paths:
+      - '**.go'
+permissions:
+  contents: read
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.20'
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+          version: latest

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -47,13 +47,16 @@ jobs:
           EOF
           DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --force-yes couchdb=${{ matrix.couchdb-version }}*
           echo "COZY_COUCHDB_URL=http://admin:password@localhost:5984/" >> $GITHUB_ENV
+
       - name: Checkout repository
         uses: actions/checkout@v3
+
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
           cache: true
+
       - name: Unit tests
         run: |
           make unit-tests

--- a/.github/workflows/js-lint.yml
+++ b/.github/workflows/js-lint.yml
@@ -1,0 +1,27 @@
+name: Lint js
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '**.js'
+  pull_request:
+    paths:
+      - '**.js'
+permissions:
+  contents: read
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: npm ci # or yarn install
+      - uses: sibiraj-s/action-eslint@v2
+        with:
+          eslint-args: '--ignore-path=.gitignore --quiet'
+          extensions: 'js,jsx,ts,tsx'
+          annotations: true


### PR DESCRIPTION
This lint job will run the golangci-lint tool on all the go files

This job have been done following the following documentation: https://github.com/golangci/golangci-lint-action