### PR TITLE
Fix cozy-stack files exec ls on files

### DIFF
--- a/cmd/files.go
+++ b/cmd/files.go
@@ -246,7 +246,7 @@ func lsCmd(c *client.Client, root string, w io.Writer, verbose, human, all bool)
 		if err != nil {
 			return err
 		}
-		if n == root {
+		if n == root && doc.Attrs.Type == consts.DirType {
 			return nil
 		}
 


### PR DESCRIPTION
When using `cozy-stack files exec ls` on directories, we list the content of the directory

However, when passing a file path as argument to ls, nothing is displayed.

This pull request fixes that behavior by showing the requested file when using `files exec ls` on a single file