### PR TITLE
feat: Log worker_id client

### DIFF
--- a/model/app/konnector.go
+++ b/model/app/konnector.go
@@ -39,6 +39,7 @@ type KonnManifest struct {
 		Name            string `json:"name"`
 		Icon            string `json:"icon"`
 		Language        string `json:"language"`
+		ClientSide      bool   `json:"clientSide"`
 		OnDeleteAccount string `json:"on_delete_account"`
 
 		// Fields with complex types
@@ -160,6 +161,11 @@ func (m *KonnManifest) Icon() string { return m.val.Icon }
 // Language returns the programming language used for executing the konnector
 // (only "node" for the moment).
 func (m *KonnManifest) Language() string { return m.val.Language }
+
+// ClientSide returns true for a konnector that runs on the client (flagship
+// app), and false for a konnector that runs on the server (nodejs executed by
+// the stack).
+func (m *KonnManifest) ClientSide() bool { return m.val.ClientSide }
 
 // OnDeleteAccount can be used to specify a file path which will be executed
 // when an account associated with the konnector is deleted.

--- a/web/apps/apps.go
+++ b/web/apps/apps.go
@@ -253,6 +253,15 @@ func logsHandler(appType consts.AppType) echo.HandlerFunc {
 			}
 		}
 
+		clientSide := false
+		if appType == consts.KonnectorType {
+			man, err := app.GetKonnectorBySlug(inst, slug)
+			if err != nil {
+				return wrapAppsError(err)
+			}
+			clientSide = man.ClientSide()
+		}
+
 		var logs []AppLog
 		if err := json.NewDecoder(c.Request().Body).Decode(&logs); err != nil {
 			return jsonapi.BadJSON()
@@ -262,6 +271,9 @@ func logsHandler(appType consts.AppType) echo.HandlerFunc {
 			WithField("slug", slug).
 			WithField("job_id", c.QueryParam("job_id"))
 
+		if clientSide {
+			l = l.WithField("worker_id", "client")
+		}
 		for _, log := range logs {
 			level, err := logger.ParseLevel(log.Level)
 			if err != nil {


### PR DESCRIPTION
When sending logs from client side konnector, let's set the worker_id to client. Like that, it's easier to monitor those konnectors.

Cozy-Stack already add this information when updating the job status.