### PR TITLE
Setup a package logger for all the packages

### DIFF
--- a/model/bi/api.go
+++ b/model/bi/api.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/cozy/cozy-stack/pkg/safehttp"
 )
 
@@ -80,8 +79,7 @@ func (c *apiClient) getNumberOfConnections(token string) (int, error) {
 		if len(msg) > 200 {
 			msg = msg[0:198] + "..."
 		}
-		logger.WithNamespace("bi").
-			Warnf("getNumberOfConnections [%d] cannot parse JSON %s: %s", res.StatusCode, msg, err)
+		plog.Warnf("getNumberOfConnections [%d] cannot parse JSON %s: %s", res.StatusCode, msg, err)
 		return 0, err
 	}
 	return data.Total, nil

--- a/model/bitwarden/domains.go
+++ b/model/bitwarden/domains.go
@@ -1,5 +1,9 @@
 package bitwarden
 
+import "github.com/cozy/cozy-stack/pkg/logger"
+
+var plog = logger.WithNamespace("bitwarden")
+
 // GlobalEquivalentDomainsType is an enum for global domain identifiers.
 type GlobalEquivalentDomainsType int
 

--- a/model/bitwarden/oauth.go
+++ b/model/bitwarden/oauth.go
@@ -121,7 +121,7 @@ func CreateAccessJWT(i *instance.Instance, c *oauth.Client) (string, error) {
 		Premium:  false,
 	})
 	if err != nil {
-		i.Logger().WithNamespace("oauth").
+		plog.WithDomain(i.Domain).
 			Errorf("Failed to create the bitwarden access token: %s", err)
 	}
 	return token, err
@@ -145,7 +145,7 @@ func CreateRefreshJWT(i *instance.Instance, c *oauth.Client) (string, error) {
 		Scope:  BitwardenScope,
 	})
 	if err != nil {
-		i.Logger().WithNamespace("oauth").
+		plog.WithDomain(i.Domain).
 			Errorf("Failed to create the bitwarden refresh token: %s", err)
 	}
 	return token, err

--- a/model/bitwarden/organization.go
+++ b/model/bitwarden/organization.go
@@ -123,13 +123,13 @@ func GetCozyOrganization(inst *instance.Instance, setting *settings.Settings) (*
 	}
 	orgKey, err := setting.OrganizationKey()
 	if err != nil {
-		inst.Logger().WithNamespace("bitwarden").
+		plog.WithDomain(inst.Domain).
 			Infof("Cannot read the organization key: %s", err)
 		return nil, err
 	}
 	key, err := crypto.EncryptWithRSA(setting.PublicKey, orgKey)
 	if err != nil {
-		inst.Logger().WithNamespace("bitwarden").
+		plog.WithDomain(inst.Domain).
 			Infof("Cannot encrypt with RSA: %s", err)
 		return nil, err
 	}
@@ -138,7 +138,7 @@ func GetCozyOrganization(inst *instance.Instance, setting *settings.Settings) (*
 	payload := []byte(consts.BitwardenCozyCollectionName)
 	name, err := crypto.EncryptWithAES256HMAC(orgKey[:32], orgKey[32:], payload, iv)
 	if err != nil {
-		inst.Logger().WithNamespace("bitwarden").
+		plog.WithDomain(inst.Domain).
 			Infof("Cannot encrypt with AES: %s", err)
 		return nil, err
 	}

--- a/model/bitwarden/settings/settings.go
+++ b/model/bitwarden/settings/settings.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/crypto"
+	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/cozy/cozy-stack/pkg/metadata"
 )
 
@@ -18,6 +19,8 @@ const DocTypeVersion = "1"
 
 // ErrMissingOrgKey is used when the organization key does not exist
 var ErrMissingOrgKey = errors.New("No organization key")
+
+var plog = logger.WithNamespace("bitwarden")
 
 // Settings is the struct that holds the birwarden settings
 type Settings struct {
@@ -164,8 +167,7 @@ func UpdateRevisionDate(inst *instance.Instance, settings *Settings) error {
 		err = settings.Save(inst)
 	}
 	if err != nil {
-		inst.Logger().WithNamespace("bitwarden").
-			Infof("Cannot update revision date: %s", err)
+		plog.WithDomain(inst.Domain).Infof("Cannot update revision date: %s", err)
 	}
 	return err
 }

--- a/model/feature/flag.go
+++ b/model/feature/flag.go
@@ -13,8 +13,11 @@ import (
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/cozy/cozy-stack/pkg/prefixer"
 )
