### PR TITLE
Remove the flag `--dns-resolution-order-ipv4first`

### DIFF
--- a/scripts/konnector-dev-run.sh
+++ b/scripts/konnector-dev-run.sh
@@ -9,16 +9,5 @@ if [ ! -f "${arg}" ] && [ ! -d "${arg}" ]; then
   exit 1
 fi
 
-USING_NODE_LTE_16_3_0() {
-  printf '%s\nv16.3.0' $(node --version) | sort -C -V
-}
-if USING_NODE_LTE_16_3_0; then
-  dnsArg=""
-else
-  # If node is >v16.3.0 then request IPv4 DNS resolutions as cozy-stack does not
-  # listen to IPv6 addresses yet.
-  dnsArg="--dns-result-order=ipv4first"
-fi
-
 [ ! -d ~/.cozy ] && mkdir -p ~/.cozy
-node $dnsArg "${arg}" 2>&1 | tee -a ~/.cozy/services.log
+node "${arg}" 2>&1 | tee -a ~/.cozy/services.log

--- a/scripts/konnector-node17-run.sh
+++ b/scripts/konnector-node17-run.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -e
 
-NODE_OPTS="--dns-result-order=ipv4first"
 NODE_BIN="/usr/bin/nodejs"
 if ! [ -x "${NODE_BIN}" ]; then
   NODE_BIN="/usr/bin/node"
@@ -17,4 +16,4 @@ if [ ! -f "${arg}" ] && [ ! -d "${arg}" ]; then
   exit 1
 fi
 
-${NODE_BIN} ${NODE_OPTS} "${arg}"
+${NODE_BIN} "${arg}"

--- a/scripts/konnector-nsjail-node17-run.sh
+++ b/scripts/konnector-nsjail-node17-run.sh
@@ -22,8 +22,6 @@ else
   exit 1
 fi
 
-NODE_OPTS="--dns-resolution-order=ipv4first"
-
 if [ -z "${COZY_JOB_ID}" ]; then
   COZY_JOB_ID="unknown"
 fi
@@ -150,7 +148,7 @@ nsjail \
   -R /dev/urandom \
   -R /etc/resolv.conf \
   -R /etc/ssl/certs \
-  -- /usr/bin/nodejs ${NODE_OPTS} "${runfile}"
+  -- /usr/bin/nodejs "${runfile}"
 
 # Via a chroot with nodejs installed inside
 # nsjail \
@@ -173,4 +171,4 @@ nsjail \
 #   -E "COZY_JOB_MANUAL_EXECUTION=${COZY_JOB_MANUAL_EXECUTION}" \
 #   -E "COZY_LOCALE=${COZY_LOCALE}" \
 #   -R "${rundir}:/usr/src/konnector/" \
-#   -- /usr/bin/nodejs ${NODE_OPTS} "${runfile}"
+#   -- /usr/bin/nodejs "${runfile}"


### PR DESCRIPTION
This flag was used to force the use of ipv4 for node 17+. As we just have enable the ipv6 listening this flag is no more useful