### PR TITLE
Remove OS in new connection emails

### DIFF
--- a/assets/mails/new_connection.text
+++ b/assets/mails/new_connection.text
@@ -3,7 +3,6 @@
 {{t "Mail New Connection Place"}} {{.Country}}
 {{t "Mail New Connection Time"}} {{.Time}}
 {{t "Mail New Connection Browser"}} {{.Browser}}
-{{t "Mail New Connection OS"}} {{.OS}}
 {{t "Mail New Connection IP"}} {{.IP}}
 
 {{t "Mail New Connection Change Passphrase instruction"}}


### PR DESCRIPTION
We did remove the OS from the new connexion email in https://github.com/cozy/cozy-stack/commit/9eae458822bd016c833480b377e58a0509353959 but forgot to remove it from the text version of the message.