### PR TITLE
fix: Preserve other metadata when updating note

### DIFF
--- a/model/note/note.go
+++ b/model/note/note.go
@@ -155,7 +155,7 @@ func (d *Document) GetDirID(inst *instance.Instance) (string, error) {
 func (d *Document) asFile(inst *instance.Instance, old *vfs.FileDoc) *vfs.FileDoc {
 	now := time.Now()
 	file := old.Clone().(*vfs.FileDoc)
-	file.Metadata = d.Metadata()
+	vfs.MergeMetadata(file, d.Metadata())
 	file.Mime = consts.NoteMimeType
 	file.MD5Sum = nil // Let the VFS compute the md5sum
 
@@ -554,7 +554,7 @@ func UpdateMetadataFromCache(inst *instance.Instance, docs []*vfs.FileDoc) {
 		}
 		var note Document
 		if err := json.Unmarshal(buf, &note); err == nil {
-			docs[i].Metadata = note.Metadata()
+			vfs.MergeMetadata(docs[i], note.Metadata())
 		}
 	}
 }


### PR DESCRIPTION
When updating a Note, we would take the new Document's metadata and
store it in stead of the old file's Metadata since the Note's title,
version, schema and content are stored there.

However, other apps can store data in a file's Metadata, such as a
qualification, and we don't want to lose this.

From now on, we'll merge the 2 Metadata objects, overriding any
existing Note metadata value but preserving metadata from other apps.