### PR TITLE
Check if a group can be added to a sharing

### DIFF
--- a/model/sharing/error.go
+++ b/model/sharing/error.go
@@ -51,4 +51,14 @@ var (
 	ErrAlreadyAccepted = errors.New("Sharing already accepted by this recipient")
 	// ErrCannotOpenFile is used when opening a file fails
 	ErrCannotOpenFile = errors.New("The file cannot be opened")
+	// ErrGroupCannotBeAddedTwice is used when trying to add a group to a
+	// sharing, but the group is already active for this sharing.
+	ErrGroupCannotBeAddedTwice = errors.New("The group cannot be added twice to the same sharing")
+	// ErrMemberAlreadyAdded is used when trying to add a group with a member
+	// already in the sharing as an individual with different rights (read-only
+	// vs read-write).
+	ErrMemberAlreadyAdded = errors.New("A group member cannot be added as they are already in the sharing")
+	// ErrMemberAlreadyInGroup is used when trying to add a group with a member
+	// already in another group of the sharing with different rights.
+	ErrMemberAlreadyInGroup = errors.New("A group member cannot be added as they are already in another group of the sharing")
 )

--- a/model/sharing/group.go
+++ b/model/sharing/group.go
@@ -33,6 +33,12 @@ type Group struct {
 // AddGroup adds a group of contacts identified by its ID to the members of the
 // sharing.
 func (s *Sharing) AddGroup(inst *instance.Instance, groupID string, readOnly bool) error {
+	for _, g := range s.Groups {
+		if g.ID == groupID && !g.Revoked {
+			return ErrGroupCannotBeAddedTwice
+		}
+	}
+
 	group, err := contact.FindGroup(inst, groupID)
 	if err != nil {
 		return err
@@ -45,6 +51,7 @@ func (s *Sharing) AddGroup(inst *instance.Instance, groupID string, readOnly boo
 	groupIndex := len(s.Groups)
 	for _, contact := range contacts {
 		m := buildMemberFromContact(contact, readOnly)
+		m.Groups = []int{groupIndex}
 		m.OnlyInGroups = true
 		_, idx, err := s.addMember(inst, m)
 		if err != nil {

--- a/model/sharing/member.go
+++ b/model/sharing/member.go
@@ -210,6 +210,7 @@ func (s *Sharing) addMember(inst *instance.Instance, m Member) (string, int, err
 		s.Members[i].Name = m.Name
 		s.Members[i].Instance = m.Instance
 		s.Members[i].ReadOnly = m.ReadOnly
+		s.Members[i].OnlyInGroups = s.Members[i].OnlyInGroups && m.OnlyInGroups
 		break
 	}
 	if idx < 1 {

--- a/model/sharing/member.go
+++ b/model/sharing/member.go
@@ -196,6 +196,12 @@ func (s *Sharing) addMember(inst *instance.Instance, m Member) (string, int, err
 		if !found {
 			continue
 		}
+		if len(m.Groups) > 0 && s.Members[i].ReadOnly != m.ReadOnly {
+			if s.Members[i].OnlyInGroups {
+				return "", -1, ErrMemberAlreadyInGroup
+			}
+			return "", -1, ErrMemberAlreadyAdded
+		}
 		if member.Status == MemberStatusReady {
 			return "", i, nil
 		}

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -1072,6 +1072,8 @@ func wrapErrors(err error) error {
 		return jsonapi.Errorf(http.StatusRequestEntityTooLarge, "%s", err)
 	case permission.ErrExpiredToken:
 		return jsonapi.BadRequest(err)
+	case sharing.ErrGroupCannotBeAddedTwice, sharing.ErrMemberAlreadyAdded, sharing.ErrMemberAlreadyInGroup:
+		return jsonapi.BadRequest(err)
 	}
 	logger.WithNamespace("sharing").Warnf("Not wrapped error: %s", err)
 	return err


### PR DESCRIPTION
If we try to add a group to a sharing, and this group contains a contact that aleady is on the sharing with different rights (read-only vs read-write), we should abort.