### PR TITLE
feat: 409 on conflict for nextcloud

### DIFF
--- a/docs/nextcloud.md
+++ b/docs/nextcloud.md
@@ -320,12 +320,31 @@ directory on the Cozy where the file will be put.
 By default, the file will be moved, but using `Copy=true` in the query-string
 will makes a copy.
 
+By default, if a file with the same name already exists in the destination
+directory, a new name will be automatically generated (e.g., "file (2).txt").
+Using `FailOnConflict=true` in the query-string will make the route return a
+409 Conflict error instead of auto-renaming the file.
+
 **Note:** a permission on `POST io.cozy.files` is required to use this route.
 
 ### Request
 
 ```http
 POST /remote/nextcloud/4ab2155707bb6613a8b9463daf00381b/downstream/Documents/Images/sunset.jpg?To=b3ecbc00f4ba013c2bf418c04daba326 HTTP/1.1
+Host: cozy.example.net
+Authorization: Bearer eyJhbG...
+```
+
+#### Query parameters
+
+- `To` (required): The ID of the directory on the Cozy where the file will be put.
+- `Copy` (optional): Set to `true` to make a copy instead of moving the file. Default is `false` (move).
+- `FailOnConflict` (optional): Set to `true` to return a 409 Conflict error if a file with the same name already exists, instead of auto-renaming. Default is `false` (auto-rename).
+
+#### Example with FailOnConflict
+
+```http
+POST /remote/nextcloud/4ab2155707bb6613a8b9463daf00381b/downstream/Documents/Images/sunset.jpg?To=b3ecbc00f4ba013c2bf418c04daba326&FailOnConflict=true HTTP/1.1
 Host: cozy.example.net
 Authorization: Bearer eyJhbG...
 ```
@@ -394,9 +413,10 @@ Content-Type: application/vnd.api+json
 #### Status codes
 
 - 201 Created, when the file has been moved from the NextCloud to the Cozy
-- 400 Bad Request, when the account is not configured for NextCloud
+- 400 Bad Request, when the account is not configured for NextCloud or the `To` parameter is missing
 - 401 Unauthorized, when authentication to the NextCloud fails
 - 404 Not Found, when the account is not found or the file is not found on the NextCloud
+- 409 Conflict, when a file with the same name already exists in the destination directory and `FailOnConflict=true` is set
 
 ## POST /remote/nextcloud/:account/upstream/*path
 

--- a/model/nextcloud/nextcloud.go
+++ b/model/nextcloud/nextcloud.go
@@ -223,7 +223,7 @@ func (nc *NextCloud) ListTrashed(path string) ([]jsonapi.Object, error) {
 	return files, nil
 }
 
