### PR TITLE
dev: Add dev konnector runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ install:
 
 ## run: start the cozy-stack for local development
 run:
-	@go run . serve --mailhog --fs-url=file://localhost${PWD}/storage --konnectors-cmd ${PWD}/scripts/konnector-node-run.sh
+	@go run . serve --mailhog --fs-url=file://localhost${PWD}/storage --konnectors-cmd ${PWD}/scripts/konnector-dev-run.sh
 .PHONY: run
 
 ## instance: create an instance for local development

--- a/cozy.example.yaml
+++ b/cozy.example.yaml
@@ -184,6 +184,7 @@ jobs:
 # konnectors execution parameters for executing external processes.
 konnectors:
   cmd: ./scripts/konnector-node-run.sh # run connectors with node
+  # cmd: ./scripts/konnector-node-run.sh # run connectors with node in dev mode
   # cmd: ./scripts/konnector-rkt-run.sh # run connectors with rkt
   # cmd: ./scripts/konnector-nsjail-node8-run.sh # run connectors with nsjail
 

--- a/scripts/konnector-dev-run.sh
+++ b/scripts/konnector-dev-run.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+set -o pipefail
+
+arg="${1}"
+
+if [ ! -f "${arg}" ] && [ ! -d "${arg}" ]; then
+  >&2 echo "${arg} does not exist"
+  exit 1
+fi
+
+USING_NODE_LTE_16_3_0() {
+  printf '%s\nv16.3.0' $(node --version) | sort -C -V
+}
+if USING_NODE_LTE_16_3_0; then
+  dnsArg=""
+else
+  # If node is >v16.3.0 then request IPv4 DNS resolutions as cozy-stack does not
+  # listen to IPv6 addresses yet.
+  dnsArg="--dns-result-order=ipv4first"
+fi
+
+[ ! -d ~/.cozy ] && mkdir -p ~/.cozy
+node $dnsArg "${arg}" 2>&1 | tee -a ~/.cozy/services.log


### PR DESCRIPTION
This runner uses NodeJS with the appropriate DNS resolution argument
depending on its version, making sure every request will use an IPv4
DNS resolution as `cozy-stack` does not listen to IPv6 addresses yet.

This runner also forwards all outputs to a dedicated log file in
`~/.cozy/services.log` for easy access.