### PR TITLE
Fix BulkUpdateDocs function

### DIFF
--- a/model/sharing/replicator.go
+++ b/model/sharing/replicator.go
@@ -32,7 +32,8 @@ const MaxRetries = 5
 // (each next retry will wait 4 times longer than its previous retry)
 const InitialBackoffPeriod = 1 * time.Minute
 
-// BatchSize is the maximal number of documents mainpulated at once by the replicator
+// BatchSize is the maximal number of documents mainpulated at once by the
+// replicator
 const BatchSize = 100
 
 // ReplicateMsg is used for jobs on the share-replicate worker.

--- a/pkg/couchdb/bulk.go
+++ b/pkg/couchdb/bulk.go
@@ -280,7 +280,7 @@ func BulkUpdateDocs(db prefixer.Prefixer, doctype string, docs, olddocs []interf
 		if len(remaining) < n {
 			n = len(remaining)
 		}
-		bulkDocs := docs[:n]
+		bulkDocs := remaining[:n]
 		remaining = remaining[n:]
 		bulkOlds := olds[:n]
 		olds = olds[n:]
@@ -313,7 +313,7 @@ func bulkUpdateDocs(db prefixer.Prefixer, doctype string, docs, olddocs []interf
 	if len(res) != len(docs) {
 		return errors.New("BulkUpdateDoc receive an unexpected number of responses")
 	}
-	logBulk(db, "BulkDeleteDocs", doctype, res)
+	logBulk(db, "BulkUpdateDocs", doctype, res)
 	for i, doc := range docs {
 		if d, ok := doc.(Doc); ok {
 			update := res[i]
@@ -403,7 +403,7 @@ func logBulk(db prefixer.Prefixer, prefix, doctype string, docs interface{}) {
 	} else if maps, ok := docs.([]map[string]interface{}); ok {
 		for _, doc := range maps {
 			id, _ := doc["_id"].(string)
-			extracted = append(extracted, fmt.Sprintf("%s", id))
+			extracted = append(extracted, id)
 		}
 	}
 


### PR DESCRIPTION
When there were more than 1000 documents in a call to BulkUpdateDocs, only the first 1000 were updated, because of a pagination bug.