### PR TITLE
Avoid double slash in couchdb status requests

### DIFF
--- a/pkg/couchdb/status.go
+++ b/pkg/couchdb/status.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/cozy/cozy-stack/pkg/config/config"
@@ -15,7 +16,7 @@ import (
 // if it is not the case.
 func CheckStatus(ctx context.Context) (time.Duration, error) {
 	couch := config.CouchCluster(prefixer.GlobalCouchCluster)
-	u := couch.URL.String() + "/_up"
+	u := strings.TrimRight(couch.URL.String(), "/") + "/_up"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
Couchdb URL is stored in configuration struct as an URL with Path set to `/`, so it is a slash-terminated url.

When requesting status endpoint, we request CouchDB `/_up` endpoint to get CouchDB status but we add `/_up` to the configured CouchDB URL, resulting in a path starting with a double-slash.

This currently works because CouchDB http server is permissive but it is sub-optimal.

This pull request fixes that behavior by avoiding double-slash when requesting CouchDB status