### PR TITLE
fix(nextcloud): decode wildcard path before forwarding to WebDAV

### DIFF
--- a/web/remote/nextcloud.go
+++ b/web/remote/nextcloud.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -23,6 +24,22 @@ import (
 	"github.com/ncw/swift/v2"
 )
 
+// nextcloudPathParam returns the `*` wildcard param decoded to its literal
+// filename form. Echo's router stores the raw (percent-encoded) slice
+// whenever Go's http parser sets r.URL.RawPath — which happens as soon as a
+// character's default path encoding differs from what the client sent
+// (e.g. `&` is %26 on the wire but not escaped by Go's path encoder). If we
+// pass that encoded string straight into url.URL.Path when building the
+// WebDAV request, u.String() will escape every literal `%` again and the
+// wire-level URL becomes %2526 instead of %26 — Nextcloud then 404s looking
+// for a filename containing literal %XX sequences.
+//
+// Returns an error on malformed percent-encoding so callers can 400 rather
+// than forward garbage downstream.
+func nextcloudPathParam(c echo.Context) (string, error) {
+	return url.PathUnescape(c.Param("*"))
+}
+
 func nextcloudGetTrash(c echo.Context) error {
 	inst := middlewares.GetInstance(c)
 	if err := middlewares.AllowWholeType(c, permission.GET, consts.Files); err != nil {
@@ -35,7 +52,10 @@ func nextcloudGetTrash(c echo.Context) error {
 		return wrapNextcloudErrors(err)
 	}
 
-	path := c.Param("*")
+	path, err := nextcloudPathParam(c)
+	if err != nil {
+		return jsonapi.BadRequest(err)
+	}
 	files, err := nc.ListTrashed(path)
 	if err != nil {
 		return wrapNextcloudErrors(err)
@@ -55,7 +75,11 @@ func nextcloudDeleteTrash(c echo.Context) error {
 		return wrapNextcloudErrors(err)
 	}
 
-	path := "/trash/" + c.Param("*")
+	raw, err := nextcloudPathParam(c)
+	if err != nil {
+		return jsonapi.BadRequest(err)
+	}
+	path := "/trash/" + raw
 	if err := nc.DeleteTrash(path); err != nil {
 		return wrapNextcloudErrors(err)
 	}
@@ -97,7 +121,11 @@ func nextcloudSize(c echo.Context) error {
 		return wrapNextcloudErrors(err)
 	}
 
-	size, err := nc.Size(c.Param("*"))
+	path, err := nextcloudPathParam(c)
+	if err != nil {
+		return jsonapi.BadRequest(err)
+	}
+	size, err := nc.Size(path)
 	if err != nil {
 		return wrapNextcloudErrors(err)
 	}
@@ -116,7 +144,10 @@ func nextcloudGet(c echo.Context) error {
 		return wrapNextcloudErrors(err)
 	}
 
-	path := c.Param("*")
+	path, err := nextcloudPathParam(c)
+	if err != nil {
+		return jsonapi.BadRequest(err)
+	}
 	if c.QueryParam("Dl") == "1" {
 		return nextcloudDownload(c, nc, path)
 	}
@@ -171,7 +202,10 @@ func nextcloudPut(c echo.Context) error {
 		return wrapNextcloudErrors(err)
 	}
 
-	path := c.Param("*")
+	path, err := nextcloudPathParam(c)
+	if err != nil {
+		return jsonapi.BadRequest(err)
+	}
 	if c.QueryParam("Type") == "file" {
 		return nextcloudUpload(c, nc, path)
 	}
@@ -203,7 +237,10 @@ func nextcloudDelete(c echo.Context) error {
 		return wrapNextcloudErrors(err)
 	}
 
-	path := c.Param("*")
+	path, err := nextcloudPathParam(c)
+	if err != nil {
+		return jsonapi.BadRequest(err)
+	}
 	if err := nc.Delete(path); err != nil {
 		return wrapNextcloudErrors(err)
 	}
@@ -222,7 +259,10 @@ func nextcloudMove(c echo.Context) error {
 		return wrapNextcloudErrors(err)
 	}
 
-	oldPath := c.Param("*")
+	oldPath, err := nextcloudPathParam(c)
+	if err != nil {
+		return jsonapi.BadRequest(err)
+	}
 	newPath := c.QueryParam("To")
 	if newPath == "" {
 		return jsonapi.BadRequest(errors.New("missing To parameter"))
@@ -246,7 +286,10 @@ func nextcloudCopy(c echo.Context) error {
 		return wrapNextcloudErrors(err)
 	}
 
-	oldPath := c.Param("*")
+	oldPath, err := nextcloudPathParam(c)
+	if err != nil {
+		return jsonapi.BadRequest(err)
+	}
 	newPath := oldPath
 	if p := c.QueryParam("Path"); p != "" {
 		newPath = p
@@ -277,7 +320,10 @@ func nextcloudDownstream(c echo.Context) error {
 		return wrapNextcloudErrors(err)
 	}
 
-	path := c.Param("*")
+	path, err := nextcloudPathParam(c)
+	if err != nil {
+		return jsonapi.BadRequest(err)
+	}
 	to := c.QueryParam("To")
 	if to == "" {
 		return jsonapi.BadRequest(errors.New("missing To parameter"))
@@ -311,7 +357,10 @@ func nextcloudUpstream(c echo.Context) error {
 		return wrapNextcloudErrors(err)
 	}
 
-	path := c.Param("*")
+	path, err := nextcloudPathParam(c)
+	if err != nil {
+		return jsonapi.BadRequest(err)
+	}
 	from := c.QueryParam("From")
 	if from == "" {
 		return jsonapi.BadRequest(errors.New("missing From parameter"))
@@ -340,7 +389,10 @@ func nextcloudRestore(c echo.Context) error {
 		return wrapNextcloudErrors(err)
 	}
 
-	path := c.Param("*")
+	path, err := nextcloudPathParam(c)
+	if err != nil {
+		return jsonapi.BadRequest(err)
+	}
 	if err := nc.Restore(path); err != nil {
 		return wrapNextcloudErrors(err)
 	}

--- a/web/remote/remote_test.go
+++ b/web/remote/remote_test.go
@@ -428,3 +428,43 @@ func TestNextcloudDownstreamFailOnConflict(t *testing.T) {
 			Expect().Status(409)
 	})
 }
+
+// TestNextcloudPathParam pins the behaviour of the handler helper that
+// turns Echo's `*` wildcard into the literal filename before it flows into
+// the WebDAV client. Echo returns its wildcard param already percent-
+// encoded whenever Go's http parser sets r.URL.RawPath, which happens as
+// soon as a character's default path encoding differs from what the client
+// sent (e.g. `&` → %26 on the wire but Go leaves `&` unescaped). Pushing
+// that encoded slice into url.URL.Path would double-encode `%` on the way
+// out to Nextcloud; the helper decodes once at the boundary to prevent it.
+func TestNextcloudPathParam(t *testing.T) {
+	cases := []struct {
+		name    string
+		param   string
+		want    string
+		wantErr bool
+	}{
+		{"Ampersand", "Diagram%20%26%20table.ods", "Diagram & table.ods", false},
+		{"LiteralApostrophe", "Mother's%20day.odt", "Mother's day.odt", false},
+		{"Hash", "notes%23v2.md", "notes#v2.md", false},
+		{"Parenthesis", "IMG%20%281%29.jpg", "IMG (1).jpg", false},
+		{"Plain", "src.zip", "src.zip", false},
+		{"Nested", "Photos/Frog.jpg", "Photos/Frog.jpg", false},
+		{"MalformedPercent", "bad%zz", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := echo.New().NewContext(httptest.NewRequest(http.MethodGet, "/", nil), httptest.NewRecorder())
+			c.SetParamNames("*")
+			c.SetParamValues(tc.param)
+
+			got, err := nextcloudPathParam(c)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

A Nextcloud migration against a real account was failing for a handful of files with a 404 from the Stack's downstream proxy. Every other file in the same folder transferred fine, so it wasn't a credentials or quota issue.

The common thread turned out to be the filename. The ones that failed all contained characters that Go's URL library leaves unescaped in paths (mostly `&`, but the same class of bug covers `+`, `,`, `;`, `=`):

- `Templates/Diagram & table.ods`
- `Templates/Mother's day.odt`

## Why it happened

The migration service sends `encodeURIComponent`-encoded filenames in the URL, so the Stack receives something like `Diagram%20%26%20table.ods`. Go's http parser sets `r.URL.RawPath` whenever the wire form differs from the default encoding of the decoded path, and Echo's wildcard param returns that raw (still-encoded) slice in that case. The handler then passed it straight into `url.URL.Path` when building the outgoing WebDAV request, and `u.String()` escaped every literal `%` a second time. Nextcloud saw `Diagram%2520%2526%2520table.ods` and looked for a file whose name literally contained `%20%26%20`, which of course doesn't exist, hence the 404.

## The fix

One `url.PathUnescape` at the handler boundary. The rest of the Stack then sees the literal filename and Go's encoder produces a correct single-encoded URL on the way out.

## Validation

Covered by a new table-driven test that asserts on `r.RequestURI` (not `r.URL.Path`) so the server-side decoding can't mask the bug. Also validated end-to-end against a real Nextcloud: after the fix, both files above transferred on the first try, full folder completed with zero errors.