### PR TITLE
Add the errname linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -46,6 +46,7 @@ linters:
   enable:
     - bidichk 
     - exportloopref 
+    - errname
     - gocritic
     - gofmt
     - govet

--- a/model/job/errors.go
+++ b/model/job/errors.go
@@ -35,12 +35,12 @@ var (
 	ErrNotCronTrigger = errors.New("Invalid type for trigger (@cron expected)")
 )
 
-// ErrBadTrigger is an error conveying the information of a trigger that is not
+// BadTriggerError is an error conveying the information of a trigger that is not
 // valid, and could be deleted.
-type ErrBadTrigger struct {
+type BadTriggerError struct {
 	Err error
 }
 
-func (e ErrBadTrigger) Error() string {
+func (e BadTriggerError) Error() string {
 	return e.Err.Error()
 }

--- a/model/job/worker.go
+++ b/model/job/worker.go
@@ -341,7 +341,7 @@ func (w *Worker) work(workerID string, closed chan<- struct{}) {
 		// Delete the trigger associated with the job (if any) when we receive a
 		// ErrBadTrigger.
 		if job.TriggerID != "" && globalJobSystem != nil {
-			if _, ok := errRun.(ErrBadTrigger); ok {
+			if _, ok := errRun.(BadTriggerError); ok {
 				_ = globalJobSystem.DeleteTrigger(job, job.TriggerID)
 			}
 		}
@@ -513,7 +513,7 @@ func (t *task) nextDelay(prevError error) (bool, time.Duration, time.Duration) {
 	// for certain kinds of errors, we do not have a retry since these error
 	// cannot be recovered from
 	{
-		if _, ok := prevError.(ErrBadTrigger); ok {
+		if _, ok := prevError.(BadTriggerError); ok {
 			return false, 0, 0
 		}
 		switch prevError {

--- a/worker/exec/konnector.go
+++ b/worker/exec/konnector.go
@@ -204,7 +204,7 @@ func (w *konnectorWorker) PrepareWorkDir(ctx *job.WorkerContext, i *instance.Ins
 	w.man, err = app.GetKonnectorBySlugAndUpdate(i, slug,
 		app.Copier(consts.KonnectorType, i), i.Registries())
 	if errors.Is(err, app.ErrNotFound) {
-		return "", cleanDir, job.ErrBadTrigger{Err: err}
+		return "", cleanDir, job.BadTriggerError{Err: err}
 	} else if err != nil {
 		return "", cleanDir, err
 	}
@@ -215,7 +215,7 @@ func (w *konnectorWorker) PrepareWorkDir(ctx *job.WorkerContext, i *instance.Ins
 		acc = &account.Account{}
 		err = couchdb.GetDoc(i, consts.Accounts, msg.Account, acc)
 		if couchdb.IsNotFoundError(err) {
-			return "", cleanDir, job.ErrBadTrigger{Err: err}
+			return "", cleanDir, job.BadTriggerError{Err: err}
 		}
 	}
 

--- a/worker/exec/service.go
+++ b/worker/exec/service.go
@@ -55,7 +55,7 @@ func (w *serviceWorker) PrepareWorkDir(ctx *job.WorkerContext, i *instance.Insta
 		app.Copier(consts.WebappType, i), i.Registries())
 	if err != nil {
 		if errors.Is(err, app.ErrNotFound) {
-			err = job.ErrBadTrigger{Err: err}
+			err = job.BadTriggerError{Err: err}
 		}
 		return
 	}
@@ -88,7 +88,7 @@ func (w *serviceWorker) PrepareWorkDir(ctx *job.WorkerContext, i *instance.Insta
 		}
 	}
 	if !ok {
-		err = job.ErrBadTrigger{Err: fmt.Errorf("Service %q was not found", name)}
+		err = job.BadTriggerError{Err: fmt.Errorf("Service %q was not found", name)}
 		return
 	}
 	// Check if the trigger is orphan
@@ -98,17 +98,17 @@ func (w *serviceWorker) PrepareWorkDir(ctx *job.WorkerContext, i *instance.Insta
 			var tInfos job.TriggerInfos
 			err = couchdb.GetDoc(i, consts.Triggers, triggerID, &tInfos)
 			if err != nil {
-				err = job.ErrBadTrigger{Err: fmt.Errorf("Trigger %q not found", triggerID)}
+				err = job.BadTriggerError{Err: fmt.Errorf("Trigger %q not found", triggerID)}
 				return
 			}
 			var msg ServiceOptions
 			err = json.Unmarshal(tInfos.Message, &msg)
 			if err != nil {
-				err = job.ErrBadTrigger{Err: fmt.Errorf("Trigger %q has bad message structure", triggerID)}
+				err = job.BadTriggerError{Err: fmt.Errorf("Trigger %q has bad message structure", triggerID)}
 				return
 			}
 			if msg.Name != name {
-				err = job.ErrBadTrigger{Err: fmt.Errorf("Trigger %q is orphan", triggerID)}
+				err = job.BadTriggerError{Err: fmt.Errorf("Trigger %q is orphan", triggerID)}
 				return
 			}
 		}


### PR DESCRIPTION
This linter enforce a naming convention proposed by the golang team: https://github.com/golang/go/wiki/Errors#naming

- All the struct representing an errors are name `XXXError`
- All the errors sentinel are named `ErrXXXX`