### PR TITLE
fix: Avoid to log the first redis lines on stderr

### DIFF
--- a/pkg/config/config/config.go
+++ b/pkg/config/config/config.go
@@ -2,11 +2,9 @@ package config
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"io"
-	stdlog "log"
 	"net"
 	"net/http"
 	"net/url"
@@ -900,18 +898,7 @@ func UseViper(v *viper.Viper) error {
 		return err
 	}
 
-	w := logger.WithNamespace("go-redis").Writer()
-	l := stdlog.New(w, "", 0)
-	redis.SetLogger(&contextPrint{l})
 	return nil
-}
-
-type contextPrint struct {
-	l *stdlog.Logger
-}
-
-func (c contextPrint) Printf(ctx context.Context, format string, args ...interface{}) {
-	c.l.Printf(format, args...)
 }
 
 func makeCouch(v *viper.Viper) (CouchDB, error) {


### PR DESCRIPTION
The `logger` package does need to setup `logger.debugger` in order to
know wich instances are in debug mode. One of the `debugger`
implementation (`RedisDebugger`) does need a redis client. The issue
is that once started the redis client log some lines but we don't have
setup the logger yet. This lead to have the first log lines from the
`debugger` redis client on stdout instead of syslog.

In order to fix this this commit setup the redis global logger juste
after setting up the global logger and before setting up the debugger.