### PR TITLE
Remove cache for instances

### DIFF
--- a/model/instance/init.go
+++ b/model/instance/init.go
@@ -1,7 +1,6 @@
 package instance
 
 import (
-	"github.com/cozy/cozy-stack/pkg/cache"
 	"github.com/cozy/cozy-stack/pkg/logger"
 )
 
@@ -14,30 +13,22 @@ var service *InstanceService
 // - [Mock] with a mock implementation
 type Service interface {
 	Get(domain string) (*Instance, error)
-	GetWithoutCache(domain string) (*Instance, error)
 	Update(inst *Instance) error
 	Delete(inst *Instance) error
 	CheckPassphrase(inst *Instance, pass []byte) error
 }
 
-func Init(c cache.Cache) *InstanceService {
-	service = NewService(c, logger.WithNamespace("instance"))
+func Init() *InstanceService {
+	service = NewService(logger.WithNamespace("instance"))
 
 	return service
 }
 
-// Get finds an instance from its domain by using CouchDB or the cache.
+// Get finds an instance from its domain by using CouchDB.
 //
 // Deprecated: Use [InstanceService.Get] instead.
 func Get(domain string) (*Instance, error) {
 	return service.Get(domain)
-}
-
-// GetFromCouch finds an instance in CouchDB from its domain.
-//
-// Deprecated: Use [InstanceService.GetWithoutCache] instead.
-func GetFromCouch(domain string) (*Instance, error) {
-	return service.GetWithoutCache(domain)
 }
 
 // Update saves the changes in CouchDB.

--- a/model/instance/lifecycle/create.go
+++ b/model/instance/lifecycle/create.go
@@ -84,7 +84,7 @@ func Create(opts *Options) (*instance.Instance, error) {
 		return nil, err
 	}
 	opts.trace("check if instance already exist", func() {
-		_, err = instance.GetFromCouch(domain)
+		_, err = instance.Get(domain)
 	})
 	if !errors.Is(err, instance.ErrNotFound) {
 		if err == nil {

--- a/model/instance/lifecycle/destroy.go
+++ b/model/instance/lifecycle/destroy.go
@@ -55,7 +55,7 @@ func Destroy(domain string) error {
 	if err != nil {
 		return err
 	}
-	inst, err := instance.GetFromCouch(domain)
+	inst, err := instance.Get(domain)
 	if err != nil {
 		return err
 	}
@@ -78,7 +78,7 @@ func Destroy(domain string) error {
 
 	// Reload the instance, it can have been updated in CouchDB if the instance
 	// had at least one account and was not up-to-date for its indexes/views.
-	inst, err = instance.GetFromCouch(domain)
+	inst, err = instance.Get(domain)
 	if err != nil {
 		return err
 	}
@@ -103,7 +103,7 @@ func Destroy(domain string) error {
 		// this document when we have concurrent updates for indexes/views
 		// version and deleting flag.
 		time.Sleep(3 * time.Second)
-		inst, errg := instance.GetFromCouch(domain)
+		inst, errg := instance.Get(domain)
 		if couchdb.IsNotFoundError(errg) {
 			err = nil
 		} else if inst != nil {

--- a/model/instance/lifecycle/get.go
+++ b/model/instance/lifecycle/get.go
@@ -39,7 +39,7 @@ func GetInstance(domain string) (*instance.Instance, error) {
 			return nil, err
 		}
 
-		i, err = instance.GetFromCouch(domain)
+		i, err = instance.Get(domain)
 		if err != nil {
 			return nil, err
 		}

--- a/model/instance/lifecycle/helpers.go
+++ b/model/instance/lifecycle/helpers.go
@@ -146,7 +146,7 @@ func checkAliases(inst *instance.Instance, aliases []string) ([]string, error) {
 		if alias == inst.Domain {
 			return nil, instance.ErrExists
 		}
-		other, err := instance.GetFromCouch(alias)
+		other, err := instance.Get(alias)
 		if !errors.Is(err, instance.ErrNotFound) {
 			if err != nil {
 				return nil, err

--- a/model/instance/service.go
+++ b/model/instance/service.go
@@ -2,56 +2,25 @@ package instance
 
 import (
 	"encoding/json"
-	"time"
 
-	"github.com/cozy/cozy-stack/pkg/cache"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/crypto"
 	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/cozy/cozy-stack/pkg/prefixer"
 )
 
-const cacheTTL = 5 * time.Minute
-const cachePrefix = "i:"
-
 type InstanceService struct {
-	cache  cache.Cache
 	logger logger.Logger
 }
 
-func NewService(cache cache.Cache, logger logger.Logger) *InstanceService {
+func NewService(logger logger.Logger) *InstanceService {
 	return &InstanceService{
-		cache:  cache,
 		logger: logger,
 	}
 }
 
-// Get finds an instance from its domain by using CouchDB or the cache.
+// Get finds an instance from its domain by using CouchDB.
 func (s *InstanceService) Get(domain string) (*Instance, error) {
-	if data, ok := s.cache.Get(cachePrefix + domain); ok {
-		inst := &Instance{}
-		err := json.Unmarshal(data, inst)
-		if err == nil && inst.MakeVFS() == nil {
-			return inst, nil
-		}
-	}
-
-	inst, err := s.GetWithoutCache(domain)
-	if err != nil {
-		return nil, err
-	}
-
-	if data, err := json.Marshal(inst); err == nil {
-		s.cache.SetNX(cacheKey(inst), data, cacheTTL)
-	}
-	return inst, nil
-}
-
-// GetWithoutCache finds an instance in CouchDB from its domain.
-//
-// NOTE: You should probably use [InstanceService.Get] instead. This method
-// is only useful if you want to bypass the cache.
-func (s *InstanceService) GetWithoutCache(domain string) (*Instance, error) {
 	var res couchdb.ViewResponse
 	err := couchdb.ExecView(prefixer.GlobalPrefixer, couchdb.DomainAndAliasesView, &couchdb.ViewRequest{
 		Key:         domain,
@@ -85,24 +54,12 @@ func (s *InstanceService) GetWithoutCache(domain string) (*Instance, error) {
 
 // Update saves the changes in CouchDB.
 func (s *InstanceService) Update(inst *Instance) error {
-	if err := couchdb.UpdateDoc(prefixer.GlobalPrefixer, inst); err != nil {
-		return err
-	}
-
-	if data, err := json.Marshal(inst); err == nil {
-		s.cache.Set(cacheKey(inst), data, cacheTTL)
-	}
-
-	return nil
+	return couchdb.UpdateDoc(prefixer.GlobalPrefixer, inst)
 }
 
 // Delete removes the instance document in CouchDB.
 func (s *InstanceService) Delete(inst *Instance) error {
-	err := couchdb.DeleteDoc(prefixer.GlobalPrefixer, inst)
-
-	s.cache.Clear(cacheKey(inst))
-
-	return err
+	return couchdb.DeleteDoc(prefixer.GlobalPrefixer, inst)
 }
 
 // CheckPassphrase confirm an instance password
@@ -130,8 +87,4 @@ func (s *InstanceService) CheckPassphrase(inst *Instance, pass []byte) error {
 		s.logger.WithDomain(inst.Domain).Errorf("Failed to update hash in db: %s", err)
 	}
 	return nil
-}
-
-func cacheKey(inst *Instance) string {
-	return cachePrefix + inst.Domain
 }

--- a/model/instance/service_mock.go
+++ b/model/instance/service_mock.go
@@ -32,17 +32,6 @@ func (m *Mock) Get(domain string) (*Instance, error) {
 	return args.Get(0).(*Instance), args.Error(1)
 }
 
-// GetWithoutCache mock method.
-func (m *Mock) GetWithoutCache(domain string) (*Instance, error) {
-	args := m.Called(domain)
-
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-
-	return args.Get(0).(*Instance), args.Error(1)
-}
-
 // Update mock method.
 func (m *Mock) Update(inst *Instance) error {
 	return m.Called(inst).Error(1)

--- a/model/stack/main.go
+++ b/model/stack/main.go
@@ -108,7 +108,7 @@ security features. Please do not use this binary as your production server.
 
 	tokenSvc := token.NewService(config.GetConfig().CacheStorage)
 	emailerSvc := emailer.Init()
-	instanceSvc := instance.Init(config.GetConfig().CacheStorage)
+	instanceSvc := instance.Init()
 	clouderySvc := cloudery.Init(config.GetConfig().Clouderies)
 
 	services := Services{

--- a/web/auth/auth_test.go
+++ b/web/auth/auth_test.go
@@ -1626,7 +1626,7 @@ func TestAuth(t *testing.T) {
 			WithHost(d).
 			Expect().Status(200)
 
-		in2, err := instance.GetFromCouch(d)
+		in2, err := instance.Get(d)
 		require.NoError(t, err)
 
 		e.POST("/auth/passphrase_renew").

--- a/web/instances/instances.go
+++ b/web/instances/instances.go
@@ -468,7 +468,7 @@ func cleanSessions(c echo.Context) error {
 }
 
 func lastActivity(c echo.Context) error {
-	inst, err := instance.GetFromCouch(c.Param("domain"))
+	inst, err := instance.Get(c.Param("domain"))
 	if err != nil {
 		return jsonapi.NotFound(err)
 	}
@@ -542,7 +542,7 @@ func lastActivity(c echo.Context) error {
 }
 
 func unxorID(c echo.Context) error {
-	inst, err := instance.GetFromCouch(c.Param("domain"))
+	inst, err := instance.Get(c.Param("domain"))
 	if err != nil {
 		return jsonapi.NotFound(err)
 	}

--- a/worker/migrations/migrate-accounts-to-organisation.go
+++ b/worker/migrations/migrate-accounts-to-organisation.go
@@ -178,7 +178,7 @@ func addCipherRelationshipToAccount(acc couchdb.JSONDoc, cipher *bitwarden.Ciphe
 // It decrypts each account, reencrypt the fields with the organization key,
 // and save it in the ciphers database.
 func migrateAccountsToOrganization(domain string) error {
-	inst, err := instance.GetFromCouch(domain)
+	inst, err := instance.Get(domain)
 	if err != nil {
 		return err
 	}

--- a/worker/migrations/migrations.go
+++ b/worker/migrations/migrations.go
@@ -113,7 +113,7 @@ func pushTrashJob(fs vfs.VFS) func(vfs.TrashJournal) error {
 }
 
 func removeUnwantedFolders(domain string) error {
-	inst, err := instance.GetFromCouch(domain)
+	inst, err := instance.Get(domain)
 	if err != nil {
 		return err
 	}
@@ -199,7 +199,7 @@ func removeUnwantedFolders(domain string) error {
 }
 
 func migrateNotesMimeType(domain string) error {
-	inst, err := instance.GetFromCouch(domain)
+	inst, err := instance.Get(domain)
 	if err != nil {
 		return err
 	}
@@ -234,7 +234,7 @@ func migrateNotesMimeType(domain string) error {
 
 func migrateToSwiftV3(domain string) error {
 	c := config.GetSwiftConnection()
-	inst, err := instance.GetFromCouch(domain)
+	inst, err := instance.Get(domain)
 	if err != nil {
 		return err
 	}
@@ -298,7 +298,7 @@ func migrateToSwiftV3(domain string) error {
 
 	meta := &swift.Metadata{"cozy-migrated-from": migratedFrom}
 	_ = c.ContainerUpdate(ctx, dstContainer, meta.ContainerHeaders())
-	if in, err := instance.GetFromCouch(domain); err == nil {
+	if in, err := instance.Get(domain); err == nil {
 		inst = in
 	}
 	inst.SwiftLayout = 2

--- a/worker/moves/workers.go
+++ b/worker/moves/workers.go
@@ -82,7 +82,7 @@ func ImportWorker(c *job.TaskContext) error {
 	if erru := lifecycle.Unblock(c.Instance); erru != nil {
 		// Try again
 		time.Sleep(10 * time.Second)
-		inst, errg := instance.GetFromCouch(c.Instance.Domain)
+		inst, errg := instance.Get(c.Instance.Domain)
 		if errg == nil {
 			erru = lifecycle.Unblock(inst)
 		}


### PR DESCRIPTION
It looks like the interactions between the eventual consistency of CouchDB and the Redis cache for instances can trigger 409 conflict errors for several minutes.