### PR TITLE
Fix the maintenance list from the apps registry

### DIFF
--- a/web/apps/maintenance.go
+++ b/web/apps/maintenance.go
@@ -1,7 +1,6 @@
 package apps
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/cozy/cozy-stack/model/app"
@@ -52,17 +51,13 @@ func listMaintenance(c echo.Context) error {
 		if !ok {
 			registries = contexts[config.DefaultInstanceContext]
 		}
-		apps, err := registry.ProxyMaintenance(registries)
+		apps, err := registry.ListMaintenance(registries)
 		if err != nil {
 			return err
 		}
 		for _, app := range apps {
-			var doc couchdb.JSONDoc
-			if err := json.Unmarshal(app, &doc); err != nil {
-				return err
-			}
-			doc.M["level"] = "registry"
-			objs = append(objs, &apiMaintenance{doc})
+			app.M["level"] = "registry"
+			objs = append(objs, &apiMaintenance{app})
 		}
 	}
 

--- a/web/registry/registry.go
+++ b/web/registry/registry.go
@@ -137,7 +137,7 @@ func proxyMaintenanceReq(c echo.Context) error {
 	if pdoc.Type != permission.TypeWebapp && pdoc.Type != permission.TypeOauth {
 		return echo.NewHTTPError(http.StatusForbidden)
 	}
-	apps, err := registry.ProxyMaintenance(i.Registries())
+	apps, err := registry.ListMaintenance(i.Registries())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When an app is present in several apps registry spaces for the same context, it may happen that a maintenance is present in a space with a lower priority and should not be sent to the client. The stack now correcty handles this case by fetching all the slugs from higher priority registries.

It requires https://github.com/cozy/cozy-apps-registry/pull/401