### PR TITLE
test: Add small timeout to test Redis config

### DIFF
--- a/pkg/config/config/testdata/full_config.yaml
+++ b/pkg/config/config/testdata/full_config.yaml
@@ -30,6 +30,7 @@ couchdb:
 
 redis:
   addrs: url-1:12 url2:23 url3:34
+  dial_timeout: 10ms
   master: some-name
   password: some-password
   databases:


### PR DESCRIPTION
  If Redis is not running on the machine the config tests are executed
  on, then each call to `config.Setup()` with the `full_config.yaml`
  files takes more than 40s.

  This time seems to be spent trying to subscribe to to Redis channels
  when setting up the Redis debbuger since the Redis client seems to
  have a super high default dial timeout.

  Setting a very small one the `full_config.yaml` prevents this issue.