### PR TITLE
Fix a race condition on realtime

### DIFF
--- a/pkg/realtime/subscriber.go
+++ b/pkg/realtime/subscriber.go
@@ -30,7 +30,7 @@ func (sub *Subscriber) Subscribe(doctype string) {
 		return
 	}
 	key := topicKey(sub, doctype)
-	go sub.hub.subscribe(sub, key)
+	sub.hub.subscribe(sub, key)
 }
 
 // Unsubscribe removes a listener for events on a whole doctype
@@ -39,7 +39,7 @@ func (sub *Subscriber) Unsubscribe(doctype string) {
 		return
 	}
 	key := topicKey(sub, doctype)
-	go sub.hub.unsubscribe(sub, key)
+	sub.hub.unsubscribe(sub, key)
 }
 
 // Watch adds a listener for events for a specific document (doctype+id)
@@ -48,7 +48,7 @@ func (sub *Subscriber) Watch(doctype, id string) {
 		return
 	}
 	key := topicKey(sub, doctype)
-	go sub.hub.watch(sub, key, id)
+	sub.hub.watch(sub, key, id)
 }
 
 // Unwatch removes a listener for events for a specific document (doctype+id)
@@ -57,7 +57,7 @@ func (sub *Subscriber) Unwatch(doctype, id string) {
 		return
 	}
 	key := topicKey(sub, doctype)
-	go sub.hub.unwatch(sub, key, id)
+	sub.hub.unwatch(sub, key, id)
 }
 
 // Close will unsubscribe to all topics and the subscriber should no longer be


### PR DESCRIPTION
When a client asks for UNSUBSCRIBE on a doctype, and just after that for SUBSCRIBE on the same doctype, there was a race condition where a part of the UNSUBSCRIBE process were done after the process for the SUBSCRIBE. It is due to the lock for the mem hub being acquired in goroutines. We are now getting the lock sooner to avoid this issue.

In practice, this bug was seen when emptying the trash in Drive web and files were still on the screen as Drive was not receiving the realtime notifications for them.