### PR TITLE
feat: Configuration for sharing inside context configuration

### DIFF
--- a/cozy.example.yaml
+++ b/cozy.example.yaml
@@ -530,6 +530,25 @@ contexts:
           - src: /logos/1_partner.png
             alt: Partner n°1
             type: secondary
+    # Sharing configuration for cozy-to-cozy sharing trust rules
+    sharing:
+      # Auto-accept sharing invitations from trusted domains or contacts(default: false)
+      auto_accept_trusted: true
+      # Auto-accept sharing invitations from trusted contacts (default: false)
+      auto_accept_trusted_contacts: true
+      # List of trusted domains for automatic sharing acceptance
+      trusted_domains:
+        - example.com
+        - mycompany.twake.app
+
+  # Default context - used as fallback when instance context is not specified
+  # or when a context doesn't have sharing configuration
+  default:
+    sharing:
+      # Conservative defaults for production
+      auto_accept_trusted: false
+      auto_accept_trusted_contacts: false
+      trusted_domains: []
 
 rabbitmq:
   enabled: true

--- a/model/sharing/oauth.go
+++ b/model/sharing/oauth.go
@@ -473,9 +473,9 @@ func (s *Sharing) SendAnswer(inst *instance.Instance, state string) error {
 	s.Active = true
 	s.Initial = s.NbFiles > 0
 
-	options := config.GetConfig().Sharing.OptionsForContext(inst.ContextName)
+	options := config.GetSharingConfig(inst.ContextName)
 	// Mark the sender's contact as trusted since we accepted their sharing
-	if *options.AutoAcceptTrustedContacts && len(s.Members) > 0 && s.Members[0].Email != "" {
+	if options.AutoAcceptTrustedContacts && len(s.Members) > 0 && s.Members[0].Email != "" {
 		c, err := contact.FindByEmail(inst, s.Members[0].Email)
 		if err != nil {
 			// Contact doesn't exist, create it using the standardized method

--- a/model/sharing/trust.go
+++ b/model/sharing/trust.go
@@ -19,9 +19,9 @@ func IsTrustedMember(inst *instance.Instance, member *Member) bool {
 	if inst == nil || member == nil {
 		return false
 	}
-	options := config.GetConfig().Sharing.OptionsForContext(inst.ContextName)
+	options := config.GetSharingConfig(inst.ContextName)
 
-	if options.AutoAcceptTrusted == nil || !*options.AutoAcceptTrusted {
+	if !options.AutoAcceptTrusted {
 		return false
 	}
 
@@ -48,7 +48,7 @@ func IsTrustedMember(inst *instance.Instance, member *Member) bool {
 	}
 
 	// Check if this member is a trusted contact
-	if options.AutoAcceptTrustedContacts == nil || !*options.AutoAcceptTrustedContacts {
+	if !options.AutoAcceptTrustedContacts {
 		return false
 	}
 	if isTrustedContact(inst, member) {

--- a/pkg/config/config/config_test.go
+++ b/pkg/config/config/config_test.go
@@ -125,16 +125,18 @@ func TestConfigUnmarshal(t *testing.T) {
 		},
 	}, cfg.CommonSettings)
 
-	falseVal := false
-	assert.EqualValues(t, SharingConfig{
-		AutoAcceptTrusted: true,
-		Contexts: map[string]SharingContext{
-			"my-context": {
-				AutoAcceptTrusted: &falseVal,
-				TrustedDomains:    []string{"context.example"},
-			},
-		},
-	}, cfg.Sharing)
+	// Test GetSharingConfig for my-context
+	myContextSharing := GetSharingConfig("my-context")
+	assert.Equal(t, true, myContextSharing.AutoAcceptTrusted)
+	assert.Equal(t, []string{"linagora.com"}, myContextSharing.TrustedDomains)
+
+	// Test GetSharingConfig for default context
+	defaultSharing := GetSharingConfig("default")
+	assert.Equal(t, true, defaultSharing.AutoAcceptTrusted)
+
+	// Test GetSharingConfig for non-existent context falls back to default
+	fallbackSharing := GetSharingConfig("non-existent")
+	assert.Equal(t, true, fallbackSharing.AutoAcceptTrusted)
 
 	// Contexts
 	assert.EqualValues(t, map[string]interface{}{
@@ -149,6 +151,10 @@ func TestConfigUnmarshal(t *testing.T) {
 				map[string]interface{}{"hide_konnector_errors": true},
 				map[string]interface{}{"home.konnectors.hide-errors": true},
 				map[string]interface{}{"home_hidden_apps": []interface{}{"foobar"}},
+			},
+			"sharing": map[string]interface{}{
+				"auto_accept_trusted": true,
+				"trusted_domains":     []interface{}{"linagora.com"},
 			},
 			"logos": map[string]interface{}{
 				"coachco2": map[string]interface{}{
@@ -191,6 +197,11 @@ func TestConfigUnmarshal(t *testing.T) {
 						},
 					},
 				},
+			},
+		},
+		"default": map[string]interface{}{
+			"sharing": map[string]interface{}{
+				"auto_accept_trusted": true,
 			},
 		},
 	}, cfg.Contexts)

--- a/pkg/config/config/testdata/full_config.yaml
+++ b/pkg/config/config/testdata/full_config.yaml
@@ -93,14 +93,6 @@ move:
 konnectors:
   cmd: some-cmd
 
-sharing:
-  auto_accept_trusted: true
-  contexts:
-    my-context:
-      auto_accept_trusted: false
-      trusted_domains:
-        - context.example
-
 registries:
   default: []
   example:
@@ -255,3 +247,11 @@ contexts:
           - src: /logos/1_partner.png
             alt: Partner n°1
             type: secondary
+    sharing:
+      auto_accept_trusted: true
+      trusted_domains:
+        - linagora.com
+
+  default:
+    sharing:
+      auto_accept_trusted: true

--- a/web/sharings/drives_test.go
+++ b/web/sharings/drives_test.go
@@ -391,11 +391,13 @@ func TestSharedDrives(t *testing.T) {
 	build.BuildMode = build.ModeDev
 	cfg := config.GetConfig()
 	cfg.Assets = "../../assets"
-	cfg.Sharing.Contexts = map[string]config.SharingContext{
-		config.DefaultInstanceContext: {
-			AutoAcceptTrustedContacts: func() *bool { b := true; return &b }(),
-			AutoAcceptTrusted:         func() *bool { b := true; return &b }(),
-			TrustedDomains:            []string{"cozy.local", "example.com"},
+	cfg.Contexts = map[string]interface{}{
+		config.DefaultInstanceContext: map[string]interface{}{
+			"sharing": map[string]interface{}{
+				"auto_accept_trusted_contacts": true,
+				"auto_accept_trusted":          true,
+				"trusted_domains":              []interface{}{"cozy.local", "example.com"},
+			},
 		},
 	}
 	_ = web.LoadSupportedLocales()
@@ -1811,15 +1813,17 @@ func TestDriveAutoAcceptTrusted(t *testing.T) {
 
 	// Configure auto-accept for trusted domains
 	cfg := config.GetConfig()
-	prevContexts := cfg.Sharing.Contexts
-	cfg.Sharing.Contexts = map[string]config.SharingContext{
-		config.DefaultInstanceContext: {
-			AutoAcceptTrusted: func() *bool { b := true; return &b }(),
-			TrustedDomains:    []string{"cozy.local", "example.com"},
+	prevContexts := cfg.Contexts
+	cfg.Contexts = map[string]interface{}{
+		config.DefaultInstanceContext: map[string]interface{}{
+			"sharing": map[string]interface{}{
+				"auto_accept_trusted": true,
+				"trusted_domains":     []interface{}{"cozy.local", "example.com"},
+			},
 		},
 	}
 	t.Cleanup(func() {
-		cfg.Sharing.Contexts = prevContexts
+		cfg.Contexts = prevContexts
 	})
 
 	// Create the Drive sharing using existing helper patterns


### PR DESCRIPTION
Moved sharing configuration from top-level to context-specific settings, following the same pattern as other context-based configurations 

  **Before:**
 ```yaml
  sharing:
    auto_accept_trusted: true
    contexts:
      twake:
        auto_accept_trusted: false
```
  **After:**
  ```yaml
  contexts:
    default:
      sharing:
        auto_accept_trusted: false
    twake:
      sharing:
        auto_accept_trusted: true
  ```      
        
