### PR TITLE
Fix a realtime issue with unwatch

### DIFF
--- a/pkg/realtime/realtime_test.go
+++ b/pkg/realtime/realtime_test.go
@@ -195,6 +195,26 @@ func TestWatch(t *testing.T) {
 	c1.Close()
 }
 
+func TestSubscribeWatchUnwatch(t *testing.T) {
+	h := newMemHub()
+	sub := h.Subscriber(testingDB)
+	defer sub.Close()
+
+	sub.Subscribe("io.cozy.testobject")
+	time.Sleep(1 * time.Millisecond)
+	sub.Watch("io.cozy.testobject", "id1")
+	time.Sleep(1 * time.Millisecond)
+	sub.Unwatch("io.cozy.testobject", "id1")
+	time.Sleep(1 * time.Millisecond)
+
+	h.Publish(testingDB, EventCreate, &testDoc{
+		doctype: "io.cozy.testobject",
+		id:      "id2",
+	}, nil)
+	e := <-sub.Channel
+	assert.Equal(t, "id2", e.Doc.ID())
+}
+
 func TestRedisRealtime(t *testing.T) {
 	if testing.Short() {
 		t.Skip("a redis is required for this test: test skipped due to the use of --short flag")

--- a/pkg/realtime/topic.go
+++ b/pkg/realtime/topic.go
@@ -90,7 +90,7 @@ func (t *topic) doUnsubscribe(w *toWatch) {
 				ids = append(ids, id)
 			}
 		}
-		if len(ids) == 0 {
+		if len(ids) == 0 && !f.whole {
 			delete(t.subs, w.sub)
 		} else {
 			f.ids = ids


### PR DESCRIPTION
When the realtime websocket receive the following messages:

1. Subscribe doctype
2. Watch doctype docid
3. Unwatch doctype docid

and a new event is published for this doctype, this event should be sent to the realtime websocket.