### PR TITLE
fix: Don't modify headers to get CLI permission

### DIFF
--- a/web/auth/register.go
+++ b/web/auth/register.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/cozy/cozy-stack/model/oauth"
-	"github.com/cozy/cozy-stack/model/permission"
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
@@ -29,8 +28,7 @@ func registerClient(c echo.Context) error {
 	// We do not allow the creation of clients allowed to have an empty scope
 	// ("login" scope), except via the CLI.
 	if client.AllowLoginScope {
-		perm, err := middlewares.GetPermission(c)
-		if err != nil || perm.Type != permission.TypeCLI {
+		if _, ok := middlewares.GetCLIPermission(c); !ok {
 			return echo.NewHTTPError(http.StatusUnauthorized,
 				"Not authorized to create client with given parameters")
 		}

--- a/web/middlewares/instance.go
+++ b/web/middlewares/instance.go
@@ -65,8 +65,7 @@ func CheckInstanceDeleting(next echo.HandlerFunc) echo.HandlerFunc {
 func CheckInstanceBlocked(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		i := GetInstance(c)
-		pdoc, err := GetPermission(c)
-		if err == nil && pdoc.Type == permission.TypeCLI {
+		if _, ok := GetCLIPermission(c); ok {
 			return next(c)
 		}
 		if i.CheckInstanceBlocked() {
@@ -197,8 +196,7 @@ func CheckOnboardingNotFinished(next echo.HandlerFunc) echo.HandlerFunc {
 func CheckTOSDeadlineExpired(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		i := GetInstance(c)
-		pdoc, err := GetPermission(c)
-		if err == nil && pdoc.Type == permission.TypeCLI {
+		if _, ok := GetCLIPermission(c); ok {
 			return next(c)
 		}
 

--- a/web/settings/passphrase.go
+++ b/web/settings/passphrase.go
@@ -266,8 +266,7 @@ func (h *HTTPHandler) updatePassphrase(c echo.Context) error {
 		canForce := false
 
 		// CLI can force the passphrase
-		p, err := middlewares.GetPermission(c)
-		if err == nil && p.Type == permission.TypeCLI {
+		if _, ok := middlewares.GetCLIPermission(c); ok {
 			canForce = true
 		}
 


### PR DESCRIPTION
  We found out that some middlewares like `CheckInstanceBlocked` would
  modify the response headers if the request's authentication token was
  invalid (e.g. because it's expired).

  This is because we use the `GetPermission` middleware to get a
  permission doc and check its type to do some specific actions when the
  request is done via the CLI and the `GetPermission` middleware will
  eventually change the response headers via a call to `ExtractClaims`
  when the token is invalid.

  We're modifying `ExtractClaims` to move the side effect outside the
  function and introducing a new `GetCLIPermission` middleware which
  will try to get a CLI permission from the context without side effects
  or erroring out.
  We can then use it to check if the request is done via the CLI.