### PR TITLE
feat: Allow creating share links with CLI tokens

### DIFF
--- a/model/permission/permissions.go
+++ b/model/permission/permissions.go
@@ -481,7 +481,7 @@ func updateAppSet(db prefixer.Prefixer, doc *Permission, typ, docType, slug stri
 }
 
 func checkSetPermissions(set Set, parent *Permission) error {
-	if parent.Type != TypeWebapp && parent.Type != TypeKonnector && parent.Type != TypeOauth {
+	if parent.Type != TypeWebapp && parent.Type != TypeKonnector && parent.Type != TypeOauth && parent.Type != TypeCLI {
 		return ErrOnlyAppCanCreateSubSet
 	}
 	if !set.IsSubSetOf(parent.Permissions) {


### PR DESCRIPTION
  We don't see any reason why share links could not be created with CLI
  tokens and this is necessary for the Twake Drive migration.

  We might want to allow updating share link permissions with CLI tokens
  as well but since it's not required for the moment we'll discuss it
  later.