### PR TITLE
Revoke cipher sharings on passphrase reset

### DIFF
--- a/model/bitwarden/cipher.go
+++ b/model/bitwarden/cipher.go
@@ -1,3 +1,5 @@
+// Package bitwarden is used for managing the ciphers, encrypted on the client
+// side.
 package bitwarden
 
 import (


### PR DESCRIPTION
When the passphrase of a Cozy is reset, the master password for Bitwarden is lost, and as such, the ciphers can no longer be decrypted. Thus, they are deleted from the Cozy. But, the stack should revoke the cipher sharings before deleting them to avoid deleting the ciphers on the Cozy instances of the other members.