### PR TITLE
Configure RAG indexing through flags for images and videos

### DIFF
--- a/model/rag/index.go
+++ b/model/rag/index.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/cozy/cozy-stack/model/feature"
 	"github.com/cozy/cozy-stack/model/instance"
 	"github.com/cozy/cozy-stack/model/job"
 	"github.com/cozy/cozy-stack/model/note"
@@ -73,6 +74,30 @@ func Index(inst *instance.Instance, logger logger.Logger, msg IndexMessage) erro
 func callRAGIndexer(inst *instance.Instance, doctype string, change couchdb.Change) error {
 	if strings.HasPrefix(change.DocID, "_design/") {
 		return nil
+	}
+	flags, err := feature.GetFlags(inst)
+	class, _ := change.Doc.Get("class").(string)
+
+	if class == consts.ImageClass {
+		// Index images only if flag allows it
+		allowImage, ok := flags.M["rag.index.image.enabled"].(bool)
+		if !ok || !allowImage {
+			return nil
+		}
+	}
+	if class == consts.VideoClass {
+		// Index videos only if flag allows it
+		allowVideo, ok := flags.M["rag.index.video.enabled"].(bool)
+		if !ok || !allowVideo {
+			return nil
+		}
+	}
+	if class == consts.AudioClass {
+		// Index audio only if flag allows it
+		allowAudio, ok := flags.M["rag.index.audio.enabled"].(bool)
+		if !ok || !allowAudio {
+			return nil
+		}
 	}
 	if change.Doc.Get("type") == consts.DirType {
 		return nil
@@ -158,6 +183,7 @@ func callRAGIndexer(inst *instance.Instance, doctype string, change couchdb.Chan
 		}
 		internalID, _ := change.Doc.Get("internal_vfs_id").(string)
 		var content io.Reader
+
 		if mime == consts.NoteMimeType {
 			metadata, _ := change.Doc.Get("metadata").(map[string]interface{})
 			schema, _ := metadata["schema"].(map[string]interface{})

--- a/pkg/consts/file.go
+++ b/pkg/consts/file.go
@@ -34,6 +34,12 @@ const (
 	DocsExtension = ".docs-note"
 	// MarkdownExtension is the extension for the markdown files.
 	MarkdownExtension = ".md"
+	// ImageClass is the class for the image files
+	ImageClass = "image"
+	// VideoClass is the class for the video files
+	VideoClass = "video"
+	// AudioClass is the class for the audio files
+	AudioClass = "audio"
 )
 
 const (


### PR DESCRIPTION
The RAG is able to index both images and videos, which is nice, but this can be a costful treatment.
Therefore, we prefer to make it configurable through flags.