### PR TITLE
Change checkbox wording at login

### DIFF
--- a/assets/locales/en.po
+++ b/assets/locales/en.po
@@ -64,7 +64,7 @@ msgid "Login Password hide"
 msgstr "Hide password"
 
 msgid "Login Long Session"
-msgstr "Remember me"
+msgstr "Remember me and my data on this device"
 
 msgid "Login Submit"
 msgstr "Log in"

--- a/assets/locales/fr.po
+++ b/assets/locales/fr.po
@@ -82,7 +82,7 @@ msgid "Login Password hide"
 msgstr "Cacher le mot de passe"
 
 msgid "Login Long Session"
-msgstr "Se souvenir de moi"
+msgstr "Se souvenir de moi et mes données sur cet appareil"
 
 msgid "Login Submit"
 msgstr "Se connecter"


### PR DESCRIPTION
We now introduce the notion of data and device to emphasize the fact that we are going to locally store data if it is checked. Otherwise, the user won't be remembered and we will prevent to store any personal data locally.

Note the wording itself might seem a bit verbose, but we chose to make it explicit here. Compared to a less verbose, but also less explicit wording, we find it legitimate here to be as explicit as possible. We believe it is important for the user security and empowerment, in case the login is made on an unsecured device.