### PR TITLE
Fix the GET /registry/maintenance response

### DIFF
--- a/web/registry/registry.go
+++ b/web/registry/registry.go
@@ -149,8 +149,12 @@ func proxyMaintenanceReq(c echo.Context) error {
 	for _, item := range maintenance {
 		list = append(list, item)
 	}
-	for _, item := range apps {
-		list = append(list, item)
+	for _, doc := range apps {
+		item, err := doc.MarshalJSON()
+		if err != nil {
+			return err
+		}
+		list = append(list, json.RawMessage(item))
 	}
 	return c.JSON(http.StatusOK, list)
 }


### PR DESCRIPTION
The JSON in the response wasn't in the expected format. The apps in maintenance from the registry were put in a couchdb.JSONDoc, but it was then casted to []interface{}, and the JSONDoc.MarshalJSON wasn't called when serializing to JSON.

The issue has been introduced by #3945