### PR TITLE
refactor: Make the lock tests much quicker

### DIFF
--- a/pkg/lock/lock.go
+++ b/pkg/lock/lock.go
@@ -42,16 +42,17 @@ type ErrorRWLocker interface {
 }
 
 type longOperation struct {
-	lock ErrorLocker
-	mu   sync.Mutex
-	tick *time.Ticker
+	lock    ErrorLocker
+	mu      sync.Mutex
+	tick    *time.Ticker
+	timeout time.Duration
 }
 
 func (l *longOperation) Lock() error {
 	if err := l.lock.Lock(); err != nil {
 		return err
 	}
-	l.tick = time.NewTicker(LockTimeout / 3)
+	l.tick = time.NewTicker(l.timeout / 3)
 	go func() {
 		for {
 			l.mu.Lock()

--- a/pkg/lock/simple_mem.go
+++ b/pkg/lock/simple_mem.go
@@ -24,7 +24,8 @@ func (i *InMemoryLockGetter) ReadWrite(_ prefixer.Prefixer, name string) ErrorRW
 // the lock in redis to avoid its automatic expiration.
 func (i *InMemoryLockGetter) LongOperation(db prefixer.Prefixer, name string) ErrorLocker {
 	return &longOperation{
-		lock: i.ReadWrite(db, name),
+		lock:    i.ReadWrite(db, name),
+		timeout: LockTimeout,
 	}
 }
 


### PR DESCRIPTION
Due to the hardcoded timeout, some tests was waiting 20s for an expiration. By setting it inside the struct we can modified it and wait only a few miliseconds