### PR TITLE
feat: Block users with exceeded clients limit

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -905,6 +905,32 @@ HTTP/1.1 204 No Content
 To use this endpoint, an application needs a permission on the type
 `io.cozy.oauth.clients` for the verb `DELETE` (only client-side apps).
 
+### GET /settings/clients/limit-exceeded
+
+Get an OAuth clients limit exceeded page if the instance has more connected
+OAuth clients than its limit allows or redirect the request to the `redirect`
+parameter's value.
+The `redirect` parameter is optional. By default, its value
+is the instance's default redirection.
+
+The page will auto-refresh every 20 seconds or when an OAuth client deletion is
+detected.
+
+#### Query-String
+
+| Parameter  | Description                                          |
+| ---------- | ---------------------------------------------------- |
+| redirect   | URL where to redirect when the limit is not exceeded |
+
+#### Request
+
+```http
+GET /settings/clients/limit-exceeded?redirect=https%3A%2F%2Falice-home.example.com%2F HTTP/1.1
+Host: alice.example.com
+Accept: application/vnd.api+json
+Cookie: sessionid=xxxx
+```
+
 ### POST /settings/synchronized
 
 Any OAuth2 client can make a request to this endpoint with its token, no

--- a/model/instance/tos.go
+++ b/model/instance/tos.go
@@ -1,12 +1,9 @@
 package instance
 
 import (
-	"net/http"
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/cozy/cozy-stack/pkg/jsonapi"
 )
 
 // BlockingReason structs holds a reason why an instance had been blocked
@@ -27,25 +24,6 @@ var (
 	// BlockedUnknown is used when an instance is blocked but the reason is unknown
 	BlockedUnknown = BlockingReason{Code: "UNKNOWN", Message: "Instance Blocked Unknown"}
 )
-
-// Warnings returns a list of possible warnings associated with the instance.
-func (i *Instance) Warnings() (warnings []*jsonapi.Error) {
-	if err := i.MovedError(); err != nil {
-		warnings = append(warnings, err)
-	}
-	notSigned, deadline := i.CheckTOSNotSignedAndDeadline()
-	if notSigned && deadline >= TOSWarning {
-		tosLink, _ := i.ManagerURL(ManagerTOSURL)
-		warnings = append(warnings, &jsonapi.Error{
-			Status: http.StatusPaymentRequired,
-			Title:  "TOS Updated",
-			Code:   "tos-updated",
-			Detail: i.Translate("Terms of services have been updated"),
-			Links:  &jsonapi.LinksList{Self: tosLink},
-		})
-	}
-	return
-}
 
 // TOSDeadline represent the state for reaching the TOS deadline.
 type TOSDeadline int

--- a/model/oauth/client.go
+++ b/model/oauth/client.go
@@ -814,4 +814,21 @@ func BuildLinkedAppScope(slug string) string {
 	return fmt.Sprintf("@%s/%s", consts.Apps, slug)
 }
 
+func CheckOAuthClientsLimitReached(i *instance.Instance, limit int) (reached, exceeded bool) {
+	if limit == -1 {
+		return
+	}
+
+	clients, _, err := GetConnectedUserClients(i, 100, "")
+	if err != nil {
+		i.Logger().Errorf("Could not fetch connected OAuth clients: %s", err)
+		return
+	}
+	count := len(clients)
+
+	reached = count >= limit
+	exceeded = count > limit
+	return
+}
+
 var _ couchdb.Doc = &Client{}

--- a/tests/testutils/test_utils.go
+++ b/tests/testutils/test_utils.go
@@ -320,7 +320,7 @@ func (c *TestSetup) InstallMiniApp() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	err = createFile(instance, appdir, "index.html", `this is index.html. <a lang="{{.Locale}}" href="https://{{.Domain}}/status/">Status</a> {{.Favicon}}`)
+	err = createFile(instance, appdir, "index.html", `<html><body>this is index.html. <a lang="{{.Locale}}" href="https://{{.Domain}}/status/">Status</a> {{.Favicon}}</body></html>`)
 	if err != nil {
 		return "", err
 	}

