### PR TITLE
create docker user and group outside of docker-entrypoint.sh

### DIFF
--- a/scripts/docker/production/Dockerfile
+++ b/scripts/docker/production/Dockerfile
@@ -69,5 +69,7 @@ VOLUME /etc/cozy
 
 EXPOSE 6060 8080
 
+USER cozy
+
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["cozy-stack","serve"]

--- a/scripts/docker/production/Dockerfile
+++ b/scripts/docker/production/Dockerfile
@@ -60,7 +60,8 @@ RUN set -eux \
     && chmod +x /usr/local/bin/*.sh \
     && groupadd -g "${GROUP_ID}" -o cozy \
     && useradd --shell /bin/bash -u "${USER_ID}" -g cozy -o -c "Cozy Stack user" -d /var/lib/cozy -m cozy \
-    && chown -R cozy: /var/lib/cozy
+    && chown -R cozy: /var/lib/cozy \
+    && chown -R cozy: /etc/cozy
 
 WORKDIR /var/lib/cozy
 

--- a/scripts/docker/production/Dockerfile
+++ b/scripts/docker/production/Dockerfile
@@ -24,7 +24,9 @@ ENV COUCHDB_PROTOCOL=http \
     COUCHDB_HOST=couchdb \
     COUCHDB_PORT=5984 \
     COUCHDB_USER=cozy \
-    COUCHDB_PASSWORD=cozy
+    COUCHDB_PASSWORD=cozy \
+    USER_ID=3552 \
+    GROUP_ID=3552
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -55,7 +57,10 @@ RUN set -eux \
     && gosu nobody true \
     && apt-get autoremove -y && apt-get clean \
     && rm -rf /tmp/* /var/tmp /var/lib/apt/lists/* /var/cache/apt \
-    && chmod +x /usr/local/bin/*.sh
+    && chmod +x /usr/local/bin/*.sh \
+    && groupadd -g "${GROUP_ID}" -o cozy \
+    && useradd --shell /bin/bash -u "${USER_ID}" -g cozy -o -c "Cozy Stack user" -d /var/lib/cozy -m cozy \
+    && chown -R cozy: /var/lib/cozy
 
 WORKDIR /var/lib/cozy
 

--- a/scripts/docker/production/Dockerfile
+++ b/scripts/docker/production/Dockerfile
@@ -61,6 +61,7 @@ RUN set -eux \
     && groupadd -g "${GROUP_ID}" -o cozy \
     && useradd --shell /bin/bash -u "${USER_ID}" -g cozy -o -c "Cozy Stack user" -d /var/lib/cozy -m cozy \
     && chown -R cozy: /var/lib/cozy \
+    && mkdir -p /etc/cozy \
     && chown -R cozy: /etc/cozy
 
 WORKDIR /var/lib/cozy

--- a/scripts/docker/production/docker-entrypoint.sh
+++ b/scripts/docker/production/docker-entrypoint.sh
@@ -51,7 +51,7 @@ if echo "$@" | grep -q "cozy-stack "; then
 
   # Then run the command itself as applicative user
   echo "Now running CMD with UID ${USER_ID} and GID ${GROUP_ID}"
-  exec gosu cozy "$@"
+  exec cozy "$@"
 else
   # Otherwise run the command as root
   exec "$@"

--- a/scripts/docker/production/docker-entrypoint.sh
+++ b/scripts/docker/production/docker-entrypoint.sh
@@ -48,11 +48,6 @@ if echo "$@" | grep -q "cozy-stack "; then
   for db in _users _replicator; do
     curl -s -X PUT "${COUCHDB_PROTOCOL}://${COUCHDB_USER}:${COUCHDB_PASSWORD}@${COUCHDB_HOST}:${COUCHDB_PORT}/${db}"
   done
-
-  # Then run the command itself as applicative user
-  echo "Now running CMD with UID ${USER_ID} and GID ${GROUP_ID}"
-  exec cozy "$@"
-else
-  # Otherwise run the command as root
-  exec "$@"
 fi
+
+exec "$@"

--- a/scripts/docker/production/docker-entrypoint.sh
+++ b/scripts/docker/production/docker-entrypoint.sh
@@ -7,16 +7,6 @@ echo "==========================================================================
 echo "Starting $0, $(date)"
 echo "=========================================================================="
 
-
-# Prepare stepping down from root to applicative user with chosen UID/GID
-USER_ID=${LOCAL_USER_ID:-3552}
-GROUP_ID=${LOCAL_GROUP_ID:-3552}
-getent group cozy >/dev/null 2>&1 || \
-    groupadd -g "${GROUP_ID}" -o cozy
-getent passwd cozy >/dev/null 2>&1 || \
-    useradd --shell /bin/bash -u "${USER_ID}" -g cozy -o -c "Cozy Stack user" -d /var/lib/cozy -m cozy
-chown -R cozy: /var/lib/cozy
-
 # Generate passphrase if missing
 if [ ! -f /etc/cozy/cozy-admin-passphrase ]; then
   if [ -z "${COZY_ADMIN_PASSPHRASE:-}" ]; then


### PR DESCRIPTION
This moves user and group creation outside of the entrypoint script and into the Dockerfile. This would allow the docker image to run unprivileged as it won't need to run `useradd` or `groupadd` every time it restarts. It also sets the run user to be cozy.

This would help fix https://github.com/cozy/cozy-stack/issues/4242