### PR TITLE
feat: Transform newlines in HTML translations

### DIFF
--- a/pkg/i18n/i18n.go
+++ b/pkg/i18n/i18n.go
@@ -34,6 +34,7 @@ func Translator(locale, contextName string) func(key string, vars ...interface{}
 }
 
 var boldRegexp = regexp.MustCompile(`\*\*(.*?)\*\*`)
+var newlineRegexp = regexp.MustCompile(`(\n)`)
 
 // TranslatorHTML returns a translation function of the locale specified, which
 // allow simple markup like **bold**.
@@ -42,6 +43,7 @@ func TranslatorHTML(locale, contextName string) func(key string, vars ...interfa
 		translated := Translate(key, locale, contextName, vars...)
 		escaped := template.HTMLEscapeString(translated)
 		replaced := boldRegexp.ReplaceAllString(escaped, "<strong>$1</strong>")
+		replaced = newlineRegexp.ReplaceAllString(replaced, "<br />")
 		return template.HTML(replaced)
 	}
 }

--- a/pkg/i18n/i18n_test.go
+++ b/pkg/i18n/i18n_test.go
@@ -1,6 +1,7 @@
 package i18n
 
 import (
+	"html/template"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -45,4 +46,52 @@ msgstr "contexte foo"
 	assert.Equal(t, "contexte foo", s)
 	s = Translate("context", "fr", "bar")
 	assert.Equal(t, "contexte", s)
+}
+
+func TestTranslatorHTML(t *testing.T) {
+	contextName := "foo"
+
+	LoadLocale("fr", "", []byte(`
+msgid "english"
+msgstr "french"
+
+msgid "hello %s"
+msgstr "bonjour **%s**"
+
+msgid "context"
+msgstr "contexte"
+`))
+
+	LoadLocale("fr", contextName, []byte(`
+msgid "english"
+msgstr "french"
+
+msgid "hello %s"
+msgstr "bonjour **%s**"
+
+msgid "context"
+msgstr ""
+"contexte\n"
+"foo"
+`))
+
+	frHTML := TranslatorHTML("fr", contextName)
+
+	h := frHTML("english")
+	assert.Equal(t, template.HTML("french"), h)
+	h = frHTML("hello %s", "toto")
+	assert.Equal(t, template.HTML("bonjour <strong>toto</strong>"), h)
+
+	enHTML := TranslatorHTML("en", contextName)
+	h = enHTML("english")
+	assert.Equal(t, template.HTML("english"), h)
+	h = enHTML("hello %s", "toto")
+	assert.Equal(t, template.HTML("hello toto"), h)
+
+	h = frHTML("context")
+	assert.Equal(t, template.HTML("contexte<br />foo"), h)
+
+	barHTML := TranslatorHTML("fr", "bar")
+	h = barHTML("context")
+	assert.Equal(t, template.HTML("contexte"), h)
 }


### PR DESCRIPTION
Some localization strings include new line characters (i.e. `\n`) to
control the flow of text while avoiding the multiplication of strings
to manage (i.e. one per line).

However, these characters were not transformed into `<br />` tags by
the HTML translator thus effectively losing the expected text flow in
the resulting HTML.