### PR TITLE
fix: Update clouderies config usage

### DIFF
--- a/model/instance/lifecycle/destroy.go
+++ b/model/instance/lifecycle/destroy.go
@@ -21,17 +21,15 @@ import (
 
 func AskDeletion(inst *instance.Instance) error {
 	clouderies := config.GetConfig().Clouderies
-	var cloudery interface{}
+	var cloudery config.ClouderyConfig
 	cloudery, ok := clouderies[inst.ContextName]
 	if !ok {
 		cloudery = clouderies[config.DefaultInstanceContext]
 	}
-	if cloudery == nil {
-		return nil
-	}
-	api := cloudery.(map[string]interface{})["api"]
-	clouderyURL, _ := api.(map[string]interface{})["url"].(string)
-	clouderyToken, _ := api.(map[string]interface{})["token"].(string)
+
+	api := cloudery.API
+	clouderyURL := api.URL
+	clouderyToken := api.Token
 
 	u, err := url.Parse(clouderyURL)
 	if err != nil {

--- a/model/instance/manager.go
+++ b/model/instance/manager.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/manager"
-	"github.com/mitchellh/mapstructure"
 )
 
 // ManagerURLKind is an enum type for the different kinds of manager URLs.
@@ -60,35 +59,23 @@ func (i *Instance) ManagerURL(k ManagerURLKind) (string, error) {
 	return baseURL.String(), nil
 }
 
-type managerConfig struct {
-	API struct {
-		URL   string
-		Token string
-	}
-}
-
 // APIManagerClient returns a client to talk to the manager via its API.
 func APIManagerClient(inst *Instance) *manager.APIClient {
-	contexts := config.GetConfig().Clouderies
-	if contexts == nil {
+	clouderies := config.GetConfig().Clouderies
+	if clouderies == nil {
 		return nil
 	}
 
-	context, ok := contexts[inst.ContextName]
+	var cloudery config.ClouderyConfig
+	cloudery, ok := clouderies[inst.ContextName]
 	if !ok {
-		context, ok = contexts[config.DefaultInstanceContext]
+		cloudery, ok = clouderies[config.DefaultInstanceContext]
 	}
 	if !ok {
 		return nil
 	}
 
-	var config managerConfig
-	err := mapstructure.Decode(context, &config)
-	if err != nil {
-		return nil
-	}
-
-	api := config.API
+	api := cloudery.API
 	if api.URL == "" || api.Token == "" {
 		return nil
 	}


### PR DESCRIPTION
Invalid cloudery config type castings were causing panics.

Clouderies config used to be maps of `string` to `interface{}`,
requiring type casting to access their attributes.
However, a dedicated `ClouderyConfig` struct was created and thus
every use of a cloudery config should not do type casting anymore and
use the struct members directly.