### PR TITLE
feat(nextcloud): cancel endpoint for in-flight migrations

### DIFF
--- a/docs/nextcloud.md
+++ b/docs/nextcloud.md
@@ -714,3 +714,47 @@ Content-Type: application/vnd.api+json
 - 500 Internal Server Error, when the conflict check, account upsert, or tracking document creation fails
 - 502 Bad Gateway, when the Nextcloud instance is unreachable
 - 503 Service Unavailable, when the migration command cannot be published to RabbitMQ. The tracking document is marked `failed` before returning
+
+## POST /remote/nextcloud/migration/:id/cancel
+
+This route asks the migration service to stop an in-flight migration. The
+Stack publishes a `nextcloud.migration.canceled` command to the `migration`
+RabbitMQ exchange; the migration service then stops the migration between
+files and transitions the tracking document to a new terminal state
+`canceled` with progress up to the last completed file preserved.
+
+The Stack does not write to the tracking document on cancel: that terminal
+state transition is owned by the migration service so there is a single
+writer for it. A `202 Accepted` means "cancel requested, poll the tracking
+document for the terminal state", not "migration stopped". Worst-case
+delay from request to observed terminal state is roughly one file transfer.
+
+**Note:** a permission on `POST io.cozy.nextcloud.migrations` is required
+to use this route.
+
+### Request
+
+```http
+POST /remote/nextcloud/migration/d4e5f6a7b8c94d0ea1b2c3d4e5f6a7b8/cancel HTTP/1.1
+Host: cozy.example.net
+Authorization: Bearer eyJhbG...
+```
+
+No request body.
+
+### Response
+
+```http
+HTTP/1.1 202 Accepted
+```
+
+Empty body.
+
+#### Status codes
+
+- 202 Accepted, when the cancel command has been published
+- 401 Unauthorized, when the bearer token is missing or invalid
+- 403 Forbidden, when the token lacks the `POST io.cozy.nextcloud.migrations` permission
+- 404 Not Found, when no tracking document with the given id exists on the instance
+- 409 Conflict, when the migration has already reached a terminal state (`completed`, `failed`, or `canceled`)
+- 503 Service Unavailable, when the cancel command cannot be published to RabbitMQ. Unlike the trigger endpoint, the tracking document is **not** marked `failed`: a broker glitch must not invalidate a migration that is still running. Retry the cancel.

--- a/model/nextcloud/cancel.go
+++ b/model/nextcloud/cancel.go
@@ -1,0 +1,86 @@
+package nextcloud
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/cozy/cozy-stack/model/instance"
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/logger"
+	"github.com/cozy/cozy-stack/pkg/rabbitmq"
+)
+
+// ErrMigrationNotFound is returned when the tracking document referenced
+// by a cancel request does not exist. Callers map it to a 404 rather
+// than publishing into the void.
+var ErrMigrationNotFound = errors.New("nextcloud migration not found")
+
+// ErrMigrationAlreadyTerminal is returned when cancel is requested on a
+// migration that has already reached completed, failed, or canceled.
+// Callers map it to a 409. The migration service's cancel_requested
+// fallback would swallow a stray message, but publishing when there is
+// nothing to stop wastes broker work and pollutes metrics.
+var ErrMigrationAlreadyTerminal = errors.New("nextcloud migration already in a terminal state")
+
+// CancelMigration validates the request and publishes a cancel command.
+// It intentionally does NOT mutate the tracking document: the terminal
+// state transition is owned by the migration service so there is a single
+// writer for it.
+//
+// The diagnostic logger is pulled from ctx via logger.FromContext so the
+// caller can attach its request-scoped fields (migration_id, etc.) once
+// with logger.WithContext rather than threading an extra parameter.
+//
+// Error contract, in priority order, so callers can map via errors.Is:
+//
+//   - [ErrMigrationNotFound]: no tracking doc with this id on the instance.
+//   - [ErrMigrationAlreadyTerminal]: the migration has already reached a
+//     terminal state (completed, failed, or canceled).
+//   - [ErrMigrationBrokerUnavailable]: the RabbitMQ publish failed.
+//     Unlike trigger, the tracking doc is NOT marked failed: a cancel
+//     publish failure does not invalidate a migration that is already
+//     running. The user retries, or the migration finishes normally.
+//   - any other error: treat as an internal server failure.
+func CancelMigration(
+	ctx context.Context,
+	inst *instance.Instance,
+	migrationID string,
+	rmq rabbitmq.Service,
+) error {
+	log := logger.FromContext(ctx)
+
+	var doc Migration
+	if err := couchdb.GetDoc(inst, consts.NextcloudMigrations, migrationID, &doc); err != nil {
+		if couchdb.IsNotFoundError(err) || couchdb.IsNoDatabaseError(err) {
+			return ErrMigrationNotFound
+		}
+		return fmt.Errorf("load migration %s: %w", migrationID, err)
+	}
+	if doc.IsTerminal() {
+		log.WithField("status", doc.Status).
+			Infof("Cancel rejected on terminal migration")
+		return ErrMigrationAlreadyTerminal
+	}
+
+	msg := rabbitmq.NextcloudMigrationCanceledMessage{
+		MigrationID:   migrationID,
+		WorkplaceFqdn: inst.Domain,
+		Timestamp:     time.Now().Unix(),
+	}
+	if err := rmq.Publish(ctx, rabbitmq.PublishRequest{
+		ContextName: inst.ContextName,
+		Exchange:    rabbitmq.ExchangeMigration,
+		RoutingKey:  rabbitmq.RoutingKeyNextcloudMigrationCanceled,
+		Payload:     msg,
+		MessageID:   migrationID,
+	}); err != nil {
+		log.Errorf("Failed to publish migration cancel: %s", err)
+		return fmt.Errorf("%w: %w", ErrMigrationBrokerUnavailable, err)
+	}
+
+	log.Infof("Nextcloud migration cancel requested")
+	return nil
+}

