### PR TITLE
feat: Add external ties route

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -617,6 +617,47 @@ Accept: application/vnd.api+json
 No permissions are required to access this route, but the request needs to be
 authenticated (webapp token, OAuth token, etc.).
 
+### GET /settings/external-ties
+
+List ties between the instance and external services such as a subscription
+vendor (e.g. mobile app stores).
+The current possible ties are:
+
+- `has_blocking_subscription` is true when the instance is linked to a premium
+  subscription paid via a third-party vendor that does not let us cancel the
+  subscription ourselves and requires it to be cancelled by the customer
+  themselves.
+
+#### Request
+
+```http
+GET /settings/external-ties HTTP/1.1
+Host: alice.example.com
+Accept: application/vnd.api+json
+```
+
+#### Response
+
+```json
+{
+    "data": {
+        "type": "io.cozy.settings",
+        "id": "io.cozy.settings.external-ties",
+        "attributes": {
+            "has_blocking_subscription": false
+        },
+        "links": {
+            "self": "/settings/external-ties"
+        }
+    }
+}
+```
+
+#### Permissions
+
+No permissions are required to access this route, but the request needs to be
+made from an authenticated Web session or Webapp.
+
 ### GET /settings/instance
 
 If the user is logged in, display all instance settings.

--- a/model/cloudery/init.go
+++ b/model/cloudery/init.go
@@ -15,6 +15,7 @@ var service Service
 // - [Mock] for the tests
 type Service interface {
 	SaveInstance(inst *instance.Instance, cmd *SaveCmd) error
+	HasBlockingSubscription(inst *instance.Instance) (bool, error)
 }
 
 func Init(contexts map[string]config.ClouderyConfig) Service {

--- a/model/cloudery/service_mock.go
+++ b/model/cloudery/service_mock.go
@@ -25,3 +25,9 @@ func NewMock(t *testing.T) *Mock {
 func (m *Mock) SaveInstance(inst *instance.Instance, cmd *SaveCmd) error {
 	return m.Called(inst, cmd).Error(0)
 }
+
+func (m *Mock) HasBlockingSubscription(inst *instance.Instance) (bool, error) {
+	args := m.Called(inst)
+
+	return args.Bool(0), args.Error(1)
+}

--- a/model/cloudery/service_noop.go
+++ b/model/cloudery/service_noop.go
@@ -11,3 +11,7 @@ type NoopService struct{}
 func (s *NoopService) SaveInstance(inst *instance.Instance, cmd *SaveCmd) error {
 	return nil
 }
+
+func (s *NoopService) HasBlockingSubscription(inst *instance.Instance) (bool, error) {
+	return false, nil
+}

--- a/model/settings/init.go
+++ b/model/settings/init.go
@@ -19,6 +19,7 @@ type Service interface {
 	ResendEmailUpdate(inst *instance.Instance) error
 	ConfirmEmailUpdate(inst *instance.Instance, tok string) error
 	CancelEmailUpdate(inst *instance.Instance) error
+	GetExternalTies(inst *instance.Instance) (*ExternalTies, error)
 }
 
 func Init(

--- a/model/settings/service.go
+++ b/model/settings/service.go
@@ -23,6 +23,10 @@ var (
 	ErrNoPendingEmail = errors.New("no pending email")
 )
 
+type ExternalTies struct {
+	HasBlockingSubscription bool `json:"has_blocking_subscription"`
+}
+
 // Storage used to persiste and fetch settings data.
 type Storage interface {
 	setInstanceSettings(db prefixer.Prefixer, doc *couchdb.JSONDoc) error
@@ -243,4 +247,16 @@ func (s *SettingsService) CancelEmailUpdate(inst *instance.Instance) error {
 	}
 
 	return nil
+}
+
+func (s *SettingsService) GetExternalTies(inst *instance.Instance) (*ExternalTies, error) {
+	hasBlockingSubscription, err := s.cloudery.HasBlockingSubscription(inst)
+	if err != nil {
+		return nil, err
+	}
+
+	ties := ExternalTies{
+		HasBlockingSubscription: hasBlockingSubscription,
+	}
+	return &ties, nil
 }

--- a/model/settings/service_mock.go
+++ b/model/settings/service_mock.go
@@ -65,3 +65,13 @@ func (m *Mock) ConfirmEmailUpdate(inst *instance.Instance, tok string) error {
 func (m *Mock) CancelEmailUpdate(inst *instance.Instance) error {
 	return m.Called(inst).Error(0)
 }
+
+func (m *Mock) GetExternalTies(inst *instance.Instance) (*ExternalTies, error) {
+	args := m.Called(inst)
+
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).(*ExternalTies), args.Error(1)
+}

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -32,6 +32,9 @@ const (
 	// CapabilitiesSettingsID is the id of the settings document with the
 	// capabilities for a given instance
 	CapabilitiesSettingsID = "io.cozy.settings.capabilities"
+	// ExternalTiesID is the id of the settings document with the external ties
+	// for a given instance
+	ExternalTiesID = "io.cozy.settings.external-ties"
 	// PassphraseParametersID is the id of settings document for the passphrase
 	// parameters used to hash the master password on client side.
 	PassphraseParametersID = "io.cozy.settings.passphrase"

--- a/web/settings/external_ties.go
+++ b/web/settings/external_ties.go
@@ -1,0 +1,54 @@
+package settings
+
+import (
+	"net/http"
+
+	csettings "github.com/cozy/cozy-stack/model/settings"
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/jsonapi"
+	"github.com/cozy/cozy-stack/web/middlewares"
+	"github.com/labstack/echo/v4"
+)
+
+type apiExternalTies struct {
+	*csettings.ExternalTies
+
+	DocID string `json:"_id,omitempty"`
+}
+
+func (c *apiExternalTies) ID() string                             { return c.DocID }
+func (c *apiExternalTies) Rev() string                            { return "" }
+func (c *apiExternalTies) DocType() string                        { return consts.Settings }
+func (c *apiExternalTies) Clone() couchdb.Doc                     { cloned := *c; return &cloned }
+func (c *apiExternalTies) SetID(id string)                        { c.DocID = id }
+func (c *apiExternalTies) SetRev(rev string)                      {}
+func (c *apiExternalTies) Relationships() jsonapi.RelationshipMap { return nil }
+func (c *apiExternalTies) Included() []jsonapi.Object             { return nil }
+func (c *apiExternalTies) Links() *jsonapi.LinksList {
+	return &jsonapi.LinksList{Self: "/settings/capabilities"}
+}
+func (c *apiExternalTies) Fetch(field string) []string { return nil }
+
+func NewExternalTies(ties *csettings.ExternalTies) jsonapi.Object {
+	return &apiExternalTies{
+		ExternalTies: ties,
+		DocID:        consts.ExternalTiesID,
+	}
+}
+
+func (h *HTTPHandler) getExternalTies(c echo.Context) error {
+	if !middlewares.IsLoggedIn(c) && !middlewares.HasWebAppToken(c) {
+		return middlewares.ErrForbidden
+	}
+	inst := middlewares.GetInstance(c)
+
+	ties, err := h.svc.GetExternalTies(inst)
+	if err != nil {
+		return jsonapi.InternalServerError(err)
+	}
+
+	doc := NewExternalTies(ties)
+
+	return jsonapi.Data(c, http.StatusOK, doc, nil)
+}

--- a/web/settings/external_ties_test.go
+++ b/web/settings/external_ties_test.go
@@ -1,0 +1,61 @@
+package settings_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/cozy/cozy-stack/model/instance/lifecycle"
+	"github.com/cozy/cozy-stack/model/session"
+	csettings "github.com/cozy/cozy-stack/model/settings"
+	"github.com/cozy/cozy-stack/pkg/config/config"
+	"github.com/cozy/cozy-stack/tests/testutils"
+	"github.com/gavv/httpexpect/v2"
+)
+
+func TestExternalTies(t *testing.T) {
+	config.UseTestFile(t)
+	testutils.NeedCouchdb(t)
+	setup := testutils.NewSetup(t, t.Name())
+	testInstance := setup.GetTestInstance(&lifecycle.Options{
+		Locale:      "en",
+		Timezone:    "Europe/Berlin",
+		Email:       "alice@example.com",
+		ContextName: "test-context",
+	})
+	sessCookie := session.CookieName(testInstance)
+
+	svc := csettings.NewServiceMock(t)
+	ts := setupRouter(t, testInstance, svc)
+
+	t.Run("WithBlockingSubscription", func(t *testing.T) {
+		svc.On("GetExternalTies", testInstance).Return(&csettings.ExternalTies{
+			HasBlockingSubscription: true,
+		}, nil).Once()
+
+		e := testutils.CreateTestClient(t, ts.URL)
+		obj := e.GET("/settings/external-ties").
+			WithCookie(sessCookie, "connected").
+			WithHeader("Accept", "application/vnd.api+json").
+			Expect().Status(200).
+			JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+			Object()
+
+		data := obj.Value("data").Object()
+		data.HasValue("type", "io.cozy.settings")
+		data.HasValue("id", "io.cozy.settings.external-ties")
+
+		attrs := data.Value("attributes").Object()
+		attrs.HasValue("has_blocking_subscription", true)
+	})
+
+	t.Run("WithClouderyError", func(t *testing.T) {
+		svc.On("GetExternalTies", testInstance).Return(nil, errors.New("unauthorized")).Once()
+
+		e := testutils.CreateTestClient(t, ts.URL)
+		e.GET("/settings/external-ties").
+			WithCookie(sessCookie, "connected").
+			WithHeader("Accept", "application/vnd.api+json").
+			Expect().Status(500).
+			Body().Contains("unauthorized")
+	})
+}

--- a/web/settings/settings.go
+++ b/web/settings/settings.go
@@ -258,6 +258,7 @@ func (h *HTTPHandler) Register(router *echo.Group) {
 	router.POST("/vault", h.createVault)
 
 	router.GET("/capabilities", h.getCapabilities)
+	router.GET("/external-ties", h.getExternalTies)
 	router.GET("/instance", h.getInstance)
 	router.PUT("/instance", h.updateInstance)
 	router.POST("/instance/deletion", h.askInstanceDeletion)


### PR DESCRIPTION
An instance can be linked to third-party services that cannot be
cancelled/unsubscribed from programmatically and require customer
actions.
We call this an external tie as these connections prevent a gracious
instance deletion and users should be made aware of these when trying
to delete their instance.

The first external tie than can exist is a blocking premium
subscription bought via the App Store or Play Store.