### PR TITLE
feat: Add subscription vendor to external ties

### DIFF
--- a/model/cloudery/init.go
+++ b/model/cloudery/init.go
@@ -15,7 +15,7 @@ var service Service
 // - [Mock] for the tests
 type Service interface {
 	SaveInstance(inst *instance.Instance, cmd *SaveCmd) error
-	HasBlockingSubscription(inst *instance.Instance) (bool, error)
+	BlockingSubscription(inst *instance.Instance) (*BlockingSubscription, error)
 }
 
 func Init(contexts map[string]config.ClouderyConfig) Service {

--- a/model/cloudery/service_mock.go
+++ b/model/cloudery/service_mock.go
@@ -26,8 +26,12 @@ func (m *Mock) SaveInstance(inst *instance.Instance, cmd *SaveCmd) error {
 	return m.Called(inst, cmd).Error(0)
 }
 
-func (m *Mock) HasBlockingSubscription(inst *instance.Instance) (bool, error) {
+func (m *Mock) BlockingSubscription(inst *instance.Instance) (*BlockingSubscription, error) {
 	args := m.Called(inst)
 
-	return args.Bool(0), args.Error(1)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).(*BlockingSubscription), args.Error(1)
 }

--- a/model/cloudery/service_noop.go
+++ b/model/cloudery/service_noop.go
@@ -12,6 +12,6 @@ func (s *NoopService) SaveInstance(inst *instance.Instance, cmd *SaveCmd) error 
 	return nil
 }
 
-func (s *NoopService) HasBlockingSubscription(inst *instance.Instance) (bool, error) {
-	return false, nil
+func (s *NoopService) BlockingSubscription(inst *instance.Instance) (*BlockingSubscription, error) {
+	return nil, nil
 }

--- a/model/settings/service.go
+++ b/model/settings/service.go
@@ -24,7 +24,8 @@ var (
 )
 
 type ExternalTies struct {
-	HasBlockingSubscription bool `json:"has_blocking_subscription"`
+	HasBlockingSubscription bool                           `json:"has_blocking_subscription"`
+	BlockingSubscription    *cloudery.BlockingSubscription `json:"blocking_subscription,omitempty"`
 }
 
 // Storage used to persiste and fetch settings data.
@@ -250,13 +251,18 @@ func (s *SettingsService) CancelEmailUpdate(inst *instance.Instance) error {
 }
 
 func (s *SettingsService) GetExternalTies(inst *instance.Instance) (*ExternalTies, error) {
-	hasBlockingSubscription, err := s.cloudery.HasBlockingSubscription(inst)
+	blockingSubscription, err := s.cloudery.BlockingSubscription(inst)
 	if err != nil {
 		return nil, err
 	}
 
-	ties := ExternalTies{
-		HasBlockingSubscription: hasBlockingSubscription,
+	var ties ExternalTies
+	if blockingSubscription != nil {
+		ties = ExternalTies{
+			HasBlockingSubscription: true,
+			BlockingSubscription:    blockingSubscription,
+		}
 	}
+
 	return &ties, nil
 }

--- a/model/settings/service_test.go
+++ b/model/settings/service_test.go
@@ -360,24 +360,26 @@ func Test_GetExternalTies(t *testing.T) {
 	}
 
 	t.Run("with blocking subscription", func(t *testing.T) {
-		clouderySvc.On("HasBlockingSubscription", &inst).Return(true, nil).Once()
+		blockingSubscription := cloudery.BlockingSubscription{Vendor: "ios"}
+
+		clouderySvc.On("BlockingSubscription", &inst).Return(&blockingSubscription, nil).Once()
 
 		ties, err := svc.GetExternalTies(&inst)
 		assert.NoError(t, err)
-		assert.EqualExportedValues(t, *ties, ExternalTies{HasBlockingSubscription: true})
+		assert.EqualExportedValues(t, ExternalTies{HasBlockingSubscription: true, BlockingSubscription: &blockingSubscription}, *ties)
 	})
 
 	t.Run("without blocking subscription", func(t *testing.T) {
-		clouderySvc.On("HasBlockingSubscription", &inst).Return(false, nil).Once()
+		clouderySvc.On("BlockingSubscription", &inst).Return(nil, nil).Once()
 
 		ties, err := svc.GetExternalTies(&inst)
 		assert.NoError(t, err)
-		assert.EqualExportedValues(t, *ties, ExternalTies{HasBlockingSubscription: false})
+		assert.EqualExportedValues(t, ExternalTies{HasBlockingSubscription: false}, *ties)
 	})
 
 	t.Run("with error from cloudery", func(t *testing.T) {
 		unauthorizedError := errors.New("unauthorized")
-		clouderySvc.On("HasBlockingSubscription", &inst).Return(false, unauthorizedError).Once()
+		clouderySvc.On("BlockingSubscription", &inst).Return(nil, unauthorizedError).Once()
 
 		ties, err := svc.GetExternalTies(&inst)
 		assert.ErrorIs(t, err, unauthorizedError)


### PR DESCRIPTION
  When a blocking subscription exists (e.g. an In-App-Purchase
  subscription), we want to know which vendor was used to buy it so we
  can display this information in the UI (instead of listing all
  possible vendors which can irritate some of them like Apple).

  Since we start returning more information about the blocking
  subscription we'll return it as an object in the
  `blocking_subscription` field of the external ties JSON response.
  We could then remove the `has_blocking_subscription` field once
  apps using this route rely solely on the new field.