### PR TITLE
Improve share-upload worker stability

### DIFF
--- a/model/sharing/upload.go
+++ b/model/sharing/upload.go
@@ -239,6 +239,9 @@ func (b *batchUpload) findNextFileToUpload() (map[string]interface{}, int, error
 		query := []couchdb.IDRev{ir}
 		results, err := couchdb.BulkGetDocs(b.Instance, consts.Files, query)
 		if err != nil {
+			if couchdb.IsDeletedError(err) {
+				continue
+			}
 			return nil, 0, err
 		}
 		if len(results) == 0 {


### PR DESCRIPTION
When the share-upload worker looks for the next file to upload, it fetches the io.cozy.shared changes feed, and then gets the io.cozy.files data with a call to bulk get. In theory, the file should be present, but a race condition or an inconsistency may happen where the file has been deleted. It is better to skip this file: there is no way the stack can upload it as it has been deleted, and if we don't do that, the share-upload worker may be stuck on this file.