### PR TITLE
Fix a regression when sharing a single file

### DIFF
--- a/model/sharing/files.go
+++ b/model/sharing/files.go
@@ -339,6 +339,11 @@ func (s *Sharing) GetSharingDir(inst *instance.Instance) (*vfs.DirDoc, error) {
 	fs := inst.VFS()
 	rule := s.FirstFilesRule()
 	if rule != nil {
+		if rule.Mime != "" {
+			inst.Logger().WithNamespace("sharing").
+				Warnf("GetSharingDir called for only one file: %s", s.SID)
+			return nil, ErrInternalServerError
+		}
 		dir, _ := fs.DirByID(rule.Values[0])
 		if dir != nil {
 			return dir, nil

--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -800,7 +800,7 @@ func (s *Sharing) EndInitial(inst *instance.Instance) error {
 		M:    map[string]interface{}{"_id": s.SID},
 	}
 	realtime.GetHub().Publish(inst, realtime.EventDelete, &doc, nil)
-	if s.FirstFilesRule() != nil {
+	if rule := s.FirstFilesRule(); rule != nil && rule.Mime == "" {
 		if _, err := s.GetSharingDir(inst); err != nil {
 			return err
 		}


### PR DESCRIPTION
The regression was introduced by
https://github.com/cozy/cozy-stack/commit/0a22f21920f7f37691fd70104e9fb232489f83e9

When a single file is shared, the call to notify the end of the initial replication tries to create a sharing directory, which creates a CouchDB conflict. The fix is just checking that case to avoid creating the directory.