### PR TITLE
fix: Fetch premium links status from config

### DIFF
--- a/model/instance/instance.go
+++ b/model/instance/instance.go
@@ -730,6 +730,15 @@ func (i *Instance) MovedError() *jsonapi.Error {
 	return &jerr
 }
 
+func (i *Instance) HasPremiumLinksEnabled() bool {
+	if ctxSettings, ok := i.SettingsContext(); ok {
+		if enabled, ok := ctxSettings["enable_premium_links"].(bool); ok {
+			return enabled
+		}
+	}
+	return false
+}
+
 // ensure Instance implements couchdb.Doc
 var (
 	_ couchdb.Doc = &Instance{}

--- a/model/notification/center/notification_center.go
+++ b/model/notification/center/notification_center.go
@@ -83,16 +83,16 @@ func init() {
 		_ = PushStack(domain, NotificationDiskQuota, n)
 	})
 
-	oauth.RegisterClientsLimitAlertCallback(func(i *instance.Instance, clientName string, clientsLimit int, enablePremiumLinks bool) {
+	oauth.RegisterClientsLimitAlertCallback(func(i *instance.Instance, clientName string, clientsLimit int) {
 		devicesLink := i.SubDomain(consts.SettingsSlug)
 		devicesLink.Fragment = "/connectedDevices"
 
 		var offersLink string
-		if enablePremiumLinks {
+		if i.HasPremiumLinksEnabled() {
 			var err error
 			offersLink, err = i.ManagerURL(instance.ManagerPremiumURL)
 			if err != nil {
-				return
+				i.Logger().Errorf("Could not get instance Premium Manager URL: %s", err.Error())
 			}
 		}
 

--- a/model/oauth/client.go
+++ b/model/oauth/client.go
@@ -524,14 +524,14 @@ func (c *Client) Create(i *instance.Instance, opts ...CreateOptions) *ClientRegi
 				Errorf("Failed to get the OAuth clients limit: %s", err)
 			return nil
 		}
+
 		limit := -1
 		if clientsLimit, ok := flags.M["cozy.oauthclients.max"].(float64); ok && clientsLimit >= 0 {
 			limit = int(clientsLimit)
 		}
 		_, exceeded := CheckOAuthClientsLimitReached(i, limit)
 		if exceeded {
-			enablePremiumLinks, _ := flags.M["enable_premium_links"].(bool)
-			PushClientsLimitAlert(i, c.ClientName, limit, enablePremiumLinks)
+			PushClientsLimitAlert(i, c.ClientName, limit)
 		}
 		return nil
 	}
@@ -851,19 +851,19 @@ func CheckOAuthClientsLimitReached(i *instance.Instance, limit int) (reached, ex
 	return
 }
 
-var cbClientsLimitAlert func(i *instance.Instance, clientName string, clientsLimit int, enablePremiumLinks bool)
+var cbClientsLimitAlert func(i *instance.Instance, clientName string, clientsLimit int)
 
 // RegisterClientsLimitAlertCallback allows to register a callback function
 // called when the connected OAuth clients limit (if present) is exceeded.
-func RegisterClientsLimitAlertCallback(cb func(i *instance.Instance, clientName string, clientsLimit int, enablePremiumLinks bool)) {
+func RegisterClientsLimitAlertCallback(cb func(i *instance.Instance, clientName string, clientsLimit int)) {
 	cbClientsLimitAlert = cb
 }
 
 // PushClientsLimitAlert can be used to notify when the connected OAuth clients
 // limit (if present) is exceeded.
-func PushClientsLimitAlert(i *instance.Instance, clientName string, clientsLimit int, enablePremiumLinks bool) {
+func PushClientsLimitAlert(i *instance.Instance, clientName string, clientsLimit int) {
 	if cbClientsLimitAlert != nil {
-		cbClientsLimitAlert(i, clientName, clientsLimit, enablePremiumLinks)
+		cbClientsLimitAlert(i, clientName, clientsLimit)
 	}
 }
 

--- a/web/auth/oauth.go
+++ b/web/auth/oauth.go
@@ -261,9 +261,9 @@ func (a *AuthorizeHTTPHandler) authorizeForm(c echo.Context) error {
 				connectedDevicesURL.Fragment = "/connectedDevices"
 				manageDevicesURL = connectedDevicesURL.String()
 
-				if enablePremiumLinks, ok := flags.M["enable_premium_links"].(bool); ok && enablePremiumLinks {
+				if inst.HasPremiumLinksEnabled() {
 					if premiumURL, err = inst.ManagerURL(instance.ManagerPremiumURL); err != nil {
-						return fmt.Errorf("Could not get Premium Manager URL for instance %s: %w", inst.DomainName(), err)
+						inst.Logger().Errorf("Could not get instance Premium Manager URL: %s", err.Error())
 					}
 				}
 

--- a/web/settings/clients.go
+++ b/web/settings/clients.go
@@ -153,13 +153,13 @@ func (h *HTTPHandler) limitExceeded(c echo.Context) error {
 			connectedDevicesURL.Fragment = "/connectedDevices"
 
 			var premiumURL string
-			if enablePremiumLinks, ok := flags.M["enable_premium_links"].(bool); ok && enablePremiumLinks {
+			if inst.HasPremiumLinksEnabled() {
 				isFlagship, _ := strconv.ParseBool(c.QueryParam("isFlagship"))
 				iapEnabled, _ := flags.M["flagship.iap.enabled"].(bool)
 				if !isFlagship || iapEnabled {
 					var err error
 					if premiumURL, err = inst.ManagerURL(instance.ManagerPremiumURL); err != nil {
-						return fmt.Errorf("Could not get Premium Manager URL for instance %s: %w", inst.DomainName(), err)
+						inst.Logger().Errorf("Could not get instance Premium Manager URL: %s", err.Error())
 					}
 				}
 			}


### PR DESCRIPTION
`enable_premium_links` is not a feature flag but actually a Context
attribute which we can get from the config.

Without this attribute, we would never show links to the manager's
offers page when the limit of connected OAuth clients is exceeded.