### PR TITLE
fix: Race condition on copy file

### DIFF
--- a/model/vfs/vfsafero/impl.go
+++ b/model/vfs/vfsafero/impl.go
@@ -267,6 +267,15 @@ func (afs *aferoVFS) CopyFile(olddoc, newdoc *vfs.FileDoc) (err error) {
 	}
 	defer afs.mu.Unlock()
 
+	// Check for duplicate filename inside the lock to avoid race conditions
+	exists, err := afs.Indexer.DirChildExists(newdoc.DirID, newdoc.DocName)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return os.ErrExist
+	}
+
 	newsize, maxsize, capsize, err := vfs.CheckAvailableDiskSpace(afs, olddoc)
 	if err != nil {
 		return err

--- a/model/vfs/vfsswift/impl_v3.go
+++ b/model/vfs/vfsswift/impl_v3.go
@@ -262,6 +262,15 @@ func (sfs *swiftVFSV3) CopyFile(olddoc, newdoc *vfs.FileDoc) error {
 	}
 	defer sfs.mu.Unlock()
 
+	// Check for duplicate filename inside the lock to avoid race conditions
+	exists, err := sfs.Indexer.DirChildExists(newdoc.DirID, newdoc.DocName)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return os.ErrExist
+	}
+
 	newsize, _, capsize, err := vfs.CheckAvailableDiskSpace(sfs, olddoc)
 	if err != nil {
 		return err


### PR DESCRIPTION
 When multiple concurrent copy requests target the same destination folder, a race condition allows duplicate files with identical names to be created.

Adds a DirChildExists check inside the VFS lock in both CopyFile implementations.