### PR TITLE
fix: Panic with NPE casting nil pointer to interface

### DIFF
--- a/pkg/realtime/redis_hub.go
+++ b/pkg/realtime/redis_hub.go
@@ -114,14 +114,18 @@ func (h *redisHub) start() {
 			log.Warnf("Error on start: %s", err)
 			continue
 		}
+		// Use local variables to avoid passing typed nil pointers as interface values.
+		var doc, old Doc
 		if je.Doc != nil {
 			je.Doc.Type = doctype
+			doc = je.Doc
 		}
 		if je.Old != nil {
 			je.Old.Type = doctype
+			old = je.Old
 		}
 		db := prefixer.NewPrefixer(je.Cluster, je.Domain, je.Prefix)
-		h.mem.Publish(db, je.Verb, je.Doc, je.Old)
+		h.mem.Publish(db, je.Verb, doc, old)
 	}
 	logger.WithNamespace("realtime-redis").Infof("End of subscribe channel")
 }


### PR DESCRIPTION
When real-time events pass through Redis with nil OldDoc, the nil *JSONDoc pointer creates a non-nil interface value. 

This causes panics when filterMapEvents calls methods on it.

 Fix by using local Doc variables that stay nil when the source pointer is nil.