### PR TITLE
fix: Prevent panic on concurrent sharing revocation

### DIFF
--- a/model/sharing/member.go
+++ b/model/sharing/member.go
@@ -958,6 +958,12 @@ func (s *Sharing) DelegateRemoveReadOnlyFlag(inst *instance.Instance, index int)
 // RevokeMember revoke the access granted to a member and contact it
 func (s *Sharing) RevokeMember(inst *instance.Instance, index int) error {
 	m := &s.Members[index]
+
+	// skip if member is already revoked
+	if m.Status == MemberStatusRevoked {
+		return nil
+	}
+
 	c := &s.Credentials[index-1]
 
 	// No need to contact the revoked member if the sharing is not ready

--- a/model/sharing/oauth.go
+++ b/model/sharing/oauth.go
@@ -649,6 +649,10 @@ func RefreshToken(
 	if err := creds.Refresh(inst, s, m); err != nil {
 		return nil, err
 	}
+	// Safety check: credentials may have been cleared by a concurrent revocation
+	if creds.AccessToken == nil {
+		return nil, ErrNoOAuthClient
+	}
 	opts.Headers["Authorization"] = "Bearer " + creds.AccessToken.AccessToken
 	if body != nil {
 		opts.Body = bytes.NewReader(body)


### PR DESCRIPTION
A nil pointer dereference panic occurred at model/sharing/oauth.go:652 when multiple goroutines concurrently revoked the same sharing members.

```
2025-11-27T10:35:49.710Z time="2025-11-27T10:35:49.683Z" level=error msg="[panic] runtime error: invalid memory address or nil pointer dereference: goroutine 8354870 [running]:
runtime/debug.Stack()
  /home/jenkins/workspace/cozy-stack/gozy-bookworm-int-01-build/build/go/src/runtime/debug/stack.go:24 +0x5e
github.com/cozy/cozy-stack/model/sharing.(*Sharing).Replicate.func1.1()
  /home/jenkins/workspace/cozy-stack/gozy-bookworm-int-01-build/build/cozy-stack/src/github.com/cozy/cozy-stack/model/sharing/replicator.go:74 +0x4f
panic({0x161eda0?, 0x299b370?})
  /home/jenkins/workspace/cozy-stack/gozy-bookworm-int-01-build/build/go/src/runtime/panic.go:770 +0x132
github.com/cozy/cozy-stack/model/sharing.RefreshToken(0xc0104578c8?, {0x1d7f680?, 0xc0118911d0?}, 0xc010a8a000?, 0xc010a980e8?, 0xc000277860, 0xc0000574c0, {0x0, 0x0, 0x0})
  /home/jenkins/workspace/cozy-stack/gozy-bookworm-int-01-build/build/cozy-stack/src/github.com/cozy/cozy-stack/model/sharing/oauth.go:652 +0x115
github.com/cozy/cozy-stack/model/sharing.(*Sharing).NotifyMemberRevocation(0xc010a8a000, 0xc0104578c8, 0xc010a980e8, 0xc000277860)
  /home/jenkins/workspace/cozy-stack/gozy-bookworm-int-01-build/build/cozy-stack/src/github.com/cozy/cozy-stack/model/sharing/member.go:1071 +0x3d3
github.com/cozy/cozy-stack/model/sharing.(*Sharing).RevokeMember(0xc010a8a000, 0xc0104578c8, 0x2)
  /home/jenkins/workspace/cozy-stack/gozy-bookworm-int-01-build/build/cozy-stack/src/github.com/cozy/cozy-stack/model/sharing/member.go:965 +0xd0
github.com/cozy/cozy-stack/model/sharing.(*Sharing).Revoke(0xc010a8a000, 0xc0104578c8)
  /home/jenkins/workspace/cozy-stack/gozy-bookworm-int-01-build/build/cozy-stack/src/github.com/cozy/cozy-stack/model/sharing/sharing.go:457 +0xb1
github.com/cozy/cozy-stack/model/sharing.(*Sharing).ReplicateTo(0xc010a8a000, 0xc0104578c8, 0xc010a988c8, 0x0)
  /home/jenkins/workspace/cozy-stack/gozy-bookworm-int-01-build/build/cozy-stack/src/github.com/cozy/cozy-stack/model/sharing/replicator.go:193 +0x565
github.com/cozy/cozy-stack/model/sharing.(*Sharing).Replicate.func [TRUNCATED]" domain=cantoine2.mytoutatice.cloud

```

`Replicate()` spawns parallel goroutines for each member and each goroutine that encountered `errRevokeSharing` independently called `s.Revoke()`