--- a/web/apps/apps.go
+++ b/web/apps/apps.go
@@ -747,6 +747,7 @@ func (o *apiOpenParams) MarshalJSON() ([]byte, error) {
 	data["ThemeCSS"] = o.params.ThemeCSS()
 	data["Favicon"] = o.params.Favicon()
 	data["DefaultWallpaper"] = o.params.DefaultWallpaper()
+	data["Warnings"], _ = o.params.Warnings()
 	return json.Marshal(data)
 }
 

--- a/web/apps/serve.go
+++ b/web/apps/serve.go
@@ -579,7 +579,7 @@ func cozybar(i *instance.Instance, loggedIn bool) (template.HTML, error) {
 	buf := new(bytes.Buffer)
 	err := barTemplate.Execute(buf, echo.Map{
 		"Domain":      i.ContextualDomain(),
-		"Warnings":    i.Warnings(),
+		"Warnings":    middlewares.ListWarnings(i),
 		"ContextName": i.ContextName,
 		"LoggedIn":    loggedIn,
 	})

--- a/web/apps/serve.go
+++ b/web/apps/serve.go
@@ -259,7 +259,31 @@ func ServeAppFile(c echo.Context, i *instance.Instance, fs appfs.FileServer, web
 		return err
 	}
 
-	tmpl, err := template.New(file).Parse(string(buf))
+	// XXX: Force include Warnings template in all app indexes
+	tmplText := string(buf)
+	if closeTagIdx := strings.Index(tmplText, "</head>"); closeTagIdx >= 0 {
+		tmplText = tmplText[:closeTagIdx] + "\n{{.Warnings}}\n" + tmplText[closeTagIdx:]
+	} else {
+		needsOpenTag := true
+		if openTagIdx := strings.Index(tmplText, "<head>"); openTagIdx >= 0 {
+			needsOpenTag = false
+		}
+
+		if bodyTagIdx := strings.Index(tmplText, "<body>"); bodyTagIdx >= 0 {
+			before := tmplText[:bodyTagIdx]
+			after := tmplText[bodyTagIdx:]
+
+			tmplText = before
+
+			if needsOpenTag {
+				tmplText += "\n<head>"
+			}
+
+			tmplText += "\n{{.Warnings}}\n</head>\n" + after
+		}
+	}
+
+	tmpl, err := template.New(file).Parse(tmplText)
 	if err != nil {
 		i.Logger().WithNamespace("apps").Warnf("%s cannot be parsed as a template: %s", file, err)
 		return fs.ServeFileContent(c.Response(), c.Request(), slug, version, shasum, filepath)
@@ -516,11 +540,11 @@ func (s serveParams) GetFlags() *feature.Flags {
 }
 
 func (s serveParams) CozyBar() (template.HTML, error) {
-	return cozybar(s.instance, s.isLoggedIn)
+	return cozybarHTML(s.instance, s.isLoggedIn)
 }
 
 func (s serveParams) CozyClientJS() (template.HTML, error) {
-	return cozyclientjs(s.instance)
+	return cozyclientjsHTML(s.instance)
 }
 
 func (s serveParams) CozyFonts() template.HTML {
@@ -542,8 +566,13 @@ func (s serveParams) DefaultWallpaper() string {
 		s.instance.ContextName)
 }
 
+func (s serveParams) Warnings() (template.HTML, error) {
+	return warningsHTML(s.instance, s.isLoggedIn)
+}
+
 var clientTemplate *template.Template
 var barTemplate *template.Template
+var warningsTemplate *template.Template
 
 // BuildTemplates ensure that cozy-client-js and the bar can be injected in templates
 func BuildTemplates() {
@@ -554,16 +583,19 @@ func BuildTemplates() {
 	barTemplate = template.Must(template.New("cozy-bar").Funcs(middlewares.FuncsMap).Parse(`
 <link rel="stylesheet" type="text/css" href="{{asset .Domain "/fonts/fonts.css" .ContextName}}">
 <link rel="stylesheet" type="text/css" href="{{asset .Domain "/css/cozy-bar.min.css" .ContextName}}">
+<script src="{{asset .Domain "/js/cozy-bar.min.js" .ContextName}}"></script>`,
+	))
+
+	warningsTemplate = template.Must(template.New("warnings").Funcs(middlewares.FuncsMap).Parse(`
 {{if .LoggedIn}}
 {{range .Warnings}}
-<meta name="user-action-required" data-title="{{ .Title }}" data-code="{{ .Code }}" data-detail="{{ .Detail }}" data-links="{{ .Links.Self }}" />
+<meta name="user-action-required" data-title="{{ .Title }}" data-code="{{ .Code }}" data-detail="{{ .Detail }}" {{with .Links}}{{with .Self}}data-links="{{ . }}"{{end}}{{end}} />
 {{end}}
-{{end}}
-<script src="{{asset .Domain "/js/cozy-bar.min.js" .ContextName}}"></script>`,
+{{end}}`,
 	))
 }
 
-func cozyclientjs(i *instance.Instance) (template.HTML, error) {
+func cozyclientjsHTML(i *instance.Instance) (template.HTML, error) {
 	buf := new(bytes.Buffer)
 	err := clientTemplate.Execute(buf, echo.Map{
 		"Domain":      i.ContextualDomain(),
@@ -575,13 +607,25 @@ func cozyclientjs(i *instance.Instance) (template.HTML, error) {
 	return template.HTML(buf.String()), nil
 }
 
-func cozybar(i *instance.Instance, loggedIn bool) (template.HTML, error) {
+func cozybarHTML(i *instance.Instance, loggedIn bool) (template.HTML, error) {
 	buf := new(bytes.Buffer)
 	err := barTemplate.Execute(buf, echo.Map{
 		"Domain":      i.ContextualDomain(),
 		"Warnings":    middlewares.ListWarnings(i),
 		"ContextName": i.ContextName,
 		"LoggedIn":    loggedIn,
+	})
+	if err != nil {
+		return "", err
+	}
+	return template.HTML(buf.String()), nil
+}
+
+func warningsHTML(i *instance.Instance, loggedIn bool) (template.HTML, error) {
+	buf := new(bytes.Buffer)
+	err := warningsTemplate.Execute(buf, echo.Map{
+		"Warnings": middlewares.ListWarnings(i),
+		"LoggedIn": loggedIn,
 	})
 	if err != nil {
 		return "", err

--- a/web/apps/serve.go
+++ b/web/apps/serve.go
@@ -69,6 +69,12 @@ func Serve(c echo.Context) error {
 	}
 
 	if file == "" || file == route.Index {
+		if !route.Public {
+			if handled, err := middlewares.CheckOAuthClientsLimitExceeded(c); handled {
+				return err
+			}
+		}
+
 		webapp = app.DoLazyUpdate(i, webapp, app.Copier(consts.WebappType, i), i.Registries()).(*app.WebappManifest)
 	}
 

--- a/web/middlewares/instance.go
+++ b/web/middlewares/instance.go
@@ -158,7 +158,7 @@ func handleBlockedInstance(c echo.Context, i *instance.Instance, next echo.Handl
 }
 
 func warningOrBlocked(i *instance.Instance, returnCode int) []*jsonapi.Error {
-	warnings := i.Warnings()
+	warnings := ListWarnings(i)
 	if len(warnings) == 0 {
 		warnings = []*jsonapi.Error{
 			{
@@ -212,7 +212,7 @@ func CheckTOSDeadlineExpired(next echo.HandlerFunc) echo.HandlerFunc {
 		if notSigned && deadline == instance.TOSBlocked {
 			switch AcceptedContentType(c) {
 			case jsonapi.ContentType, echo.MIMEApplicationJSON:
-				return c.JSON(http.StatusPaymentRequired, i.Warnings())
+				return c.JSON(http.StatusPaymentRequired, ListWarnings(i))
 			default:
 				return c.Redirect(http.StatusFound, redirect)
 			}

--- a/web/middlewares/warnings.go
+++ b/web/middlewares/warnings.go
@@ -1,0 +1,27 @@
+package middlewares
+
+import (
+	"net/http"
+
+	"github.com/cozy/cozy-stack/model/instance"
+	"github.com/cozy/cozy-stack/pkg/jsonapi"
+)
+
+// List returns a list of possible warnings associated with the instance.
+func ListWarnings(i *instance.Instance) (warnings []*jsonapi.Error) {
+	if err := i.MovedError(); err != nil {
+		warnings = append(warnings, err)
+	}
+	notSigned, deadline := i.CheckTOSNotSignedAndDeadline()
+	if notSigned && deadline >= instance.TOSWarning {
+		tosLink, _ := i.ManagerURL(instance.ManagerTOSURL)
+		warnings = append(warnings, &jsonapi.Error{
+			Status: http.StatusPaymentRequired,
+			Title:  "TOS Updated",
+			Code:   "tos-updated",
+			Detail: i.Translate("Terms of services have been updated"),
+			Links:  &jsonapi.LinksList{Self: tosLink},
+		})
+	}
+	return
+}

--- a/web/routing.go
+++ b/web/routing.go
@@ -217,7 +217,8 @@ func SetupRoutes(router *echo.Echo, services *stack.Services) error {
 		}
 		mws := append(mwsNotBlocked,
 			middlewares.CheckInstanceBlocked,
-			middlewares.CheckTOSDeadlineExpired)
+			middlewares.CheckTOSDeadlineExpired,
+		)
 		registry.Routes(router.Group("/registry", mws...))
 		data.Routes(router.Group("/data", mws...))
 		files.Routes(router.Group("/files", mws...))

--- a/web/settings/settings.go
+++ b/web/settings/settings.go
@@ -228,6 +228,7 @@ func (h *HTTPHandler) Register(router *echo.Group) {
 
 	router.GET("/clients", h.listClients)
 	router.DELETE("/clients/:id", h.revokeClient)
+	router.GET("/clients/limit-exceeded", h.limitExceeded)
 	router.POST("/synchronized", h.synchronized)
 
 	router.GET("/onboarded", h.onboarded)

--- a/web/settings/settings.go
+++ b/web/settings/settings.go
@@ -64,7 +64,7 @@ func (h *HTTPHandler) getSessions(c echo.Context) error {
 	return jsonapi.DataList(c, http.StatusOK, objs, nil)
 }
 
-func (h *HTTPHandler) warnings(c echo.Context) error {
+func (h *HTTPHandler) listWarnings(c echo.Context) error {
 	inst := middlewares.GetInstance(c)
 
 	// Any request with a token can ask for the context (no permissions are required)
@@ -72,12 +72,9 @@ func (h *HTTPHandler) warnings(c echo.Context) error {
 		return err
 	}
 
-	warnings := inst.Warnings()
-	if warnings == nil {
-		warnings = []*jsonapi.Error{}
-	}
+	w := middlewares.ListWarnings(inst)
 
-	if len(warnings) == 0 {
+	if len(w) == 0 {
 		// Sends a 404 when there is no warnings
 		resp := c.Response()
 		resp.Header().Set(echo.HeaderContentType, jsonapi.ContentType)
@@ -86,7 +83,7 @@ func (h *HTTPHandler) warnings(c echo.Context) error {
 		return err
 	}
 
-	return jsonapi.DataErrorList(c, warnings...)
+	return jsonapi.DataErrorList(c, w...)
 }
 
 // postEmail handle POST /settings/email
@@ -235,5 +232,5 @@ func (h *HTTPHandler) Register(router *echo.Group) {
 
 	router.GET("/onboarded", h.onboarded)
 	router.GET("/context", h.context)
-	router.GET("/warnings", h.warnings)
+	router.GET("/warnings", h.listWarnings)
 }


### PR DESCRIPTION
If the user manages to connect more OAuth clients than is allowed
(e.g. by trying to connect a Flagship app while the limit was already
reached), we want to redirect them to the Settings app to manage their
clients or increase their limit if they can.

If the request is asking for a JSON response, we'll return the list of
warnings (including a new warning for the reached OAuth clients limit)
instead of redirecting.