### PR TITLE
Fix a path inconsistency

### DIFF
--- a/model/sharing/files.go
+++ b/model/sharing/files.go
@@ -995,6 +995,7 @@ func (s *Sharing) CreateDir(inst *instance.Instance, target map[string]interface
 		if name != "" {
 			indexer.IncrementRevision()
 			dir.DocName = name
+			dir.Fullpath = path.Join(path.Dir(dir.Fullpath), dir.DocName)
 		}
 		err = fs.CreateDir(dir)
 	}
@@ -1084,6 +1085,7 @@ func (s *Sharing) UpdateDir(
 		if name != "" {
 			indexer.IncrementRevision()
 			dir.DocName = name
+			dir.Fullpath = path.Join(path.Dir(dir.Fullpath), dir.DocName)
 		}
 		err = fs.UpdateDirDoc(oldDoc, dir)
 	}

--- a/model/sharing/upload.go
+++ b/model/sharing/upload.go
@@ -478,6 +478,7 @@ func (s *Sharing) updateFileMetadata(inst *instance.Instance, target *FileDocWit
 		if name != "" {
 			indexer.IncrementRevision()
 			newdoc.DocName = name
+			newdoc.ResetFullpath()
 		}
 		err = fs.UpdateFileDoc(olddoc, newdoc)
 	}
@@ -762,6 +763,7 @@ func (s *Sharing) UploadExistingFile(inst *instance.Instance, target *FileDocWit
 		if name != "" {
 			indexer.IncrementRevision()
 			newdoc.DocName = name
+			newdoc.ResetFullpath()
 		}
 		err = fs.UpdateFileDoc(tmpdoc, newdoc)
 	}


### PR DESCRIPTION
When a conflict happens for two directories with the same path, one directory is renamed. Its path wasn't updated with the new name in this case.