### PR TITLE
Run lint tasks on GitHub Actions for more cases

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -4,9 +4,13 @@ on:
     branches:
       - master
     paths:
+      - '.golangci.yaml'
+      - 'Makefile'
       - '**.go'
   pull_request:
     paths:
+      - '.golangci.yaml'
+      - 'Makefile'
       - '**.go'
 permissions:
   contents: read

--- a/.github/workflows/js-lint.yml
+++ b/.github/workflows/js-lint.yml
@@ -4,9 +4,13 @@ on:
     branches:
       - master
     paths:
+      - 'scripts/eslintrc.json'
+      - 'scripts/package.json'
       - '**.js'
   pull_request:
     paths:
+      - 'scripts/eslintrc.json'
+      - 'scripts/package.json'
       - '**.js'
 permissions:
   contents: read


### PR DESCRIPTION
When jslint is updated, the package.json file is updated, and we should run the JS lint task on GitHub Actions.

When golangci-lint is updated in the Makefile, we should run the Go lint task on GitHub Actions.