### PR TITLE
Fix OO save for a file without extension

### DIFF
--- a/model/office/callback.go
+++ b/model/office/callback.go
@@ -1,3 +1,5 @@
+// Package office is for interactions with an OnlyOffice server to allow users
+// to view/edit their office documents online.
 package office
 
 import (
@@ -135,9 +137,6 @@ func saveFile(inst *instance.Instance, detector conflictDetector, downloadURL st
 	file, err := fs.FileByID(detector.ID)
 	if err != nil {
 		return nil, err
-	}
-	if !isOfficeDocument(file) {
-		return nil, ErrInvalidFile
 	}
 
 	res, err := docserverClient.Get(downloadURL)


### PR DESCRIPTION
1. An office document is shared
2. One user edits the document in OnlyOffice
3. Another user renames the file and change/remove the extension
4. The first user has finished editing the document

Here, OnlyOffice sends a callback to the stack to save the document. The stack was responding with a 500 code as the file wasn't seen as an office document. We should check that only when opening a document, not for saving it.