### PR TITLE
fix: We need to check PassPhrase

### DIFF
--- a/docs/delegated-auth.md
+++ b/docs/delegated-auth.md
@@ -213,6 +213,7 @@ Content-Type: application/x-www-form-urlencoded
 
 ```
 code=xxx&
+password=myHashedPassword&
 client_id=mobile&
 deviceType=0&
 deviceIdentifier=aac2e34a-44db-42ab-a733-5322dd582c3d&

--- a/web/oidc/oidc.go
+++ b/web/oidc/oidc.go
@@ -135,7 +135,7 @@ func BitwardenExchange(c echo.Context) error {
 			"error": "invalid code",
 		})
 	}
-    if err := instance.CheckPassphrase(inst, []byte(pass)); err != nil {
+	if err := instance.CheckPassphrase(inst, []byte(pass)); err != nil {
 		return c.JSON(http.StatusUnauthorized, echo.Map{
 			"error": "invalid password",
 		})

--- a/web/oidc/oidc.go
+++ b/web/oidc/oidc.go
@@ -116,6 +116,7 @@ func BitwardenExchange(c echo.Context) error {
 	inst := middlewares.GetInstance(c)
 
 	code := c.FormValue("code")
+	pass := c.FormValue("password")
 	if code == "" {
 		return c.JSON(http.StatusBadRequest, echo.Map{
 			"error": "code parameter is required",
@@ -132,6 +133,11 @@ func BitwardenExchange(c echo.Context) error {
 			sub, inst.OIDCID, inst.Domain)
 		return c.JSON(http.StatusBadRequest, echo.Map{
 			"error": "invalid code",
+		})
+	}
+    if err := instance.CheckPassphrase(inst, []byte(pass)); err != nil {
+		return c.JSON(http.StatusUnauthorized, echo.Map{
+			"error": "invalid password",
 		})
 	}
 


### PR DESCRIPTION
In order to have the same behavior as the previous route `/connect/token` we need to check that the passphrase is OK.