### PR TITLE
Create root directory before saving avatar

### DIFF
--- a/model/vfs/vfsafero/avatar.go
+++ b/model/vfs/vfsafero/avatar.go
@@ -35,6 +35,9 @@ func (u *avatarUpload) Close() error {
 }
 
 func (a *avatarFS) CreateAvatar(contentType string) (io.WriteCloser, error) {
+	if err := a.fs.MkdirAll("/", 0755); err != nil {
+		return nil, err
+	}
 	f, err := afero.TempFile(a.fs, "/", AvatarFilename)
 	if err != nil {
 		return nil, err

--- a/web/settings/settings_test.go
+++ b/web/settings/settings_test.go
@@ -1082,6 +1082,21 @@ func TestSettings(t *testing.T) {
 			Expect().Status(302).
 			Header("location").IsEqual(testInstance.DefaultRedirection().String())
 	})
+
+	t.Run("PutAvatar", func(t *testing.T) {
+		e := testutils.CreateTestClient(t, ts.URL)
+		sessCookie := session.CookieName(testInstance)
+
+		// Create a sample avatar image
+		avatarContent := "fake image content"
+
+		e.PUT("/settings/avatar").
+			WithCookie(sessCookie, "connected").
+			WithHeader("Authorization", "Bearer "+token).
+			WithHeader("Content-Type", "image/png").
+			WithBytes([]byte(avatarContent)).
+			Expect().Status(204)
+	})
 }
 
 func TestRegisterPassphraseForFlagshipApp(t *testing.T) {


### PR DESCRIPTION
Fix avatar creation when no thumbnails have been created before. The avatar is persisted in the same directory than thumbnails for Afero VFS, and this directory needs to be created.