### PR TITLE
feat(nextcloud): trigger endpoint for bulk migrations

### DIFF
--- a/docs/nextcloud.md
+++ b/docs/nextcloud.md
@@ -579,3 +579,138 @@ Authorization: Bearer eyJhbG...
 ```http
 HTTP/1.1 204 No Content
 ```
+
+## GET /remote/nextcloud/:account/size/*path
+
+This route returns the recursive size in bytes of a folder (or a single
+file) on the NextCloud account. It is backed by a single Depth:0 PROPFIND
+asking for the `oc:size` property that NextCloud maintains in its metadata
+table, so it runs in constant time regardless of how many files are in the
+tree. Pass the account root by using an empty `*path` (just `/size/`).
+
+The `:account` parameter is the identifier of the NextCloud `io.cozy.account`.
+
+**Note:** a permission on `GET io.cozy.files` is required to use this route.
+
+### Request (sub-folder)
+
+```http
+GET /remote/nextcloud/4ab2155707bb6613a8b9463daf00381b/size/Photos HTTP/1.1
+Host: cozy.example.net
+Authorization: Bearer eyJhbG...
+```
+
+### Response
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+```
+
+```json
+{
+  "size": 5656463
+}
+```
+
+### Request (account root)
+
+```http
+GET /remote/nextcloud/4ab2155707bb6613a8b9463daf00381b/size/ HTTP/1.1
+Host: cozy.example.net
+Authorization: Bearer eyJhbG...
+```
+
+#### Status codes
+
+- 200 OK, with the recursive byte total of the target path
+- 401 Unauthorized, when the NextCloud credentials are rejected
+- 404 Not Found, when the account or the target path does not exist
+
+## POST /remote/nextcloud/migration
+
+This route triggers a one-shot bulk migration of a user's Nextcloud files into
+their Cozy. The Stack validates the credentials, persists an
+`io.cozy.accounts` document, creates an `io.cozy.nextcloud.migrations`
+tracking document in `pending` state, and publishes a
+`nextcloud.migration.requested` command to the `migration` RabbitMQ exchange.
+The actual transfer is performed by an external migration service that
+consumes the command and drives the existing `/remote/nextcloud/:account/*`
+routes, updating the tracking document as it progresses.
+
+Before persisting anything, the Stack probes the supplied credentials against
+the Nextcloud instance via the OCS `user_status` endpoint, so wrong passwords
+and unreachable hosts surface synchronously instead of being deferred to the
+migration service. The probe also resolves the WebDAV user ID, which is
+cached on the account document so the migration service does not need to
+re-fetch it.
+
+When an existing `io.cozy.accounts` document for the same `account_type:
+"nextcloud"` + `auth.url` + `auth.login` triplet is found, it is reused with
+its stored password and `webdav_user_id` refreshed from the request. Only one
+migration can be in flight per instance at a time: if a `pending` or `running`
+tracking document already exists, the Stack returns `409 Conflict`. Failed
+migrations do not block new attempts.
+
+**Note:** a permission on `POST io.cozy.nextcloud.migrations` is required to
+use this route.
+
+### Request
+
+```http
+POST /remote/nextcloud/migration HTTP/1.1
+Host: cozy.example.net
+Authorization: Bearer eyJhbG...
+Content-Type: application/json
+```
+
+```json
+{
+  "nextcloud_url": "https://nextcloud.example.com",
+  "nextcloud_login": "alice",
+  "nextcloud_app_password": "xxxxx-xxxxx-xxxxx-xxxxx-xxxxx",
+  "source_path": "/"
+}
+```
+
+`source_path` is optional and defaults to `/`. The `nextcloud_app_password`
+should be a Nextcloud app password, not the user's main account password.
+
+### Response
+
+```http
+HTTP/1.1 201 Created
+Content-Type: application/vnd.api+json
+```
+
+```json
+{
+  "data": {
+    "id": "d4e5f6a7b8c94d0ea1b2c3d4e5f6a7b8",
+    "type": "io.cozy.nextcloud.migrations",
+    "attributes": {
+      "status": "pending",
+      "target_dir": "/Nextcloud",
+      "progress": {
+        "files_imported": 0,
+        "files_total": 0,
+        "bytes_imported": 0,
+        "bytes_total": 0
+      },
+      "errors": [],
+      "skipped": [],
+      "started_at": null,
+      "finished_at": null
+    }
+  }
+}
+```
+
+#### Status codes
+
+- 201 Created, when the migration has been queued and the tracking document is returned
+- 401 Unauthorized, when the Nextcloud credentials are rejected by the remote host
+- 409 Conflict, when a `pending` or `running` migration already exists
+- 500 Internal Server Error, when the conflict check, account upsert, or tracking document creation fails
+- 502 Bad Gateway, when the Nextcloud instance is unreachable
+- 503 Service Unavailable, when the migration command cannot be published to RabbitMQ. The tracking document is marked `failed` before returning

--- a/docs/rabbitmq.md
+++ b/docs/rabbitmq.md
@@ -134,6 +134,46 @@ rabbitmq:
 - If queue-level `dlx_name`/`dlq_name` are not specified, exchange-level defaults are used.
 - Messages that exceed the `delivery_limit` or are rejected will be sent to the DLX and routed to the DLQ.
 
+### Publishers
+
+The Stack also publishes messages to RabbitMQ. Publishers do not declare any
+queue or exchange on the Stack side: the exchange must already exist on the
+broker, and a queue must be bound by the consuming service. Publishes use the
+AMQP `mandatory` flag, so a publish to an exchange with no matching binding
+fails with `PublishReturnedError` and the caller is expected to surface the
+failure to the user.
+
+#### `auth` exchange
+
+Routing key: `user.deletion.requested`. Published from
+`POST /settings/instance/deletion/force` when a user requests permanent
+deletion of their account. The payload is the `UserDeletionRequestedMessage`
+struct in `pkg/rabbitmq/contracts.go`.
+
+#### `migration` exchange
+
+Routing key: `nextcloud.migration.requested`. Published from
+`POST /remote/nextcloud/migration` when a user starts a Nextcloud-to-Cozy
+bulk migration. The payload is the `NextcloudMigrationRequestedMessage`
+struct in `pkg/rabbitmq/contracts.go`:
+
+```json
+{
+  "migrationId": "d4e5f6a7b8c94d0ea1b2c3d4e5f6a7b8",
+  "workplaceFqdn": "alice.cozy.example.com",
+  "accountId": "a1b2c3d4e5f6",
+  "sourcePath": "/",
+  "timestamp": 1712563200
+}
+```
+
+Credentials are never in the payload: they live in the `io.cozy.accounts`
+document referenced by `accountId`. The Stack populates `MessageID` with the
+migration ID for cross-system tracing. The consuming service is responsible
+for declaring its queue, binding it to this exchange, and processing the
+messages; if no queue is bound when the Stack publishes, the user receives
+`503` and the tracking document is marked `failed`.
+
 ### Handlers
 
 Handlers implement a simple interface:

--- a/model/nextcloud/migration.go
+++ b/model/nextcloud/migration.go
@@ -1,0 +1,233 @@
+package nextcloud
+
+import (
+	"errors"
+	"time"
+
+	"github.com/cozy/cozy-stack/model/account"
+	"github.com/cozy/cozy-stack/model/instance"
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
+	"github.com/cozy/cozy-stack/pkg/jsonapi"
+)
+
+const nextcloudAccountType = "nextcloud"
+
+const (
+	MigrationStatusPending   = "pending"
+	MigrationStatusRunning   = "running"
+	MigrationStatusCompleted = "completed"
+	MigrationStatusFailed    = "failed"
+)
+
+const DefaultMigrationTargetDir = "/Nextcloud"
+
+var ErrMigrationConflict = errors.New("a nextcloud migration is already in progress")
+
+// Migration is the io.cozy.nextcloud.migrations tracking document.
+//
+// The schema (especially the nested Progress object) is the contract with
+// twake-migration-nextcloud. Flat counters would crash the service's progress
+// reducer because it spreads doc.progress and adds to its fields.
+type Migration struct {
+	DocID      string            `json:"_id,omitempty"`
+	DocRev     string            `json:"_rev,omitempty"`
+	Status     string            `json:"status"`
+	TargetDir  string            `json:"target_dir"`
+	Progress   MigrationProgress `json:"progress"`
+	Errors     []MigrationError  `json:"errors"`
+	Skipped    []SkippedFile     `json:"skipped"`
+	StartedAt  *time.Time        `json:"started_at"`
+	FinishedAt *time.Time        `json:"finished_at"`
+}
+
+type MigrationProgress struct {
+	FilesImported int64 `json:"files_imported"`
+	FilesTotal    int64 `json:"files_total"`
+	BytesImported int64 `json:"bytes_imported"`
+	BytesTotal    int64 `json:"bytes_total"`
+}
+
+type MigrationError struct {
+	Path    string    `json:"path"`
+	Message string    `json:"message"`
+	At      time.Time `json:"at"`
+}
+
+type SkippedFile struct {
+	Path   string `json:"path"`
+	Reason string `json:"reason"`
+	Size   int64  `json:"size"`
+}
+
+func (m *Migration) ID() string        { return m.DocID }
+func (m *Migration) Rev() string       { return m.DocRev }
+func (m *Migration) DocType() string   { return consts.NextcloudMigrations }
+func (m *Migration) SetID(id string)   { m.DocID = id }
+func (m *Migration) SetRev(rev string) { m.DocRev = rev }
+
+func (m *Migration) Clone() couchdb.Doc {
+	cloned := *m
+
+	if m.Errors != nil {
+		cloned.Errors = make([]MigrationError, len(m.Errors))
+		copy(cloned.Errors, m.Errors)
+	}
+	if m.Skipped != nil {
+		cloned.Skipped = make([]SkippedFile, len(m.Skipped))
+		copy(cloned.Skipped, m.Skipped)
+	}
+	if m.StartedAt != nil {
+		t := *m.StartedAt
+		cloned.StartedAt = &t
+	}
+	if m.FinishedAt != nil {
+		t := *m.FinishedAt
+		cloned.FinishedAt = &t
+	}
+	return &cloned
+}
+
+func (m *Migration) Links() *jsonapi.LinksList              { return nil }
+func (m *Migration) Relationships() jsonapi.RelationshipMap { return nil }
+func (m *Migration) Included() []jsonapi.Object             { return nil }
+
+var (
+	_ couchdb.Doc    = (*Migration)(nil)
+	_ jsonapi.Object = (*Migration)(nil)
+)
+
+// NewPendingMigration returns a fresh Migration document in the pending state.
+// Errors and Skipped are explicit empty slices so the JSON serialization
+// produces "[]" rather than "null" — the migration service consumes them as
+// arrays and would crash on null.
+func NewPendingMigration(targetDir string) *Migration {
+	if targetDir == "" {
+		targetDir = DefaultMigrationTargetDir
+	}
+	return &Migration{
+		Status:    MigrationStatusPending,
+		TargetDir: targetDir,
+		Errors:    []MigrationError{},
+		Skipped:   []SkippedFile{},
+	}
+}
+
+func (m *Migration) MarkFailed(inst *instance.Instance, cause error) error {
+	now := time.Now().UTC()
+	m.Status = MigrationStatusFailed
+	if m.FinishedAt == nil {
+		m.FinishedAt = &now
+	}
+	m.Errors = append(m.Errors, MigrationError{
+		Message: cause.Error(),
+		At:      now,
+	})
+	return couchdb.UpdateDoc(inst, m)
+}
+
+// FindNextcloudAccount returns the unique Nextcloud account for the given
+// instance, or (nil, nil) if none exists yet. By design there is at most
+// one account with `account_type: "nextcloud"` per instance: the migration
+// trigger endpoint overwrites the existing account on every call so a
+// retry with a corrected password or a different login does not leave
+// orphaned docs the Settings UI cannot surface.
+//
+// If multiple legacy nextcloud accounts exist (left over from when the
+// konnector flow kept one account per (url, login) pair), the function
+// returns the first one scanned. Newly-triggered migrations will update
+// that single doc; the rest stay in the database untouched until a real
+// cleanup is wired up. A linear scan is cheaper than maintaining a Mango
+// index because the per-instance account count is tiny.
+func FindNextcloudAccount(inst *instance.Instance) (*couchdb.JSONDoc, error) {
+	var accounts []*couchdb.JSONDoc
+	req := &couchdb.AllDocsRequest{Limit: 1000}
+	err := couchdb.GetAllDocs(inst, consts.Accounts, req, &accounts)
+	if err != nil {
+		if couchdb.IsNoDatabaseError(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	for _, doc := range accounts {
+		if doc == nil || doc.M == nil {
+			continue
+		}
+		if accType, _ := doc.M["account_type"].(string); accType == nextcloudAccountType {
+			return doc, nil
+		}
+	}
+	return nil, nil
+}
+
+// EnsureAccount upserts the single Nextcloud account for the instance and
+// returns its id. If an account already exists, its auth block and
+// webdav_user_id are rewritten with the given values regardless of what
+// they were before — this is the keyed-by-type policy that keeps the
+// Settings UI free of orphans at the cost of multi-account support. The
+// password is encrypted at rest before persistence.
+func EnsureAccount(inst *instance.Instance, ncURL, login, password, userID string) (string, error) {
+	authMap := map[string]interface{}{
+		"url":      ncURL,
+		"login":    login,
+		"password": password,
+	}
+
+	existing, err := FindNextcloudAccount(inst)
+	if err != nil {
+		return "", err
+	}
+	if existing != nil {
+		existing.Type = consts.Accounts
+		existing.M["webdav_user_id"] = userID
+		existing.M["auth"] = authMap
+		account.Encrypt(*existing)
+		if err := couchdb.UpdateDoc(inst, existing); err != nil {
+			return "", err
+		}
+		return existing.ID(), nil
+	}
+
+	doc := &couchdb.JSONDoc{
+		Type: consts.Accounts,
+		M: map[string]interface{}{
+			"account_type":   nextcloudAccountType,
+			"webdav_user_id": userID,
+			"auth":           authMap,
+		},
+	}
+	account.Encrypt(*doc)
+	account.ComputeName(*doc)
+
+	if err := couchdb.CreateDoc(inst, doc); err != nil {
+		return "", err
+	}
+	return doc.ID(), nil
+}
+
+// FindActiveMigration returns the first pending or running migration, or
+// (nil, nil) if none. A missing doctype database or index is treated as "no
+// active migration" so the first call on a fresh instance succeeds.
+func FindActiveMigration(inst *instance.Instance) (*Migration, error) {
+	var docs []*Migration
+	req := &couchdb.FindRequest{
+		UseIndex: "by-status",
+		Selector: mango.In("status", []interface{}{
+			MigrationStatusPending,
+			MigrationStatusRunning,
+		}),
+		Limit: 1,
+	}
+	err := couchdb.FindDocs(inst, consts.NextcloudMigrations, req, &docs)
+	if err != nil {
+		if couchdb.IsNoDatabaseError(err) || couchdb.IsNoUsableIndexError(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if len(docs) == 0 {
+		return nil, nil
+	}
+	return docs[0], nil
+}

--- a/model/nextcloud/nextcloud.go
+++ b/model/nextcloud/nextcloud.go
@@ -3,7 +3,9 @@
 package nextcloud
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -20,6 +22,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/jsonapi"
+	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/cozy/cozy-stack/pkg/safehttp"
 	"github.com/cozy/cozy-stack/pkg/webdav"
 	"github.com/labstack/echo/v4"
@@ -63,10 +66,11 @@ func (f *File) Links() *jsonapi.LinksList {
 var _ jsonapi.Object = (*File)(nil)
 
 type NextCloud struct {
-	inst      *instance.Instance
-	accountID string
-	userID    string
-	webdav    *webdav.Client
+	inst        *instance.Instance
+	accountID   string
+	userID      string
+	installRoot string
+	webdav      *webdav.Client
 }
 
 func New(inst *instance.Instance, accountID string) (*NextCloud, error) {
@@ -97,19 +101,21 @@ func New(inst *instance.Instance, accountID string) (*NextCloud, error) {
 	}
 	username, _ := auth["login"].(string)
 	password, _ := auth["password"].(string)
+	installRoot := normalizeInstallRoot(u.Path)
 	logger := inst.Logger().WithNamespace("nextcloud")
 	webdav := &webdav.Client{
 		Scheme:   u.Scheme,
 		Host:     u.Host,
 		Username: username,
 		Password: password,
-		BasePath: "/remote.php/dav",
+		BasePath: installRoot + "/remote.php/dav",
 		Logger:   logger,
 	}
 	nc := &NextCloud{
-		inst:      inst,
-		accountID: accountID,
-		webdav:    webdav,
+		inst:        inst,
+		accountID:   accountID,
+		installRoot: installRoot,
+		webdav:      webdav,
 	}
 	if err := nc.fillUserID(&doc); err != nil {
 		return nil, err
@@ -119,6 +125,15 @@ func New(inst *instance.Instance, accountID string) (*NextCloud, error) {
 
 func (nc *NextCloud) Download(path string) (*webdav.Download, error) {
 	return nc.webdav.Get("/files/" + nc.userID + "/" + path)
+}
+
+// Size returns the recursive byte total of the resource at path, as
+// reported by Nextcloud's cached `oc:size` property. Works on the account
+// root (pass an empty string or "/") and on any sub-folder. Equivalent to
+// a single Depth:0 PROPFIND on the server, not a tree walk, so the cost
+// is constant regardless of how many files the folder contains.
+func (nc *NextCloud) Size(path string) (uint64, error) {
+	return nc.webdav.Size("/files/" + nc.userID + "/" + path)
 }
 
 func (nc *NextCloud) Upload(path, mime string, contentLength int64, body io.Reader) error {
@@ -360,16 +375,53 @@ func (nc *NextCloud) buildTrashedURL(item webdav.Item, path string) string {
 	return u.String()
 }
 
-// https://docs.nextcloud.com/server/latest/developer_manual/client_apis/OCS/ocs-status-api.html#fetch-your-own-status
-func (nc *NextCloud) fetchUserID() (string, error) {
-	logger := nc.webdav.Logger
-	u := url.URL{
-		Scheme: nc.webdav.Scheme,
-		Host:   nc.webdav.Host,
-		User:   url.UserPassword(nc.webdav.Username, nc.webdav.Password),
-		Path:   "/ocs/v2.php/apps/user_status/api/v1/user_status",
+// FetchUserIDWithCredentials probes the OCS cloud/user endpoint and returns
+// the user ID, or webdav.ErrInvalidAuth if the credentials are rejected.
+// The logger used for diagnostics is pulled from ctx via logger.FromContext,
+// so callers should attach a request-scoped logger with logger.WithContext
+// before calling.
+//
+// https://docs.nextcloud.com/server/latest/developer_manual/client_apis/OCS/ocs-api-overview.html
+func FetchUserIDWithCredentials(ctx context.Context, nextcloudURL, username, password string) (string, error) {
+	u, err := url.Parse(nextcloudURL)
+	if err != nil {
+		return "", err
 	}
-	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if u.Scheme == "" || u.Host == "" {
+		return "", ErrInvalidAccount
+	}
+	return fetchUserIDFromHost(ctx, u.Scheme, u.Host, normalizeInstallRoot(u.Path), username, password)
+}
+
+const probeTimeout = 30 * time.Second
+
+// cloudUserProbePath is OCS Core and cannot be disabled by an admin, unlike
+// apps/user_status which some managed Nextcloud providers strip. Probing Core
+// avoids misclassifying a stripped-optional-app install as an auth failure.
+const cloudUserProbePath = "/ocs/v2.php/cloud/user"
+
+// normalizeInstallRoot strips the trailing slash from a Nextcloud install
+// root path so concatenation with absolute API paths (always starting with
+// "/") produces clean URLs regardless of whether the caller passed
+// https://host/nextcloud or https://host/nextcloud/.
+func normalizeInstallRoot(path string) string {
+	return strings.TrimSuffix(path, "/")
+}
+
+func fetchUserIDFromHost(ctx context.Context, scheme, host, installRoot, username, password string) (string, error) {
+	log := logger.FromContext(ctx)
+	u := url.URL{
+		Scheme: scheme,
+		Host:   host,
+		User:   url.UserPassword(username, password),
+		Path:   installRoot + cloudUserProbePath,
+	}
+	// Cap the probe so a hung Nextcloud server can't pin a request goroutine —
+	// safehttp.ClientWithKeepAlive has handshake timeouts but no overall
+	// request deadline.
+	reqCtx, cancel := context.WithTimeout(ctx, probeTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, u.String(), nil)
 	if err != nil {
 		return "", err
 	}
@@ -380,26 +432,38 @@ func (nc *NextCloud) fetchUserID() (string, error) {
 	res, err := safehttp.ClientWithKeepAlive.Do(req)
 	elapsed := time.Since(start)
 	if err != nil {
-		logger.Warnf("user_status %s: %s (%s)", u.Host, err, elapsed)
+		log.Warnf("cloud/user %s: %s (%s)", u.Host, err, elapsed)
 		return "", err
 	}
 	defer res.Body.Close()
-	logger.Infof("user_status %s: %d (%s)", u.Host, res.StatusCode, elapsed)
-	if res.StatusCode != 200 {
+	log.Infof("cloud/user %s: %d (%s)", u.Host, res.StatusCode, elapsed)
+	switch res.StatusCode {
+	case http.StatusOK:
+	case http.StatusUnauthorized, http.StatusForbidden:
 		return "", webdav.ErrInvalidAuth
+	default:
+		return "", fmt.Errorf("unexpected status %d from nextcloud cloud/user probe", res.StatusCode)
 	}
 	var payload OCSPayload
 	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
-		logger.Warnf("cannot fetch NextCloud userID: %s", err)
+		log.Warnf("cannot fetch NextCloud userID: %s", err)
 		return "", err
 	}
 	return payload.OCS.Data.UserID, nil
 }
 
+func (nc *NextCloud) fetchUserID() (string, error) {
+	// Receiver predates ctx-threading in this package; mint a local ctx
+	// carrying the webdav client's logger so the probe still surfaces
+	// under the same diagnostics.
+	ctx := logger.WithContext(context.Background(), nc.webdav.Logger)
+	return fetchUserIDFromHost(ctx, nc.webdav.Scheme, nc.webdav.Host, nc.installRoot, nc.webdav.Username, nc.webdav.Password)
+}
+
 type OCSPayload struct {
 	OCS struct {
 		Data struct {
-			UserID string `json:"userId"`
+			UserID string `json:"id"`
 		} `json:"data"`
 	} `json:"ocs"`
 }

--- a/model/nextcloud/nextcloud_test.go
+++ b/model/nextcloud/nextcloud_test.go
@@ -1,0 +1,113 @@
+package nextcloud
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	build "github.com/cozy/cozy-stack/pkg/config"
+	"github.com/cozy/cozy-stack/pkg/logger"
+	"github.com/cozy/cozy-stack/pkg/webdav"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchUserIDWithCredentials(t *testing.T) {
+	// safehttp refuses loopback hosts outside dev mode.
+	oldBuildMode := build.BuildMode
+	build.BuildMode = build.ModeDev
+	t.Cleanup(func() { build.BuildMode = oldBuildMode })
+
+	ctx := logger.WithContext(context.Background(), logger.WithNamespace("nextcloud-test"))
+
+	t.Run("resolves user ID against OCS cloud/user on a Nextcloud without user_status", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/ocs/v2.php/cloud/user" {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprint(w, `{"ocs":{"meta":{"status":"ok","statuscode":200},"data":{"id":"alice-webdav"}}}`)
+				return
+			}
+			// Any other path (including user_status) returns 404, matching
+			// managed Nextcloud hosts that strip optional OCS apps.
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		t.Cleanup(srv.Close)
+
+		userID, err := FetchUserIDWithCredentials(ctx, srv.URL+"/", "alice", "app-password")
+		require.NoError(t, err)
+		assert.Equal(t, "alice-webdav", userID)
+	})
+
+	t.Run("returns ErrInvalidAuth on 401", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		t.Cleanup(srv.Close)
+
+		_, err := FetchUserIDWithCredentials(ctx, srv.URL+"/", "alice", "bad")
+		assert.ErrorIs(t, err, webdav.ErrInvalidAuth)
+	})
+
+	t.Run("returns ErrInvalidAuth on 403", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+		}))
+		t.Cleanup(srv.Close)
+
+		_, err := FetchUserIDWithCredentials(ctx, srv.URL+"/", "alice", "bad")
+		assert.ErrorIs(t, err, webdav.ErrInvalidAuth)
+	})
+
+	t.Run("does not conflate a 500 with an auth failure", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		t.Cleanup(srv.Close)
+
+		_, err := FetchUserIDWithCredentials(ctx, srv.URL+"/", "alice", "app-password")
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, webdav.ErrInvalidAuth),
+			"a 500 from Nextcloud must not be reported as invalid credentials")
+	})
+
+	t.Run("honors a sub-path install when the nextcloud URL has a base path", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Only serve the sub-path. A probe that strips /nextcloud from
+			// the base URL would land on /ocs/... and get a 404 here.
+			if r.URL.Path == "/nextcloud/ocs/v2.php/cloud/user" {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprint(w, `{"ocs":{"meta":{"status":"ok","statuscode":200},"data":{"id":"subpath-alice"}}}`)
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		t.Cleanup(srv.Close)
+
+		userID, err := FetchUserIDWithCredentials(ctx, srv.URL+"/nextcloud/", "alice", "app-password")
+		require.NoError(t, err)
+		assert.Equal(t, "subpath-alice", userID)
+	})
+
+	t.Run("normalizes missing and trailing slashes in the base URL path", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/nextcloud/ocs/v2.php/cloud/user" {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprint(w, `{"ocs":{"meta":{"status":"ok","statuscode":200},"data":{"id":"norm-alice"}}}`)
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		t.Cleanup(srv.Close)
+
+		// Both with and without the trailing slash must resolve to the
+		// same probe URL.
+		for _, base := range []string{srv.URL + "/nextcloud", srv.URL + "/nextcloud/"} {
+			userID, err := FetchUserIDWithCredentials(ctx, base, "alice", "app-password")
+			require.NoError(t, err, "base=%q", base)
+			assert.Equal(t, "norm-alice", userID, "base=%q", base)
+		}
+	})
+}

--- a/model/nextcloud/trigger.go
+++ b/model/nextcloud/trigger.go
@@ -1,0 +1,160 @@
+package nextcloud
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/cozy/cozy-stack/model/instance"
+	"github.com/cozy/cozy-stack/pkg/config/config"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/logger"
+	"github.com/cozy/cozy-stack/pkg/rabbitmq"
+	"github.com/cozy/cozy-stack/pkg/webdav"
+)
+
+// migrationTriggerLockName is the per-instance lock held across the
+// re-check, account upsert, tracking-doc insert, and RabbitMQ publish.
+// Without it, two concurrent triggers could both see no active migration
+// and both commit a pending tracking document, breaking the
+// one-migration-per-instance invariant.
+const migrationTriggerLockName = "nextcloud/migration-trigger"
+
+// ErrNextcloudUnreachable wraps any error surfaced while probing the
+// Nextcloud server other than an explicit auth rejection (401/403). The
+// caller should translate it to a 502 Bad Gateway for the HTTP client.
+var ErrNextcloudUnreachable = errors.New("nextcloud unreachable")
+
+// ErrMigrationBrokerUnavailable is returned when the RabbitMQ publish
+// fails after the tracking document has been created. The tracking
+// document is marked failed before this error is returned, so retries
+// are not blocked by a stuck pending doc.
+var ErrMigrationBrokerUnavailable = errors.New("migration broker unavailable")
+
+// TriggerMigrationRequest carries the user-supplied inputs needed to
+// start a bulk Nextcloud-to-Cozy migration. Field semantics match the
+// HTTP request body on POST /remote/nextcloud/migration.
+type TriggerMigrationRequest struct {
+	NextcloudURL         string
+	NextcloudLogin       string
+	NextcloudAppPassword string
+	SourcePath           string
+	// TargetDir is the absolute Cozy path under which the migration service
+	// writes imported files. Empty means "use DefaultMigrationTargetDir".
+	TargetDir string
+}
+
+// TriggerMigration is the single entry point for "start a Nextcloud
+// migration for this instance with these credentials". It probes the
+// remote host, serializes itself against concurrent triggers via a
+// per-instance lock, upserts the io.cozy.accounts document, creates a
+// pending tracking document, and publishes the migration command to
+// RabbitMQ. On success it returns the created tracking document.
+//
+// Error contract, in priority order, so callers can map them to HTTP
+// status codes via errors.Is:
+//
+//   - [ErrMigrationConflict]: a pending or running migration already
+//     exists for this instance.
+//   - [webdav.ErrInvalidAuth]: the Nextcloud host rejected the supplied
+//     credentials with 401/403.
+//   - [ErrNextcloudUnreachable]: the credentials probe failed for any
+//     other reason (DNS, TLS, unexpected status, decode error).
+//   - [ErrMigrationBrokerUnavailable]: the RabbitMQ publish failed and
+//     the tracking document was marked failed.
+//   - any other error: treat as an internal server failure.
+func TriggerMigration(
+	ctx context.Context,
+	inst *instance.Instance,
+	req TriggerMigrationRequest,
+	rmq rabbitmq.Service,
+	log logger.Logger,
+) (*Migration, error) {
+	// Cheap pre-check outside the lock: avoid a probe round trip when a
+	// migration is already in flight. The authoritative check happens
+	// inside the lock below.
+	if active, err := FindActiveMigration(inst); err != nil {
+		log.Errorf("Failed to query active migrations: %s", err)
+		return nil, fmt.Errorf("find active migration: %w", err)
+	} else if active != nil {
+		log.WithField("active_migration_id", active.ID()).
+			Infof("Rejecting new Nextcloud migration: one is already in flight")
+		return nil, ErrMigrationConflict
+	}
+
+	// Probe outside the lock: the network call can take seconds and must
+	// not serialize unrelated triggers. Attach the request-scoped logger
+	// to ctx so the probe can surface its diagnostics under the same
+	// instance/migration fields the handler already tagged.
+	probeCtx := logger.WithContext(ctx, log)
+	userID, err := FetchUserIDWithCredentials(probeCtx, req.NextcloudURL, req.NextcloudLogin, req.NextcloudAppPassword)
+	if err != nil {
+		if errors.Is(err, webdav.ErrInvalidAuth) {
+			log.Infof("Nextcloud credentials probe rejected by remote host")
+			return nil, err
+		}
+		log.Warnf("Nextcloud credentials probe failed: %s", err)
+		return nil, fmt.Errorf("%w: %w", ErrNextcloudUnreachable, err)
+	}
+
+	mutex := config.Lock().ReadWrite(inst, migrationTriggerLockName)
+	if err := mutex.Lock(); err != nil {
+		log.Errorf("Failed to acquire migration trigger lock: %s", err)
+		return nil, fmt.Errorf("acquire migration lock: %w", err)
+	}
+	defer mutex.Unlock()
+
+	// Authoritative re-check under the lock: a racer may have inserted a
+	// pending document between the cheap pre-check above and this line.
+	if active, err := FindActiveMigration(inst); err != nil {
+		log.Errorf("Failed to query active migrations: %s", err)
+		return nil, fmt.Errorf("find active migration: %w", err)
+	} else if active != nil {
+		log.WithField("active_migration_id", active.ID()).
+			Infof("Lost migration trigger race to a concurrent request")
+		return nil, ErrMigrationConflict
+	}
+
+	accountID, err := EnsureAccount(inst, req.NextcloudURL, req.NextcloudLogin, req.NextcloudAppPassword, userID)
+	if err != nil {
+		log.Errorf("Failed to ensure nextcloud account: %s", err)
+		return nil, fmt.Errorf("ensure nextcloud account: %w", err)
+	}
+
+	doc := NewPendingMigration(req.TargetDir)
+	if err := couchdb.CreateDoc(inst, doc); err != nil {
+		log.WithField("account_id", accountID).
+			Errorf("Failed to create migration tracking doc: %s", err)
+		return nil, fmt.Errorf("create migration tracking doc: %w", err)
+	}
+	triggerLogger := log.WithFields(logger.Fields{
+		"migration_id": doc.DocID,
+		"account_id":   accountID,
+	})
+
+	msg := rabbitmq.NextcloudMigrationRequestedMessage{
+		MigrationID:   doc.DocID,
+		WorkplaceFqdn: inst.Domain,
+		AccountID:     accountID,
+		SourcePath:    req.SourcePath,
+		Timestamp:     time.Now().Unix(),
+	}
+	if err := rmq.Publish(ctx, rabbitmq.PublishRequest{
+		ContextName: inst.ContextName,
+		Exchange:    rabbitmq.ExchangeMigration,
+		RoutingKey:  rabbitmq.RoutingKeyNextcloudMigrationRequested,
+		Payload:     msg,
+		MessageID:   doc.DocID,
+	}); err != nil {
+		triggerLogger.Errorf("Failed to publish migration command: %s", err)
+		if markErr := doc.MarkFailed(inst, fmt.Errorf("publish migration command: %w", err)); markErr != nil {
+			triggerLogger.Errorf("Failed to mark migration as failed after publish error: %s", markErr)
+		}
+		return nil, fmt.Errorf("%w: %w", ErrMigrationBrokerUnavailable, err)
+	}
+
+	triggerLogger.WithField("source_path", req.SourcePath).
+		Infof("Nextcloud migration triggered")
+	return doc, nil
+}

--- a/pkg/consts/doctype.go
+++ b/pkg/consts/doctype.go
@@ -142,6 +142,9 @@ const (
 	// NextCloudFiles doc type is used when listing files from a NextCloud via
 	// WebDAV.
 	NextCloudFiles = "io.cozy.remote.nextcloud.files"
+	// NextcloudMigrations doc type is used to track bulk Nextcloud to Cozy
+	// migrations orchestrated by the external migration service.
+	NextcloudMigrations = "io.cozy.nextcloud.migrations"
 	// ChatAssistants doc type for AI chat assistants.
 	ChatAssistants = "io.cozy.ai.chat.assistants"
 	// ChatConversations doc type is used for a chat between the user and a chatbot.

--- a/pkg/couchdb/index.go
+++ b/pkg/couchdb/index.go
@@ -14,7 +14,7 @@ import (
 
 // IndexViewsVersion is the version of current definition of views & indexes.
 // This number should be incremented when this file changes.
-const IndexViewsVersion int = 37
+const IndexViewsVersion int = 38
 
 // Indexes is the index list required by an instance to run properly.
 var Indexes = []*mango.Index{
@@ -72,6 +72,10 @@ var Indexes = []*mango.Index{
 
 	// Used to find the active sharings
 	mango.MakeIndex(consts.Sharings, "active", mango.IndexDef{Fields: []string{"active"}}),
+
+	// Used to detect an already in-flight Nextcloud migration when a user
+	// tries to start a new one.
+	mango.MakeIndex(consts.NextcloudMigrations, "by-status", mango.IndexDef{Fields: []string{"status"}}),
 }
 
 // DiskUsageView is the view used for computing the disk usage for files

--- a/pkg/logger/context.go
+++ b/pkg/logger/context.go
@@ -1,0 +1,30 @@
+package logger
+
+import "context"
+
+// loggerContextKey is the private key type used to stash a Logger on a
+// context.Context. Keeping it unexported guarantees no other package can
+// collide with the same key.
+type loggerContextKey struct{}
+
+// WithContext returns a copy of ctx with log attached. Helper functions
+// deep in a call stack can then retrieve the caller's request-scoped
+// logger via FromContext instead of taking an explicit parameter.
+func WithContext(ctx context.Context, log Logger) context.Context {
+	if log == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, loggerContextKey{}, log)
+}
+
+// FromContext returns the Logger previously attached with WithContext.
+// If ctx carries no logger, it falls back to a fresh "default" namespace
+// logger so callers can log unconditionally without nil-checking.
+func FromContext(ctx context.Context) Logger {
+	if ctx != nil {
+		if log, ok := ctx.Value(loggerContextKey{}).(Logger); ok && log != nil {
+			return log
+		}
+	}
+	return WithNamespace("default")
+}

--- a/pkg/rabbitmq/contracts.go
+++ b/pkg/rabbitmq/contracts.go
@@ -1,7 +1,8 @@
 package rabbitmq
 
 const (
-	ExchangeAuth = "auth"
+	ExchangeAuth      = "auth"
+	ExchangeMigration = "migration"
 )
 
 const (
@@ -15,8 +16,9 @@ const (
 )
 
 const (
-	RoutingKeyUserPasswordUpdated   = "user.password.updated"
-	RoutingKeyUserDeletionRequested = "user.deletion.requested"
+	RoutingKeyUserPasswordUpdated         = "user.password.updated"
+	RoutingKeyUserDeletionRequested       = "user.deletion.requested"
+	RoutingKeyNextcloudMigrationRequested = "nextcloud.migration.requested"
 )
 
 // UserDeletionRequestedMessage is published when a user asks Twake to delete the account linked to the current cozy instance.
@@ -25,4 +27,20 @@ type UserDeletionRequestedMessage struct {
 	Reason        string `json:"reason"`
 	RequestedBy   string `json:"requestedBy"`
 	RequestedAt   int64  `json:"requestedAt"`
+}
+
+// NextcloudMigrationRequestedMessage is published when a user starts a
+// Nextcloud to Cozy migration from the Settings UI. The external migration
+// service consumes it, fetches an app audience token from the Cloudery, and
+// orchestrates the transfer through the Stack's Nextcloud routes.
+//
+// Credentials for the Nextcloud account are stored in the io.cozy.accounts
+// document referenced by AccountID. They MUST NOT be included in this
+// message: the broker is not a trust boundary for secrets.
+type NextcloudMigrationRequestedMessage struct {
+	MigrationID   string `json:"migrationId"`
+	WorkplaceFqdn string `json:"workplaceFqdn"`
+	AccountID     string `json:"accountId"`
+	SourcePath    string `json:"sourcePath,omitempty"`
+	Timestamp     int64  `json:"timestamp"`
 }

--- a/pkg/webdav/webdav.go
+++ b/pkg/webdav/webdav.go
@@ -260,6 +260,71 @@ func (c *Client) List(path string) ([]Item, error) {
 	return items, nil
 }
 
+// Size returns the recursive byte total of the resource at path, as
+// reported by the Nextcloud server's cached `oc:size` property. Equivalent
+// to `du -sb` on the path, computed in constant time on the server side
+// (no traversal). Supported by any Nextcloud/ownCloud host that serves
+// the `http://owncloud.org/ns` WebDAV namespace — confirmed against the
+// managed hosts we tested (nextcloud05.webo.cloud, use22.thegood.cloud).
+func (c *Client) Size(path string) (uint64, error) {
+	path = fixSlashes(path)
+	headers := map[string]string{
+		"Content-Type": "application/xml;charset=UTF-8",
+		"Accept":       "application/xml",
+		"Depth":        "0",
+	}
+	payload := strings.NewReader(sizeFilesPayload)
+	res, err := c.req("PROPFIND", path, 0, headers, payload)
+	if err != nil {
+		return 0, err
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, res.Body)
+		_ = res.Body.Close()
+	}()
+
+	switch res.StatusCode {
+	case 200, 207:
+		// continue
+	case 401, 403:
+		return 0, ErrInvalidAuth
+	case 404:
+		return 0, ErrNotFound
+	default:
+		return 0, ErrInternalServerError
+	}
+
+	var multistatus multistatus
+	if err := xml.NewDecoder(res.Body).Decode(&multistatus); err != nil {
+		return 0, err
+	}
+	for _, response := range multistatus.Responses {
+		for _, propstat := range response.Props {
+			parts := strings.Split(propstat.Status, " ")
+			if len(parts) < 2 || parts[1] != "200" {
+				continue
+			}
+			if propstat.OcSize == "" {
+				continue
+			}
+			return strconv.ParseUint(propstat.OcSize, 10, 64)
+		}
+	}
+	return 0, ErrNotFound
+}
+
+// sizeFilesPayload asks Nextcloud for only the `oc:size` property on the
+// target resource. Depth:0 means the server returns the resource itself,
+// not its children, so this is one small round trip regardless of how
+// many files the directory contains.
+const sizeFilesPayload = `<?xml version="1.0"?>
+<d:propfind xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
+  <d:prop>
+        <oc:size />
+  </d:prop>
+</d:propfind>
+`
+
 type Item struct {
 	ID           string
 	Type         string
@@ -290,6 +355,7 @@ type props struct {
 	TrashedName  string   `xml:"prop>trashbin-filename"`
 	RestorePath  string   `xml:"prop>trashbin-original-location"`
 	Size         string   `xml:"prop>getcontentlength"`
+	OcSize       string   `xml:"prop>size"`
 	ContentType  string   `xml:"prop>getcontenttype"`
 	LastModified string   `xml:"prop>getlastmodified"`
 	ETag         string   `xml:"prop>getetag"`

--- a/web/remote/app_token_verification_test.go
+++ b/web/remote/app_token_verification_test.go
@@ -1,0 +1,114 @@
+package remote
+
+import (
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/cozy/cozy-stack/model/account"
+	"github.com/cozy/cozy-stack/model/permission"
+	build "github.com/cozy/cozy-stack/pkg/config"
+	"github.com/cozy/cozy-stack/pkg/config/config"
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/tests/testutils"
+	weberrors "github.com/cozy/cozy-stack/web/errors"
+	"github.com/gavv/httpexpect/v2"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAppAudienceTokenPassesNextcloudPermissionCheck guards that an app
+// audience token whose webapp permission doc holds io.cozy.files can reach
+// GET /remote/nextcloud/:account/ without being rejected by the permission
+// middleware.
+func TestAppAudienceTokenPassesNextcloudPermissionCheck(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	config.UseTestFile(t)
+	testutils.NeedCouchdb(t)
+
+	oldBuildMode := build.BuildMode
+	build.BuildMode = build.ModeDev
+	t.Cleanup(func() { build.BuildMode = oldBuildMode })
+
+	setup := testutils.NewSetup(t, t.Name())
+	testInstance := setup.GetTestInstance()
+
+	rules := permission.Set{
+		permission.Rule{Type: consts.Files, Verbs: permission.ALL},
+		permission.Rule{Type: consts.NextcloudMigrations, Verbs: permission.ALL},
+	}
+	permReq := permission.Permission{
+		Permissions: rules,
+		Type:        permission.TypeWebapp,
+		SourceID:    consts.Apps + "/migrator",
+	}
+	require.NoError(t, couchdb.CreateDoc(testInstance, &permReq))
+	manifest := &couchdb.JSONDoc{
+		Type: consts.Apps,
+		M: map[string]interface{}{
+			"_id":         consts.Apps + "/migrator",
+			"slug":        "migrator",
+			"permissions": rules,
+		},
+	}
+	require.NoError(t, couchdb.CreateNamedDocWithDB(testInstance, manifest))
+	token := testInstance.BuildAppToken("migrator", "")
+	require.NotEmpty(t, token)
+
+	mockWebDAV := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/ocs/v2.php/cloud/user" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"ocs":{"data":{"id":"migrator"}}}`))
+			return
+		}
+		if r.Method == "PROPFIND" {
+			body, _ := xml.Marshal(struct {
+				XMLName xml.Name `xml:"d:multistatus"`
+				Xmlns   string   `xml:"xmlns:d,attr"`
+			}{Xmlns: "DAV:"})
+			w.Header().Set("Content-Type", "application/xml; charset=utf-8")
+			w.WriteHeader(http.StatusMultiStatus)
+			_, _ = w.Write(body)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(mockWebDAV.Close)
+
+	accountDoc := &couchdb.JSONDoc{
+		Type: consts.Accounts,
+		M: map[string]interface{}{
+			"account_type": "nextcloud",
+			"name":         "Migration Source",
+			"auth": map[string]interface{}{
+				"login":    "migrator",
+				"password": "secret",
+				"url":      mockWebDAV.URL + "/",
+			},
+			"webdav_user_id": "migrator",
+		},
+	}
+	account.Encrypt(*accountDoc)
+	require.NoError(t, couchdb.CreateDoc(testInstance, accountDoc))
+	accountID := accountDoc.ID()
+
+	ts := setup.GetTestServer("/remote", Routes)
+	ts.Config.Handler.(*echo.Echo).HTTPErrorHandler = weberrors.ErrorHandler
+	t.Cleanup(ts.Close)
+
+	e := testutils.CreateTestClient(t, ts.URL)
+
+	e.GET("/remote/nextcloud/"+accountID+"/").
+		WithHeader("Authorization", "Bearer "+token).
+		WithHost(testInstance.Domain).
+		Expect().Status(http.StatusOK).
+		JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+		Object().
+		Value("data").Array()
+}

--- a/web/remote/migration.go
+++ b/web/remote/migration.go
@@ -1,0 +1,112 @@
+package remote
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"path"
+	"strings"
+
+	"github.com/cozy/cozy-stack/model/nextcloud"
+	"github.com/cozy/cozy-stack/model/permission"
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/jsonapi"
+	"github.com/cozy/cozy-stack/pkg/logger"
+	"github.com/cozy/cozy-stack/pkg/utils"
+	"github.com/cozy/cozy-stack/pkg/webdav"
+	"github.com/cozy/cozy-stack/web/middlewares"
+	"github.com/labstack/echo/v4"
+)
+
+const nextcloudMigrationLogNamespace = "nextcloud-migration"
+
+type nextcloudMigrationRequest struct {
+	NextcloudURL         string `json:"nextcloud_url"`
+	NextcloudLogin       string `json:"nextcloud_login"`
+	NextcloudAppPassword string `json:"nextcloud_app_password"`
+	SourcePath           string `json:"source_path,omitempty"`
+	TargetDir            string `json:"target_dir,omitempty"`
+}
+
+func (r *nextcloudMigrationRequest) normalize() error {
+	r.NextcloudURL = strings.TrimSpace(r.NextcloudURL)
+	r.NextcloudLogin = strings.TrimSpace(r.NextcloudLogin)
+	r.NextcloudAppPassword = strings.TrimSpace(r.NextcloudAppPassword)
+	r.SourcePath = strings.TrimSpace(r.SourcePath)
+	r.TargetDir = strings.TrimSpace(r.TargetDir)
+
+	required := []struct {
+		name  string
+		value string
+	}{
+		{"nextcloud_url", r.NextcloudURL},
+		{"nextcloud_login", r.NextcloudLogin},
+		{"nextcloud_app_password", r.NextcloudAppPassword},
+	}
+	for _, f := range required {
+		if f.value == "" {
+			return fmt.Errorf("%s is required", f.name)
+		}
+	}
+	r.NextcloudURL = utils.EnsureHasSuffix(r.NextcloudURL, "/")
+	if r.SourcePath == "" {
+		r.SourcePath = "/"
+	}
+	if r.TargetDir != "" {
+		r.TargetDir = strings.TrimRight(r.TargetDir, "/")
+		if !strings.HasPrefix(r.TargetDir, "/") || path.Clean(r.TargetDir) != r.TargetDir {
+			return errors.New("target_dir must be a clean absolute path")
+		}
+	}
+	return nil
+}
+
+func (h *HTTPHandler) postNextcloudMigration(c echo.Context) error {
+	if err := middlewares.AllowWholeType(c, permission.POST, consts.NextcloudMigrations); err != nil {
+		return err
+	}
+	inst := middlewares.GetInstance(c)
+
+	var body nextcloudMigrationRequest
+	if err := c.Bind(&body); err != nil {
+		return jsonapi.BadRequest(errors.New("invalid JSON body"))
+	}
+	if err := body.normalize(); err != nil {
+		return jsonapi.BadRequest(err)
+	}
+
+	reqLogger := inst.Logger().WithNamespace(nextcloudMigrationLogNamespace).WithFields(logger.Fields{
+		"nextcloud_host":  utils.ExtractInstanceHost(body.NextcloudURL),
+		"nextcloud_login": body.NextcloudLogin,
+	})
+
+	doc, err := nextcloud.TriggerMigration(c.Request().Context(), inst, nextcloud.TriggerMigrationRequest{
+		NextcloudURL:         body.NextcloudURL,
+		NextcloudLogin:       body.NextcloudLogin,
+		NextcloudAppPassword: body.NextcloudAppPassword,
+		SourcePath:           body.SourcePath,
+		TargetDir:            body.TargetDir,
+	}, h.rmq, reqLogger)
+	if err != nil {
+		return mapNextcloudMigrationError(err)
+	}
+	return jsonapi.Data(c, http.StatusCreated, doc, nil)
+}
+
+// mapNextcloudMigrationError translates the typed errors returned by
+// [nextcloud.TriggerMigration] into the HTTP status codes the Settings UI
+// expects. Unknown errors fall through as 500.
+func mapNextcloudMigrationError(err error) error {
+	switch {
+	case errors.Is(err, nextcloud.ErrMigrationConflict):
+		return jsonapi.Conflict(err)
+	case errors.Is(err, webdav.ErrInvalidAuth):
+		return jsonapi.Unauthorized(errors.New("nextcloud credentials are invalid"))
+	case errors.Is(err, nextcloud.ErrNextcloudUnreachable):
+		return jsonapi.BadGateway(fmt.Errorf("nextcloud unreachable: %w", err))
+	case errors.Is(err, nextcloud.ErrMigrationBrokerUnavailable):
+		return jsonapi.NewError(http.StatusServiceUnavailable, "migration service is unavailable, please retry later")
+	default:
+		return jsonapi.InternalServerError(err)
+	}
+}

--- a/web/remote/migration_test.go
+++ b/web/remote/migration_test.go
@@ -1,0 +1,631 @@
+package remote_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cozy/cozy-stack/model/instance"
+	"github.com/cozy/cozy-stack/model/nextcloud"
+	"github.com/cozy/cozy-stack/model/permission"
+	build "github.com/cozy/cozy-stack/pkg/config"
+	"github.com/cozy/cozy-stack/pkg/config/config"
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/rabbitmq"
+	"github.com/cozy/cozy-stack/tests/testutils"
+	weberrors "github.com/cozy/cozy-stack/web/errors"
+	"github.com/cozy/cozy-stack/web/remote"
+	"github.com/gavv/httpexpect/v2"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type spyRabbitMQ struct {
+	mu       sync.Mutex
+	messages []rabbitmq.PublishRequest
+	err      error
+}
+
+func (s *spyRabbitMQ) StartManagers() ([]*rabbitmq.RabbitMQManager, error) {
+	return nil, nil
+}
+
+func (s *spyRabbitMQ) Publish(_ context.Context, req rabbitmq.PublishRequest) error {
+	if s.err != nil {
+		return s.err
+	}
+	if req.Payload != nil {
+		payload, err := json.Marshal(req.Payload)
+		if err != nil {
+			return err
+		}
+		req.Payload = payload
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messages = append(s.messages, req)
+	return nil
+}
+
+func (s *spyRabbitMQ) last() rabbitmq.PublishRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.messages[len(s.messages)-1]
+}
+
+func (s *spyRabbitMQ) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.messages)
+}
+
+type nextcloudMockOptions struct {
+	authStatus int
+	userID     string
+}
+
+func startMockNextcloud(t *testing.T, opts nextcloudMockOptions) (url string, calls *int32) {
+	t.Helper()
+	if opts.authStatus == 0 {
+		opts.authStatus = http.StatusOK
+	}
+	if opts.userID == "" {
+		opts.userID = "alice"
+	}
+	var counter int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/ocs/v2.php/cloud/user" {
+			atomic.AddInt32(&counter, 1)
+			if opts.authStatus != http.StatusOK {
+				w.WriteHeader(opts.authStatus)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprintf(w, `{"ocs":{"data":{"id":%q}}}`, opts.userID)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL + "/", &counter
+}
+
+func migrationPermission() *permission.Permission {
+	return &permission.Permission{
+		Type:     permission.TypeWebapp,
+		SourceID: consts.Apps + "/" + consts.SettingsSlug,
+		Permissions: permission.Set{
+			permission.Rule{
+				Type:  consts.NextcloudMigrations,
+				Verbs: permission.Verbs(permission.POST),
+			},
+		},
+	}
+}
+
+func setupMigrationRouter(t *testing.T, inst *instance.Instance, pdoc *permission.Permission, rmq rabbitmq.Service) *httptest.Server {
+	t.Helper()
+
+	handler := echo.New()
+	handler.HTTPErrorHandler = weberrors.ErrorHandler
+	group := handler.Group("/remote", func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			c.Set("instance", inst)
+			if pdoc != nil {
+				c.Set("permissions_doc", pdoc)
+			}
+			return next(c)
+		}
+	})
+
+	remote.NewHTTPHandler(rmq).Register(group)
+
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func migrationRequestBody(url string, extra map[string]interface{}) map[string]interface{} {
+	body := map[string]interface{}{
+		"nextcloud_url":          url,
+		"nextcloud_login":        "alice",
+		"nextcloud_app_password": "app-password-xxx",
+		"source_path":            "/",
+	}
+	for k, v := range extra {
+		body[k] = v
+	}
+	return body
+}
+
+func TestPostNextcloudMigration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	config.UseTestFile(t)
+	testutils.NeedCouchdb(t)
+
+	// safehttp refuses loopback hosts outside dev mode; flip the flag so
+	// httptest.NewServer URLs are reachable.
+	oldBuildMode := build.BuildMode
+	build.BuildMode = build.ModeDev
+	t.Cleanup(func() { build.BuildMode = oldBuildMode })
+
+	t.Run("HappyPath", func(t *testing.T) {
+		setup := testutils.NewSetup(t, "ncmigration-happy")
+		inst := setup.GetTestInstance()
+
+		ncURL, probeCalls := startMockNextcloud(t, nextcloudMockOptions{userID: "alice-webdav"})
+		spy := &spyRabbitMQ{}
+		ts := setupMigrationRouter(t, inst, migrationPermission(), spy)
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		obj := e.POST("/remote/nextcloud/migration").
+			WithHeader("Accept", "application/vnd.api+json").
+			WithJSON(migrationRequestBody(ncURL, nil)).
+			Expect().Status(http.StatusCreated).
+			JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+			Object()
+
+		data := obj.Value("data").Object()
+		data.Value("type").String().IsEqual(consts.NextcloudMigrations)
+		migrationID := data.Value("id").String().NotEmpty().Raw()
+		attrs := data.Value("attributes").Object()
+		attrs.Value("status").String().IsEqual(nextcloud.MigrationStatusPending)
+		attrs.Value("target_dir").String().IsEqual(nextcloud.DefaultMigrationTargetDir)
+		attrs.Value("errors").Array().IsEmpty()
+		attrs.Value("skipped").Array().IsEmpty()
+		progress := attrs.Value("progress").Object()
+		progress.Value("files_imported").Number().IsEqual(0)
+		progress.Value("files_total").Number().IsEqual(0)
+		progress.Value("bytes_imported").Number().IsEqual(0)
+		progress.Value("bytes_total").Number().IsEqual(0)
+
+		require.Equal(t, int32(1), atomic.LoadInt32(probeCalls), "probe should hit the OCS endpoint once")
+		require.Equal(t, 1, spy.count(), "expected one RabbitMQ publish")
+		pub := spy.last()
+		assert.Equal(t, rabbitmq.ExchangeMigration, pub.Exchange)
+		assert.Equal(t, rabbitmq.RoutingKeyNextcloudMigrationRequested, pub.RoutingKey)
+		assert.Equal(t, migrationID, pub.MessageID)
+
+		var payload rabbitmq.NextcloudMigrationRequestedMessage
+		require.NoError(t, json.Unmarshal(pub.Payload.([]byte), &payload))
+		assert.Equal(t, migrationID, payload.MigrationID)
+		assert.Equal(t, inst.Domain, payload.WorkplaceFqdn)
+		assert.NotEmpty(t, payload.AccountID)
+		assert.Equal(t, "/", payload.SourcePath)
+		assert.NotZero(t, payload.Timestamp)
+
+		var stored nextcloud.Migration
+		require.NoError(t, couchdb.GetDoc(inst, consts.NextcloudMigrations, migrationID, &stored))
+		assert.Equal(t, nextcloud.MigrationStatusPending, stored.Status)
+
+		var accDoc couchdb.JSONDoc
+		require.NoError(t, couchdb.GetDoc(inst, consts.Accounts, payload.AccountID, &accDoc))
+		assert.Equal(t, "nextcloud", accDoc.M["account_type"])
+		assert.Equal(t, "alice-webdav", accDoc.M["webdav_user_id"],
+			"probe-resolved userID must be cached on the account")
+		auth, ok := accDoc.M["auth"].(map[string]interface{})
+		require.True(t, ok, "auth should be a map")
+		assert.Equal(t, "alice", auth["login"])
+		assert.Nil(t, auth["password"], "plaintext password must not be persisted")
+		assert.NotEmpty(t, auth["credentials_encrypted"], "credentials should be encrypted at rest")
+	})
+
+	t.Run("CustomTargetDirIsPersisted", func(t *testing.T) {
+		setup := testutils.NewSetup(t, "ncmigration-target-dir")
+		inst := setup.GetTestInstance()
+
+		ncURL, _ := startMockNextcloud(t, nextcloudMockOptions{userID: "alice-webdav"})
+		spy := &spyRabbitMQ{}
+		ts := setupMigrationRouter(t, inst, migrationPermission(), spy)
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		obj := e.POST("/remote/nextcloud/migration").
+			WithHeader("Accept", "application/vnd.api+json").
+			WithJSON(migrationRequestBody(ncURL, map[string]interface{}{
+				"target_dir": "/Imports/From Nextcloud",
+			})).
+			Expect().Status(http.StatusCreated).
+			JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+			Object()
+
+		obj.Value("data").Object().
+			Value("attributes").Object().
+			Value("target_dir").String().IsEqual("/Imports/From Nextcloud")
+	})
+
+	t.Run("InvalidTargetDirRejected", func(t *testing.T) {
+		setup := testutils.NewSetup(t, "ncmigration-target-dir-invalid")
+		inst := setup.GetTestInstance()
+
+		ncURL, _ := startMockNextcloud(t, nextcloudMockOptions{userID: "alice-webdav"})
+		spy := &spyRabbitMQ{}
+		ts := setupMigrationRouter(t, inst, migrationPermission(), spy)
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		cases := []string{"Imports", "/foo/../bar", "/foo//bar", "/./bar"}
+		for _, td := range cases {
+			e.POST("/remote/nextcloud/migration").
+				WithHeader("Accept", "application/vnd.api+json").
+				WithJSON(migrationRequestBody(ncURL, map[string]interface{}{
+					"target_dir": td,
+				})).
+				Expect().Status(http.StatusBadRequest)
+		}
+		assert.Equal(t, 0, spy.count(), "no publish for invalid target_dir")
+	})
+
+	t.Run("WrongCredentialsReturn401", func(t *testing.T) {
+		setup := testutils.NewSetup(t, "ncmigration-wrong-creds")
+		inst := setup.GetTestInstance()
+
+		ncURL, probeCalls := startMockNextcloud(t, nextcloudMockOptions{authStatus: http.StatusUnauthorized})
+		spy := &spyRabbitMQ{}
+		ts := setupMigrationRouter(t, inst, migrationPermission(), spy)
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		e.POST("/remote/nextcloud/migration").
+			WithHeader("Accept", "application/vnd.api+json").
+			WithJSON(migrationRequestBody(ncURL, nil)).
+			Expect().Status(http.StatusUnauthorized)
+
+		assert.Equal(t, int32(1), atomic.LoadInt32(probeCalls))
+		assert.Equal(t, 0, spy.count(), "no publish when credentials are invalid")
+
+		var docs []*nextcloud.Migration
+		req := &couchdb.AllDocsRequest{Limit: 10}
+		err := couchdb.GetAllDocs(inst, consts.NextcloudMigrations, req, &docs)
+		if err != nil && !couchdb.IsNoDatabaseError(err) {
+			t.Fatalf("unexpected error listing migrations: %s", err)
+		}
+		assert.Empty(t, docs, "no tracking doc should be created on auth failure")
+
+		var accounts []*couchdb.JSONDoc
+		accReq := &couchdb.AllDocsRequest{Limit: 10}
+		err = couchdb.GetAllDocs(inst, consts.Accounts, accReq, &accounts)
+		if err != nil && !couchdb.IsNoDatabaseError(err) {
+			t.Fatalf("unexpected error listing accounts: %s", err)
+		}
+		for _, a := range accounts {
+			if a.M["account_type"] == "nextcloud" {
+				t.Fatalf("no nextcloud account should be created on auth failure, got %s", a.ID())
+			}
+		}
+	})
+
+	t.Run("NextcloudUnreachableReturns502", func(t *testing.T) {
+		setup := testutils.NewSetup(t, "ncmigration-unreachable")
+		inst := setup.GetTestInstance()
+
+		// Close the server immediately so the URL points at a dead listener.
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		deadURL := srv.URL + "/"
+		srv.Close()
+
+		spy := &spyRabbitMQ{}
+		ts := setupMigrationRouter(t, inst, migrationPermission(), spy)
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		e.POST("/remote/nextcloud/migration").
+			WithHeader("Accept", "application/vnd.api+json").
+			WithJSON(migrationRequestBody(deadURL, nil)).
+			Expect().Status(http.StatusBadGateway)
+
+		assert.Equal(t, 0, spy.count())
+	})
+
+	t.Run("ConcurrentTriggersSerializeUnderTheLock", func(t *testing.T) {
+		setup := testutils.NewSetup(t, "ncmigration-concurrent")
+		inst := setup.GetTestInstance()
+
+		ncURL, _ := startMockNextcloud(t, nextcloudMockOptions{})
+		spy := &spyRabbitMQ{}
+		ts := setupMigrationRouter(t, inst, migrationPermission(), spy)
+
+		body, err := json.Marshal(migrationRequestBody(ncURL, nil))
+		require.NoError(t, err)
+
+		const parallel = 5
+		statuses := make([]int, parallel)
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		for i := 0; i < parallel; i++ {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				<-start
+				req, rerr := http.NewRequest(http.MethodPost, ts.URL+"/remote/nextcloud/migration", bytes.NewReader(body))
+				require.NoError(t, rerr)
+				req.Header.Set("Accept", "application/vnd.api+json")
+				req.Header.Set("Content-Type", "application/json")
+				resp, rerr := http.DefaultClient.Do(req)
+				require.NoError(t, rerr)
+				resp.Body.Close()
+				statuses[idx] = resp.StatusCode
+			}(i)
+		}
+		close(start)
+		wg.Wait()
+
+		var created, conflict int
+		for _, s := range statuses {
+			switch s {
+			case http.StatusCreated:
+				created++
+			case http.StatusConflict:
+				conflict++
+			default:
+				t.Errorf("unexpected status %d", s)
+			}
+		}
+		assert.Equal(t, 1, created, "exactly one concurrent trigger must win")
+		assert.Equal(t, parallel-1, conflict, "the rest must see a 409 from the lock-protected re-check")
+
+		// And there must be exactly one pending/running tracking doc on
+		// disk, not one per parallel request.
+		var docs []*nextcloud.Migration
+		require.NoError(t, couchdb.GetAllDocs(inst, consts.NextcloudMigrations, &couchdb.AllDocsRequest{Limit: 20}, &docs))
+		assert.Len(t, docs, 1, "one tracking doc, not %d", len(docs))
+		assert.Equal(t, 1, spy.count(), "one RabbitMQ publish, not %d", spy.count())
+	})
+
+	t.Run("ConflictWhenMigrationAlreadyRunning", func(t *testing.T) {
+		setup := testutils.NewSetup(t, "ncmigration-conflict")
+		inst := setup.GetTestInstance()
+
+		existing := nextcloud.NewPendingMigration("")
+		existing.Status = nextcloud.MigrationStatusRunning
+		require.NoError(t, couchdb.CreateDoc(inst, existing))
+
+		ncURL, _ := startMockNextcloud(t, nextcloudMockOptions{})
+		spy := &spyRabbitMQ{}
+		ts := setupMigrationRouter(t, inst, migrationPermission(), spy)
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		e.POST("/remote/nextcloud/migration").
+			WithHeader("Accept", "application/vnd.api+json").
+			WithJSON(migrationRequestBody(ncURL, nil)).
+			Expect().Status(http.StatusConflict)
+
+		assert.Equal(t, 0, spy.count(), "no message should be published on conflict")
+	})
+
+	t.Run("PublishFailureMarksMigrationFailed", func(t *testing.T) {
+		setup := testutils.NewSetup(t, "ncmigration-publish-fail")
+		inst := setup.GetTestInstance()
+
+		ncURL, _ := startMockNextcloud(t, nextcloudMockOptions{})
+		spy := &spyRabbitMQ{err: fmt.Errorf("broker unreachable")}
+		ts := setupMigrationRouter(t, inst, migrationPermission(), spy)
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		e.POST("/remote/nextcloud/migration").
+			WithHeader("Accept", "application/vnd.api+json").
+			WithJSON(migrationRequestBody(ncURL, nil)).
+			Expect().Status(http.StatusServiceUnavailable)
+
+		active, err := nextcloud.FindActiveMigration(inst)
+		require.NoError(t, err)
+		assert.Nil(t, active, "failed migrations must not block new ones")
+
+		var docs []*nextcloud.Migration
+		req := &couchdb.AllDocsRequest{Limit: 10}
+		require.NoError(t, couchdb.GetAllDocs(inst, consts.NextcloudMigrations, req, &docs))
+		require.Len(t, docs, 1)
+		assert.Equal(t, nextcloud.MigrationStatusFailed, docs[0].Status)
+		require.NotEmpty(t, docs[0].Errors)
+		assert.Contains(t, docs[0].Errors[0].Message, "broker unreachable")
+	})
+
+	t.Run("AccountIsReusedOnSecondMigration", func(t *testing.T) {
+		setup := testutils.NewSetup(t, "ncmigration-account-reuse")
+		inst := setup.GetTestInstance()
+
+		ncURL, _ := startMockNextcloud(t, nextcloudMockOptions{})
+		spy := &spyRabbitMQ{}
+		ts := setupMigrationRouter(t, inst, migrationPermission(), spy)
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		first := e.POST("/remote/nextcloud/migration").
+			WithHeader("Accept", "application/vnd.api+json").
+			WithJSON(migrationRequestBody(ncURL, nil)).
+			Expect().Status(http.StatusCreated).
+			JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+			Object()
+		firstID := first.Value("data").Object().Value("id").String().Raw()
+		require.Equal(t, 1, spy.count())
+		firstAccountID := decodeAccountID(t, spy.last().Payload.([]byte))
+
+		// Flip the first migration to completed so the conflict check lets
+		// the second one through.
+		var doc nextcloud.Migration
+		require.NoError(t, couchdb.GetDoc(inst, consts.NextcloudMigrations, firstID, &doc))
+		doc.Status = nextcloud.MigrationStatusCompleted
+		require.NoError(t, couchdb.UpdateDoc(inst, &doc))
+
+		e.POST("/remote/nextcloud/migration").
+			WithHeader("Accept", "application/vnd.api+json").
+			WithJSON(migrationRequestBody(ncURL, nil)).
+			Expect().Status(http.StatusCreated)
+		require.Equal(t, 2, spy.count())
+		secondAccountID := decodeAccountID(t, spy.last().Payload.([]byte))
+
+		assert.Equal(t, firstAccountID, secondAccountID, "account should be reused across migrations")
+
+		var accounts []*couchdb.JSONDoc
+		req := &couchdb.AllDocsRequest{Limit: 10}
+		require.NoError(t, couchdb.GetAllDocs(inst, consts.Accounts, req, &accounts))
+		var nextcloudAccountIDs []string
+		for _, a := range accounts {
+			if a.M["account_type"] == "nextcloud" {
+				nextcloudAccountIDs = append(nextcloudAccountIDs, a.ID())
+			}
+		}
+		assert.Len(t, nextcloudAccountIDs, 1)
+	})
+
+	t.Run("SecondMigrationWithDifferentLoginReusesTheSameAccount", func(t *testing.T) {
+		// Policy: keyed-by-type-only. Triggering the endpoint with a
+		// different login rewrites the existing nextcloud account in
+		// place instead of creating a ghost doc the Settings UI cannot
+		// surface. The downside (no multi-account support, and losing a
+		// previously valid account on a typo retry) is accepted.
+		setup := testutils.NewSetup(t, "ncmigration-account-rekey")
+		inst := setup.GetTestInstance()
+
+		ncURL, _ := startMockNextcloud(t, nextcloudMockOptions{userID: "first"})
+		spy := &spyRabbitMQ{}
+		ts := setupMigrationRouter(t, inst, migrationPermission(), spy)
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		// First migration with login "alice".
+		firstResp := e.POST("/remote/nextcloud/migration").
+			WithHeader("Accept", "application/vnd.api+json").
+			WithJSON(migrationRequestBody(ncURL, nil)).
+			Expect().Status(http.StatusCreated).
+			JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+			Object()
+		firstMigrationID := firstResp.Value("data").Object().Value("id").String().Raw()
+		require.Equal(t, 1, spy.count())
+		firstAccountID := decodeAccountID(t, spy.last().Payload.([]byte))
+
+		// Unblock the next trigger by marking the first migration failed
+		// (failed does not count as active).
+		var firstDoc nextcloud.Migration
+		require.NoError(t, couchdb.GetDoc(inst, consts.NextcloudMigrations, firstMigrationID, &firstDoc))
+		firstDoc.Status = nextcloud.MigrationStatusFailed
+		require.NoError(t, couchdb.UpdateDoc(inst, &firstDoc))
+
+		// Second migration with a different login ("bob").
+		e.POST("/remote/nextcloud/migration").
+			WithHeader("Accept", "application/vnd.api+json").
+			WithJSON(migrationRequestBody(ncURL, map[string]interface{}{
+				"nextcloud_login": "bob",
+			})).
+			Expect().Status(http.StatusCreated)
+		require.Equal(t, 2, spy.count())
+		secondAccountID := decodeAccountID(t, spy.last().Payload.([]byte))
+
+		assert.Equal(t, firstAccountID, secondAccountID,
+			"the single nextcloud account must be rewritten, not orphaned")
+
+		// Exactly one nextcloud account on disk, with login now "bob".
+		var accounts []*couchdb.JSONDoc
+		require.NoError(t, couchdb.GetAllDocs(inst, consts.Accounts, &couchdb.AllDocsRequest{Limit: 10}, &accounts))
+		var ncAccounts []*couchdb.JSONDoc
+		for _, a := range accounts {
+			if a.M["account_type"] == "nextcloud" {
+				ncAccounts = append(ncAccounts, a)
+			}
+		}
+		require.Len(t, ncAccounts, 1)
+		auth, ok := ncAccounts[0].M["auth"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "bob", auth["login"], "login on the rewritten account")
+	})
+
+	t.Run("AccountReuseRefreshesStoredPassword", func(t *testing.T) {
+		setup := testutils.NewSetup(t, "ncmigration-refresh-password")
+		inst := setup.GetTestInstance()
+
+		ncURL, _ := startMockNextcloud(t, nextcloudMockOptions{})
+		spy := &spyRabbitMQ{}
+		ts := setupMigrationRouter(t, inst, migrationPermission(), spy)
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		stale := &couchdb.JSONDoc{
+			Type: consts.Accounts,
+			M: map[string]interface{}{
+				"account_type":   "nextcloud",
+				"webdav_user_id": "stale-userid",
+				"auth": map[string]interface{}{
+					"url":      ncURL,
+					"login":    "alice",
+					"password": "old-wrong-pass",
+				},
+			},
+		}
+		require.NoError(t, couchdb.CreateDoc(inst, stale))
+		staleID := stale.ID()
+
+		e.POST("/remote/nextcloud/migration").
+			WithHeader("Accept", "application/vnd.api+json").
+			WithJSON(migrationRequestBody(ncURL, map[string]interface{}{
+				"nextcloud_app_password": "fresh-correct-pass",
+			})).
+			Expect().Status(http.StatusCreated)
+
+		require.Equal(t, 1, spy.count())
+		reusedID := decodeAccountID(t, spy.last().Payload.([]byte))
+		assert.Equal(t, staleID, reusedID, "existing account should be reused, not duplicated")
+
+		var refreshed couchdb.JSONDoc
+		require.NoError(t, couchdb.GetDoc(inst, consts.Accounts, staleID, &refreshed))
+		assert.Equal(t, "alice", refreshed.M["webdav_user_id"],
+			"webdav_user_id should be refreshed from the probe")
+		auth, ok := refreshed.M["auth"].(map[string]interface{})
+		require.True(t, ok)
+		assert.NotEmpty(t, auth["credentials_encrypted"])
+		assert.Nil(t, auth["password"])
+	})
+
+	t.Run("RejectsMissingCredentials", func(t *testing.T) {
+		setup := testutils.NewSetup(t, "ncmigration-reject-missing")
+		inst := setup.GetTestInstance()
+
+		ncURL, _ := startMockNextcloud(t, nextcloudMockOptions{})
+		spy := &spyRabbitMQ{}
+		ts := setupMigrationRouter(t, inst, migrationPermission(), spy)
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		e.POST("/remote/nextcloud/migration").
+			WithHeader("Accept", "application/vnd.api+json").
+			WithJSON(migrationRequestBody(ncURL, map[string]interface{}{
+				"nextcloud_app_password": "",
+			})).
+			Expect().Status(http.StatusBadRequest)
+
+		assert.Equal(t, 0, spy.count())
+	})
+
+	t.Run("RejectsWithoutPermission", func(t *testing.T) {
+		setup := testutils.NewSetup(t, "ncmigration-reject-nomore")
+		inst := setup.GetTestInstance()
+
+		ncURL, _ := startMockNextcloud(t, nextcloudMockOptions{})
+		pdoc := &permission.Permission{
+			Type:     permission.TypeWebapp,
+			SourceID: consts.Apps + "/" + consts.SettingsSlug,
+		}
+		spy := &spyRabbitMQ{}
+		ts := setupMigrationRouter(t, inst, pdoc, spy)
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		e.POST("/remote/nextcloud/migration").
+			WithHeader("Accept", "application/vnd.api+json").
+			WithJSON(migrationRequestBody(ncURL, nil)).
+			Expect().Status(http.StatusForbidden)
+
+		assert.Equal(t, 0, spy.count())
+	})
+}
+
+func decodeAccountID(t *testing.T, payload []byte) string {
+	t.Helper()
+	var msg rabbitmq.NextcloudMigrationRequestedMessage
+	require.NoError(t, json.Unmarshal(payload, &msg))
+	return msg.AccountID
+}

--- a/web/remote/nextcloud.go
+++ b/web/remote/nextcloud.go
@@ -80,6 +80,30 @@ func nextcloudEmptyTrash(c echo.Context) error {
 	return c.NoContent(http.StatusNoContent)
 }
 
+// nextcloudSize proxies the Nextcloud "recursive size" probe for the
+// resource at :path. It answers `{"size": <bytes>}` and costs one
+// constant-time PROPFIND against Nextcloud regardless of the folder's
+// depth or file count, because it relies on the server-maintained
+// `oc:size` property instead of walking the tree.
+func nextcloudSize(c echo.Context) error {
+	inst := middlewares.GetInstance(c)
+	if err := middlewares.AllowWholeType(c, permission.GET, consts.Files); err != nil {
+		return err
+	}
+
+	accountID := c.Param("account")
+	nc, err := nextcloud.New(inst, accountID)
+	if err != nil {
+		return wrapNextcloudErrors(err)
+	}
+
+	size, err := nc.Size(c.Param("*"))
+	if err != nil {
+		return wrapNextcloudErrors(err)
+	}
+	return c.JSON(http.StatusOK, echo.Map{"size": size})
+}
+
 func nextcloudGet(c echo.Context) error {
 	inst := middlewares.GetInstance(c)
 	if err := middlewares.AllowWholeType(c, permission.GET, consts.Files); err != nil {
@@ -328,6 +352,7 @@ func nextcloudRoutes(router *echo.Group) {
 	group.GET("/trash/*", nextcloudGetTrash)
 	group.DELETE("/trash/*", nextcloudDeleteTrash)
 	group.DELETE("/trash", nextcloudEmptyTrash)
+	group.GET("/size/*", nextcloudSize)
 	group.GET("/*", nextcloudGet)
 	group.PUT("/*", nextcloudPut)
 	group.DELETE("/*", nextcloudDelete)

--- a/web/remote/remote.go
+++ b/web/remote/remote.go
@@ -10,9 +10,31 @@ import (
 	"github.com/cozy/cozy-stack/model/remote"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/jsonapi"
+	"github.com/cozy/cozy-stack/pkg/rabbitmq"
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/labstack/echo/v4"
 )
+
+// HTTPHandler owns the remote routes that need stack services injected from
+// the main process (for example the RabbitMQ broker for the Nextcloud
+// migration trigger). Stateless routes are wired through the package-level
+// [Routes] function.
+type HTTPHandler struct {
+	rmq rabbitmq.Service
+}
+
+// NewHTTPHandler builds a handler with the given service dependencies.
+func NewHTTPHandler(rmq rabbitmq.Service) *HTTPHandler {
+	return &HTTPHandler{rmq: rmq}
+}
+
+// Register wires every route the remote package serves, stateless and
+// stateful, onto the given router. The caller should no longer call [Routes]
+// separately once it holds an HTTPHandler.
+func (h *HTTPHandler) Register(router *echo.Group) {
+	Routes(router)
+	router.POST("/nextcloud/migration", h.postNextcloudMigration)
+}
 
 func allDoctypes(c echo.Context) error {
 	if err := middlewares.AllowWholeType(c, permission.GET, consts.Doctypes); err != nil {

--- a/web/remote/remote_test.go
+++ b/web/remote/remote_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -106,6 +107,174 @@ func generateAppToken(inst *instance.Instance, slug, doctype string) string {
 	return inst.BuildAppToken(slug, "")
 }
 
+func TestNextcloudSize(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	config.UseTestFile(t)
+	testutils.NeedCouchdb(t)
+
+	oldBuildMode := build.BuildMode
+	build.BuildMode = build.ModeDev
+	t.Cleanup(func() { build.BuildMode = oldBuildMode })
+
+	setup := testutils.NewSetup(t, t.Name())
+	testInstance := setup.GetTestInstance()
+	token := generateAppToken(testInstance, "testapp", consts.Files)
+
+	// Mock Nextcloud: answer the OCS probe for the account constructor,
+	// and a Depth:0 PROPFIND that asks for oc:size with a multistatus
+	// reply carrying a hard-coded byte total. The test asserts the stack
+	// parses and surfaces that number verbatim.
+	const wantSize uint64 = 67365343
+	var lastPropfindPath string
+	mockWebDAV := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/ocs/v2.php/cloud/user" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ocs":{"data":{"id":"testuser"}}}`))
+			return
+		}
+		if r.Method == "PROPFIND" && strings.HasPrefix(r.URL.Path, "/remote.php/dav/files/testuser/") {
+			lastPropfindPath = r.URL.Path
+			w.Header().Set("Content-Type", "application/xml; charset=utf-8")
+			w.WriteHeader(http.StatusMultiStatus)
+			_, _ = w.Write([]byte(`<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
+  <d:response>
+    <d:href>` + r.URL.Path + `</d:href>
+    <d:propstat>
+      <d:prop><oc:size>67365343</oc:size></d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+</d:multistatus>`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(mockWebDAV.Close)
+
+	ts := setup.GetTestServer("/remote", Routes)
+	ts.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler
+	t.Cleanup(ts.Close)
+
+	accountDoc := &couchdb.JSONDoc{
+		Type: consts.Accounts,
+		M: map[string]interface{}{
+			"account_type": "nextcloud",
+			"name":         "Test NextCloud",
+			"auth": map[string]interface{}{
+				"login":    "testuser",
+				"password": "testpass",
+				"url":      mockWebDAV.URL + "/",
+			},
+			"webdav_user_id": "testuser",
+		},
+	}
+	account.Encrypt(*accountDoc)
+	require.NoError(t, couchdb.CreateDoc(testInstance, accountDoc))
+	accountID := accountDoc.ID()
+
+	e := testutils.CreateTestClient(t, ts.URL)
+
+	t.Run("ReturnsTheRecursiveSizeOfASubfolder", func(t *testing.T) {
+		obj := e.GET("/remote/nextcloud/"+accountID+"/size/Photos").
+			WithHeader("Authorization", "Bearer "+token).
+			WithHost(testInstance.Domain).
+			Expect().Status(http.StatusOK).
+			JSON().Object()
+
+		obj.Value("size").Number().IsEqual(wantSize)
+		assert.Equal(t, "/remote.php/dav/files/testuser/Photos/", lastPropfindPath,
+			"should PROPFIND the requested sub-path")
+	})
+
+	t.Run("TreatsAnEmptyPathAsTheAccountRoot", func(t *testing.T) {
+		lastPropfindPath = ""
+		obj := e.GET("/remote/nextcloud/"+accountID+"/size/").
+			WithHeader("Authorization", "Bearer "+token).
+			WithHost(testInstance.Domain).
+			Expect().Status(http.StatusOK).
+			JSON().Object()
+
+		obj.Value("size").Number().IsEqual(wantSize)
+		assert.Equal(t, "/remote.php/dav/files/testuser/", lastPropfindPath,
+			"should PROPFIND the account root for an empty sub-path")
+	})
+
+	t.Run("Returns404WhenTheAccountDoesNotExist", func(t *testing.T) {
+		e.GET("/remote/nextcloud/does-not-exist/size/Photos").
+			WithHeader("Authorization", "Bearer "+token).
+			WithHost(testInstance.Domain).
+			Expect().Status(http.StatusNotFound)
+	})
+}
+
+func TestNextcloudSizeErrorClassification(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	config.UseTestFile(t)
+	testutils.NeedCouchdb(t)
+
+	oldBuildMode := build.BuildMode
+	build.BuildMode = build.ModeDev
+	t.Cleanup(func() { build.BuildMode = oldBuildMode })
+
+	setup := testutils.NewSetup(t, t.Name())
+	testInstance := setup.GetTestInstance()
+	token := generateAppToken(testInstance, "testapp", consts.Files)
+
+	// Mock Nextcloud that always rejects credentials on PROPFIND so the
+	// stack's error-wrapping layer has to pick a mapping. Anything other
+	// than 401 would mean wrapNextcloudErrors missed a branch.
+	mockWebDAV := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/ocs/v2.php/cloud/user" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ocs":{"data":{"id":"testuser"}}}`))
+			return
+		}
+		if r.Method == "PROPFIND" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(mockWebDAV.Close)
+
+	ts := setup.GetTestServer("/remote", Routes)
+	ts.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler
+	t.Cleanup(ts.Close)
+
+	accountDoc := &couchdb.JSONDoc{
+		Type: consts.Accounts,
+		M: map[string]interface{}{
+			"account_type": "nextcloud",
+			"name":         "Test NextCloud",
+			"auth": map[string]interface{}{
+				"login":    "testuser",
+				"password": "testpass",
+				"url":      mockWebDAV.URL + "/",
+			},
+			"webdav_user_id": "testuser",
+		},
+	}
+	account.Encrypt(*accountDoc)
+	require.NoError(t, couchdb.CreateDoc(testInstance, accountDoc))
+	accountID := accountDoc.ID()
+
+	e := testutils.CreateTestClient(t, ts.URL)
+
+	t.Run("Surfaces401WhenNextcloudRejectsTheCredentials", func(t *testing.T) {
+		e.GET("/remote/nextcloud/"+accountID+"/size/Photos").
+			WithHeader("Authorization", "Bearer "+token).
+			WithHost(testInstance.Domain).
+			Expect().Status(http.StatusUnauthorized)
+	})
+}
+
 func TestNextcloudDownstreamFailOnConflict(t *testing.T) {
 	if testing.Short() {
 		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
@@ -142,11 +311,11 @@ func TestNextcloudDownstreamFailOnConflict(t *testing.T) {
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
-		// Handle user_status endpoint (needed to get webdav_user_id)
-		if r.URL.Path == "/ocs/v2.php/apps/user_status/api/v1/user_status" {
+		// Handle OCS cloud/user endpoint (needed to get webdav_user_id)
+		if r.URL.Path == "/ocs/v2.php/cloud/user" {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"ocs":{"data":{"userId":"testuser"}}}`))
+			w.Write([]byte(`{"ocs":{"data":{"id":"testuser"}}}`))
 			return
 		}
 		w.WriteHeader(http.StatusNotFound)

--- a/web/routing.go
+++ b/web/routing.go
@@ -234,7 +234,7 @@ func SetupRoutes(router *echo.Echo, services *stack.Services) error {
 		realtime.Routes(router.Group("/realtime", mws...))
 		notes.Routes(router.Group("/notes", mws...))
 		office.Routes(router.Group("/office", mws...))
-		remote.Routes(router.Group("/remote", mws...))
+		remote.NewHTTPHandler(services.RabbitMQ).Register(router.Group("/remote", mws...))
 		sharings.Routes(router.Group("/sharings", mws...))
 		bitwarden.Routes(router.Group("/bitwarden", mws...))
 		shortcuts.Routes(router.Group("/shortcuts", mws...))


### PR DESCRIPTION
## Summary

Adds `POST /remote/nextcloud/migration` so the Settings UI can start a Nextcloud-to-Cozy bulk migration end-to-end. The endpoint probes the supplied credentials, upserts an `io.cozy.accounts` document with the resolved WebDAV user ID, creates an `io.cozy.nextcloud.migrations` tracking document in `pending` state, and publishes a `nextcloud.migration.requested` command to the `migration` RabbitMQ exchange. A separate service consumes the command and drives the existing `/remote/nextcloud/:account/*` routes, writing progress back to the tracking document so the UI can render a real-time progress bar.

Only one migration per instance can be in flight at a time; failed migrations do not block retries.

## API

`POST /remote/nextcloud/migration` (requires `POST io.cozy.nextcloud.migrations`)

```json
{
  "nextcloud_url": "https://nextcloud.example.com",
  "nextcloud_login": "alice",
  "nextcloud_app_password": "xxxxx-xxxxx-xxxxx-xxxxx-xxxxx",
  "source_path": "/",
  "target_dir": "/Nextcloud"
}
```

`source_path` and `target_dir` are optional. `source_path` defaults to `/`. `target_dir` defaults to `/Nextcloud` and must be a clean absolute path (validated with `path.Clean`, so `..`, double slashes, and relative segments are rejected). `nextcloud_app_password` should be a Nextcloud app password, not the account password.

### Error responses

| Code | When |
| ---- | ---- |
| 400 Bad Request | Required fields missing or `target_dir` is not a clean absolute path |
| 401 Unauthorized | The Nextcloud server rejected the supplied credentials |
| 409 Conflict | A `pending` or `running` migration already exists for this instance |
| 500 Internal Server Error | Account upsert or tracking document creation failed |
| 502 Bad Gateway | The Nextcloud instance is unreachable |
| 503 Service Unavailable | RabbitMQ publish failed; the tracking document is marked `failed` before returning |

## Companion route: recursive size

`GET /remote/nextcloud/:account/size/*path` returns the recursive byte total of a Nextcloud folder via a single PROPFIND on `oc:size`. The migration consumer uses it as a pre-flight quota check so it knows the true source size before starting; the previous shallow-sum estimate could be off by several orders of magnitude on deep trees.

## RabbitMQ contract

Exchange `migration`, routing key `nextcloud.migration.requested`. The consumer is responsible for declaring its queue and binding.

```json
{
  "migrationId": "d4e5f6a7b8c94d0ea1b2c3d4e5f6a7b8",
  "workplaceFqdn": "alice.cozy.example.com",
  "accountId": "a1b2c3d4e5f6",
  "sourcePath": "/",
  "timestamp": 1712563200
}
```

Credentials are never in the payload; they live in the `io.cozy.accounts` document referenced by `accountId`. `target_dir` is read by the consumer from the tracking document so legacy messages and new ones both flow through the same path. `MessageID` is set to the migration ID for cross-system tracing.

## Credentials probe

The OCS probe itself is not new. It already existed as a lazy fallback behind `(nc *NextCloud).fetchUserID()`, called from `fillUserID` only when an existing account document was missing its cached `webdav_user_id`. In practice that path was almost never exercised, so a latent bug sat there undetected: the probe targeted `apps/user_status`, and any non-200 (including a 404 from a managed Nextcloud host that strips the optional `user_status` app) was turned into `webdav.ErrInvalidAuth`.

What this PR adds is the synchronous, user-facing path: the migration trigger endpoint calls `FetchUserIDWithCredentials` before persisting anything, so the probe is now on the critical path of every trigger. That exposure turned the latent classification bug into a user-visible 401 for anyone pointing the feature at a managed Nextcloud like `thegood.cloud`.

A follow-up commit on this branch fixes it by switching the probe to OCS Core (`/ocs/v2.php/cloud/user`, which cannot be disabled by an admin) and narrowing the auth-failure classification to 401/403 only, so other non-2xx statuses bubble up with their real cause. Both code paths (the old lazy fallback and the new synchronous call) benefit from the fix.

Validated end-to-end against a real Nextcloud instance: the probe, the encrypted-at-rest account persistence, the tracking document, the `/size/*path` pre-flight, the RabbitMQ publish with no credentials in the payload, and the consumer-driven transfer all behave as documented.