### PR TITLE
Remove support for Go 1.18

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -24,7 +24,7 @@ jobs:
           - go-version: '1.21.x'
             couchdb-version: '3.3.2'
           # More exotic version
-          - go-version: '1.18.x'
+          - go-version: '1.19.x'
             couchdb-version: '3.2.3'
     steps:
       - name: Install CouchDB

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,12 +3,6 @@ run:
   # Timeout for analysis, e.g. 30s, 5m.
   # Default: 1m
   timeout: 3m
-  # Exit code when at least one issue was found.
-  # Default: 1
-  issues-exit-code: 1
-  # Include test files or not.
-  # Default: true
-  tests: true
   # Which dirs to skip: issues from them won't be reported.
   # Can use regexp here: `generated.*`, regexp is applied on full path.
   # Default value is empty list,
@@ -30,13 +24,6 @@ run:
   skip-files:
     # - ".*\\.my\\.go$"
     # - lib/bad.go
-  # Allow multiple parallel golangci-lint instances running.
-  # If false (default) - golangci-lint acquires file lock on start.
-  allow-parallel-runners: false
-  # Define the Go version limit.
-  # Mainly related to generics support since go1.18.
-  # Default: use Go version from the go.mod file, fallback on the env var `GOVERSION`, fallback on 1.18
-  go: '1.18'
 linters:
   # Disable all linters.
   # Default: false

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -42,7 +42,7 @@ executable bit (`chmod +x cozy-stack`) and put it in your `$PATH`.
 #### Compile the binary using `go`
 
 You can compile a `cozy-stack` from the source.
-First, you need to [install go](https://golang.org/doc/install), version >= 1.18. With `go`
+First, you need to [install go](https://golang.org/doc/install), version >= 1.19. With `go`
 installed and configured, you can run the following commands:
 
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cozy/cozy-stack
 
-go 1.18
+go 1.19
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1


### PR DESCRIPTION
The latest versions of some of our dependencies require Go 1.19 at least.