### PR TITLE
Remove an unwanted param in a test assert

### DIFF
--- a/model/sharing/replicator_test.go
+++ b/model/sharing/replicator_test.go
@@ -200,7 +200,7 @@ func TestReplicator(t *testing.T) {
 			assert.Equal(t, 2, twoRef.Infos[s.SID].Rule)
 			if id == updateID {
 				assert.Equal(t, updateRev, twoRef.Revisions.Rev)
-				assert.Equal(t, inst, updateDoc.Rev(), twoRef.Revisions.Branches[0].Rev)
+				assert.Equal(t, updateDoc.Rev(), twoRef.Revisions.Branches[0].Rev)
 			}
 		}
 


### PR DESCRIPTION
This param seems to have been added by an incorrect `sed` command

Fix issues from #3796
