### PR TITLE
fix: Remove duplicated manager url config

### DIFF
--- a/model/instance/instance_test.go
+++ b/model/instance/instance_test.go
@@ -61,7 +61,6 @@ func TestInstance(t *testing.T) {
 
 		cfg.Contexts = map[string]interface{}{
 			"context": map[string]interface{}{
-				"manager_url": "http://manager.example.org",
 				"logos": map[string]interface{}{
 					"coachco2": map[string]interface{}{
 						"light": []interface{}{
@@ -173,8 +172,7 @@ func TestInstance(t *testing.T) {
         }
       ]
     }
-  },
-  "manager_url": "http://manager.example.org"
+  }
 }`
 		assert.Equal(t, expected, string(bytes))
 	})

--- a/model/oauth/client_test.go
+++ b/model/oauth/client_test.go
@@ -32,8 +32,6 @@ func TestClient(t *testing.T) {
 	}
 
 	config.UseTestFile(t)
-	conf := config.GetConfig()
-	conf.Contexts[config.DefaultInstanceContext] = map[string]interface{}{"manager_url": "http://manager.example.org"}
 	setup := testutils.NewSetup(t, t.Name())
 	testInstance := setup.GetTestInstance()
 
@@ -197,7 +195,7 @@ func TestClient(t *testing.T) {
 		premiumLink := assertClientsLimitAlertMailWasSent(t, testInstance, "notificationWithoutPremium", 1)
 		assert.Empty(t, premiumLink)
 
-		testutils.WithManager(t, testInstance)
+		testutils.WithManager(t, testInstance, testutils.ManagerConfig{URL: "http://manager.example.org", WithPremiumLinks: true})
 
 		notificationWithPremium = &oauth.Client{
 			ClientName:   "notificationWithPremium",

--- a/pkg/config/config/config.go
+++ b/pkg/config/config/config.go
@@ -1150,6 +1150,7 @@ func createTestViper() *viper.Viper {
 	v.SetDefault("log.level", "info")
 	v.SetDefault("assets_polling_disabled", false)
 	v.SetDefault("assets_polling_interval", 2*time.Minute)
+	v.SetDefault("contexts", map[string]interface{}{DefaultInstanceContext: map[string]interface{}{}})
 	applyDefaults(v)
 	return v
 }

--- a/pkg/config/config/config_test.go
+++ b/pkg/config/config/config_test.go
@@ -116,7 +116,6 @@ func TestConfigUnmarshal(t *testing.T) {
 	// Contexts
 	assert.EqualValues(t, map[string]interface{}{
 		"my-context": map[string]interface{}{
-			"manager_url":              "https://manager-url",
 			"onboarded_redirection":    "home/intro",
 			"default_redirection":      "home/",
 			"help_link":                "https://cozy.io/fr/support",
@@ -214,6 +213,12 @@ func TestConfigUnmarshal(t *testing.T) {
 			API: ClouderyAPI{
 				URL:   "https://some-url",
 				Token: "some-token",
+			},
+		},
+		"my-context": {
+			API: ClouderyAPI{
+				URL:   "https://manager-url",
+				Token: "manager-token",
 			},
 		},
 	}, cfg.Clouderies)

--- a/pkg/config/config/testdata/full_config.yaml
+++ b/pkg/config/config/testdata/full_config.yaml
@@ -109,6 +109,10 @@ clouderies:
     api:
       url: https://some-url
       token: some-token
+  my-context:
+    api:
+      url: https://manager-url
+      token: manager-token
 
 password_reset_interval: 1h
 
@@ -163,7 +167,6 @@ log:
 
 contexts:
   my-context:
-    manager_url: https://manager-url
     onboarded_redirection: home/intro
     default_redirection: home/
     help_link: https://cozy.io/fr/support

--- a/tests/testutils/test_utils.go
+++ b/tests/testutils/test_utils.go
@@ -3,6 +3,7 @@ package testutils
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -469,7 +470,14 @@ func compress(content string) []byte {
 	return buf.Bytes()
 }
 
-func WithManager(t *testing.T, inst *instance.Instance) (shouldRemoveUUID bool) {
+type ManagerConfig struct {
+	URL              string
+	WithPremiumLinks bool
+}
+
+func WithManager(t *testing.T, inst *instance.Instance, managerConfig ManagerConfig) (shouldRemoveUUID bool) {
+	require.NotEmpty(t, managerConfig.URL, "Could not enable test instance manager: cloudery API URL is required")
+
 	if inst.UUID == "" {
 		uuid, err := uuid.NewV7()
 		require.NoError(t, err, "Could not enable test instance manager")
@@ -477,18 +485,19 @@ func WithManager(t *testing.T, inst *instance.Instance) (shouldRemoveUUID bool) 
 		shouldRemoveUUID = true
 	}
 
-	config, ok := inst.SettingsContext()
-	require.True(t, ok, "Could not enable test instance manager: could not fetch test instance settings context")
+	cfg := config.GetConfig()
+	originalCfg, _ := json.Marshal(cfg)
 
-	managerURL, ok := config["manager_url"].(string)
-	require.True(t, ok, "Could not enable test instance manager: manager_url config is required")
-	require.NotEmpty(t, managerURL, "Could not enable test instance manager: manager_url config is required")
-
-	was := config["enable_premium_links"]
-	config["enable_premium_links"] = true
+	if cfg.Contexts == nil {
+		cfg.Contexts = map[string]interface{}{}
+	}
+	context, contextName := getContext(inst, cfg)
+	context["manager_url"] = managerConfig.URL
+	context["enable_premium_links"] = managerConfig.WithPremiumLinks
+	cfg.Contexts[contextName] = context
 
 	t.Cleanup(func() {
-		config["enable_premium_links"] = was
+		json.Unmarshal(originalCfg, cfg)
 
 		if shouldRemoveUUID {
 			inst.UUID = ""
@@ -500,6 +509,19 @@ func WithManager(t *testing.T, inst *instance.Instance) (shouldRemoveUUID bool) 
 	require.NoError(t, err, "Could not enable test instance manager")
 
 	return shouldRemoveUUID
+}
+
+// getContext returns the most relevant context config depending on the
+// instance context name or creates a new one if none exist.
+// It also returns the name of the context associated with the config.
+func getContext(inst *instance.Instance, cfg *config.Config) (map[string]interface{}, string) {
+	if context, ok := cfg.Contexts[inst.ContextName].(map[string]interface{}); ok {
+		return context, inst.ContextName
+	}
+	if context, ok := cfg.Contexts[config.DefaultInstanceContext].(map[string]interface{}); ok {
+		return context, config.DefaultInstanceContext
+	}
+	return map[string]interface{}{}, config.DefaultInstanceContext
 }
 
 func DisableManager(inst *instance.Instance, shouldRemoveUUID bool) error {

--- a/web/apps/apps_test.go
+++ b/web/apps/apps_test.go
@@ -66,7 +66,6 @@ func TestApps(t *testing.T) {
 		Host:   "localhost",
 		Path:   tempdir,
 	}
-	cfg.Contexts[config.DefaultInstanceContext] = map[string]interface{}{"manager_url": "http://manager.example.org"}
 	was := cfg.Subdomains
 	cfg.Subdomains = config.NestedSubdomains
 	defer func() { cfg.Subdomains = was }()
@@ -205,7 +204,7 @@ func TestApps(t *testing.T) {
 
 		// TOS not signed warning
 
-		testutils.WithManager(t, testInstance)
+		testutils.WithManager(t, testInstance, testutils.ManagerConfig{URL: "http://manager.example.org", WithPremiumLinks: true})
 
 		tosSigned := testInstance.TOSSigned
 		tosLatest := testInstance.TOSLatest

--- a/web/auth/confirm.go
+++ b/web/auth/confirm.go
@@ -149,12 +149,8 @@ func checkRedirectToAuthorized(c echo.Context) (*url.URL, error) {
 }
 
 func checkRedirectToManager(inst *instance.Instance, redirect *url.URL) bool {
-	config, ok := inst.SettingsContext()
-	if !ok {
-		return false
-	}
-	managerURL, ok := config["manager_url"].(string)
-	if !ok {
+	managerURL, err := inst.ManagerURL(instance.ManagerBaseURL)
+	if err != nil {
 		return false
 	}
 	manager, err := url.Parse(managerURL)

--- a/web/settings/settings_test.go
+++ b/web/settings/settings_test.go
@@ -74,7 +74,6 @@ func TestSettings(t *testing.T) {
 	conf := config.GetConfig()
 	conf.Assets = "../../assets"
 	conf.Contexts[config.DefaultInstanceContext] = map[string]interface{}{
-		"manager_url": "http://manager.example.org",
 		"logos": map[string]interface{}{
 			"home": map[string]interface{}{
 				"light": []interface{}{
@@ -111,6 +110,8 @@ func TestSettings(t *testing.T) {
 
 	t.Run("GetContext", func(t *testing.T) {
 		e := testutils.CreateTestClient(t, tsURL)
+
+		testutils.WithManager(t, testInstance, testutils.ManagerConfig{URL: "http://manager.example.org"})
 
 		obj := e.GET("/settings/context").
 			WithCookie(sessCookie, "connected").
@@ -1021,7 +1022,7 @@ func TestSettings(t *testing.T) {
 			Contains("/#/connectedDevices").
 			NotContains("http://manager.example.org")
 
-		testutils.WithManager(t, testInstance)
+		testutils.WithManager(t, testInstance, testutils.ManagerConfig{URL: "http://manager.example.org", WithPremiumLinks: true})
 
 		e.GET("/settings/clients/limit-exceeded").
 			WithCookie(sessCookie, "connected").


### PR DESCRIPTION
We used to store the manager url in the context config in the
`manager_url` attribute.
We're now storing it as part of the `clouderies` config so we can
remove the old attribute and its use.

However, some clients still make use of the old context attribute so
we're adding it back in the context API response for backwards
compatibility.