--- a/model/nextcloud/migration.go
+++ b/model/nextcloud/migration.go
@@ -19,6 +19,7 @@ const (
 	MigrationStatusRunning   = "running"
 	MigrationStatusCompleted = "completed"
 	MigrationStatusFailed    = "failed"
+	MigrationStatusCanceled  = "canceled"
 )
 
 const DefaultMigrationTargetDir = "/Nextcloud"
@@ -30,16 +31,21 @@ var ErrMigrationConflict = errors.New("a nextcloud migration is already in progr
 // The schema (especially the nested Progress object) is the contract with
 // twake-migration-nextcloud. Flat counters would crash the service's progress
 // reducer because it spreads doc.progress and adds to its fields.
+//
+// CancelRequested and CanceledAt are written by the migration service;
+// the Stack round-trips them without modification.
 type Migration struct {
-	DocID      string            `json:"_id,omitempty"`
-	DocRev     string            `json:"_rev,omitempty"`
-	Status     string            `json:"status"`
-	TargetDir  string            `json:"target_dir"`
-	Progress   MigrationProgress `json:"progress"`
-	Errors     []MigrationError  `json:"errors"`
-	Skipped    []SkippedFile     `json:"skipped"`
-	StartedAt  *time.Time        `json:"started_at"`
-	FinishedAt *time.Time        `json:"finished_at"`
+	DocID           string            `json:"_id,omitempty"`
+	DocRev          string            `json:"_rev,omitempty"`
+	Status          string            `json:"status"`
+	TargetDir       string            `json:"target_dir"`
+	Progress        MigrationProgress `json:"progress"`
+	Errors          []MigrationError  `json:"errors"`
+	Skipped         []SkippedFile     `json:"skipped"`
+	StartedAt       *time.Time        `json:"started_at"`
+	FinishedAt      *time.Time        `json:"finished_at"`
+	CancelRequested bool              `json:"cancel_requested,omitempty"`
+	CanceledAt      *time.Time        `json:"canceled_at,omitempty"`
 }
 
 type MigrationProgress struct {
@@ -86,7 +92,22 @@ func (m *Migration) Clone() couchdb.Doc {
 		t := *m.FinishedAt
 		cloned.FinishedAt = &t
 	}
+	if m.CanceledAt != nil {
+		t := *m.CanceledAt
+		cloned.CanceledAt = &t
+	}
 	return &cloned
+}
+
+// IsTerminal reports whether the migration has reached a state that the
+// Stack must not try to cancel (completed, failed, or canceled).
+func (m *Migration) IsTerminal() bool {
+	switch m.Status {
+	case MigrationStatusCompleted, MigrationStatusFailed, MigrationStatusCanceled:
+		return true
+	default:
+		return false
+	}
 }
 
 func (m *Migration) Links() *jsonapi.LinksList              { return nil }

--- a/pkg/rabbitmq/contracts.go
+++ b/pkg/rabbitmq/contracts.go
@@ -19,6 +19,7 @@ const (
 	RoutingKeyUserPasswordUpdated         = "user.password.updated"
 	RoutingKeyUserDeletionRequested       = "user.deletion.requested"
 	RoutingKeyNextcloudMigrationRequested = "nextcloud.migration.requested"
+	RoutingKeyNextcloudMigrationCanceled  = "nextcloud.migration.canceled"
 )
 
 // UserDeletionRequestedMessage is published when a user asks Twake to delete the account linked to the current cozy instance.
@@ -42,5 +43,15 @@ type NextcloudMigrationRequestedMessage struct {
 	WorkplaceFqdn string `json:"workplaceFqdn"`
 	AccountID     string `json:"accountId"`
 	SourcePath    string `json:"sourcePath,omitempty"`
+	Timestamp     int64  `json:"timestamp"`
+}
+
+// NextcloudMigrationCanceledMessage is published when a user requests
+// cancellation of an in-flight Nextcloud migration. The Stack does not
+// touch the tracking document for cancel — the migration service owns
+// the terminal state so there is a single writer.
+type NextcloudMigrationCanceledMessage struct {
+	MigrationID   string `json:"migrationId"`
+	WorkplaceFqdn string `json:"workplaceFqdn"`
 	Timestamp     int64  `json:"timestamp"`
 }

--- a/web/remote/migration.go
+++ b/web/remote/migration.go
@@ -110,3 +110,40 @@ func mapNextcloudMigrationError(err error) error {
 		return jsonapi.InternalServerError(err)
 	}
 }
