### PR TITLE
feat: Use separate RabbitMQ Managers per contexts

### DIFF
--- a/pkg/config/config/config.go
+++ b/pkg/config/config/config.go
@@ -160,12 +160,18 @@ type Config struct {
 	AssetsPollingInterval time.Duration
 }
 
-// RabbitMQ contains configuration for the RabbitMQ consumer.
+// RabbitMQ contains configuration for the RabbitMQ consumers.
 type RabbitMQ struct {
-	Enabled   bool             `mapstructure:"enabled" yaml:"enabled"`
-	URL       string           `mapstructure:"url" yaml:"url"`
-	Exchanges []RabbitExchange `mapstructure:"exchanges" yaml:"exchanges"`
-	TLS       RabbitMQTLS      `mapstructure:"tls" yaml:"tls"`
+	Enabled   bool                    `mapstructure:"enabled" yaml:"enabled"`
+	Nodes     map[string]RabbitMQNode `mapstructure:"nodes" yaml:"nodes"`
+	Exchanges []RabbitExchange        `mapstructure:"exchanges" yaml:"exchanges"`
+}
+
+// RabbitMQNode defines the configuration for the connection with a RabbitMQ node.
+type RabbitMQNode struct {
+	Enabled bool        `mapstructure:"enabled" yaml:"enabled"`
+	URL     string      `mapstructure:"url" yaml:"url"`
+	TLS     RabbitMQTLS `mapstructure:"tls" yaml:"tls"`
 }
 
 // RabbitMQTLS defines TLS settings for the RabbitMQ connection.
@@ -967,12 +973,6 @@ func UseViper(v *viper.Viper) error {
 
 		AssetsPollingDisabled: v.GetBool("assets_polling_disabled"),
 		AssetsPollingInterval: v.GetDuration("assets_polling_interval"),
-
-		RabbitMQ: func() RabbitMQ {
-			var rabbitmq RabbitMQ
-			v.UnmarshalKey("rabbitmq", &rabbitmq)
-			return rabbitmq
-		}(),
 	}
 
 	err = v.UnmarshalKey("deprecated_apps", &config.DeprecatedApps)
