### PR TITLE
Move the vault logic into a new package

### DIFF
--- a/model/account/credentials.go
+++ b/model/account/credentials.go
@@ -63,7 +63,7 @@ func EncryptCredentialsWithKey(encryptorKey *keymgmt.NACLKey, login, password st
 // EncryptCredentialsData takes any json encodable data and encode and encrypts
 // it using the vault public key.
 func EncryptCredentialsData(data interface{}) (string, error) {
-	encryptorKey := config.GetVault().CredentialsEncryptorKey()
+	encryptorKey := config.GetKeyring().CredentialsEncryptorKey()
 	if encryptorKey == nil {
 		return "", errCannotEncrypt
 	}
@@ -97,7 +97,7 @@ func EncryptBufferWithKey(encryptorKey *keymgmt.NACLKey, buf []byte) ([]byte, er
 // EncryptCredentials encrypts the given credentials with the specified encryption
 // key.
 func EncryptCredentials(login, password string) (string, error) {
-	encryptorKey := config.GetVault().CredentialsEncryptorKey()
+	encryptorKey := config.GetKeyring().CredentialsEncryptorKey()
 	if encryptorKey == nil {
 		return "", errCannotEncrypt
 	}
@@ -107,7 +107,7 @@ func EncryptCredentials(login, password string) (string, error) {
 // DecryptCredentials takes an encrypted credentials, constiting of a login /
 // password pair, and decrypts it using the vault private key.
 func DecryptCredentials(encryptedData string) (login, password string, err error) {
-	decryptorKey := config.GetVault().CredentialsDecryptorKey()
+	decryptorKey := config.GetKeyring().CredentialsDecryptorKey()
 	if decryptorKey == nil {
 		return "", "", errCannotDecrypt
 	}
@@ -164,7 +164,7 @@ func DecryptCredentialsWithKey(decryptorKey *keymgmt.NACLKey, encryptedCreds []b
 // DecryptCredentialsData takes an encryted buffer and decrypts and decode its
 // content.
 func DecryptCredentialsData(encryptedData string) (interface{}, error) {
-	decryptorKey := config.GetVault().CredentialsDecryptorKey()
+	decryptorKey := config.GetKeyring().CredentialsDecryptorKey()
 	if decryptorKey == nil {
 		return nil, errCannotDecrypt
 	}
@@ -219,7 +219,7 @@ func DecryptBufferWithKey(decryptorKey *keymgmt.NACLKey, encryptedBuffer []byte)
 // Encrypts sensitive fields inside the account. The document
 // is modified in place.
 func Encrypt(doc couchdb.JSONDoc) bool {
-	if config.GetVault().CredentialsEncryptorKey() != nil {
+	if config.GetKeyring().CredentialsEncryptorKey() != nil {
 		return encryptMap(doc.M)
 	}
 	return false
@@ -228,7 +228,7 @@ func Encrypt(doc couchdb.JSONDoc) bool {
 // Decrypts sensitive fields inside the account. The document
 // is modified in place.
 func Decrypt(doc couchdb.JSONDoc) bool {
-	if config.GetVault().CredentialsDecryptorKey() != nil {
+	if config.GetKeyring().CredentialsDecryptorKey() != nil {
 		return decryptMap(doc.M)
 	}
 	return false

--- a/model/account/credentials_test.go
+++ b/model/account/credentials_test.go
@@ -176,12 +176,12 @@ func TestRandomBitFlipsBuffer(t *testing.T) {
 	_, err := io.ReadFull(cryptorand.Reader, plainBuffer)
 	require.NoError(t, err)
 
-	original, err := EncryptBufferWithKey(config.GetVault().CredentialsEncryptorKey(), plainBuffer)
+	original, err := EncryptBufferWithKey(config.GetKeyring().CredentialsEncryptorKey(), plainBuffer)
 	require.NoError(t, err)
 
 	flipped := make([]byte, len(original))
 	copy(flipped, original)
-	testBuffer, err := DecryptBufferWithKey(config.GetVault().CredentialsDecryptorKey(), flipped)
+	testBuffer, err := DecryptBufferWithKey(config.GetKeyring().CredentialsDecryptorKey(), flipped)
 	require.NoError(t, err)
 
 	assert.True(t, bytes.Equal(plainBuffer, testBuffer))
@@ -208,7 +208,7 @@ func TestRandomBitFlipsBuffer(t *testing.T) {
 			mask := byte(0x1 << uint(flipValue%8))
 			flipped[flipValue/8] ^= mask
 		}
-		_, err := DecryptBufferWithKey(config.GetVault().CredentialsDecryptorKey(), flipped)
+		_, err := DecryptBufferWithKey(config.GetKeyring().CredentialsDecryptorKey(), flipped)
 		if !assert.Error(t, err) {
 			t.Fatalf("Failed with flips %v", flipsSet)
 			return

--- a/pkg/keyring/service.go
+++ b/pkg/keyring/service.go
@@ -1,0 +1,89 @@
+package keyring
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/cozy/cozy-stack/pkg/keymgmt"
+)
+
+var (
+	ErrFieldRequired = errors.New("field required")
+)
+
+// Keyring handle the encryption/decryption keys
+type Keyring interface {
+	// CredentialsEncryptorKey returns the key used to encrypt credentials values,
+	// stored in accounts.
+	CredentialsEncryptorKey() *keymgmt.NACLKey
+	// CredentialsDecryptorKey returns the key used to decrypt credentials values,
+	// stored in accounts.
+	CredentialsDecryptorKey() *keymgmt.NACLKey
+}
+
+// Config used to setup a [Keyring] service.
+type Config struct {
+	EncryptorKeyPath string `mapstructure:"credentials_encryptor_key"`
+	DecryptorKeyPath string `mapstructure:"credentials_decryptor_key"`
+}
+
+// Service contains security keys used for various encryption or signing of
+// critical assets.
+type Service struct {
+	credsEncryptor *keymgmt.NACLKey
+	credsDecryptor *keymgmt.NACLKey
+}
+
+func NewFromConfig(conf Config) (Keyring, error) {
+	if conf.DecryptorKeyPath == "" || conf.EncryptorKeyPath == "" {
+		return NewStub()
+	}
+
+	return NewService(conf)
+}
+
+// NewService instantiate a new [Keyring].
+func NewService(conf Config) (*Service, error) {
+	if conf.EncryptorKeyPath == "" {
+		return nil, fmt.Errorf("credentials_encryptor_key: %w", ErrFieldRequired)
+	}
+
+	if conf.DecryptorKeyPath == "" {
+		return nil, fmt.Errorf("credentials_decryptor_key: %w", ErrFieldRequired)
+	}
+
+	credsEncryptor, err := decodeKeyFromPath(conf.EncryptorKeyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	credsDecryptor, err := decodeKeyFromPath(conf.DecryptorKeyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Service{credsEncryptor, credsDecryptor}, nil
+}
+
+func (s *Service) CredentialsEncryptorKey() *keymgmt.NACLKey {
+	return s.credsEncryptor
+}
+
+func (s *Service) CredentialsDecryptorKey() *keymgmt.NACLKey {
+	return s.credsDecryptor
+}
+
+func decodeKeyFromPath(path string) (*keymgmt.NACLKey, error) {
+	keyBytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file %q: %w", path, err)
+	}
+
+	creds, err := keymgmt.UnmarshalNACLKey(keyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal NACL key: %w", err)
+	}
+
+	return creds, nil
+}

--- a/pkg/keyring/stub.go
+++ b/pkg/keyring/stub.go
@@ -1,0 +1,41 @@
+package keyring
+
+import (
+	"fmt"
+
+	"github.com/cozy/cozy-stack/pkg/keymgmt"
+	"github.com/cozy/cozy-stack/pkg/utils"
+)
+
+// Stub is a minimal *UNSECURE* implementation of [Keyring].
+//
+// As the credentials should remain the same between several
+// executions of the stack, we are using some credentials generated
+// with a seed defined at build time. It is obviously not a good idea
+// from a security point of view, and it should not be used to store
+// sensible data. This implem is not safe and should never be used in
+// production.
+type Stub struct {
+	credsEncryptor *keymgmt.NACLKey
+	credsDecryptor *keymgmt.NACLKey
+}
+
+// NewStub instantiate a new [Stub].
+func NewStub() (*Stub, error) {
+	r := utils.NewSeededRand(42)
+
+	credsEncryptor, credsDecryptor, err := keymgmt.GenerateKeyPair(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate NACL key pair: %w", err)
+	}
+
+	return &Stub{credsEncryptor, credsDecryptor}, nil
+}
+
+func (s *Stub) CredentialsEncryptorKey() *keymgmt.NACLKey {
+	return s.credsEncryptor
+}
+
+func (s *Stub) CredentialsDecryptorKey() *keymgmt.NACLKey {
+	return s.credsDecryptor
+}


### PR DESCRIPTION
Previously the vault logic was living inside the `/pkg/config` package in a global alongs with other config stuff.

This PR goal is to make a clear separation between the vault logic, where some important secrets are handled and the config logic. It also remove the global variable and move to the same initialization logic than the cache or lock package: It create an object and put it into the `Config` object.