### PR TITLE
Fix onlyoffice behavior

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -68,7 +68,8 @@ $ docker run -it --rm --name=oodev --net=host cozy/onlyoffice-dev
 and run the stack with:
 
 ```bash
-$ cozy-stack serve --disable-csp --onlyoffice-url=http://localhost:8000/ --onlyoffice-inbox-secret=inbox_secret --onlyoffice-outbox-secret=outbox_secret
+$ cozy-stack serve --disable-csp --onlyoffice-url=http://localhost:8000 --onlyoffice-inbox-secret=inbox_secret --onlyoffice-outbox-secret=outbox_secret
+$ cozy-stack features defaults '{"drive.office": {"enabled": true, "write": true}}'
 ```
 
 If you need to rebuild it, you can do that with:

--- a/docs/office.md
+++ b/docs/office.md
@@ -121,7 +121,7 @@ Content-Type: application/vnd.api+json
 }
 ```
 
-### GET /office/keys/:key
+### POST /office/keys/:key
 
 If a document is being edited while a new version is uploaded (via the desktop
 for example), the OO webapp should call this endpoint if the user chooses to
@@ -131,7 +131,7 @@ created, so that no work is lost.
 #### Request
 
 ```http
-GET /office/keys/7c7ccc2e7137ba774b7e44de HTTP/1.1
+POST /office/keys/7c7ccc2e7137ba774b7e44de HTTP/1.1
 Host: bob.cozy.example
 ```
 

--- a/docs/office.md
+++ b/docs/office.md
@@ -121,6 +121,66 @@ Content-Type: application/vnd.api+json
 }
 ```
 
