### PR TITLE
fix: Add aria-expanded to password hint form

### DIFF
--- a/assets/scripts/cirrus.js
+++ b/assets/scripts/cirrus.js
@@ -56,6 +56,12 @@
     expand.addEventListener('click', function (event) {
       event.preventDefault()
       expand.classList.toggle('expanded')
+
+      if (expand.getAttribute("aria-expanded") === "true") {
+        expand.setAttribute("aria-expanded", "false")
+      } else {
+        expand.setAttribute("aria-expanded", "true")
+      }
     })
   }
 })(window, document)

--- a/assets/templates/passphrase_choose.html
+++ b/assets/templates/passphrase_choose.html
@@ -48,7 +48,7 @@
           </div>
           <p id="password-tip" class="text-muted mb-3">{{t "Passphrase renew Help"}}</p>
 
-          <a href="#password-hint" class="expand mb-4 align-self-start text-decoration-none align-items-center">
+          <a href="#password-hint" class="expand mb-4 align-self-start text-decoration-none align-items-center" role="button" aria-expanded="false">
             <span class="icon icon-right me-2"></span>
             {{t "Passphrase Onboarding Show hint form"}}
           </a>


### PR DESCRIPTION
  Accessibility best practices recommend that widget following the
  disclosure pattern (see
  https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/) use the
  `aria-expanded` attribute on the element toggling the hidden/visible
  state.