### PR TITLE
[VO-848] feat: Rename Shared drives into Drives

### DIFF
--- a/assets/locales/de.po
+++ b/assets/locales/de.po
@@ -25,7 +25,7 @@ msgid "Tree Notes"
 msgstr "Notizen"
 
 msgid "Tree Shared Drives"
-msgstr "Shared drives"
+msgstr "Drives"
 
 msgid "Tree Shared with me"
 msgstr "Posteingang der Freigaben"

--- a/assets/locales/en.po
+++ b/assets/locales/en.po
@@ -16,7 +16,7 @@ msgid "Tree Notes"
 msgstr "Notes"
 
 msgid "Tree Shared Drives"
-msgstr "Shared drives"
+msgstr "Drives"
 
 msgid "Tree Shared with me"
 msgstr "Inbox of sharings"

--- a/assets/locales/es.po
+++ b/assets/locales/es.po
@@ -20,7 +20,7 @@ msgid "Tree Notes"
 msgstr "Notas"
 
 msgid "Tree Shared Drives"
-msgstr "Shared drives"
+msgstr "Drives"
 
 msgid "Tree Shared with me"
 msgstr "Compartido conmigo"

--- a/assets/locales/fr.po
+++ b/assets/locales/fr.po
@@ -30,7 +30,7 @@ msgid "Tree Notes"
 msgstr "Notes"
 
 msgid "Tree Shared Drives"
-msgstr "Drives partagés"
+msgstr "Drives"
 
 msgid "Tree Shared with me"
 msgstr "Partages reçus"

--- a/assets/locales/ja.po
+++ b/assets/locales/ja.po
@@ -20,7 +20,7 @@ msgid "Tree Notes"
 msgstr "メモ"
 
 msgid "Tree Shared Drives"
-msgstr "Shared drives"
+msgstr "Drives"
 
 msgid "Tree Shared with me"
 msgstr "私と共有"

--- a/assets/locales/nl_NL.po
+++ b/assets/locales/nl_NL.po
@@ -23,7 +23,7 @@ msgid "Tree Notes"
 msgstr "Notities"
 
 msgid "Tree Shared Drives"
-msgstr "Shared drives"
+msgstr "Drives"
 
 msgid "Tree Shared with me"
 msgstr "Gedeeld met mij"

--- a/docs/files.md
+++ b/docs/files.md
@@ -152,8 +152,8 @@ Content-Type: application/vnd.api+json
     },
     "attributes": {
       "type": "directory",
-      "name": "Shared drives",
-      "path": "/Shared drives",
+      "name": "Drives",
+      "path": "/Drives",
       "created_at": "2024-03-25T15:22:00Z",
       "updated_at": "2024-03-25T15:22:00Z",
       "cozyMetadata": {


### PR DESCRIPTION
The product has decided to change the name of the folder. I'm going to force it on the cozy-drive side, but I'm thinking that to keep consistency into Desktop, we'd better change the translation here.