+
+// postNextcloudMigrationCancel publishes a cancel command for the given
+// migration id. 202 means "cancel requested; poll the tracking document
+// for the terminal state", not "migration stopped".
+func (h *HTTPHandler) postNextcloudMigrationCancel(c echo.Context) error {
+	if err := middlewares.AllowWholeType(c, permission.POST, consts.NextcloudMigrations); err != nil {
+		return err
+	}
+	inst := middlewares.GetInstance(c)
+	migrationID := c.Param("id")
+	if migrationID == "" {
+		return jsonapi.BadRequest(errors.New("missing migration id"))
+	}
+
+	reqLogger := inst.Logger().WithNamespace(nextcloudMigrationLogNamespace).WithFields(logger.Fields{
+		"migration_id": migrationID,
+	})
+	ctx := logger.WithContext(c.Request().Context(), reqLogger)
+
+	if err := nextcloud.CancelMigration(ctx, inst, migrationID, h.rmq); err != nil {
+		return mapNextcloudMigrationCancelError(err)
+	}
+	return c.NoContent(http.StatusAccepted)
+}
+
+func mapNextcloudMigrationCancelError(err error) error {
+	switch {
+	case errors.Is(err, nextcloud.ErrMigrationNotFound):
+		return jsonapi.NotFound(err)
+	case errors.Is(err, nextcloud.ErrMigrationAlreadyTerminal):
+		return jsonapi.Conflict(err)
+	case errors.Is(err, nextcloud.ErrMigrationBrokerUnavailable):
+		return jsonapi.NewError(http.StatusServiceUnavailable, "migration service is unavailable, please retry later")
+	default:
+		return jsonapi.InternalServerError(err)
+	}
+}

--- a/web/remote/migration_test.go
+++ b/web/remote/migration_test.go
@@ -629,3 +629,140 @@ func decodeAccountID(t *testing.T, payload []byte) string {
 	require.NoError(t, json.Unmarshal(payload, &msg))
 	return msg.AccountID
 }
