### PR TITLE
Create the `Logger` abstraction around the use of logrus

### DIFF
--- a/model/app/fetcher_file.go
+++ b/model/app/fetcher_file.go
@@ -13,14 +13,14 @@ import (
 
 type fileFetcher struct {
 	manFilename string
-	log         *logger.Entry
+	log         logger.Logger
 }
 
 // The file fetcher is mostly used in development mode. The version of the
 // application installed with this mode is appended with a random number so
 // that multiple version can be installed from the same directory without
 // having to increase the version number from the manifest.
-func newFileFetcher(manFilename string, log *logger.Entry) *fileFetcher {
+func newFileFetcher(manFilename string, log logger.Logger) *fileFetcher {
 	return &fileFetcher{
 		manFilename: manFilename,
 		log:         log,

--- a/model/app/fetcher_git.go
+++ b/model/app/fetcher_git.go
@@ -37,10 +37,10 @@ var (
 
 type gitFetcher struct {
 	manFilename string
-	log         *logger.Entry
+	log         logger.Logger
 }
 
-func newGitFetcher(manFilename string, log *logger.Entry) *gitFetcher {
+func newGitFetcher(manFilename string, log logger.Logger) *gitFetcher {
 	return &gitFetcher{
 		manFilename: manFilename,
 		log:         log,

--- a/model/app/fetcher_http.go
+++ b/model/app/fetcher_http.go
@@ -31,10 +31,10 @@ var httpClient = http.Client{
 type httpFetcher struct {
 	manFilename string
 	prefix      string
-	log         *logger.Entry
+	log         logger.Logger
 }
 
-func newHTTPFetcher(manFilename string, log *logger.Entry) *httpFetcher {
+func newHTTPFetcher(manFilename string, log logger.Logger) *httpFetcher {
 	return &httpFetcher{
 		manFilename: manFilename,
 		log:         log,

--- a/model/app/fetcher_registry.go
+++ b/model/app/fetcher_registry.go
@@ -14,12 +14,12 @@ import (
 )
 
 type registryFetcher struct {
-	log        *logger.Entry
+	log        logger.Logger
 	registries []*url.URL
 	version    *registry.Version
 }
 
-func newRegistryFetcher(registries []*url.URL, log *logger.Entry) Fetcher {
+func newRegistryFetcher(registries []*url.URL, log logger.Logger) Fetcher {
 	return &registryFetcher{log: log, registries: registries}
 }
 

--- a/model/app/installer.go
+++ b/model/app/installer.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cozy/cozy-stack/pkg/realtime"
 	"github.com/cozy/cozy-stack/pkg/registry"
 	"github.com/cozy/cozy-stack/pkg/utils"
-	"github.com/sirupsen/logrus"
 )
 
 var slugReg = regexp.MustCompile(`^[a-z0-9\-]+$`)
@@ -60,7 +59,7 @@ type Installer struct {
 	context string
 
 	manc chan Manifest
-	log  *logger.Entry
+	log  logger.Logger
 }
 
 // InstallerOptions provides the slug name of the application along with the
@@ -138,7 +137,7 @@ func NewInstaller(in *instance.Instance, fs appfs.Copier, opts *InstallerOptions
 		installType = "delete"
 	}
 
-	log := logger.WithDomain(in.DomainName()).WithFields(logrus.Fields{
+	log := logger.WithDomain(in.DomainName()).WithFields(logger.Fields{
 		"nspace":        "apps",
 		"slug":          man.Slug(),
 		"version_start": man.Version(),

--- a/model/job/mem_broker.go
+++ b/model/job/mem_broker.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/limits"
+	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/cozy/cozy-stack/pkg/prefixer"
 	multierror "github.com/hashicorp/go-multierror"
-	"github.com/sirupsen/logrus"
 )
 
 type (
@@ -193,7 +193,7 @@ func (b *memBroker) PushJob(db prefixer.Prefixer, req *JobRequest) (*Job, error)
 	if err == nil {
 		err := config.GetRateLimiter().CheckRateLimit(db, ct)
 		if errors.Is(err, limits.ErrRateLimitReached) {
-			joblog.WithFields(logrus.Fields{
+			joblog.WithFields(logger.Fields{
 				"worker_type": req.WorkerType,
 				"instance":    db.DomainName(),
 			}).Warn(err.Error())

--- a/model/job/redis_broker.go
+++ b/model/job/redis_broker.go
@@ -12,10 +12,10 @@ import (
 
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/limits"
+	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/cozy/cozy-stack/pkg/prefixer"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/redis/go-redis/v9"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -213,7 +213,7 @@ func (b *redisBroker) PushJob(db prefixer.Prefixer, req *JobRequest) (*Job, erro
 	if err == nil {
 		err := config.GetRateLimiter().CheckRateLimit(db, ct)
 		if errors.Is(err, limits.ErrRateLimitReached) {
-			joblog.WithFields(logrus.Fields{
+			joblog.WithFields(logger.Fields{
 				"worker_type": req.WorkerType,
 				"instance":    db.DomainName(),
 			}).Warn(err.Error())

--- a/model/note/note.go
+++ b/model/note/note.go
@@ -748,7 +748,7 @@ func UpdateSchema(inst *instance.Instance, file *vfs.FileDoc, schema map[string]
 				}
 				stack := make([]byte, 4<<10) // 4 KB
 				length := runtime.Stack(stack, false)
-				log := inst.Logger().WithField("panic", true).WithNamespace("note")
+				log := inst.Logger().WithNamespace("note").WithField("panic", true)
 				log.Errorf("PANIC RECOVER %s: %s", err.Error(), stack[:length])
 			}
 		}()

--- a/model/sharing/member.go
+++ b/model/sharing/member.go
@@ -1001,7 +1001,7 @@ func (s *Sharing) NotifyRecipients(inst *instance.Instance, except *Member) {
 			}
 			stack := make([]byte, 4<<10) // 4 KB
 			length := runtime.Stack(stack, false)
-			log := inst.Logger().WithField("panic", true).WithNamespace("sharing")
+			log := inst.Logger().WithNamespace("sharing").WithField("panic", true)
 			log.Errorf("PANIC RECOVER %s: %s", err.Error(), stack[:length])
 		}
 	}()

--- a/model/sharing/setup.go
+++ b/model/sharing/setup.go
@@ -79,7 +79,7 @@ func (s *Sharing) Setup(inst *instance.Instance, m *Member) {
 			}
 			stack := make([]byte, 4<<10) // 4 KB
 			length := runtime.Stack(stack, false)
-			log := inst.Logger().WithField("panic", true).WithNamespace("sharing")
+			log := inst.Logger().WithNamespace("sharing").WithField("panic", true)
 			log.Errorf("PANIC RECOVER %s: %s", err.Error(), stack[:length])
 		}
 	}()

--- a/pkg/couchdb/couchdb.go
+++ b/pkg/couchdb/couchdb.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/cozy/cozy-stack/pkg/realtime"
 	"github.com/labstack/echo/v4"
-	"github.com/sirupsen/logrus"
 )
 
 // MaxString is the unicode character "\uFFFF", useful in query as
@@ -531,7 +530,7 @@ func DeleteDoc(db prefixer.Prefixer, doc Doc) error {
 	// metric.
 	if doc.DocType() == consts.Accounts {
 		logger.WithDomain(db.DomainName()).
-			WithFields(logrus.Fields{
+			WithFields(logger.Fields{
 				"log_id":      "account_delete",
 				"account_id":  doc.ID(),
 				"account_rev": doc.Rev(),

--- a/pkg/lock/simple_redis.go
+++ b/pkg/lock/simple_redis.go
@@ -196,7 +196,7 @@ func (rl *redisLock) RUnlock() {
 
 var redislocksMu sync.Mutex
 var redisRng *rand.Rand
-var redisLogger *logger.Entry
+var redisLogger logger.Logger
 
 type RedisLockGetter struct {
 	client redis.UniversalClient

--- a/pkg/logger/level.go
+++ b/pkg/logger/level.go
@@ -1,0 +1,87 @@
+package logger
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Level type
+type Level uint8
+
+// These are the different logging levels.
+const (
+	// levelUnknown represent an unparsable level
+	levelUnknown Level = iota
+
+	// ErrorLevel logs important errors when failure append.
+	ErrorLevel
+
+	// WarnLevel logs non critical entries that deserve some intention.
+	WarnLevel
+
+	// InfoLevel log general operational entries about what's going on inside
+	// the application.
+	InfoLevel
+
+	// DebugLevel logs is only enabled when debugging is setup. It can be
+	// very verbose logging and should be activated only on a limited period.
+	DebugLevel
+)
+
+var (
+	ErrInvalidLevel = errors.New("not a valid logging Level")
+)
+
+// Convert the Level to a string. E.g. LevelDebug becomes "debug".
+func (level Level) String() string {
+	if b, err := level.MarshalText(); err == nil {
+		return string(b)
+	}
+
+	return "unknown"
+}
+
+// ParseLevel takes a string level and returns the log level constant.
+func ParseLevel(lvl string) (Level, error) {
+	switch strings.ToLower(lvl) {
+	case "error":
+		return ErrorLevel, nil
+	case "warn", "warning":
+		return WarnLevel, nil
+	case "info":
+		return InfoLevel, nil
+	case "debug":
+		return DebugLevel, nil
+	}
+
+	return levelUnknown, fmt.Errorf("%q: %w", lvl, ErrInvalidLevel)
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (level *Level) UnmarshalText(text []byte) error {
+	l, err := ParseLevel(string(text))
+	if err != nil {
+		return err
+	}
+
+	*level = l
+
+	return nil
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (level Level) MarshalText() ([]byte, error) {
+	switch level {
+	case DebugLevel:
+		return []byte("debug"), nil
+	case InfoLevel:
+		return []byte("info"), nil
+	case WarnLevel:
+		return []byte("warning"), nil
+	case ErrorLevel:
+		return []byte("error"), nil
+	}
+
+	return nil, fmt.Errorf("not a valid logging level %d", level)
+}

--- a/pkg/logger/level_test.go
+++ b/pkg/logger/level_test.go
@@ -1,0 +1,87 @@
+package logger
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoggerParseLevel(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected Level
+		err      error
+	}{
+		{
+			name:     "Valid",
+			input:    "error",
+			expected: LevelError,
+			err:      nil,
+		},
+		{
+			name:     "ValidWithShortcut",
+			input:    "warn",
+			expected: LevelWarning,
+			err:      nil,
+		},
+		{
+			name:     "UpperCase",
+			input:    "INFO",
+			expected: LevelInfo,
+			err:      nil,
+		},
+		{
+			name:     "MixUpperLowerCase",
+			input:    "Debug",
+			expected: LevelDebug,
+			err:      nil,
+		},
+		{
+			name:     "WithPrefix",
+			input:    "-Debug",
+			expected: levelUnknown,
+			err:      ErrInvalidLevel,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			res, err := ParseLevel(test.input)
+
+			assert.Equal(t, test.expected, res)
+			assert.ErrorIs(t, err, test.err)
+		})
+	}
+}
+
+func TestLoggerLevelString(t *testing.T) {
+	t.Run("ValidInput", func(t *testing.T) {
+		assert.Equal(t, "error", LevelError.String())
+		assert.Equal(t, "debug", LevelDebug.String())
+		assert.Equal(t, "warning", LevelWarning.String())
+		assert.Equal(t, "info", LevelInfo.String())
+	})
+
+	t.Run("InvalidInput", func(t *testing.T) {
+		assert.Equal(t, "unknown", Level(42).String())
+	})
+}
+
+func TestLoggerUnmarshalText(t *testing.T) {
+	t.Run("ValidInput", func(t *testing.T) {
+		var lvl Level
+
+		err := lvl.UnmarshalText([]byte("error"))
+		assert.NoError(t, err)
+		assert.Equal(t, LevelError, lvl)
+	})
+
+	t.Run("InvalidInput", func(t *testing.T) {
+		var lvl Level
+
+		err := lvl.UnmarshalText([]byte("invalid-stuff"))
+		assert.EqualError(t, err, `"invalid-stuff": not a valid logging Level`)
+		assert.ErrorIs(t, err, ErrInvalidLevel)
+	})
+}

--- a/pkg/logger/level_test.go
+++ b/pkg/logger/level_test.go
@@ -16,25 +16,25 @@ func TestLoggerParseLevel(t *testing.T) {
 		{
 			name:     "Valid",
 			input:    "error",
-			expected: LevelError,
+			expected: ErrorLevel,
 			err:      nil,
 		},
 		{
 			name:     "ValidWithShortcut",
 			input:    "warn",
-			expected: LevelWarning,
+			expected: WarnLevel,
 			err:      nil,
 		},
 		{
 			name:     "UpperCase",
 			input:    "INFO",
-			expected: LevelInfo,
+			expected: InfoLevel,
 			err:      nil,
 		},
 		{
 			name:     "MixUpperLowerCase",
 			input:    "Debug",
-			expected: LevelDebug,
+			expected: DebugLevel,
 			err:      nil,
 		},
 		{
@@ -57,10 +57,10 @@ func TestLoggerParseLevel(t *testing.T) {
 
 func TestLoggerLevelString(t *testing.T) {
 	t.Run("ValidInput", func(t *testing.T) {
-		assert.Equal(t, "error", LevelError.String())
-		assert.Equal(t, "debug", LevelDebug.String())
-		assert.Equal(t, "warning", LevelWarning.String())
-		assert.Equal(t, "info", LevelInfo.String())
+		assert.Equal(t, "error", ErrorLevel.String())
+		assert.Equal(t, "debug", DebugLevel.String())
+		assert.Equal(t, "warning", WarnLevel.String())
+		assert.Equal(t, "info", InfoLevel.String())
 	})
 
 	t.Run("InvalidInput", func(t *testing.T) {
@@ -74,7 +74,7 @@ func TestLoggerUnmarshalText(t *testing.T) {
 
 		err := lvl.UnmarshalText([]byte("error"))
 		assert.NoError(t, err)
-		assert.Equal(t, LevelError, lvl)
+		assert.Equal(t, ErrorLevel, lvl)
 	})
 
 	t.Run("InvalidInput", func(t *testing.T) {

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"sync"
 	"time"
 
 	build "github.com/cozy/cozy-stack/pkg/config"
@@ -13,6 +14,30 @@ import (
 )
 
 var debugLogger *logrus.Logger
+
+var domains = new(sync.Map)
+
+// Fields type, used to pass to [Logger.WithFields].
+type Fields map[string]interface{}
+
+// Logger allows to emits logs to the divers log systems.
+type Logger interface {
+	Debugf(format string, args ...interface{})
+	Infof(format string, args ...interface{})
+	Warnf(format string, args ...interface{})
+	Errorf(format string, args ...interface{})
+
+	Debug(msg string)
+	Info(msg string)
+	Warn(msg string)
+	Error(msg string)
+
+	WithField(fn string, fv interface{}) Logger
+	WithFields(fields Fields) Logger
+	WithTime(t time.Time) Logger
+
+	Log(level Level, msg string)
+}
 
 // Options contains the configuration values of the logger system
 type Options struct {
@@ -69,33 +94,36 @@ func WithDomain(domain string) *Entry {
 // WithNamespace returns a logger with the specified nspace field.
 func WithNamespace(nspace string) *Entry {
 	entry := logrus.WithField("nspace", nspace)
+
 	return &Entry{entry}
 }
 
 // WithNamespace adds a namespace (nspace field).
 func (e *Entry) WithNamespace(nspace string) *Entry {
-	return e.WithField("nspace", nspace)
+	entry := e.entry.WithField("nspace", nspace)
+	return &Entry{entry}
 }
 
 // WithDomain add a domain field.
 func (e *Entry) WithDomain(domain string) *Entry {
-	return e.WithField("domain", domain)
+	entry := e.entry.WithField("domain", domain)
+	return &Entry{entry}
 }
 
 // WithField adds a single field to the Entry.
-func (e *Entry) WithField(key string, value interface{}) *Entry {
+func (e *Entry) WithField(key string, value interface{}) Logger {
 	entry := e.entry.WithField(key, value)
 	return &Entry{entry}
 }
 
 // WithFields adds a map of fields to the Entry.
-func (e *Entry) WithFields(fields logrus.Fields) *Entry {
-	entry := e.entry.WithFields(fields)
+func (e *Entry) WithFields(fields Fields) Logger {
+	entry := e.entry.WithFields(logrus.Fields(fields))
 	return &Entry{entry}
 }
 
 // WithTime overrides the Entry's time
-func (e *Entry) WithTime(t time.Time) *Entry {
+func (e *Entry) WithTime(t time.Time) Logger {
 	entry := e.entry.WithTime(t)
 	return &Entry{entry}
 }
@@ -122,37 +150,37 @@ func (e *Entry) AddHook(hook logrus.Hook) {
 // with syslog.
 const maxLineWidth = 2000
 
-func (e *Entry) Log(level logrus.Level, msg string) {
+func (e *Entry) Log(level Level, msg string) {
 	if len(msg) > maxLineWidth {
 		msg = msg[:maxLineWidth-12] + " [TRUNCATED]"
 	}
 
 	domain, haveDomain := e.entry.Data["domain"]
 
-	if haveDomain && level == logrus.DebugLevel && debugger.ExpiresAt(domain.(string)) != nil {
+	if haveDomain && level == DebugLevel && debugger.ExpiresAt(domain.(string)) != nil {
 		// The domain is listed in the debug domains and the ttl is valid, use the debuglogger
 		// to debug
 		debugLogger.WithFields(e.entry.Data).Log(logrus.DebugLevel, msg)
 		return
 	}
 
-	e.entry.Log(level, msg)
+	e.entry.Log(getLogrusLevel(level), msg)
 }
 
 func (e *Entry) Debug(msg string) {
-	e.Log(logrus.DebugLevel, msg)
+	e.Log(DebugLevel, msg)
 }
 
 func (e *Entry) Info(msg string) {
-	e.Log(logrus.InfoLevel, msg)
+	e.Log(InfoLevel, msg)
 }
 
 func (e *Entry) Warn(msg string) {
-	e.Log(logrus.WarnLevel, msg)
+	e.Log(WarnLevel, msg)
 }
 
 func (e *Entry) Error(msg string) {
-	e.Log(logrus.ErrorLevel, msg)
+	e.Log(ErrorLevel, msg)
 }
 
 func (e *Entry) Debugf(format string, args ...interface{}) {
@@ -209,4 +237,20 @@ type contextPrint struct {
 
 func (c contextPrint) Printf(ctx context.Context, format string, args ...interface{}) {
 	c.l.Printf(format, args...)
+}
+
+func getLogrusLevel(lvl Level) logrus.Level {
+	var logrusLevel logrus.Level
+	switch lvl {
+	case DebugLevel:
+		logrusLevel = logrus.DebugLevel
+	case InfoLevel:
+		logrusLevel = logrus.InfoLevel
+	case WarnLevel:
+		logrusLevel = logrus.WarnLevel
+	default:
+		logrusLevel = logrus.ErrorLevel
+	}
+
+	return logrusLevel
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"sync"
 	"time"
 
 	build "github.com/cozy/cozy-stack/pkg/config"
@@ -14,8 +13,6 @@ import (
 )
 
 var debugLogger *logrus.Logger
-
-var domains = new(sync.Map)
 
 // Fields type, used to pass to [Logger.WithFields].
 type Fields map[string]interface{}

--- a/web/apps/apps.go
+++ b/web/apps/apps.go
@@ -34,7 +34,6 @@ import (
 	"github.com/cozy/cozy-stack/web/jobs"
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/labstack/echo/v4"
-	"github.com/sirupsen/logrus"
 )
 
 // JSMimeType is the content-type for javascript
@@ -259,21 +258,23 @@ func logsHandler(appType consts.AppType) echo.HandlerFunc {
 			return jsonapi.BadJSON()
 		}
 
-		logger := logger.WithDomain(inst.Domain).
-			WithNamespace("jobs").
+		l := logger.WithDomain(inst.Domain).WithNamespace("jobs").
 			WithField("slug", slug).
 			WithField("job_id", c.QueryParam("job_id"))
 
-		if v := c.QueryParam("version"); v != "" {
-			logger = logger.WithField("version", v)
-		}
-
 		for _, log := range logs {
-			level, err := logrus.ParseLevel(log.Level)
+			level, err := logger.ParseLevel(log.Level)
 			if err != nil {
 				return jsonapi.InvalidAttribute("level", err)
 			}
-			logger.WithTime(log.Time).Log(level, log.Msg)
+
+			l := l.WithTime(log.Time)
+
+			if v := c.QueryParam("version"); v != "" {
+				l = l.WithField("version", v)
+			}
+
+			l.Log(level, log.Msg)
 		}
 
 		return c.NoContent(http.StatusNoContent)
@@ -445,7 +446,7 @@ func deleteKonnectorWithAccounts(instance *instance.Instance, man *app.KonnManif
 				}
 				stack := make([]byte, 4<<10) // 4 KB
 				length := runtime.Stack(stack, false)
-				log := instance.Logger().WithField("panic", true).WithNamespace("konnectors")
+				log := instance.Logger().WithNamespace("konnectors").WithField("panic", true)
 				log.Errorf("PANIC RECOVER %s: %s", err.Error(), stack[:length])
 			}
 		}()

--- a/web/jobs/jobs.go
+++ b/web/jobs/jobs.go
@@ -634,10 +634,12 @@ func patchJob(c echo.Context) error {
 	}
 
 	log := inst.Logger().
+		WithNamespace("jobs").
 		WithField("job_id", j.ID()).
-		WithField("worker_id", "client").
-		WithNamespace("jobs")
+		WithField("worker_id", "client")
+
 	msg := &exec.KonnectorMessage{}
+
 	if err := j.Message.Unmarshal(&msg); err == nil {
 		log = log.
 			WithField("slug", msg.Konnector).

--- a/web/statik/handler.go
+++ b/web/statik/handler.go
@@ -23,8 +23,6 @@ import (
 	"github.com/cozy/cozy-stack/pkg/utils"
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/labstack/echo/v4"
-
-	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -219,7 +217,7 @@ func AssetPath(domain, name string, context ...string) string {
 	}
 	f, ok := assets.Head(name, ctx)
 	if !ok {
-		logger.WithNamespace("assets").WithFields(logrus.Fields{
+		logger.WithNamespace("assets").WithFields(logger.Fields{
 			"domain":  domain,
 			"name":    name,
 			"context": ctx,

--- a/worker/exec/common.go
+++ b/worker/exec/common.go
@@ -56,7 +56,7 @@ type execWorker interface {
 	PrepareCmdEnv(ctx *job.WorkerContext, i *instance.Instance) (cmd string, env []string, err error)
 	ScanOutput(ctx *job.WorkerContext, i *instance.Instance, line []byte) error
 	Error(i *instance.Instance, err error) error
-	Logger(ctx *job.WorkerContext) *logger.Entry
+	Logger(ctx *job.WorkerContext) logger.Logger
 	Commit(ctx *job.WorkerContext, errjob error) error
 }
 

--- a/worker/exec/konnector.go
+++ b/worker/exec/konnector.go
@@ -578,7 +578,7 @@ func (w *konnectorWorker) PrepareCmdEnv(ctx *job.WorkerContext, i *instance.Inst
 	return
 }
 
-func (w *konnectorWorker) Logger(ctx *job.WorkerContext) *logger.Entry {
+func (w *konnectorWorker) Logger(ctx *job.WorkerContext) logger.Logger {
 	return ctx.Logger().WithField("slug", w.slug)
 }
 

--- a/worker/exec/service.go
+++ b/worker/exec/service.go
@@ -195,7 +195,7 @@ func (w *serviceWorker) PrepareCmdEnv(ctx *job.WorkerContext, i *instance.Instan
 	return
 }
 
-func (w *serviceWorker) Logger(ctx *job.WorkerContext) *logger.Entry {
+func (w *serviceWorker) Logger(ctx *job.WorkerContext) logger.Logger {
 	log := ctx.Logger().WithField("slug", w.Slug())
 	if w.name != "" {
 		log = log.WithField("name", w.name)

--- a/worker/push/push.go
+++ b/worker/push/push.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/cozy/cozy-stack/pkg/mail"
-	"github.com/sirupsen/logrus"
 
 	fcm "github.com/appleboy/go-fcm"
 
@@ -144,7 +143,7 @@ func Worker(ctx *job.WorkerContext) error {
 			}
 		} else {
 			ctx.Logger().
-				WithFields(logrus.Fields{
+				WithFields(logger.Fields{
 					"device_id":       c.ID(),
 					"device_platform": c.NotificationPlatform,
 				}).
@@ -177,7 +176,7 @@ func Worker(ctx *job.WorkerContext) error {
 			}
 		} else {
 			ctx.Logger().
-				WithFields(logrus.Fields{
+				WithFields(logger.Fields{
 					"device_id":       c.ID(),
 					"device_platform": c.NotificationPlatform,
 				}).

--- a/worker/sms/sms.go
+++ b/worker/sms/sms.go
@@ -64,7 +64,7 @@ func sendSMS(ctx *job.WorkerContext, msg *center.SMS) error {
 	}
 }
 
-func sendSenAPI(cfg *config.SMS, msg *center.SMS, number string, log *logger.Entry) error {
+func sendSenAPI(cfg *config.SMS, msg *center.SMS, number string, log logger.Logger) error {
 	payload, err := json.Marshal(map[string]interface{}{
 		"content":  msg.Message,
 		"receiver": []interface{}{number},

--- a/worker/thumbnail/thumbnail.go
+++ b/worker/thumbnail/thumbnail.go
@@ -91,13 +91,13 @@ func Worker(ctx *job.WorkerContext) error {
 	}
 
 	log := ctx.Logger()
-	log.WithNamespace("thumbnail").Debugf("%s %s", img.Verb, img.Doc.ID())
+	log.Debugf("%s %s", img.Verb, img.Doc.ID())
 	switch img.Verb {
 	case "CREATED":
 		return generateThumbnails(ctx, &img.Doc)
 	case "UPDATED":
 		if err := removeThumbnails(ctx.Instance, &img.Doc); err != nil {
-			log.WithNamespace("thumbnail").Debugf("failed to remove thumbnails for %s: %s", img.Doc.ID(), err)
+			log.Debugf("failed to remove thumbnails for %s: %s", img.Doc.ID(), err)
 		}
 		return generateThumbnails(ctx, &img.Doc)
 	case "DELETED":

--- a/worker/updates/updates.go
+++ b/worker/updates/updates.go
@@ -13,9 +13,9 @@ import (
 	"github.com/cozy/cozy-stack/model/job"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/cozy/cozy-stack/pkg/registry"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -41,8 +41,8 @@ type updateError struct {
 	reason error
 }
 
-func (u *updateError) toFields() logrus.Fields {
-	fields := make(logrus.Fields, 4)
+func (u *updateError) toFields() logger.Fields {
+	fields := make(logger.Fields, 4)
 	fields["step"] = u.step
 	fields["reason"] = u.reason.Error()
 	if u.domain != "" {


### PR DESCRIPTION
This interface aims to bring two main advantages:

- This open the possibility to have several different implementation
  for a logger and switch between them when needed. For example we will
  be able to create:
    - A logger for the tests based on `testing.T.Logf` which will attach
  the logs to a given test and improve the errors readability.
    - A NoOp logger logging nothing when we don't want to polute the tests
  with useless logger. We can a
    - A mock logger when we need to test whate have been send to the
    logger.

- It allow to standardise and greatly reduce the number of available methods
  for the loggers. We don't have access to unwanted methods from the lib.
