### PR TITLE
fix: Set correct bitwarden error (JSON) when wrong 2FA code

### DIFF
--- a/web/bitwarden/bitwarden.go
+++ b/web/bitwarden/bitwarden.go
@@ -360,6 +360,16 @@ func checkTwoFactor(c echo.Context, inst *instance.Instance) bool {
 		if token, ok := cache.Get(key); ok {
 			if inst.ValidateTwoFactorPasscode(token, passcode) {
 				return true
+			} else {
+				_ = c.JSON(http.StatusBadRequest, echo.Map{
+					"error":             "invalid_grant",
+					"error_description": "invalid_username_or_password",
+					"ErrorModel": map[string]string{
+						"Message": "Two-step token is invalid. Try again.",
+						"Object":  "error",
+					},
+				})
+				return false
 			}
 		}
 	}


### PR DESCRIPTION
On Cozy Pass mobile when the login requires 2FA and when the user enters a wrong password, then the API should return a dedicated error message

With previous implementation, the same error would be returned on first login attempt and on second one containing a 2FA token. This would result on the app completing the login process but displaying an empty vault. This behaviour is wrong but is from Bitwarden's implementation. However with correct server implementation the correct behaviour happens