### PR TITLE
Fix jobs when restarting the stack

### DIFF
--- a/model/job/globals.go
+++ b/model/job/globals.go
@@ -1,3 +1,6 @@
+// Package job is for the scheduling and execution of asynchronous jobs via the
+// workers. The scheduling is done via the triggers. The jobs are put in queues
+// before being processed by a worker.
 package job
 
 import (

--- a/model/job/mem_broker_test.go
+++ b/model/job/mem_broker_test.go
@@ -84,7 +84,7 @@ func TestMemBroker(t *testing.T) {
 			{
 				WorkerType:  "test",
 				Concurrency: 4,
-				WorkerFunc: func(ctx *job.WorkerContext) error {
+				WorkerFunc: func(ctx *job.TaskContext) error {
 					var msg string
 					err := ctx.UnmarshalMessage(&msg)
 					if !assert.NoError(t, err) {
@@ -161,7 +161,7 @@ func TestMemBroker(t *testing.T) {
 			{
 				WorkerType:  "test",
 				Concurrency: 4,
-				WorkerFunc: func(ctx *job.WorkerContext) error {
+				WorkerFunc: func(ctx *job.TaskContext) error {
 					var msg string
 					err := ctx.UnmarshalMessage(&msg)
 					assert.Error(t, err)
@@ -192,7 +192,7 @@ func TestMemBroker(t *testing.T) {
 				Concurrency:  1,
 				MaxExecCount: 1,
 				Timeout:      1 * time.Millisecond,
-				WorkerFunc: func(ctx *job.WorkerContext) error {
+				WorkerFunc: func(ctx *job.TaskContext) error {
 					<-ctx.Done()
 					w.Done()
 					return ctx.Err()
@@ -224,7 +224,7 @@ func TestMemBroker(t *testing.T) {
 				MaxExecCount: maxExecCount,
 				Timeout:      1 * time.Millisecond,
 				RetryDelay:   1 * time.Millisecond,
-				WorkerFunc: func(ctx *job.WorkerContext) error {
+				WorkerFunc: func(ctx *job.TaskContext) error {
 					<-ctx.Done()
 					w.Done()
 					count++
@@ -258,7 +258,7 @@ func TestMemBroker(t *testing.T) {
 				Concurrency:  1,
 				MaxExecCount: maxExecCount,
 				RetryDelay:   1 * time.Millisecond,
-				WorkerFunc: func(ctx *job.WorkerContext) error {
+				WorkerFunc: func(ctx *job.TaskContext) error {
 					w.Done()
 					panic("oops")
 				},
@@ -288,7 +288,7 @@ func TestMemBroker(t *testing.T) {
 				Concurrency:  1,
 				MaxExecCount: 1,
 				RetryDelay:   1 * time.Millisecond,
-				WorkerFunc: func(ctx *job.WorkerContext) error {
+				WorkerFunc: func(ctx *job.TaskContext) error {
 					var i int
 					if err := ctx.UnmarshalMessage(&i); err != nil {
 						return err
@@ -319,7 +319,7 @@ func TestMemBroker(t *testing.T) {
 			{
 				WorkerType:  "thumbnail",
 				Concurrency: 4,
-				WorkerFunc: func(ctx *job.WorkerContext) error {
+				WorkerFunc: func(ctx *job.TaskContext) error {
 					return nil
 				},
 			},

--- a/model/job/mem_scheduler_test.go
+++ b/model/job/mem_scheduler_test.go
@@ -56,7 +56,7 @@ func TestMemScheduler(t *testing.T) {
 				Concurrency:  1,
 				MaxExecCount: 1,
 				Timeout:      1 * time.Millisecond,
-				WorkerFunc: func(_ *job.WorkerContext) error {
+				WorkerFunc: func(_ *job.TaskContext) error {
 					atomic.AddInt32(&called, 1)
 					return nil
 				},

--- a/model/job/redis_broker_test.go
+++ b/model/job/redis_broker_test.go
@@ -47,7 +47,7 @@ func TestRedisBroker(t *testing.T) {
 			{
 				WorkerType:  "test",
 				Concurrency: 4,
-				WorkerFunc: func(ctx *job.WorkerContext) error {
+				WorkerFunc: func(ctx *job.TaskContext) error {
 					var msg string
 					err := ctx.UnmarshalMessage(&msg)
 					if !assert.NoError(t, err) {
@@ -127,7 +127,7 @@ func TestRedisBroker(t *testing.T) {
 			{
 				WorkerType:  "thumbnail",
 				Concurrency: 4,
-				WorkerFunc: func(ctx *job.WorkerContext) error {
+				WorkerFunc: func(ctx *job.TaskContext) error {
 					return nil
 				},
 			},

--- a/model/job/redis_scheduler_test.go
+++ b/model/job/redis_scheduler_test.go
@@ -59,7 +59,7 @@ func TestRedisScheduler(t *testing.T) {
 				Concurrency:  1,
 				MaxExecCount: 1,
 				Timeout:      1 * time.Millisecond,
-				WorkerFunc: func(ctx *job.WorkerContext) error {
+				WorkerFunc: func(ctx *job.TaskContext) error {
 					var msg string
 					if err := ctx.UnmarshalMessage(&msg); err != nil {
 						return err

--- a/model/job/trigger_event_test.go
+++ b/model/job/trigger_event_test.go
@@ -36,7 +36,7 @@ func TestTrigger(t *testing.T) {
 				Concurrency:  1,
 				MaxExecCount: 1,
 				Timeout:      1 * time.Millisecond,
-				WorkerFunc: func(ctx *job.WorkerContext) error {
+				WorkerFunc: func(ctx *job.TaskContext) error {
 					defer wg.Done()
 					var msg string
 					if err := ctx.UnmarshalMessage(&msg); err != nil {

--- a/web/dev.go
+++ b/web/dev.go
@@ -38,7 +38,8 @@ func devMailsHandler(c echo.Context) error {
 	data := devData(c)
 	j := &job.Job{JobID: "1", Domain: data["Domain"].(string)}
 	inst := middlewares.GetInstance(c)
-	ctx := job.NewWorkerContext("0", j, inst)
+	ctx, cancel := job.NewTaskContext("0", j, inst)
+	defer cancel()
 	_, parts, err := mails.RenderMail(ctx, name, layout, locale, recipientName, data)
 	if err != nil {
 		return err

--- a/web/jobs/jobs_test.go
+++ b/web/jobs/jobs_test.go
@@ -29,7 +29,7 @@ func TestJobs(t *testing.T) {
 	job.AddWorker(&job.WorkerConfig{
 		WorkerType:  "print",
 		Concurrency: 4,
-		WorkerFunc: func(ctx *job.WorkerContext) error {
+		WorkerFunc: func(ctx *job.TaskContext) error {
 			var msg string
 			if err := ctx.UnmarshalMessage(&msg); err != nil {
 				return err

--- a/web/oidc/oidc_test.go
+++ b/web/oidc/oidc_test.go
@@ -39,7 +39,7 @@ func TestOidc(t *testing.T) {
 	wl := &job.WorkerConfig{
 		WorkerType:  "sendmail",
 		Concurrency: 4,
-		WorkerFunc: func(ctx *job.WorkerContext) error {
+		WorkerFunc: func(ctx *job.TaskContext) error {
 			return nil
 		},
 	}

--- a/worker/archive/unzip.go
+++ b/worker/archive/unzip.go
@@ -19,7 +19,7 @@ type unzipMessage struct {
 }
 
 // WorkerUnzip is a worker that unzip a file.
-func WorkerUnzip(ctx *job.WorkerContext) error {
+func WorkerUnzip(ctx *job.TaskContext) error {
 	msg := &unzipMessage{}
 	if err := ctx.UnmarshalMessage(msg); err != nil {
 		return err

--- a/worker/archive/zip.go
+++ b/worker/archive/zip.go
@@ -16,7 +16,7 @@ type zipMessage struct {
 }
 
 // WorkerZip is a worker that creates zip archives.
-func WorkerZip(ctx *job.WorkerContext) error {
+func WorkerZip(ctx *job.TaskContext) error {
 	msg := &zipMessage{}
 	if err := ctx.UnmarshalMessage(msg); err != nil {
 		return err

--- a/worker/exec/konnector.go
+++ b/worker/exec/konnector.go
@@ -185,7 +185,7 @@ func beforeHookKonnector(j *job.Job) (bool, error) {
 	return true, nil
 }
 
-func (w *konnectorWorker) PrepareWorkDir(ctx *job.WorkerContext, i *instance.Instance) (string, func(), error) {
+func (w *konnectorWorker) PrepareWorkDir(ctx *job.TaskContext, i *instance.Instance) (string, func(), error) {
 	cleanDir := func() {}
 
 	// Reset the errors from previous runs on retries
@@ -283,7 +283,7 @@ func (w *konnectorWorker) PrepareWorkDir(ctx *job.WorkerContext, i *instance.Ins
 
 // ensureFolderToSave tries hard to give a folder to the konnector where it can
 // write its files if it needs to do so.
-func (w *konnectorWorker) ensureFolderToSave(ctx *job.WorkerContext, inst *instance.Instance, acc *account.Account) error {
+func (w *konnectorWorker) ensureFolderToSave(ctx *job.TaskContext, inst *instance.Instance, acc *account.Account) error {
 	fs := inst.VFS()
 	msg := w.msg
 
@@ -533,7 +533,7 @@ func (w *konnectorWorker) Slug() string {
 	return w.slug
 }
 
-func (w *konnectorWorker) PrepareCmdEnv(ctx *job.WorkerContext, i *instance.Instance) (cmd string, env []string, err error) {
+func (w *konnectorWorker) PrepareCmdEnv(ctx *job.TaskContext, i *instance.Instance) (cmd string, env []string, err error) {
 	parameters := w.man.Parameters()
 
 	accountTypes, err := account.FindAccountTypesBySlug(w.slug, i.ContextName)
@@ -589,11 +589,11 @@ func (w *konnectorWorker) PrepareCmdEnv(ctx *job.WorkerContext, i *instance.Inst
 	return
 }
 
-func (w *konnectorWorker) Logger(ctx *job.WorkerContext) logger.Logger {
+func (w *konnectorWorker) Logger(ctx *job.TaskContext) logger.Logger {
 	return ctx.Logger().WithField("slug", w.slug)
 }
 
-func (w *konnectorWorker) ScanOutput(ctx *job.WorkerContext, i *instance.Instance, line []byte) error {
+func (w *konnectorWorker) ScanOutput(ctx *job.TaskContext, i *instance.Instance, line []byte) error {
 	var msg struct {
 		Type    string `json:"type"`
 		Message string `json:"message"`
@@ -648,7 +648,7 @@ func (w *konnectorWorker) Error(i *instance.Instance, err error) error {
 	return err
 }
 
-func (w *konnectorWorker) Commit(ctx *job.WorkerContext, errjob error) error {
+func (w *konnectorWorker) Commit(ctx *job.TaskContext, errjob error) error {
 	log := w.Logger(ctx)
 	if w.msg != nil {
 		log = log.WithField("account_id", w.msg.Account)

--- a/worker/exec/konnector_test.go
+++ b/worker/exec/konnector_test.go
@@ -51,8 +51,9 @@ func TestExecKonnector(t *testing.T) {
 			Message:    msg,
 			WorkerType: "konnector",
 		})
-		ctx := job.NewWorkerContext("id", j, nil).
-			WithCookie(&konnectorWorker{})
+		ctx, cancel := job.NewTaskContext("id", j, nil)
+		defer cancel()
+		ctx = ctx.WithCookie(&konnectorWorker{})
 		err = worker(ctx)
 		assert.Error(t, err)
 		assert.Equal(t, "Instance not found", err.Error())
@@ -67,8 +68,9 @@ func TestExecKonnector(t *testing.T) {
 			Message:    msg,
 			WorkerType: "konnector",
 		})
-		ctx := job.NewWorkerContext("id", j, inst).
-			WithCookie(&konnectorWorker{})
+		ctx, cancel := job.NewTaskContext("id", j, inst)
+		defer cancel()
+		ctx = ctx.WithCookie(&konnectorWorker{})
 		err = worker(ctx)
 		assert.Error(t, err)
 		assert.Equal(t, "Application is not installed", err.Error())
@@ -102,8 +104,9 @@ func TestExecKonnector(t *testing.T) {
 		})
 
 		config.GetConfig().Konnectors.Cmd = ""
-		ctx := job.NewWorkerContext("id", j, inst).
-			WithCookie(&konnectorWorker{})
+		ctx, cancel := job.NewTaskContext("id", j, inst)
+		defer cancel()
+		ctx = ctx.WithCookie(&konnectorWorker{})
 		err = worker(ctx)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "exec")
@@ -196,8 +199,9 @@ echo "{\"type\": \"manifest\", \"message\": \"$(ls ${1}/manifest.konnector)\" }"
 		})
 
 		config.GetConfig().Konnectors.Cmd = tmpScript
-		ctx := job.NewWorkerContext("id", j, inst).
-			WithCookie(&konnectorWorker{})
+		ctx, cancel := job.NewTaskContext("id", j, inst)
+		defer cancel()
+		ctx = ctx.WithCookie(&konnectorWorker{})
 		err = worker(ctx)
 		assert.NoError(t, err)
 
@@ -282,8 +286,9 @@ echo "{\"type\": \"params\", \"message\": ${SECRET} }"
 		})
 
 		config.GetConfig().Konnectors.Cmd = tmpScript
-		ctx := job.NewWorkerContext("id", j, inst).
-			WithCookie(&konnectorWorker{})
+		ctx, cancel := job.NewTaskContext("id", j, inst)
+		defer cancel()
+		ctx = ctx.WithCookie(&konnectorWorker{})
 		err = worker(ctx)
 		assert.NoError(t, err)
 
@@ -373,8 +378,9 @@ echo "{\"type\": \"toto\", \"message\": \"COZY_URL=${COZY_URL}\"}"
 		})
 
 		config.GetConfig().Konnectors.Cmd = tmpScript
-		ctx := job.NewWorkerContext("id", j, inst).
-			WithCookie(&konnectorWorker{})
+		ctx, cancel := job.NewTaskContext("id", j, inst)
+		defer cancel()
+		ctx = ctx.WithCookie(&konnectorWorker{})
 		err = worker(ctx)
 		require.NoError(t, err)
 
@@ -412,8 +418,9 @@ echo "{\"type\": \"toto\", \"message\": \"COZY_URL=${COZY_URL}\"}"
 		config.GetConfig().Konnectors.Cmd = tmpScript
 		defer func() { config.GetConfig().Konnectors.Cmd = origCmd }()
 
-		ctx = job.NewWorkerContext("id", j, inst).
-			WithCookie(&konnectorWorker{})
+		ctx, cancel = job.NewTaskContext("id", j, inst)
+		defer cancel()
+		ctx = ctx.WithCookie(&konnectorWorker{})
 		err = worker(ctx)
 		require.NoError(t, err)
 

--- a/worker/exec/service.go
+++ b/worker/exec/service.go
@@ -37,7 +37,7 @@ type serviceWorker struct {
 	workDir string
 }
 
-func (w *serviceWorker) PrepareWorkDir(ctx *job.WorkerContext, i *instance.Instance) (workDir string, cleanDir func(), err error) {
+func (w *serviceWorker) PrepareWorkDir(ctx *job.TaskContext, i *instance.Instance) (workDir string, cleanDir func(), err error) {
 	cleanDir = func() {}
 	opts := &ServiceOptions{}
 	if err = ctx.UnmarshalMessage(&opts); err != nil {
@@ -157,7 +157,7 @@ func (w *serviceWorker) Slug() string {
 	return w.slug
 }
 
-func (w *serviceWorker) PrepareCmdEnv(ctx *job.WorkerContext, i *instance.Instance) (cmd string, env []string, err error) {
+func (w *serviceWorker) PrepareCmdEnv(ctx *job.TaskContext, i *instance.Instance) (cmd string, env []string, err error) {
 	type serviceEvent struct {
 		Doc interface{} `json:"doc"`
 	}
@@ -195,7 +195,7 @@ func (w *serviceWorker) PrepareCmdEnv(ctx *job.WorkerContext, i *instance.Instan
 	return
 }
 
-func (w *serviceWorker) Logger(ctx *job.WorkerContext) logger.Logger {
+func (w *serviceWorker) Logger(ctx *job.TaskContext) logger.Logger {
 	log := ctx.Logger().WithField("slug", w.Slug())
 	if w.name != "" {
 		log = log.WithField("name", w.name)
@@ -203,7 +203,7 @@ func (w *serviceWorker) Logger(ctx *job.WorkerContext) logger.Logger {
 	return log
 }
 
-func (w *serviceWorker) ScanOutput(ctx *job.WorkerContext, i *instance.Instance, line []byte) error {
+func (w *serviceWorker) ScanOutput(ctx *job.TaskContext, i *instance.Instance, line []byte) error {
 	var msg struct {
 		Type    string `json:"type"`
 		Message string `json:"message"`
@@ -235,7 +235,7 @@ func (w *serviceWorker) Error(i *instance.Instance, err error) error {
 	return err
 }
 
-func (w *serviceWorker) Commit(ctx *job.WorkerContext, errjob error) error {
+func (w *serviceWorker) Commit(ctx *job.TaskContext, errjob error) error {
 	log := w.Logger(ctx)
 	if errjob == nil {
 		log.Info("Service success")

--- a/worker/log/log.go
+++ b/worker/log/log.go
@@ -18,7 +18,7 @@ func init() {
 }
 
 // Worker is the worker that just logs its message (useful for debugging)
-func Worker(ctx *job.WorkerContext) error {
+func Worker(ctx *job.TaskContext) error {
 	var msg string
 	if err := ctx.UnmarshalMessage(&msg); err != nil {
 		return err

--- a/worker/mails/exec.go
+++ b/worker/mails/exec.go
@@ -13,7 +13,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-func execMjml(ctx *job.WorkerContext, template []byte) ([]byte, error) {
+func execMjml(ctx *job.TaskContext, template []byte) ([]byte, error) {
 	log := ctx.Logger()
 
 	workDir, cleanDir, err := prepareWorkDir()
@@ -72,7 +72,7 @@ func prepareWorkDir() (string, func(), error) {
 	return workDir, cleanDir, err
 }
 
-func prepareCmdEnv(ctx *job.WorkerContext) (string, []string) {
+func prepareCmdEnv(ctx *job.TaskContext) (string, []string) {
 	cmd := config.GetConfig().Konnectors.Cmd
 	env := []string{
 		"COZY_URL=" + ctx.Instance.PageURL("/", nil),

--- a/worker/mails/mail.go
+++ b/worker/mails/mail.go
@@ -30,7 +30,7 @@ var mailTemplater MailTemplater
 var sendMail = doSendMail
 
 // SendMail is the sendmail worker function.
-func SendMail(ctx *job.WorkerContext) error {
+func SendMail(ctx *job.TaskContext) error {
 	opts := mail.Options{}
 	err := ctx.UnmarshalMessage(&opts)
 	if err != nil {
@@ -165,7 +165,7 @@ func addressFromInstance(i *instance.Instance) (*mail.Address, error) {
 	}, nil
 }
 
-func doSendMail(ctx *job.WorkerContext, opts *mail.Options, domain string) error {
+func doSendMail(ctx *job.TaskContext, opts *mail.Options, domain string) error {
 	if opts.TemplateName == "" && opts.Subject == "" {
 		return errors.New("Missing mail subject")
 	}
@@ -263,7 +263,7 @@ func addPart(mail *gomail.Message, part *mail.Part) error {
 	return nil
 }
 
-func sendSupportMail(ctx *job.WorkerContext, opts *mail.Options, domain string) error {
+func sendSupportMail(ctx *job.TaskContext, opts *mail.Options, domain string) error {
 	email := gomail.NewMessage()
 	dialerOptions := opts.Dialer
 	if dialerOptions == nil {

--- a/worker/mails/mail_templates.go
+++ b/worker/mails/mail_templates.go
@@ -45,7 +45,7 @@ func initMailTemplates() {
 
 // RenderMail returns a rendered mail for the given template name with the
 // specified locale, recipient name and template data values.
-func RenderMail(ctx *job.WorkerContext, name, layout, locale, recipientName string, templateValues map[string]interface{}) (string, []*mail.Part, error) {
+func RenderMail(ctx *job.TaskContext, name, layout, locale, recipientName string, templateValues map[string]interface{}) (string, []*mail.Part, error) {
 	return mailTemplater.Execute(ctx, name, layout, locale, recipientName, templateValues)
 }
 
@@ -62,7 +62,7 @@ type subjectEntry struct {
 // Execute will execute the HTML and text templates for the template with the
 // specified name. It returns the mail parts that should be added to the sent
 // mail.
-func (m MailTemplater) Execute(ctx *job.WorkerContext, name, layout, locale string, recipientName string, data map[string]interface{}) (string, []*mail.Part, error) {
+func (m MailTemplater) Execute(ctx *job.TaskContext, name, layout, locale string, recipientName string, data map[string]interface{}) (string, []*mail.Part, error) {
 	entry, ok := m[name]
 	if !ok {
 		err := fmt.Errorf("Could not find email named %q", name)
@@ -125,7 +125,7 @@ func buildText(name, context, locale string, data map[string]interface{}) (strin
 	return buf.String(), nil
 }
 
-func buildHTML(name string, layout string, ctx *job.WorkerContext, context, locale string, data map[string]interface{}) (string, error) {
+func buildHTML(name string, layout string, ctx *job.TaskContext, context, locale string, data map[string]interface{}) (string, error) {
 	buf := new(bytes.Buffer)
 	b, err := loadTemplate("/mails/"+name+".mjml", context)
 	if err != nil {

--- a/worker/mails/mail_test.go
+++ b/worker/mails/mail_test.go
@@ -85,7 +85,8 @@ QUIT
 				Locale: "en",
 			}
 			j := &job.Job{JobID: "1", Domain: "cozy.example.com"}
-			ctx := job.NewWorkerContext("0", j, nil)
+			ctx, cancel := job.NewTaskContext("0", j, nil)
+			defer cancel()
 			return sendMail(ctx, msg, "cozy.example.com")
 		})
 	})
@@ -152,7 +153,8 @@ QUIT
 				Locale: "en",
 			}
 			j := &job.Job{JobID: "1", Domain: "cozy.example.com"}
-			ctx := job.NewWorkerContext("0", j, nil)
+			ctx, cancel := job.NewTaskContext("0", j, nil)
+			defer cancel()
 			return sendMail(ctx, msg, "cozy.example.com")
 		})
 	})
@@ -164,7 +166,8 @@ QUIT
 			Locale: "en",
 		}
 		j := &job.Job{JobID: "1", Domain: "cozy.example.com"}
-		ctx := job.NewWorkerContext("0", j, nil)
+		ctx, cancel := job.NewTaskContext("0", j, nil)
+		defer cancel()
 		err := sendMail(ctx, msg, "cozy.example.com")
 		if assert.Error(t, err) {
 			assert.Equal(t, "Missing mail subject", err.Error())
@@ -185,7 +188,8 @@ QUIT
 			Locale: "en",
 		}
 		j := &job.Job{JobID: "1", Domain: "cozy.example.com"}
-		ctx := job.NewWorkerContext("0", j, nil)
+		ctx, cancel := job.NewTaskContext("0", j, nil)
+		defer cancel()
 		err := sendMail(ctx, msg, "cozy.example.com")
 		if assert.Error(t, err) {
 			assert.Equal(t, "Unknown body content-type text/qsdqsd", err.Error())
@@ -193,7 +197,7 @@ QUIT
 	})
 
 	t.Run("send with NoReply", func(t *testing.T) {
-		sendMail = func(_ *job.WorkerContext, opts *mail.Options, domain string) error {
+		sendMail = func(_ *job.TaskContext, opts *mail.Options, domain string) error {
 			assert.NotNil(t, opts.From)
 			assert.NotNil(t, opts.To)
 			assert.Len(t, opts.To, 1)
@@ -220,14 +224,16 @@ QUIT
 			Message:    msg,
 			WorkerType: "sendmail",
 		})
-		err := SendMail(job.NewWorkerContext("123", j, inst))
+		ctx, cancel := job.NewTaskContext("123", j, inst)
+		defer cancel()
+		err := SendMail(ctx)
 		if assert.Error(t, err) {
 			assert.Equal(t, "yes", err.Error())
 		}
 	})
 
 	t.Run("send with From", func(t *testing.T) {
-		sendMail = func(_ *job.WorkerContext, opts *mail.Options, domain string) error {
+		sendMail = func(_ *job.TaskContext, opts *mail.Options, domain string) error {
 			assert.NotNil(t, opts.From)
 			assert.NotNil(t, opts.To)
 			assert.Len(t, opts.To, 1)
@@ -256,7 +262,9 @@ QUIT
 			Message:    msg,
 			WorkerType: "sendmail",
 		})
-		err := SendMail(job.NewWorkerContext("123", j, inst))
+		ctx, cancel := job.NewTaskContext("123", j, inst)
+		defer cancel()
+		err := SendMail(ctx)
 		if assert.Error(t, err) {
 			assert.Equal(t, "yes", err.Error())
 		}

--- a/worker/migrations/migrations.go
+++ b/worker/migrations/migrations.go
@@ -62,7 +62,7 @@ type message struct {
 	Type string `json:"type"`
 }
 
-func worker(ctx *job.WorkerContext) error {
+func worker(ctx *job.TaskContext) error {
 	var msg message
 	if err := ctx.UnmarshalMessage(&msg); err != nil {
 		return err
@@ -87,7 +87,7 @@ func worker(ctx *job.WorkerContext) error {
 	}
 }
 
-func commit(ctx *job.WorkerContext, err error) error {
+func commit(ctx *job.TaskContext, err error) error {
 	var msg message
 	var migrationType string
 

--- a/worker/moves/workers.go
+++ b/worker/moves/workers.go
@@ -30,7 +30,7 @@ func init() {
 
 // ExportWorker is the worker responsible for creating an export of the
 // instance.
-func ExportWorker(c *job.WorkerContext) error {
+func ExportWorker(c *job.TaskContext) error {
 	var opts move.ExportOptions
 	if err := c.UnmarshalMessage(&opts); err != nil {
 		return err
@@ -67,7 +67,7 @@ func ExportWorker(c *job.WorkerContext) error {
 
 // ImportWorker is the worker responsible for inserting the data from an export
 // inside an instance.
-func ImportWorker(c *job.WorkerContext) error {
+func ImportWorker(c *job.TaskContext) error {
 	var opts move.ImportOptions
 	if err := c.UnmarshalMessage(&opts); err != nil {
 		return err

--- a/worker/notes/notes.go
+++ b/worker/notes/notes.go
@@ -22,7 +22,7 @@ func init() {
 // WorkerPersist is used to persist a note to its file in the VFS. The changes
 // (title and steps) on a notes can happen with a high frequency, and
 // debouncing them allows to not make too many calls to Swift.
-func WorkerPersist(ctx *job.WorkerContext) error {
+func WorkerPersist(ctx *job.TaskContext) error {
 	var msg note.DebounceMessage
 	if err := ctx.UnmarshalMessage(&msg); err != nil {
 		return err

--- a/worker/oauth/client.go
+++ b/worker/oauth/client.go
@@ -21,7 +21,7 @@ func init() {
 }
 
 // WorkerClean is used to clean unused OAuth clients.
-func WorkerClean(ctx *job.WorkerContext) error {
+func WorkerClean(ctx *job.TaskContext) error {
 	var msg oauth.CleanMessage
 	if err := ctx.UnmarshalMessage(&msg); err != nil {
 		return err

--- a/worker/push/push.go
+++ b/worker/push/push.go
@@ -113,7 +113,7 @@ func Init() (err error) {
 }
 
 // Worker is the worker that send push messages.
-func Worker(ctx *job.WorkerContext) error {
+func Worker(ctx *job.TaskContext) error {
 	var msg center.PushMessage
 	if err := ctx.UnmarshalMessage(&msg); err != nil {
 		return err
@@ -194,7 +194,7 @@ func Worker(ctx *job.WorkerContext) error {
 	return nil
 }
 
-func push(ctx *job.WorkerContext, c *oauth.Client, msg *center.PushMessage) error {
+func push(ctx *job.TaskContext, c *oauth.Client, msg *center.PushMessage) error {
 	switch c.NotificationPlatform {
 	case oauth.PlatformFirebase, "android", "ios":
 		return pushToFirebase(ctx, c, msg)
@@ -209,7 +209,7 @@ func push(ctx *job.WorkerContext, c *oauth.Client, msg *center.PushMessage) erro
 
 // Firebase Cloud Messaging HTTP Protocol
 // https://firebase.google.com/docs/cloud-messaging/http-server-ref
-func pushToFirebase(ctx *job.WorkerContext, c *oauth.Client, msg *center.PushMessage) error {
+func pushToFirebase(ctx *job.TaskContext, c *oauth.Client, msg *center.PushMessage) error {
 	slug := msg.Slug()
 	if c.Flagship {
 		slug = ""
@@ -306,7 +306,7 @@ func getFirebaseClient(slug, contextName string) *fcm.Client {
 	return fcmClient
 }
 
-func pushToAPNS(ctx *job.WorkerContext, c *oauth.Client, msg *center.PushMessage) error {
+func pushToAPNS(ctx *job.TaskContext, c *oauth.Client, msg *center.PushMessage) error {
 	if iosClient == nil {
 		ctx.Logger().Warn("Could not send iOS notification: not configured")
 		return nil
@@ -348,7 +348,7 @@ func pushToAPNS(ctx *job.WorkerContext, c *oauth.Client, msg *center.PushMessage
 	return nil
 }
 
-func pushToHuawei(ctx *job.WorkerContext, c *oauth.Client, msg *center.PushMessage) error {
+func pushToHuawei(ctx *job.TaskContext, c *oauth.Client, msg *center.PushMessage) error {
 	if huaweiClient == nil {
 		ctx.Logger().Warn("Could not send Huawei notification: not configured")
 		return nil

--- a/worker/share/share.go
+++ b/worker/share/share.go
@@ -45,7 +45,7 @@ func init() {
 
 // WorkerTrack is used to update the io.cozy.shared database when a document
 // that matches a sharing rule is created/updated/remove
-func WorkerTrack(ctx *job.WorkerContext) error {
+func WorkerTrack(ctx *job.TaskContext) error {
 	var msg sharing.TrackMessage
 	if err := ctx.UnmarshalMessage(&msg); err != nil {
 		return err
@@ -61,7 +61,7 @@ func WorkerTrack(ctx *job.WorkerContext) error {
 
 // WorkerReplicate is used for the replication of documents to the other
 // members of a sharing.
-func WorkerReplicate(ctx *job.WorkerContext) error {
+func WorkerReplicate(ctx *job.TaskContext) error {
 	var msg sharing.ReplicateMsg
 	if err := ctx.UnmarshalMessage(&msg); err != nil {
 		return err
@@ -79,7 +79,7 @@ func WorkerReplicate(ctx *job.WorkerContext) error {
 }
 
 // WorkerUpload is used to upload files for a sharing
-func WorkerUpload(ctx *job.WorkerContext) error {
+func WorkerUpload(ctx *job.TaskContext) error {
 	var msg sharing.UploadMsg
 	if err := ctx.UnmarshalMessage(&msg); err != nil {
 		return err
@@ -93,5 +93,5 @@ func WorkerUpload(ctx *job.WorkerContext) error {
 	if !s.Active {
 		return nil
 	}
-	return s.Upload(ctx.Instance, msg.Errors)
+	return s.Upload(ctx.Instance, ctx.Context, msg.Errors)
 }

--- a/worker/sms/sms.go
+++ b/worker/sms/sms.go
@@ -31,7 +31,7 @@ func init() {
 }
 
 // Worker is the worker that send SMS.
-func Worker(ctx *job.WorkerContext) error {
+func Worker(ctx *job.TaskContext) error {
 	var msg center.SMS
 	if err := ctx.UnmarshalMessage(&msg); err != nil {
 		return err
@@ -45,7 +45,7 @@ func Worker(ctx *job.WorkerContext) error {
 	return err
 }
 
-func sendSMS(ctx *job.WorkerContext, msg *center.SMS) error {
+func sendSMS(ctx *job.TaskContext, msg *center.SMS) error {
 	inst := ctx.Instance
 	cfg, err := getConfig(inst)
 	if err != nil {

--- a/worker/thumbnail/thumbnail.go
+++ b/worker/thumbnail/thumbnail.go
@@ -64,7 +64,7 @@ func init() {
 }
 
 // Worker is a worker that creates thumbnails for photos and images.
-func Worker(ctx *job.WorkerContext) error {
+func Worker(ctx *job.TaskContext) error {
 	var msg ImageMessage
 	if err := ctx.UnmarshalMessage(&msg); err != nil {
 		return err
@@ -139,7 +139,7 @@ type thumbnailMsg struct {
 
 // WorkerCheck is a worker function that checks all the images to generate
 // missing thumbnails.
-func WorkerCheck(ctx *job.WorkerContext) error {
+func WorkerCheck(ctx *job.TaskContext) error {
 	var msg thumbnailMsg
 	if err := ctx.UnmarshalMessage(&msg); err != nil {
 		return err
@@ -218,7 +218,7 @@ func calculateMetadata(fs vfs.VFS, img *vfs.FileDoc) (*vfs.Metadata, error) {
 	return &meta, nil
 }
 
-func generateSingleThumbnail(ctx *job.WorkerContext, img *vfs.FileDoc, format string) error {
+func generateSingleThumbnail(ctx *job.TaskContext, img *vfs.FileDoc, format string) error {
 	if ok := checkByteSize(img); !ok {
 		return nil
 	}
@@ -252,7 +252,7 @@ func generateSingleThumbnail(ctx *job.WorkerContext, img *vfs.FileDoc, format st
 	return err
 }
 
-func generateThumbnails(ctx *job.WorkerContext, img *vfs.FileDoc) error {
+func generateThumbnails(ctx *job.TaskContext, img *vfs.FileDoc) error {
 	if ok := checkByteSize(img); !ok {
 		return nil
 	}
@@ -311,7 +311,7 @@ func checkByteSize(img *vfs.FileDoc) bool {
 	return img.ByteSize < limit
 }
 
-func recGenerateThumb(ctx *job.WorkerContext, in io.Reader, fs vfs.Thumbser, img *vfs.FileDoc, format string, env []string, noOuput bool) (r io.Reader, err error) {
+func recGenerateThumb(ctx *job.TaskContext, in io.Reader, fs vfs.Thumbser, img *vfs.FileDoc, format string, env []string, noOuput bool) (r io.Reader, err error) {
 	defer func() {
 		if inCloser, ok := in.(io.Closer); ok {
 			if errc := inCloser.Close(); errc != nil && err == nil {
@@ -360,7 +360,7 @@ func recGenerateThumb(ctx *job.WorkerContext, in io.Reader, fs vfs.Thumbser, img
 // We are using some complicated ImageMagick options to optimize the speed and
 // quality of the generated thumbnails.
 // See https://www.smashingmagazine.com/2015/06/efficient-image-resizing-with-imagemagick/
-func generateThumb(ctx *job.WorkerContext, in io.Reader, out io.Writer, fileID string, format string, env []string) error {
+func generateThumb(ctx *job.TaskContext, in io.Reader, out io.Writer, fileID string, format string, env []string) error {
 	convertCmd := config.GetConfig().Jobs.ImageMagickConvertCmd
 	if convertCmd == "" {
 		convertCmd = "convert"
@@ -410,7 +410,7 @@ func removeThumbnails(i *instance.Instance, img *vfs.FileDoc) error {
 	return i.ThumbsFS().RemoveThumbs(img, vfs.ThumbnailFormatNames)
 }
 
-func resizeNoteImage(ctx *job.WorkerContext, img *note.Image) error {
+func resizeNoteImage(ctx *job.TaskContext, img *note.Image) error {
 	fs := ctx.Instance.ThumbsFS()
 	in, err := fs.OpenNoteThumb(img.ID(), consts.NoteImageOriginalFormat)
 	if err != nil {

--- a/worker/trash/trash.go
+++ b/worker/trash/trash.go
@@ -38,7 +38,7 @@ func init() {
 // WorkerTrashFiles is a worker to remove files in Swift after they have been
 // removed from CouchDB. It is used when cleaning the trash, as removing a lot
 // of files from Swift can take some time.
-func WorkerTrashFiles(ctx *job.WorkerContext) error {
+func WorkerTrashFiles(ctx *job.TaskContext) error {
 	opts := vfs.TrashJournal{}
 	if err := ctx.UnmarshalMessage(&opts); err != nil {
 		return err
@@ -56,7 +56,7 @@ func WorkerTrashFiles(ctx *job.WorkerContext) error {
 // directories that are in the trash for too long. The threshold for deletion
 // is configurable per context in the config file, via the
 // fs.auto_clean_trashed_after parameter.
-func WorkerCleanOldTrashed(ctx *job.WorkerContext) error {
+func WorkerCleanOldTrashed(ctx *job.TaskContext) error {
 	cfg := config.GetConfig().Fs.AutoCleanTrashedAfter
 	after, ok := cfg[ctx.Instance.ContextName]
 	if !ok || after == "" {


### PR DESCRIPTION
The share-upload jobs can be quite long, and they can create other jobs (share-track). When the stack stops for a deployment, it can happen that the share-upload tries to puhs share-track jobs after the 2 minutes deadline, and it fails as the redis connection is closed.

The workers were modified to cancel the task context when the stack is stopping, and the share-upload checks if the task context has been canceled after each file upload. If the context has been canceled, it stops there.