### PR TITLE
Add the lock for OAuth clients to more places

### DIFF
--- a/web/auth/auth.go
+++ b/web/auth/auth.go
@@ -603,7 +603,7 @@ func Routes(router *echo.Group) {
 	// Register OAuth clients
 	router.POST("/register", registerClient, middlewares.AcceptJSON, middlewares.ContentTypeJSON)
 	router.GET("/register/:client-id", readClient, middlewares.AcceptJSON, checkRegistrationToken)
-	router.PUT("/register/:client-id", updateClient, middlewares.AcceptJSON, middlewares.ContentTypeJSON, checkRegistrationToken)
+	router.PUT("/register/:client-id", updateClient, middlewares.AcceptJSON, middlewares.ContentTypeJSON)
 	router.DELETE("/register/:client-id", deleteClient)
 	router.POST("/clients/:client-id/challenge", postChallenge, checkRegistrationToken)
 	router.POST("/clients/:client-id/attestation", postAttestation)

--- a/web/auth/oauth.go
+++ b/web/auth/oauth.go
@@ -814,7 +814,7 @@ type AccessTokenReponse struct {
 	Refresh string `json:"refresh_token,omitempty"`
 }
 
-func lockOAuthClient(inst *instance.Instance, clientID string) func() {
+func LockOAuthClient(inst *instance.Instance, clientID string) func() {
 	mu := config.Lock().ReadWrite(inst, "oauth/"+clientID)
 	_ = mu.Lock()
 	return mu.Unlock
@@ -842,7 +842,7 @@ func accessToken(c echo.Context) error {
 			"error": "the client_secret parameter is mandatory",
 		})
 	}
-	defer lockOAuthClient(instance, clientID)()
+	defer LockOAuthClient(instance, clientID)()
 
 	client, err := oauth.FindClient(instance, clientID)
 	if err != nil {

--- a/web/settings/clients.go
+++ b/web/settings/clients.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/jsonapi"
+	"github.com/cozy/cozy-stack/web/auth"
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/labstack/echo/v4"
 )
@@ -82,7 +83,10 @@ func (h *HTTPHandler) revokeClient(c echo.Context) error {
 		return err
 	}
 
-	client, err := oauth.FindClient(instance, c.Param("id"))
+	clientID := c.Param("id")
+	defer auth.LockOAuthClient(instance, clientID)()
+
+	client, err := oauth.FindClient(instance, clientID)
 	if err != nil {
 		return err
 	}
@@ -105,6 +109,8 @@ func (h *HTTPHandler) synchronized(c echo.Context) error {
 	if err != nil {
 		return err
 	}
+
+	defer auth.LockOAuthClient(instance, claims.Subject)()
 
 	client, err := oauth.FindClient(instance, claims.Subject)
 	if err != nil {


### PR DESCRIPTION
There is a follow-up of e3b2bbb. We are adding the lock around OAuth client writes to the endpoints that updates its synchronization date, that updates the client information, or delete a client.