### PR TITLE
Fix a panic with invalid sharing

### DIFF
--- a/web/instances/instances.go
+++ b/web/instances/instances.go
@@ -554,7 +554,7 @@ func unxorID(c echo.Context) error {
 		err := errors.New("it only works on a recipient's instance")
 		return jsonapi.BadRequest(err)
 	}
-	if len(s.Credentials) != 1 {
+	if len(s.Credentials) != 1 || len(s.Credentials[0].XorKey) == 0 {
 		err := errors.New("unexpected credentials")
 		return jsonapi.BadRequest(err)
 	}


### PR DESCRIPTION
When calling the admin route
/instances/:domain/sharings/:id/unxor/:doc-id for a sharing where the XorID is missing in the credential, we should return an error instead of a panic.