### PR TITLE
Improve views and indexes update

### DIFF
--- a/model/instance/lifecycle/get.go
+++ b/model/instance/lifecycle/get.go
@@ -26,7 +26,7 @@ func GetInstance(domain string) (*instance.Instance, error) {
 		}
 
 		i.Logger().Debugf("Indexes outdated: wanted %d; got %d", couchdb.IndexViewsVersion, i.IndexViewsVersion)
-		if err = DefineViewsAndIndex(i); err != nil {
+		if err = UpdateViewsAndIndex(i); err != nil {
 			i.Logger().Errorf("Could not re-define indexes and views: %s", err.Error())
 			return nil, err
 		}

--- a/model/instance/lifecycle/helpers.go
+++ b/model/instance/lifecycle/helpers.go
@@ -43,12 +43,25 @@ func installApp(inst *instance.Instance, slug string) error {
 }
 
 // DefineViewsAndIndex can be used to ensure that the CouchDB views and indexes
-// used by the stack are correctly set.
+// used by the stack are correctly set. It expects that most index/view don't
+// exist. It is faster when creating a new instance for example.
 func DefineViewsAndIndex(inst *instance.Instance) error {
 	g, _ := errgroup.WithContext(context.Background())
 	couchdb.DefineIndexes(g, inst, couchdb.Indexes)
 	couchdb.DefineViews(g, inst, couchdb.Views)
 	if err := g.Wait(); err != nil {
+		return err
+	}
+	inst.IndexViewsVersion = couchdb.IndexViewsVersion
+	return nil
+}
+
+// UpdateViewsAndIndex can be used to ensure that the CouchDB views and indexes
+// used by the stack are correctly set. It has the same effect as
+// DefineViewsAndIndex, but it expect most index/views already exist.
+func UpdateViewsAndIndex(inst *instance.Instance) error {
+	err := couchdb.UpdateIndexesAndViews(inst, couchdb.Indexes, couchdb.Views)
+	if err != nil {
 		return err
 	}
 	inst.IndexViewsVersion = couchdb.IndexViewsVersion

--- a/pkg/couchdb/bulk.go
+++ b/pkg/couchdb/bulk.go
@@ -93,6 +93,15 @@ func CountNormalDocs(db prefixer.Prefixer, doctype string) (int, error) {
 // GetAllDocs returns all documents of a specified doctype. It filters
 // out the possible _design document.
 func GetAllDocs(db prefixer.Prefixer, doctype string, req *AllDocsRequest, results interface{}) (err error) {
+	return getAllDocs(db, doctype, req, results, false)
+}
+
+// GetDesignDocs does the same as GetAllDocs, but it keeps the design docs.
+func GetDesignDocs(db prefixer.Prefixer, doctype string, req *AllDocsRequest, results interface{}) (err error) {
+	return getAllDocs(db, doctype, req, results, true)
+}
+
+func getAllDocs(db prefixer.Prefixer, doctype string, req *AllDocsRequest, results interface{}, includeDesignDocs bool) (err error) {
 	var v url.Values
 	if req != nil {
 		v, err = req.Values()
@@ -123,7 +132,7 @@ func GetAllDocs(db prefixer.Prefixer, doctype string, req *AllDocsRequest, resul
 
 	var docs []json.RawMessage
 	for _, row := range response.Rows {
-		if !strings.HasPrefix(row.ID, "_design") {
+		if includeDesignDocs || !strings.HasPrefix(row.ID, "_design") {
 			docs = append(docs, row.Doc)
 		}
 	}

--- a/pkg/couchdb/views.go
+++ b/pkg/couchdb/views.go
@@ -1,0 +1,290 @@
+package couchdb
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"reflect"
+	"time"
+
+	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
+	"github.com/cozy/cozy-stack/pkg/logger"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
+	"golang.org/x/sync/errgroup"
+)
+
+// View is the map/reduce thing in CouchDB
+type View struct {
+	Name    string      `json:"-"`
+	Doctype string      `json:"-"`
+	Map     interface{} `json:"map"`
+	Reduce  interface{} `json:"reduce,omitempty"`
+	Options interface{} `json:"options,omitempty"`
+}
+
+// DesignDoc is the structure if a _design doc containing views
+type DesignDoc struct {
+	ID    string           `json:"_id,omitempty"`
+	Rev   string           `json:"_rev,omitempty"`
+	Lang  string           `json:"language"`
+	Views map[string]*View `json:"views"`
+}
+
+// IndexCreationResponse is the response from couchdb when we create an Index
+type IndexCreationResponse struct {
+	Result string `json:"result,omitempty"`
+	Error  string `json:"error,omitempty"`
+	Reason string `json:"reason,omitempty"`
+	ID     string `json:"id,omitempty"`
+	Name   string `json:"name,omitempty"`
+}
+
+// DefineViews creates a design doc with some views
+func DefineViews(g *errgroup.Group, db prefixer.Prefixer, views []*View) {
+	for i := range views {
+		view := views[i]
+		g.Go(func() error {
+			return DefineView(db, view)
+		})
+	}
+}
+
+// DefineView ensure that a view exists, or creates it.
+func DefineView(db prefixer.Prefixer, v *View) error {
+	id := "_design/" + v.Name
+	url := url.PathEscape(id)
+	doc := &DesignDoc{
+		ID:    id,
+		Lang:  "javascript",
+		Views: map[string]*View{v.Name: v},
+	}
+	err := makeRequest(db, v.Doctype, http.MethodPut, url, &doc, nil)
+	if IsNoDatabaseError(err) {
+		err = CreateDB(db, v.Doctype)
+		if err != nil && !IsFileExists(err) {
+			if err != nil {
+				logger.WithDomain(db.DomainName()).
+					Infof("Cannot create view %s %s: cannot create DB - %s",
+						db.DBPrefix(), v.Doctype, err)
+			}
+			return err
+		}
+		err = makeRequest(db, v.Doctype, http.MethodPut, url, &doc, nil)
+	}
+	if IsConflictError(err) {
+		var old DesignDoc
+		err = makeRequest(db, v.Doctype, http.MethodGet, url, nil, &old)
+		if err != nil {
+			if err != nil {
+				logger.WithDomain(db.DomainName()).
+					Infof("Cannot create view %s %s: conflict - %s",
+						db.DBPrefix(), v.Doctype, err)
+			}
+			return err
+		}
+		if !equalViews(&old, doc) {
+			doc.Rev = old.Rev
+			err = makeRequest(db, v.Doctype, http.MethodPut, url, &doc, nil)
+		} else {
+			err = nil
+		}
+	}
+	if err != nil {
+		logger.WithDomain(db.DomainName()).
+			Infof("Cannot create view %s %s: %s", db.DBPrefix(), v.Doctype, err)
+	}
+	return err
+}
+
+// UpdateIndexesAndViews creates views and indexes that are missing or not
+// up-to-date.
+func UpdateIndexesAndViews(db prefixer.Prefixer, indexes []*mango.Index, views []*View) error {
+	g, _ := errgroup.WithContext(context.Background())
+
+	// Load the existing design docs
+	idsByDoctype := map[string][]string{}
+	for _, view := range views {
+		list := idsByDoctype[view.Doctype]
+		list = append(list, "_design/"+view.Name)
+		idsByDoctype[view.Doctype] = list
+	}
+	for _, index := range indexes {
+		list := idsByDoctype[index.Doctype]
+		list = append(list, "_design/"+index.Request.DDoc)
+		idsByDoctype[index.Doctype] = list
+	}
+	ddocsByDoctype := map[string][]*DesignDoc{}
+	for doctype, ids := range idsByDoctype {
+		req := &AllDocsRequest{Keys: ids, Limit: 10000}
+		results := []*DesignDoc{}
+		err := GetDesignDocs(db, doctype, req, &results)
+		if err != nil {
+			continue
+		}
+		ddocsByDoctype[doctype] = results
+	}
+
+	// Define views that don't exist
+	for i := range views {
+		view := views[i]
+		ddoc := &DesignDoc{
+			ID:    "_design/" + view.Name,
+			Lang:  "javascript",
+			Views: map[string]*View{view.Name: view},
+		}
+		exists := false
+		for _, old := range ddocsByDoctype[view.Doctype] {
+			if equalViews(old, ddoc) {
+				exists = true
+			}
+		}
+		if exists {
+			continue
+		}
+		g.Go(func() error {
+			return DefineView(db, view)
+		})
+	}
+
+	// Define indexes that don't exist
+	for i := range indexes {
+		index := indexes[i]
+		ddoc := &DesignDoc{
+			ID:   "_design/" + index.Request.DDoc,
+			Lang: "query",
+		}
+		exists := false
+		for _, old := range ddocsByDoctype[index.Doctype] {
+			name := "undefined"
+			for key := range old.Views {
+				name = key
+			}
+			mapFields := map[string]interface{}{}
+			defFields := []interface{}{}
+			for _, field := range index.Request.Index {
+				mapFields[field] = "asc"
+				defFields = append(defFields, field)
+			}
+			view := &View{
+				Name:    name,
+				Doctype: index.Doctype,
+				Map: map[string]interface{}{
+					"fields":                  mapFields,
+					"partial_filter_selector": map[string]interface{}{},
+				},
+				Reduce: "_count",
+				Options: map[string]interface{}{
+					"def": map[string]interface{}{
+						"fields": defFields,
+					},
+				},
+			}
+			ddoc.Views = map[string]*View{name: view}
+			if equalViews(old, ddoc) {
+				exists = true
+			}
+		}
+		if exists {
+			continue
+		}
+		g.Go(func() error {
+			return DefineIndex(db, index)
+		})
+	}
+
+	return g.Wait()
+}
+
+func equalViews(v1 *DesignDoc, v2 *DesignDoc) bool {
+	if v1.Lang != v2.Lang {
+		return false
+	}
+	if len(v1.Views) != len(v2.Views) {
+		return false
+	}
+	for name, view1 := range v1.Views {
+		view2, ok := v2.Views[name]
+		if !ok {
+			return false
+		}
+		if !reflect.DeepEqual(view1.Map, view2.Map) ||
+			!reflect.DeepEqual(view1.Reduce, view2.Reduce) ||
+			!reflect.DeepEqual(view1.Options, view2.Options) {
+			return false
+		}
+	}
+	return true
+}
+
+// ExecView executes the specified view function
+func ExecView(db prefixer.Prefixer, view *View, req *ViewRequest, results interface{}) error {
+	viewurl := fmt.Sprintf("_design/%s/_view/%s", view.Name, view.Name)
+	if req.GroupLevel > 0 {
+		req.Group = true
+	}
+	v, err := req.Values()
+	if err != nil {
+		return err
+	}
+	viewurl += "?" + v.Encode()
+	if req.Keys != nil {
+		return makeRequest(db, view.Doctype, http.MethodPost, viewurl, req, &results)
+	}
+	err = makeRequest(db, view.Doctype, http.MethodGet, viewurl, nil, &results)
+	if IsInternalServerError(err) {
+		time.Sleep(1 * time.Second)
+		// Retry the error on 500, as it may be just that CouchDB is slow to build the view
+		err = makeRequest(db, view.Doctype, http.MethodGet, viewurl, nil, &results)
+		if IsInternalServerError(err) {
+			logger.
+				WithDomain(db.DomainName()).
+				WithNamespace("couchdb").
+				WithField("critical", "true").
+				Errorf("500 on requesting view: %s", err)
+		}
+	}
+	return err
+}
+
+// DefineIndexes defines a list of indexes.
+func DefineIndexes(g *errgroup.Group, db prefixer.Prefixer, indexes []*mango.Index) {
+	for i := range indexes {
+		index := indexes[i]
+		g.Go(func() error { return DefineIndex(db, index) })
+	}
+}
+
+// DefineIndex define the index on the doctype database
+// see query package on how to define an index
+func DefineIndex(db prefixer.Prefixer, index *mango.Index) error {
+	_, err := DefineIndexRaw(db, index.Doctype, index.Request)
+	if err != nil {
+		logger.WithDomain(db.DomainName()).
+			Infof("Cannot create index %s %s: %s", db.DBPrefix(), index.Doctype, err)
+	}
+	return err
+}
+
+// DefineIndexRaw defines a index
+func DefineIndexRaw(db prefixer.Prefixer, doctype string, index interface{}) (*IndexCreationResponse, error) {
+	url := "_index"
+	response := &IndexCreationResponse{}
+	err := makeRequest(db, doctype, http.MethodPost, url, &index, &response)
+	if IsNoDatabaseError(err) {
+		if err = CreateDB(db, doctype); err != nil && !IsFileExists(err) {
+			return nil, err
+		}
+		err = makeRequest(db, doctype, http.MethodPost, url, &index, &response)
+	}
+	// XXX when creating the same index twice at the same time, CouchDB respond
+	// with a 500, so let's just retry as a work-around...
+	if IsInternalServerError(err) {
+		time.Sleep(100 * time.Millisecond)
+		err = makeRequest(db, doctype, http.MethodPost, url, &index, &response)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
+}


### PR DESCRIPTION
When a Cozy was created before the set of indexes or views for an instance was last changed, it has a different IndexViewsVersion. This number can be used by the stack when a Cozy is used to check if the views and indexes must be updated.

Before this commit, the update process was the same as the creation process. We iterate on all views and indexes, trying to create them, and if it fails, look if the view/index exists and has the right definition, and if necessary update it.

With this commit, the update tries to opmitize this process, by first looking what views and indexes exists, and only try to create/update it when missing or not the right definition. It should help to lower the load on the CouchDB cluster when we release a stack with an increased IndexViewsVersion.