### PR TITLE
Fix sharing with different modes

### DIFF
--- a/model/sharing/member.go
+++ b/model/sharing/member.go
@@ -196,11 +196,12 @@ func (s *Sharing) addMember(inst *instance.Instance, m Member) (string, int, err
 		if !found {
 			continue
 		}
-		if len(m.Groups) > 0 && s.Members[i].ReadOnly != m.ReadOnly {
+		if s.Members[i].ReadOnly != m.ReadOnly {
 			if s.Members[i].OnlyInGroups {
 				return "", -1, ErrMemberAlreadyInGroup
+			} else if len(m.Groups) > 0 {
+				return "", -1, ErrMemberAlreadyAdded
 			}
-			return "", -1, ErrMemberAlreadyAdded
 		}
 		if member.Status == MemberStatusReady {
 			return "", i, nil


### PR DESCRIPTION
When a group is added in read-only to a sharing, it is no longer possible to add an individual who is a member of this group in read-write for this sharing.