### PR TITLE
Verbose instance creation

### DIFF
--- a/cmd/instances.go
+++ b/cmd/instances.go
@@ -176,6 +176,7 @@ be used as the error message.
 		}
 
 		domain := args[0]
+		fmt.Fprintf(os.Stdout, "Creating instance for domain \"%s\": please wait...\n", domain)
 		ac := newAdminClient()
 		in, err := ac.CreateInstance(&client.InstanceOptions{
 			Domain:          domain,


### PR DESCRIPTION
When creating a new instance, the creation can be quite long, especially on a fresh install when installing multiple applications (on self-hosted stacks for example).

Currently, `cozy-stack`  does not output anything before the instance is fully created (or the creation fails), living the user uncertain if the command is running or not.

This PR adds a message confirming the instance is being creating and inviting the user to wait for completion.