### PR TITLE
Build packages for Ubuntu 24.04 Noble Numbat

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,7 @@ jobs:
             "debian:12",
             "ubuntu:20.04",
             "ubuntu:22.04",
+            "ubuntu:24.04",
           ]
     runs-on: ubuntu-latest
     needs: create_release

--- a/scripts/packaging/docker_package.sh
+++ b/scripts/packaging/docker_package.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-TARGETS="debian:10 debian:11 debian:12 ubuntu:20.04 ubuntu:22.04"
+TARGETS="debian:10 debian:11 debian:12 ubuntu:20.04 ubuntu:22.04 ubuntu:24.04"
 
 if [ $# -ne 0 ]; then
   TARGETS="$@"


### PR DESCRIPTION
Ubuntu 24.04 Noble Numbat has been released on April 25, 2024.

This PR adds releases packages for Ubuntu 24.04 Noble Numbat.