### PR TITLE
Fix trigger webhook integration test

### DIFF
--- a/tests/integration/tests/trigger_webhook.rb
+++ b/tests/integration/tests/trigger_webhook.rb
@@ -10,7 +10,7 @@ describe "A webhook trigger" do
     # No debounce
     inst = Instance.create
     source_url = "file://" + File.expand_path("../konnector", __dir__)
-    konnector_name = Faker::Creature::Cat.name.downcase
+    konnector_name = Faker::Creature::Cat.name.downcase.delete(" ")
     inst.install_konnector konnector_name, source_url
     account = Account.create inst, type: konnector_name, name: "1_#{Faker::TvShows::DrWho.character}"
     args = { "konnector" => konnector_name, "account" => account.couch_id, "foo" => "bar" }


### PR DESCRIPTION
It may happen that the konnector name has a space, and a space is forbidden in the slug. Let's ensure that we have no space in the konnector name.