### PR TITLE
fix: show mismatch error page for custom-instance sub mismatch

### DIFF
--- a/web/oidc/oidc.go
+++ b/web/oidc/oidc.go
@@ -45,7 +45,7 @@ var (
 )
 
 // DomainMismatchError is returned when the user tries to connect to an
-// instance but has an active OIDC session for a different instance.
+// instance but has an active OIDC session for a different instance/account.
 type DomainMismatchError struct {
 	ExpectedDomain string // The instance the user is trying to access
 	ActualDomain   string // The instance from the OIDC token
@@ -1289,12 +1289,19 @@ func checkDomainFromUserInfo(conf *Config, inst *instance.Instance, token string
 		if conf.Provider == oidcprovider.FranceConnectProvider {
 			expected = inst.FranceConnectID
 		}
-		if !ok || sub == "" || sub != expected {
+		if !ok || sub == "" {
 			inst.Logger().WithNamespace("oidc").Errorf("Invalid sub: %s != %s", sub, expected)
 			if conf.Provider == oidcprovider.FranceConnectProvider {
 				return ErrFranceConnectFailed
 			}
 			return ErrAuthenticationFailed
+		}
+		if sub != expected {
+			inst.Logger().WithNamespace("oidc").Errorf("Invalid sub: %s != %s", sub, expected)
+			if conf.Provider == oidcprovider.FranceConnectProvider {
+				return ErrFranceConnectFailed
+			}
+			return &DomainMismatchError{ExpectedDomain: inst.Domain, ActualDomain: sub}
 		}
 		return nil
 	}
@@ -1386,9 +1393,14 @@ func checkIDToken(conf *Config, inst *instance.Instance, idToken string) error {
 		logger.WithNamespace("oidc").Errorf("Error on VerifyIDToken: %s", err)
 		return ErrInvalidToken
 	}
-	if claims["sub"] == "" || claims["sub"] != inst.OIDCID {
-		inst.Logger().WithNamespace("oidc").Errorf("Invalid sub: %s != %s", claims["sub"], inst.OIDCID)
+	sub, _ := claims["sub"].(string)
+	if sub == "" {
+		inst.Logger().WithNamespace("oidc").Errorf("Invalid sub: %v != %s", claims["sub"], inst.OIDCID)
 		return ErrAuthenticationFailed
+	}
+	if sub != inst.OIDCID {
+		inst.Logger().WithNamespace("oidc").Errorf("Invalid sub: %s != %s", sub, inst.OIDCID)
+		return &DomainMismatchError{ExpectedDomain: inst.Domain, ActualDomain: sub}
 	}
 
 	return nil

--- a/web/oidc/oidc_test.go
+++ b/web/oidc/oidc_test.go
@@ -207,6 +207,45 @@ func TestOidc(t *testing.T) {
 			Expect().Status(404)
 	})
 
+	t.Run("LoginWithCustomInstanceSubMismatch", func(t *testing.T) {
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		onboardingFinished := true
+		_ = lifecycle.Patch(testInstance, &lifecycle.Options{
+			OnboardingFinished: &onboardingFinished,
+			OIDCID:             "expected-sub",
+		})
+
+		originalAuth := conf.Authentication["foocontext"]
+		conf.Authentication["foocontext"] = map[string]interface{}{
+			"oidc": map[string]interface{}{
+				"redirect_uri":          "http://foobar.com/redirect",
+				"client_id":             "foo",
+				"client_secret":         "bar",
+				"scope":                 "openid profile",
+				"authorize_url":         "http://foobar.com/authorize",
+				"userinfo_url":          ts.URL + "/api/v1/userinfo",
+				"allow_oauth_token":     true,
+				"allow_custom_instance": true,
+			},
+		}
+		t.Cleanup(func() {
+			conf.Authentication["foocontext"] = originalAuth
+		})
+
+		body := e.GET("/oidc/login").
+			WithHost(testInstance.Domain).
+			WithRedirectPolicy(httpexpect.DontFollowRedirects).
+			WithQuery("access_token", "fc_token").
+			Expect().Status(400).
+			ContentType("text/html").
+			Body()
+
+		body.Contains(testInstance.Domain)
+		body.Contains("fc_sub")
+		body.NotContains("Error from the identity provider.")
+	})
+
 	t.Run("LoginWith2FA", func(t *testing.T) {
 		e := testutils.CreateTestClient(t, ts.URL)
 


### PR DESCRIPTION
 ## Summary

  When a user tries to access a Twake instance while already authenticated in the IdP with another account, we should display the dedicated OIDC mismatch page.

 This behavior was added in #4646  but in practice, it only worked for the domain-based OIDC flow.
  In the `allow_custom_instance=true` flow, the stack validates the authenticated user through `sub -> instance.oidc_id` matching instead of `userinfo_instance_field -> domain` matching. 

There are 2 different OIDC validation paths in the stack:

  - `allow_custom_instance=false`
    The stack extracts the target instance from `userinfo_instance_field`, builds the domain, and compares it to `inst.Domain`.
    This path was updated by #4646 to return `DomainMismatchError`, which renders the dedicated mismatch page.

  - `allow_custom_instance=true`
    The stack ignores `userinfo_instance_field` and instead compares `userinfo.sub` to `inst.OIDCID`(current one).
