### PR TITLE
Rename the `CI` job to `Go tests`

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Go tests
 on:
   push:
     branches:


### PR DESCRIPTION
This will make the job title more explicit