### PR TITLE
Fix cozy-stack config ls-contexts

### DIFF
--- a/web/instances/contexts.go
+++ b/web/instances/contexts.go
@@ -26,7 +26,11 @@ func showContext(c echo.Context) error {
 	contexts := config.GetConfig().Contexts
 	cfg, ok := contexts[contextName].(map[string]interface{})
 	if !ok {
-		return c.NoContent(http.StatusNotFound)
+		registries := config.GetConfig().Registries
+		_, ok := registries[contextName]
+		if !ok {
+			return c.NoContent(http.StatusNotFound)
+		}
 	}
 	return c.JSON(http.StatusOK, getContextAPI(contextName, cfg))
 }

--- a/web/instances/contexts.go
+++ b/web/instances/contexts.go
@@ -33,7 +33,6 @@ func showContext(c echo.Context) error {
 
 func lsContexts(c echo.Context) error {
 	contexts := config.GetConfig().Contexts
-
 	result := []contextAPI{}
 	for contextName, ctx := range contexts {
 		cfg, ok := ctx.(map[string]interface{})
@@ -41,6 +40,11 @@ func lsContexts(c echo.Context) error {
 			cfg = map[string]interface{}{}
 		}
 		result = append(result, getContextAPI(contextName, cfg))
+	}
+	for contextName := range config.GetConfig().Registries {
+		if _, ok := contexts[contextName]; !ok {
+			result = append(result, getContextAPI(contextName, nil))
+		}
 	}
 	return c.JSON(http.StatusOK, result)
 }


### PR DESCRIPTION
When the default context has no configuration, it should still be listed with the `cozy-stack config ls-contexts` command. It has a list of registries.