+### GET /office/keys/:key
+
+If a document is being edited while a new version is uploaded (via the desktop
+for example), the OO webapp should call this endpoint if the user chooses to
+continue editing the version on which they were working. A conflict file is
+created, so that no work is lost.
+
+#### Request
+
+```http
+GET /office/keys/7c7ccc2e7137ba774b7e44de HTTP/1.1
+Host: bob.cozy.example
+```
+
+#### Response
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/vnd.api+json
+```
+
+```json
+{
+  "data": {
+    "type": "io.cozy.files",
+    "id": "32e07d806f9b0139c541543d7eb8149c",
+    "meta": {
+      "rev": "3-18c04daba326"
+    },
+    "attributes": {
+      "type": "file",
+      "name": "slideshow (2).pptx",
+      "trashed": false,
+      "md5sum": "ODZmYjI2OWQxOTBkMmM4NQo=",
+      "created_at": "2023-09-30T21:42:05Z",
+      "updated_at": "2023-09-30T22:38:04Z",
+      "tags": [],
+      "metadata": {},
+      "size": 12345,
+      "executable": false,
+      "class": "slide",
+      "mime": "application/vnd.ms-powerpoint",
+      "cozyMetadata": {
+        "doctypeVersion": "1",
+        "metadataVersion": 1,
+        "createdAt": "2023-09-30T21:42:05Z",
+        "createdByApp": "drive",
+        "createdOn": "https://bob.cozy.example/",
+        "updatedAt": "2023-09-30T22:38:04Z",
+        "uploadedAt": "2023-09-30T22:38:04Z",
+        "uploadedOn": "https://bob.cozy.example/",
+        "uploadedBy": {
+          "slug": "onlyoffice-server"
+        }
+      }
+    }
+  }
+}
+```
+
 ### POST /office/callback
 
 This is the callback handler for OnlyOffice. It is called when the document

--- a/model/office/callback.go
+++ b/model/office/callback.go
@@ -28,6 +28,10 @@ const (
 	StatusForceSaveRequested = 6
 )
 
+// OOSlug is the slug for uploadedBy field of the CozyMetadata when a file has
+// been modified in the online OnlyOffice.
+const OOSlug = "onlyoffice-server"
+
 // CallbackParameters is a struct for the parameters sent by the document
 // server to the stack.
 // Cf https://api.onlyoffice.com/editors/callback
@@ -148,6 +152,7 @@ func saveFile(inst *instance.Instance, detector conflictDetector, downloadURL st
 	newfile.UpdatedAt = time.Now()
 	newfile.CozyMetadata.UpdatedAt = newfile.UpdatedAt
 	newfile.CozyMetadata.UploadedAt = &newfile.UpdatedAt
+	newfile.CozyMetadata.UploadedBy = &vfs.UploadedByEntry{Slug: OOSlug}
 
 	// If the file was renamed while OO editor was opened, the revision has
 	// been changed, but we still should avoid creating a conflict if the

--- a/model/office/callback.go
+++ b/model/office/callback.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"path"
+	"strings"
 	"time"
 
 	"github.com/cozy/cozy-stack/model/instance"
@@ -162,15 +165,24 @@ func saveFile(inst *instance.Instance, detector conflictDetector, downloadURL st
 		file = nil
 		newfile.SetID("")
 		newfile.SetRev("")
-		newfile.DocName = fmt.Sprintf("%s - conflict - %d", newfile.DocName, time.Now().Unix())
+	}
+
+	basename := newfile.DocName
+	var f vfs.File
+	for i := 2; i < 100; i++ {
+		f, err = fs.CreateFile(newfile, file)
+		if err == nil {
+			break
+		} else if !errors.Is(err, os.ErrExist) {
+			return nil, err
+		}
+		ext := path.Ext(basename)
+		filename := strings.TrimSuffix(path.Base(basename), ext)
+		newfile.DocName = fmt.Sprintf("%s (%d)%s", filename, i, ext)
 		newfile.ResetFullpath()
 		_, _ = newfile.Path(inst.VFS()) // Prefill the fullpath
 	}
 
-	f, err := fs.CreateFile(newfile, file)
-	if err != nil {
-		return nil, err
-	}
 	_, err = io.Copy(f, res.Body)
 	if cerr := f.Close(); cerr != nil && err == nil {
 		err = cerr

--- a/model/office/callback.go
+++ b/model/office/callback.go
@@ -101,7 +101,7 @@ func checkToken(cfg *config.Office, params CallbackParameters) error {
 func finalSaveFile(inst *instance.Instance, key, downloadURL string) error {
 	detector, err := GetStore().GetDoc(inst, key)
 	if err != nil || detector == nil || detector.ID == "" || detector.Rev == "" {
-		return errors.New("invalid key")
+		return ErrInvalidKey
 	}
 
 	_, err = saveFile(inst, *detector, downloadURL)
@@ -114,7 +114,7 @@ func finalSaveFile(inst *instance.Instance, key, downloadURL string) error {
 func forceSaveFile(inst *instance.Instance, key, downloadURL string) error {
 	detector, err := GetStore().GetDoc(inst, key)
 	if err != nil || detector == nil || detector.ID == "" || detector.Rev == "" {
-		return errors.New("invalid key")
+		return ErrInvalidKey
 	}
 
 	updated, err := saveFile(inst, *detector, downloadURL)

--- a/model/office/errors.go
+++ b/model/office/errors.go
@@ -11,4 +11,6 @@ var (
 	// ErrInternalServerError is used when something goes wrong (like no
 	// connection to redis)
 	ErrInternalServerError = errors.New("Internal server error")
+	// ErrInvalidKey is used when the key is not found in the store
+	ErrInvalidKey = errors.New("invalid key")
 )

--- a/model/office/file_by_key.go
+++ b/model/office/file_by_key.go
@@ -7,7 +7,12 @@ import (
 	"github.com/cozy/cozy-stack/model/vfs"
 )
 
-func GetFileByKey(inst *instance.Instance, key string) (*vfs.FileDoc, error) {
+// EnsureFileForKey returns the file that will be written when OnlyOffice will
+// save a document with the given key. The general case is that is the file
+// that has been opened. But, it can also be a new file if a conflict has
+// happened because a new version has been uploaded for this file (by the
+// desktop client for example).
+func EnsureFileForKey(inst *instance.Instance, key string) (*vfs.FileDoc, error) {
 	detector, err := GetStore().GetDoc(inst, key)
 	if err != nil {
 		return nil, err

--- a/model/office/file_by_key.go
+++ b/model/office/file_by_key.go
@@ -1,0 +1,44 @@
+package office
+
+import (
+	"bytes"
+
+	"github.com/cozy/cozy-stack/model/instance"
+	"github.com/cozy/cozy-stack/model/vfs"
+)
+
+func GetFileByKey(inst *instance.Instance, key string) (*vfs.FileDoc, error) {
+	detector, err := GetStore().GetDoc(inst, key)
+	if err != nil {
+		return nil, err
+	}
+	if detector == nil || detector.ID == "" || detector.Rev == "" {
+		return nil, ErrInvalidKey
+	}
+
+	fs := inst.VFS()
+	file, err := fs.FileByID(detector.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	if file.Rev() == detector.Rev || bytes.Equal(file.MD5Sum, detector.MD5Sum) {
+		return file, nil
+	}
+
+	// Manage the conflict
+	conflictName := vfs.ConflictName(fs, file.DirID, file.DocName, true)
+	newfile := vfs.CreateFileDocCopy(file, file.DirID, conflictName)
+	newfile.CozyMetadata = vfs.NewCozyMetadata(inst.PageURL("/", nil))
+	newfile.CozyMetadata.UpdatedAt = newfile.UpdatedAt
+	newfile.CozyMetadata.UploadedAt = &newfile.UpdatedAt
+	newfile.CozyMetadata.UploadedBy = &vfs.UploadedByEntry{Slug: OOSlug}
+	if err := fs.CopyFile(file, newfile); err != nil {
+		return nil, err
+	}
+
+	updated := conflictDetector{ID: newfile.ID(), Rev: newfile.Rev(), MD5Sum: newfile.MD5Sum}
+	_ = GetStore().UpdateSecret(inst, key, file.ID(), newfile.ID())
+	_ = GetStore().UpdateDoc(inst, key, updated)
+	return newfile, nil
+}

--- a/model/office/store.go
+++ b/model/office/store.go
@@ -29,7 +29,7 @@ type Store interface {
 }
 
 // storeTTL is the time an entry stay alive
-var storeTTL = 24 * time.Hour
+var storeTTL = 30 * 24 * time.Hour
 
 // storeCleanInterval is the time interval between each cleanup.
 var storeCleanInterval = 1 * time.Hour

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -2198,6 +2198,11 @@ func updateFileCozyMetadata(c echo.Context, file *vfs.FileDoc, setUploadFields b
 		if len(fcm.UpdatedByApps) > 0 {
 			file.CozyMetadata.UpdatedByApp(fcm.UpdatedByApps[0])
 		}
+		if setUploadFields {
+			file.CozyMetadata.UploadedAt = fcm.UploadedAt
+			file.CozyMetadata.UploadedBy = fcm.UploadedBy
+			file.CozyMetadata.UploadedOn = fcm.UploadedOn
+		}
 	}
 
 	if setUploadFields {

--- a/web/files/files_test.go
+++ b/web/files/files_test.go
@@ -1392,8 +1392,9 @@ func TestFiles(t *testing.T) {
 			Object()
 
 		data1 := obj.Value("data").Object()
-		attrs1 := data1.Value("attributes").Object()
 		file1ID := data1.Value("id").String().NotEmpty().Raw()
+		attrs1 := data1.Value("attributes").Object()
+		uploadedAt1 := attrs1.Path("$.cozyMetadata.uploadedAt").String().NotEmpty().Raw()
 
 		buf, err := readFile(storage, "/willbemodified")
 		assert.NoError(t, err)
@@ -1435,6 +1436,7 @@ func TestFiles(t *testing.T) {
 		attrs.ValueEqual("class", "audio")
 		attrs.ValueEqual("mime", "audio/mp3")
 		attrs.ValueEqual("executable", false)
+		attrs.Path("$.cozyMetadata.uploadedAt").NotEqual(uploadedAt1)
 
 		buf, err = readFile(storage, "/willbemodified")
 		assert.NoError(t, err)

--- a/web/office/office.go
+++ b/web/office/office.go
@@ -61,9 +61,9 @@ func Open(c echo.Context) error {
 	return jsonapi.Data(c, http.StatusOK, doc, nil)
 }
 
-func GetFileByKey(c echo.Context) error {
+func FileByKey(c echo.Context) error {
 	inst := middlewares.GetInstance(c)
-	file, err := office.GetFileByKey(inst, c.Param("key"))
+	file, err := office.EnsureFileForKey(inst, c.Param("key"))
 	if err != nil {
 		return wrapError(err)
 	}
@@ -102,7 +102,7 @@ func Callback(c echo.Context) error {
 // Routes sets the routing for the collaborative edition of office documents.
 func Routes(router *echo.Group) {
 	router.GET("/:id/open", Open)
-	router.GET("/keys/:key", GetFileByKey)
+	router.POST("/keys/:key", FileByKey)
 	router.POST("/callback", Callback)
 }
 

--- a/web/office/office_test.go
+++ b/web/office/office_test.go
@@ -145,7 +145,7 @@ func TestOffice(t *testing.T) {
 		key = document.Value("key").String().NotEmpty().Raw()
 
 		// the key is associated to this file
-		obj = e.GET("/office/keys/"+key).
+		obj = e.POST("/office/keys/"+key).
 			WithHeader("Authorization", "Bearer "+token).
 			Expect().Status(200).
 			JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
@@ -160,7 +160,7 @@ func TestOffice(t *testing.T) {
 		// When an upload is made that changes the content of this document,
 		// the key will now be associated to a conflict file
 		updateFile(t, inst, fileID)
-		obj = e.GET("/office/keys/"+key).
+		obj = e.POST("/office/keys/"+key).
 			WithHeader("Authorization", "Bearer "+token).
 			Expect().Status(200).
 			JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
@@ -175,7 +175,7 @@ func TestOffice(t *testing.T) {
 		assert.Equal(t, "letter (2).docx", conflictName)
 
 		// When another user uses the same key, they obtains the same file
-		obj = e.GET("/office/keys/"+key).
+		obj = e.POST("/office/keys/"+key).
 			WithHeader("Authorization", "Bearer "+token).
 			Expect().Status(200).
 			JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).

--- a/web/office/office_test.go
+++ b/web/office/office_test.go
@@ -128,21 +128,85 @@ func TestOffice(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "version 2", string(buf))
 	})
+
+	t.Run("Conflict after an upload", func(t *testing.T) {
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		// If a user opens an office document
+		obj := e.GET("/office/"+fileID+"/open").
+			WithHeader("Authorization", "Bearer "+token).
+			Expect().Status(200).
+			JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+			Object()
+		data := obj.Value("data").Object()
+		attrs := data.Value("attributes").Object()
+		oo := attrs.Value("onlyoffice").Object()
+		document := oo.Value("document").Object()
+		key = document.Value("key").String().NotEmpty().Raw()
+
+		// And an upload is made that changes the content of this document
+		updateFile(t, inst, fileID)
+
+		// If another user opens the document, a new key is given
+		obj = e.GET("/office/"+fileID+"/open").
+			WithHeader("Authorization", "Bearer "+token).
+			Expect().Status(200).
+			JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+			Object()
+		data = obj.Value("data").Object()
+		attrs = data.Value("attributes").Object()
+		oo = attrs.Value("onlyoffice").Object()
+		document = oo.Value("document").Object()
+		newkey := document.Value("key").String().NotEmpty().Raw()
+		assert.NotEqual(t, key, newkey)
+
+		// And if the document is saved (first key), a new file is created
+		e.POST("/office/callback").
+			WithHeader("Content-Type", "application/json").
+			WithBytes([]byte(fmt.Sprintf(`{
+      "actions": [{"type": 0, "userid": "78e1e841"}],
+      "key": "%s",
+      "status": 2,
+      "url": "%s",
+      "users": ["6d5a81d0"]
+    }`, key, ooURL+"/dl"))).
+			Expect().Status(200)
+		conflict, err := inst.VFS().FileByPath("/letter (2).docx")
+		require.NoError(t, err)
+		assert.Equal(t, "onlyoffice-server", conflict.CozyMetadata.UploadedBy.Slug)
+	})
 }
 
 func createFile(t *testing.T, inst *instance.Instance) string {
 	dirID := consts.RootDirID
-
 	filedoc, err := vfs.NewFileDoc("letter.docx", dirID, -1, nil,
 		"application/msword", "text", time.Now(), false, false, false, nil)
 	require.NoError(t, err)
 
 	f, err := inst.VFS().CreateFile(filedoc, nil)
 	require.NoError(t, err)
-
 	require.NoError(t, f.Close())
 
 	return filedoc.ID()
+}
+
+func updateFile(t *testing.T, inst *instance.Instance, fileID string) {
+	olddoc, err := inst.VFS().FileByID(fileID)
+	require.NoError(t, err)
+
+	newdoc := olddoc.Clone().(*vfs.FileDoc)
+	newdoc.ByteSize = -1
+	newdoc.MD5Sum = nil
+	newdoc.CozyMetadata.UploadedBy = &vfs.UploadedByEntry{
+		Slug:    "desktop",
+		Version: "0.0.1",
+	}
+
+	f, err := inst.VFS().CreateFile(newdoc, olddoc)
+	require.NoError(t, err)
+	_, err = io.WriteString(f, "updated")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
 }
 
 func (f *fakeServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
When a new version of an office document is uploaded to a Cozy, the
stack will now open this new version, even if the previous version of
the document was already in the cache of OO. It was too confusing for
the user that has uploaded a new version to not see their changes if
they open the document in OO. If there was other users editing the
document in OO, they will be alerted of the conflict by cozy-drive and
can refresh their tab to see the new version. And if there were changes,
they are not lost, but will be saved in a conflict document.