### PR TITLE
fix: No app slug in disk quota push notification

### DIFF
--- a/docs/flagship.md
+++ b/docs/flagship.md
@@ -115,6 +115,9 @@ token, the stack will then try to send the notification to the flagship apps.
 If it fails again, the stack then fallbacks on email.
 
 If the notification is sent to the flagship app, the title is modified to
-preprend the application name. The name is taken from the `appName` field of
-the additional parameters (`data`). It allows the user to have more context
-when reading the notification on their mobile.
+preprend the application name. By default, the notification `slug` is used but,
+if present, the name is taken from the `appName` field of the additional
+parameters (`data`). It allows the user to have more context when reading the
+notification on their mobile. The `data.appName` field can also be used to
+completely remove the application name from the notification title if set to an
+empty string.

--- a/model/notification/center/notification_center.go
+++ b/model/notification/center/notification_center.go
@@ -72,6 +72,7 @@ func init() {
 				"CozyDriveLink": cozyDriveLink.String(),
 
 				// For mobile push notification
+				"appName":      "",
 				"redirectLink": redirectLink,
 			},
 			PreferredChannels: []string{"mobile"},

--- a/worker/push/push.go
+++ b/worker/push/push.go
@@ -159,7 +159,9 @@ func Worker(ctx *job.WorkerContext) error {
 	if str, ok := msg.Data["appName"].(string); ok {
 		name = str
 	}
-	msg.Title = fmt.Sprintf("%s - %s", name, msg.Title)
+	if name != "" {
+		msg.Title = fmt.Sprintf("%s - %s", name, msg.Title)
+	}
 	for _, c := range cs {
 		if _, ok := seen[c.NotificationDeviceToken]; ok {
 			continue


### PR DESCRIPTION
Don't include the app's slug in the disk quota push notification
title.