### PR TITLE
Fix adding a contact by Cozy URL to a sharing with delegation

### DIFF
--- a/model/sharing/invitation.go
+++ b/model/sharing/invitation.go
@@ -74,17 +74,13 @@ func (s *Sharing) SendInvitationsToMembers(inst *instance.Instance, members []Me
 		if key == "" {
 			key = m.Instance
 		}
-		sent := false
-		link := m.InvitationLink(inst, s, states[key], nil)
-		if m.Instance != "" {
-			if err := m.SendShortcut(inst, s, link); err != nil {
-				sent = true
-			}
-		}
-		if !sent {
+		// If an instance URL is available, the owner's Cozy has already
+		// created a shortcut, so we don't need to send an invitation.
+		if m.Instance == "" {
 			if m.Email == "" {
 				return ErrInvitationNotSent
 			}
+			link := m.InvitationLink(inst, s, states[key], nil)
 			if err := m.SendMail(inst, s, sharer, desc, link); err != nil {
 				inst.Logger().WithNamespace("sharing").
 					Errorf("Can't send email for %#v: %s", m.Email, err)

--- a/model/sharing/member.go
+++ b/model/sharing/member.go
@@ -360,8 +360,12 @@ func (s *Sharing) DelegateAddContacts(inst *instance.Instance, contactIDs map[st
 // AddDelegatedContact adds a contact on the owner cozy, but for a contact from
 // a recipient (open_sharing: true only)
 func (s *Sharing) AddDelegatedContact(inst *instance.Instance, email, instanceURL string, readOnly bool) (string, error) {
+	status := MemberStatusPendingInvitation
+	if instanceURL != "" {
+		status = MemberStatusMailNotSent
+	}
 	m := Member{
-		Status:   MemberStatusPendingInvitation,
+		Status:   status,
 		Email:    email,
 		Instance: instanceURL,
 		ReadOnly: readOnly,

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -363,7 +363,21 @@ func AddRecipientsDelegated(c echo.Context) error {
 				} else {
 					states[email] = state
 				}
+
+				// If we have an URL for the Cozy, we can create a shortcut as an invitation
+				if cozy != "" {
+					var perms *permission.Permission
+					if s.PreviewPath != "" {
+						if perms, err = s.CreatePreviewPermissions(inst); err != nil {
+							return wrapErrors(err)
+						}
+					}
+					if err = s.SendInvitations(inst, perms); err != nil {
+						return wrapErrors(err)
+					}
+				}
 			}
+
 			if err := couchdb.UpdateDoc(inst, s); err != nil {
 				return wrapErrors(err)
 			}


### PR DESCRIPTION
If Alice creates a sharing with Bob in read/write mode, and with the open_sharing set tot true, Bob can add recipients to this sharing. If Bob has a contact with a Cozy URL but no email, adding this contact to the sharing was failing. Bob's Cozy was trying to send the invitation, but it can't create the shortcut as it requires the Xor key for this new recipient (only available on Alice's Cozy), and it can't send an email as the email address is not known. We have fixed this issue by making the owner's Cozy creating the shortcut in that case.