### PR TITLE
Forbid IP like 169.254.169.254 in safehttp

### DIFF
--- a/pkg/safehttp/client.go
+++ b/pkg/safehttp/client.go
@@ -77,6 +77,10 @@ func safeControl(network string, address string, conn syscall.RawConn) error {
 		return fmt.Errorf("%s is not a valid IP address", host)
 	}
 
+	if ipaddress.IsUnspecified() || ipaddress.IsLinkLocalUnicast() || ipaddress.IsLinkLocalMulticast() {
+		return fmt.Errorf("%s is not a valid IP address", host)
+	}
+
 	if ipaddress.IsPrivate() {
 		return fmt.Errorf("%s is not a public IP address", ipaddress)
 	}


### PR DESCRIPTION
Safehttp package is used to prevent Server-Side Requests Forgery. It prevents making HTTP requests to private IP addresses for things controlled by the user, like Bitwarden icons. This commit adds some more rules for link-local unicast and multicast.

Fix #4380