### PR TITLE
Sync B2B contact on RabbitMQ `user.created` and `user.deleted` events

### DIFF
--- a/cozy.example.yaml
+++ b/cozy.example.yaml
@@ -606,7 +606,7 @@ rabbitmq:
       dlx_name: auth.dlx
       dlq_name: auth.dlq
       queues:
-        - name: user.password.updated
+        - name: stack.user.password.updated
           declare: true
           declare_dlx: true
           declare_dlq: true
@@ -614,3 +614,26 @@ rabbitmq:
           delivery_limit: 5
           bindings:
             - password.changed
+        - name: stack.user.created
+          declare: true
+          declare_dlx: true
+          declare_dlq: true
+          prefetch: 8
+          delivery_limit: 5
+          bindings:
+            - user.created
+    - name: b2b
+      kind: topic
+      durable: true
+      declare_exchange: true
+      dlx_name: b2b.dlx
+      dlq_name: b2b.dlq
+      queues:
+        - name: stack.b2b.user.deleted
+          declare: true
+          declare_dlx: true
+          declare_dlq: true
+          prefetch: 8
+          delivery_limit: 5
+          bindings:
+            - user.deleted

--- a/cozy.example.yaml
+++ b/cozy.example.yaml
@@ -594,46 +594,92 @@ contexts:
 
 rabbitmq:
   enabled: true
-  url: amqp://guest:guest@localhost:5672/
-  tls:
-    # root_ca: /etc/ssl/certs/ca.pem
-    insecure_skip_validation: false
+  nodes:
+    default:
+      enabled: true
+      url: amqp://guest:guest@localhost:5672/
+      tls:
+        # root_ca: /etc/ssl/certs/ca.pem
+        insecure_skip_validation: false
   exchanges:
     - name: auth
       kind: topic
       durable: true
-      declare_exchange: true
-      dlx_name: auth.dlx
-      dlq_name: auth.dlq
+      declare_exchange: false
       queues:
         - name: stack.user.password.updated
           declare: true
           declare_dlx: true
           declare_dlq: true
+          dlx_name: stack.auth.dlx
+          dlq_name: stack.dead.letter.user.password.updated
+          dl_routing_key: password.updated.dead
           prefetch: 8
           delivery_limit: 5
           bindings:
-            - password.changed
+            - user.password.updated
         - name: stack.user.created
           declare: true
           declare_dlx: true
           declare_dlq: true
+          dlx_name: stack.auth.dlx
+          dlq_name: stack.dead.letter.user.created
+          dl_routing_key: user.created.dead
           prefetch: 8
           delivery_limit: 5
           bindings:
             - user.created
-    - name: b2b
-      kind: topic
-      durable: true
-      declare_exchange: true
-      dlx_name: b2b.dlx
-      dlq_name: b2b.dlq
-      queues:
-        - name: stack.b2b.user.deleted
+        - name: stack.user.phone.updated
           declare: true
           declare_dlx: true
           declare_dlq: true
+          dlx_name: stack.auth.dlx
+          dlq_name: stack.dead.letter.user.phone.updated
+          dl_routing_key: user.phone.updated.dead
           prefetch: 8
           delivery_limit: 5
           bindings:
-            - user.deleted
+            - user.phone.updated
+    - name: billing
+      kind: topic
+      durable: true
+      declare_exchange: false
+      queues:
+        - name: stack.domain.subscription.changed
+          declare: true
+          declare_dlx: true
+          declare_dlq: true
+          dlx_name: stack.billing.dlx
+          dlq_name: stack.dead.letter.domain.subscription.changed
+          dl_routing_key: domain.subscription.changed.dead
+          prefetch: 8
+          delivery_limit: 5
+          bindings:
+            - domain.subscription.changed
+    - name: b2b
+      kind: topic
+      durable: true
+      declare_exchange: false
+      queues:
+        - name: stack.user.lifecycle.queue
+          declare: true
+          declare_dlx: true
+          declare_dlq: true
+          dlx_name: stack.b2b.dlx
+          dlq_name: stack.dead.letter.user.lifecycle
+          dl_routing_key: domain.user.deleted.dead
+          prefetch: 8
+          delivery_limit: 5
+          bindings:
+            - domain.user.deleted
+        - name: stack.app.commands.queue
+          declare: true
+          declare_dlx: true
+          declare_dlq: true
+          dlx_name: stack.b2b.dlx
+          dlq_name: stack.dead.letter.app.commands
+          dl_routing_key: app.installation.requested.dead
+          prefetch: 8
+          delivery_limit: 5
+          bindings:
+            - app.installation.requested

--- a/docs/rabbitmq.md
+++ b/docs/rabbitmq.md
@@ -46,6 +46,7 @@ rabbitmq:
   enabled: true
   nodes:
     default:
+      enabled: true
       url: amqp://guest:guest@localhost:5672/
       tls:
         # root_ca: /etc/ssl/certs/ca.pem
@@ -55,41 +56,84 @@ rabbitmq:
     - name: auth
       kind: topic
       durable: true
-      declare_exchange: true
-      dlx_name: auth.dlx
-      dlq_name: auth.dlq
+      declare_exchange: false
       queues:
         - name: stack.user.password.updated
           declare: true
           declare_dlx: true
           declare_dlq: true
+          dlx_name: stack.auth.dlx
+          dlq_name: stack.dead.letter.user.password.updated
+          dl_routing_key: password.updated.dead
           prefetch: 8
           delivery_limit: 5
           bindings:
-            - password.changed
+            - user.password.updated
         - name: stack.user.created
           declare: true
-          declare_dlx: false
+          declare_dlx: true
           declare_dlq: true
+          dlx_name: stack.auth.dlx
+          dlq_name: stack.dead.letter.user.created
+          dl_routing_key: user.created.dead
           prefetch: 8
           delivery_limit: 5
           bindings:
             - user.created
-    - name: b2b
-      kind: topic
-      durable: true
-      declare_exchange: true
-      dlx_name: b2b.dlx
-      dlq_name: b2b.dlq
-      queues:
-        - name: stack.b2b.user.deleted
+        - name: stack.user.phone.updated
           declare: true
           declare_dlx: true
           declare_dlq: true
+          dlx_name: stack.auth.dlx
+          dlq_name: stack.dead.letter.user.phone.updated
+          dl_routing_key: user.phone.updated.dead
           prefetch: 8
           delivery_limit: 5
           bindings:
-            - user.deleted
+            - user.phone.updated
+    - name: billing
+      kind: topic
+      durable: true
+      declare_exchange: false
+      queues:
+        - name: stack.domain.subscription.changed
+          declare: true
+          declare_dlx: true
+          declare_dlq: true
+          dlx_name: stack.billing.dlx
+          dlq_name: stack.dead.letter.domain.subscription.changed
+          dl_routing_key: domain.subscription.changed.dead
+          prefetch: 8
+          delivery_limit: 5
+          bindings:
+            - domain.subscription.changed
+    - name: b2b
+      kind: topic
+      durable: true
+      declare_exchange: false
+      queues:
+        - name: stack.user.lifecycle.queue
+          declare: true
+          declare_dlx: true
+          declare_dlq: true
+          dlx_name: stack.b2b.dlx
+          dlq_name: stack.dead.letter.user.lifecycle
+          dl_routing_key: domain.user.deleted.dead
+          prefetch: 8
+          delivery_limit: 5
+          bindings:
+            - domain.user.deleted
+        - name: stack.app.commands.queue
+          declare: true
+          declare_dlx: true
+          declare_dlq: true
+          dlx_name: stack.b2b.dlx
+          dlq_name: stack.dead.letter.app.commands
+          dl_routing_key: app.installation.requested.dead
+          prefetch: 8
+          delivery_limit: 5
+          bindings:
+            - app.installation.requested
 ```
 
 ### Dead Letter Exchange (DLX) and Dead Letter Queue (DLQ)
@@ -114,28 +158,35 @@ rabbitmq:
   enabled: true
   nodes:
     default:
+      enabled: true
       url: amqp://guest:guest@localhost:5672/
+    linagora_default:
+      enabled: false
+      url: amqp://guest:guest@localhost:5673/
   exchanges:
     - name: auth
       kind: topic
       durable: true
-      declare_exchange: true
-      dlx_name: auth.dlx
-      dlq_name: auth.dlq
+      declare_exchange: false
       queues:
         - name: stack.user.password.updated
           declare: true
           declare_dlx: true
           declare_dlq: true
+          dlx_name: stack.auth.dlx
+          dlq_name: stack.dead.letter.user.password.updated
+          dl_routing_key: password.updated.dead
           prefetch: 8
           delivery_limit: 5
           bindings:
-            - password.changed
+            - user.password.updated
         - name: stack.user.created
           declare: true
-          declare_dlx: false
+          declare_dlx: true
           declare_dlq: true
-          dlq_name: user.created.dlq  # Override exchange default
+          dlx_name: stack.auth.dlx
+          dlq_name: stack.dead.letter.user.created
+          dl_routing_key: user.created.dead
           prefetch: 8
           delivery_limit: 5
           bindings:
@@ -203,10 +254,10 @@ Returning `nil` acknowledges the message. Returning a non-nil error causes the m
 
 Queue names are mapped to handlers in the stack. For example:
 
-- `user.password.updated` → updates an instance passphrase when a `password.changed` routing key is received.
+- `user.password.updated` → updates an instance passphrase when a `user.password.updated` routing key is received.
 - `user.created` → validates and processes user creation events.
 - `user.phone.updated` → updates the phone number stored in user settings.
-- `user.deleted` on the `b2b` exchange → removes externally managed organization contacts.
+- `domain.user.deleted` on the `b2b` exchange → removes externally managed organization contacts.
 
 Message schemas are JSON and validated in the handler. Example payload for `user.password.updated`:
 
@@ -244,7 +295,7 @@ Example payload for `user.created`:
 ```
 
 
