### PR TITLE
Optimize some calls to Swift server

### DIFF
--- a/model/vfs/vfsswift/fsck_v1.go
+++ b/model/vfs/vfsswift/fsck_v1.go
@@ -52,7 +52,8 @@ func (sfs *swiftVFS) checkFiles(
 ) error {
 	var orphansObjs []swift.Object
 
-	err := sfs.c.ObjectsWalk(sfs.ctx, sfs.container, nil, func(ctx context.Context, opts *swift.ObjectsOpts) (interface{}, error) {
+	opts := &swift.ObjectsOpts{Limit: 10_000}
+	err := sfs.c.ObjectsWalk(sfs.ctx, sfs.container, opts, func(ctx context.Context, opts *swift.ObjectsOpts) (interface{}, error) {
 		objs, err := sfs.c.Objects(sfs.ctx, sfs.container, opts)
 		if err != nil {
 			return nil, err

--- a/model/vfs/vfsswift/fsck_v2.go
+++ b/model/vfs/vfsswift/fsck_v2.go
@@ -49,7 +49,8 @@ func (sfs *swiftVFSV2) checkFiles(
 	accumulate func(log *vfs.FsckLog),
 	failFast bool,
 ) error {
-	err := sfs.c.ObjectsWalk(sfs.ctx, sfs.container, nil, func(ctx context.Context, opts *swift.ObjectsOpts) (interface{}, error) {
+	opts := &swift.ObjectsOpts{Limit: 10_000}
+	err := sfs.c.ObjectsWalk(sfs.ctx, sfs.container, opts, func(ctx context.Context, opts *swift.ObjectsOpts) (interface{}, error) {
 		objs, err := sfs.c.Objects(sfs.ctx, sfs.container, opts)
 		if err != nil {
 			return nil, err

--- a/model/vfs/vfsswift/fsck_v3.go
+++ b/model/vfs/vfsswift/fsck_v3.go
@@ -84,7 +84,8 @@ func (sfs *swiftVFSV3) checkFiles(
 		fileIDs[f.DocID] = struct{}{}
 	}
 
-	err = sfs.c.ObjectsWalk(sfs.ctx, sfs.container, nil, func(ctx context.Context, opts *swift.ObjectsOpts) (interface{}, error) {
+	opts := &swift.ObjectsOpts{Limit: 10_000}
+	err = sfs.c.ObjectsWalk(sfs.ctx, sfs.container, opts, func(ctx context.Context, opts *swift.ObjectsOpts) (interface{}, error) {
 		objs, err := sfs.c.Objects(sfs.ctx, sfs.container, opts)
 		if err != nil {
 			return nil, err

--- a/pkg/appfs/server.go
+++ b/pkg/appfs/server.go
@@ -225,6 +225,7 @@ func (s *swiftServer) makeObjectName(slug, version, shasum, file string) string 
 func (s *swiftServer) FilesList(slug, version, shasum string) ([]string, error) {
 	prefix := s.makeObjectName(slug, version, shasum, "") + "/"
 	names, err := s.c.ObjectNamesAll(s.ctx, s.container, &swift.ObjectsOpts{
+		Limit:  10_000,
 		Prefix: prefix,
 	})
 	if err != nil {

--- a/pkg/assets/dynamic/impl_swift.go
+++ b/pkg/assets/dynamic/impl_swift.go
@@ -73,7 +73,8 @@ func (s *SwiftFS) Remove(context, name string) error {
 func (s *SwiftFS) List() (map[string][]*model.Asset, error) {
 	objs := map[string][]*model.Asset{}
 
-	objNames, err := s.swiftConn.ObjectNamesAll(s.ctx, DynamicAssetsContainerName, nil)
+	opts := &swift.ObjectsOpts{Limit: 10_000}
+	objNames, err := s.swiftConn.ObjectNamesAll(s.ctx, DynamicAssetsContainerName, opts)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Use the ObjectNamesAll method instead of walk+names
- Use explicit pagination parameter (limit)