### PR TITLE
Add support for XDG Base Directory specification for the config file

### DIFF
--- a/pkg/config/config/config.go
+++ b/pkg/config/config/config.go
@@ -46,6 +46,8 @@ var Paths = []string{
 	".",
 	".cozy",
 	"$HOME/.cozy",
+	"$HOME/.config/cozy",
+	"$XDG_CONFIG_HOME/cozy",
 	"/etc/cozy",
 }
 


### PR DESCRIPTION
As precised in https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html the config files should be hosted inside the folder `$XDG_CONFIG_HOME`.

In order to allow a retro-compatibility with the previous path we use this file only when it's available.