### PR TITLE
Fix some lock issues

### DIFF
--- a/pkg/lock/simple_mem.go
+++ b/pkg/lock/simple_mem.go
@@ -24,7 +24,7 @@ func (i *InMemoryLockGetter) ReadWrite(_ prefixer.Prefixer, name string) ErrorRW
 // the lock in redis to avoid its automatic expiration.
 func (i *InMemoryLockGetter) LongOperation(db prefixer.Prefixer, name string) ErrorLocker {
 	return &longOperation{
-		lock:    i.ReadWrite(db, name),
+		lock:    i.ReadWrite(db, name).(*memLock),
 		timeout: LockTimeout,
 	}
 }
@@ -35,5 +35,6 @@ type memLock struct {
 
 func (ml *memLock) Lock() error  { ml.RWMutex.Lock(); return nil }
 func (ml *memLock) RLock() error { ml.RWMutex.RLock(); return nil }
+func (ml *memLock) Extend()      {}
 func (ml *memLock) Unlock()      { ml.RWMutex.Unlock() }
 func (ml *memLock) RUnlock()     { ml.RWMutex.RUnlock() }

--- a/pkg/lock/simple_redis.go
+++ b/pkg/lock/simple_redis.go
@@ -29,15 +29,14 @@ const (
 	// is ours. If two stack were to generate the same value, locks will break.
 	lockTokenSize = 20
 
-	// LockTimeout is the expiration of a redis lock
-	// if any operation is longer than this, it should
-	// refresh the lock
+	// LockTimeout is the expiration of a redis lock if any operation is longer
+	// than this, it should refresh the lock.
 	LockTimeout = 20 * time.Second
 
-	// WaitTimeout maximum time to wait before returning control to caller.
+	// WaitTimeout is the maximum time to wait before returning control to caller.
 	WaitTimeout = 1 * time.Minute
 
-	// WaitRetry time to wait between retries
+	// WaitRetry is the time to wait between retries.
 	WaitRetry = 100 * time.Millisecond
 )
 
@@ -46,153 +45,6 @@ var (
 	// we never managed to get a lock
 	ErrTooManyRetries = errors.New("abort after too many failures without getting the lock")
 )
-
-type redisLock struct {
-	client subRedisInterface
-	ctx    context.Context
-	mu     sync.Mutex
-	key    string
-	token  string
-	// readers is the number of readers when the lock is acquired for reading
-	// or 0 when it is unlocked, or -1 when it is locked for writing.
-	readers   int
-	timeout   time.Duration
-	waitRetry time.Duration
-}
-
-func (rl *redisLock) extends() (bool, error) {
-	if rl.token == "" || rl.readers < 0 {
-		return false, nil
-	}
-
-	// we already have a lock, attempts to extends it
-	ttl := strconv.FormatInt(int64(LockTimeout/time.Millisecond), 10)
-	ok, err := rl.client.Eval(rl.ctx, luaRefresh, []string{rl.key}, rl.token, ttl).Result()
-	if err != nil {
-		return false, err // most probably redis connectivity error
-	}
-
-	if ok == int64(1) {
-		rl.readers++
-		return true, nil
-	}
-
-	return false, nil
-}
-
-func (rl *redisLock) obtains(writing bool, token string) (bool, error) {
-	// Try to obtain a lock
-	ok, err := rl.client.SetNX(rl.ctx, rl.key, token, rl.timeout).Result()
-	if err != nil {
-		return false, err // most probably redis connectivity error
-	}
-	if !ok {
-		return false, nil
-	}
-
-	rl.token = token
-	if writing {
-		rl.readers = -1
-	} else {
-		rl.readers++
-	}
-	return true, nil
-}
-
-func (rl *redisLock) obtainsWriting(token string) (bool, error) {
-	rl.mu.Lock()
-	defer rl.mu.Unlock()
-	return rl.obtains(true, token)
-}
-
-func (rl *redisLock) LockWithTimeout(timeout time.Duration) error {
-	// Calculate the timestamp we are willing to wait for
-	stop := time.Now().Add(timeout)
-	redislocksMu.Lock()
-	token := utils.RandomStringFast(redisRng, lockTokenSize)
-	redislocksMu.Unlock()
-	for {
-		ok, err := rl.obtainsWriting(token)
-		if err != nil || ok {
-			return err
-		}
-		if time.Now().Add(rl.waitRetry).After(stop) {
-			break
-		}
-		time.Sleep(rl.waitRetry)
-	}
-
-	return ErrTooManyRetries
-}
-
-func (rl *redisLock) Lock() error {
-	return rl.LockWithTimeout(rl.timeout)
-}
-
-func (rl *redisLock) extendsOrObtainsReading(token string) (bool, error) {
-	rl.mu.Lock()
-	defer rl.mu.Unlock()
-	if ok, err := rl.extends(); err != nil || ok {
-		return ok, err
-	}
-	return rl.obtains(false, token)
-}
-
-func (rl *redisLock) RLock() error {
-	stop := time.Now().Add(rl.timeout)
-	redislocksMu.Lock()
-	token := utils.RandomStringFast(redisRng, lockTokenSize)
-	redislocksMu.Unlock()
-	for {
-		ok, err := rl.extendsOrObtainsReading(token)
-		if err != nil || ok {
-			return err
-		}
-		if time.Now().Add(rl.waitRetry).After(stop) {
-			break
-		}
-		time.Sleep(rl.waitRetry)
-	}
-
-	return ErrTooManyRetries
-}
-
-func (rl *redisLock) unlock(writing bool) {
-	rl.mu.Lock()
-	defer rl.mu.Unlock()
-
-	if (writing && rl.readers > 0) || (!writing && rl.readers < 0) {
-		redisLogger.Errorf("Invalid unlocking: %v %d (%s)", writing, rl.readers, rl.key)
-		return
-	}
-
-	if !writing && rl.readers > 1 {
-		rl.readers--
-		return
-	}
-
-	_, err := rl.client.Eval(rl.ctx, luaRelease, []string{rl.key}, rl.token).Result()
-	if err != nil {
-		redisLogger.Warnf("Failed to unlock: %s (%s)", err.Error(), rl.key)
-	}
-
-	if writing {
-		rl.readers = 0
-	} else {
-		rl.readers--
-	}
-	if rl.readers == 0 {
-		rl.token = ""
-	}
-}
-
-func (rl *redisLock) Unlock() {
-	rl.unlock(true)
-}
-
-func (rl *redisLock) RUnlock() {
-	rl.unlock(false)
-}
 
 var redislocksMu sync.Mutex
 var redisRng *rand.Rand
@@ -218,9 +70,9 @@ func (r *RedisLockGetter) ReadWrite(db prefixer.Prefixer, name string) ErrorRWLo
 	lock, _ := r.locks.LoadOrStore(ns, &redisLock{
 		client:    r.client,
 		ctx:       context.Background(),
-		key:       basicLockNS + ns,
 		timeout:   LockTimeout,
 		waitRetry: WaitRetry,
+		key:       basicLockNS + ns,
 	})
 
 	return lock.(*redisLock)
@@ -230,7 +82,162 @@ func (r *RedisLockGetter) ReadWrite(db prefixer.Prefixer, name string) ErrorRWLo
 // the lock in redis to avoid its automatic expiration.
 func (r *RedisLockGetter) LongOperation(db prefixer.Prefixer, name string) ErrorLocker {
 	return &longOperation{
-		lock:    r.ReadWrite(db, name),
+		lock:    r.ReadWrite(db, name).(*redisLock),
 		timeout: LockTimeout,
 	}
+}
+
+type redisLock struct {
+	client    subRedisInterface
+	ctx       context.Context
+	mu        sync.Mutex
+	timeout   time.Duration
+	waitRetry time.Duration
+	key       string
+	token     string
+	// readers is the number of readers when the lock is acquired for reading
+	// or -1 when it is locked for writing. 0 means that the lock is free.
+	readers int
+}
+
+func (rl *redisLock) Lock() error {
+	// Calculate the timestamp we are willing to wait for.
+	stop := time.Now().Add(rl.timeout)
+
+	redislocksMu.Lock()
+	token := utils.RandomStringFast(redisRng, lockTokenSize)
+	redislocksMu.Unlock()
+
+	for {
+		ok, err := rl.obtainsWriting(token)
+		if err != nil || ok {
+			return err
+		}
+		if time.Now().Add(rl.waitRetry).After(stop) {
+			return ErrTooManyRetries
+		}
+		time.Sleep(rl.waitRetry)
+	}
+}
+
+func (rl *redisLock) Extend() {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	_, _ = rl.extends()
+}
+
+func (rl *redisLock) RLock() error {
+	// Note that the current code does not try to allow two cozy-stacks to
+	// share a lock for reading. If one cozy-stack has locked for reading a
+	// lock, another cozy-stack will have to wait that the lock has been
+	// released before being able to give a lock for reading on the same name.
+	// It may be improved, but I prefer to err on the safe side for now. And it
+	// still allows to have two readers on the same cozy-stack.
+
+	stop := time.Now().Add(rl.timeout)
+
+	redislocksMu.Lock()
+	token := utils.RandomStringFast(redisRng, lockTokenSize)
+	redislocksMu.Unlock()
+
+	for {
+		ok, err := rl.extendsOrObtainsReading(token)
+		if err != nil || ok {
+			return err
+		}
+		if time.Now().Add(rl.waitRetry).After(stop) {
+			return ErrTooManyRetries
+		}
+		time.Sleep(rl.waitRetry)
+	}
+}
+
+func (rl *redisLock) obtainsWriting(token string) (bool, error) {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	if rl.readers != 0 {
+		return false, nil
+	}
+	return rl.obtains(true, token)
+}
+
+func (rl *redisLock) extendsOrObtainsReading(token string) (bool, error) {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	if rl.readers < 0 {
+		return false, nil
+	}
+	ok, err := rl.extends()
+	if ok {
+		rl.readers++
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return rl.obtains(false, token)
+}
+
+func (rl *redisLock) obtains(writing bool, token string) (bool, error) {
+	// Try to obtain a lock
+	ok, err := rl.client.SetNX(rl.ctx, rl.key, token, rl.timeout).Result()
+	if err != nil {
+		return false, err // most probably redis connectivity error
+	}
+	if !ok {
+		return false, nil
+	}
+
+	rl.token = token
+	if writing {
+		rl.readers = -1
+	} else {
+		rl.readers++
+	}
+	return true, nil
+}
+
+func (rl *redisLock) extends() (bool, error) {
+	if rl.token == "" {
+		return false, nil
+	}
+
+	// we already have a lock, attempts to extends it
+	ttl := strconv.FormatInt(int64(LockTimeout/time.Millisecond), 10)
+	ret, err := rl.client.Eval(rl.ctx, luaRefresh, []string{rl.key}, rl.token, ttl).Result()
+	if err != nil {
+		return false, err // most probably redis connectivity error
+	}
+	return ret == int64(1), nil
+}
+
+func (rl *redisLock) Unlock() {
+	rl.unlock(true)
+}
+
+func (rl *redisLock) RUnlock() {
+	rl.unlock(false)
+}
+
+func (rl *redisLock) unlock(writing bool) {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	if (writing && rl.readers > 0) || (!writing && rl.readers < 0) {
+		redisLogger.Errorf("Invalid unlocking: %v %d (%s)", writing, rl.readers, rl.key)
+		return
+	}
+
+	if !writing && rl.readers > 1 {
+		rl.readers--
+		return
+	}
+
+	_, err := rl.client.Eval(rl.ctx, luaRelease, []string{rl.key}, rl.token).Result()
+	if err != nil {
+		redisLogger.Warnf("Failed to unlock: %s (%s)", err.Error(), rl.key)
+	}
+
+	rl.readers = 0
+	rl.token = ""
 }


### PR DESCRIPTION
The lock tests were flaky on the CI, but it wasn't the fault of the test. There were some issues in the code:

- there was a race condition when a long lock in redis was trying to extend, allowing another writer to potentially gain the lock
- the long operation lock could not be reused (its internal mutex wasn't unlocked at the end).

And the order of functions for the redis implementation was changed to have the same structure as the in-memory implementation.