### PR TITLE
Add a reference to sourceAccountIdentifier

### DIFF
--- a/model/vfs/cozy_metadata.go
+++ b/model/vfs/cozy_metadata.go
@@ -29,10 +29,6 @@ type FilesCozyMetadata struct {
 	UploadedBy *UploadedByEntry `json:"uploadedBy,omitempty"`
 	// Instance URL where the content has been changed the last time
 	UploadedOn string `json:"uploadedOn,omitempty"`
-	// Identifier of the account in io.cozy.accounts (for konnectors)
-	SourceAccount string `json:"sourceAccount,omitempty"`
-	// Identifier unique to the account targeted by the connector (login most of the time)
-	SourceIdentifier string `json:"sourceAccountIdentifier,omitempty"`
 }
 
 // NewCozyMetadata initializes a new FilesCozyMetadata struct

--- a/pkg/consts/doctype.go
+++ b/pkg/consts/doctype.go
@@ -136,4 +136,7 @@ const (
 	// AuthConfirmations doc type used for realtime events when confirming
 	// authentication.
 	AuthConfirmations = "io.cozy.auth.confirmations"
+	// SourceAccountIdentifier doc type is used to link a directory to the
+	// konnector account that imports documents inside it.
+	SourceAccountIdentifier = "io.cozy.accounts.sourceAccountIdentifier"
 )

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -41,6 +41,10 @@ type CozyMetadata struct {
 	UpdatedAt time.Time `json:"updatedAt"`
 	// List of objects representing the applications which modified the cozy document
 	UpdatedByApps []*UpdatedByAppEntry `json:"updatedByApps,omitempty"`
+	// Identifier of the account in io.cozy.accounts (for konnectors)
+	SourceAccount string `json:"sourceAccount,omitempty"`
+	// Identifier unique to the account targeted by the connector (login most of the time)
+	SourceIdentifier string `json:"sourceAccountIdentifier,omitempty"`
 }
 
 // New initializes a new CozyMetadata structure


### PR DESCRIPTION
When the stack executes a konnector that imports files, it checks that a directory exists for those files. And if the directory doesn't exist, it creates it. We have added a referencedBy on the directory for the sourceAccountIdentifier to be able to deal with several accounts for the same konnector, as each account should have its own directory.