### PR TITLE
Fix a sharing bug with sharing dir not created

### DIFF
--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -800,6 +800,11 @@ func (s *Sharing) EndInitial(inst *instance.Instance) error {
 		M:    map[string]interface{}{"_id": s.SID},
 	}
 	realtime.GetHub().Publish(inst, realtime.EventDelete, &doc, nil)
+	if s.FirstFilesRule() != nil {
+		if _, err := s.GetSharingDir(inst); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
Scenario:

1. The URL of Bob's Cozy is known by Alice's Cozy from a previous sharing
2. Alice creates a directory Foo and puts a file Bar inside it
3. Alice sends a sharing invitation for this directory to Bob
4. Alice deletes the Bar file making Foo empty
5. Bob accepts to synchronize the sharing on their Cozy

Expected: the shortcut for the sharing on Bob's Cozy is replaced by an empty Foo directory
Actual: it doesn't happen because initial_number_of_files_to_sync is computed when the sharing is created, and no file is shared.

This fix ensures that the sharing directory exists when the initial synchronization is done (by creating it if needed).