### PR TITLE
Fix sharing stuck because of a missing shared ref

### DIFF
--- a/model/sharing/upload.go
+++ b/model/sharing/upload.go
@@ -247,7 +247,7 @@ func (b *batchUpload) findNextFileToUpload() (map[string]interface{}, int, error
 		if len(results) == 0 {
 			b.Instance.Logger().WithNamespace("upload").
 				Warnf("missing results for bulk get %v", query)
-			return nil, 0, ErrInternalServerError
+			continue
 		}
 		if results[0]["_deleted"] == true {
 			b.Instance.Logger().WithNamespace("upload").

--- a/tests/system/lib/couch.rb
+++ b/tests/system/lib/couch.rb
@@ -49,7 +49,7 @@ class Couch
     opts = {
       content_type: "application/json"
     }
-    id = doc["_id"]
+    id = doc["_id"].gsub("/", "%2F")
     doctype = doctype.gsub(/\W/, '-')
     @client["/#{prefix domain}%2F#{doctype}/#{id}"].put(doc.to_json, opts)
   end

--- a/tests/system/tests/multiple_sharings.rb
+++ b/tests/system/tests/multiple_sharings.rb
@@ -95,6 +95,13 @@ describe "A folder" do
     child1_charlie = Folder.find inst_charlie, child1_charlie_id
     assert_equal child1_charlie.name, child1_bob.name
 
+    # Check that the stack is not stuck when an io.cozy.shared has not been created
+    shared_bob = Helpers.couch.get_doc inst_bob.domain, "io.cozy.shared", "io.cozy.files%2f#{file_bob.couch_id}"
+    shared_bob["_deleted"] = true
+    Helpers.couch.update_doc inst_bob.domain, "io.cozy.shared", shared_bob
+    file.overwrite inst_alice
+    sleep 12
+
     # Check that the files are the same on disk
     da = File.join Helpers.current_dir, inst_alice.domain, folder.name
     db = File.join Helpers.current_dir, inst_bob.domain,


### PR DESCRIPTION
It happens that the job for creating an io.cozy.shared has been lost (stack restart for example), and we need to do something to avoid having the sharing stuck. The most efficient way to do that is to check that the file is actually in the sharing directory, and if it is the case, to create the missing io.cozy.shared.