### PR TITLE
fix: Pending email with cozy-client

### DIFF
--- a/model/settings/service.go
+++ b/model/settings/service.go
@@ -195,7 +195,7 @@ func (s *SettingsService) ConfirmEmailUpdate(inst *instance.Instance, tok string
 	}
 
 	settings.M["email"] = pendingEmail
-	delete(settings.M, "pending_email")
+	settings.M["pending_email"] = nil
 
 	err = s.storage.setInstanceSettings(inst, settings)
 	if err != nil {
@@ -228,7 +228,7 @@ func (s *SettingsService) CancelEmailUpdate(inst *instance.Instance) error {
 		return nil
 	}
 
-	delete(settings.M, "pending_email")
+	settings.M["pending_email"] = nil
 
 	err = s.storage.setInstanceSettings(inst, settings)
 	if err != nil {

--- a/model/settings/service_test.go
+++ b/model/settings/service_test.go
@@ -160,8 +160,9 @@ func TestConfirmEmailUpdate_success(t *testing.T) {
 
 	storage.On("setInstanceSettings", &inst, &couchdb.JSONDoc{
 		M: map[string]interface{}{
-			"public_name": "Jane Doe",
-			"email":       "some@email.com",
+			"public_name":   "Jane Doe",
+			"email":         "some@email.com",
+			"pending_email": nil,
 		},
 	}).Return(nil).Once()
 
@@ -251,8 +252,9 @@ func Test_CancelEmailUpdate_success(t *testing.T) {
 
 	storage.On("setInstanceSettings", &inst, &couchdb.JSONDoc{
 		M: map[string]interface{}{
-			"public_name": "Jane Doe",
-			"email":       "foo@bar.baz",
+			"public_name":   "Jane Doe",
+			"email":         "foo@bar.baz",
+			"pending_email": nil,
 		},
 	}).Return(nil).Once()
 


### PR DESCRIPTION
The Cozy client has difficulty handling field deletion via realTime. When merging, it will use the previously present field if field is not find. This allows it to update documents with requests that only select a few fields in a document. If the field is present with a value (null or empty), it will update it and the interface will react.