### PR TITLE
fix: Run eslint without third-party action

### DIFF
--- a/.github/workflows/js-lint.yml
+++ b/.github/workflows/js-lint.yml
@@ -19,13 +19,9 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-      - name: Yarn install 
+      - name: Yarn install
         run: |
           cd ./scripts
           yarn install
-      - uses: sibiraj-s/action-eslint@v3
-        with:
-          eslint-args: '--config scripts/eslintrc.json --ignore-path=.gitignore --quiet'
-          extensions: 'js,jsx,ts,tsx'
-          bin-path: 'scripts/node_modules/eslint/bin'
-          annotations: true
+      - name: Run eslint
+        run: make jslint


### PR DESCRIPTION
The third-party `eslint` action we were using has changed its API
making it very hard for us to check files from folders outside the
`scripts` folder.

Since it's pretty easy to run `eslint`, we'll stop using the action
altogether.