+
+func TestPostNextcloudMigrationCancel(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	config.UseTestFile(t)
+	testutils.NeedCouchdb(t)
+
+	oldBuildMode := build.BuildMode
+	build.BuildMode = build.ModeDev
+	t.Cleanup(func() { build.BuildMode = oldBuildMode })
+
+	t.Run("PublishesAndReturns202", func(t *testing.T) {
+		setup := testutils.NewSetup(t, "ncmigration-cancel-happy")
+		inst := setup.GetTestInstance()
+
+		doc := nextcloud.NewPendingMigration("")
+		doc.Status = nextcloud.MigrationStatusRunning
+		require.NoError(t, couchdb.CreateDoc(inst, doc))
+
+		spy := &spyRabbitMQ{}
+		ts := setupMigrationRouter(t, inst, migrationPermission(), spy)
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		e.POST("/remote/nextcloud/migration/" + doc.ID() + "/cancel").
+			WithHost(inst.Domain).
+			Expect().Status(http.StatusAccepted)
+
+		require.Equal(t, 1, spy.count(), "expected a single publish")
+		pub := spy.last()
+		assert.Equal(t, rabbitmq.ExchangeMigration, pub.Exchange)
+		assert.Equal(t, rabbitmq.RoutingKeyNextcloudMigrationCanceled, pub.RoutingKey)
+		assert.Equal(t, doc.ID(), pub.MessageID)
+
+		var msg rabbitmq.NextcloudMigrationCanceledMessage
+		require.NoError(t, json.Unmarshal(pub.Payload.([]byte), &msg))
+		assert.Equal(t, doc.ID(), msg.MigrationID)
+		assert.Equal(t, inst.Domain, msg.WorkplaceFqdn)
+		assert.NotZero(t, msg.Timestamp)
+
+		// The Stack must not mutate the tracking doc — that transition is
+		// owned by the migration service (single-writer invariant for the
+		// terminal state).
+		var stored nextcloud.Migration
+		require.NoError(t, couchdb.GetDoc(inst, consts.NextcloudMigrations, doc.ID(), &stored))
+		assert.Equal(t, nextcloud.MigrationStatusRunning, stored.Status)
+		assert.False(t, stored.CancelRequested)
+	})
+
+	t.Run("UnknownMigrationReturns404", func(t *testing.T) {
+		setup := testutils.NewSetup(t, "ncmigration-cancel-unknown")
+		inst := setup.GetTestInstance()
+
+		spy := &spyRabbitMQ{}
+		ts := setupMigrationRouter(t, inst, migrationPermission(), spy)
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		e.POST("/remote/nextcloud/migration/does-not-exist/cancel").
+			WithHost(inst.Domain).
+			Expect().Status(http.StatusNotFound)
+
+		assert.Equal(t, 0, spy.count(), "must not publish for unknown migrations")
+	})
+
+	for _, status := range []string{
+		nextcloud.MigrationStatusCompleted,
+		nextcloud.MigrationStatusFailed,
+		nextcloud.MigrationStatusCanceled,
+	} {
+		status := status
+		t.Run("TerminalStatus_"+status, func(t *testing.T) {
+			setup := testutils.NewSetup(t, "ncmigration-cancel-"+status)
+			inst := setup.GetTestInstance()
+
+			doc := nextcloud.NewPendingMigration("")
+			doc.Status = status
+			require.NoError(t, couchdb.CreateDoc(inst, doc))
+
+			spy := &spyRabbitMQ{}
+			ts := setupMigrationRouter(t, inst, migrationPermission(), spy)
+			e := testutils.CreateTestClient(t, ts.URL)
+
+			e.POST("/remote/nextcloud/migration/" + doc.ID() + "/cancel").
+				WithHost(inst.Domain).
+				Expect().Status(http.StatusConflict)
+
+			assert.Equal(t, 0, spy.count(), "terminal migrations must not publish")
+		})
+	}
+
+	t.Run("PublishFailureReturns503", func(t *testing.T) {
+		setup := testutils.NewSetup(t, "ncmigration-cancel-publishfail")
+		inst := setup.GetTestInstance()
+
+		doc := nextcloud.NewPendingMigration("")
+		doc.Status = nextcloud.MigrationStatusRunning
+		require.NoError(t, couchdb.CreateDoc(inst, doc))
+
+		spy := &spyRabbitMQ{err: fmt.Errorf("broker down")}
+		ts := setupMigrationRouter(t, inst, migrationPermission(), spy)
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		e.POST("/remote/nextcloud/migration/" + doc.ID() + "/cancel").
+			WithHost(inst.Domain).
+			Expect().Status(http.StatusServiceUnavailable)
+
+		// Unlike trigger, a cancel publish failure must not flip the
+		// tracking doc to failed. The migration is still running.
+		var stored nextcloud.Migration
+		require.NoError(t, couchdb.GetDoc(inst, consts.NextcloudMigrations, doc.ID(), &stored))
+		assert.Equal(t, nextcloud.MigrationStatusRunning, stored.Status)
+	})
+
+	t.Run("RejectsWithoutPermission", func(t *testing.T) {
+		setup := testutils.NewSetup(t, "ncmigration-cancel-forbidden")
+		inst := setup.GetTestInstance()
+
+		doc := nextcloud.NewPendingMigration("")
+		doc.Status = nextcloud.MigrationStatusRunning
+		require.NoError(t, couchdb.CreateDoc(inst, doc))
+
+		pdoc := &permission.Permission{
+			Type:     permission.TypeWebapp,
+			SourceID: consts.Apps + "/" + consts.SettingsSlug,
+		}
+		spy := &spyRabbitMQ{}
+		ts := setupMigrationRouter(t, inst, pdoc, spy)
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		e.POST("/remote/nextcloud/migration/" + doc.ID() + "/cancel").
+			WithHost(inst.Domain).
+			Expect().Status(http.StatusForbidden)
+
+		assert.Equal(t, 0, spy.count())
+	})
+}

