### PR TITLE
Do not change the CouchDB views

### DIFF
--- a/model/sharing/indexer.go
+++ b/model/sharing/indexer.go
@@ -143,8 +143,8 @@ func (s *sharingIndexer) TrashUsage() (int64, error) {
 	return s.indexer.TrashUsage()
 }
 
-func (s *sharingIndexer) DirSizeAndCount(doc *vfs.DirDoc) (int64, int64, error) {
-	return s.indexer.DirSizeAndCount(doc)
+func (s *sharingIndexer) DirSize(doc *vfs.DirDoc) (int64, error) {
+	return s.indexer.DirSize(doc)
 }
 
 func (s *sharingIndexer) CreateFileDoc(doc *vfs.FileDoc) error {

--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -59,7 +59,7 @@ type Sharing struct {
 	PreviewPath string    `json:"preview_path,omitempty"`
 	CreatedAt   time.Time `json:"created_at"`
 	UpdatedAt   time.Time `json:"updated_at"`
-	NbFiles     int64     `json:"initial_number_of_files_to_sync,omitempty"`
+	NbFiles     int       `json:"initial_number_of_files_to_sync,omitempty"`
 	Initial     bool      `json:"initial_sync,omitempty"`
 	ShortcutID  string    `json:"shortcut_id,omitempty"`
 	MovedFrom   string    `json:"moved_from,omitempty"`

--- a/model/sharing/upload.go
+++ b/model/sharing/upload.go
@@ -626,7 +626,7 @@ func (s *Sharing) UploadNewFile(inst *instance.Instance, target *FileDocWithRevi
 // countReceivedFiles counts the number of files received during the initial
 // sync, and pushs an event to the real-time system with this count
 func (s *Sharing) countReceivedFiles(inst *instance.Instance) {
-	var count int64
+	count := 0
 	req := &couchdb.ViewRequest{
 		Key:         s.SID,
 		IncludeDocs: true,

--- a/model/vfs/vfs.go
+++ b/model/vfs/vfs.go
@@ -168,8 +168,8 @@ type Indexer interface {
 	// TrashUsage computes the total size of the files contained in the trash.
 	TrashUsage() (int64, error)
 	// DirSize returns the size of a directory, including files in
-	// subdirectories, and the number of files.
-	DirSizeAndCount(doc *DirDoc) (int64, int64, error)
+	// subdirectories.
+	DirSize(doc *DirDoc) (int64, error)
 
 	// CreateFileDoc creates and add in the index a new file document.
 	CreateFileDoc(doc *FileDoc) error

--- a/pkg/couchdb/index.go
+++ b/pkg/couchdb/index.go
@@ -11,7 +11,7 @@ import (
 
 // IndexViewsVersion is the version of current definition of views & indexes.
 // This number should be incremented when this file changes.
-const IndexViewsVersion int = 34
+const IndexViewsVersion int = 35
 
 // Indexes is the index list required by an instance to run properly.
 var Indexes = []*mango.Index{
@@ -69,7 +69,7 @@ function(doc) {
   }
 }
 `,
-	Reduce: "_stats",
+	Reduce: "_sum",
 }
 
 // OldVersionsDiskUsageView is the view used for computing the disk usage for

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -812,7 +812,7 @@ func GetDirSize(c echo.Context) error {
 		return err
 	}
 
-	size, _, err := fs.DirSizeAndCount(dir)
+	size, err := fs.DirSize(dir)
 	if err != nil {
 		return WrapVfsError(err)
 	}


### PR DESCRIPTION
In commit ce5f1b0219e189203954dddaef805f008bd4c217, we tried to optimize the counting of files by using a CouchDB view. We changed the reduce property, and I thought CouchDB wouldn't recalculate the whole view. But it does, and it is too heavy for our servers. So, let's use the view as it is today, even if it needs more code and is a bit less optimized.