### PR TITLE
Fix delegate userinfo endpoint

### DIFF
--- a/docs/admin.md
+++ b/docs/admin.md
@@ -876,7 +876,14 @@ response, the stack can create a delegated code associated to the sub.
 ```http
 POST /oidc/dev/franceconnect/code HTTP/1.1
 Accept: application/json
+Content-Type: application/json
 Authorization: Bearer ZmE2ZTFmN
+```
+
+```json
+{
+  "access_token": "ZmE2ZTFmN"
+}
 ```
 
 ```http

--- a/web/oidc/oidc.go
+++ b/web/oidc/oidc.go
@@ -852,9 +852,14 @@ func GetDelegatedCode(c echo.Context) error {
 		})
 	}
 
-	authorization := c.Request().Header.Get(echo.HeaderAuthorization)
-	token := strings.TrimPrefix(authorization, "Bearer ")
-	params, err := getUserInfo(conf, token)
+	var reqBody struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := c.Bind(&reqBody); err != nil {
+		return err
+	}
+
+	params, err := getUserInfo(conf, reqBody.AccessToken)
 	if err != nil {
 		return err
 	}

--- a/web/oidc/oidc_test.go
+++ b/web/oidc/oidc_test.go
@@ -236,8 +236,8 @@ func TestOidc(t *testing.T) {
 		})
 
 		obj := e.POST("/admin-oidc/"+testInstance.ContextName+"/franceconnect/code").
-			WithHeader("Authorization", "Bearer fc_token").
 			WithHeader("Content-Type", "application/json").
+			WithBytes([]byte(`{ "access_token": "fc_token" }`)).
 			Expect().Status(200).
 			JSON().
 			Object()


### PR DESCRIPTION
The delegate userinfo endpoint for OIDC was using an Authorization header for the access_token. But, as it was on the admin endpoint, there was also an Authorization header for basic auth of admin. And the two headers were conflicting: they were not manager correctly by cloudery and stack. We can fix the issue by passing the access_token in the POST body (as JSON).