### PR TITLE
Fix share-track jobs when out of order (bis)

### DIFF
--- a/model/sharing/revisions.go
+++ b/model/sharing/revisions.go
@@ -117,21 +117,24 @@ func (rt *RevsTree) Add(rev string) *RevsTree {
 	if rev == rt.Rev {
 		return rt
 	}
+
+	if revision.Generation(rev) < revision.Generation(rt.Rev) {
+		rt.Branches = []RevsTree{
+			{Rev: rt.Rev, Branches: rt.Branches},
+		}
+		rt.Rev = rev
+		return rt
+	}
+
 	if len(rt.Branches) > 0 {
 		// XXX This condition shouldn't be true, but it can help to limit
 		// damage in case bugs happen.
 		if rt.Branches[0].Rev == rev {
 			return &rt.Branches[0]
 		}
-		if revision.Generation(rev) < revision.Generation(rt.Branches[0].Rev) {
-			rt.Branches = []RevsTree{
-				{Rev: rt.Rev, Branches: rt.Branches},
-			}
-			rt.Rev = rev
-			return rt
-		}
 		return rt.Branches[0].Add(rev)
 	}
+
 	rt.Branches = []RevsTree{
 		{Rev: rev},
 	}

--- a/model/sharing/revisions_test.go
+++ b/model/sharing/revisions_test.go
@@ -81,6 +81,15 @@ func TestRevsTreeAdd(t *testing.T) {
 	assert.Len(t, sub.Branches, 0)
 
 	tree = &RevsTree{Rev: "2-bbb"}
+	ret = tree.Add("1-aaa")
+	assert.Equal(t, "1-aaa", ret.Rev)
+	assert.Equal(t, "1-aaa", tree.Rev)
+	require.Len(t, tree.Branches, 1)
+	sub = tree.Branches[0]
+	assert.Equal(t, "2-bbb", sub.Rev)
+	require.Len(t, sub.Branches, 0)
+
+	tree = &RevsTree{Rev: "2-bbb"}
 	ret = tree.Add("3-ccc")
 	assert.Equal(t, "3-ccc", ret.Rev)
 	ret = tree.Add("1-aaa")


### PR DESCRIPTION
It is a follow-up of #3582. When an io.cozy.file is created and modified just after, it may happen that the share-track job for the update is processed before the job for the creation. When this happens, the revs tree for the io.cozy.shared wasn't correct: the revision 2 was coming before the revision 1. The previous commit was fixing some cases, but there is one more case that we should handle.