-Example payload for `b2b/user.deleted`:
+Example payload for `b2b/domain.user.deleted`:
 
 ```json
 {

--- a/docs/rabbitmq.md
+++ b/docs/rabbitmq.md
@@ -59,7 +59,7 @@ rabbitmq:
       dlx_name: auth.dlx
       dlq_name: auth.dlq
       queues:
-        - name: user.password.updated
+        - name: stack.user.password.updated
           declare: true
           declare_dlx: true
           declare_dlq: true
@@ -67,7 +67,7 @@ rabbitmq:
           delivery_limit: 5
           bindings:
             - password.changed
-        - name: user.created
+        - name: stack.user.created
           declare: true
           declare_dlx: false
           declare_dlq: true
@@ -75,6 +75,21 @@ rabbitmq:
           delivery_limit: 5
           bindings:
             - user.created
+    - name: b2b
+      kind: topic
+      durable: true
+      declare_exchange: true
+      dlx_name: b2b.dlx
+      dlq_name: b2b.dlq
+      queues:
+        - name: stack.b2b.user.deleted
+          declare: true
+          declare_dlx: true
+          declare_dlq: true
+          prefetch: 8
+          delivery_limit: 5
+          bindings:
+            - user.deleted
 ```
 
 ### Dead Letter Exchange (DLX) and Dead Letter Queue (DLQ)
@@ -108,7 +123,7 @@ rabbitmq:
       dlx_name: auth.dlx
       dlq_name: auth.dlq
       queues:
-        - name: user.password.updated
+        - name: stack.user.password.updated
           declare: true
           declare_dlx: true
           declare_dlq: true
@@ -116,7 +131,7 @@ rabbitmq:
           delivery_limit: 5
           bindings:
             - password.changed
-        - name: user.created
+        - name: stack.user.created
           declare: true
           declare_dlx: false
           declare_dlq: true
@@ -191,6 +206,7 @@ Queue names are mapped to handlers in the stack. For example:
 - `user.password.updated` → updates an instance passphrase when a `password.changed` routing key is received.
 - `user.created` → validates and processes user creation events.
 - `user.phone.updated` → updates the phone number stored in user settings.
+- `user.deleted` on the `b2b` exchange → removes externally managed organization contacts.
 
 Message schemas are JSON and validated in the handler. Example payload for `user.password.updated`:
 
@@ -219,9 +235,32 @@ Example payload for `user.created`:
   "publicKey": "base64",
   "privateKey": "cipherString",
   "key": "cipherString",
-  "timestamp": 1726040000
+  "timestamp": 1726040000,
+  "workplaceFqdn": "alice.example.twake.app",
+  "organizationId": "org-uuid-123",
+  "organizationDomain": "example.com",
+  "canUpgrade": false
 }
 ```
+
+
+Example payload for `b2b/user.deleted`:
+
+```json
+{
+  "emitter": "admin-panel",
+  "type": "user.deleted",
+  "workplaceFqdn": "alice.example.twake.app",
+  "internalEmail": "alice@example.com",
+  "reason": "user deleted",
+  "organizationId": "org-uuid-123",
+  "userId": "alice",
+  "domain": "example.com"
+}
+```
+
+The delete handler removes the single matching contact found by `internalEmail`
+when `metadata.external` is true. 
 
 Example payload for `user.phone.updated`:
 
@@ -330,4 +369,3 @@ ch.PublishWithContext(ctx,
     },
 )
 ```
-

