### PR TITLE
Fix the io.cozy.shared for some files

### DIFF
--- a/model/sharing/shared.go
+++ b/model/sharing/shared.go
@@ -301,6 +301,11 @@ func updateRemovedForFiles(inst *instance.Instance, sharingID, dirID string, rul
 			rev := file.Rev()
 			if ref.Rev() == "" {
 				ref.Revisions = &RevsTree{Rev: rev}
+			} else if !removed {
+				chain, err := addMissingRevsToChain(inst, &ref, []string{rev})
+				if err == nil {
+					ref.Revisions.InsertChain(chain)
+				}
 			}
 			docs = append(docs, ref)
 		}


### PR DESCRIPTION
When some files have been in a sharing, they have an io.cozy.shared. If they are later moved out the sharing, the io.cozy.shared remains to synchronize this removal to the other Cozy instances. Outside of the sharing, the files may be updated, but the revs chain of the io.cozy.shared won't be updated. If the folder that contains those files is moved to a sharing, the files are also added to the sharing, and their io.cozy.shared is updated for that. What was missing was to also update the revisions chain in that case.