### PR TITLE
Avoid double admin password request on instances add

### DIFF
--- a/client/admin_client.go
+++ b/client/admin_client.go
@@ -27,7 +27,7 @@ func (ac *AdminClient) NewInstanceClient(domain string, scopes ...string) (*Clie
 	httpClient, clientURL, err := tlsclient.NewHTTPClient(tlsclient.HTTPEndpoint{
 		Host:      config.GetConfig().Host,
 		Port:      config.GetConfig().Port,
-		Timeout:   5 * time.Minute,
+		Timeout:   15 * time.Minute,
 		EnvPrefix: "COZY_HOST",
 	})
 	if err != nil {

--- a/cmd/instances.go
+++ b/cmd/instances.go
@@ -217,7 +217,13 @@ be used as the error message.
 		if len(flagApps) == 0 {
 			return nil
 		}
-		apps, err := newClient(domain, consts.Apps).ListApps(consts.Apps)
+		c, err := ac.NewInstanceClient(domain, consts.Apps)
+		if err != nil {
+			errPrintfln("Could not generate access to domain %s", domain)
+			errPrintfln("%s", err)
+			os.Exit(1)
+		}
+		apps, err := c.ListApps(consts.Apps)
 		if err == nil && len(flagApps) != len(apps) {
 			for _, slug := range flagApps {
 				found := false

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cozy/cozy-stack/client/request"
 	build "github.com/cozy/cozy-stack/pkg/config"
 	"github.com/cozy/cozy-stack/pkg/config/config"
-	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/tlsclient"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -57,32 +56,7 @@ func newClientSafe(domain string, scopes ...string) (*client.Client, error) {
 	// We may want in the future rely on OAuth to handle the permissions with
 	// more granularity.
 	ac := newAdminClient()
-	token, err := ac.GetToken(&client.TokenOptions{
-		Domain:   domain,
-		Subject:  "CLI",
-		Audience: consts.CLIAudience,
-		Scope:    scopes,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	httpClient, clientURL, err := tlsclient.NewHTTPClient(tlsclient.HTTPEndpoint{
-		Host:      config.GetConfig().Host,
-		Port:      config.GetConfig().Port,
-		Timeout:   15 * time.Minute,
-		EnvPrefix: "COZY_HOST",
-	})
-	if err != nil {
-		return nil, err
-	}
-	return &client.Client{
-		Scheme:     clientURL.Scheme,
-		Addr:       clientURL.Host,
-		Domain:     domain,
-		Client:     httpClient,
-		Authorizer: &request.BearerAuthorizer{Token: token},
-	}, nil
+	return ac.NewInstanceClient(domain, scopes...)
 }
 
 func newClient(domain string, scopes ...string) *client.Client {


### PR DESCRIPTION
When adding a new instance and cozy-stack admin password has not been set in the environment variable, then it asks twice for admin password, one time to effectively create the instance and then another time to check if all required applications have been installed.

This pull request get rid of code duplication between `adminClient.NewInstanceClient()` and `newClientSafe()` and create a new client from adminClient on instance creation to avoid asking for the admin password more than once.