### PR TITLE
fix: Use right strings in disk quota notification

### DIFF
--- a/assets/locales/de.po
+++ b/assets/locales/de.po
@@ -847,12 +847,6 @@ msgstr "You've reached 90% of your storage"
 msgid "Notifications Disk Quota Close Message"
 msgstr "You are using over 90% of your storage. Please delete files, or upgrade your offer to get more space."
 
-msgid "Notifications Disk Quota Reached Title"
-msgstr "Your Cozy is full"
-
-msgid "Notifications Disk Quota Reached Message"
-msgstr "You've reached the limit of your storage. Please delete files, or upgrade your offer to get more space."
-
 msgid "Notifications Disk Quota Subject"
 msgstr "Du hast mitterweile 90% deines Speicherplatzes gefüllt. "
 

--- a/assets/locales/en.po
+++ b/assets/locales/en.po
@@ -1126,12 +1126,6 @@ msgstr "You've reached 90% of your storage"
 msgid "Notifications Disk Quota Close Message"
 msgstr "You are using over 90% of your storage. Please delete files, or upgrade your offer to get more space."
 
-msgid "Notifications Disk Quota Reached Title"
-msgstr "Your Cozy is full"
-
-msgid "Notifications Disk Quota Reached Message"
-msgstr "You've reached the limit of your storage. Please delete files, or upgrade your offer to get more space."
-
 msgid "Notifications Disk Quota Subject"
 msgstr "You have currently reached 90% of your space."
 

--- a/assets/locales/es.po
+++ b/assets/locales/es.po
@@ -861,12 +861,6 @@ msgstr "You've reached 90% of your storage"
 msgid "Notifications Disk Quota Close Message"
 msgstr "You are using over 90% of your storage. Please delete files, or upgrade your offer to get more space."
 
-msgid "Notifications Disk Quota Reached Title"
-msgstr "Your Cozy is full"
-
-msgid "Notifications Disk Quota Reached Message"
-msgstr "You've reached the limit of your storage. Please delete files, or upgrade your offer to get more space."
-
 msgid "Notifications Disk Quota Subject"
 msgstr "Usted ha alcanzado el 90% de su espacio Cozy."
 

--- a/assets/locales/fr.po
+++ b/assets/locales/fr.po
@@ -1231,12 +1231,6 @@ msgstr "Quota de stockage supérieur à 90%"
 msgid "Notifications Disk Quota Close Message"
 msgstr "Supprimez des fichiers ou changez d'offre pour obtenir plus d'espace de stockage."
 
-msgid "Notifications Disk Quota Reached Title"
-msgstr "Le stockage de votre Cozy est plein"
-
-msgid "Notifications Disk Quota Reached Message"
-msgstr "Supprimez des fichiers ou changez d'offre pour obtenir plus d'espace de stockage."
-
 msgid "Notifications Disk Quota Subject"
 msgstr "Vous avez atteint 90% de votre espace de stockage."
 

--- a/assets/locales/ja.po
+++ b/assets/locales/ja.po
@@ -669,12 +669,6 @@ msgstr "You've reached 90% of your storage"
 msgid "Notifications Disk Quota Close Message"
 msgstr "You are using over 90% of your storage. Please delete files, or upgrade your offer to get more space."
 
-msgid "Notifications Disk Quota Reached Title"
-msgstr "Your Cozy is full"
-
-msgid "Notifications Disk Quota Reached Message"
-msgstr "You've reached the limit of your storage. Please delete files, or upgrade your offer to get more space."
-
 msgid "Notifications Disk Quota Subject"
 msgstr "現在、容量が 90％ に達しています。"
 

--- a/assets/locales/nl_NL.po
+++ b/assets/locales/nl_NL.po
@@ -1045,12 +1045,6 @@ msgstr "You've reached 90% of your storage"
 msgid "Notifications Disk Quota Close Message"
 msgstr "You are using over 90% of your storage. Please delete files, or upgrade your offer to get more space."
 
-msgid "Notifications Disk Quota Reached Title"
-msgstr "Your Cozy is full"
-
-msgid "Notifications Disk Quota Reached Message"
-msgstr "You've reached the limit of your storage. Please delete files, or upgrade your offer to get more space."
-
 msgid "Notifications Disk Quota Subject"
 msgstr "Je hebt momenteel 90% van je beschikbare opslagruimte verbruikt."
 

--- a/model/notification/center/notification_center.go
+++ b/model/notification/center/notification_center.go
@@ -40,7 +40,7 @@ var (
 )
 
 func init() {
-	vfs.RegisterDiskQuotaAlertCallback(func(domain string, exceeded bool) {
+	vfs.RegisterDiskQuotaAlertCallback(func(domain string, capsizeExceeded bool) {
 		i, err := lifecycle.GetInstance(domain)
 		if err != nil {
 			return
@@ -48,24 +48,18 @@ func init() {
 
 		title := i.Translate("Notifications Disk Quota Close Title")
 		message := i.Translate("Notifications Disk Quota Close Message")
-		if exceeded {
-			title = i.Translate("Notifications Disk Quota Reached Title")
-			message = i.Translate("Notifications Disk Quota Reached Message")
-		}
-
 		offersLink, err := i.ManagerURL(instance.ManagerPremiumURL)
 		if err != nil {
 			return
 		}
 		cozyDriveLink := i.SubDomain(consts.DriveSlug)
-
 		redirectLink := consts.SettingsSlug + "/#/storage"
 
 		n := &notification.Notification{
 			Title:   title,
 			Message: message,
 			Slug:    consts.SettingsSlug,
-			State:   exceeded,
+			State:   capsizeExceeded,
 			Data: map[string]interface{}{
 				// For email notification
 				"OffersLink":    offersLink,


### PR DESCRIPTION
Based on a misunderstanding, we were sending a push notification when
reaching 90% of the disk quota (i.e. the `capsize`) with a message
intended for a fully reached quota.

However, there are 2 things to note:
1. there are no notifications when reaching 100% of the disk quota (so the term "exceeded" in the existing notification refers to the capsize or 90% of the disk quota)
2. because the disk quota can never be reached from below since `cozy-stack` will refuse the upload if it would mean reaching the quota

Therefore, we can completely remove strings related to an hypothetical
reached disk quota notification and always use those of the reached
capsize.