### PR TITLE
Send the confirmation email to the new address

### DIFF
--- a/docs/workers.md
+++ b/docs/workers.md
@@ -190,6 +190,7 @@ file at the root of this repository.
 
 -   `mode`: string specifying the mode of the send:
     -   `noreply` to send a notification mail to the user
+    -   `pending` to send a mail to the user to confirm their new email address
     -   `from` to send a mail from the user
     -   `support` to send both an email to the support and a confirmation to
         the user

--- a/model/settings/service.go
+++ b/model/settings/service.go
@@ -120,7 +120,7 @@ func (s *SettingsService) StartEmailUpdate(inst *instance.Instance, cmd *UpdateE
 		"token": []string{token},
 	})
 
-	err = s.emailer.SendEmail(inst, &emailer.SendEmailCmd{
+	err = s.emailer.SendPendingEmail(inst, &emailer.SendEmailCmd{
 		TemplateName: "update_email",
 		TemplateValues: map[string]interface{}{
 			"PublicName":      publicName,
@@ -160,7 +160,7 @@ func (s *SettingsService) ResendEmailUpdate(inst *instance.Instance) error {
 		"token": []string{token},
 	})
 
-	err = s.emailer.SendEmail(inst, &emailer.SendEmailCmd{
+	err = s.emailer.SendPendingEmail(inst, &emailer.SendEmailCmd{
 		TemplateName: "update_email",
 		TemplateValues: map[string]interface{}{
 			"PublicName":      publicName,

--- a/model/settings/service_test.go
+++ b/model/settings/service_test.go
@@ -50,7 +50,7 @@ func Test_StartEmailUpdate_success(t *testing.T) {
 		},
 	}).Return(nil).Once()
 
-	emailerSvc.On("SendEmail", &inst, &emailer.SendEmailCmd{
+	emailerSvc.On("SendPendingEmail", &inst, &emailer.SendEmailCmd{
 		TemplateName: "update_email",
 		TemplateValues: map[string]interface{}{
 			"PublicName":      "Jane Doe",
@@ -121,7 +121,7 @@ func Test_StartEmailUpdate_with_a_missing_public_name(t *testing.T) {
 		},
 	}).Return(nil).Once()
 
-	emailerSvc.On("SendEmail", &inst, &emailer.SendEmailCmd{
+	emailerSvc.On("SendPendingEmail", &inst, &emailer.SendEmailCmd{
 		TemplateName: "update_email",
 		TemplateValues: map[string]interface{}{
 			"PublicName":      "foo", // Change here
@@ -309,7 +309,7 @@ func Test_ResendEmailUpdate_success(t *testing.T) {
 	tokenSvc.On("GenerateAndSave", &inst, token.EmailUpdate, "foo.mycozy.cloud", TokenExpiration).
 		Return("some-token", nil).Once()
 
-	emailerSvc.On("SendEmail", &inst, &emailer.SendEmailCmd{
+	emailerSvc.On("SendPendingEmail", &inst, &emailer.SendEmailCmd{
 		TemplateName: "update_email",
 		TemplateValues: map[string]interface{}{
 			"PublicName":      "Jane Doe",

--- a/pkg/emailer/init.go
+++ b/pkg/emailer/init.go
@@ -14,6 +14,7 @@ var service *EmailerService
 // - [Mock] with a mock implementation
 type Emailer interface {
 	SendEmail(inst *instance.Instance, cmd *SendEmailCmd) error
+	SendPendingEmail(inst *instance.Instance, cmd *SendEmailCmd) error
 }
 
 // Init the emailer package by setting up a service based on the

--- a/pkg/emailer/service_mock.go
+++ b/pkg/emailer/service_mock.go
@@ -25,3 +25,8 @@ func NewMock(t *testing.T) *Mock {
 func (m *Mock) SendEmail(inst *instance.Instance, cmd *SendEmailCmd) error {
 	return m.Called(inst, cmd).Error(0)
 }
+
+// SendPendingEmail mock method.
+func (m *Mock) SendPendingEmail(inst *instance.Instance, cmd *SendEmailCmd) error {
+	return m.Called(inst, cmd).Error(0)
+}

--- a/pkg/mail/mail.go
+++ b/pkg/mail/mail.go
@@ -10,6 +10,9 @@ const (
 	// ModeFromStack is the no-reply mode of a mail, to send mail "to" the
 	// user's mail, as a noreply@
 	ModeFromStack = "noreply"
+	// ModePendingEmail is used to send an email to confirm the new email
+	// address of the user
+	ModePendingEmail = "pending"
 	// ModeFromUser is the "from" mode of a mail, to send mail "from" the user's
 	// mail.
 	ModeFromUser = "from"


### PR DESCRIPTION
When the user wants to use a new email address in the settings of their Cozy, the stack will send an email to new address to confirm that they can receive emails on this address.