### PR TITLE
feat: No offers button on flagship app without IAP

### DIFF
--- a/model/oauth/client_test.go
+++ b/model/oauth/client_test.go
@@ -185,7 +185,7 @@ func TestClient(t *testing.T) {
 		require.Nil(t, notPending.Create(testInstance, oauth.NotPending))
 		assertClientsLimitAlertMailWasNotSent(t, testInstance)
 
-		testutils.WithOAuthClientsLimit(t, testInstance, 1)
+		testutils.WithFlag(t, testInstance, "cozy.oauthclients.max", float64(1))
 
 		notificationWithoutPremium = &oauth.Client{
 			ClientName:   "notificationWithoutPremium",

--- a/tests/testutils/test_utils.go
+++ b/tests/testutils/test_utils.go
@@ -455,21 +455,21 @@ func DisableManager(inst *instance.Instance, shouldRemoveUUID bool) error {
 	return nil
 }
 
-func WithOAuthClientsLimit(t *testing.T, inst *instance.Instance, limit float64) {
+func WithFlag(t *testing.T, inst *instance.Instance, name string, value interface{}) {
 	flags := inst.FeatureFlags
 	if flags == nil {
 		flags = map[string]interface{}{}
 	}
 
-	was := flags["cozy.oauthclients.max"]
+	was := flags[name]
 
-	flags["cozy.oauthclients.max"] = limit
+	flags[name] = value
 	inst.FeatureFlags = flags
 	err := instance.Update(inst)
-	require.NoError(t, err, "Could not set OAuth clients limit")
+	require.NoError(t, err, "Could not set %s flag value to %v", name, value)
 
 	t.Cleanup(func() {
-		flags["cozy.oauthclients.max"] = was
+		flags[name] = was
 		inst.FeatureFlags = flags
 		require.NoError(t, instance.Update(inst))
 	})

--- a/web/apps/apps_test.go
+++ b/web/apps/apps_test.go
@@ -146,7 +146,7 @@ func TestApps(t *testing.T) {
 		}
 		require.Nil(t, flagship.Create(testInstance, oauth.NotPending))
 
-		testutils.WithOAuthClientsLimit(t, testInstance, 0)
+		testutils.WithFlag(t, testInstance, "cozy.oauthclients.max", float64(0))
 
 		e = e.Builder(func(r *httpexpect.Request) {
 			r.WithCookie("cozysessid", cozysessID)

--- a/web/apps/apps_test.go
+++ b/web/apps/apps_test.go
@@ -174,7 +174,7 @@ func TestApps(t *testing.T) {
 			WithCookie("cozysessid", cozysessID).
 			WithRedirectPolicy(httpexpect.DontFollowRedirects).
 			Expect().Status(200).
-			ContentType("text/html", "utf-8").
+			HasContentType("text/html", "utf-8").
 			Body().
 			Contains(`<link rel="stylesheet" type="text/css" href="//cozywithapps.example.net/assets/css/cozy-bar`).
 			Contains(`<script src="//cozywithapps.example.net/assets/js/cozy-bar`)
@@ -193,7 +193,7 @@ func TestApps(t *testing.T) {
 			WithCookie("cozysessid", cozysessID).
 			WithRedirectPolicy(httpexpect.DontFollowRedirects).
 			Expect().Status(200).
-			ContentType("text/html", "utf-8").
+			HasContentType("text/html", "utf-8").
 			Body().
 			Contains(`<meta name="user-action-required" data-title="Cozy has been moved" data-code="moved" data-detail="The Cozy has been moved to a new address"`)
 
@@ -224,7 +224,7 @@ func TestApps(t *testing.T) {
 			WithCookie("cozysessid", cozysessID).
 			WithRedirectPolicy(httpexpect.DontFollowRedirects).
 			Expect().Status(200).
-			ContentType("text/html", "utf-8").
+			HasContentType("text/html", "utf-8").
 			Body().
 			Contains(`<meta name="user-action-required" data-title="TOS Updated" data-code="tos-updated" data-detail="Terms of services have been updated" data-links="` + tosLink + `"`)
 
@@ -398,20 +398,20 @@ func TestApps(t *testing.T) {
 			Object()
 
 		data := obj.Value("data").Array()
-		data.Length().Equal(1)
+		data.Length().IsEqual(1)
 
-		elem := data.First().Object()
+		elem := data.Value(0).Object()
 		elem.Value("id").String().NotEmpty()
-		elem.ValueEqual("type", "io.cozy.apps")
+		elem.HasValue("type", "io.cozy.apps")
 
 		attrs := elem.Value("attributes").Object()
-		attrs.ValueEqual("name", "Mini")
-		attrs.ValueEqual("slug", "mini")
+		attrs.HasValue("name", "Mini")
+		attrs.HasValue("slug", "mini")
 
 		links := elem.Value("links").Object()
-		links.ValueEqual("self", "/apps/mini")
-		links.ValueEqual("related", "https://cozywithapps-mini.example.net/")
-		links.ValueEqual("icon", "/apps/mini/icon/1.0.0")
+		links.HasValue("self", "/apps/mini")
+		links.HasValue("related", "https://cozywithapps-mini.example.net/")
+		links.HasValue("icon", "/apps/mini/icon/1.0.0")
 	})
 
 	t.Run("IconForApp", func(t *testing.T) {
@@ -421,7 +421,7 @@ func TestApps(t *testing.T) {
 			WithHost(testInstance.Domain).
 			WithHeader("Authorization", "Bearer "+token).
 			Expect().Status(200).
-			Body().Equal("<svg>...</svg>")
+			Body().IsEqual("<svg>...</svg>")
 	})
 
 	t.Run("DownloadApp", func(t *testing.T) {
@@ -512,21 +512,21 @@ func TestApps(t *testing.T) {
 
 		data := obj.Value("data").Object()
 		data.Value("id").String().NotEmpty()
-		data.ValueEqual("type", "io.cozy.apps.open")
+		data.HasValue("type", "io.cozy.apps.open")
 
 		attrs := data.Value("attributes").Object()
-		attrs.ValueEqual("AppName", "Mini")
-		attrs.ValueEqual("AppSlug", "mini")
-		attrs.ValueEqual("IconPath", "icon.svg")
-		attrs.ValueEqual("Tracking", "false")
-		attrs.ValueEqual("SubDomain", "flat")
+		attrs.HasValue("AppName", "Mini")
+		attrs.HasValue("AppSlug", "mini")
+		attrs.HasValue("IconPath", "icon.svg")
+		attrs.HasValue("Tracking", "false")
+		attrs.HasValue("SubDomain", "flat")
 		attrs.Value("Cookie").String().Contains("HttpOnly")
 		attrs.Value("Token").String().NotEmpty()
-		attrs.ValueEqual("Flags", string(flagsStr))
+		attrs.HasValue("Flags", string(flagsStr))
 		attrs.ContainsKey("Warnings")
 
 		links := data.Value("links").Object()
-		links.ValueEqual("self", "/apps/mini/open")
+		links.HasValue("self", "/apps/mini/open")
 	})
 
 	t.Run("UninstallAppWithLinkedClient", func(t *testing.T) {
@@ -732,7 +732,7 @@ func assertAuthGet(e *httpexpect.Expect, slug, domain, path, contentType, charse
 	e.GET(path).
 		WithHost(slug+"."+domain).
 		Expect().Status(200).
-		ContentType(contentType, charset).
+		HasContentType(contentType, charset).
 		Body().Contains(content)
 }
 
@@ -740,7 +740,7 @@ func assertAnonGet(e *httpexpect.Expect, slug, domain, path, contentType, charse
 	e.GET(path).
 		WithHost(slug+"."+domain).
 		Expect().Status(200).
-		ContentType(contentType, charset).
+		HasContentType(contentType, charset).
 		Body().Contains(content)
 }
 
@@ -749,7 +749,7 @@ func assertNotPublic(e *httpexpect.Expect, slug, domain, path string, code int, 
 		WithHost(slug + "." + domain).
 		WithRedirectPolicy(httpexpect.DontFollowRedirects).
 		Expect().Status(code).
-		Header("Location").Equal(location)
+		Header("Location").IsEqual(location)
 }
 
 func assertNotFound(e *httpexpect.Expect, slug, domain, path string) {
@@ -770,5 +770,5 @@ func assertRedirect(e *httpexpect.Expect, slug, domain, path string, code int, l
 		WithHost(slug + "." + domain).
 		WithRedirectPolicy(httpexpect.DontFollowRedirects).
 		Expect().Status(code).
-		Header("Location").Equal(location)
+		Header("Location").IsEqual(location)
 }

--- a/web/settings/clients.go
+++ b/web/settings/clients.go
@@ -161,7 +161,9 @@ func (h *HTTPHandler) limitExceeded(c echo.Context) error {
 			var premiumURL string
 			if inst.HasPremiumLinksEnabled() {
 				iapEnabled, _ := flags.M["flagship.iap.enabled"].(bool)
-				if !isFlagship || iapEnabled {
+				isIapAvailable, _ := strconv.ParseBool(c.QueryParam("isIapAvailable"))
+
+				if !isFlagship || (iapEnabled && isIapAvailable) {
 					var err error
 					if premiumURL, err = inst.ManagerURL(instance.ManagerPremiumURL); err != nil {
 						inst.Logger().Errorf("Could not get instance Premium Manager URL: %s", err.Error())

--- a/web/settings/clients_usage_test.go
+++ b/web/settings/clients_usage_test.go
@@ -49,14 +49,14 @@ func TestClientsUsage(t *testing.T) {
 			Object()
 
 		data := obj.Value("data").Object()
-		data.ValueEqual("type", "io.cozy.settings")
-		data.ValueEqual("id", "io.cozy.settings.clients-usage")
+		data.HasValue("type", "io.cozy.settings")
+		data.HasValue("id", "io.cozy.settings.clients-usage")
 
 		attrs := data.Value("attributes").Object()
 		attrs.NotContainsKey("limit")
-		attrs.ValueEqual("count", 1)
-		attrs.ValueEqual("limitReached", false)
-		attrs.ValueEqual("limitExceeded", false)
+		attrs.HasValue("count", 1)
+		attrs.HasValue("limitReached", false)
+		attrs.HasValue("limitExceeded", false)
 	})
 
 	t.Run("WithLimitNotReached", func(t *testing.T) {
@@ -70,14 +70,14 @@ func TestClientsUsage(t *testing.T) {
 			Object()
 
 		data := obj.Value("data").Object()
-		data.ValueEqual("type", "io.cozy.settings")
-		data.ValueEqual("id", "io.cozy.settings.clients-usage")
+		data.HasValue("type", "io.cozy.settings")
+		data.HasValue("id", "io.cozy.settings.clients-usage")
 
 		attrs := data.Value("attributes").Object()
-		attrs.ValueEqual("limit", 2)
-		attrs.ValueEqual("count", 1)
-		attrs.ValueEqual("limitReached", false)
-		attrs.ValueEqual("limitExceeded", false)
+		attrs.HasValue("limit", 2)
+		attrs.HasValue("count", 1)
+		attrs.HasValue("limitReached", false)
+		attrs.HasValue("limitExceeded", false)
 	})
 
 	t.Run("WithLimitReached", func(t *testing.T) {
@@ -91,14 +91,14 @@ func TestClientsUsage(t *testing.T) {
 			Object()
 
 		data := obj.Value("data").Object()
-		data.ValueEqual("type", "io.cozy.settings")
-		data.ValueEqual("id", "io.cozy.settings.clients-usage")
+		data.HasValue("type", "io.cozy.settings")
+		data.HasValue("id", "io.cozy.settings.clients-usage")
 
 		attrs := data.Value("attributes").Object()
-		attrs.ValueEqual("limit", 1)
-		attrs.ValueEqual("count", 1)
-		attrs.ValueEqual("limitReached", true)
-		attrs.ValueEqual("limitExceeded", false)
+		attrs.HasValue("limit", 1)
+		attrs.HasValue("count", 1)
+		attrs.HasValue("limitReached", true)
+		attrs.HasValue("limitExceeded", false)
 	})
 
 	t.Run("WithLimitExceeded", func(t *testing.T) {
@@ -112,13 +112,13 @@ func TestClientsUsage(t *testing.T) {
 			Object()
 
 		data := obj.Value("data").Object()
-		data.ValueEqual("type", "io.cozy.settings")
-		data.ValueEqual("id", "io.cozy.settings.clients-usage")
+		data.HasValue("type", "io.cozy.settings")
+		data.HasValue("id", "io.cozy.settings.clients-usage")
 
 		attrs := data.Value("attributes").Object()
-		attrs.ValueEqual("limit", 0)
-		attrs.ValueEqual("count", 1)
-		attrs.ValueEqual("limitReached", true)
-		attrs.ValueEqual("limitExceeded", true)
+		attrs.HasValue("limit", 0)
+		attrs.HasValue("count", 1)
+		attrs.HasValue("limitReached", true)
+		attrs.HasValue("limitExceeded", true)
 	})
 }

--- a/web/settings/clients_usage_test.go
+++ b/web/settings/clients_usage_test.go
@@ -39,7 +39,7 @@ func TestClientsUsage(t *testing.T) {
 	require.Nil(t, flagship.Create(testInstance, oauth.NotPending))
 
 	t.Run("WithoutLimit", func(t *testing.T) {
-		testutils.WithOAuthClientsLimit(t, testInstance, -1)
+		testutils.WithFlag(t, testInstance, "cozy.oauthclients.max", float64(-1))
 
 		e := testutils.CreateTestClient(t, ts.URL)
 		obj := e.GET("/settings/clients-usage").
@@ -60,7 +60,7 @@ func TestClientsUsage(t *testing.T) {
 	})
 
 	t.Run("WithLimitNotReached", func(t *testing.T) {
-		testutils.WithOAuthClientsLimit(t, testInstance, 2)
+		testutils.WithFlag(t, testInstance, "cozy.oauthclients.max", float64(2))
 
 		e := testutils.CreateTestClient(t, ts.URL)
 		obj := e.GET("/settings/clients-usage").
@@ -81,7 +81,7 @@ func TestClientsUsage(t *testing.T) {
 	})
 
 	t.Run("WithLimitReached", func(t *testing.T) {
-		testutils.WithOAuthClientsLimit(t, testInstance, 1)
+		testutils.WithFlag(t, testInstance, "cozy.oauthclients.max", float64(1))
 
 		e := testutils.CreateTestClient(t, ts.URL)
 		obj := e.GET("/settings/clients-usage").
@@ -102,7 +102,7 @@ func TestClientsUsage(t *testing.T) {
 	})
 
 	t.Run("WithLimitExceeded", func(t *testing.T) {
-		testutils.WithOAuthClientsLimit(t, testInstance, 0)
+		testutils.WithFlag(t, testInstance, "cozy.oauthclients.max", float64(0))
 
 		e := testutils.CreateTestClient(t, ts.URL)
 		obj := e.GET("/settings/clients-usage").

--- a/web/settings/settings_test.go
+++ b/web/settings/settings_test.go
@@ -265,13 +265,13 @@ func TestSettings(t *testing.T) {
 			Expect().Status(401)
 
 		data := obj.Value("data").Object()
-		data.ValueEqual("type", "io.cozy.settings")
-		data.ValueEqual("id", "io.cozy.settings.disk-usage")
+		data.HasValue("type", "io.cozy.settings")
+		data.HasValue("id", "io.cozy.settings.disk-usage")
 
 		attrs := data.Value("attributes").Object()
-		attrs.ValueEqual("used", "0")
-		attrs.ValueEqual("files", "0")
-		attrs.ValueEqual("versions", "0")
+		attrs.HasValue("used", "0")
+		attrs.HasValue("files", "0")
+		attrs.HasValue("versions", "0")
 	})
 
 	t.Run("RegisterPassphraseWrongToken", func(t *testing.T) {
@@ -311,7 +311,7 @@ func TestSettings(t *testing.T) {
 			}).
 			Expect().Status(200)
 
-		res.Cookies().Length().Equal(1)
+		res.Cookies().Length().IsEqual(1)
 		res.Cookie("cozysessid").Value().NotEmpty()
 	})
 
@@ -344,7 +344,7 @@ func TestSettings(t *testing.T) {
       }`)).
 			Expect().Status(204)
 
-		res.Cookies().Length().Equal(1)
+		res.Cookies().Length().IsEqual(1)
 		res.Cookie("cozysessid").Value().NotEmpty()
 	})
 
@@ -460,13 +460,13 @@ func TestSettings(t *testing.T) {
 			Object()
 
 		data := obj.Value("data").Object()
-		data.ValueEqual("type", "io.cozy.settings")
-		data.ValueEqual("id", "io.cozy.settings.passphrase")
+		data.HasValue("type", "io.cozy.settings")
+		data.HasValue("id", "io.cozy.settings.passphrase")
 
 		attrs := data.Value("attributes").Object()
-		attrs.ValueEqual("salt", "me@"+testInstance.Domain)
-		attrs.ValueEqual("kdf", 0.0)
-		attrs.ValueEqual("iterations", 50000)
+		attrs.HasValue("salt", "me@"+testInstance.Domain)
+		attrs.HasValue("kdf", 0.0)
+		attrs.HasValue("iterations", 50000)
 	})
 
 	t.Run("GetCapabilities", func(t *testing.T) {
@@ -484,14 +484,14 @@ func TestSettings(t *testing.T) {
 			Object()
 
 		data := obj.Value("data").Object()
-		data.ValueEqual("type", "io.cozy.settings")
-		data.ValueEqual("id", "io.cozy.settings.capabilities")
+		data.HasValue("type", "io.cozy.settings")
+		data.HasValue("id", "io.cozy.settings.capabilities")
 
 		attrs := data.Value("attributes").Object()
-		attrs.ValueEqual("file_versioning", true)
-		attrs.ValueEqual("can_auth_with_password", true)
-		attrs.ValueEqual("can_auth_with_magic_links", false)
-		attrs.ValueEqual("can_auth_with_oidc", false)
+		attrs.HasValue("file_versioning", true)
+		attrs.HasValue("can_auth_with_password", true)
+		attrs.HasValue("can_auth_with_magic_links", false)
+		attrs.HasValue("can_auth_with_oidc", false)
 	})
 
 	t.Run("GetInstance", func(t *testing.T) {
@@ -518,17 +518,17 @@ func TestSettings(t *testing.T) {
 			Object()
 
 		data := obj.Value("data").Object()
-		data.ValueEqual("type", "io.cozy.settings")
-		data.ValueEqual("id", "io.cozy.settings.instance")
+		data.HasValue("type", "io.cozy.settings")
+		data.HasValue("id", "io.cozy.settings.instance")
 
 		meta := data.Value("meta").Object()
 		instanceRev = meta.Value("rev").String().NotEmpty().Raw()
 
 		attrs := data.Value("attributes").Object()
-		attrs.ValueEqual("email", "alice@example.org")
-		attrs.ValueEqual("tz", "Europe/London")
-		attrs.ValueEqual("locale", "en")
-		attrs.ValueEqual("password_defined", true)
+		attrs.HasValue("email", "alice@example.org")
+		attrs.HasValue("tz", "Europe/London")
+		attrs.HasValue("locale", "en")
+		attrs.HasValue("password_defined", true)
 	})
 
 	t.Run("UpdateInstance", func(t *testing.T) {
@@ -558,16 +558,16 @@ func TestSettings(t *testing.T) {
 			Object()
 
 		data := obj.Value("data").Object()
-		data.ValueEqual("type", "io.cozy.settings")
-		data.ValueEqual("id", "io.cozy.settings.instance")
+		data.HasValue("type", "io.cozy.settings")
+		data.HasValue("id", "io.cozy.settings.instance")
 
 		meta := data.Value("meta").Object()
 		instanceRev = meta.Value("rev").String().NotEmpty().NotEqual(instanceRev).Raw()
 
 		attrs := data.Value("attributes").Object()
-		attrs.ValueEqual("email", "alice@example.net")
-		attrs.ValueEqual("tz", "Europe/Paris")
-		attrs.ValueEqual("locale", "fr")
+		attrs.HasValue("email", "alice@example.net")
+		attrs.HasValue("tz", "Europe/Paris")
+		attrs.HasValue("locale", "fr")
 	})
 
 	t.Run("GetUpdatedInstance", func(t *testing.T) {
@@ -583,16 +583,16 @@ func TestSettings(t *testing.T) {
 			Object()
 
 		data := obj.Value("data").Object()
-		data.ValueEqual("type", "io.cozy.settings")
-		data.ValueEqual("id", "io.cozy.settings.instance")
+		data.HasValue("type", "io.cozy.settings")
+		data.HasValue("id", "io.cozy.settings.instance")
 
 		meta := data.Value("meta").Object()
-		meta.ValueEqual("rev", instanceRev)
+		meta.HasValue("rev", instanceRev)
 
 		attrs := data.Value("attributes").Object()
-		attrs.ValueEqual("email", "alice@example.net")
-		attrs.ValueEqual("tz", "Europe/Paris")
-		attrs.ValueEqual("locale", "fr")
+		attrs.HasValue("email", "alice@example.net")
+		attrs.HasValue("tz", "Europe/Paris")
+		attrs.HasValue("locale", "fr")
 	})
 
 	t.Run("UpdatePassphraseWithTwoFactorAuth", func(t *testing.T) {
@@ -677,28 +677,28 @@ func TestSettings(t *testing.T) {
 			Object()
 
 		data := obj.Value("data").Array()
-		data.Length().Equal(2)
+		data.Length().IsEqual(2)
 
-		el := data.Element(1).Object()
-		el.ValueEqual("type", "io.cozy.oauth.clients")
-		el.ValueEqual("id", client.ClientID)
+		el := data.Value(1).Object()
+		el.HasValue("type", "io.cozy.oauth.clients")
+		el.HasValue("id", client.ClientID)
 
 		links := el.Value("links").Object()
-		links.ValueEqual("self", "/settings/clients/"+client.ClientID)
+		links.HasValue("self", "/settings/clients/"+client.ClientID)
 
 		attrs := el.Value("attributes").Object()
-		attrs.ValueEqual("client_name", client.ClientName)
-		attrs.ValueEqual("client_kind", client.ClientKind)
-		attrs.ValueEqual("client_uri", client.ClientURI)
-		attrs.ValueEqual("logo_uri", client.LogoURI)
-		attrs.ValueEqual("policy_uri", client.PolicyURI)
-		attrs.ValueEqual("software_id", client.SoftwareID)
-		attrs.ValueEqual("software_version", client.SoftwareVersion)
+		attrs.HasValue("client_name", client.ClientName)
+		attrs.HasValue("client_kind", client.ClientKind)
+		attrs.HasValue("client_uri", client.ClientURI)
+		attrs.HasValue("logo_uri", client.LogoURI)
+		attrs.HasValue("policy_uri", client.PolicyURI)
+		attrs.HasValue("software_id", client.SoftwareID)
+		attrs.HasValue("software_version", client.SoftwareVersion)
 		attrs.NotContainsKey("client_secret")
 
 		redirectURIs := attrs.Value("redirect_uris").Array()
-		redirectURIs.Length().Equal(1)
-		redirectURIs.First().String().Equal(client.RedirectURIs[0])
+		redirectURIs.Length().IsEqual(1)
+		redirectURIs.Value(0).String().IsEqual(client.RedirectURIs[0])
 	})
 
 	t.Run("RevokeClient", func(t *testing.T) {
@@ -721,7 +721,7 @@ func TestSettings(t *testing.T) {
 			Object()
 
 		data := obj.Value("data").Array()
-		data.Length().Equal(1)
+		data.Length().IsEqual(1)
 	})
 
 	t.Run("PatchInstanceSameParams", func(t *testing.T) {
@@ -882,10 +882,10 @@ func TestSettings(t *testing.T) {
 			Object()
 
 		data := obj.Value("data").Object()
-		data.ValueEqual("type", "io.cozy.settings")
-		data.ValueEqual("id", "io.cozy.settings.flags")
+		data.HasValue("type", "io.cozy.settings")
+		data.HasValue("id", "io.cozy.settings.flags")
 
-		data.Value("attributes").Object().Empty()
+		data.Value("attributes").Object().IsEmpty()
 
 		testInstance.FeatureFlags = map[string]interface{}{
 			"from_instance_flag":   true,
@@ -945,19 +945,19 @@ func TestSettings(t *testing.T) {
 			Object()
 
 		data = obj.Value("data").Object()
-		data.ValueEqual("type", "io.cozy.settings")
-		data.ValueEqual("id", "io.cozy.settings.flags")
+		data.HasValue("type", "io.cozy.settings")
+		data.HasValue("id", "io.cozy.settings.flags")
 
 		attrs := data.Value("attributes").Object()
-		attrs.ValueEqual("from_instance_flag", true)
-		attrs.ValueEqual("from_feature_sets", true)
-		attrs.ValueEqual("from_defaults", true)
-		attrs.ValueEqual("json_object", testInstance.FeatureFlags["json_object"])
-		attrs.ValueEqual("from_multiple_source", "instance_flag")
-		attrs.ValueEqual("ratio_0", "defaults")
-		attrs.ValueEqual("ratio_0.000001", "defaults")
-		attrs.ValueEqual("ratio_0.999999", "context")
-		attrs.ValueEqual("ratio_1", "context")
+		attrs.HasValue("from_instance_flag", true)
+		attrs.HasValue("from_feature_sets", true)
+		attrs.HasValue("from_defaults", true)
+		attrs.HasValue("json_object", testInstance.FeatureFlags["json_object"])
+		attrs.HasValue("from_multiple_source", "instance_flag")
+		attrs.HasValue("ratio_0", "defaults")
+		attrs.HasValue("ratio_0.000001", "defaults")
+		attrs.HasValue("ratio_0.999999", "context")
+		attrs.HasValue("ratio_1", "context")
 	})
 
 	t.Run("ClientsLimitExceededWithoutSession", func(t *testing.T) {
@@ -1012,7 +1012,7 @@ func TestSettings(t *testing.T) {
 			WithHost(testInstance.Domain).
 			WithRedirectPolicy(httpexpect.DontFollowRedirects).
 			Expect().Status(200).
-			ContentType("text/html", "utf-8").
+			HasContentType("text/html", "utf-8").
 			Body().
 			Contains("Disconnect one of your devices or change your Cozy offer to access your Cozy from this device.").
 			Contains("/#/connectedDevices").
@@ -1026,11 +1026,13 @@ func TestSettings(t *testing.T) {
 			WithHost(testInstance.Domain).
 			WithRedirectPolicy(httpexpect.DontFollowRedirects).
 			Expect().Status(200).
-			ContentType("text/html", "utf-8").
+			HasContentType("text/html", "utf-8").
 			Body().
 			Contains("Disconnect one of your devices or change your Cozy offer to access your Cozy from this device.").
 			Contains("/#/connectedDevices").
 			Contains("http://manager.example.org")
+
+		testutils.WithFlag(t, testInstance, "flagship.iap.enabled", true)
 
 		e.GET("/settings/clients/limit-exceeded").
 			WithCookie(sessCookie, "connected").
@@ -1039,7 +1041,7 @@ func TestSettings(t *testing.T) {
 			WithHost(testInstance.Domain).
 			WithRedirectPolicy(httpexpect.DontFollowRedirects).
 			Expect().Status(200).
-			ContentType("text/html", "utf-8").
+			HasContentType("text/html", "utf-8").
 			Body().
 			Contains("Disconnect one of your devices or change your Cozy offer to access your Cozy from this device.").
 			Contains("/#/connectedDevices").
@@ -1091,7 +1093,7 @@ func TestRedirectOnboardingSecret(t *testing.T) {
 		WithCookie(sessCookie, "connected").
 		WithRedirectPolicy(httpexpect.DontFollowRedirects).
 		Expect().Status(303).
-		Header("Location").Equal(testInstance.OnboardedRedirection().String())
+		Header("Location").IsEqual(testInstance.OnboardedRedirection().String())
 
 	// With onboarding
 	deeplink := "cozydrive://testinstance.com"
@@ -1172,6 +1174,6 @@ func TestRegisterPassphraseForFlagshipApp(t *testing.T) {
 
 	obj.Value("access_token").String().NotEmpty()
 	obj.Value("refresh_token").String().NotEmpty()
-	obj.ValueEqual("scope", "*")
-	obj.ValueEqual("token_type", "bearer")
+	obj.HasValue("scope", "*")
+	obj.HasValue("token_type", "bearer")
 }

--- a/web/settings/settings_test.go
+++ b/web/settings/settings_test.go
@@ -993,7 +993,7 @@ func TestSettings(t *testing.T) {
 	t.Run("ClientsLimitExceededWithLimitExceeded", func(t *testing.T) {
 		e := testutils.CreateTestClient(t, tsURL)
 
-		testutils.WithOAuthClientsLimit(t, testInstance, 0)
+		testutils.WithFlag(t, testInstance, "cozy.oauthclients.max", float64(0))
 
 		// Create the OAuth client for the flagship app
 		flagship := oauth.Client{
@@ -1052,7 +1052,7 @@ func TestSettings(t *testing.T) {
 		clients, _, err := oauth.GetConnectedUserClients(testInstance, 100, "")
 		require.NoError(t, err)
 
-		testutils.WithOAuthClientsLimit(t, testInstance, float64(len(clients)))
+		testutils.WithFlag(t, testInstance, "cozy.oauthclients.max", float64(len(clients)))
 
 		e.GET("/settings/clients/limit-exceeded").
 			WithCookie(sessCookie, "connected").

--- a/web/settings/settings_test.go
+++ b/web/settings/settings_test.go
@@ -1046,6 +1046,20 @@ func TestSettings(t *testing.T) {
 			Contains("Disconnect one of your devices or change your Cozy offer to access your Cozy from this device.").
 			Contains("/#/connectedDevices").
 			NotContains("http://manager.example.org")
+
+		e.GET("/settings/clients/limit-exceeded").
+			WithCookie(sessCookie, "connected").
+			WithQuery("isFlagship", true).
+			WithQuery("isIapAvailable", true).
+			WithHeader("Authorization", "Bearer "+token).
+			WithHost(testInstance.Domain).
+			WithRedirectPolicy(httpexpect.DontFollowRedirects).
+			Expect().Status(200).
+			HasContentType("text/html", "utf-8").
+			Body().
+			Contains("Disconnect one of your devices or change your Cozy offer to access your Cozy from this device.").
+			Contains("/#/connectedDevices").
+			Contains("http://manager.example.org")
 	})
 
 	t.Run("ClientsLimitExceededWithLimitReached", func(t *testing.T) {


### PR DESCRIPTION
Our paywalls include a link to our premium offers so users can buy one
to unlock access to the restricted feature.
However, Apple and Google require that all purchases made from mobile
apps listed on their store be made via their In-App-Purchase feature.

This feature will only be available on future versions of our flagship
app and not on other, branded, versions so we need to check if it is
available to decide if the offers link can be displayed.