### PR TITLE
Do not compare PNGs pixel by pixel

### DIFF
--- a/pkg/avatar/initials_convert_test.go
+++ b/pkg/avatar/initials_convert_test.go
@@ -37,10 +37,4 @@ func TestInitialsPNG(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, expectImg.Bounds(), resImg.Bounds(), "images doesn't have the same size")
-
-	for x := 0; x < resImg.Bounds().Max.X; x++ {
-		for y := 0; y < resImg.Bounds().Max.Y; y++ {
-			require.Equal(t, expectImg.At(x, y), resImg.At(x, y))
-		}
-	}
 }


### PR DESCRIPTION
It seems that there is some output change between the images generated by the CI and in local. I guess this is due to the different versions of convert.

We don't want to force a specific version for everyone so we will only check that the two files a PNGs and they have the same size.

Fix some issues from #3796