### PR TITLE
Fix a source of VFS inconsistency

### DIFF
--- a/model/vfs/vfsafero/impl.go
+++ b/model/vfs/vfsafero/impl.go
@@ -15,7 +15,6 @@ import (
 	"sync"
 
 	"github.com/cozy/cozy-stack/model/vfs"
-	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/filetype"
 	"github.com/cozy/cozy-stack/pkg/lock"
 
@@ -772,14 +771,12 @@ func (f *aferoFileCreation) Write(p []byte) (int, error) {
 func (f *aferoFileCreation) Close() (err error) {
 	defer func() {
 		if err != nil {
-			// remove the temporary file if an error occurred
+			// Remove the temporary file if an error occurred
 			_ = f.afs.fs.Remove(f.tmppath)
-			// If an error has occurred that is not due to the index update, we should
-			// delete the file from the index.
+			// If an error has occurred when creating a new file, we should
+			// also delete the file from the index.
 			if f.olddoc == nil {
-				if _, isCouchErr := couchdb.IsCouchError(err); !isCouchErr {
-					_ = f.afs.Indexer.DeleteFileDoc(f.newdoc)
-				}
+				_ = f.afs.Indexer.DeleteFileDoc(f.newdoc)
 			}
 		}
 	}()

--- a/model/vfs/vfsswift/impl_v3.go
+++ b/model/vfs/vfsswift/impl_v3.go
@@ -758,12 +758,11 @@ func (f *swiftFileCreationV3) Write(p []byte) (int, error) {
 func (f *swiftFileCreationV3) Close() (err error) {
 	defer func() {
 		if err != nil {
-			// remove the temporary file if an error occurred
+			// Remove the temporary file from Swift if an error occurred
 			_ = f.fs.c.ObjectDelete(f.fs.ctx, f.fs.container, f.name)
-			// If an error has occurred that is not due to the index update, we should
-			// delete the file from the index.
-			_, isCouchErr := couchdb.IsCouchError(err)
-			if !isCouchErr && f.olddoc == nil {
+			// If an error has occurred when creating a new file, we should
+			// also delete the file from the index.
+			if f.olddoc == nil {
 				_ = f.fs.Indexer.DeleteFileDoc(f.newdoc)
 			}
 		}


### PR DESCRIPTION
When a new file is uploaded, and the stack tries to save the io.cozy.files in CouchDB, it may happen that an error occurs and the stack doesn't know if the document has been saved or not in CouchDB (timeout, network issue, CouchDB unavailable). In that case, it is safer to try to delete the document in CouchDB.

It is not perfect. For example, if CouchDB has accepted the document just before becoming unavailable, the deletion will fail (CouchDB unavailable), and it will still have an inconsistency. But, at least, it should reduce the number of cases.