### PR TITLE
fix: Typo in flagship app registration message

### DIFF
--- a/assets/locales/fr.po
+++ b/assets/locales/fr.po
@@ -345,7 +345,7 @@ msgstr "Application non certifiée"
 msgid "Authorize Confirm Flagship help"
 msgstr ""
 "La provenance de cette application n'est pas certifiée. Un code à 6 chiffres"
-" vous a été evoyé par email à l’adresse : %s. Saisissez le code pour "
+" vous a été envoyé par email à l’adresse : %s. Saisissez le code pour "
 "confirmer votre volonté d’utiliser l’application"
 
 msgid "Authorize Confirm Flagship more link"


### PR DESCRIPTION
Correcting a typo in cozy flagship app registration message.

I don't know well the testing/merging process.
You take the baby ?