### PR TITLE
🐛 fix(common-settings update): return after creating the common-settings

### DIFF
--- a/model/settings/common/common.go
+++ b/model/settings/common/common.go
@@ -94,8 +94,11 @@ func UpdateCommonSettings(inst *instance.Instance, settings *couchdb.JSONDoc) (b
 	if cfg == nil {
 		return false, nil
 	}
+
 	if inst.CommonSettingsVersion == 0 {
 		CreateCommonSettings(inst, settings)
+
+		return true, nil
 	}
 	inst.CommonSettingsVersion++
 	request := buildRequest(inst, settings)


### PR DESCRIPTION
after creating the common settings we should not continue to perform the update query