### PR TITLE
Block password reset for not onboarded instance

### DIFF
--- a/web/auth/passphrase.go
+++ b/web/auth/passphrase.go
@@ -22,6 +22,17 @@ import (
 
 func passphraseResetForm(c echo.Context) error {
 	instance := middlewares.GetInstance(c)
+	if !instance.OnboardingFinished {
+		return c.Render(http.StatusOK, "need_onboarding.html", echo.Map{
+			"Domain":       instance.ContextualDomain(),
+			"ContextName":  instance.ContextName,
+			"Locale":       instance.Locale,
+			"Title":        instance.TemplateTitle(),
+			"Favicon":      middlewares.Favicon(instance),
+			"SupportEmail": instance.SupportEmailAddress(),
+		})
+	}
+
 	hasHint := false
 	if setting, err := settings.Get(instance); err == nil {
 		hasHint = setting.PassphraseHint != ""
@@ -65,7 +76,7 @@ func passphraseForm(c echo.Context) error {
 			"Locale":       inst.Locale,
 			"Title":        inst.TemplateTitle(),
 			"Favicon":      middlewares.Favicon(inst),
-			"SupportEmail": "contact@cozycloud.cc",
+			"SupportEmail": inst.SupportEmailAddress(),
 		})
 	}
 


### PR DESCRIPTION
If an instance has not been onboarded, the stack will show an error screen if the user tries to reset their password. It may happen when trying to connect the Pass extension, typing the instance URL, and then then the "password forgotten" button.