--- a/web/remote/remote.go
+++ b/web/remote/remote.go
@@ -34,6 +34,7 @@ func NewHTTPHandler(rmq rabbitmq.Service) *HTTPHandler {
 func (h *HTTPHandler) Register(router *echo.Group) {
 	Routes(router)
 	router.POST("/nextcloud/migration", h.postNextcloudMigration)
+	router.POST("/nextcloud/migration/:id/cancel", h.postNextcloudMigrationCancel)
 }
 
 func allDoctypes(c echo.Context) error {


### PR DESCRIPTION
## Summary

There was no way for a user to stop an in-flight Nextcloud migration. Once triggered, migrations ran to completion regardless of user intent. This adds the endpoint that asks the migration service to stop.

## How it works

The migration service already accepts a cancel command over RabbitMQ. This PR publishes that message when asked. The service then stops the migration between files, leaving the tracking document in a new terminal state `canceled` with progress up to the last completed file preserved. Worst-case delay from request to observed terminal state is roughly one file transfer.

The Stack does not write to the tracking document. The migration service owns the terminal state transition so there is a single writer.

## API

`POST /remote/nextcloud/migration/:id/cancel` (requires `POST io.cozy.nextcloud.migrations`)

No request body. A `202` means "cancel requested, poll the tracking document for the terminal state", not "migration stopped".

### Responses

| Code | When |
| ---- | ---- |
| 202 Accepted | Cancel published. The migration will reach `canceled` shortly |
| 401 Unauthorized | Missing or invalid token |
| 403 Forbidden | Token lacks the `POST io.cozy.nextcloud.migrations` permission |
| 404 Not Found | No tracking document with this id on the instance |
| 409 Conflict | Migration has already reached a terminal state (`completed`, `failed`, or `canceled`) |
| 503 Service Unavailable | RabbitMQ publish failed. The tracking document is NOT marked failed (unlike trigger), because a broker glitch must not invalidate a running migration. Retry the cancel. |

## RabbitMQ contract

Exchange `migration`, routing key `nextcloud.migration.canceled` (new). Payload:

```json
{
  "migrationId": "d4e5f6a7b8c94d0ea1b2c3d4e5f6a7b8",
  "workplaceFqdn": "alice.cozy.example.com",
  "timestamp": 1712563260
}
```

Same exchange as the trigger message, same publisher pattern.

## Tracking document

The `canceled` state is new. The migration service writes two optional fields when it processes the cancel:

- `cancel_requested: true` (durable flag)
- `canceled_at` (ISO 8601 timestamp)

The `Migration` struct on the Stack side round-trips these fields without modification.

## Validation

Tested end-to-end against a real Nextcloud. Mid-flight cancel on a 65-file / 67 MB migration landed in ~15s, tracking document reached `canceled` with 20 files already imported and progress preserved. Re-cancel returned 409, unknown id 404, no-auth 401. The no-cancel happy path completed normally with no regression.

ref: https://github.com/linagora/twake-migration-nextcloud/pull/25