### PR TITLE
feat: Allow to dev in local with the `install` cmd

### DIFF
--- a/model/permission/permissions.go
+++ b/model/permission/permissions.go
@@ -566,6 +566,23 @@ func ForceWebapp(db prefixer.Prefixer, slug string, set Set) error {
 	return couchdb.UpdateDoc(db, doc)
 }
 
+// ForceKonnector creates or updates a Permission doc for a given konnector
+func ForceKonnector(db prefixer.Prefixer, slug string, set Set) error {
+	existing, _ := GetForKonnector(db, slug)
+	doc := &Permission{
+		Type:        TypeKonnector,
+		SourceID:    consts.Konnectors + "/" + slug,
+		Permissions: set,
+	}
+	if existing == nil {
+		return couchdb.CreateDoc(db, doc)
+	}
+
+	doc.SetID(existing.ID())
+	doc.SetRev(existing.Rev())
+	return couchdb.UpdateDoc(db, doc)
+}
+
 // DestroyWebapp remove all Permission docs for a given app
 func DestroyWebapp(db prefixer.Prefixer, slug string) error {
 	return destroyApp(db, TypeWebapp, consts.Apps, slug)

--- a/web/apps/apps.go
+++ b/web/apps/apps.go
@@ -665,7 +665,6 @@ func iconHandler(appType consts.AppType) echo.HandlerFunc {
 				fs = app.AppsFileServer(instance)
 			}
 		case consts.KonnectorType:
-			a := a.(*app.KonnManifest)
 			filepath = path.Join("/", a.Icon())
 			fs = app.KonnectorsFileServer(instance)
 		}


### PR DESCRIPTION
This forces the konnectors/apps refresh from their source after each reload for apps or each run for konnectors.

This should improve the dev experience by allowing them to install a local application using the following command:

`cozy-stack konnectors install foo file://my/project/folder/build`