### PR TITLE
Fix sending push notification to flagship app

### DIFF
--- a/worker/push/push.go
+++ b/worker/push/push.go
@@ -209,7 +209,11 @@ func push(ctx *job.WorkerContext, c *oauth.Client, msg *center.PushMessage) erro
 // Firebase Cloud Messaging HTTP Protocol
 // https://firebase.google.com/docs/cloud-messaging/http-server-ref
 func pushToFirebase(ctx *job.WorkerContext, c *oauth.Client, msg *center.PushMessage) error {
-	client := getFirebaseClient(msg.Slug(), ctx.Instance.ContextName)
+	slug := msg.Slug()
+	if c.Flagship {
+		slug = ""
+	}
+	client := getFirebaseClient(slug, ctx.Instance.ContextName)
 
 	if client == nil {
 		ctx.Logger().Warn("Could not send android notification: not configured")


### PR DESCRIPTION
If an application is sending a push notification, and the user doesn't have the mobile app for it, but has the flagship app, the stack will fallback to send the push notification to the flagship app. But the firebase configuration can be different for the mobile app and the flagship app. This commit fixes the firebase configuration used when fallbacking to the flagship app.