### PR TITLE
Clean the files left by ImageMagick every hour

### DIFF
--- a/pkg/avatar/initials_convert_test.go
+++ b/pkg/avatar/initials_convert_test.go
@@ -17,6 +17,7 @@ func TestInitialsPNG(t *testing.T) {
 
 	client, err := NewPNGInitials("convert")
 	require.NoError(t, err)
+	defer os.RemoveAll(client.tempDir)
 
 	ctx := context.Background()
 

--- a/pkg/avatar/service.go
+++ b/pkg/avatar/service.go
@@ -46,6 +46,8 @@ func NewService(cache cache.Cache, cmd string) (*Service, error) {
 		return nil, fmt.Errorf("failed to create the PNG initials implem: %w", err)
 	}
 
+	go initials.RunCleanJob()
+
 	return &Service{cache, initials}, nil
 }
 


### PR DESCRIPTION
ImageMagick leaves a file on the filesystem after each run. They need to be cleaned periodically in order to avoid taking unnecessary space.