### PR TITLE
Fix uploading files to NextCloud via WebDAV

### DIFF
--- a/docs/nextcloud.md
+++ b/docs/nextcloud.md
@@ -264,7 +264,8 @@ HTTP/1.1 204 No Content
 
 This route can be used to create a copy of a file in the same directory, with a
 copy suffix in its name. The new name can be optionaly given with the `Name`
-parameter in the query-string.
+parameter in the query-string, or the full path can be given with `Path`
+parameter.
 
 The `:account` parameter is the identifier of the NextCloud `io.cozy.account`.
 
@@ -275,7 +276,7 @@ The `*path` parameter is the path of the file on the NextCloud.
 ### Request
 
 ```http
-POST /remote/nextcloud/4ab2155707bb6613a8b9463daf00381b/copy/Documents/wallpaper.jpg HTTP/1.1
+POST /remote/nextcloud/4ab2155707bb6613a8b9463daf00381b/copy/Documents/wallpaper.jpg?Path=/Images/beach.jpg HTTP/1.1
 Host: cozy.example.net
 Authorization: Bearer eyJhbG...
 ```

--- a/docs/nextcloud.md
+++ b/docs/nextcloud.md
@@ -392,7 +392,7 @@ Content-Type: application/vnd.api+json
 
 ## POST /remote/nextcloud/:account/upstream/*path
 
-This route can be used to move a file from the Cozy to the NextCloud.
+This route can be used to move/copy a file from the Cozy to the NextCloud.
 
 The `:account` parameter is the identifier of the NextCloud `io.cozy.account`.
 
@@ -400,6 +400,9 @@ The `*path` parameter is the path of the file on the NextCloud.
 
 The `From` parameter in the query-string must be given, as the ID of the
 file on the Cozy that will be moved.
+
+By default, the file will be moved, but using `Copy=true` in the query-string
+will makes a copy.
 
 **Note:** a permission on `POST io.cozy.files` is required to use this route.
 

--- a/docs/nextcloud.md
+++ b/docs/nextcloud.md
@@ -303,7 +303,7 @@ Content-Type: application/json
 
 ## POST /remote/nextcloud/:account/downstream/*path
 
-This route can be used to move a file from the NextCloud to the Cozy.
+This route can be used to move/copy a file from the NextCloud to the Cozy.
 
 The `:account` parameter is the identifier of the NextCloud `io.cozy.account`.
 
@@ -311,6 +311,9 @@ The `*path` parameter is the path of the file on the NextCloud.
 
 The `To` parameter in the query-string must be given, as the ID of the
 directory on the Cozy where the file will be put.
+
+By default, the file will be moved, but using `Copy=true` in the query-string
+will makes a copy.
 
 **Note:** a permission on `POST io.cozy.files` is required to use this route.
 

--- a/model/nextcloud/nextcloud.go
+++ b/model/nextcloud/nextcloud.go
@@ -109,11 +109,11 @@ func (nc *NextCloud) Download(path string) (*webdav.Download, error) {
 	return nc.webdav.Get(path)
 }
 
