### PR TITLE
Use the logger setup by `job.WorkerContext `instead of the global one 

### DIFF
--- a/model/job/worker.go
+++ b/model/job/worker.go
@@ -114,10 +114,11 @@ func (w *WorkerConfig) Clone() *WorkerConfig {
 func NewWorkerContext(workerID string, job *Job, inst *instance.Instance) *WorkerContext {
 	ctx := context.Background()
 	id := fmt.Sprintf("%s/%s", workerID, job.ID())
-	log := logger.WithDomain(job.Domain).
+	log := logger.
+		WithNamespace("jobs").
+		WithDomain(job.Domain).
 		WithField("job_id", job.ID()).
-		WithField("worker_id", workerID).
-		WithNamespace("jobs")
+		WithField("worker_id", workerID)
 
 	if job.ForwardLogs {
 		hook := realtime.LogHook(job, realtime.GetHub(), consts.Jobs, job.ID())

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -108,6 +108,11 @@ func (e *Entry) WithNamespace(nspace string) *Entry {
 	return e.WithField("nspace", nspace)
 }
 
+// WithDomain add a domain field.
+func (e *Entry) WithDomain(domain string) *Entry {
+	return e.WithField("domain", domain)
+}
+
 // WithField adds a single field to the Entry.
 func (e *Entry) WithField(key string, value interface{}) *Entry {
 	entry := e.entry.WithField(key, value)

--- a/worker/exec/konnector.go
+++ b/worker/exec/konnector.go
@@ -341,8 +341,7 @@ func (w *konnectorWorker) ensureFolderToSave(ctx *job.WorkerContext, inst *insta
 	if err != nil {
 		dir, err = fs.DirByPath(folderPath)
 		if err != nil {
-			log := inst.Logger().WithNamespace("konnector")
-			log.Warnf("Can't create the default folder %s: %s", folderPath, err)
+			ctx.Logger().Warnf("Can't create the default folder %s: %s", folderPath, err)
 			return err
 		}
 	}

--- a/worker/migrations/migrate-accounts-to-organisation.go
+++ b/worker/migrations/migrate-accounts-to-organisation.go
@@ -177,7 +177,10 @@ func addCipherRelationshipToAccount(acc couchdb.JSONDoc, cipher *bitwarden.Ciphe
 // Migrates all the encrypted accounts to Bitwarden ciphers.
 // It decrypts each account, reencrypt the fields with the organization key,
 // and save it in the ciphers database.
-func migrateAccountsToOrganization(domain string) error {
+func migrateAccountsToOrganization(ctx *job.WorkerContext) error {
+	domain := ctx.Instance.Domain
+	log := ctx.Logger()
+
 	inst, err := instance.GetFromCouch(domain)
 	if err != nil {
 		return err
@@ -187,7 +190,6 @@ func migrateAccountsToOrganization(domain string) error {
 		return err
 	}
 	defer mu.Unlock()
-	log := inst.Logger().WithNamespace("migration")
 
 	setting, err := settings.Get(inst)
 	if err != nil {

--- a/worker/moves/workers.go
+++ b/worker/moves/workers.go
@@ -44,8 +44,7 @@ func ExportWorker(c *job.WorkerContext) error {
 
 	exportDoc, err := move.CreateExport(c.Instance, opts, archiver)
 	if err != nil {
-		c.Instance.Logger().WithNamespace("move").
-			Warnf("Export failed: %s", err)
+		c.Logger().Warnf("Export failed: %s", err)
 		if opts.MoveTo != nil {
 			move.Abort(c.Instance, opts.MoveTo.URL, opts.MoveTo.Token)
 		}
@@ -97,8 +96,7 @@ func ImportWorker(c *job.WorkerContext) error {
 		if opts.MoveFrom != nil {
 			status = move.StatusMoveFailure
 		}
-		c.Instance.Logger().WithNamespace("move").
-			Warnf("Import failed: %s", err)
+		c.Logger().Warnf("Import failed: %s", err)
 	}
 
 	if opts.MoveFrom != nil {

--- a/worker/notes/notes.go
+++ b/worker/notes/notes.go
@@ -27,11 +27,10 @@ func WorkerPersist(ctx *job.WorkerContext) error {
 	if err := ctx.UnmarshalMessage(&msg); err != nil {
 		return err
 	}
-	log := ctx.Instance.Logger().WithNamespace("notes")
-	log.Debugf("Persist %#v", msg)
+	ctx.Logger().Debugf("Persist %#v", msg)
 	err := note.Update(ctx.Instance, msg.NoteID)
 	if err != nil {
-		log.Warnf("Cannot persist note %s: %s", msg.NoteID, err)
+		ctx.Logger().Warnf("Cannot persist note %s: %s", msg.NoteID, err)
 	}
 	return err
 }

--- a/worker/share/share.go
+++ b/worker/share/share.go
@@ -54,8 +54,7 @@ func WorkerTrack(ctx *job.WorkerContext) error {
 	if err := ctx.UnmarshalEvent(&evt); err != nil {
 		return err
 	}
-	ctx.Instance.Logger().WithNamespace("share").
-		Debugf("Track %#v - %#v", msg, evt)
+	ctx.Logger().Debugf("Track %#v - %#v", msg, evt)
 	return sharing.UpdateShared(ctx.Instance, msg, evt)
 }
 
@@ -66,8 +65,7 @@ func WorkerReplicate(ctx *job.WorkerContext) error {
 	if err := ctx.UnmarshalMessage(&msg); err != nil {
 		return err
 	}
-	ctx.Instance.Logger().WithNamespace("share").
-		Debugf("Replicate %#v", msg)
+	ctx.Logger().Debugf("Replicate %#v", msg)
 	s, err := sharing.FindSharing(ctx.Instance, msg.SharingID)
 	if err != nil {
 		return err
@@ -84,7 +82,7 @@ func WorkerUpload(ctx *job.WorkerContext) error {
 	if err := ctx.UnmarshalMessage(&msg); err != nil {
 		return err
 	}
-	ctx.Instance.Logger().WithNamespace("share").
+	ctx.Logger().
 		Debugf("Upload %#v", msg)
 	s, err := sharing.FindSharing(ctx.Instance, msg.SharingID)
 	if err != nil {

--- a/worker/thumbnail/thumbnail.go
+++ b/worker/thumbnail/thumbnail.go
@@ -91,13 +91,13 @@ func Worker(ctx *job.WorkerContext) error {
 	}
 
 	log := ctx.Logger()
-	log.WithNamespace("thumbnail").Debugf("%s %s", img.Verb, img.Doc.ID())
+	log.Debugf("%s %s", img.Verb, img.Doc.ID())
 	switch img.Verb {
 	case "CREATED":
 		return generateThumbnails(ctx, &img.Doc)
 	case "UPDATED":
 		if err := removeThumbnails(ctx.Instance, &img.Doc); err != nil {
-			log.WithNamespace("thumbnail").Debugf("failed to remove thumbnails for %s: %s", img.Doc.ID(), err)
+			log.Debugf("failed to remove thumbnails for %s: %s", img.Doc.ID(), err)
 		}
 		return generateThumbnails(ctx, &img.Doc)
 	case "DELETED":


### PR DESCRIPTION
`WorkerContext.Logger()` have already all the required field setup so
there is no need to create a new logger.