### PR TITLE
Fix a panic

### DIFF
--- a/model/sharing/upload.go
+++ b/model/sharing/upload.go
@@ -106,7 +106,7 @@ func (s *Sharing) sendInitialEndNotif(inst *instance.Instance, m *Member) error 
 		return err
 	}
 	c := s.FindCredentials(m)
-	if c == nil {
+	if c == nil || c.AccessToken == nil {
 		return ErrInvalidSharing
 	}
 	opts := &request.Options{


### PR DESCRIPTION
When a sharing is revoked during its initial synchronization, it may happen that the stack panics.