### PR TITLE
Fix io.cozy.files inconsistency on a sharing

### DIFF
--- a/model/sharing/files.go
+++ b/model/sharing/files.go
@@ -209,7 +209,7 @@ func EnsureSharedWithMeDir(inst *instance.Instance) (*vfs.DirDoc, error) {
 		} else {
 			dir.CozyMetadata.UpdatedAt = now
 		}
-		_, err = vfs.RestoreDir(fs, dir)
+		dir, err = vfs.RestoreDir(fs, dir)
 		if err != nil {
 			inst.Logger().WithNamespace("sharing").
 				Warnf("EnsureSharedWithMeDir failed to restore the dir: %s", err)


### PR DESCRIPTION
When someone puts the io.cozy.files.shared-with-me-dir directory to the trash and then accepts a sharing, the new directory was created with the wrong path. The io.cozy.files.shared-with-me-dir was restored, and the new directory path was computed with the old path in /.cozy-trash.