### PR TITLE
fix: Delete triggers for `client` trigger

### DIFF
--- a/model/account/accounts.go
+++ b/model/account/accounts.go
@@ -142,7 +142,7 @@ func GetTriggers(jobsSystem job.JobSystem, db prefixer.Prefixer, accountID strin
 
 	var toDelete []job.Trigger
 	for _, t := range triggers {
-		if t.Infos().WorkerType != "konnector" {
+		if !(t.Infos().WorkerType == "konnector" || t.Infos().WorkerType == "client") {
 			continue
 		}
 


### PR DESCRIPTION
When we delete an account related to a client side konnector or when we uninstall a client side konnector, we want the stack to delete orphaned triggers.

So we have to not ignore `client` trigger.

