### PR TITLE
fix: Handle correctly the ClientOS field

### DIFF
--- a/web/auth/deprecated_app_list.go
+++ b/web/auth/deprecated_app_list.go
@@ -1,11 +1,12 @@
 package auth
 
 import (
+	"strings"
+
 	"github.com/cozy/cozy-stack/model/instance"
 	"github.com/cozy/cozy-stack/model/oauth"
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/web/middlewares"
-	"github.com/mssola/user_agent"
 )
 
 const DefaultStoreURL = "https://cozy.io/fr/download/"
@@ -41,7 +42,7 @@ func (d *DeprecatedAppList) RenderArgs(client *oauth.Client, inst *instance.Inst
 		}
 	}
 
-	os := user_agent.New(client.ClientOS).OS()
+	os := strings.ToLower(client.ClientOS)
 
 	storeURL := DefaultStoreURL
 	if url, ok := app.StoreURLs[os]; ok {

--- a/web/auth/deprecated_app_list_test.go
+++ b/web/auth/deprecated_app_list_test.go
@@ -22,8 +22,8 @@ func Test_DeprecatedAppList(t *testing.T) {
 					SoftwareID: "github.com/cozy/super-app",
 					Name:       "Super App",
 					StoreURLs: map[string]string{
-						"Android": "https://some-android/url",
-						"Iphone":  "https://some-IOS/url",
+						"android": "https://some-android/url",
+						"iphone":  "https://some-IOS/url",
 					},
 				},
 			},
@@ -59,8 +59,7 @@ func Test_DeprecatedAppList(t *testing.T) {
 			ClientName:   "Super App",
 			ClientKind:   "mobile",
 			SoftwareID:   "github.com/cozy/super-app",
-			// User on Android Firefox
-			ClientOS: "Mozilla/5.0 (Android; Mobile; rv:17.0) Gecko/17.0 Firefox/17.0",
+			ClientOS:     "Android",
 		}
 
 		inst := &instance.Instance{
@@ -75,8 +74,8 @@ func Test_DeprecatedAppList(t *testing.T) {
 					SoftwareID: "github.com/cozy/super-app",
 					Name:       "Super App",
 					StoreURLs: map[string]string{
-						"Android": "https://some-android/url",
-						"Iphone":  "https://some-IOS/url",
+						"android": "https://some-android/url",
+						"iphone":  "https://some-IOS/url",
 					},
 				},
 			},
@@ -90,7 +89,7 @@ func Test_DeprecatedAppList(t *testing.T) {
 			"Title":       instance.DefaultTemplateTitle,
 			"Favicon":     middlewares.Favicon(inst),
 			"AppName":     "Super App",
-			"OS":          "Android",
+			"OS":          "android",
 			"StoreURL":    "https://some-android/url",
 		}, args)
 	})


### PR DESCRIPTION
This ClientOS field is already parsed so no need to use the user_agent package again. There is also some issues withe some unexpected upercase inside the OSs names. This commit normalize the name by using the lowercase everywhere