### PR TITLE
feat: Prefer mobile push for quota notification

### DIFF
--- a/assets/locales/de.po
+++ b/assets/locales/de.po
@@ -841,6 +841,18 @@ msgstr "URL vergessen? Keine Panik."
 msgid "Sharing Forgotten URL email"
 msgstr "Durchsuche dein E-Mail Postfach nach \"Cozy\"."
 
+msgid "Notifications Disk Quota Close Title"
+msgstr "You've reached 90% of your storage"
+
+msgid "Notifications Disk Quota Close Message"
+msgstr "You are using over 90% of your storage. Please delete files, or upgrade your offer to get more space."
+
+msgid "Notifications Disk Quota Reached Title"
+msgstr "Your Cozy is full"
+
+msgid "Notifications Disk Quota Reached Message"
+msgstr "You've reached the limit of your storage. Please delete files, or upgrade your offer to get more space."
+
 msgid "Notifications Disk Quota Subject"
 msgstr "Du hast mitterweile 90% deines Speicherplatzes gefüllt. "
 

--- a/assets/locales/en.po
+++ b/assets/locales/en.po
@@ -1120,6 +1120,18 @@ msgstr "Discover Cozy now!"
 msgid "Sharing Forgotten URL"
 msgstr "I have forgotten my address"
 
+msgid "Notifications Disk Quota Close Title"
+msgstr "You've reached 90% of your storage"
+
+msgid "Notifications Disk Quota Close Message"
+msgstr "You are using over 90% of your storage. Please delete files, or upgrade your offer to get more space."
+
+msgid "Notifications Disk Quota Reached Title"
+msgstr "Your Cozy is full"
+
+msgid "Notifications Disk Quota Reached Message"
+msgstr "You've reached the limit of your storage. Please delete files, or upgrade your offer to get more space."
+
 msgid "Notifications Disk Quota Subject"
 msgstr "You have currently reached 90% of your space."
 

--- a/assets/locales/es.po
+++ b/assets/locales/es.po
@@ -855,6 +855,18 @@ msgstr "¿Ha olvidado la URL? No hay que tener miedo alguno."
 msgid "Sharing Forgotten URL email"
 msgstr "Busque en la bandeja de entrada de su correo electrónico \"Cozy\"."
 
+msgid "Notifications Disk Quota Close Title"
+msgstr "You've reached 90% of your storage"
+
+msgid "Notifications Disk Quota Close Message"
+msgstr "You are using over 90% of your storage. Please delete files, or upgrade your offer to get more space."
+
+msgid "Notifications Disk Quota Reached Title"
+msgstr "Your Cozy is full"
+
+msgid "Notifications Disk Quota Reached Message"
+msgstr "You've reached the limit of your storage. Please delete files, or upgrade your offer to get more space."
+
 msgid "Notifications Disk Quota Subject"
 msgstr "Usted ha alcanzado el 90% de su espacio Cozy."
 

--- a/assets/locales/fr.po
+++ b/assets/locales/fr.po
@@ -1225,6 +1225,18 @@ msgstr "Découvrez Cozy maintenant !"
 msgid "Sharing Forgotten URL"
 msgstr "J'ai oublié mon adresse"
 
+msgid "Notifications Disk Quota Close Title"
+msgstr "Quota de stockage supérieur à 90%"
+
+msgid "Notifications Disk Quota Close Message"
+msgstr "Supprimez des fichiers ou changez d'offre pour obtenir plus d'espace de stockage."
+
+msgid "Notifications Disk Quota Reached Title"
+msgstr "Le stockage de votre Cozy est plein"
+
+msgid "Notifications Disk Quota Reached Message"
+msgstr "Supprimez des fichiers ou changez d'offre pour obtenir plus d'espace de stockage."
+
 msgid "Notifications Disk Quota Subject"
 msgstr "Vous avez atteint 90% de votre espace de stockage."
 

--- a/assets/locales/ja.po
+++ b/assets/locales/ja.po
@@ -663,6 +663,18 @@ msgstr "URL をお忘れですか? 慌てないでください"
 msgid "Sharing Forgotten URL email"
 msgstr "メールの受信トレイで \"Cozy\" を検索してください。"
 
+msgid "Notifications Disk Quota Close Title"
+msgstr "You've reached 90% of your storage"
+
+msgid "Notifications Disk Quota Close Message"
+msgstr "You are using over 90% of your storage. Please delete files, or upgrade your offer to get more space."
+
+msgid "Notifications Disk Quota Reached Title"
+msgstr "Your Cozy is full"
+
+msgid "Notifications Disk Quota Reached Message"
+msgstr "You've reached the limit of your storage. Please delete files, or upgrade your offer to get more space."
+
 msgid "Notifications Disk Quota Subject"
 msgstr "現在、容量が 90％ に達しています。"
 

--- a/assets/locales/nl_NL.po
+++ b/assets/locales/nl_NL.po
@@ -1039,6 +1039,18 @@ msgstr "Ben je de url vergeten? Maak je geen zorgen."
 msgid "Sharing Forgotten URL email"
 msgstr "Zoek naar \"Cozy\" in je Postvak IN."
 
+msgid "Notifications Disk Quota Close Title"
+msgstr "You've reached 90% of your storage"
+
+msgid "Notifications Disk Quota Close Message"
+msgstr "You are using over 90% of your storage. Please delete files, or upgrade your offer to get more space."
+
+msgid "Notifications Disk Quota Reached Title"
+msgstr "Your Cozy is full"
+
+msgid "Notifications Disk Quota Reached Message"
+msgstr "You've reached the limit of your storage. Please delete files, or upgrade your offer to get more space."
+
 msgid "Notifications Disk Quota Subject"
 msgstr "Je hebt momenteel 90% van je beschikbare opslagruimte verbruikt."
 

--- a/model/notification/center/notification_center.go
+++ b/model/notification/center/notification_center.go
@@ -45,17 +45,36 @@ func init() {
 		if err != nil {
 			return
 		}
+
+		title := i.Translate("Notifications Disk Quota Close Title")
+		message := i.Translate("Notifications Disk Quota Close Message")
+		if exceeded {
+			title = i.Translate("Notifications Disk Quota Reached Title")
+			message = i.Translate("Notifications Disk Quota Reached Message")
+		}
+
 		offersLink, err := i.ManagerURL(instance.ManagerPremiumURL)
 		if err != nil {
 			return
 		}
 		cozyDriveLink := i.SubDomain(consts.DriveSlug)
+
+		redirectLink := consts.SettingsSlug + "/#/storage"
+
 		n := &notification.Notification{
-			State: exceeded,
+			Title:   title,
+			Message: message,
+			Slug:    consts.SettingsSlug,
+			State:   exceeded,
 			Data: map[string]interface{}{
+				// For email notification
 				"OffersLink":    offersLink,
 				"CozyDriveLink": cozyDriveLink.String(),
+
+				// For mobile push notification
+				"redirectLink": redirectLink,
 			},
+			PreferredChannels: []string{"mobile"},
 		}
 		_ = PushStack(domain, NotificationDiskQuota, n)
 	})


### PR DESCRIPTION
We set `mobile` as the preferred channel for the (almost) reached
quota notification that was sent only by e-mail.
The notification will redirect the user to the storage view of the
Settings application when opened.

E-mail is still added as a fallback transport when no mobile
devices are reachable.