### PR TITLE
Refactor the way `/pkg/logger handle` the debug mode

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -108,6 +108,11 @@ func (e *Entry) WithNamespace(nspace string) *Entry {
 	return e.WithField("nspace", nspace)
 }
 
+// WithDomain add a domain field.
+func (e *Entry) WithDomain(domain string) *Entry {
+	return e.WithField("domain", domain)
+}
+
 // WithField adds a single field to the Entry.
 func (e *Entry) WithField(key string, value interface{}) *Entry {
 	entry := e.entry.WithField(key, value)


### PR DESCRIPTION
This refactoring brings three main advantage:
- It remove the global lock inside `/pkg/logger` and replace it by a `sync.Map`. This shoud reduce the number of request hanged, waiting to have access to the logger

- It reduce the number of access to the new `loggers` variable by accessing it only when we log in debug with the domain field setup and not each time we had a domain field.

- It make the `AddDomain` function behave like a classic new field. This will allow us to link this method to `Entry`.