### PR TITLE
Add RAG support for notes as markdown

### DIFF
--- a/pkg/consts/file.go
+++ b/pkg/consts/file.go
@@ -28,6 +28,10 @@ const (
 	ShortcutMimeType = "application/internet-shortcut"
 	// NoteMimeType is the mime-type for the .cozy-note files.
 	NoteMimeType = "text/vnd.cozy.note+markdown"
+	// NoteExtension is the extension for the .cozy-note files.
+	NoteExtension = ".cozy-note"
+	// MarkdownExtension is the extension for the markdown files.
+	MarkdownExtension = ".md"
 )
 
 const (


### PR DESCRIPTION
The new RAG relies on the file extension to infer the mime type. So, we rename the .cozy-note into .md so it can be correctly indexed.