### PR TITLE
fix: Redirect to clients paywall only if logged in

### DIFF
--- a/web/apps/serve.go
+++ b/web/apps/serve.go
@@ -69,12 +69,6 @@ func Serve(c echo.Context) error {
 	}
 
 	if file == "" || file == route.Index {
-		if !route.Public {
-			if handled, err := middlewares.CheckOAuthClientsLimitExceeded(c); handled {
-				return err
-			}
-		}
-
 		webapp = app.DoLazyUpdate(i, webapp, app.Copier(consts.WebappType, i), i.Registries()).(*app.WebappManifest)
 	}
 
@@ -313,6 +307,14 @@ func ServeAppFile(c echo.Context, i *instance.Instance, fs appfs.FileServer, web
 	sessID := ""
 	if isLoggedIn {
 		sessID = sess.ID()
+
+		if file == "" || file == route.Index {
+			if !route.Public {
+				if handled, err := middlewares.CheckOAuthClientsLimitExceeded(c); handled {
+					return err
+				}
+			}
+		}
 	}
 	params := buildServeParams(c, i, webapp, isLoggedIn, sessID)
 


### PR DESCRIPTION
  When an instance has more connected OAuth clients than their current
  plan and options allows them to, we redirect them to a paywall from
  any web app except the Settings app (because it allows disconnecting
  clients).

  However, if the user is not logged in, the paywall will return an
  unauthorized error.

  Therefore, we'll make sure the redirection to the paywall only occurs
  when the user is logged in (we don't duplicate the logic to redirect
  them to the login page in the paywall middleware).