### PR TITLE
fix: Check both konnector types when cleaning data

### DIFF
--- a/model/account/accounts.go
+++ b/model/account/accounts.go
@@ -142,7 +142,7 @@ func GetTriggers(jobsSystem job.JobSystem, db prefixer.Prefixer, accountID strin
 
 	var toDelete []job.Trigger
 	for _, t := range triggers {
-		if !(t.Infos().WorkerType == "konnector" || t.Infos().WorkerType == "client") {
+		if !t.Infos().IsKonnectorTrigger() {
 			continue
 		}
 
@@ -278,6 +278,10 @@ func ComputeName(doc couchdb.JSONDoc) {
 func init() {
 	couchdb.AddHook(consts.Accounts, couchdb.EventDelete,
 		func(db prefixer.Prefixer, doc couchdb.Doc, old couchdb.Doc) error {
+			logger.WithDomain(db.DomainName()).
+				WithField("account_id", old.ID()).
+				Info("Executing account deletion hook")
+
 			manualCleaning := false
 			switch v := doc.(type) {
 			case *Account:

--- a/model/job/scheduler.go
+++ b/model/job/scheduler.go
@@ -107,6 +107,10 @@ func (t *TriggerInfos) DomainName() string {
 	return t.Domain
 }
 
+func (t *TriggerInfos) IsKonnectorTrigger() bool {
+	return t.WorkerType == "konnector" || t.WorkerType == "client"
+}
+
 // NewTrigger creates the trigger associates with the specified trigger
 // options.
 func NewTrigger(db prefixer.Prefixer, infos TriggerInfos, data interface{}) (Trigger, error) {

--- a/web/apps/apps.go
+++ b/web/apps/apps.go
@@ -395,7 +395,7 @@ func findAccountsToDelete(instance *instance.Instance, slug string) ([]account.C
 
 	var toDelete []account.CleanEntry
 	for _, t := range triggers {
-		if t.Infos().WorkerType != "konnector" {
+		if !t.Infos().IsKonnectorTrigger() {
 			continue
 		}
 


### PR DESCRIPTION
This is a followup of https://github.com/cozy/cozy-stack/pull/3862.

When deleting an account, uninstalling a konnector or destroying an
instance, we try to clean orphaned konnector accounts and triggers.

However, when checking triggers types, we forgot to take into account
the type associated with client side konnectors thus leaving their
triggers untouched.

We'll now use a new `trigger.IsKonnectorTrigger()` method to make this
check and make sure all orphaned konnector triggers are removed.