### PR TITLE
Only reload nginx if active

### DIFF
--- a/debian/cozy-stack.postinst
+++ b/debian/cozy-stack.postinst
@@ -52,7 +52,9 @@ configure)
 		install -o cozy-stack -g cozy -m u=rwX,g=rwX,o= -d /var/lib/cozy
 
 		[ -f /usr/sbin/rsyslogd ] && systemctl restart rsyslog
-		[ -f /usr/sbin/nginx ] && systemctl reload nginx
+		if systemctl -q is-active nginx; then
+		  systemctl reload nginx
+		fi
 	else
 		if [ ! -f /etc/cozy/.cozy-admin-passphrase ]; then
 			db_input critical cozy-stack/admin/passphrase


### PR DESCRIPTION
When installing cozy-stack deb package, nginx is a recommended dependency.

On Ubuntu, recommended dependencies are installed by default with the package so nginx get installed with cozy-stack.

In postinstall script, we reload nginx if we find it installed but in case nginx is installed but not active (not started yet), reload fails and the whole postinst script fail, leaving cozy-stack package in an unconfigured state.

To prevent this situation, we now only reload nginx if it is active (running)