### PR TITLE
fix: Cleanup after OnDeleteAccount konnector run

### DIFF
--- a/worker/exec/konnector.go
+++ b/worker/exec/konnector.go
@@ -269,7 +269,7 @@ func (w *konnectorWorker) PrepareWorkDir(ctx *job.WorkerContext, i *instance.Ins
 		if fileExecPath == "" {
 			return "", cleanDir, job.ErrAbort
 		}
-		workDir = path.Join(workDir, fileExecPath)
+		return path.Join(workDir, fileExecPath), cleanDir, nil
 	}
 
 	return workDir, cleanDir, nil


### PR DESCRIPTION
  When running a konnector, the worker will copy the konnector's source
  code to a temporary directory and execute the scripts from this
  workdir.
  After the run, the worker will call a cleanup function that's supposed
  to delete the workdir.
  Both the workdir and cleanup functions are defined and returned by the
  worker's `PrepareWorkDir` method.

  However, in the konnector worker's case, when preparing for an
  `OnDeleteAccount` script execution, we change the workdir to the
  script's path thinking the cleanup function would be left untouched.
  But it happens that this function uses the workdir variable that we
  modify so we end up removing only the `OnDeleteAccount` script instead
  of the whole directory.

  This is a simplified version of what was happening:
  ```go
    var workdir string
    cleanDir := func() {}

    workdir = "konnector/tmp/dir"
    cleanDir = func() {
      fmt.Println(workdir)
    }

    workdir = "script/path.js"

    cleanDir() // We expect "konnector/tmp/dir" and get "script/path.js"
  ```