### PR TITLE
feat: Add Hourly trigger

### DIFF
--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -29,6 +29,7 @@ Jobs can be launched by different types of triggers:
 - `@at` to schedule a one-time job executed after at a specific time in the
   future
 - `@in` to schedule a one-time job executed after a specific amount of time
+- `@hourly` to schedule jobs that run once an hour
 - `@daily` to schedule jobs that run once a day
 - `@weekly` to schedule jobs that run once a week
 - `@monthly` to schedule jobs that run once a month

--- a/model/job/scheduler.go
+++ b/model/job/scheduler.go
@@ -141,6 +141,8 @@ func fromTriggerInfos(infos *TriggerInfos) (Trigger, error) {
 		return NewAtTrigger(infos)
 	case "@in":
 		return NewInTrigger(infos)
+	case "@hourly":
+		return NewHourlyTrigger(infos)
 	case "@daily":
 		return NewDailyTrigger(infos)
 	case "@weekly":

--- a/model/job/trigger_cron.go
+++ b/model/job/trigger_cron.go
@@ -68,6 +68,13 @@ func NewDailyTrigger(infos *TriggerInfos) (*CronTrigger, error) {
 	return newPeriodicTrigger(infos, DailyKind)
 }
 
+// NewHourlyTrigger returns a new instance of CronTrigger given the specified
+// options as @hourly. It will take a random minute in the possible range to
+// spread the triggers from the same app manifest.
+func NewHourlyTrigger(infos *TriggerInfos) (*CronTrigger, error) {
+	return newPeriodicTrigger(infos, HourlyKind)
+}
+
 func newPeriodicTrigger(infos *TriggerInfos, frequency FrequencyKind) (*CronTrigger, error) {
 	spec, err := periodicParser.Parse(frequency, infos.Arguments)
 	if err != nil {


### PR DESCRIPTION
In order to be able to run a trigger hourly.
It was already possible to do it from the manifest but not from the API.