### PR TITLE
Improve the way we get the sharing dir

### DIFF
--- a/model/sharing/files.go
+++ b/model/sharing/files.go
@@ -335,7 +335,7 @@ func (s *Sharing) AddReferenceForSharingDir(inst *instance.Instance, rule *Rule)
 // GetSharingDir returns the directory used by this sharing for putting files
 // and folders that have no dir_id.
 func (s *Sharing) GetSharingDir(inst *instance.Instance) (*vfs.DirDoc, error) {
-	// When we can, find the sharding dir by its ID
+	// When we can, find the sharing dir by its ID
 	fs := inst.VFS()
 	rule := s.FirstFilesRule()
 	if rule != nil {

--- a/model/sharing/files.go
+++ b/model/sharing/files.go
@@ -335,6 +335,17 @@ func (s *Sharing) AddReferenceForSharingDir(inst *instance.Instance, rule *Rule)
 // GetSharingDir returns the directory used by this sharing for putting files
 // and folders that have no dir_id.
 func (s *Sharing) GetSharingDir(inst *instance.Instance) (*vfs.DirDoc, error) {
+	// When we can, find the sharding dir by its ID
+	fs := inst.VFS()
+	rule := s.FirstFilesRule()
+	if rule != nil {
+		dir, _ := fs.DirByID(rule.Values[0])
+		if dir != nil {
+			return dir, nil
+		}
+	}
+
+	// Else, try to find it by a reference
 	key := []string{consts.Sharings, s.SID}
 	end := []string{key[0], key[1], couchdb.MaxString}
 	req := &couchdb.ViewRequest{
@@ -351,7 +362,7 @@ func (s *Sharing) GetSharingDir(inst *instance.Instance) (*vfs.DirDoc, error) {
 	}
 	var parentID string
 	if len(res.Rows) > 0 {
-		dir, file, err := inst.VFS().DirOrFileByID(res.Rows[0].ID)
+		dir, file, err := fs.DirOrFileByID(res.Rows[0].ID)
 		if err != nil {
 			inst.Logger().WithNamespace("sharing").
 				Warnf("GetSharingDir failed to find dir: %s", err)
@@ -362,7 +373,7 @@ func (s *Sharing) GetSharingDir(inst *instance.Instance) (*vfs.DirDoc, error) {
 		}
 		// file is a shortcut
 		parentID = file.DirID
-		if err := inst.VFS().DestroyFile(file); err != nil {
+		if err := fs.DestroyFile(file); err != nil {
 			inst.Logger().WithNamespace("sharing").
 				Warnf("GetSharingDir failed to delete shortcut: %s", err)
 			return nil, err
@@ -370,12 +381,12 @@ func (s *Sharing) GetSharingDir(inst *instance.Instance) (*vfs.DirDoc, error) {
 		s.ShortcutID = ""
 		_ = couchdb.UpdateDoc(inst, s)
 	}
-	rule := s.FirstFilesRule()
 	if rule == nil {
 		inst.Logger().WithNamespace("sharing").
 			Errorf("no first rule for: %#v", s)
 		return nil, ErrInternalServerError
 	}
+	// And, we may have to create it in last resort
 	return s.CreateDirForSharing(inst, rule, parentID)
 }
 


### PR DESCRIPTION
It happens that the stack needs the main directory for a sharing. For example, when it receives a new file that is inside the shared directory. The stack was using a referenced_by to find it, but we have found in production that the referenced_by can have been put on the wrong directories. We will now use the ID when we have it, and only use the referenced_by if not.