### PR TITLE
Avoid using startkey_docid in _all_docs

### DIFF
--- a/model/move/cursor.go
+++ b/model/move/cursor.go
@@ -85,9 +85,9 @@ func listFilesFromCursor(inst *instance.Instance, exportDoc *ExportDoc, start Cu
 
 	var files []*vfs.FileDoc
 	req := couchdb.AllDocsRequest{
-		StartKeyDocID: start.ID,
-		EndKeyDocID:   end.ID,
-		Limit:         1000,
+		StartKey: start.ID,
+		EndKey:   end.ID,
+		Limit:    1000,
 	}
 	for {
 		var results []*vfs.FileDoc
@@ -105,7 +105,7 @@ func listFilesFromCursor(inst *instance.Instance, exportDoc *ExportDoc, start Cu
 				files = append(files, res)
 			}
 		}
-		req.StartKeyDocID = results[len(results)-1].DocID
+		req.StartKey = results[len(results)-1].DocID
 		req.Skip = 1 // Do not fetch again the last file from this page
 	}
 
@@ -133,9 +133,9 @@ func listVersionsFromCursor(inst *instance.Instance, exportDoc *ExportDoc, start
 
 	var versions []*vfs.Version
 	req := couchdb.AllDocsRequest{
-		StartKeyDocID: start.ID,
-		EndKeyDocID:   end.ID,
-		Limit:         1000,
+		StartKey: start.ID,
+		EndKey:   end.ID,
+		Limit:    1000,
 	}
 	for {
 		var results []*vfs.Version
@@ -151,7 +151,7 @@ func listVersionsFromCursor(inst *instance.Instance, exportDoc *ExportDoc, start
 			}
 			versions = append(versions, res)
 		}
-		req.StartKeyDocID = results[len(results)-1].DocID
+		req.StartKey = results[len(results)-1].DocID
 		req.Skip = 1 // Do not fetch again the last file from this page
 	}
 

--- a/pkg/couchdb/bulk.go
+++ b/pkg/couchdb/bulk.go
@@ -20,14 +20,12 @@ import (
 
 // AllDocsRequest is used to build a _all_docs request
 type AllDocsRequest struct {
-	Descending    bool     `url:"descending,omitempty"`
-	Limit         int      `url:"limit,omitempty"`
-	Skip          int      `url:"skip,omitempty"`
-	StartKey      string   `url:"startkey,omitempty"`
-	StartKeyDocID string   `url:"startkey_docid,omitempty"`
-	EndKey        string   `url:"endkey,omitempty"`
-	EndKeyDocID   string   `url:"endkey_docid,omitempty"`
-	Keys          []string `url:"keys,omitempty"`
+	Descending bool     `url:"descending,omitempty"`
+	Limit      int      `url:"limit,omitempty"`
+	Skip       int      `url:"skip,omitempty"`
+	StartKey   string   `url:"startkey,omitempty"`
+	EndKey     string   `url:"endkey,omitempty"`
+	Keys       []string `url:"keys,omitempty"`
 }
 
 // AllDocsResponse is the response we receive from an _all_docs request
@@ -208,9 +206,9 @@ func ForeachDocsWithCustomPagination(db prefixer.Prefixer, doctype string, limit
 			skip = 1
 		}
 		req := &AllDocsRequest{
-			StartKeyDocID: startKey,
-			Skip:          skip,
-			Limit:         limit,
+			StartKey: startKey,
+			Skip:     skip,
+			Limit:    limit,
 		}
 		v, err := query.Values(req)
 		if err != nil {


### PR DESCRIPTION
It was working, but relying on a bug of CouchDB, which may be fixed in later versions. Let's use a safer version with `startkey` and `endkey`.