### PR TITLE
Optimize sharing for instances on the same stack

### DIFF
--- a/model/sharing/member.go
+++ b/model/sharing/member.go
@@ -79,6 +79,16 @@ func (m *Member) PrimaryName() string {
 	return m.Email
 }
 
+// InstanceHost returns the domain part of the Cozy URL of the member, which
+// can be used to find the instance in CouchDB. It may includes the port.
+func (m *Member) InstanceHost() string {
+	u, err := url.Parse(m.Instance)
+	if err != nil {
+		return ""
+	}
+	return u.Host
+}
+
 // Credentials is the struct with the secret stuff used for authentication &
 // authorization.
 type Credentials struct {

--- a/model/vfs/vfs.go
+++ b/model/vfs/vfs.go
@@ -126,6 +126,11 @@ type Fs interface {
 	// version.
 	ImportFileVersion(version *Version, content io.ReadCloser) error
 
+	// CopyFileFromOtherFS creates or updates a file by copying the content of
+	// a file in another Cozy. It is used for sharings, to optimize I/O when
+	// two instances are on the same stack.
+	CopyFileFromOtherFS(olddoc, newdoc *FileDoc, srcFS Fs, srcDoc *FileDoc) error
+
 	// Fsck return the list of inconsistencies in the VFS
 	Fsck(func(log *FsckLog), bool) (err error)
 	CheckFilesConsistency(func(*FsckLog), bool) error

--- a/model/vfs/vfsafero/impl.go
+++ b/model/vfs/vfsafero/impl.go
@@ -1,3 +1,6 @@
+// Package vfsafero is the implementation of the Virtual File System by using
+// afero. Afero is a library for manipulating files and directory on the local
+// file system.
 package vfsafero
 
 import (
@@ -570,6 +573,30 @@ func (afs *aferoVFS) RevertFileVersion(doc *vfs.FileDoc, version *vfs.Version) e
 	}
 
 	return nil
+}
+
+func (afs *aferoVFS) CopyFileFromOtherFS(
+	newdoc, olddoc *vfs.FileDoc,
+	srcFS vfs.Fs,
+	srcDoc *vfs.FileDoc,
+) error {
+	content, err := srcFS.OpenFile(srcDoc)
+	if err != nil {
+		return err
+	}
+	defer content.Close()
+
+	fd, err := afs.CreateFile(newdoc, olddoc)
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(fd, content)
+	errc := fd.Close()
+	if err != nil {
+		return err
+	}
+	return errc
 }
 
 // UpdateFileDoc overrides the indexer's one since the afero.Fs is by essence

--- a/tests/system/tests/sharing_moves_n_delete.rb
+++ b/tests/system/tests/sharing_moves_n_delete.rb
@@ -7,18 +7,21 @@ describe "A shared directory" do
     Helpers.scenario "moves_n_delete"
     Helpers.start_mailhog
 
-    # Create the instance
+    # Create the instances
     inst = Instance.create name: "Alice"
     inst_bob = Instance.create name: "Bob"
-    inst_charlie = Instance.create name: "Charlie"
+    inst_charlie = Instance.create name: "Charlie", port: inst.stack.port
 
     # Create hierarchy
     folder = Folder.create inst
     folder.couch_id.wont_be_empty
     subdir = Folder.create inst, dir_id: folder.couch_id
-    child1 = Folder.create inst, dir_id: subdir.couch_id
-    child2 = Folder.create inst, dir_id: subdir.couch_id
-    child3 = Folder.create inst, dir_id: subdir.couch_id
+    childname1 = "c_#{Faker::Internet.slug}1"
+    childname2 = "c_#{Faker::Internet.slug}1"
+    childname3 = "c_#{Faker::Internet.slug}1"
+    child1 = Folder.create inst, dir_id: subdir.couch_id, name: childname1
+    child2 = Folder.create inst, dir_id: subdir.couch_id, name: childname2
+    child3 = Folder.create inst, dir_id: subdir.couch_id, name: childname3
     filename1 = "#{Faker::Internet.slug}1.txt"
     filename2 = "#{Faker::Internet.slug}2.txt"
     filename3 = "#{Faker::Internet.slug}3.txt"


### PR DESCRIPTION
When two instances are on the same stack and there is a sharing between for files, the stack can optimize the share-upload worker. Before this change, the content of the file was fetched from the VFS of the source instance, then uploaded to the destination instance, which copies it to its VFS. Now, the stack just makes a copy from one VFS to the other. It's a lot lighter on I/O, and should help making the share-upload worker faster.