### PR TITLE
fix: Log expected security stamp only when fetched

### DIFF
--- a/web/middlewares/permissions.go
+++ b/web/middlewares/permissions.go
@@ -193,8 +193,13 @@ func ExtractClaims(c echo.Context, instance *instance.Instance, token string) (*
 	if claims.SStamp != "" {
 		settings, err := settings.Get(instance)
 		if err != nil || claims.SStamp != settings.SecurityStamp {
-			logger.WithNamespace("permissions").
-				Debugf("invalid token: bad security stamp %s != %s", claims.SStamp, settings.SecurityStamp)
+			if err != nil {
+				logger.WithNamespace("permissions").
+					Debugf("could not get instance settings: %s", err)
+			} else {
+				logger.WithNamespace("permissions").
+					Debugf("invalid token: bad security stamp %s != %s", claims.SStamp, settings.SecurityStamp)
+			}
 			c.Response().Header().Set(echo.HeaderWWWAuthenticate, `Bearer error="invalid_token"`)
 			return nil, permission.ErrInvalidToken
 		}


### PR DESCRIPTION
When validating permission claims from a Cozy Pass client, we want to
log token security stamp differences.

However, if we had a CouchDB error while fetching the expected
security stamp from the settings, trying to log it will panic as it
means dereferencing a nil pointer.

In this case, we'll log a more generic error encapsulating the
original error message.