### PR TITLE
fix: Correctly parse Bitwarden DeviceType

### DIFF
--- a/model/bitwarden/oauth.go
+++ b/model/bitwarden/oauth.go
@@ -61,25 +61,26 @@ func ParseBitwardenDeviceType(deviceType string) (string, string) {
 			// 15 = Android (amazon variant)
 			// 16 = UWP
 			return "mobile", "github.com/bitwarden/mobile"
-		case 5, 6, 7:
-			// 5 = Windows
-			// 6 = macOS
-			// 7 = Linux
+		case 6, 7, 8:
+			// 6 = Windows
+			// 7 = macOS
+			// 8 = Linux
 			return "desktop", "github.com/bitwarden/desktop"
-		case 2, 3, 4, 19, 20:
+		case 2, 3, 4, 5, 19, 20:
 			// 2 = Chrome extension
 			// 3 = Firefox extension
-			// 4 = Edge extension
+			// 4 = Opera extension
+			// 5 = Edge extension
 			// 19 = Vivaldi extension
 			// 20 = Safari extension
 			return "browser", "github.com/bitwarden/browser"
-		case 8, 9, 10, 11, 12, 13, 14, 17, 18:
-			// 8 = Chrome
-			// 9 = Firefox
-			// 10 = Opera
-			// 11 = Edge
-			// 12 = Internet Explorer
-			// 13 = Unknown browser
+		case 9, 10, 11, 12, 13, 14, 17, 18:
+			// 9 = Chrome
+			// 10 = Firefox
+			// 11 = Opera
+			// 12 = Edge
+			// 13 = Internet Explorer
+			// 14 = Unknown browser
 			// 17 = Safari
 			// 18 = Vivaldi
 			return "web", "github.com/bitwarden/web"

--- a/tests/integration/tests/accounts-to-ciphers.rb
+++ b/tests/integration/tests/accounts-to-ciphers.rb
@@ -5,17 +5,13 @@ require 'pry-rescue/minitest' unless ENV['CI']
 def setup_ciphers(override_account_attrs = {})
   inst = Instance.create name: "Alice"
 
-  bw = Bitwarden.new inst
-  bw.login
-  assert_equal bw.sync, "Syncing complete."
-
   source_url = "file://" + File.expand_path("../konnector", __dir__)
   inst.install_konnector "bankone", source_url
 
   account_attrs = {
     type: "bankone",
     name: "Bank one",
-    auth: {login: "Isabelle", zipcode: "64000"}
+    auth: { login: "Isabelle", zipcode: "64000" }
   }
 
   account_attrs = account_attrs.merge(override_account_attrs)
@@ -30,14 +26,17 @@ def setup_ciphers(override_account_attrs = {})
     message: { konnector: "bankone", account: account.couch_id }
   )
 
-  job = inst.run_job "migrations", {:type => "accounts-to-organization"}
+  # We execute manually the job to be sure to wait that it has finished
+  job = inst.run_job "migrations", { type: "accounts-to-organization" }
   10.times do
     sleep 1
     done = job.done?(inst)
     break if done
   end
 
-  bw.sync
+  bw = Bitwarden.new inst
+  bw.login
+  assert_equal bw.sync, "Syncing complete."
 
   return {
     :bw => bw,


### PR DESCRIPTION
There was an offset in parsed DeviceType number as `Edge extension` is not `4` but `5` (`4` is `Opera extension`). So everything above `4` and under `15` was impacted by this offset

This means we wrongly attributed `desktop` to `Edge extension` (`5`) clients and `web` to `Linux` (`8`) desktop clients
 
This is based on JSLib enum targeted by current cozy-pass-web version

Related file:
https://github.com/bitwarden/jslib/blob/c8eca37183c5fa67d0b0988402aea49d0f0f505c/src/enums/deviceType.ts#L7-L10