### PR TITLE
Update deb package dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,8 +14,8 @@ Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends},
 			adduser, members, curl, sed,
 			git, imagemagick, libprotobuf-c1, fonts-lato
-Recommends: nginx, debootstrap, lsb-release,
-			mail-transport-agent, nodejs (>= 16)
+Recommends: lsb-release, nodejs (>= 16)
+Suggests: nginx, mail-transport-agent
 Description: Cozy: Simple, Versatile, Yours
  Cozy (https://cozy.io) is a platform that brings all your web services
  in the same private space.


### PR DESCRIPTION
By default, apt installs recommended dependencies so installing cozy-stack package ileads to nstalling nginx and postfix.

In our selfhosting documentation, we instruct to install nginx and configure email **after** cozy-stack installation.

This pull request move these recommended dependencies to suggested dependencies, which are disabled by default

It also removes dependency on debootstrap which was used to build a chroot environment for use with nsjail and is not needed anymore