### PR TITLE
feat: Add settings permission to bitwarden client

### DIFF
--- a/model/bitwarden/oauth.go
+++ b/model/bitwarden/oauth.go
@@ -23,6 +23,7 @@ var BitwardenScope = strings.Join([]string{
 	consts.Konnectors,
 	consts.AppsSuggestion,
 	consts.Support,
+	consts.Settings,
 }, " ")
 
 // oldBitwardenScope is here to help the transition of bitwarden tokens, as the


### PR DESCRIPTION
In order to create a "premium link", the client needs to fetch the uuid of the instance from the io.cozy.settings/instance document.

This permission will also be used to request
/data/io.cozy.settings/io.cozy.settings.bitwarden in order to get the organizationId and collectionId.