### PR TITLE
Send logs from http.Server to syslog

### DIFF
--- a/model/stack/main.go
+++ b/model/stack/main.go
@@ -14,10 +14,10 @@ import (
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/emailer"
+	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/cozy/cozy-stack/pkg/utils"
 
 	"github.com/google/gops/agent"
-	"github.com/sirupsen/logrus"
 )
 
 // Options can be used to give options when starting the stack.
@@ -80,7 +80,7 @@ security features. Please do not use this binary as your production server.
 		}
 		err = fmt.Errorf("could not reach Couchdb database: %s", err.Error())
 		if i < attempts-1 {
-			logrus.Warnf("%s, retrying in %v", err, attemptsSpacing)
+			logger.WithNamespace("stack").Warnf("%s, retrying in %v", err, attemptsSpacing)
 			time.Sleep(attemptsSpacing)
 		}
 	}

--- a/web/server.go
+++ b/web/server.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"net/http"
 	"os"
@@ -185,7 +186,6 @@ func NewServers() *Servers {
 // The 'addrs' arguments must be in the format `"host:port"`. If the host
 // is not a valid IPv4/IPv6/hostname or if the port not present an error is
 // returned.
-
 func (s *Servers) Start(handler http.Handler, name string, addr string) error {
 	addrs := []string{}
 
@@ -217,10 +217,13 @@ func (s *Servers) Start(handler http.Handler, name string, addr string) error {
 			return err
 		}
 
+		writer := logger.WithNamespace("stack").Writer()
+		logger := log.New(writer, "", 0)
 		server := &http.Server{
 			Addr:              addr,
 			Handler:           handler,
 			ReadHeaderTimeout: ReadHeaderTimeout,
+			ErrorLog:          logger,
 		}
 
 		s.serversByName[name] = server


### PR DESCRIPTION
When syslog is configured, the logs emitted by the http.Server from the stdlib should be sent to syslog, not written on stderr. We can do that by configuring an ErrorLog for the http.Server.