### PR TITLE
feat: Allow creating instances with feature sets

### DIFF
--- a/client/instances.go
+++ b/client/instances.go
@@ -36,6 +36,7 @@ type Instance struct {
 		OIDCID               string    `json:"oidc_id,omitempty"`
 		ContextName          string    `json:"context,omitempty"`
 		Sponsorships         []string  `json:"sponsorships,omitempty"`
+		FeatureSets          []string  `json:"feature_sets,omitempty"`
 		TOSSigned            string    `json:"tos,omitempty"`
 		TOSLatest            string    `json:"tos_latest,omitempty"`
 		AuthMode             int       `json:"auth_mode,omitempty"`

--- a/model/instance/lifecycle/create.go
+++ b/model/instance/lifecycle/create.go
@@ -36,6 +36,7 @@ type Options struct {
 	Timezone           string
 	ContextName        string
 	Sponsorships       []string
+	FeatureSets        []string
 	Email              string
 	PublicName         string
 	Settings           string
@@ -121,6 +122,7 @@ func Create(opts *Options) (*instance.Instance, error) {
 	i.TOSLatest = opts.TOSLatest
 	i.ContextName = opts.ContextName
 	i.Sponsorships = opts.Sponsorships
+	i.FeatureSets = opts.FeatureSets
 	i.BytesDiskQuota = opts.DiskQuota
 	i.IndexViewsVersion = couchdb.IndexViewsVersion
 	opts.trace("generate secrets", func() {
@@ -316,6 +318,10 @@ func buildSettings(inst *instance.Instance, opts *Options) (*couchdb.JSONDoc, er
 	if sponsorships, ok := settings.M["sponsorships"].([]string); ok {
 		opts.Sponsorships = sponsorships
 		delete(settings.M, "sponsorships")
+	}
+	if featureSets, ok := settings.M["feature_sets"].([]string); ok {
+		opts.FeatureSets = featureSets
+		delete(settings.M, "feature_sets")
 	}
 	if locale, ok := settings.M["locale"].(string); ok {
 		opts.Locale = locale

--- a/tests/testutils/test_utils.go
+++ b/tests/testutils/test_utils.go
@@ -194,6 +194,21 @@ func (c *TestSetup) GetTestClient(scopes string) (*oauth.Client, string) {
 	return &client, token
 }
 
+// GetTestAdminClient creates an oauth client and associated token with access to admin routes
+func (c *TestSetup) GetTestAdminClient() (*oauth.Client, string) {
+	inst := c.GetTestInstance()
+	client := oauth.Client{
+		RedirectURIs: []string{"http://localhost/oauth/callback"},
+		ClientName:   "client-" + c.host,
+		SoftwareID:   "github.com/cozy/cozy-stack/testing/" + c.name,
+	}
+	client.Create(inst, oauth.NotPending)
+	token, err := c.inst.MakeJWT(consts.CLIAudience, client.ClientID, "*", "", time.Now())
+	require.NoError(c.t, err, "Cannot create oauth token")
+
+	return &client, token
+}
+
 // stupidRenderer is a renderer for echo that does nothing.
 // It is used just to avoid the error "Renderer not registered" for rendering
 // error pages.

--- a/web/instances/instances.go
+++ b/web/instances/instances.go
@@ -78,6 +78,9 @@ func createHandler(c echo.Context) error {
 	if sponsorships := c.QueryParam("sponsorships"); sponsorships != "" {
 		opts.Sponsorships = strings.Split(sponsorships, ",")
 	}
+	if featureSets := c.QueryParam("feature_sets"); featureSets != "" {
+		opts.FeatureSets = strings.Split(featureSets, ",")
+	}
 	if autoUpdate := c.QueryParam("AutoUpdate"); autoUpdate != "" {
 		b, err := strconv.ParseBool(autoUpdate)
 		if err != nil {

--- a/web/instances/instances_test.go
+++ b/web/instances/instances_test.go
@@ -1,0 +1,67 @@
+package instances
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/cozy/cozy-stack/model/instance/lifecycle"
+	"github.com/cozy/cozy-stack/pkg/config/config"
+	"github.com/cozy/cozy-stack/tests/testutils"
+	"github.com/cozy/cozy-stack/web/errors"
+	"github.com/cozy/cozy-stack/web/middlewares"
+	"github.com/gavv/httpexpect/v2"
+	"github.com/labstack/echo/v4"
+)
+
+func TestInstances(t *testing.T) {
+	config.UseTestFile(t)
+
+	testutils.NeedCouchdb(t)
+	setup := testutils.NewSetup(t, t.Name())
+
+	config.GetConfig().Fs.URL = &url.URL{
+		Scheme: "file",
+		Host:   "localhost",
+		Path:   t.TempDir(),
+	}
+
+	_, token := setup.GetTestAdminClient()
+	ts := setup.GetTestServer("/instances", Routes, func(r *echo.Echo) *echo.Echo {
+		secure := middlewares.Secure(&middlewares.SecureConfig{
+			CSPDefaultSrc:     []middlewares.CSPSource{middlewares.CSPSrcSelf},
+			CSPFrameAncestors: []middlewares.CSPSource{middlewares.CSPSrcNone},
+		})
+		r.Use(secure)
+		return r
+	})
+	ts.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler
+	t.Cleanup(ts.Close)
+
+	t.Run("Create", func(t *testing.T) {
+		domain := "alice.cozy.localhost"
+		t.Cleanup(func() { _ = lifecycle.Destroy(domain) })
+
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		// Create instance with feature sets
+		e.POST("/instances").
+			WithQuery("DiskQuota", 5000000000).
+			WithQuery("Domain", domain).
+			WithQuery("Email", "alice@example.com").
+			WithQuery("Locale", "en").
+			WithQuery("PublicName", "alice").
+			WithQuery("Settings", "partner:cozy,context:cozy_beta,tos:1.0.0").
+			WithQuery("SwiftLayout", "-1").
+			WithQuery("TOSSigned", "1.0.0").
+			WithQuery("UUID", "60bac7e8-abd9-11ee-8201-9cb6d0907fa3").
+			WithQuery("feature_sets", "71df3022-abd9-11ee-b79b-9cb6d0907fa3,790789f8-abd9-11ee-ae09-9cb6d0907fa3").
+			WithQuery("sponsorships", "").
+			WithHeader("Authorization", "Bearer "+token).
+			Expect().Status(201).
+			JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+			Object().Path("$.data.attributes.feature_sets").
+			Array().
+			HasValue(0, "71df3022-abd9-11ee-b79b-9cb6d0907fa3").
+			HasValue(1, "790789f8-abd9-11ee-ae09-9cb6d0907fa3")
+	})
+}


### PR DESCRIPTION
This would allow the cloudery to pass the instance's feature sets
directly during the creation instead of making a second request to
pass them to cozy-stack.