### PR TITLE
Fix the 'bootstrap failed' error on some CLI commands

### DIFF
--- a/pkg/logger/debugger_redis.go
+++ b/pkg/logger/debugger_redis.go
@@ -46,11 +46,7 @@ func NewRedisDebugger(client redis.UniversalClient) (*RedisDebugger, error) {
 		sub:    client.Subscribe(ctx, debugRedisAddChannel, debugRedisRmvChannel),
 	}
 
-	err := dbg.bootstrap(ctx)
-	if err != nil {
-		return nil, err
-	}
-
+	go dbg.bootstrap(ctx)
 	go dbg.subscribeEvents()
 
 	return dbg, nil
@@ -132,10 +128,10 @@ func (r *RedisDebugger) Close() error {
 	return nil
 }
 
-func (r *RedisDebugger) bootstrap(ctx context.Context) error {
+func (r *RedisDebugger) bootstrap(ctx context.Context) {
 	keys, err := r.client.Keys(ctx, debugRedisPrefix+"*").Result()
 	if err != nil {
-		return fmt.Errorf("bootstrap failed: %w", err)
+		return
 	}
 
 	for _, key := range keys {
@@ -147,6 +143,4 @@ func (r *RedisDebugger) bootstrap(ctx context.Context) error {
 		domain := strings.TrimPrefix(key, debugRedisPrefix)
 		r.store.AddDomain(domain, ttl)
 	}
-
-	return nil
 }

--- a/pkg/logger/debugger_redis_test.go
+++ b/pkg/logger/debugger_redis_test.go
@@ -72,15 +72,6 @@ func TestLogger_RedisDebugger(t *testing.T) {
 		err = dbg.AddDomain("foo/bar", time.Second)
 		assert.ErrorIs(t, err, ErrInvalidDomainFormat)
 	})
-
-	t.Run("Start with an invalid redis client", func(t *testing.T) {
-		badOpt, err := redis.ParseURL("redis://invalid:6379/0")
-		require.NoError(t, err)
-
-		dbg, err := NewRedisDebugger(redis.NewClient(badOpt))
-		assert.Nil(t, dbg)
-		require.ErrorContains(t, err, "bootstrap failed")
-	})
 }
 
 func createValidName(t *testing.T) string {


### PR DESCRIPTION
It happens that we want to execute some cozy-stack CLI commands without having the credentials for redis. In that case, it was failing when initializing the logger, when trying to load the instances in debug mode. We can ignore this error, as it not a big deal if stack doesn't load them.