-func (nc *NextCloud) Downstream(path, dirID string, kind OperationKind, cozyMetadata *vfs.FilesCozyMetadata) (*vfs.FileDoc, error) {
+func (nc *NextCloud) Downstream(path, dirID string, kind OperationKind, cozyMetadata *vfs.FilesCozyMetadata, failOnConflict bool) (*vfs.FileDoc, error) {
 	path = "/files/" + nc.userID + "/" + path
 	dl, err := nc.webdav.Get(path)
 	if err != nil {
@@ -257,6 +257,9 @@ func (nc *NextCloud) Downstream(path, dirID string, kind OperationKind, cozyMeta
 		return nil, err
 	}
 	if exists {
+		if failOnConflict {
+			return nil, vfs.ErrConflict
+		}
 		doc.DocName = vfs.ConflictName(fs, doc.DirID, doc.DocName, true)
 	}
 

--- a/web/remote/nextcloud.go
+++ b/web/remote/nextcloud.go
@@ -264,8 +264,10 @@ func nextcloudDownstream(c echo.Context) error {
 		kind = nextcloud.CopyOperation
 	}
 
+	failOnConflict, _ := strconv.ParseBool(c.QueryParam("FailOnConflict"))
+
 	cozyMetadata, _ := files.CozyMetadataFromClaims(c, true)
-	f, err := nc.Downstream(path, to, kind, cozyMetadata)
+	f, err := nc.Downstream(path, to, kind, cozyMetadata, failOnConflict)
 	if err != nil {
 		return wrapNextcloudErrors(err)
 	}
@@ -344,7 +346,7 @@ func wrapNextcloudErrors(err error) error {
 		return jsonapi.BadRequest(err)
 	case webdav.ErrInvalidAuth:
 		return jsonapi.Unauthorized(err)
-	case webdav.ErrAlreadyExist, vfs.ErrConflict:
+	case webdav.ErrAlreadyExist, vfs.ErrConflict, os.ErrExist:
 		return jsonapi.Conflict(err)
 	case webdav.ErrParentNotFound:
 		return jsonapi.NotFound(err)

--- a/web/remote/remote_test.go
+++ b/web/remote/remote_test.go
@@ -1,14 +1,24 @@
 package remote
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
 	"testing"
+	"time"
 
+	"github.com/cozy/cozy-stack/model/account"
 	"github.com/cozy/cozy-stack/model/instance"
 	"github.com/cozy/cozy-stack/model/permission"
+	"github.com/cozy/cozy-stack/model/vfs"
+	build "github.com/cozy/cozy-stack/pkg/config"
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/tests/testutils"
+	"github.com/cozy/cozy-stack/web/errors"
+	"github.com/gavv/httpexpect/v2"
+	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -94,4 +104,158 @@ func generateAppToken(inst *instance.Instance, slug, doctype string) string {
 		return ""
 	}
 	return inst.BuildAppToken(slug, "")
+}
+
+func TestNextcloudDownstreamFailOnConflict(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	config.UseTestFile(t)
+	testutils.NeedCouchdb(t)
+
+	// Allow loopback addresses for the mock server
+	oldBuildMode := build.BuildMode
+	build.BuildMode = build.ModeDev
+	t.Cleanup(func() {
+		build.BuildMode = oldBuildMode
+	})
+
+	setup := testutils.NewSetup(t, t.Name())
+
+	testInstance := setup.GetTestInstance()
+	token := generateAppToken(testInstance, "testapp", consts.Files)
+
+	// Create a minimal mock NextCloud WebDAV server
+	mockWebDAV := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Handle file download requests (webdav client adds trailing slash)
+		if r.Method == "GET" && (r.URL.Path == "/remote.php/dav/files/testuser/testfile.txt/" ||
+			r.URL.Path == "/remote.php/dav/files/testuser/testfile2.txt/") {
+			content := []byte("downloaded content")
+			w.Header().Set("Content-Type", "text/plain")
+			w.Header().Set("Content-Length", strconv.Itoa(len(content)))
+			w.WriteHeader(http.StatusOK)
+			w.Write(content)
+			return
+		}
+		if r.Method == "DELETE" {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		// Handle user_status endpoint (needed to get webdav_user_id)
+		if r.URL.Path == "/ocs/v2.php/apps/user_status/api/v1/user_status" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"ocs":{"data":{"userId":"testuser"}}}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer mockWebDAV.Close()
+
+	ts := setup.GetTestServer("/remote", Routes)
+	ts.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler
+	t.Cleanup(ts.Close)
+
+	e := testutils.CreateTestClient(t, ts.URL)
+
+	// Create a nextcloud account pointing to our mock server
+	accountDoc := &couchdb.JSONDoc{
+		Type: consts.Accounts,
+		M: map[string]interface{}{
+			"account_type": "nextcloud",
+			"name":         "Test NextCloud",
+			"auth": map[string]interface{}{
+				"login":    "testuser",
+				"password": "testpass",
+				"url":      mockWebDAV.URL + "/",
+			},
+			"webdav_user_id": "testuser",
+		},
+	}
+	account.Encrypt(*accountDoc)
+	err := couchdb.CreateDoc(testInstance, accountDoc)
+	require.NoError(t, err)
+	accountID := accountDoc.ID()
+
+	// Create a file in the VFS that will conflict
+	fs := testInstance.VFS()
+	dirDoc, err := vfs.NewDirDoc(fs, "testdir", "", nil)
+	require.NoError(t, err)
+	err = fs.CreateDir(dirDoc)
+	require.NoError(t, err)
+
+	t.Run("DownstreamWithoutFailOnConflict", func(t *testing.T) {
+		// First, create a file that will conflict
+		existingContent := []byte("existing")
+		conflictFile, err := vfs.NewFileDoc(
+			"testfile.txt",
+			dirDoc.ID(),
+			int64(len(existingContent)),
+			nil,
+			"text/plain",
+			"",
+			time.Now(),
+			false,
+			false,
+			false,
+			nil,
+		)
+		require.NoError(t, err)
+		file, err := fs.CreateFile(conflictFile, nil)
+		require.NoError(t, err)
+		_, err = file.Write([]byte("existing"))
+		require.NoError(t, err)
+		err = file.Close()
+		require.NoError(t, err)
+
+		// Without FailOnConflict, it should auto-rename and succeed
+		res := e.POST("/remote/nextcloud/"+accountID+"/downstream/testfile.txt").
+			WithQuery("To", dirDoc.ID()).
+			WithQuery("FailOnConflict", "false").
+			WithHeader("Authorization", "Bearer "+token).
+			WithHost(testInstance.Domain).
+			Expect().Status(201).
+			JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+			Object()
+
+		// The file should be created with an auto-generated name
+		attrs := res.Path("$.data.attributes").Object()
+		name := attrs.Value("name").String().Raw()
+		assert.Contains(t, name, "testfile")
+		assert.NotEqual(t, "testfile.txt", name, "File should be renamed due to conflict")
+	})
+
+	t.Run("DownstreamWithFailOnConflict", func(t *testing.T) {
+		// Create a file that will conflict (use a different name to avoid leftover from previous test)
+		existingContent := []byte("existing")
+		conflictFile, err := vfs.NewFileDoc(
+			"testfile2.txt",
+			dirDoc.ID(),
+			int64(len(existingContent)),
+			nil,
+			"text/plain",
+			"",
+			time.Now(),
+			false,
+			false,
+			false,
+			nil,
+		)
+		require.NoError(t, err)
+		file, err := fs.CreateFile(conflictFile, nil)
+		require.NoError(t, err)
+		_, err = file.Write(existingContent)
+		require.NoError(t, err)
+		err = file.Close()
+		require.NoError(t, err)
+
+		// With FailOnConflict=true, it should return 409 Conflict
+		e.POST("/remote/nextcloud/"+accountID+"/downstream/testfile2.txt").
+			WithQuery("To", dirDoc.ID()).
+			WithQuery("FailOnConflict", "true").
+			WithHeader("Authorization", "Bearer "+token).
+			WithHost(testInstance.Domain).
+			Expect().Status(409)
+	})
 }


### PR DESCRIPTION
The idea is to get a 409 conflict error when we already have the same name. It'll be useful for the basic import, like that, we can easily skip without making any find request. 

I didn't want to add a webdav mock server, but if I understood well the concept of mock in GoLang, I had to create an interface for the webdav client & else. So I try the "shortest way", but I don't know if it'll work. 