### PR TITLE
More explicit error on app install type mismatch

### DIFF
--- a/model/app/installer_konnector_test.go
+++ b/model/app/installer_konnector_test.go
@@ -468,7 +468,7 @@ func TestInstallerKonnector(t *testing.T) {
 		assert.NoError(t, err)
 		_, err = inst.RunSync()
 		assert.Error(t, err)
-		assert.ErrorIs(t, err, app.ErrInvalidManifestTypes)
+		assert.ErrorIs(t, err, app.ErrInvalidManifestForKonnector)
 	})
 }
 

--- a/model/app/installer_webapp_test.go
+++ b/model/app/installer_webapp_test.go
@@ -1121,7 +1121,7 @@ func TestInstallerWebApp(t *testing.T) {
 		assert.NoError(t, err)
 		_, err = inst.RunSync()
 		assert.Error(t, err)
-		assert.ErrorIs(t, err, app.ErrInvalidManifestTypes)
+		assert.ErrorIs(t, err, app.ErrInvalidManifestForWebapp)
 	})
 }
 


### PR DESCRIPTION
Send more explicit error to client when type mismatch on installing a webapp or konnector