### PR TITLE
Add an old domain field to Cozy instances

### DIFF
--- a/client/instances.go
+++ b/client/instances.go
@@ -30,6 +30,7 @@ type Instance struct {
 	Attrs struct {
 		Domain               string    `json:"domain"`
 		DomainAliases        []string  `json:"domain_aliases,omitempty"`
+		OldDomain            string    `json:"old_domain,omitempty"`
 		Prefix               string    `json:"prefix,omitempty"`
 		Locale               string    `json:"locale"`
 		UUID                 string    `json:"uuid,omitempty"`
@@ -59,6 +60,7 @@ type Instance struct {
 type InstanceOptions struct {
 	Domain             string
 	DomainAliases      []string
+	OldDomain          string
 	Locale             string
 	UUID               string
 	OIDCID             string
@@ -148,6 +150,7 @@ func (ac *AdminClient) CreateInstance(opts *InstanceOptions) (*Instance, error) 
 	}
 	q := url.Values{
 		"Domain":          {opts.Domain},
+		"OldDomain":       {opts.OldDomain},
 		"Locale":          {opts.Locale},
 		"UUID":            {opts.UUID},
 		"OIDCID":          {opts.OIDCID},
@@ -229,6 +232,7 @@ func (ac *AdminClient) ModifyInstance(opts *InstanceOptions) (*Instance, error) 
 		return nil, fmt.Errorf("Invalid domain: %s", domain)
 	}
 	q := url.Values{
+		"OldDomain":       {opts.OldDomain},
 		"Locale":          {opts.Locale},
 		"UUID":            {opts.UUID},
 		"OIDCID":          {opts.OIDCID},

--- a/cmd/instances.go
+++ b/cmd/instances.go
@@ -26,6 +26,7 @@ import (
 )
 
 var flagDomainAliases []string
+var flagOldDomain string
 var flagListFields []string
 var flagLocale string
 var flagTimezone string
@@ -183,6 +184,7 @@ be used as the error message.
 		in, err := ac.CreateInstance(&client.InstanceOptions{
 			Domain:          domain,
 			DomainAliases:   flagDomainAliases,
+			OldDomain:       flagOldDomain,
 			Locale:          flagLocale,
 			UUID:            flagUUID,
 			OIDCID:          flagOIDCID,
@@ -272,6 +274,7 @@ settings for a specified domain.
 		opts := &client.InstanceOptions{
 			Domain:          domain,
 			DomainAliases:   flagDomainAliases,
+			OldDomain:       flagOldDomain,
 			Locale:          flagLocale,
 			UUID:            flagUUID,
 			OIDCID:          flagOIDCID,
@@ -1083,6 +1086,7 @@ func init() {
 	instanceCmdGroup.AddCommand(setAuthModeCmd)
 	instanceCmdGroup.AddCommand(cleanSessionsCmd)
 	addInstanceCmd.Flags().StringSliceVar(&flagDomainAliases, "domain-aliases", nil, "Specify one or more aliases domain for the instance (separated by ',')")
+	addInstanceCmd.Flags().StringVar(&flagOldDomain, "old-domain", "", "Old domain of the cozy instance")
 	addInstanceCmd.Flags().StringVar(&flagLocale, "locale", consts.DefaultLocale, "Locale of the new cozy instance")
 	addInstanceCmd.Flags().StringVar(&flagUUID, "uuid", "", "The UUID of the instance")
 	addInstanceCmd.Flags().StringVar(&flagOIDCID, "oidc_id", "", "The identifier for checking authentication from OIDC")
@@ -1104,6 +1108,7 @@ func init() {
 	addInstanceCmd.Flags().BoolVar(&flagTrace, "trace", false, "Show where time is spent")
 	addInstanceCmd.Flags().StringVar(&flagPassphrase, "passphrase", "", "Register the instance with this passphrase (useful for tests)")
 	modifyInstanceCmd.Flags().StringSliceVar(&flagDomainAliases, "domain-aliases", nil, "Specify one or more aliases domain for the instance (separated by ',')")
+	modifyInstanceCmd.Flags().StringVar(&flagOldDomain, "old-domain", "", "Old domain of the cozy instance")
 	modifyInstanceCmd.Flags().StringVar(&flagLocale, "locale", "", "New locale")
 	modifyInstanceCmd.Flags().StringVar(&flagUUID, "uuid", "", "New UUID")
 	modifyInstanceCmd.Flags().StringVar(&flagOIDCID, "oidc_id", "", "New identifier for checking authentication from OIDC")

--- a/docs/cli/cozy-stack_instances_add.md
+++ b/docs/cli/cozy-stack_instances_add.md
@@ -38,6 +38,7 @@ $ cozy-stack instances add --passphrase cozy --apps drive,photos,settings,home,s
       --locale string             Locale of the new cozy instance (default "en")
       --magic_link                Enable authentication with magic links sent by email
       --oidc_id string            The identifier for checking authentication from OIDC
+      --old-domain string         Old domain of the cozy instance
       --passphrase string         Register the instance with this passphrase (useful for tests)
       --phone string              The phone number of the owner
       --public-name string        The public name of the owner

--- a/docs/cli/cozy-stack_instances_modify.md
+++ b/docs/cli/cozy-stack_instances_modify.md
@@ -28,6 +28,7 @@ cozy-stack instances modify <domain> [flags]
       --locale string               New locale
       --magic_link                  Enable authentication with magic links sent by email
       --oidc_id string              New identifier for checking authentication from OIDC
+      --old-domain string           Old domain of the cozy instance
       --onboarding-finished         Force the finishing of the onboarding
       --phone string                New phone number
       --public-name string          New public name

--- a/model/instance/lifecycle/create.go
+++ b/model/instance/lifecycle/create.go
@@ -28,6 +28,7 @@ import (
 type Options struct {
 	Domain             string
 	DomainAliases      []string
+	OldDomain          string
 	Locale             string
 	UUID               string
 	OIDCID             string
@@ -115,6 +116,7 @@ func Create(opts *Options) (*instance.Instance, error) {
 	if err != nil {
 		return nil, err
 	}
+	i.OldDomain = opts.OldDomain
 	i.Prefix = "cozy" + hex.EncodeToString(prefix[:16])
 	i.Locale = locale
 	i.UUID = opts.UUID

--- a/model/instance/lifecycle/patch.go
+++ b/model/instance/lifecycle/patch.go
@@ -68,6 +68,11 @@ func Patch(i *instance.Instance, opts *Options) error {
 			needUpdate = true
 		}
 
+		if opts.OldDomain != "" && opts.OldDomain != i.OldDomain {
+			i.OldDomain = opts.OldDomain
+			needUpdate = true
+		}
+
 		if opts.UUID != "" && opts.UUID != i.UUID {
 			i.UUID = opts.UUID
 			needUpdate = true

--- a/pkg/couchdb/index.go
+++ b/pkg/couchdb/index.go
@@ -318,6 +318,7 @@ func IndexesByDoctype(doctype string) []*mango.Index {
 var globalIndexes = []*mango.Index{
 	mango.MakeIndex(consts.Exports, "by-domain", mango.IndexDef{Fields: []string{"domain", "created_at"}}),
 	mango.MakeIndex(consts.Instances, "by-oidcid", mango.IndexDef{Fields: []string{"oidc_id"}}),
+	mango.MakeIndex(consts.Instances, "by-olddomain", mango.IndexDef{Fields: []string{"old_domain"}}),
 }
 
 // secretIndexes is the index list required on the secret databases to run

--- a/web/instances/instances.go
+++ b/web/instances/instances.go
@@ -56,6 +56,7 @@ func createHandler(c echo.Context) error {
 	var err error
 	opts := &lifecycle.Options{
 		Domain:          c.QueryParam("Domain"),
+		OldDomain:       c.QueryParam("OldDomain"),
 		Locale:          c.QueryParam("Locale"),
 		UUID:            c.QueryParam("UUID"),
 		OIDCID:          c.QueryParam("OIDCID"),
@@ -164,6 +165,7 @@ func modifyHandler(c echo.Context) error {
 	domain := c.Param("domain")
 	opts := &lifecycle.Options{
 		Domain:          domain,
+		OldDomain:       c.QueryParam("OldDomain"),
 		Locale:          c.QueryParam("Locale"),
 		UUID:            c.QueryParam("UUID"),
 		OIDCID:          c.QueryParam("OIDCID"),


### PR DESCRIPTION
For the migration from Cozy to Twake Workplace, we need a way to redirect from the old domains to the new ones. So, an old domain field was added to the Cozy instances, and the stack will do the redirections from the old domains to the new ones. It works for the API endpoint, but also for the apps pages (eg old.mycozy.cloud -> new.twake.app).

The old domain of a Cozy instance can be set with the `cozy-stack instances modify` command, or directly by modifying the `old_domain` field of the CouchDB document of the instance in the global database.