### PR TITLE
Allow the Pass clients to read the instance settings

### DIFF
--- a/web/settings/instance.go
+++ b/web/settings/instance.go
@@ -64,6 +64,9 @@ func getInstance(c echo.Context) error {
 	}
 
 	if err = middlewares.Allow(c, permission.GET, doc); err != nil {
+		// Allow bitwarden clients to read the instance settings, even if they
+		// don't have a permission for it
+		err = middlewares.AllowWholeType(c, permission.GET, consts.Support)
 		return err
 	}
 


### PR DESCRIPTION
We want to implement a feature in the Pass clients (bases on bitwarden) that requires to read the instance settings. The bitwarden protocol has a based on OAuth2 with a fixed set of permission coded in the stack. Changing this set of permissions would work for new clients, but for existing clients, a migration would be required and quite complex. So, we have prefered to modify how the permissions are checked for reading the instance settings.