@@ -983,6 +983,11 @@ func UseViper(v *viper.Viper) error {
 	err = v.UnmarshalKey("clouderies", &config.Clouderies)
 	if err != nil {
 		return fmt.Errorf(`failed to parse the config for "clouderies": %w`, err)
+	}
+
+	err = v.UnmarshalKey("rabbitmq", &config.RabbitMQ)
+	if err != nil {
+		return fmt.Errorf(`failed to parse the config for "rabbitmq": %w`, err)
 	}
 
 	// For compatibility

--- a/pkg/config/config/config_test.go
+++ b/pkg/config/config/config_test.go
@@ -345,7 +345,10 @@ func TestRabbitMQConfig(t *testing.T) {
 	yamlContent := `
 rabbitmq:
   enabled: true
-  url: "amqp://test:test@localhost:5672/"
+  nodes:
+    default:
+      enabled: true
+      url: "amqp://test:test@localhost:5672/"
   exchanges:
     - name: "user-password-updates"
       kind: "topic"
@@ -385,7 +388,11 @@ rabbitmq:
 	rabbitmq := cfg.RabbitMQ
 
 	assert.True(t, rabbitmq.Enabled)
-	assert.Equal(t, "amqp://test:test@localhost:5672/", rabbitmq.URL)
+	assert.Len(t, rabbitmq.Nodes, 1, "Should have exactly 1 node")
+	node := rabbitmq.Nodes["default"]
+	assert.NotNil(t, node, "Should have default node config")
+	assert.True(t, node.Enabled)
+	assert.Equal(t, "amqp://test:test@localhost:5672/", node.URL)
 
 	require.Len(t, rabbitmq.Exchanges, 2, "Should have exactly 2 exchanges")
 

--- a/pkg/config/config/testdata/full_config.yaml
+++ b/pkg/config/config/testdata/full_config.yaml
@@ -117,11 +117,13 @@ clouderies:
 
 rabbitmq:
   enabled: true
-  url: amqp://guest:guest@localhost:5672/
-  tls:
-    root_ca: /etc/ssl/certs/ca.pem
-    insecure_skip_validation: false
-    server_name: rabbit.internal
+  nodes:
+    default:
+      url: amqp://guest:guest@localhost:5672/
+      tls:
+        root_ca: /etc/ssl/certs/ca.pem
+        insecure_skip_validation: false
+        server_name: rabbit.internal
   exchanges:
     - name: auth
       kind: topic

--- a/pkg/rabbitmq/init.go
+++ b/pkg/rabbitmq/init.go
@@ -1,0 +1,25 @@
+package rabbitmq
+
+import (
+	"github.com/cozy/cozy-stack/pkg/config/config"
+	"github.com/cozy/cozy-stack/pkg/logger"
+)
+
+var log = logger.WithNamespace("rabbitmq")
+
+// Service handles all the interactions with RabbitMQ
+//
+// Several implementations exist:
+// - [RabbitMQService] interacts with the RabbitMQ nodes
+// - [NoopService] when no config is setup
+type Service interface {
+	StartManagers() ([]*RabbitMQManager, error)
+}
+
+func Init(cfg config.RabbitMQ) (Service, error) {
+	if !cfg.Enabled || cfg.Nodes == nil {
+		return new(NoopService), nil
+	}
+
+	return NewService(cfg)
+}

--- a/pkg/rabbitmq/service.go
+++ b/pkg/rabbitmq/service.go
@@ -1,0 +1,61 @@
+package rabbitmq
+
+import (
+	"context"
+
+	"github.com/cozy/cozy-stack/pkg/config/config"
+)
+
+type RabbitMQService struct {
+	Managers map[string]*RabbitMQManager
+}
+
+func NewService(cfg config.RabbitMQ) (*RabbitMQService, error) {
+	managers := map[string]*RabbitMQManager{}
+	for context, node := range cfg.Nodes {
+		if !node.Enabled {
+			log.Infof("No RabbitMQ manager for context %s", context)
+			continue
+		}
+
+		manager, err := buildManager(node, cfg.Exchanges)
+		if err != nil {
+			log.Errorf("Error while building RabbitMQ manager: %v", err)
+			return nil, err
+		}
+
+		managers[context] = manager
+	}
+
+	return &RabbitMQService{managers}, nil
+}
+
+func buildManager(node config.RabbitMQNode, exchangesCfg []config.RabbitExchange) (*RabbitMQManager, error) {
+	connection, err := BuildConnection(node)
+	if err != nil {
+		return nil, err
+	}
+
+	exchanges := BuildExchangeSpecs(exchangesCfg)
+
+	return NewRabbitMQManager(connection, exchanges), nil
+}
+
+// StartManagers runs the managers in background and returns Shutdowners
+func (s *RabbitMQService) StartManagers() (managers []*RabbitMQManager, err error) {
+	log.Info("Starting RabbitMQ managers")
+
+	for c, m := range s.Managers {
+		log.Infof("Starting RabbitMQ manager for context %s", c)
+
+		started, err := m.Start(context.Background())
+		if err == nil {
+			managers = append(managers, started)
+		} else {
+			log.Errorf("Failed to start RabbitMQ manager for context %s: %v", c, err)
+			break
+		}
+	}
+
+	return
+}

--- a/pkg/rabbitmq/service_noop.go
+++ b/pkg/rabbitmq/service_noop.go
@@ -1,0 +1,12 @@
+package rabbitmq
+
+// NoopService implements [Service].
+//
+// This implem does nothing. It is used when no config is provided.
+type NoopService struct{}
+
+// StartManagers does nothing.
+func (s *NoopService) StartManagers() ([]*RabbitMQManager, error) {
+	log.Warnf("No RabbitMQ managers to start")
+	return nil, nil
+}

--- a/pkg/rabbitmq/service_test.go
+++ b/pkg/rabbitmq/service_test.go
@@ -1,0 +1,147 @@
+package rabbitmq_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cozy/cozy-stack/model/instance/lifecycle"
+	"github.com/cozy/cozy-stack/pkg/config/config"
+	"github.com/cozy/cozy-stack/pkg/rabbitmq"
+	"github.com/cozy/cozy-stack/tests/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServiceImplem(t *testing.T) {
+	assert.Implements(t, (*rabbitmq.Service)(nil), new(rabbitmq.RabbitMQService))
+}
+
+func TestRabbitMQService(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test skipped with --short")
+	}
+
+	config.UseTestFile(t)
+	testutils.NeedCouchdb(t)
+	setup := testutils.NewSetup(t, "RabbitMQService")
+	inst := setup.GetTestInstance()
+
+	defaultNode := testutils.StartRabbitMQ(t, true, false)
+	twakeNode := testutils.StartRabbitMQ(t, true, false)
+
+	cfg := config.RabbitMQ{
+		Enabled: true,
+		Nodes: map[string]config.RabbitMQNode{
+			"default": {
+				Enabled: true,
+				URL:     defaultNode.AMQPURL,
+			},
+			"linagora_default": {
+				Enabled: false,
+				URL:     "amqp://linagora:password@localhost",
+			},
+			"twake_default": {
+				Enabled: true,
+				URL:     twakeNode.AMQPURL,
+			},
+		},
+		Exchanges: []config.RabbitExchange{
+			{
+				Name:            "auth",
+				Kind:            "topic",
+				Durable:         false,
+				DeclareExchange: true,
+				Queues: []config.RabbitQueue{
+					{
+						Name:     "stack.user.password.updated",
+						Bindings: []string{"user.password.updated"},
+						Declare:  true,
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("NewServiceBuildsManagerForEachNode", func(t *testing.T) {
+		t.Parallel()
+
+		svc, err := rabbitmq.NewService(cfg)
+		require.NoError(t, err)
+
+		require.Len(t, svc.Managers, 2)
+		assert.NotNil(t, svc.Managers["default"])
+		assert.NotNil(t, svc.Managers["twake_default"])
+	})
+
+	t.Run("StartManagersStartsEachManager", func(t *testing.T) {
+		t.Parallel()
+
+		svc, err := rabbitmq.NewService(cfg)
+		require.NoError(t, err)
+
+		managers, err := svc.StartManagers()
+		require.NoError(t, err)
+		require.Len(t, managers, 2)
+
+		err = managers[0].WaitReady(context.Background())
+		assert.Nil(t, err, "RabbitMQ manager for context default failed to start")
+
+		err = managers[1].WaitReady(context.Background())
+		assert.Nil(t, err, "RabbitMQ manager for context twake_default failed to start")
+	})
+
+	t.Run("RabbitMQManagersReceiveMessages", func(t *testing.T) {
+		// TODO: find a way to make sure each message is handled only by the
+		// appropriate manager.
+		t.Parallel()
+
+		svc, err := rabbitmq.NewService(cfg)
+		require.NoError(t, err)
+
+		_, err = svc.StartManagers()
+		require.NoError(t, err)
+
+		slug, domain := inst.SlugAndDomain()
+
+		// 1. Update instance password via default RabbitMQ node
+		defaultSender := newTestMessageSender(t, defaultNode.AMQPURL, "auth", "user.password.updated")
+		hashText, hashB64 := hashPassphrase(t)
+		msg := rabbitmq.PasswordChangeMessage{
+			TwakeID:       slug,
+			Iterations:    100000,
+			Hash:          hashB64,
+			PublicKey:     "PUB",
+			Key:           "KEY",
+			Timestamp:     time.Now().Unix(),
+			WorkplaceFqdn: slug + "." + domain,
+		}
+		defaultSender.publish(msg)
+
+		// Wait until the instance hash is updated
+		testutils.WaitForOrFail(t, 10*time.Second, func() bool {
+			updated, err := lifecycle.GetInstance(inst.Domain)
+			return err == nil && string(updated.PassphraseHash) == hashText
+		})
+
+		// 2. Update instance password via twake RabbitMQ node
+		twakeSender := newTestMessageSender(t, twakeNode.AMQPURL, "auth", "user.password.updated")
+		hashText, hashB64 = hashPassphrase(t)
+		msg = rabbitmq.PasswordChangeMessage{
+			TwakeID:       slug,
+			Iterations:    100000,
+			Hash:          hashB64,
+			PublicKey:     "PUB",
+			Key:           "KEY",
+			Timestamp:     time.Now().Unix(),
+			WorkplaceFqdn: slug + "." + domain,
+		}
+		twakeSender.publish(msg)
+
+		// Wait until the instance hash is updated
+		testutils.WaitForOrFail(t, 10*time.Second, func() bool {
+			updated, err := lifecycle.GetInstance(inst.Domain)
+			return err == nil && string(updated.PassphraseHash) == hashText
+		})
+	})
+}

--- a/tests/testutils/rabbitmq_utils.go
+++ b/tests/testutils/rabbitmq_utils.go
@@ -2,9 +2,7 @@ package testutils
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"github.com/cozy/cozy-stack/pkg/rabbitmq"
 	"net"
 	"os/exec"
 	"path/filepath"
@@ -15,7 +13,6 @@ import (
 	"time"
 
 	"github.com/docker/go-connections/nat"
-	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/stretchr/testify/require"
 
 	c "github.com/docker/docker/api/types/container"
@@ -127,30 +124,6 @@ func StartRabbitMQ(t *testing.T, withVolume bool, enableTLS bool) *RabbitFixture
 	})
 
 	return fixture
-}
-
-func (f *RabbitFixture) Publish() {
-	conn, err := amqp.Dial(f.AMQPURL)
-	require.NoError(f.t, err)
-	ch, err := conn.Channel()
-	require.NoError(f.t, err)
-	f.t.Cleanup(func() { _ = ch.Close(); _ = conn.Close() })
-
-	// Compose message
-	testHash := "testhash123"
-	domain := "test.example.com"
-	msg := rabbitmq.PasswordChangeMessage{
-		TwakeID:    "user-123",
-		Iterations: 100000,
-		Hash:       testHash,
-		PublicKey:  "PUB",
-		PrivateKey: "PRIV",
-		Key:        "KEY",
-		Timestamp:  time.Now().Unix(),
-		Domain:     domain,
-	}
-	_, err = json.Marshal(msg)
-	require.NoError(f.t, err)
 }
 
 func (f *RabbitFixture) Restart(ctx context.Context, timeout time.Duration) {


### PR DESCRIPTION
  We want to be able to isolate RabbitMQ messages per contexts to
  prevent conflicts and provide different QoS levels.

  Each context can be associated with a specific RabbitMQ node via its
  URL and be disabled separately.
  If a `default` context configuration is defined, messages meant for a
  context without configuration will be sent using this `default` node.

  Exchanges and queues definitions are shared across all contexts
  though.