### PR TITLE
Retry for more times on CouchDB error for a move

### DIFF
--- a/model/move/importer.go
+++ b/model/move/importer.go
@@ -232,8 +232,14 @@ func (im *importer) flush() error {
 	if err := couchdb.BulkUpdateDocs(im.inst, im.doctype, im.docs, olds); err != nil {
 		// XXX CouchDB can be overloaded sometimes when importing lots of documents.
 		// Let's wait a bit and retry...
-		time.Sleep(10 * time.Minute)
-		if err = couchdb.BulkUpdateDocs(im.inst, im.doctype, im.docs, olds); err != nil {
+		for i := 0; i < 12; i++ {
+			time.Sleep(5 * time.Minute)
+			err = couchdb.BulkUpdateDocs(im.inst, im.doctype, im.docs, olds)
+			if err == nil {
+				break
+			}
+		}
+		if err != nil {
 			return err
 		}
 	}

--- a/worker/moves/workers.go
+++ b/worker/moves/workers.go
@@ -23,7 +23,7 @@ func init() {
 		WorkerType:   "import",
 		Concurrency:  runtime.NumCPU(),
 		MaxExecCount: 1,
-		Timeout:      1 * time.Hour,
+		Timeout:      3 * time.Hour,
 		WorkerFunc:   ImportWorker,
 	})
 }


### PR DESCRIPTION
When importing documents in CouchDB for a move, it may happen that CouchDB is overloaded for a database and we have to wait minutes before another request to this database can succeed. In this commit, we increasse the number of retries to help workaround this issue.