### PR TITLE
fix: not being able to copy notes when io.cozy.notes.images db does not exist

### DIFF
--- a/model/note/image.go
+++ b/model/note/image.go
@@ -238,6 +238,10 @@ func getImages(db prefixer.Prefixer, fileID string) ([]*Image, error) {
 		EndKey:   endkey(fileID),
 	}
 	if err := couchdb.GetAllDocs(db, consts.NotesImages, &req, &images); err != nil {
+		if couchdb.IsNoDatabaseError(err) {
+			return images, nil
+		}
+
 		return nil, err
 	}
 	return images, nil


### PR DESCRIPTION
### issue
When attempting to copy a note file, the stack checks for images in the note by checking `io.cozy.notes.images` db.

This `io.cozy.notes.images` is created when you insert an image in a note for the first time, which means when this database does not exist, and you attempt to copy a note, the error "Database does not exist." will be thrown.

### what's changed

ensure we don't block the copy operation in the case of a "Database does not exist." 