### PR TITLE
Add realtime event for password_defined

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -537,6 +537,16 @@ Cookie: sessionid=xxxx
 To use this endpoint, an application needs a permission on the type
 `io.cozy.settings` for the verb `GET`.
 
+#### Note about `password_defined`
+
+There are a few fields that are persisted on the instance its-self, not on its
+settings document. When they are updated, it won't be reflected in the realtime
+when listening on the `io.cozy.settings.instance` document.
+
+For `password_defined`, it is possible to be notified when the password is
+defined by watching a synthetic document with the doctype `io.cozy.settings`,
+and the id `io.cozy.settings.passphrase`.
+
 ### POST /settings/instance/deletion
 
 The settings application can use this route if the user wants to delete their

--- a/model/instance/lifecycle/create.go
+++ b/model/instance/lifecycle/create.go
@@ -240,7 +240,7 @@ func CreateWithoutHooks(opts *Options) (*instance.Instance, error) {
 		i.OnboardingFinished = true
 	}
 
-	i.PasswordDefined = &passwordDefined
+	i.SetPasswordDefined(passwordDefined)
 	if onboardingFinished := opts.OnboardingFinished; onboardingFinished != nil {
 		i.OnboardingFinished = *onboardingFinished
 	}

--- a/model/instance/lifecycle/passphrase.go
+++ b/model/instance/lifecycle/passphrase.go
@@ -286,8 +286,7 @@ func setPassphraseKdfAndSecret(inst *instance.Instance, settings *settings.Setti
 	if params.PublicKey != "" && params.PrivateKey != "" {
 		_ = settings.SetKeyPair(inst, params.PublicKey, params.PrivateKey)
 	}
-	passwordDefined := true
-	inst.PasswordDefined = &passwordDefined
+	inst.SetPasswordDefined(true)
 }
 
 // CreatePassphraseKey creates an encryption key for Bitwarden. It returns in

--- a/web/realtime/realtime.go
+++ b/web/realtime/realtime.go
@@ -198,17 +198,23 @@ func readPump(ctx context.Context, c echo.Context, i *instance.Instance, ws *web
 			continue
 		}
 		permType := cmd.Payload.Type
+		permID := cmd.Payload.ID
 		// XXX: thumbnails is a synthetic doctype, listening to its events
 		// requires a permissions on io.cozy.files. Same for note events.
 		if permType == consts.Thumbnails || permType == consts.NotesEvents {
 			permType = consts.Files
+		}
+		// XXX: the passphrase settings document is synthetic, and a
+		// permission on the instance settings is enough to watch it.
+		if permType == consts.Settings && permID == consts.PassphraseParametersID {
+			permID = consts.InstanceSettingsID
 		}
 		// XXX: no permissions are required for io.cozy.sharings.initial_sync
 		// and io.cozy.auth.confirmations
 		if withAuthentication &&
 			cmd.Payload.Type != consts.SharingsInitialSync &&
 			cmd.Payload.Type != consts.AuthConfirmations {
-			if !authorized(i, pdoc.Permissions, permType, cmd.Payload.ID) {
+			if !authorized(i, pdoc.Permissions, permType, permID) {
 				sendErr(ctx, errc, forbidden(cmd))
 				continue
 			}


### PR DESCRIPTION
When the password is defined for an instance, an app can be notified with the realtime websocket by listening on a synthetic document. This document have the io.cozy.settings doctype, and
io.cozy.settings.passphrase for the id.