### PR TITLE
Don't send 2FA code by email on empty submit

### DIFF
--- a/web/auth/flagship.go
+++ b/web/auth/flagship.go
@@ -204,7 +204,7 @@ func loginFlagship(c echo.Context) error {
 	}
 
 	if inst.HasAuthMode(instance.TwoFactorMail) {
-		if len(args.TwoFactorPasscode) == 0 || len(args.TwoFactorToken) == 0 {
+		if len(args.TwoFactorToken) == 0 {
 			twoFactorToken, err := lifecycle.SendTwoFactorPasscode(inst)
 			if err != nil {
 				return err

--- a/web/oidc/oidc.go
+++ b/web/oidc/oidc.go
@@ -309,7 +309,7 @@ func AccessToken(c echo.Context) error {
 
 	if inst.HasAuthMode(instance.TwoFactorMail) {
 		token := []byte(reqBody.TwoFactorToken)
-		if len(reqBody.TwoFactorCode) == 0 || len(reqBody.TwoFactorToken) == 0 {
+		if len(token) == 0 {
 			twoFactorToken, err := lifecycle.SendTwoFactorPasscode(inst)
 			if err != nil {
 				return err


### PR DESCRIPTION
When a user clicks on submit with an empty 2FA code, the stack sends again a new code. We should avoid and just tell the user to use the first sent code.