### PR TITLE
Make file:// the default fs:url scheme

### DIFF
--- a/pkg/config/config/config.go
+++ b/pkg/config/config/config.go
@@ -502,7 +502,13 @@ func max(a, b int) int {
 
 // UseViper sets the configured instance of Config
 func UseViper(v *viper.Viper) error {
-	fsURL, err := url.Parse(v.GetString("fs.url"))
+	fs_url := v.GetString("fs.url")
+	// Allow for plain directory path as fs.url
+	// file:// is the default implicit scheme
+	if strings.HasPrefix(fs_url, "/") {
+		fs_url = "file://" + fs_url
+	}
+	fsURL, err := url.Parse(fs_url)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
`fs:url` config entry should be a valid url so cozy-stack fail if it is given an absolute path to a directory.

This PR makes `file://` the default `fs:url` scheme when it is omitted and the value is an absolute path (i.e. it start with a `/`)

This allow defining `fs:url` config item or `COZY_FS_URL` config env variable as an absolute path for better readability