### PR TITLE
Fix digest comparison for Play Integrity API

### DIFF
--- a/model/oauth/android_play_integrity.go
+++ b/model/oauth/android_play_integrity.go
@@ -203,9 +203,17 @@ func checkPlayIntegrityCertificateDigest(claims jwt.MapClaims) error {
 		if digest == certDigest[0] {
 			return nil
 		}
+		// XXX Google was using standard base64 for SafetyNet, but the safe-URL
+		// variant for Play Integrity...
+		urlSafeDigest := strings.TrimRight(digest, "=")
+		urlSafeDigest = strings.ReplaceAll(urlSafeDigest, "+", "-")
+		urlSafeDigest = strings.ReplaceAll(urlSafeDigest, "/", "_")
+		if urlSafeDigest == certDigest[0] {
+			return nil
+		}
 	}
 	logger.WithNamespace("oauth").
-		Debugf("Invalid certificate digest, expected %s, got %s", digests[0], certDigest)
+		Debugf("Invalid certificate digest, expected %s, got %s", digests[0], certDigest[0])
 	return errors.New("invalid certificate digest")
 }
 

--- a/model/oauth/android_safety_net.go
+++ b/model/oauth/android_safety_net.go
@@ -74,7 +74,7 @@ func checkSafetyNetCertificateDigest(claims jwt.MapClaims) error {
 		}
 	}
 	logger.WithNamespace("oauth").
-		Debugf("Invalid certificate digest, expected %s, got %s", digests[0], certDigest)
+		Debugf("Invalid certificate digest, expected %s, got %s", digests[0], certDigest[0])
 	return errors.New("invalid certificate digest")
 }
 


### PR DESCRIPTION
Google was using a standard base64 for the certificate digest in the Safety Net API, buit it's now the URL-safe variant for Play Integrity.