### PR TITLE
Clean the pkg/avatar package

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -104,7 +104,7 @@ example), you can use the --appdir flag like this:
 			return err
 		}
 
-		group := utils.NewGroupShutdown(servers, processes, config.Avatars())
+		group := utils.NewGroupShutdown(servers, processes)
 
 		sigs := make(chan os.Signal, 1)
 		signal.Notify(sigs, os.Interrupt)

--- a/pkg/avatar/initials_convert_test.go
+++ b/pkg/avatar/initials_convert_test.go
@@ -2,7 +2,6 @@ package avatar
 
 import (
 	"bytes"
-	"context"
 	"image/png"
 	"os"
 	"testing"
@@ -15,13 +14,8 @@ func Test_Initials_PNG(t *testing.T) {
 		t.Skipf("this test require the \"convert\" binary, skip it due to the \"--short\" flag")
 	}
 
-	client, err := NewPNGInitials("convert")
-	require.NoError(t, err)
-	defer client.Shutdown(context.Background())
-
-	ctx := context.Background()
-
-	rawRes, err := client.Generate(ctx, "JD", "#FF7F1B")
+	client := NewPNGInitials("convert")
+	rawRes, err := client.Generate("JD", "#FF7F1B")
 	require.NoError(t, err)
 
 	rawExpected, err := os.ReadFile("./testdata/initials-convert.png")

--- a/pkg/config/config/config.go
+++ b/pkg/config/config/config.go
@@ -733,11 +733,7 @@ func UseViper(v *viper.Viper) error {
 	}
 
 	cacheStorage := cache.New(cacheRedis)
-
-	avatars, err := avatar.NewService(cacheStorage, v.GetString("jobs.imagemagick_convert_cmd"))
-	if err != nil {
-		return fmt.Errorf("failed to create the avatar service: %w", err)
-	}
+	avatars := avatar.NewService(cacheStorage, v.GetString("jobs.imagemagick_convert_cmd"))
 
 	// Setup keyring
 	var keyringCfg keyring.Config


### PR DESCRIPTION
Each cozy-stack command was creating a temporary directory for image magick that was not removed later. We are now using a temporary directory for each initials image creation, and we clean it when image magick has finished running.