### PR TITLE
Improve the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,18 @@ on:
     tags:
       - "*.*.*" # Matching a version number like 1.4.19
 jobs:
-  publish_on_release:
+  create_release:
     runs-on: ubuntu-22.04
+    steps:
+      - name: Create the release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag_name="${GITHUB_REF##*/}"
+          gh release create "$tag_name" --target "$GITHUB_SHA"
+  publish_binaries:
+    runs-on: ubuntu-22.04
+    needs: create_release
     steps:
       - name: Install Go
         uses: actions/setup-go@v4
@@ -18,12 +28,22 @@ jobs:
           GOOS=linux   GOARCH=amd64 ./scripts/build.sh release
           GOOS=linux   GOARCH=arm   ./scripts/build.sh release
           GOOS=freebsd GOARCH=amd64 ./scripts/build.sh release
-      - name: Create the release
+      - name: Upload binaries to release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           tag_name="${GITHUB_REF##*/}"
-          gh release create "$tag_name" cozy-stack-* --target "$GITHUB_SHA"
+          gh release upload "$tag_name" cozy-stack-*
+  publish_cozy-app-dev_image:
+    runs-on: ubuntu-22.04
+    needs: create_release
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.21.x"
+      - name: Checkout code
+        uses: actions/checkout@v4
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -31,7 +51,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_SECRET }}
       - name: Build and publish the cozy-app-dev image
         run: scripts/release.sh
-  build_deb_packages:
+  publish_deb_packages:
     strategy:
       matrix:
         os:
@@ -43,7 +63,7 @@ jobs:
             "ubuntu:22.04",
           ]
     runs-on: ubuntu-latest
-    needs: publish_on_release
+    needs: create_release
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Improve the release workflow by splitting release creation from binaries and docker image build and upload and parallelizing binary building, docker image creation and packages building.