-func (nc *NextCloud) Upload(path, mime string, body io.Reader) error {
+func (nc *NextCloud) Upload(path, mime string, contentLength int64, body io.Reader) error {
 	headers := map[string]string{
 		echo.HeaderContentType: mime,
 	}
-	return nc.webdav.Put(path, headers, body)
+	return nc.webdav.Put(path, contentLength, headers, body)
 }
 
 func (nc *NextCloud) Mkdir(path string) error {
@@ -218,10 +218,9 @@ func (nc *NextCloud) Upstream(path, from string) error {
 	defer f.Close()
 
 	headers := map[string]string{
-		echo.HeaderContentType:   doc.Mime,
-		echo.HeaderContentLength: strconv.Itoa(int(doc.ByteSize)),
+		echo.HeaderContentType: doc.Mime,
 	}
-	if err := nc.webdav.Put(path, headers, f); err != nil {
+	if err := nc.webdav.Put(path, doc.ByteSize, headers, f); err != nil {
 		return err
 	}
 	_ = fs.DestroyFile(doc)

--- a/model/nextcloud/nextcloud.go
+++ b/model/nextcloud/nextcloud.go
@@ -24,6 +24,13 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
+type OperationKind int
+
+const (
+	MoveOperation OperationKind = iota
+	CopyOperation
+)
+
 type File struct {
 	DocID     string `json:"id,omitempty"`
 	Type      string `json:"type"`
@@ -205,7 +212,7 @@ func (nc *NextCloud) Downstream(path, dirID string, cozyMetadata *vfs.FilesCozyM
 	return doc, nil
 }
 
-func (nc *NextCloud) Upstream(path, from string) error {
+func (nc *NextCloud) Upstream(path, from string, kind OperationKind) error {
 	fs := nc.inst.VFS()
 	doc, err := fs.FileByID(from)
 	if err != nil {
@@ -223,7 +230,9 @@ func (nc *NextCloud) Upstream(path, from string) error {
 	if err := nc.webdav.Put(path, doc.ByteSize, headers, f); err != nil {
 		return err
 	}
-	_ = fs.DestroyFile(doc)
+	if kind == MoveOperation {
+		_ = fs.DestroyFile(doc)
+	}
 	return nil
 }
 

--- a/model/nextcloud/nextcloud.go
+++ b/model/nextcloud/nextcloud.go
@@ -167,7 +167,7 @@ func (nc *NextCloud) ListFiles(path string) ([]jsonapi.Object, error) {
 	return files, nil
 }
 
-func (nc *NextCloud) Downstream(path, dirID string, cozyMetadata *vfs.FilesCozyMetadata) (*vfs.FileDoc, error) {
+func (nc *NextCloud) Downstream(path, dirID string, kind OperationKind, cozyMetadata *vfs.FilesCozyMetadata) (*vfs.FileDoc, error) {
 	dl, err := nc.webdav.Get(path)
 	if err != nil {
 		return nil, err
@@ -208,7 +208,9 @@ func (nc *NextCloud) Downstream(path, dirID string, cozyMetadata *vfs.FilesCozyM
 		return nil, err
 	}
 
-	_ = nc.webdav.Delete(path)
+	if kind == MoveOperation {
+		_ = nc.webdav.Delete(path)
+	}
 	return doc, nil
 }
 

--- a/web/remote/nextcloud.go
+++ b/web/remote/nextcloud.go
@@ -199,8 +199,13 @@ func nextcloudDownstream(c echo.Context) error {
 		return jsonapi.BadRequest(errors.New("missing To parameter"))
 	}
 
+	kind := nextcloud.MoveOperation
+	if c.QueryParam("Copy") != "" {
+		kind = nextcloud.CopyOperation
+	}
+
 	cozyMetadata, _ := files.CozyMetadataFromClaims(c, true)
-	f, err := nc.Downstream(path, to, cozyMetadata)
+	f, err := nc.Downstream(path, to, kind, cozyMetadata)
 	if err != nil {
 		return wrapNextcloudErrors(err)
 	}

--- a/web/remote/nextcloud.go
+++ b/web/remote/nextcloud.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/cozy/cozy-stack/model/nextcloud"
@@ -202,7 +203,7 @@ func nextcloudDownstream(c echo.Context) error {
 	}
 
 	kind := nextcloud.MoveOperation
-	if c.QueryParam("Copy") != "" {
+	if isCopy, _ := strconv.ParseBool(c.QueryParam("Copy")); isCopy {
 		kind = nextcloud.CopyOperation
 	}
 
@@ -234,7 +235,7 @@ func nextcloudUpstream(c echo.Context) error {
 	}
 
 	kind := nextcloud.MoveOperation
-	if c.QueryParam("Copy") != "" {
+	if isCopy, _ := strconv.ParseBool(c.QueryParam("Copy")); isCopy {
 		kind = nextcloud.CopyOperation
 	}
 

--- a/web/remote/nextcloud.go
+++ b/web/remote/nextcloud.go
@@ -103,7 +103,7 @@ func nextcloudPut(c echo.Context) error {
 func nextcloudUpload(c echo.Context, nc *nextcloud.NextCloud, path string) error {
 	req := c.Request()
 	mime := req.Header.Get(echo.HeaderContentType)
-	if err := nc.Upload(path, mime, req.Body); err != nil {
+	if err := nc.Upload(path, mime, req.ContentLength, req.Body); err != nil {
 		return wrapNextcloudErrors(err)
 	}
 	return c.JSON(http.StatusCreated, echo.Map{"ok": true})

--- a/web/remote/nextcloud.go
+++ b/web/remote/nextcloud.go
@@ -226,7 +226,12 @@ func nextcloudUpstream(c echo.Context) error {
 		return jsonapi.BadRequest(errors.New("missing From parameter"))
 	}
 
-	if err := nc.Upstream(path, from); err != nil {
+	kind := nextcloud.MoveOperation
+	if c.QueryParam("Copy") != "" {
+		kind = nextcloud.CopyOperation
+	}
+
+	if err := nc.Upstream(path, from, kind); err != nil {
 		return wrapNextcloudErrors(err)
 	}
 	return c.NoContent(http.StatusNoContent)

--- a/web/remote/nextcloud.go
+++ b/web/remote/nextcloud.go
@@ -166,7 +166,9 @@ func nextcloudCopy(c echo.Context) error {
 
 	oldPath := c.Param("*")
 	newPath := oldPath
-	if newName := c.QueryParam("Name"); newName != "" {
+	if p := c.QueryParam("Path"); p != "" {
+		newPath = p
+	} else if newName := c.QueryParam("Name"); newName != "" {
 		newPath = filepath.Join(filepath.Dir(oldPath), newName)
 	} else {
 		ext := filepath.Ext(oldPath)


### PR DESCRIPTION
The HTTP request to NextCloud was made with Transfer-Encoding: chunked, because of the way the Content-Length was set. But it looks like NextCloud doesn't support that, and files were created empty. We can avoid that by setting request.ContentLength.