### PR TITLE
Fix the cozy-stack check sharing command

### DIFF
--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -1381,6 +1381,10 @@ func (s *Sharing) checkSharingMembers() (checks []map[string]interface{}, validM
 			continue
 		}
 
+		if !s.Owner && m.Instance == "" {
+			continue
+		}
+
 		u, err := url.ParseRequestURI(m.Instance)
 		if err != nil {
 			checks = append(checks, map[string]interface{}{


### PR DESCRIPTION
It should not report an error when a member has no instance in a sharing (except for the owner). It is expected, as the stack doesn't send the instance from the owner to the other members for privacy reasons.