### PR TITLE
Fix deb package recommended dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,8 +14,7 @@ Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends},
 			adduser, members, curl, sed,
 			git, imagemagick, libprotobuf-c1, fonts-lato
-Recommends: couchdb (>= 2.3), nginx,
-			debootstrap, lsb-release,
+Recommends: nginx, debootstrap, lsb-release,
 			mail-transport-agent, nodejs (>= 16)
 Description: Cozy: Simple, Versatile, Yours
  Cozy (https://cozy.io) is a platform that brings all your web services

--- a/scripts/packaging/buildpackage.sh
+++ b/scripts/packaging/buildpackage.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-if command -v go > /dev/null; then 
+if command -v go > /dev/null; then
   eval "$(go env)"
   export GOROOT GOPATH
 else


### PR DESCRIPTION
When a package upgrade needs installing other dependency packages, `apt upgrade` do not update the package to avoid adding other packages. You have to use `apt dist-upgrade` or `apt install`.

By default, apt installs recommended dependencies. so having couchdb as a recommended dependency blocks simple package upgrade from our legacy package on debian buster.

This PR removes couchdb recommended dependency to ease debian buster migration