### PR TITLE
Fix last-activity when OAuth clients are deleted

### DIFF
--- a/model/instance/instance.go
+++ b/model/instance/instance.go
@@ -108,6 +108,10 @@ type Instance struct {
 	// FeatureSets is a list of feature sets from the manager
 	FeatureSets []string `json:"feature_sets,omitempty"`
 
+	// LastActivityFromDeletedOAuthClients is the date of the last activity for
+	// OAuth clients that have been deleted
+	LastActivityFromDeletedOAuthClients *time.Time `json:"last_activity_from_deleted_oauth_clients,omitempty"`
+
 	vfs              vfs.VFS
 	contextualDomain string
 }

--- a/web/instances/instances.go
+++ b/web/instances/instances.go
@@ -473,6 +473,9 @@ func lastActivity(c echo.Context) error {
 		return jsonapi.NotFound(err)
 	}
 	last := time.Date(2018, time.January, 1, 0, 0, 0, 0, time.UTC)
+	if inst.LastActivityFromDeletedOAuthClients != nil {
+		last = *inst.LastActivityFromDeletedOAuthClients
+	}
 
 	err = couchdb.ForeachDocs(inst, consts.SessionsLogins, func(_ string, data json.RawMessage) error {
 		var entry session.LoginEntry


### PR DESCRIPTION
The last-activity is guessed from the web sessions and the OAuth clients. But OAuth clients can be revoked/deleted, which can lose the information. For example, if a Cozy instance has only been used with the flagship app, and the flagship app is revoked, the last-activity would be really wrong. We fix that by keeping a date on the instance for the last activity for deleted OAuth clients.