+
+var plog = logger.WithNamespace("flags")
 
 // Flags is a struct for a set of feature flags.
 type Flags struct {
@@ -82,19 +85,19 @@ func GetFlags(inst *instance.Instance) (*Flags, error) {
 	}
 	flags.addInstanceFlags(inst)
 	if err := flags.addManager(inst); err != nil {
-		inst.Logger().WithNamespace("flags").
+		plog.WithDomain(inst.Domain).
 			Warnf("Cannot get the flags from the manager: %s", err)
 	}
 	if err := flags.addConfig(inst); err != nil {
-		inst.Logger().WithNamespace("flags").
+		plog.WithDomain(inst.Domain).
 			Warnf("Cannot get the flags from the config: %s", err)
 	}
 	if err := flags.addContext(inst); err != nil {
-		inst.Logger().WithNamespace("flags").
+		plog.WithDomain(inst.Domain).
 			Warnf("Cannot get the flags from the context: %s", err)
 	}
 	if err := flags.addDefaults(inst); err != nil {
-		inst.Logger().WithNamespace("flags").
+		plog.WithDomain(inst.Domain).
 			Warnf("Cannot get the flags from the defaults: %s", err)
 	}
 	return flags, nil

--- a/model/instance/lifecycle/create.go
+++ b/model/instance/lifecycle/create.go
@@ -262,7 +262,7 @@ func CreateWithoutHooks(opts *Options) (*instance.Instance, error) {
 		for _, app := range opts.Apps {
 			go func(app string) {
 				if err := installApp(i, app); err != nil {
-					i.Logger().Errorf("Failed to install %s: %s", app, err)
+					plog.WithDomain(i.Domain).Errorf("Failed to install %s: %s", app, err)
 				}
 				done <- struct{}{}
 			}(app)

--- a/model/instance/lifecycle/destroy.go
+++ b/model/instance/lifecycle/destroy.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/hooks"
-	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/cozy/cozy-stack/pkg/mail"
 	"github.com/labstack/echo/v4"
 )
@@ -99,12 +98,12 @@ func destroyWithoutHooks(domain string) error {
 	removeTriggers(inst)
 
 	if err = couchdb.DeleteAllDBs(inst); err != nil {
-		inst.Logger().Errorf("Could not delete all CouchDB databases: %s", err.Error())
+		plog.WithDomain(inst.Domain).Errorf("Could not delete all CouchDB databases: %s", err.Error())
 		return err
 	}
 
 	if err = inst.VFS().Delete(); err != nil {
-		inst.Logger().Errorf("Could not delete VFS: %s", err.Error())
+		plog.WithDomain(inst.Domain).Errorf("Could not delete VFS: %s", err.Error())
 		return err
 	}
 
@@ -213,8 +212,7 @@ func removeTriggers(inst *instance.Instance) {
 	if err == nil {
 		for _, t := range triggers {
 			if err = sched.DeleteTrigger(inst, t.Infos().TID); err != nil {
-				logger.WithDomain(inst.Domain).Errorf(
-					"Failed to remove trigger: %s", err)
+				plog.WithDomain(inst.Domain).Errorf("Failed to remove trigger: %s", err)
 			}
 		}
 	}

--- a/model/instance/lifecycle/get.go
+++ b/model/instance/lifecycle/get.go
@@ -25,9 +25,9 @@ func GetInstance(domain string) (*instance.Instance, error) {
 			break
 		}
 
-		i.Logger().Debugf("Indexes outdated: wanted %d; got %d", couchdb.IndexViewsVersion, i.IndexViewsVersion)
+		plog.WithDomain(i.Domain).Debugf("Indexes outdated: wanted %d; got %d", couchdb.IndexViewsVersion, i.IndexViewsVersion)
 		if err = DefineViewsAndIndex(i); err != nil {
-			i.Logger().Errorf("Could not re-define indexes and views: %s", err.Error())
+			plog.WithDomain(i.Domain).Errorf("Could not re-define indexes and views: %s", err.Error())
 			return nil, err
 		}
 

--- a/model/instance/lifecycle/helpers.go
+++ b/model/instance/lifecycle/helpers.go
@@ -12,15 +12,18 @@ import (
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/cozy/cozy-stack/pkg/utils"
 	multierror "github.com/hashicorp/go-multierror"
 	"golang.org/x/net/idna"
 	"golang.org/x/sync/errgroup"
 )
 
+var plog = logger.WithNamespace("lifecycle")
+
 func update(inst *instance.Instance) error {
 	if err := inst.Update(); err != nil {
-		inst.Logger().Errorf("Could not update: %s", err.Error())
+		plog.WithDomain(inst.Domain).Errorf("Could not update: %s", err.Error())
 		return err
 	}
 	return nil

--- a/model/instance/lifecycle/passphrase.go
+++ b/model/instance/lifecycle/passphrase.go
@@ -69,7 +69,7 @@ func RegisterPassphrase(inst *instance.Instance, tok []byte, params PassParamete
 // SendHint sends by mail the hint for the passphrase.
 func SendHint(inst *instance.Instance) error {
 	if inst.RegisterToken != nil {
-		inst.Logger().Info("Send hint ignored: not registered")
+		plog.WithDomain(inst.Domain).Info("Send hint ignored: not registered")
 		return nil
 	}
 	publicName, err := inst.PublicName()
@@ -97,14 +97,14 @@ func RequestPassphraseReset(inst *instance.Instance) error {
 	// If a registration token is set, we do not generate another token than the
 	// registration one, and bail.
 	if inst.RegisterToken != nil {
-		inst.Logger().Info("Passphrase reset ignored: not registered")
+		plog.WithDomain(inst.Domain).Info("Passphrase reset ignored: not registered")
 		return nil
 	}
 	// If a passphrase reset token is set and valid, we do not generate new one,
 	// and bail.
 	if inst.PassphraseResetToken != nil && inst.PassphraseResetTime != nil &&
 		time.Now().UTC().Before(*inst.PassphraseResetTime) {
-		inst.Logger().Infof("Passphrase reset ignored: already sent at %s",
+		plog.WithDomain(inst.Domain).Infof("Passphrase reset ignored: already sent at %s",
 			inst.PassphraseResetTime.String())
 		return instance.ErrResetAlreadyRequested
 	}
@@ -363,7 +363,7 @@ func CheckPassphrase(inst *instance.Instance, pass []byte) error {
 
 	inst.PassphraseHash = newHash
 	if err = update(inst); err != nil {
-		inst.Logger().Errorf("Failed to update hash in db: %s", err)
+		plog.WithDomain(inst.Domain).Errorf("Failed to update hash in db: %s", err)
 	}
 	return nil
 }

--- a/model/instance/lifecycle/patch.go
+++ b/model/instance/lifecycle/patch.go
@@ -162,7 +162,7 @@ func Patch(i *instance.Instance, opts *Options) error {
 			go func() {
 				inst := i.Clone().(*instance.Instance)
 				if err := AskReupload(inst); err != nil {
-					inst.Logger().WithNamespace("lifecycle").
+					plog.WithDomain(inst.Domain).WithNamespace("lifecycle").
 						Warnf("sharing.AskReupload failed with %s", err)
 				}
 			}()
@@ -214,7 +214,7 @@ func managerUpdateSettings(inst *instance.Instance, changes map[string]interface
 
 	url := fmt.Sprintf("/api/v1/instances/%s?source=stack", url.PathEscape(inst.UUID))
 	if err := client.Put(url, changes); err != nil {
-		inst.Logger().Errorf("Error during cloudery settings update %s", err)
+		plog.WithDomain(inst.Domain).Errorf("Error during cloudery settings update %s", err)
 	}
 }
 

--- a/model/instance/lifecycle/reset.go
+++ b/model/instance/lifecycle/reset.go
@@ -79,7 +79,7 @@ func Reset(inst *instance.Instance) error {
 
 	for _, app := range []string{"home", "store", "settings"} {
 		if err = installApp(inst, app); err != nil {
-			inst.Logger().Errorf("Failed to install %s: %s", app, err)
+			plog.WithDomain(inst.Domain).Errorf("Failed to install %s: %s", app, err)
 		}
 	}
 	return nil

--- a/model/move/doc.go
+++ b/model/move/doc.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
 	"github.com/cozy/cozy-stack/pkg/crypto"
 	"github.com/cozy/cozy-stack/pkg/jsonapi"
+	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/cozy/cozy-stack/pkg/mail"
 	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/cozy/cozy-stack/pkg/realtime"
@@ -34,6 +35,8 @@ const (
 	// ExportStateError is used when the export document is finshed with error.
 	ExportStateError = "error"
 )
+
+var plog = logger.WithNamespace("move")
 
 // ExportDoc is a documents storing the metadata of an export.
 type ExportDoc struct {

--- a/model/move/import.go
+++ b/model/move/import.go
@@ -37,14 +37,12 @@ type FromOptions struct {
 func CheckImport(inst *instance.Instance, settingsURL string) error {
 	manifestURL, err := transformSettingsURLToManifestURL(settingsURL)
 	if err != nil {
-		inst.Logger().WithNamespace("move").
-			Debugf("Invalid settings URL %s: %s", settingsURL, err)
+		plog.WithDomain(inst.Domain).Debugf("Invalid settings URL %s: %s", settingsURL, err)
 		return ErrExportNotFound
 	}
 	manifest, err := fetchManifest(manifestURL)
 	if err != nil {
-		inst.Logger().WithNamespace("move").
-			Warnf("Cannot fetch manifest: %s", err)
+		plog.WithDomain(inst.Domain).Warnf("Cannot fetch manifest: %s", err)
 		return ErrExportNotFound
 	}
 	if inst.BytesDiskQuota > 0 && manifest.TotalSize > inst.BytesDiskQuota {

--- a/model/move/importer.go
+++ b/model/move/importer.go
@@ -40,7 +40,7 @@ func (im *importer) importPart(cursor string) error {
 	defer func() {
 		if im.tmpFile != "" {
 			if err := os.Remove(im.tmpFile); err != nil {
-				im.inst.Logger().WithNamespace("move").
+				plog.WithDomain(im.inst.Domain).
 					Warnf("Cannot remove temp file %s: %s", im.tmpFile, err)
 			}
 		}

--- a/model/move/request.go
+++ b/model/move/request.go
@@ -279,8 +279,7 @@ func CallFinalize(inst *instance.Instance, otherURL, token string, vault bool) {
 	u.RawQuery = url.Values{"subdomain": {subdomainType}}.Encode()
 	req, err := http.NewRequest("POST", u.String(), nil)
 	if err != nil {
-		inst.Logger().
-			WithNamespace("move").
+		plog.WithDomain(inst.Domain).
 			WithField("url", otherURL).
 			Warnf("Cannot finalize: %s", err)
 		return
@@ -288,16 +287,14 @@ func CallFinalize(inst *instance.Instance, otherURL, token string, vault bool) {
 	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
 	res, err := safehttp.ClientWithKeepAlive.Do(req)
 	if err != nil {
-		inst.Logger().
-			WithNamespace("move").
+		plog.WithDomain(inst.Domain).
 			WithField("url", otherURL).
 			Warnf("Cannot finalize: %s", err)
 		return
 	}
 	defer res.Body.Close()
 	if res.StatusCode != 204 {
-		inst.Logger().
-			WithNamespace("move").
+		plog.WithDomain(inst.Domain).
 			WithField("url", otherURL).
 			Warnf("Cannot finalize: code=%d", res.StatusCode)
 	}
@@ -309,8 +306,7 @@ func CallFinalize(inst *instance.Instance, otherURL, token string, vault bool) {
 			doc.M["import_vault"] = true
 		}
 		if err := couchdb.UpdateDoc(inst, doc); err != nil {
-			inst.Logger().
-				WithNamespace("move").
+			plog.WithDomain(inst.Domain).
 				WithField("moved_from", u.Host).
 				WithField("vault", strconv.FormatBool(vault)).
 				Warnf("Cannot save settings: %s", err)
@@ -393,8 +389,7 @@ func Abort(inst *instance.Instance, otherURL, token string) {
 	u.Path = "/move/abort"
 	req, err := http.NewRequest("POST", u.String(), nil)
 	if err != nil {
-		inst.Logger().
-			WithNamespace("move").
+		plog.WithDomain(inst.Domain).
 			WithField("url", otherURL).
 			Warnf("Cannot abort: %s", err)
 		return
@@ -402,16 +397,14 @@ func Abort(inst *instance.Instance, otherURL, token string) {
 	req.Header.Add(echo.HeaderAuthorization, "Bearer "+token)
 	res, err := safehttp.ClientWithKeepAlive.Do(req)
 	if err != nil {
-		inst.Logger().
-			WithNamespace("move").
+		plog.WithDomain(inst.Domain).
 			WithField("url", otherURL).
 			Warnf("Cannot abort: %s", err)
 		return
 	}
 	defer res.Body.Close()
 	if res.StatusCode != 204 {
-		inst.Logger().
-			WithNamespace("move").
+		plog.WithDomain(inst.Domain).
 			WithField("url", otherURL).
 			Warnf("Cannot abort: code=%d", res.StatusCode)
 	}

--- a/model/note/import.go
+++ b/model/note/import.go
@@ -49,8 +49,7 @@ func ImportFile(inst *instance.Instance, newdoc, olddoc *vfs.FileDoc, body io.Re
 		fillMetadata(newdoc, olddoc, schemaSpecs, content)
 	} else {
 		_, _ = io.Copy(io.Discard, reader)
-		inst.Logger().WithNamespace("notes").
-			Warnf("Cannot import notes: %s", err)
+		plog.WithDomain(inst.Domain).Warnf("Cannot import notes: %s", err)
 	}
 	if err := file.Close(); err != nil {
 		return err

--- a/model/note/step.go
+++ b/model/note/step.go
@@ -173,14 +173,14 @@ func ApplySteps(inst *instance.Instance, file *vfs.FileDoc, lastVersion string, 
 func apply(inst *instance.Instance, doc *Document, steps []Step) error {
 	schema, err := doc.Schema()
 	if err != nil {
-		inst.Logger().WithNamespace("notes").
+		plog.WithDomain(inst.Domain).
 			Infof("Cannot instantiate the schema: %s", err)
 		return ErrInvalidSchema
 	}
 
 	content, err := doc.Content()
 	if err != nil {
-		inst.Logger().WithNamespace("notes").
+		plog.WithDomain(inst.Domain).
 			Infof("Cannot instantiate the document: %s", err)
 		return ErrInvalidFile
 	}
@@ -189,13 +189,13 @@ func apply(inst *instance.Instance, doc *Document, steps []Step) error {
 	for i, s := range steps {
 		step, err := transform.StepFromJSON(schema, s)
 		if err != nil {
-			inst.Logger().WithNamespace("notes").
+			plog.WithDomain(inst.Domain).
 				Infof("Cannot instantiate a step: %s", err)
 			return ErrInvalidSteps
 		}
 		result := step.Apply(content)
 		if result.Failed != "" {
-			inst.Logger().WithNamespace("notes").
+			plog.WithDomain(inst.Domain).
 				Infof("Cannot apply a step: %s (version=%d)", result.Failed, doc.Version)
 			return ErrCannotApply
 		}
@@ -227,7 +227,7 @@ func purgeOldSteps(inst *instance.Instance, fileID string) {
 	}
 	if err := couchdb.GetAllDocs(inst, consts.NotesSteps, &req, &steps); err != nil {
 		if !couchdb.IsNoDatabaseError(err) {
-			inst.Logger().WithNamespace("notes").
+			plog.WithDomain(inst.Domain).
 				Warnf("Cannot purge old steps for file %s: %s", fileID, err)
 		}
 		return
@@ -248,8 +248,7 @@ func purgeOldSteps(inst *instance.Instance, fileID string) {
 		return
 	}
 	if err := couchdb.BulkDeleteDocs(inst, consts.NotesSteps, docs); err != nil {
-		inst.Logger().WithNamespace("notes").
-			Warnf("Cannot purge old steps for file %s: %s", fileID, err)
+		plog.WithDomain(inst.Domain).Warnf("Cannot purge old steps for file %s: %s", fileID, err)
 	}
 }
 
@@ -265,8 +264,7 @@ func purgeAllSteps(inst *instance.Instance, fileID string) {
 	})
 	if err != nil {
 		if !couchdb.IsNoDatabaseError(err) {
-			inst.Logger().WithNamespace("notes").
-				Warnf("Cannot purge all steps for file %s: %s", fileID, err)
+			plog.WithDomain(inst.Domain).Warnf("Cannot purge all steps for file %s: %s", fileID, err)
 		}
 		return
 	}
@@ -275,7 +273,7 @@ func purgeAllSteps(inst *instance.Instance, fileID string) {
 	}
 
 	if err := couchdb.BulkDeleteDocs(inst, consts.NotesSteps, docs); err != nil {
-		inst.Logger().WithNamespace("notes").
+		plog.WithDomain(inst.Domain).
 			Warnf("Cannot purge all steps for file %s: %s", fileID, err)
 	}
 }

--- a/model/oauth/android.go
+++ b/model/oauth/android.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/cozy/cozy-stack/model/instance"
 	"github.com/cozy/cozy-stack/pkg/config/config"
-	"github.com/cozy/cozy-stack/pkg/logger"
 	jwt "github.com/golang-jwt/jwt/v4"
 )
 
@@ -29,7 +28,7 @@ func (c *Client) checkAndroidAttestation(inst *instance.Instance, req Attestatio
 	if !ok {
 		return errors.New("invalid claims type")
 	}
-	inst.Logger().Debugf("checkAndroidAttestation claims = %#v", claims)
+	plog.WithDomain(inst.Domain).Debugf("checkAndroidAttestation claims = %#v", claims)
 
 	nonce, ok := claims["nonce"].(string)
 	if !ok || len(nonce) == 0 {
@@ -73,8 +72,7 @@ func checkCertificateDigest(claims jwt.MapClaims) error {
 			return nil
 		}
 	}
-	logger.WithNamespace("oauth").
-		Debugf("Invalid certificate digest, expected %s, got %s", digests[0], certDigest)
+	plog.Debugf("Invalid certificate digest, expected %s, got %s", digests[0], certDigest)
 	return errors.New("invalid certificate digest")
 }
 

--- a/model/oauth/ios.go
+++ b/model/oauth/ios.go
@@ -79,7 +79,7 @@ func (c *Client) checkAppleAttestation(inst *instance.Instance, req AttestationR
 	if err != nil {
 		return fmt.Errorf("cannot parse attestation: %s", err)
 	}
-	inst.Logger().Debugf("checkAppleAttestation claims = %#v", obj)
+	plog.WithDomain(inst.Domain).Debugf("checkAppleAttestation claims = %#v", obj)
 
 	if err := obj.checkCertificate(req.Challenge, req.KeyID); err != nil {
 		return err

--- a/model/sharing/api_sharing.go
+++ b/model/sharing/api_sharing.go
@@ -6,8 +6,13 @@ import (
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/jsonapi"
+	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/labstack/echo/v4"
 )
+
+var sharLog = logger.WithNamespace("share")
+var replLog = logger.WithNamespace("replicator")
+var uploadLog = logger.WithNamespace("upload")
 
 // InfoByDocTypeData returns the sharings info as data array in the JSON-API format
 func InfoByDocTypeData(c echo.Context, statusCode int, sharings []*APISharing) error {

--- a/model/sharing/indexer.go
+++ b/model/sharing/indexer.go
@@ -37,7 +37,7 @@ func newSharingIndexer(inst *instance.Instance, bulkRevs *bulkRevs, shared *Shar
 		indexer:  vfs.NewCouchdbIndexer(inst),
 		bulkRevs: bulkRevs,
 		shared:   shared,
-		log:      inst.Logger().WithNamespace("sharing-indexer"),
+		log:      logger.WithNamespace("sharing-indexer").WithDomain(inst.Domain),
 	}
 }
 

--- a/model/sharing/invitation.go
+++ b/model/sharing/invitation.go
@@ -48,7 +48,7 @@ func (s *Sharing) SendInvitations(inst *instance.Instance, perms *permission.Per
 				return ErrInvitationNotSent
 			}
 			if err := m.SendMail(inst, s, sharer, desc, link); err != nil {
-				inst.Logger().WithNamespace("sharing").
+				sharLog.WithDomain(inst.Domain).
 					Errorf("Can't send email for %#v: %s", m.Email, err)
 				return ErrInvitationNotSent
 			}
@@ -86,7 +86,7 @@ func (s *Sharing) SendInvitationsToMembers(inst *instance.Instance, members []Me
 				return ErrInvitationNotSent
 			}
 			if err := m.SendMail(inst, s, sharer, desc, link); err != nil {
-				inst.Logger().WithNamespace("sharing").
+				sharLog.WithDomain(inst.Domain).
 					Errorf("Can't send email for %#v: %s", m.Email, err)
 				return ErrInvitationNotSent
 			}
@@ -296,7 +296,7 @@ func (s *Sharing) CreateShortcut(inst *instance.Instance, previewURL string, see
 
 	s.ShortcutID = fileDoc.DocID
 	if err := couchdb.UpdateDoc(inst, s); err != nil {
-		inst.Logger().Warnf("Cannot save shortcut id %s: %s", s.ShortcutID, err)
+		sharLog.WithDomain(inst.Domain).Warnf("Cannot save shortcut id %s: %s", s.ShortcutID, err)
 	}
 
 	return s.SendShortcutMail(inst, fileDoc, previewURL)

--- a/model/sharing/oauth.go
+++ b/model/sharing/oauth.go
@@ -235,7 +235,7 @@ func (s *Sharing) RegisterCozyURL(inst *instance.Instance, m *Member, cozyURL st
 		return ErrInvalidSharing
 	}
 	if err = m.CreateSharingRequest(inst, s, creds, u); err != nil {
-		inst.Logger().WithNamespace("sharing").Warnf("Error on sharing request: %s", err)
+		sharLog.WithDomain(inst.Domain).Warnf("Error on sharing request: %s", err)
 		if errors.Is(err, ErrAlreadyAccepted) {
 			return err
 		}
@@ -373,7 +373,7 @@ func (s *Sharing) SendAnswer(inst *instance.Instance, state string) error {
 	}
 	name, err := inst.PublicName()
 	if err != nil {
-		inst.Logger().WithNamespace("sharing").
+		sharLog.WithDomain(inst.Domain).
 			Infof("No name for instance %v", inst)
 	}
 	ac := APICredentials{
@@ -488,8 +488,7 @@ func (s *Sharing) ProcessAnswer(inst *instance.Instance, creds *APICredentials) 
 			if email := s.Members[i+1].Email; email != "" {
 				if c, err := contact.FindByEmail(inst, email); err == nil {
 					if err := c.AddNameIfMissing(inst, s.Members[i+1].PublicName, email); err != nil {
-						inst.Logger().WithNamespace("sharing").
-							Warnf("Error on saving contact: %s", err)
+						sharLog.WithDomain(inst.Domain).Warnf("Error on saving contact: %s", err)
 					}
 				}
 			}

--- a/model/sharing/revoke_trashed.go
+++ b/model/sharing/revoke_trashed.go
@@ -30,7 +30,7 @@ func revokeTrashed(db prefixer.Prefixer, sharingID string) {
 		Domain: db.DomainName(),
 	}
 
-	log := inst.Logger().WithNamespace("sharing")
+	log := sharLog.WithDomain(inst.Domain)
 	log.Infof("revokeTrashed called for sharing %s", sharingID)
 	if s.Owner {
 		err = s.Revoke(inst)

--- a/model/sharing/shared.go
+++ b/model/sharing/shared.go
@@ -399,7 +399,7 @@ func UpdateShared(inst *instance.Instance, msg TrackMessage, evt TrackEvent) err
 		}
 	} else {
 		if evt.OldDoc == nil {
-			inst.Logger().WithNamespace("sharing").
+			sharLog.WithDomain(inst.Domain).
 				Infof("Updating an io.cozy.shared with no previous revision: %v %v", evt, ref)
 			if subtree, _ := ref.Revisions.Find(rev); subtree == nil {
 				ref.Revisions.Add(rev)
@@ -421,7 +421,7 @@ func UpdateShared(inst *instance.Instance, msg TrackMessage, evt TrackEvent) err
 	if needToUpdateFiles {
 		err := updateRemovedForFiles(inst, msg.SharingID, evt.Doc.ID(), ruleIndex, removed)
 		if err != nil {
-			inst.Logger().WithNamespace("sharing").
+			sharLog.WithDomain(inst.Domain).
 				Warnf("Error on updateRemovedForFiles for %v: %s", evt, err)
 		}
 	}

--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -377,7 +377,7 @@ func (s *Sharing) Create(inst *instance.Instance) (*permission.Permission, error
 	}
 	if rule := s.FirstFilesRule(); rule != nil && rule.Selector != couchdb.SelectorReferencedBy {
 		if err := s.AddReferenceForSharingDir(inst, rule); err != nil {
-			inst.Logger().WithNamespace("sharing").
+			sharLog.WithDomain(inst.Domain).
 				Warnf("Error on referenced_by for the sharing dir (%s): %s", s.SID, err)
 		}
 	}
@@ -518,12 +518,12 @@ func (s *Sharing) RevokeRecipientBySelf(inst *instance.Instance, sharingDirTrash
 		return err
 	}
 	if err := RemoveSharedRefs(inst, s.SID); err != nil {
-		inst.Logger().WithNamespace("sharing").
+		sharLog.WithDomain(inst.Domain).
 			Warnf("RevokeRecipientBySelf failed to remove shared refs (%s)': %s", s.ID(), err)
 	}
 	if !sharingDirTrashed && s.FirstFilesRule() != nil {
 		if err := s.RemoveSharingDir(inst); err != nil {
-			inst.Logger().WithNamespace("sharing").
+			sharLog.WithDomain(inst.Domain).
 				Warnf("RevokeRecipientBySelf failed to delete dir %s: %s", s.ID(), err)
 		}
 	}

--- a/pkg/couchdb/bulk.go
+++ b/pkg/couchdb/bulk.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/couchdb/revision"
-	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/cozy/cozy-stack/pkg/realtime"
 	"github.com/google/go-querystring/query"
@@ -152,7 +151,7 @@ func MakeAllDocsRequest(db prefixer.Prefixer, doctype string, params *AllDocsReq
 	path := "_all_docs?" + v.Encode()
 	method := http.MethodGet
 
-	log := logger.WithDomain(db.DomainName()).WithNamespace("couchdb")
+	log := plog.WithDomain(db.DomainName())
 	if log.IsDebug() {
 		log.Debugf("request: %s %s %s", method, path, "")
 	}
@@ -309,7 +308,7 @@ func bulkUpdateDocs(db prefixer.Prefixer, doctype string, docs, olddocs []interf
 		if d, ok := doc.(Doc); ok {
 			update := res[i]
 			if update.Error != "" {
-				logger.WithDomain(db.DomainName()).WithNamespace("couchdb").
+				plog.WithDomain(db.DomainName()).
 					Warnf("bulkUpdateDocs error for %s %s: %s - %s", doctype, update.ID, update.Error, update.Reason)
 			}
 			if update.ID == "" || update.Rev == "" || !update.Ok {
@@ -411,7 +410,6 @@ func logBulk(db prefixer.Prefixer, prefix, doctype string, docs interface{}) {
 	}
 
 	for _, msg := range messages {
-		logger.WithDomain(db.DomainName()).WithNamespace("couchdb").
-			Infof("%s for %s: %s", prefix, doctype, msg)
+		plog.WithDomain(db.DomainName()).Infof("%s for %s: %s", prefix, doctype, msg)
 	}
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -108,6 +108,11 @@ func (e *Entry) WithNamespace(nspace string) *Entry {
 	return e.WithField("nspace", nspace)
 }
 
+// WithDomain add a domain field.
+func (e *Entry) WithDomain(domain string) *Entry {
+	return e.WithField("domain", domain)
+}
+
 // WithField adds a single field to the Entry.
 func (e *Entry) WithField(key string, value interface{}) *Entry {
 	entry := e.entry.WithField(key, value)

--- a/web/auth/confirm.go
+++ b/web/auth/confirm.go
@@ -63,7 +63,7 @@ func confirmAuth(c echo.Context) error {
 		err := config.GetRateLimiter().CheckRateLimit(inst, limits.AuthType)
 		if limits.IsLimitReachedOrExceeded(err) {
 			if err = LoginRateExceeded(inst); err != nil {
-				inst.Logger().WithNamespace("auth").Warn(err.Error())
+				plog.WithDomain(inst.Domain).WithNamespace("auth").Warn(err.Error())
 			}
 		}
 		return c.JSON(http.StatusUnauthorized, echo.Map{
@@ -111,7 +111,7 @@ func ConfirmSuccess(c echo.Context, inst *instance.Instance, state string) error
 	}
 	code, err := GetStore().AddCode(inst)
 	if err != nil {
-		inst.Logger().Warnf("Cannot add confirm code: %s", err)
+		plog.WithDomain(inst.Domain).Warnf("Cannot add confirm code: %s", err)
 		return c.NoContent(http.StatusInternalServerError)
 	}
 	q := redirect.Query()
@@ -165,7 +165,7 @@ func confirmCode(c echo.Context) error {
 	}
 	ok, err := GetStore().GetCode(inst, code)
 	if err != nil {
-		inst.Logger().Warnf("Cannot get confirm code: %s", err)
+		plog.WithDomain(inst.Domain).Warnf("Cannot get confirm code: %s", err)
 		return c.NoContent(http.StatusInternalServerError)
 	}
 	if !ok {

--- a/web/auth/flagship.go
+++ b/web/auth/flagship.go
@@ -60,7 +60,7 @@ func ReturnSessionCode(c echo.Context, statusCode int, inst *instance.Instance) 
 	if ip == "" {
 		ip = strings.Split(req.RemoteAddr, ":")[0]
 	}
-	inst.Logger().WithField("nspace", "loginaudit").
+	plog.WithDomain(inst.Domain).WithField("nspace", "loginaudit").
 		Infof("New session_code created from %s at %s", ip, time.Now())
 
 	return c.JSON(statusCode, echo.Map{
@@ -133,7 +133,7 @@ func postAttestation(c echo.Context) error {
 		})
 	}
 	if err := client.Attest(inst, data); err != nil {
-		inst.Logger().Infof("Cannot attest %s client: %s", client.ID(), err.Error())
+		plog.WithDomain(inst.Domain).Infof("Cannot attest %s client: %s", client.ID(), err.Error())
 		return c.JSON(http.StatusBadRequest, echo.Map{
 			"error": err.Error(),
 		})
@@ -194,7 +194,7 @@ func loginFlagship(c echo.Context) error {
 		err := config.GetRateLimiter().CheckRateLimit(inst, limits.AuthType)
 		if limits.IsLimitReachedOrExceeded(err) {
 			if err = LoginRateExceeded(inst); err != nil {
-				inst.Logger().WithNamespace("auth").Warn(err.Error())
+				plog.WithDomain(inst.Domain).Warn(err.Error())
 			}
 		}
 		return c.JSON(http.StatusUnauthorized, echo.Map{

--- a/web/auth/oauth.go
+++ b/web/auth/oauth.go
@@ -164,7 +164,7 @@ func authorizeForm(c echo.Context) error {
 			req := c.Request()
 			if err == nil {
 				if err = session.StoreNewLoginEntry(instance, sessionID, "", req, "session_code", false); err != nil {
-					instance.Logger().Errorf("Could not store session history %q: %s", sessionID, err)
+					plog.WithDomain(instance.Domain).Errorf("Could not store session history %q: %s", sessionID, err)
 				}
 			}
 			redirect := req.URL
@@ -379,7 +379,7 @@ func createAccessCode(c echo.Context, params authorizeParams, u *url.URL, q url.
 	if ip == "" {
 		ip = strings.Split(c.Request().RemoteAddr, ":")[0]
 	}
-	params.instance.Logger().WithNamespace("loginaudit").
+	plog.WithDomain(params.instance.Domain).WithNamespace("loginaudit").
 		Infof("Access code created from %s at %s with scope %s", ip, time.Now(), access.Scope)
 
 	// We should be sending "code" only, but for compatibility reason, we keep
@@ -692,7 +692,7 @@ func authorizeMove(c echo.Context) error {
 		err := config.GetRateLimiter().CheckRateLimit(inst, limits.AuthType)
 		if limits.IsLimitReachedOrExceeded(err) {
 			if err = LoginRateExceeded(inst); err != nil {
-				inst.Logger().WithNamespace("auth").Warn(err.Error())
+				plog.WithDomain(inst.Domain).Warn(err.Error())
 			}
 		}
 		return c.JSON(http.StatusUnauthorized, echo.Map{
@@ -869,7 +869,7 @@ func accessToken(c echo.Context) error {
 		// Delete the access code, it can be used only once
 		err = couchdb.DeleteDoc(instance, accessCode)
 		if err != nil {
-			instance.Logger().Errorf(
+			plog.WithDomain(instance.Domain).Errorf(
 				"[oauth] Failed to delete the access code: %s", err)
 		}
 

--- a/web/auth/passphrase.go
+++ b/web/auth/passphrase.go
@@ -236,7 +236,7 @@ func passphraseRenew(c echo.Context) error {
 		})
 	}
 	if err := bitwarden.DeleteUnrecoverableCiphers(inst); err != nil {
-		inst.Logger().WithNamespace("bitwarden").
+		plog.WithDomain(inst.Domain).
 			Warnf("Error on ciphers deletion after password reset: %s", err)
 	}
 

--- a/web/auth/rate_limiting.go
+++ b/web/auth/rate_limiting.go
@@ -13,7 +13,7 @@ import (
 // login
 func LoginRateExceeded(i *instance.Instance) error {
 	err := fmt.Errorf("Instance was blocked because of too many login failed attempts")
-	i.Logger().WithNamespace("rate_limiting").Warn(err.Error())
+	plog.WithDomain(i.Domain).Warn(err.Error())
 	return lifecycle.Block(i, instance.BlockedLoginFailed.Code)
 }
 
@@ -34,7 +34,7 @@ func TwoFactorRateExceeded(i *instance.Instance) error {
 // regenerate a 2FA code within an hour
 func TwoFactorGenerationExceeded(i *instance.Instance) error {
 	err := fmt.Errorf("Instance was blocked because of too many 2FA passcode generations")
-	i.Logger().WithNamespace("rate_limiting").Warn(err.Error())
+	plog.WithDomain(i.Domain).Warn(err.Error())
 
 	return lifecycle.Block(i, instance.BlockedLoginFailed.Code)
 }

--- a/web/auth/twofactor.go
+++ b/web/auth/twofactor.go
@@ -164,7 +164,7 @@ func twoFactorFailed(c echo.Context, inst *instance.Instance, token []byte) erro
 	errCheckRateLimit := config.GetRateLimiter().CheckRateLimit(inst, limits.TwoFactorType)
 	if errCheckRateLimit == limits.ErrRateLimitExceeded {
 		if err := TwoFactorRateExceeded(inst); err != nil {
-			inst.Logger().WithNamespace("auth").Warn(err.Error())
+			plog.WithDomain(inst.Domain).Warn(err.Error())
 			errorMessage = inst.Translate(TwoFactorExceededErrorKey)
 		}
 	}

--- a/web/bitwarden/bitwarden.go
+++ b/web/bitwarden/bitwarden.go
@@ -20,9 +20,12 @@ import (
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/labstack/echo/v4"
 )
+
+var plog = logger.WithNamespace("bitwarden")
 
 func migrateAccountsToCiphers(inst *instance.Instance) error {
 	msg, err := job.NewMessage(map[string]interface{}{
@@ -123,7 +126,8 @@ func UpdateProfile(c echo.Context) error {
 // SetKeyPair is the handler for setting the key pair: public and private keys.
 func SetKeyPair(c echo.Context) error {
 	inst := middlewares.GetInstance(c)
-	log := inst.Logger().WithNamespace("bitwarden")
+
+	log := plog.WithDomain(inst.Domain)
 	if err := middlewares.AllowWholeType(c, permission.POST, consts.BitwardenProfiles); err != nil {
 		return c.JSON(http.StatusUnauthorized, echo.Map{
 			"error": "invalid token",
@@ -242,7 +246,7 @@ type AccessTokenReponse struct {
 
 func getInitialCredentials(c echo.Context) error {
 	inst := middlewares.GetInstance(c)
-	log := inst.Logger().WithNamespace("bitwarden")
+	log := plog.WithDomain(inst.Domain)
 	pass := []byte(c.FormValue("password"))
 
 	// Authentication
@@ -330,7 +334,7 @@ func getInitialCredentials(c echo.Context) error {
 	if ip == "" {
 		ip = strings.Split(c.Request().RemoteAddr, ":")[0]
 	}
-	inst.Logger().WithNamespace("loginaudit").
+	plog.WithDomain(inst.Domain).
 		Infof("New bitwarden client from %s at %s", ip, time.Now())
 
 	// Send the response

--- a/web/bitwarden/ciphers.go
+++ b/web/bitwarden/ciphers.go
@@ -824,23 +824,20 @@ func ShareCipher(c echo.Context) error {
 
 	var req shareCipherRequest
 	if err := json.NewDecoder(c.Request().Body).Decode(&req); err != nil {
-		inst.Logger().WithNamespace("bitwarden").
-			Infof("Bad JSON: %v", err)
+		plog.WithDomain(inst.Domain).Infof("Bad JSON: %v", err)
 		return c.JSON(http.StatusBadRequest, echo.Map{
 			"error": "invalid JSON",
 		})
 	}
 	cipher, err := req.Cipher.toCipher()
 	if err != nil {
-		inst.Logger().WithNamespace("bitwarden").
-			Infof("Bad cipher: %v", err)
+		plog.WithDomain(inst.Domain).Infof("Bad cipher: %v", err)
 		return c.JSON(http.StatusBadRequest, echo.Map{
 			"error": err.Error(),
 		})
 	}
 	if req.Cipher.OrganizationID == "" {
-		inst.Logger().WithNamespace("bitwarden").
-			Infof("Bad organization: %v", req)
+		plog.WithDomain(inst.Domain).Infof("Bad organization: %v", req)
 		return c.JSON(http.StatusBadRequest, echo.Map{
 			"error": "organizationId not provided",
 		})

--- a/web/bitwarden/icons.go
+++ b/web/bitwarden/icons.go
@@ -31,7 +31,7 @@ func GetIcon(c echo.Context) error {
 	}
 
 	inst := middlewares.GetInstance(c)
-	inst.Logger().WithNamespace("bitwarden").Debugf("Error for icon %s: %s", domain, err)
+	plog.WithDomain(inst.Domain).Debugf("Error for icon %s: %s", domain, err)
 	if c.QueryParam("fallback") == "404" {
 		return echo.NewHTTPError(http.StatusNotFound, "Page not found")
 	}

--- a/web/notes/notes.go
+++ b/web/notes/notes.go
@@ -19,10 +19,13 @@ import (
 	"github.com/cozy/cozy-stack/model/vfs"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/jsonapi"
+	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/cozy/cozy-stack/web/files"
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/labstack/echo/v4"
 )
+
+var plog = logger.WithNamespace("notes")
 
 // CreateNote is the API handler for POST /notes. It creates a note, aka a file
 // with a set of metadata to enable collaborative edition.
@@ -385,7 +388,7 @@ func UploadImage(c echo.Context) error {
 	name := c.QueryParam("Name")
 	upload, err := note.NewImageUpload(inst, doc, name, contentType)
 	if err != nil {
-		inst.Logger().WithNamespace("notes").Infof("Image upload has failed: %s", err)
+		plog.WithDomain(inst.Domain).Infof("Image upload has failed: %s", err)
 		return jsonapi.BadRequest(errors.New("Upload has failed"))
 	}
 
@@ -395,7 +398,7 @@ func UploadImage(c echo.Context) error {
 		err = cerr
 	}
 	if err != nil {
-		inst.Logger().WithNamespace("notes").Infof("Image upload has failed: %s", err)
+		plog.WithDomain(inst.Domain).Infof("Image upload has failed: %s", err)
 		return jsonapi.BadRequest(errors.New("Upload has failed"))
 	}
 

--- a/web/office/office.go
+++ b/web/office/office.go
@@ -12,9 +12,12 @@ import (
 	"github.com/cozy/cozy-stack/model/vfs"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/jsonapi"
+	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/labstack/echo/v4"
 )
+
+var plog = logger.WithNamespace("office")
 
 // Open returns the parameters to open an office document.
 func Open(c echo.Context) error {
@@ -66,16 +69,14 @@ func Callback(c echo.Context) error {
 	inst := middlewares.GetInstance(c)
 	var params office.CallbackParameters
 	if err := c.Bind(&params); err != nil {
-		inst.Logger().WithNamespace("office").
-			Warnf("Cannot bind callback parameters: %s", err)
+		plog.WithDomain(inst.Domain).Warnf("Cannot bind callback parameters: %s", err)
 		return c.JSON(http.StatusBadRequest, echo.Map{"error": "Invalid request"})
 	}
 	header := c.Request().Header.Get(echo.HeaderAuthorization)
 	params.Token = strings.TrimPrefix(header, "Bearer ")
 
 	if err := office.Callback(inst, params); err != nil {
-		inst.Logger().WithNamespace("office").
-			Infof("Error on the callback: %s", err)
+		plog.WithDomain(inst.Domain).Infof("Error on the callback: %s", err)
 		code := http.StatusInternalServerError
 		if httpError, ok := err.(*echo.HTTPError); ok {
 			code = httpError.Code

--- a/web/oidc/statestore.go
+++ b/web/oidc/statestore.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/crypto"
-	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -96,8 +95,7 @@ func (store *redisStateStorage) Find(id string) *stateHolder {
 	var s stateHolder
 	err = json.Unmarshal(serialized, &s)
 	if err != nil {
-		logger.WithNamespace("redis-state").Errorf(
-			"Bad state in redis %s", string(serialized))
+		plog.Errorf("Bad state in redis %s", string(serialized))
 		return nil
 	}
 	return &s

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -26,6 +26,8 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
+var sharLog = logger.WithNamespace("sharing")
+
 // CreateSharing initializes a new sharing (on the sharer)
 func CreateSharing(c echo.Context) error {
 	inst := middlewares.GetInstance(c)
@@ -177,7 +179,7 @@ func GetSharingsInfoByDocType(c echo.Context) error {
 
 	sharings, err := sharing.GetSharingsByDocType(inst, docType)
 	if err != nil {
-		inst.Logger().WithNamespace("sharing").Errorf("GetSharingsByDocType error: %s", err)
+		sharLog.WithDomain(inst.Domain).Errorf("GetSharingsByDocType error: %s", err)
 		return wrapErrors(err)
 	}
 	if err := middlewares.AllowWholeType(c, permission.GET, docType); err != nil {
@@ -192,7 +194,7 @@ func GetSharingsInfoByDocType(c echo.Context) error {
 	}
 	sDocs, err := sharing.GetSharedDocsBySharingIDs(inst, sharingIDs)
 	if err != nil {
-		inst.Logger().WithNamespace("sharing").Errorf("GetSharedDocsBySharingIDs error: %s", err)
+		sharLog.WithDomain(inst.Domain).Errorf("GetSharedDocsBySharingIDs error: %s", err)
 		return wrapErrors(err)
 	}
 
@@ -894,6 +896,6 @@ func wrapErrors(err error) error {
 	case permission.ErrExpiredToken:
 		return jsonapi.BadRequest(err)
 	}
-	logger.WithNamespace("sharing").Warnf("Not wrapped error: %s", err)
+	sharLog.Warnf("Not wrapped error: %s", err)
 	return err
 }


### PR DESCRIPTION
This PR is a #3849 follow up

This logger setup at the package level have have the `namespace`
field setup. Moving to this pre-setup logger bring several advantages:

- There is no more need to precise the namespace for each log.
- It allow a consistent namespace accross all the packages. We can't
  forget a namepace field.
- This will improve the CPU/Memory performance as it will reuse the
  same namespace field for each log.