### PR TITLE
Update to Go 1.24

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.x'
+          go-version: '1.24.x'
       - name: Install
         run: |
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.x'
+          go-version: '1.24.x'
       - name: Install
         run: |
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.23.x"
+          go-version: "1.24.x"
       - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v5

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         include:
           # Recommended version
-          - go-version: '1.23.x'
+          - go-version: '1.24.x'
             couchdb-version: '3.3.3'
           # More exotic version
           - go-version: '1.21.x'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23.x"
+          go-version: "1.24.x"
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Build the binaries
@@ -71,7 +71,6 @@ jobs:
             "debian:10",
             "debian:11",
             "debian:12",
-            "ubuntu:20.04",
             "ubuntu:22.04",
             "ubuntu:24.04",
           ]

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.x'
+          go-version: '1.24.x'
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -35,7 +35,6 @@ linters:
     - govet
     - misspell
     - nolintlint
-    - tenv
     - unconvert
     - unused
     - whitespace

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ lint: scripts/golangci-lint
 .PHONY: lint
 
 scripts/golangci-lint: Makefile
-	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./scripts v1.63.1
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./scripts v1.64.5
 
 ## jslint: enforce a consistent code style for Js code
 jslint: scripts/node_modules

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -41,7 +41,7 @@ docker run -it --rm --name cozy-stack \
     --workdir /app \
     -v $(pwd):/app \
     -v $(pwd):/go/bin \
-    golang:1.23 \
+    golang:1.24 \
     go get -v github.com/cozy/cozy-stack
 ```
 

--- a/pkg/i18n/i18n.go
+++ b/pkg/i18n/i18n.go
@@ -51,7 +51,7 @@ func TranslatorHTML(locale, contextName string) func(key string, vars ...interfa
 // Translate translates the given key on the specified locale.
 func Translate(key, locale, contextName string, vars ...interface{}) string {
 	if po, ok := translations[contextName+"/"+locale]; ok {
-		translated := po.Get(key) //nolint:govet // key is given by the stack and is safe
+		translated := po.Get(key)
 		if translated != key && translated != "" {
 			if len(vars) > 0 {
 				return fmt.Sprintf(translated, vars...)
@@ -60,7 +60,7 @@ func Translate(key, locale, contextName string, vars ...interface{}) string {
 		}
 	}
 	if po, ok := translations[locale]; ok {
-		translated := po.Get(key) //nolint:govet // key is given by the stack and is safe
+		translated := po.Get(key)
 		if translated != key && translated != "" {
 			if len(vars) > 0 {
 				return fmt.Sprintf(translated, vars...)

--- a/scripts/packaging/installrequirements.sh
+++ b/scripts/packaging/installrequirements.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-GOVERSION="${GOVERSION:-1.23.0}"
+GOVERSION="${GOVERSION:-1.24.0}"
 
 cd "$(dirname $0)/../.."
 if [ -f debian/changelog ]; then


### PR DESCRIPTION
- Use go 1.24 for CI where 1.23 was used
- Update golangci-lint (and removes a deprecated linter, tenv)
- Remove packaging for Ubuntu 20.04 (no longer supported by GitHub Actions)