### PR TITLE
Don't try to upload deleted files

### DIFF
--- a/model/sharing/upload.go
+++ b/model/sharing/upload.go
@@ -224,6 +224,11 @@ func (s *Sharing) findNextFileToUpload(inst *instance.Instance, since string) (m
 				Warnf("missing results for bulk get %v", query)
 			return nil, 0, since, ErrInternalServerError
 		}
+		if results[0]["_deleted"] == true {
+			inst.Logger().WithNamespace("upload").
+				Warnf("cannot upload file %v", results[0])
+			return nil, 0, since, ErrInternalServerError
+		}
 		return results[0], int(idx), since, nil
 	}
 	return nil, 0, since, nil

--- a/model/sharing/upload.go
+++ b/model/sharing/upload.go
@@ -226,7 +226,7 @@ func (s *Sharing) findNextFileToUpload(inst *instance.Instance, since string) (m
 		}
 		if results[0]["_deleted"] == true {
 			inst.Logger().WithNamespace("upload").
-				Warnf("cannot upload file %v", results[0])
+				Warnf("cannot upload _deleted file %v", results[0])
 			return nil, 0, since, ErrInternalServerError
 		}
 		return results[0], int(idx), since, nil


### PR DESCRIPTION
It should not happen, but if the stack try to upload a deleted file, it should detect it and skip this file instead of looping on this file with an error.