### PR TITLE
Allow logged-in users to reset their password

### DIFF
--- a/web/auth/passphrase.go
+++ b/web/auth/passphrase.go
@@ -156,10 +156,6 @@ func passphraseReset(c echo.Context) error {
 
 func passphraseRenewForm(c echo.Context) error {
 	inst := middlewares.GetInstance(c)
-	if middlewares.IsLoggedIn(c) {
-		redirect := inst.DefaultRedirection().String()
-		return c.Redirect(http.StatusSeeOther, redirect)
-	}
 
 	// Check that the token is actually defined and well encoded. The actual
 	// token value checking is also done on the passphraseRenew handler.
@@ -200,13 +196,6 @@ func passphraseRenewForm(c echo.Context) error {
 
 func passphraseRenew(c echo.Context) error {
 	inst := middlewares.GetInstance(c)
-	if middlewares.IsLoggedIn(c) {
-		redirect := inst.DefaultRedirection().String()
-		if wantsJSON(c) {
-			return c.JSON(http.StatusOK, echo.Map{"redirect": redirect})
-		}
-		return c.Redirect(http.StatusSeeOther, redirect)
-	}
 	pass := []byte(c.FormValue("passphrase"))
 	iterations, _ := strconv.Atoi(c.FormValue("iterations"))
 	token, err := hex.DecodeString(c.FormValue("passphrase_reset_token"))


### PR DESCRIPTION
Users with OIDC can have a password for their vault, and if they forgot it, they should be able to reset it. The path to do that makes them logged-in (via OIDC) when the passwor is renewed.