### PR TITLE
fix: Import notes' images from revoked sharings 

### DIFF
--- a/model/note/note.go
+++ b/model/note/note.go
@@ -208,7 +208,7 @@ func Create(inst *instance.Instance, doc *Document) (*vfs.FileDoc, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := setupTrigger(inst, file.ID()); err != nil {
+	if err := SetupTrigger(inst, file.ID()); err != nil {
 		return nil, err
 	}
 	return file, nil
@@ -341,7 +341,7 @@ type DebounceMessage struct {
 	NoteID string `json:"note_id"`
 }
 
-func setupTrigger(inst *instance.Instance, fileID string) error {
+func SetupTrigger(inst *instance.Instance, fileID string) error {
 	sched := job.System()
 	infos := job.TriggerInfos{
 		Type:       "@event",

--- a/model/office/callback.go
+++ b/model/office/callback.go
@@ -69,7 +69,7 @@ func (c *callbackClaims) GetAudience() (jwt.ClaimStrings, error)       { return 
 
 // Callback will manage the callback from the document server.
 func Callback(inst *instance.Instance, params CallbackParameters) error {
-	cfg := getConfig(inst.ContextName)
+	cfg := GetConfig(inst.ContextName)
 	if err := checkToken(cfg, params); err != nil {
 		return err
 	}
@@ -132,7 +132,7 @@ func forceSaveFile(inst *instance.Instance, key, downloadURL string) error {
 }
 
 // saveFile saves the file with content from the given URL and returns the new revision.
-func saveFile(inst *instance.Instance, detector conflictDetector, downloadURL string) (*conflictDetector, error) {
+func saveFile(inst *instance.Instance, detector ConflictDetector, downloadURL string) (*ConflictDetector, error) {
 	fs := inst.VFS()
 	file, err := fs.FileByID(detector.ID)
 	if err != nil {
@@ -197,6 +197,6 @@ func saveFile(inst *instance.Instance, detector conflictDetector, downloadURL st
 	if cerr := f.Close(); cerr != nil && err == nil {
 		err = cerr
 	}
-	updated := conflictDetector{ID: newfile.ID(), Rev: newfile.Rev(), MD5Sum: newfile.MD5Sum}
+	updated := ConflictDetector{ID: newfile.ID(), Rev: newfile.Rev(), MD5Sum: newfile.MD5Sum}
 	return &updated, err
 }

--- a/model/office/config.go
+++ b/model/office/config.go
@@ -1,0 +1,13 @@
+package office
+
+import "github.com/cozy/cozy-stack/pkg/config/config"
+
+func GetConfig(contextName string) *config.Office {
+	configuration := config.GetConfig().Office
+	if c, ok := configuration[contextName]; ok {
+		return &c
+	} else if c, ok := configuration[config.DefaultInstanceContext]; ok {
+		return &c
+	}
+	return nil
+}

--- a/model/office/file_by_key.go
+++ b/model/office/file_by_key.go
@@ -42,7 +42,7 @@ func EnsureFileForKey(inst *instance.Instance, key string) (*vfs.FileDoc, error)
 		return nil, err
 	}
 
-	updated := conflictDetector{ID: newfile.ID(), Rev: newfile.Rev(), MD5Sum: newfile.MD5Sum}
+	updated := ConflictDetector{ID: newfile.ID(), Rev: newfile.Rev(), MD5Sum: newfile.MD5Sum}
 	_ = GetStore().UpdateSecret(inst, key, file.ID(), newfile.ID())
 	_ = GetStore().UpdateDoc(inst, key, updated)
 	return newfile, nil

--- a/model/sharing/files.go
+++ b/model/sharing/files.go
@@ -701,6 +701,12 @@ func (s *Sharing) FixRevokedNotes(inst *instance.Instance) error {
 
 	var errm error
 	for _, doc := range docs {
+		// If the note came from another cozy via a sharing that is now revoked, we
+		// may need to recreate the trigger.
+		if err := note.SetupTrigger(inst, doc.ID()); err != nil {
+			errm = multierror.Append(errm, fmt.Errorf("failed to setup revoked note trigger: %w", err))
+		}
+
 		if err := note.ImportImages(inst, doc); err != nil {
 			errm = multierror.Append(errm, fmt.Errorf("failed to import revoked note images: %w", err))
 		}

--- a/model/sharing/open_note.go
+++ b/model/sharing/open_note.go
@@ -81,6 +81,9 @@ func (o *NoteOpener) GetResult(memberIndex int, readOnly bool) (jsonapi.Object, 
 func (o *NoteOpener) openLocalNote(memberIndex int, readOnly bool) (*apiNoteURL, error) {
 	// If the note came from another cozy via a sharing that is now revoked, we
 	// may need to recreate the trigger.
+	// This should be taken care of when revoking the sharing now but we leave
+	// this call to make sure notes from previously revoked sharings will
+	// continue to work.
 	_ = note.SetupTrigger(o.Inst, o.File.ID())
 
 	code, err := o.GetSharecode(memberIndex, readOnly)

--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -523,6 +523,11 @@ func (s *Sharing) RevokeRecipientBySelf(inst *instance.Instance, sharingDirTrash
 			Warnf("RevokeRecipientBySelf failed to remove shared refs (%s)': %s", s.ID(), err)
 	}
 	if !sharingDirTrashed {
+		if err := s.FixRevokedNotes(inst); err != nil {
+			inst.Logger().WithNamespace("sharing").
+				Warnf("RevokeRecipientBySelf failed to fix notes for revoked sharing %s: %s", s.ID(), err)
+		}
+
 		if rule := s.FirstFilesRule(); rule != nil && rule.Mime == "" {
 			if err := s.RemoveSharingDir(inst); err != nil {
 				inst.Logger().WithNamespace("sharing").
@@ -608,6 +613,10 @@ func (s *Sharing) RevokeByNotification(inst *instance.Instance) error {
 	}
 	if err := RemoveSharedRefs(inst, s.SID); err != nil {
 		return err
+	}
+	if err := s.FixRevokedNotes(inst); err != nil {
+		inst.Logger().WithNamespace("sharing").
+			Warnf("RevokeByNotification failed to fix notes for revoked sharing %s: %s", s.ID(), err)
 	}
 	if rule := s.FirstFilesRule(); rule != nil && rule.Mime == "" {
 		if err := s.RemoveSharingDir(inst); err != nil {

--- a/web/notes/notes.go
+++ b/web/notes/notes.go
@@ -300,7 +300,7 @@ func ForceNoteSync(c echo.Context) error {
 func OpenNoteURL(c echo.Context) error {
 	inst := middlewares.GetInstance(c)
 	fileID := c.Param("id")
-	open, err := note.Open(inst, fileID)
+	open, err := sharing.OpenNote(inst, fileID)
 	if err != nil {
 		return wrapError(err)
 	}

--- a/web/office/office.go
+++ b/web/office/office.go
@@ -21,7 +21,7 @@ import (
 func Open(c echo.Context) error {
 	inst := middlewares.GetInstance(c)
 	fileID := c.Param("id")
-	open, err := office.Open(inst, fileID)
+	open, err := sharing.OpenOffice(inst, fileID)
 	if err != nil {
 		return wrapError(err)
 	}


### PR DESCRIPTION
The `io.cozy.notes.images` documents associated with a Cozy Note are
  not shared with the note itself.
  Therefore, when the sharing is revoked and the note opened by the
  sharing recipient on their own Cozy (i.e. shared notes are opened on
  their creator's Cozy while the sharing is active), included images are
  shown as missing because we can't find their associated
  `io.cozy.notes.images` documents.

  However, the image binaries themselves are stored wihtin the note's
  binary (which is an archive in this case) and thus can be imported on
  the recipient's Cozy as `io.cozy.notes.images` documents and the note
  content can be updated to reference these documents.
  After that, the images will be displayed as expected when opening the
  note.