### PR TITLE
Fix redirectLink for sharings push notification

### DIFF
--- a/model/sharing/invitation.go
+++ b/model/sharing/invitation.go
@@ -360,14 +360,14 @@ func (s *Sharing) SendShortcutNotification(inst *instance.Instance, fileDoc *vfs
 	if sharerName == "" {
 		sharerName = inst.Translate("Sharing Empty name")
 	}
-	if err := s.SendShortcutPush(inst, fileDoc, previewURL, sharerName); err != nil {
+	if err := s.SendShortcutPush(inst, fileDoc, sharerName); err != nil {
 		inst.Logger().WithNamespace("sharing").
 			Warnf("Cannot send push notification: %s", err)
 	}
 	return s.SendShortcutMail(inst, fileDoc, previewURL, sharerName)
 }
 
-func (s *Sharing) SendShortcutPush(inst *instance.Instance, fileDoc *vfs.FileDoc, previewURL, sharerName string) error {
+func (s *Sharing) SendShortcutPush(inst *instance.Instance, fileDoc *vfs.FileDoc, sharerName string) error {
 	notifiables, err := oauth.GetNotifiables(inst)
 	if err != nil {
 		return err
@@ -390,7 +390,7 @@ func (s *Sharing) SendShortcutPush(inst *instance.Instance, fileDoc *vfs.FileDoc
 		Title:          title,
 		Message:        message,
 		Data: map[string]interface{}{
-			"redirectLink": previewURL,
+			"redirectLink": "drive/#/sharings",
 		},
 	}
 	msg, err := job.NewMessage(&push)

--- a/tests/system/nextcloud/before-starting/create-account.sh
+++ b/tests/system/nextcloud/before-starting/create-account.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-# echo -ne fred | md5sum
-export OC_PASS=570a90bfbf8c7eab5dc5d4e26832d5b1
+# echo -ne fred-password | md5sum
+export OC_PASS=796ecbcc9e42a074e22b2c9aa03b79c6
 php occ user:add --password-from-env --display-name="Fred" --group="users" fred

--- a/tests/system/tests/webdav_nextcloud.rb
+++ b/tests/system/tests/webdav_nextcloud.rb
@@ -22,7 +22,7 @@ describe "NextCloud" do
       host = container.host
       port = container.first_mapped_port
       user = "fred"
-      pass = "570a90bfbf8c7eab5dc5d4e26832d5b1"
+      pass = "796ecbcc9e42a074e22b2c9aa03b79c6"
 
       inst = Instance.create name: "Fred"
       auth = { login: user, password: pass, url: "http://#{host}:#{port}/" }


### PR DESCRIPTION
The flagship app doesn't support links to an external Cozy in a push notification currently. So, let's send the user to the list of their sharings for the moment.