--- a/model/contact/contact_test.go
+++ b/model/contact/contact_test.go
@@ -2,6 +2,7 @@ package contact
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -13,6 +14,90 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestFindAllByEmail(t *testing.T) {
+	config.UseTestFile(t)
+	instPrefix := prefixer.NewPrefixer(0, "contact-by-email", "contact-by-email")
+	require.NoError(t, couchdb.ResetDB(instPrefix, consts.Contacts))
+	t.Cleanup(func() { _ = couchdb.DeleteDB(instPrefix, consts.Contacts) })
+	require.NoError(t, couchdb.DefineView(instPrefix, couchdb.ContactByEmail))
+
+	external := New()
+	external.M["fullname"] = "Alice"
+	external.M["email"] = []map[string]interface{}{
+		{"address": "alice@example.com", "primary": true},
+	}
+	external.M["metadata"] = map[string]interface{}{"external": true}
+	require.NoError(t, couchdb.CreateDoc(instPrefix, external))
+
+	other := New()
+	other.M["fullname"] = "Bob"
+	other.M["email"] = []map[string]interface{}{
+		{"address": "alice@example.com", "primary": true},
+	}
+	require.NoError(t, couchdb.CreateDoc(instPrefix, other))
+
+	docs, err := FindAllByEmail(instPrefix, "alice@example.com")
+	require.NoError(t, err)
+	require.Len(t, docs, 2)
+	ids := []string{docs[0].ID(), docs[1].ID()}
+	assert.Contains(t, ids, external.ID())
+	assert.True(t, docs[0].IsExternal() || docs[1].IsExternal())
+
+	_, err = FindAllByEmail(instPrefix, "missing@example.com")
+	assert.True(t, errors.Is(err, ErrNotFound))
+}
+
+func TestCreate(t *testing.T) {
+	config.UseTestFile(t)
+	instPrefix := prefixer.NewPrefixer(0, "contact-create", "contact-create")
+	require.NoError(t, couchdb.ResetDB(instPrefix, consts.Contacts))
+	t.Cleanup(func() { _ = couchdb.DeleteDB(instPrefix, consts.Contacts) })
+	require.NoError(t, couchdb.DefineView(instPrefix, couchdb.ContactByEmail))
+
+	t.Run("WithAllFields", func(t *testing.T) {
+		doc, err := Create(instPrefix, CreateOptions{
+			Email:    "alice@example.com",
+			Name:     "Alice Doe",
+			CozyURL:  "https://alice.example",
+			Phone:    "+33123456789",
+			External: true,
+		})
+		require.NoError(t, err)
+
+		stored, err := Find(instPrefix, doc.ID())
+		require.NoError(t, err)
+		require.Equal(t, "Alice Doe", stored.PrimaryName())
+		require.Equal(t, "https://alice.example", stored.PrimaryCozyURL())
+		require.Equal(t, "+33123456789", stored.PrimaryPhoneNumber())
+		require.True(t, stored.IsExternal())
+		addr, err := stored.ToMailAddress()
+		require.NoError(t, err)
+		require.Equal(t, "alice@example.com", addr.Email)
+
+		indexes, ok := stored.M["indexes"].(map[string]interface{})
+		require.True(t, ok)
+		require.Equal(t, "https://alice.example", indexes["byFamilyNameGivenNameEmailCozyUrl"])
+	})
+
+	t.Run("FallbackNameUsesEmailLocalPart", func(t *testing.T) {
+		doc, err := Create(instPrefix, CreateOptions{
+			Email: "bob@example.com",
+		})
+		require.NoError(t, err)
+
+		stored, err := Find(instPrefix, doc.ID())
+		require.NoError(t, err)
+		require.Equal(t, "bob", stored.PrimaryName())
+		displayName, _ := stored.M["displayName"].(string)
+		require.Equal(t, "bob@example.com", displayName)
+	})
+
+	t.Run("MissingEmail", func(t *testing.T) {
+		_, err := Create(instPrefix, CreateOptions{})
+		require.ErrorIs(t, err, ErrNoMailAddress)
+	})
+}
 
 func TestGetAllContacts(t *testing.T) {
 	config.UseTestFile(t)

--- a/model/contact/contacts.go
+++ b/model/contact/contacts.go
@@ -237,13 +237,17 @@ func Find(db prefixer.Prefixer, contactID string) (*Contact, error) {
 	return doc, err
 }
 
-// FindByEmail returns the contact with the given email address, when possible
-func FindByEmail(db prefixer.Prefixer, email string) (*Contact, error) {
+// FindAllByEmail returns all contacts with the given email address, when possible.
+func FindAllByEmail(db prefixer.Prefixer, email string) ([]*Contact, error) {
+	email = strings.TrimSpace(email)
+	if email == "" {
+		return nil, ErrNotFound
+	}
+
 	var res couchdb.ViewResponse
 	err := couchdb.ExecView(db, couchdb.ContactByEmail, &couchdb.ViewRequest{
 		Key:         email,
 		IncludeDocs: true,
-		Limit:       1,
 	}, &res)
 	if err != nil {
 		return nil, err
@@ -251,9 +255,35 @@ func FindByEmail(db prefixer.Prefixer, email string) (*Contact, error) {
 	if len(res.Rows) == 0 {
 		return nil, ErrNotFound
 	}
-	doc := &Contact{}
-	err = json.Unmarshal(res.Rows[0].Doc, &doc)
-	return doc, err
+
+	docs := make([]*Contact, 0, len(res.Rows))
+	for _, row := range res.Rows {
+		doc := &Contact{}
+		if err := json.Unmarshal(row.Doc, doc); err != nil {
+			return nil, err
+		}
+		docs = append(docs, doc)
+	}
+	return docs, nil
+}
+
+// FindByEmail returns the contact with the given email address, when possible.
+func FindByEmail(db prefixer.Prefixer, email string) (*Contact, error) {
+	docs, err := FindAllByEmail(db, email)
+	if err != nil {
+		return nil, err
+	}
+	return docs[0], nil
+}
+
+// IsExternal returns true if this contact was created from an external source.
+func (c *Contact) IsExternal() bool {
+	metadata, ok := c.Get("metadata").(map[string]interface{})
+	if !ok {
+		return false
+	}
+	external, _ := metadata["external"].(bool)
+	return external
 }
 
 // CreateMyself creates the myself contact document from the instance settings.
@@ -294,9 +324,18 @@ func CreateMyself(inst *instance.Instance, settings *couchdb.JSONDoc) (*Contact,
 	return doc, nil
 }
 
-// CreateFromSharingMember creates a contact from sharing member information.
-// This is useful when accepting a sharing and we want to create a contact for the sender.
-func CreateFromSharingMember(inst *instance.Instance, email, name, cozyURL string) (*Contact, error) {
+// CreateOptions describes the input used to create a contact.
+type CreateOptions struct {
+	Email    string
+	Name     string
+	CozyURL  string
+	Phone    string
+	External bool
+}
+
+// Create creates a contact from the provided options.
+func Create(db prefixer.Prefixer, opts CreateOptions) (*Contact, error) {
+	email := strings.TrimSpace(opts.Email)
 	if email == "" {
 		return nil, ErrNoMailAddress
 	}
@@ -306,7 +345,8 @@ func CreateFromSharingMember(inst *instance.Instance, email, name, cozyURL strin
 		{"address": email, "primary": true},
 	}
 
-	displayName := name
+	name := strings.TrimSpace(opts.Name)
+	displayName := strings.TrimSpace(opts.Name)
 	if name == "" {
 		parts := strings.SplitN(email, "@", 2)
 		name = parts[0]
@@ -317,9 +357,20 @@ func CreateFromSharingMember(inst *instance.Instance, email, name, cozyURL strin
 	}
 	doc.JSONDoc.M["displayName"] = displayName
 
+	cozyURL := strings.TrimSpace(opts.CozyURL)
 	if cozyURL != "" {
 		doc.JSONDoc.M["cozy"] = []map[string]interface{}{
 			{"url": cozyURL, "primary": true},
+		}
+	}
+	if phone := strings.TrimSpace(opts.Phone); phone != "" {
+		doc.JSONDoc.M["phone"] = []map[string]interface{}{
+			{"number": phone, "primary": true},
+		}
+	}
+	if opts.External {
+		doc.JSONDoc.M["metadata"] = map[string]interface{}{
+			"external": true,
 		}
 	}
 
@@ -331,7 +382,7 @@ func CreateFromSharingMember(inst *instance.Instance, email, name, cozyURL strin
 		"byFamilyNameGivenNameEmailCozyUrl": index,
 	}
 
-	if err := couchdb.CreateDoc(inst, doc); err != nil {
+	if err := couchdb.CreateDoc(db, doc); err != nil {
 		return nil, err
 	}
 	return doc, nil

--- a/model/contact/contacts.go
+++ b/model/contact/contacts.go
@@ -346,7 +346,7 @@ func Create(db prefixer.Prefixer, opts CreateOptions) (*Contact, error) {
 	}
 
 	name := strings.TrimSpace(opts.Name)
-	displayName := strings.TrimSpace(opts.Name)
+	displayName := name
 	if name == "" {
 		parts := strings.SplitN(email, "@", 2)
 		name = parts[0]

--- a/model/instance/lifecycle/destroy.go
+++ b/model/instance/lifecycle/destroy.go
@@ -202,7 +202,10 @@ func sendAlert(inst *instance.Instance, e error) {
 }
 
 func removeTriggers(inst *instance.Instance) {
-	sched := job.System()
+	sched := job.SystemUnsafe()
+	if sched == nil {
+		return
+	}
 	triggers, err := sched.GetAllTriggers(inst)
 	if err == nil {
 		for _, t := range triggers {

--- a/model/job/globals.go
+++ b/model/job/globals.go
@@ -52,3 +52,8 @@ func System() JobSystem {
 	}
 	return globalJobSystem
 }
+
+// SystemUnsafe returns the global job system, even if it's not initialized
+func SystemUnsafe() JobSystem {
+	return globalJobSystem
+}

--- a/model/sharing/oauth.go
+++ b/model/sharing/oauth.go
@@ -535,7 +535,11 @@ func (s *Sharing) SendAnswer(inst *instance.Instance, state string) error {
 		c, err := contact.FindByEmail(inst, s.Members[0].Email)
 		if err != nil {
 			// Contact doesn't exist, create it using the standardized method
-			c, err = contact.CreateFromSharingMember(inst, s.Members[0].Email, s.Members[0].Name, s.Members[0].Instance)
+			c, err = contact.Create(inst, contact.CreateOptions{
+				Email:   s.Members[0].Email,
+				Name:    s.Members[0].Name,
+				CozyURL: s.Members[0].Instance,
+			})
 			if err != nil {
 				if couchdb.IsConflictError(err) {
 					c, err = contact.FindByEmail(inst, s.Members[0].Email)

--- a/pkg/config/config/testdata/full_config.yaml
+++ b/pkg/config/config/testdata/full_config.yaml
@@ -129,10 +129,10 @@ rabbitmq:
       kind: topic
       durable: true
       declare_exchange: true
-      dlx_name: auth.dlx
-      dlq_name: auth.dlq
+      dlx_name: stack.dlx
+      dlq_name: stack.auth.dlq
       queues:
-        - name: user.password.updated
+        - name: stack.user.password.updated
           declare: true
           declare_dlx: true
           declare_dlq: true
@@ -140,7 +140,7 @@ rabbitmq:
           delivery_limit: 5
           bindings:
             - password.changed
-        - name: user.created
+        - name: stack.user.created
           declare: true
           declare_dlx: false
           declare_dlq: true
@@ -148,6 +148,21 @@ rabbitmq:
           delivery_limit: 5
           bindings:
             - user.created
+    - name: b2b
+      kind: topic
+      durable: true
+      declare_exchange: false
+      dlx_name: stack.dlx
+      dlq_name: stack.b2b.dlq
+      queues:
+        - name: stack.b2b.user.deleted
+          declare: true
+          declare_dlx: true
+          declare_dlq: true
+          prefetch: 8
+          delivery_limit: 5
+          bindings:
+            - user.deleted
 
 common_settings:
   default:

--- a/pkg/config/config/testdata/full_config.yaml
+++ b/pkg/config/config/testdata/full_config.yaml
@@ -129,7 +129,7 @@ rabbitmq:
       kind: topic
       durable: true
       declare_exchange: true
-      dlx_name: stack.dlx
+      dlx_name: stack.auth.dlx
       dlq_name: stack.auth.dlq
       queues:
         - name: stack.user.password.updated
@@ -152,7 +152,7 @@ rabbitmq:
       kind: topic
       durable: true
       declare_exchange: false
-      dlx_name: stack.dlx
+      dlx_name: stack.b2b.dlx
       dlq_name: stack.b2b.dlq
       queues:
         - name: stack.b2b.user.deleted

--- a/pkg/rabbitmq/contracts.go
+++ b/pkg/rabbitmq/contracts.go
@@ -12,11 +12,13 @@ const (
 	QueueDomainSubscriptionChanged = "stack.domain.subscription.changed"
 	QueueUser2FAUpdated            = "stack.user.2fa.updated"
 	QueueUserRecoveryEmailUpdated  = "stack.user.recovery-email.updated"
+	QueueB2BUserDeleted            = "stack.b2b.user.deleted"
 	QueueAppCommands               = "stack.app.commands.queue"
 )
 
 const (
 	RoutingKeyUserPasswordUpdated         = "user.password.updated"
+	RoutingKeyB2BUserDeleted              = "user.deleted"
 	RoutingKeyUserDeletionRequested       = "user.deletion.requested"
 	RoutingKeyNextcloudMigrationRequested = "nextcloud.migration.requested"
 	RoutingKeyNextcloudMigrationCanceled  = "nextcloud.migration.canceled"

--- a/pkg/rabbitmq/handlers.go
+++ b/pkg/rabbitmq/handlers.go
@@ -138,7 +138,6 @@ type UserCreatedMessage struct {
 	WorkplaceFqdn      string `json:"workplaceFqdn"` // The fully qualified workplace domain
 	OrganizationID     string `json:"organizationId,omitempty"`
 	OrganizationDomain string `json:"organizationDomain,omitempty"`
-	CanUpgrade         *bool  `json:"canUpgrade,omitempty"`
 }
 
 // Handle processes a user created message.

--- a/pkg/rabbitmq/handlers.go
+++ b/pkg/rabbitmq/handlers.go
@@ -125,17 +125,20 @@ func NewUserCreatedHandler() *UserCreatedHandler {
 
 // UserCreatedMessage represents a user creation message.
 type UserCreatedMessage struct {
-	TwakeID       string `json:"twakeId"`
-	Domain        string `json:"domain"`
-	Mobile        string `json:"mobile"`
-	InternalEmail string `json:"internalEmail"`
-	Iterations    int    `json:"iterations"`
-	Hash          string `json:"hash"`
-	PublicKey     string `json:"publicKey"`
-	PrivateKey    string `json:"privateKey"`
-	Key           string `json:"key"`
-	Timestamp     int64  `json:"timestamp"`
-	WorkplaceFqdn string `json:"workplaceFqdn"` // The fully qualified workplace domain
+	TwakeID            string `json:"twakeId"`
+	Domain             string `json:"domain"`
+	Mobile             string `json:"mobile"`
+	InternalEmail      string `json:"internalEmail"`
+	Iterations         int    `json:"iterations"`
+	Hash               string `json:"hash"`
+	PublicKey          string `json:"publicKey"`
+	PrivateKey         string `json:"privateKey"`
+	Key                string `json:"key"`
+	Timestamp          int64  `json:"timestamp"`
+	WorkplaceFqdn      string `json:"workplaceFqdn"` // The fully qualified workplace domain
+	OrganizationID     string `json:"organizationId,omitempty"`
+	OrganizationDomain string `json:"organizationDomain,omitempty"`
+	CanUpgrade         *bool  `json:"canUpgrade,omitempty"`
 }
 
 // Handle processes a user created message.
@@ -216,6 +219,70 @@ func (h *UserCreatedHandler) Handle(ctx context.Context, d amqp.Delivery) error 
 		return fmt.Errorf("user.created: update passphrase: %w", err)
 	}
 	log.Infof("user.created: successfully updated passphrase for instance: %s (PasswordDefined: %v)", inst.Domain, inst.PasswordDefined)
+
+	if msg.OrganizationDomain != "" {
+		if err := SyncCreatedOrgContact(ctx, inst, msg); err != nil {
+			log.Errorf("user.created: failed to sync organization contacts for %s: %v", msg.WorkplaceFqdn, err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+// UserDeletedHandler handles B2B user deletion messages.
+type UserDeletedHandler struct{}
+
+// NewUserDeletedHandler creates a new user deleted handler.
+func NewUserDeletedHandler() *UserDeletedHandler {
+	return &UserDeletedHandler{}
+}
+
+// UserDeletedMessage represents a B2B user deletion message.
+type UserDeletedMessage struct {
+	Emitter        string `json:"emitter"`
+	Type           string `json:"type"`
+	WorkplaceFqdn  string `json:"workplaceFqdn"`
+	InternalEmail  string `json:"internalEmail"`
+	Reason         string `json:"reason"`
+	OrganizationID string `json:"organizationId"`
+	UserID         string `json:"userId"`
+	Domain         string `json:"domain"`
+}
+
+// Handle processes a B2B user deletion message.
+func (h *UserDeletedHandler) Handle(ctx context.Context, d amqp.Delivery) error {
+	log.Infof("user.deleted: received message: %s", d.RoutingKey)
+	log.Debugf("user.deleted: message details - MessageId: %s, ContentType: %s, Body size: %d bytes",
+		d.MessageId, d.ContentType, len(d.Body))
+
+	var msg UserDeletedMessage
+	if err := json.Unmarshal(d.Body, &msg); err != nil {
+		return fmt.Errorf("user.deleted: failed to unmarshal message: %w", err)
+	}
+
+	msg.WorkplaceFqdn = strings.TrimSpace(msg.WorkplaceFqdn)
+	msg.InternalEmail = strings.TrimSpace(msg.InternalEmail)
+	msg.Domain = strings.TrimSpace(msg.Domain)
+
+	if msg.WorkplaceFqdn == "" {
+		return fmt.Errorf("user.deleted: missing workplaceFqdn")
+	}
+	if msg.InternalEmail == "" {
+		return fmt.Errorf("user.deleted: missing internalEmail")
+	}
+	if msg.Domain == "" {
+		return fmt.Errorf("user.deleted: missing organization domain")
+	}
+
+	log.Infof("user.deleted: processing message - UserID: %s, InternalEmail: %s, WorkplaceFqdn: %s, Domain: %s, OrganizationID: %s, Reason: %s",
+		msg.UserID, msg.InternalEmail, msg.WorkplaceFqdn, msg.Domain, msg.OrganizationID, msg.Reason)
+
+	if err := SyncDeletedOrgContact(ctx, msg); err != nil {
+		log.Errorf("user.deleted: failed to sync organization contacts for %s: %v", msg.WorkplaceFqdn, err)
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/rabbitmq/org_contacts.go
+++ b/pkg/rabbitmq/org_contacts.go
@@ -1,0 +1,166 @@
+package rabbitmq
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/cozy/cozy-stack/model/contact"
+	"github.com/cozy/cozy-stack/model/instance"
+	"github.com/cozy/cozy-stack/model/instance/lifecycle"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/utils"
+)
+
+// SyncCreatedOrgContact syncs a newly created B2B user as an external contact
+// into every other instance of the organization.
+func SyncCreatedOrgContact(ctx context.Context, target *instance.Instance, msg UserCreatedMessage) error {
+	email := strings.TrimSpace(msg.InternalEmail)
+	if email == "" {
+		return fmt.Errorf("user.created: missing internalEmail for organization contact sync")
+	}
+	name, err := target.SettingsPublicName()
+	if err != nil {
+		return fmt.Errorf("user.created: resolve contact name for %s: %w", target.Domain, err)
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return fmt.Errorf("user.created: missing public_name in settings for %s", target.Domain)
+	}
+	targetURL := target.PageURL("", nil)
+
+	instances, err := listOrgContactInstances("user.created", msg.OrganizationDomain)
+	if err != nil {
+		return err
+	}
+
+	var lastErr error
+	for _, inst := range instances {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if inst.HasDomain(msg.WorkplaceFqdn) {
+			log.Debugf("user.created: skipping own instance %s for organization contact %s", inst.Domain, targetURL)
+			continue
+		}
+
+		existing, err := findExternalOrgContactByEmail(inst, email)
+		if err != nil {
+			wrappedErr := fmt.Errorf("user.created: find external contact for %s in %s: %w", email, inst.Domain, err)
+			log.Errorf("%v", wrappedErr)
+			lastErr = wrappedErr
+			continue
+		}
+		if existing != nil {
+			log.Infof("user.created: external contact for %s already exists in %s, skipping", email, inst.Domain)
+			continue
+		}
+
+		if _, err := contact.Create(inst, contact.CreateOptions{
+			Email:    email,
+			Name:     name,
+			CozyURL:  targetURL,
+			Phone:    msg.Mobile,
+			External: true,
+		}); err != nil {
+			wrappedErr := fmt.Errorf("user.created: create contact for %s in %s: %w", email, inst.Domain, err)
+			log.Errorf("%v", wrappedErr)
+			lastErr = wrappedErr
+			continue
+		}
+		log.Infof("user.created: created organization contact for %s in %s", email, inst.Domain)
+	}
+
+	return lastErr
+}
+
+// SyncDeletedOrgContact removes a deleted B2B user from every other instance
+// of the organization.
+func SyncDeletedOrgContact(ctx context.Context, msg UserDeletedMessage) error {
+	if strings.TrimSpace(msg.WorkplaceFqdn) == "" {
+		return fmt.Errorf("user.deleted: missing workplaceFqdn")
+	}
+	email := strings.TrimSpace(msg.InternalEmail)
+	if email == "" {
+		return fmt.Errorf("user.deleted: missing internalEmail")
+	}
+
+	instances, err := listOrgContactInstances("user.deleted", msg.Domain)
+	if err != nil {
+		return err
+	}
+
+	var lastErr error
+	for _, inst := range instances {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if inst.HasDomain(msg.WorkplaceFqdn) {
+			log.Debugf("user.deleted: skipping own instance %s for organization contact %s", inst.Domain, msg.WorkplaceFqdn)
+			continue
+		}
+
+		existing, err := findExternalOrgContactByEmail(inst, email)
+		if err != nil {
+			wrappedErr := fmt.Errorf("user.deleted: find external contact for %s in %s: %w", email, inst.Domain, err)
+			log.Errorf("%v", wrappedErr)
+			lastErr = wrappedErr
+			continue
+		}
+		if existing == nil {
+			log.Infof("user.deleted: no external contact for %s in %s, skipping", email, inst.Domain)
+			continue
+		}
+		if err := couchdb.DeleteDoc(inst, existing); err != nil {
+			wrappedErr := fmt.Errorf("user.deleted: delete contact %s for %s in %s: %w", existing.ID(), email, inst.Domain, err)
+			log.Errorf("%v", wrappedErr)
+			lastErr = wrappedErr
+			continue
+		}
+		log.Infof("user.deleted: deleted organization contact for %s in %s", email, inst.Domain)
+	}
+
+	return lastErr
+}
+
+func listOrgContactInstances(eventName, orgDomain string) ([]*instance.Instance, error) {
+	orgDomain = utils.NormalizeDomain(orgDomain)
+	if orgDomain == "" {
+		return nil, fmt.Errorf("%s: missing organization domain", eventName)
+	}
+
+	list, err := lifecycle.ListOrgInstances(orgDomain)
+	if err != nil {
+		return nil, fmt.Errorf("%s: list organization instances by domain %s: %w", eventName, orgDomain, err)
+	}
+	if len(list) == 0 {
+		log.Infof("%s: no instances found for organization domain %s", eventName, orgDomain)
+		return nil, fmt.Errorf("%s: organization has no instances", eventName)
+	}
+	return list, nil
+}
+
+func findExternalOrgContactByEmail(inst *instance.Instance, email string) (*contact.Contact, error) {
+	matches, err := contact.FindAllByEmail(inst, email)
+	if errors.Is(err, contact.ErrNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var external []*contact.Contact
+	for _, doc := range matches {
+		if doc.IsExternal() {
+			external = append(external, doc)
+		}
+	}
+	if len(external) > 1 {
+		return nil, fmt.Errorf("multiple external contacts found for email %s", email)
+	}
+	if len(external) == 1 {
+		return external[0], nil
+	}
+	return nil, nil
+}

--- a/pkg/rabbitmq/org_contacts_test.go
+++ b/pkg/rabbitmq/org_contacts_test.go
@@ -19,8 +19,7 @@ import (
 func TestSyncCreatedOrgContact(t *testing.T) {
 	t.Run("CreatesExternalContactsForOtherMembers", func(t *testing.T) {
 		config.UseTestFile(t)
-		setup := testutils.NewSetup(t, "TestSyncCreatedOrgContactCreatesExternalContactsForOtherMembers")
-		_ = setup.GetTestInstance()
+		testutils.NeedCouchdb(t)
 
 		suffix := fmt.Sprintf("%d", time.Now().UnixNano())
 		orgDomain := "sync-created-" + suffix + ".example"
@@ -82,8 +81,7 @@ func TestSyncCreatedOrgContact(t *testing.T) {
 
 	t.Run("SkipsExistingExternalContact", func(t *testing.T) {
 		config.UseTestFile(t)
-		setup := testutils.NewSetup(t, "TestSyncCreatedOrgContactSkipsExistingExternalContact")
-		_ = setup.GetTestInstance()
+		testutils.NeedCouchdb(t)
 
 		suffix := fmt.Sprintf("%d", time.Now().UnixNano())
 		orgDomain := "sync-created-existing-" + suffix + ".example"
@@ -120,8 +118,7 @@ func TestSyncCreatedOrgContact(t *testing.T) {
 
 	t.Run("FailsOnMultipleExternalContactsForEmail", func(t *testing.T) {
 		config.UseTestFile(t)
-		setup := testutils.NewSetup(t, "TestSyncCreatedOrgContactFailsOnMultipleExternalContactsForEmail")
-		_ = setup.GetTestInstance()
+		testutils.NeedCouchdb(t)
 
 		suffix := fmt.Sprintf("%d", time.Now().UnixNano())
 		orgDomain := "sync-created-dup-" + suffix + ".example"
@@ -143,8 +140,7 @@ func TestSyncCreatedOrgContact(t *testing.T) {
 
 	t.Run("ContinuesAfterInstanceError", func(t *testing.T) {
 		config.UseTestFile(t)
-		setup := testutils.NewSetup(t, "TestSyncCreatedOrgContactContinuesAfterInstanceError")
-		_ = setup.GetTestInstance()
+		testutils.NeedCouchdb(t)
 
 		suffix := fmt.Sprintf("%d", time.Now().UnixNano())
 		orgDomain := "sync-created-continue-" + suffix + ".example"
@@ -173,8 +169,7 @@ func TestSyncCreatedOrgContact(t *testing.T) {
 
 	t.Run("MissingInternalEmail", func(t *testing.T) {
 		config.UseTestFile(t)
-		setup := testutils.NewSetup(t, "TestSyncCreatedOrgContactMissingInternalEmail")
-		_ = setup.GetTestInstance()
+		testutils.NeedCouchdb(t)
 
 		suffix := fmt.Sprintf("%d", time.Now().UnixNano())
 		orgDomain := "sync-created-missing-email-" + suffix + ".example"
@@ -191,8 +186,7 @@ func TestSyncCreatedOrgContact(t *testing.T) {
 
 	t.Run("MissingPublicName", func(t *testing.T) {
 		config.UseTestFile(t)
-		setup := testutils.NewSetup(t, "TestSyncCreatedOrgContactMissingPublicName")
-		_ = setup.GetTestInstance()
+		testutils.NeedCouchdb(t)
 
 		suffix := fmt.Sprintf("%d", time.Now().UnixNano())
 		orgDomain := "sync-created-missing-name-" + suffix + ".example"
@@ -211,8 +205,7 @@ func TestSyncCreatedOrgContact(t *testing.T) {
 
 	t.Run("MissingOrganizationDomain", func(t *testing.T) {
 		config.UseTestFile(t)
-		setup := testutils.NewSetup(t, "TestSyncCreatedOrgContactMissingOrganizationDomain")
-		_ = setup.GetTestInstance()
+		testutils.NeedCouchdb(t)
 
 		suffix := fmt.Sprintf("%d", time.Now().UnixNano())
 		orgDomain := "sync-created-missing-org-" + suffix + ".example"
@@ -229,8 +222,7 @@ func TestSyncCreatedOrgContact(t *testing.T) {
 
 	t.Run("OrganizationHasNoInstances", func(t *testing.T) {
 		config.UseTestFile(t)
-		setup := testutils.NewSetup(t, "TestSyncCreatedOrgContactOrganizationHasNoInstances")
-		_ = setup.GetTestInstance()
+		testutils.NeedCouchdb(t)
 
 		suffix := fmt.Sprintf("%d", time.Now().UnixNano())
 		orgDomain := "sync-created-zero-" + suffix + ".example"
@@ -250,8 +242,7 @@ func TestSyncCreatedOrgContact(t *testing.T) {
 func TestSyncDeletedOrgContact(t *testing.T) {
 	t.Run("DeletesExternalContactsFromOtherMembers", func(t *testing.T) {
 		config.UseTestFile(t)
-		setup := testutils.NewSetup(t, "TestSyncDeletedOrgContactDeletesExternalContactsFromOtherMembers")
-		_ = setup.GetTestInstance()
+		testutils.NeedCouchdb(t)
 
 		suffix := fmt.Sprintf("%d", time.Now().UnixNano())
 		orgDomain := "sync-deleted-" + suffix + ".example"
@@ -294,8 +285,7 @@ func TestSyncDeletedOrgContact(t *testing.T) {
 
 	t.Run("NoExternalContactIsNoOp", func(t *testing.T) {
 		config.UseTestFile(t)
-		setup := testutils.NewSetup(t, "TestSyncDeletedOrgContactNoExternalContactIsNoOp")
-		_ = setup.GetTestInstance()
+		testutils.NeedCouchdb(t)
 
 		suffix := fmt.Sprintf("%d", time.Now().UnixNano())
 		orgDomain := "sync-deleted-noop-" + suffix + ".example"
@@ -321,8 +311,7 @@ func TestSyncDeletedOrgContact(t *testing.T) {
 
 	t.Run("FailsOnMultipleExternalContactsForEmail", func(t *testing.T) {
 		config.UseTestFile(t)
-		setup := testutils.NewSetup(t, "TestSyncDeletedOrgContactFailsOnMultipleExternalContactsForEmail")
-		_ = setup.GetTestInstance()
+		testutils.NeedCouchdb(t)
 
 		suffix := fmt.Sprintf("%d", time.Now().UnixNano())
 		orgDomain := "sync-deleted-dup-" + suffix + ".example"
@@ -344,8 +333,7 @@ func TestSyncDeletedOrgContact(t *testing.T) {
 
 	t.Run("ContinuesAfterInstanceError", func(t *testing.T) {
 		config.UseTestFile(t)
-		setup := testutils.NewSetup(t, "TestSyncDeletedOrgContactContinuesAfterInstanceError")
-		_ = setup.GetTestInstance()
+		testutils.NeedCouchdb(t)
 
 		suffix := fmt.Sprintf("%d", time.Now().UnixNano())
 		orgDomain := "sync-deleted-continue-" + suffix + ".example"
@@ -399,8 +387,7 @@ func TestSyncDeletedOrgContact(t *testing.T) {
 
 	t.Run("OrganizationHasNoInstances", func(t *testing.T) {
 		config.UseTestFile(t)
-		setup := testutils.NewSetup(t, "TestSyncDeletedOrgContactOrganizationHasNoInstances")
-		_ = setup.GetTestInstance()
+		testutils.NeedCouchdb(t)
 
 		suffix := fmt.Sprintf("%d", time.Now().UnixNano())
 		orgDomain := "sync-deleted-zero-" + suffix + ".example"

--- a/pkg/rabbitmq/org_contacts_test.go
+++ b/pkg/rabbitmq/org_contacts_test.go
@@ -1,0 +1,426 @@
+package rabbitmq_test
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cozy/cozy-stack/model/contact"
+	"github.com/cozy/cozy-stack/model/instance"
+	"github.com/cozy/cozy-stack/pkg/config/config"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/rabbitmq"
+	"github.com/cozy/cozy-stack/tests/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSyncCreatedOrgContact(t *testing.T) {
+	t.Run("CreatesExternalContactsForOtherMembers", func(t *testing.T) {
+		config.UseTestFile(t)
+		setup := testutils.NewSetup(t, "TestSyncCreatedOrgContactCreatesExternalContactsForOtherMembers")
+		_ = setup.GetTestInstance()
+
+		suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+		orgDomain := "sync-created-" + suffix + ".example"
+		orgID := "org-sync-created-" + suffix
+		target := createInstanceInOrg(t, "sync-created-alice-"+suffix+".local", orgDomain, orgID, "alice@example.com", "Alice")
+		bob := createInstanceInOrg(t, "sync-created-bob-"+suffix+".local", orgDomain, orgID, "bob@example.com", "Bob")
+		carol := createInstanceInOrg(t, "sync-created-carol-"+suffix+".local", orgDomain, orgID, "carol@example.com", "Carol")
+		targetURL := target.PageURL("", nil)
+
+		preexisting := createContact(t, bob, "alice@example.com", "https://manual.example", false, "Existing Alice")
+
+		err := rabbitmq.SyncCreatedOrgContact(testCtx(t), target, rabbitmq.UserCreatedMessage{
+			InternalEmail:      "alice@example.com",
+			Mobile:             "+33123456789",
+			WorkplaceFqdn:      target.Domain,
+			OrganizationDomain: strings.ToUpper(orgDomain) + ".",
+		})
+		require.NoError(t, err)
+
+		bobContacts, err := contact.FindAllByEmail(bob, "alice@example.com")
+		require.NoError(t, err)
+		require.Len(t, bobContacts, 2)
+		var bobExternalCount int
+		var bobFoundManual bool
+		for _, doc := range bobContacts {
+			if doc.ID() == preexisting.ID() {
+				bobFoundManual = true
+				require.Equal(t, "Existing Alice", doc.PrimaryName())
+				require.False(t, doc.IsExternal())
+				continue
+			}
+			if doc.IsExternal() {
+				bobExternalCount++
+				require.Equal(t, "Alice", doc.PrimaryName())
+				require.Equal(t, "+33123456789", doc.PrimaryPhoneNumber())
+				require.Equal(t, targetURL, doc.PrimaryCozyURL())
+			}
+		}
+		require.True(t, bobFoundManual)
+		require.Equal(t, 1, bobExternalCount)
+
+		carolContacts, err := contact.FindAllByEmail(carol, "alice@example.com")
+		require.NoError(t, err)
+		require.Len(t, carolContacts, 1)
+		require.True(t, carolContacts[0].IsExternal())
+		require.Equal(t, "Alice", carolContacts[0].PrimaryName())
+		require.Equal(t, "+33123456789", carolContacts[0].PrimaryPhoneNumber())
+		require.Equal(t, targetURL, carolContacts[0].PrimaryCozyURL())
+
+		targetContacts, err := contact.FindAllByEmail(target, "alice@example.com")
+		if err == nil {
+			for _, doc := range targetContacts {
+				require.False(t, doc.IsExternal())
+			}
+		} else {
+			require.True(t, errors.Is(err, contact.ErrNotFound))
+		}
+	})
+
+	t.Run("SkipsExistingExternalContact", func(t *testing.T) {
+		config.UseTestFile(t)
+		setup := testutils.NewSetup(t, "TestSyncCreatedOrgContactSkipsExistingExternalContact")
+		_ = setup.GetTestInstance()
+
+		suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+		orgDomain := "sync-created-existing-" + suffix + ".example"
+		orgID := "org-sync-created-existing-" + suffix
+		target := createInstanceInOrg(t, "sync-created-existing-alice-"+suffix+".local", orgDomain, orgID, "alice@example.com", "Alice")
+		bob := createInstanceInOrg(t, "sync-created-existing-bob-"+suffix+".local", orgDomain, orgID, "bob@example.com", "Bob")
+		carol := createInstanceInOrg(t, "sync-created-existing-carol-"+suffix+".local", orgDomain, orgID, "carol@example.com", "Carol")
+		targetURL := target.PageURL("", nil)
+
+		existing := createContact(t, bob, "alice@example.com", "https://old.example", true, "Old Alice")
+
+		err := rabbitmq.SyncCreatedOrgContact(testCtx(t), target, rabbitmq.UserCreatedMessage{
+			InternalEmail:      "alice@example.com",
+			Mobile:             "+33123456789",
+			WorkplaceFqdn:      target.Domain,
+			OrganizationDomain: orgDomain,
+		})
+		require.NoError(t, err)
+
+		bobContacts, err := contact.FindAllByEmail(bob, "alice@example.com")
+		require.NoError(t, err)
+		require.Len(t, bobContacts, 1)
+		require.Equal(t, existing.ID(), bobContacts[0].ID())
+		require.True(t, bobContacts[0].IsExternal())
+		require.Equal(t, "Old Alice", bobContacts[0].PrimaryName())
+		require.Equal(t, "https://old.example", bobContacts[0].PrimaryCozyURL())
+
+		carolContacts, err := contact.FindAllByEmail(carol, "alice@example.com")
+		require.NoError(t, err)
+		require.Len(t, carolContacts, 1)
+		require.True(t, carolContacts[0].IsExternal())
+		require.Equal(t, targetURL, carolContacts[0].PrimaryCozyURL())
+	})
+
+	t.Run("FailsOnMultipleExternalContactsForEmail", func(t *testing.T) {
+		config.UseTestFile(t)
+		setup := testutils.NewSetup(t, "TestSyncCreatedOrgContactFailsOnMultipleExternalContactsForEmail")
+		_ = setup.GetTestInstance()
+
+		suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+		orgDomain := "sync-created-dup-" + suffix + ".example"
+		orgID := "org-sync-created-dup-" + suffix
+		target := createInstanceInOrg(t, "sync-created-dup-alice-"+suffix+".local", orgDomain, orgID, "alice@example.com", "Alice")
+		bob := createInstanceInOrg(t, "sync-created-dup-bob-"+suffix+".local", orgDomain, orgID, "bob@example.com", "Bob")
+
+		createContact(t, bob, "alice@example.com", "https://old-a.example", true, "Alice External A")
+		createContact(t, bob, "alice@example.com", "https://old-b.example", true, "Alice External B")
+
+		err := rabbitmq.SyncCreatedOrgContact(testCtx(t), target, rabbitmq.UserCreatedMessage{
+			InternalEmail:      "alice@example.com",
+			WorkplaceFqdn:      target.Domain,
+			OrganizationDomain: orgDomain,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "multiple external contacts found for email alice@example.com")
+	})
+
+	t.Run("ContinuesAfterInstanceError", func(t *testing.T) {
+		config.UseTestFile(t)
+		setup := testutils.NewSetup(t, "TestSyncCreatedOrgContactContinuesAfterInstanceError")
+		_ = setup.GetTestInstance()
+
+		suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+		orgDomain := "sync-created-continue-" + suffix + ".example"
+		orgID := "org-sync-created-continue-" + suffix
+		target := createInstanceInOrg(t, "sync-created-continue-alice-"+suffix+".local", orgDomain, orgID, "alice@example.com", "Alice")
+		bob := createInstanceInOrg(t, "sync-created-continue-bob-"+suffix+".local", orgDomain, orgID, "bob@example.com", "Bob")
+		carol := createInstanceInOrg(t, "sync-created-continue-carol-"+suffix+".local", orgDomain, orgID, "carol@example.com", "Carol")
+
+		createContact(t, bob, "alice@example.com", "https://old-a.example", true, "Alice External A")
+		createContact(t, bob, "alice@example.com", "https://old-b.example", true, "Alice External B")
+
+		err := rabbitmq.SyncCreatedOrgContact(testCtx(t), target, rabbitmq.UserCreatedMessage{
+			InternalEmail:      "alice@example.com",
+			WorkplaceFqdn:      target.Domain,
+			OrganizationDomain: orgDomain,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "multiple external contacts found for email alice@example.com")
+
+		carolContacts, err := contact.FindAllByEmail(carol, "alice@example.com")
+		require.NoError(t, err)
+		require.Len(t, carolContacts, 1)
+		require.True(t, carolContacts[0].IsExternal())
+		require.Equal(t, target.PageURL("", nil), carolContacts[0].PrimaryCozyURL())
+	})
+
+	t.Run("MissingInternalEmail", func(t *testing.T) {
+		config.UseTestFile(t)
+		setup := testutils.NewSetup(t, "TestSyncCreatedOrgContactMissingInternalEmail")
+		_ = setup.GetTestInstance()
+
+		suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+		orgDomain := "sync-created-missing-email-" + suffix + ".example"
+		orgID := "org-sync-created-missing-email-" + suffix
+		target := createInstanceInOrg(t, "sync-created-missing-email-"+suffix+".local", orgDomain, orgID, "alice@example.com", "Alice")
+
+		err := rabbitmq.SyncCreatedOrgContact(testCtx(t), target, rabbitmq.UserCreatedMessage{
+			WorkplaceFqdn:      target.Domain,
+			OrganizationDomain: orgDomain,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "missing internalEmail")
+	})
+
+	t.Run("MissingPublicName", func(t *testing.T) {
+		config.UseTestFile(t)
+		setup := testutils.NewSetup(t, "TestSyncCreatedOrgContactMissingPublicName")
+		_ = setup.GetTestInstance()
+
+		suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+		orgDomain := "sync-created-missing-name-" + suffix + ".example"
+		orgID := "org-sync-created-missing-name-" + suffix
+		target := createInstanceInOrg(t, "sync-created-missing-name-"+suffix+".local", orgDomain, orgID, "alice@example.com", "Alice")
+		clearInstancePublicName(t, target)
+
+		err := rabbitmq.SyncCreatedOrgContact(testCtx(t), target, rabbitmq.UserCreatedMessage{
+			InternalEmail:      "alice@example.com",
+			WorkplaceFqdn:      target.Domain,
+			OrganizationDomain: orgDomain,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "missing public_name in settings")
+	})
+
+	t.Run("MissingOrganizationDomain", func(t *testing.T) {
+		config.UseTestFile(t)
+		setup := testutils.NewSetup(t, "TestSyncCreatedOrgContactMissingOrganizationDomain")
+		_ = setup.GetTestInstance()
+
+		suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+		orgDomain := "sync-created-missing-org-" + suffix + ".example"
+		orgID := "org-sync-created-missing-org-" + suffix
+		target := createInstanceInOrg(t, "sync-created-missing-org-"+suffix+".local", orgDomain, orgID, "alice@example.com", "Alice")
+
+		err := rabbitmq.SyncCreatedOrgContact(testCtx(t), target, rabbitmq.UserCreatedMessage{
+			InternalEmail: "alice@example.com",
+			WorkplaceFqdn: target.Domain,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "missing organization domain")
+	})
+
+	t.Run("OrganizationHasNoInstances", func(t *testing.T) {
+		config.UseTestFile(t)
+		setup := testutils.NewSetup(t, "TestSyncCreatedOrgContactOrganizationHasNoInstances")
+		_ = setup.GetTestInstance()
+
+		suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+		orgDomain := "sync-created-zero-" + suffix + ".example"
+		orgID := "org-sync-created-zero-" + suffix
+		target := createInstanceInOrg(t, "sync-created-zero-"+suffix+".local", orgDomain, orgID, "alice@example.com", "Alice")
+
+		err := rabbitmq.SyncCreatedOrgContact(testCtx(t), target, rabbitmq.UserCreatedMessage{
+			InternalEmail:      "alice@example.com",
+			WorkplaceFqdn:      target.Domain,
+			OrganizationDomain: "missing-sync-created-" + suffix + ".example",
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "organization has no instances")
+	})
+}
+
+func TestSyncDeletedOrgContact(t *testing.T) {
+	t.Run("DeletesExternalContactsFromOtherMembers", func(t *testing.T) {
+		config.UseTestFile(t)
+		setup := testutils.NewSetup(t, "TestSyncDeletedOrgContactDeletesExternalContactsFromOtherMembers")
+		_ = setup.GetTestInstance()
+
+		suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+		orgDomain := "sync-deleted-" + suffix + ".example"
+		orgID := "org-sync-deleted-" + suffix
+		target := createInstanceInOrg(t, "sync-deleted-alice-"+suffix+".local", orgDomain, orgID, "alice@example.com", "Alice")
+		bob := createInstanceInOrg(t, "sync-deleted-bob-"+suffix+".local", orgDomain, orgID, "bob@example.com", "Bob")
+		carol := createInstanceInOrg(t, "sync-deleted-carol-"+suffix+".local", orgDomain, orgID, "carol@example.com", "Carol")
+		targetURL := target.PageURL("", nil)
+
+		createContact(t, bob, "alice@example.com", targetURL, true, "Alice External")
+		carolManual := createContact(t, carol, "alice@example.com", "https://manual.example", false, "Alice Manual")
+		targetExternal := createContact(t, target, "alice@example.com", targetURL, true, "Alice Own External")
+
+		err := rabbitmq.SyncDeletedOrgContact(testCtx(t), rabbitmq.UserDeletedMessage{
+			WorkplaceFqdn: target.Domain,
+			InternalEmail: "alice@example.com",
+			Domain:        orgDomain,
+		})
+		require.NoError(t, err)
+
+		_, err = contact.FindAllByEmail(bob, "alice@example.com")
+		require.True(t, errors.Is(err, contact.ErrNotFound))
+
+		carolContacts, err := contact.FindAllByEmail(carol, "alice@example.com")
+		require.NoError(t, err)
+		require.Len(t, carolContacts, 1)
+		require.Equal(t, carolManual.ID(), carolContacts[0].ID())
+		require.False(t, carolContacts[0].IsExternal())
+
+		targetContacts, err := contact.FindAllByEmail(target, "alice@example.com")
+		require.NoError(t, err)
+		var foundTargetExternal bool
+		for _, doc := range targetContacts {
+			if doc.ID() == targetExternal.ID() {
+				foundTargetExternal = true
+			}
+		}
+		require.True(t, foundTargetExternal)
+	})
+
+	t.Run("NoExternalContactIsNoOp", func(t *testing.T) {
+		config.UseTestFile(t)
+		setup := testutils.NewSetup(t, "TestSyncDeletedOrgContactNoExternalContactIsNoOp")
+		_ = setup.GetTestInstance()
+
+		suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+		orgDomain := "sync-deleted-noop-" + suffix + ".example"
+		orgID := "org-sync-deleted-noop-" + suffix
+		target := createInstanceInOrg(t, "sync-deleted-noop-alice-"+suffix+".local", orgDomain, orgID, "alice@example.com", "Alice")
+		bob := createInstanceInOrg(t, "sync-deleted-noop-bob-"+suffix+".local", orgDomain, orgID, "bob@example.com", "Bob")
+
+		manual := createContact(t, bob, "alice@example.com", "https://manual.example", false, "Alice Manual")
+
+		err := rabbitmq.SyncDeletedOrgContact(testCtx(t), rabbitmq.UserDeletedMessage{
+			WorkplaceFqdn: target.Domain,
+			InternalEmail: "alice@example.com",
+			Domain:        orgDomain,
+		})
+		require.NoError(t, err)
+
+		bobContacts, err := contact.FindAllByEmail(bob, "alice@example.com")
+		require.NoError(t, err)
+		require.Len(t, bobContacts, 1)
+		require.Equal(t, manual.ID(), bobContacts[0].ID())
+		require.False(t, bobContacts[0].IsExternal())
+	})
+
+	t.Run("FailsOnMultipleExternalContactsForEmail", func(t *testing.T) {
+		config.UseTestFile(t)
+		setup := testutils.NewSetup(t, "TestSyncDeletedOrgContactFailsOnMultipleExternalContactsForEmail")
+		_ = setup.GetTestInstance()
+
+		suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+		orgDomain := "sync-deleted-dup-" + suffix + ".example"
+		orgID := "org-sync-deleted-dup-" + suffix
+		target := createInstanceInOrg(t, "sync-deleted-dup-alice-"+suffix+".local", orgDomain, orgID, "alice@example.com", "Alice")
+		bob := createInstanceInOrg(t, "sync-deleted-dup-bob-"+suffix+".local", orgDomain, orgID, "bob@example.com", "Bob")
+
+		createContact(t, bob, "alice@example.com", target.PageURL("", nil), true, "Alice External A")
+		createContact(t, bob, "alice@example.com", "https://old-b.example", true, "Alice External B")
+
+		err := rabbitmq.SyncDeletedOrgContact(testCtx(t), rabbitmq.UserDeletedMessage{
+			WorkplaceFqdn: target.Domain,
+			InternalEmail: "alice@example.com",
+			Domain:        orgDomain,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "multiple external contacts found for email alice@example.com")
+	})
+
+	t.Run("ContinuesAfterInstanceError", func(t *testing.T) {
+		config.UseTestFile(t)
+		setup := testutils.NewSetup(t, "TestSyncDeletedOrgContactContinuesAfterInstanceError")
+		_ = setup.GetTestInstance()
+
+		suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+		orgDomain := "sync-deleted-continue-" + suffix + ".example"
+		orgID := "org-sync-deleted-continue-" + suffix
+		target := createInstanceInOrg(t, "sync-deleted-continue-alice-"+suffix+".local", orgDomain, orgID, "alice@example.com", "Alice")
+		bob := createInstanceInOrg(t, "sync-deleted-continue-bob-"+suffix+".local", orgDomain, orgID, "bob@example.com", "Bob")
+		carol := createInstanceInOrg(t, "sync-deleted-continue-carol-"+suffix+".local", orgDomain, orgID, "carol@example.com", "Carol")
+
+		createContact(t, bob, "alice@example.com", target.PageURL("", nil), true, "Alice External A")
+		createContact(t, bob, "alice@example.com", "https://old-b.example", true, "Alice External B")
+		createContact(t, carol, "alice@example.com", target.PageURL("", nil), true, "Alice External")
+
+		err := rabbitmq.SyncDeletedOrgContact(testCtx(t), rabbitmq.UserDeletedMessage{
+			WorkplaceFqdn: target.Domain,
+			InternalEmail: "alice@example.com",
+			Domain:        orgDomain,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "multiple external contacts found for email alice@example.com")
+
+		_, err = contact.FindAllByEmail(carol, "alice@example.com")
+		require.True(t, errors.Is(err, contact.ErrNotFound))
+	})
+
+	t.Run("MissingWorkplaceFqdn", func(t *testing.T) {
+		err := rabbitmq.SyncDeletedOrgContact(testCtx(t), rabbitmq.UserDeletedMessage{
+			InternalEmail: "alice@example.com",
+			Domain:        "example.com",
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "missing workplaceFqdn")
+	})
+
+	t.Run("MissingInternalEmail", func(t *testing.T) {
+		err := rabbitmq.SyncDeletedOrgContact(testCtx(t), rabbitmq.UserDeletedMessage{
+			WorkplaceFqdn: "alice.example.com",
+			Domain:        "example.com",
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "missing internalEmail")
+	})
+
+	t.Run("MissingOrganizationDomain", func(t *testing.T) {
+		err := rabbitmq.SyncDeletedOrgContact(testCtx(t), rabbitmq.UserDeletedMessage{
+			WorkplaceFqdn: "alice.example.com",
+			InternalEmail: "alice@example.com",
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "missing organization domain")
+	})
+
+	t.Run("OrganizationHasNoInstances", func(t *testing.T) {
+		config.UseTestFile(t)
+		setup := testutils.NewSetup(t, "TestSyncDeletedOrgContactOrganizationHasNoInstances")
+		_ = setup.GetTestInstance()
+
+		suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+		orgDomain := "sync-deleted-zero-" + suffix + ".example"
+		orgID := "org-sync-deleted-zero-" + suffix
+		target := createInstanceInOrg(t, "sync-deleted-zero-"+suffix+".local", orgDomain, orgID, "alice@example.com", "Alice")
+
+		err := rabbitmq.SyncDeletedOrgContact(testCtx(t), rabbitmq.UserDeletedMessage{
+			WorkplaceFqdn: target.Domain,
+			InternalEmail: "alice@example.com",
+			Domain:        "missing-sync-deleted-" + suffix + ".example",
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "organization has no instances")
+	})
+}
+
+func clearInstancePublicName(t *testing.T, inst *instance.Instance) {
+	t.Helper()
+	doc, err := inst.SettingsDocument()
+	require.NoError(t, err)
+	doc.M["public_name"] = ""
+	require.NoError(t, couchdb.UpdateDoc(inst, doc))
+}

--- a/pkg/rabbitmq/rabbitmq.go
+++ b/pkg/rabbitmq/rabbitmq.go
@@ -269,6 +269,8 @@ func BuildExchangeSpecs(exchangesCfg []config.RabbitExchange) []ExchangeSpec {
 				handler = NewUserRecoveryEmailUpdatedHandler()
 			case QueueDomainSubscriptionChanged:
 				handler = NewDomainSubscriptionChangedHandler()
+			case QueueB2BUserDeleted:
+				handler = NewUserDeletedHandler()
 			case QueueAppCommands:
 				handler = NewAppInstallHandler()
 			}

--- a/pkg/rabbitmq/rabbitmq_test.go
+++ b/pkg/rabbitmq/rabbitmq_test.go
@@ -351,6 +351,10 @@ func TestHandlers(t *testing.T) {
 
 		ch, err := getChannel(t, MQ)
 		require.NoError(t, err)
+		waitForDeclaredQueues(t, MQ, queuePassiveCheck{
+			name:         rabbitmq.QueueB2BUserDeleted,
+			dlRoutingKey: rabbitmq.RoutingKeyB2BUserDeleted,
+		})
 
 		msg := rabbitmq.UserDeletedMessage{
 			Emitter:        "admin-panel",
@@ -928,25 +932,29 @@ func getChannel(t *testing.T, mq *testutils.RabbitFixture) (*amqp.Channel, error
 	return ch, err
 }
 
-func waitForDeclaredQueues(t *testing.T, mq *testutils.RabbitFixture, queueNames ...string) {
+type queuePassiveCheck struct {
+	name         string
+	dlRoutingKey string
+}
+
+func waitForDeclaredQueues(t *testing.T, mq *testutils.RabbitFixture, checks ...queuePassiveCheck) {
 	t.Helper()
 
 	testutils.WaitForOrFail(t, 10*time.Second, func() bool {
-		for _, queueName := range queueNames {
-			conn, err := amqp.Dial(mq.AMQPURL)
-			if err != nil {
-				return false
-			}
+		conn, err := amqp.Dial(mq.AMQPURL)
+		if err != nil {
+			return false
+		}
+		defer func() { _ = conn.Close() }()
 
-			ch, err := conn.Channel()
-			if err != nil {
-				_ = conn.Close()
-				return false
-			}
+		ch, err := conn.Channel()
+		if err != nil {
+			return false
+		}
+		defer func() { _ = ch.Close() }()
 
-			_, err = ch.QueueInspect(queueName)
-			_ = ch.Close()
-			_ = conn.Close()
+		for _, check := range checks {
+			_, err = ch.QueueInspect(check.name)
 			if err != nil {
 				return false
 			}
@@ -1074,19 +1082,7 @@ func setUpRabbitMQConfig(t *testing.T, mq *testutils.RabbitFixture, name string)
 		},
 	}
 
-	// Start the stack via testutils and create an instance
 	setup := testutils.NewSetup(t, name)
-	_ = setup.GetTestInstance()
-	waitForDeclaredQueues(t, mq,
-		rabbitmq.QueueUserPasswordUpdated,
-		rabbitmq.QueueUserCreated,
-		rabbitmq.QueueUserPhoneUpdated,
-		rabbitmq.QueueUser2FAUpdated,
-		rabbitmq.QueueUserRecoveryEmailUpdated,
-		rabbitmq.QueueDomainSubscriptionChanged,
-		rabbitmq.QueueB2BUserDeleted,
-		rabbitmq.QueueAppCommands,
-	)
 	return setup
 }
 

--- a/pkg/rabbitmq/rabbitmq_test.go
+++ b/pkg/rabbitmq/rabbitmq_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cozy/cozy-stack/model/app"
 	"github.com/cozy/cozy-stack/model/bitwarden/settings"
+	"github.com/cozy/cozy-stack/model/contact"
 	"github.com/cozy/cozy-stack/model/instance"
 	"github.com/cozy/cozy-stack/model/settings/common"
 	"github.com/cozy/cozy-stack/pkg/consts"
@@ -334,6 +335,55 @@ func TestHandlers(t *testing.T) {
 		// Public and private keys must remain unchanged when only Key is provided
 		require.Equal(t, prevPub, bw.PublicKey)
 		require.Equal(t, prevPriv, bw.PrivateKey)
+	})
+
+	t.Run("DeleteUserHandler", func(t *testing.T) {
+		setup := setUpRabbitMQConfig(t, MQ, "DeleteUserHandler")
+		_ = setup.GetTestInstance()
+
+		suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+		orgDomain := "delete-handler-" + suffix + ".example"
+		orgID := "org-delete-handler-" + suffix
+		target := createInstanceInOrg(t, "delete-handler-alice-"+suffix+".local", orgDomain, orgID, "alice@example.com", "Alice")
+		bob := createInstanceInOrg(t, "delete-handler-bob-"+suffix+".local", orgDomain, orgID, "bob@example.com", "Bob")
+
+		createContact(t, bob, "alice@example.com", target.PageURL("", nil), true, "Alice External")
+
+		ch, err := getChannel(t, MQ)
+		require.NoError(t, err)
+
+		msg := rabbitmq.UserDeletedMessage{
+			Emitter:        "admin-panel",
+			Type:           "user.deleted",
+			WorkplaceFqdn:  target.Domain,
+			InternalEmail:  "alice@example.com",
+			Reason:         "user deleted",
+			OrganizationID: orgID,
+			UserID:         "alice",
+			Domain:         orgDomain,
+		}
+		body, err := json.Marshal(msg)
+		require.NoError(t, err)
+
+		err = ch.PublishWithContext(
+			testCtx(t),
+			"b2b",
+			"user.deleted",
+			false,
+			false,
+			amqp.Publishing{
+				DeliveryMode: amqp.Persistent,
+				ContentType:  "application/json",
+				Body:         body,
+				MessageId:    fmt.Sprintf("%d", time.Now().UnixNano()),
+			},
+		)
+		require.NoError(t, err)
+
+		testutils.WaitForOrFail(t, 10*time.Second, func() bool {
+			_, err := contact.FindAllByEmail(bob, "alice@example.com")
+			return err == contact.ErrNotFound
+		})
 	})
 
 	t.Run("UpdateUserPhone", func(t *testing.T) {
@@ -811,6 +861,53 @@ func TestHandlers(t *testing.T) {
 	})
 }
 
+func TestUserDeletedHandlerValidation(t *testing.T) {
+	t.Run("MissingWorkplaceFqdn", func(t *testing.T) {
+		body, err := json.Marshal(rabbitmq.UserDeletedMessage{
+			InternalEmail: "alice@example.com",
+			Domain:        "example.com",
+		})
+		require.NoError(t, err)
+
+		err = rabbitmq.NewUserDeletedHandler().Handle(testCtx(t), amqp.Delivery{
+			RoutingKey: "user.deleted",
+			Body:       body,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "missing workplaceFqdn")
+	})
+
+	t.Run("MissingInternalEmail", func(t *testing.T) {
+		body, err := json.Marshal(rabbitmq.UserDeletedMessage{
+			WorkplaceFqdn: "alice.example.com",
+			Domain:        "example.com",
+		})
+		require.NoError(t, err)
+
+		err = rabbitmq.NewUserDeletedHandler().Handle(testCtx(t), amqp.Delivery{
+			RoutingKey: "user.deleted",
+			Body:       body,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "missing internalEmail")
+	})
+
+	t.Run("MissingOrganizationDomain", func(t *testing.T) {
+		body, err := json.Marshal(rabbitmq.UserDeletedMessage{
+			WorkplaceFqdn: "alice.example.com",
+			InternalEmail: "alice@example.com",
+		})
+		require.NoError(t, err)
+
+		err = rabbitmq.NewUserDeletedHandler().Handle(testCtx(t), amqp.Delivery{
+			RoutingKey: "user.deleted",
+			Body:       body,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "missing organization domain")
+	})
+}
+
 func hashPassphrase(t *testing.T) (string, string) {
 	t.Helper()
 	passphrase := []byte("super-secret-create-user-key")
@@ -829,6 +926,59 @@ func getChannel(t *testing.T, mq *testutils.RabbitFixture) (*amqp.Channel, error
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = ch.Close(); _ = conn.Close() })
 	return ch, err
+}
+
+func waitForDeclaredQueues(t *testing.T, mq *testutils.RabbitFixture, queueNames ...string) {
+	t.Helper()
+
+	testutils.WaitForOrFail(t, 10*time.Second, func() bool {
+		for _, queueName := range queueNames {
+			conn, err := amqp.Dial(mq.AMQPURL)
+			if err != nil {
+				return false
+			}
+
+			ch, err := conn.Channel()
+			if err != nil {
+				_ = conn.Close()
+				return false
+			}
+
+			_, err = ch.QueueInspect(queueName)
+			_ = ch.Close()
+			_ = conn.Close()
+			if err != nil {
+				return false
+			}
+		}
+		return true
+	})
+}
+
+func createInstanceInOrg(t *testing.T, domain, orgDomain, orgID, email, publicName string) *instance.Instance {
+	t.Helper()
+	inst, err := lifecycle.Create(&lifecycle.Options{
+		Domain:     domain,
+		OrgDomain:  orgDomain,
+		OrgID:      orgID,
+		Email:      email,
+		PublicName: publicName,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = lifecycle.Destroy(inst.Domain) })
+	return inst
+}
+
+func createContact(t *testing.T, inst *instance.Instance, email, cozyURL string, external bool, name string) *contact.Contact {
+	t.Helper()
+	c, err := contact.Create(inst, contact.CreateOptions{
+		Email:    email,
+		Name:     name,
+		CozyURL:  cozyURL,
+		External: external,
+	})
+	require.NoError(t, err)
+	return c
 }
 
 func setUpRabbitMQConfig(t *testing.T, mq *testutils.RabbitFixture, name string) *testutils.TestSetup {
@@ -895,6 +1045,20 @@ func setUpRabbitMQConfig(t *testing.T, mq *testutils.RabbitFixture, name string)
 			},
 		},
 		{
+			Name:            "b2b",
+			Kind:            "topic",
+			Durable:         true,
+			DeclareExchange: true,
+			Queues: []config.RabbitQueue{
+				{
+					Name:     "stack.b2b.user.deleted",
+					Bindings: []string{"user.deleted"},
+					Prefetch: 4,
+					Declare:  true,
+				},
+			},
+		},
+		{
 			Name:            "stack",
 			Kind:            "topic",
 			Durable:         true,
@@ -912,6 +1076,17 @@ func setUpRabbitMQConfig(t *testing.T, mq *testutils.RabbitFixture, name string)
 
 	// Start the stack via testutils and create an instance
 	setup := testutils.NewSetup(t, name)
+	_ = setup.GetTestInstance()
+	waitForDeclaredQueues(t, mq,
+		rabbitmq.QueueUserPasswordUpdated,
+		rabbitmq.QueueUserCreated,
+		rabbitmq.QueueUserPhoneUpdated,
+		rabbitmq.QueueUser2FAUpdated,
+		rabbitmq.QueueUserRecoveryEmailUpdated,
+		rabbitmq.QueueDomainSubscriptionChanged,
+		rabbitmq.QueueB2BUserDeleted,
+		rabbitmq.QueueAppCommands,
+	)
 	return setup
 }
 


### PR DESCRIPTION
## Summary 
 For B2B users, the stack now keeps an external contact in every other instance of the same organization:
  - on `auth / user.created`, create the contact in all other org instances
  - on `b2b / user.deleted`, remove that external contact from all other org instances

The sync is idempotent, skips the user’s own instance, and fails loudly on inconsistent data so the message can be retried / dead-lettered.

  ### Implementation
  - filters to `metadata.external: true`
  - organization lookup is **domain-only**
  - contact lookup is email-based, then filtered to external contacts
  - contact creation uses the shared `contact.Create(...)` model API

