### PR TITLE
feat(nextcloud): endpoint to delete migrated folder from Nextcloud

### DIFF
--- a/model/nextcloud/delete_source.go
+++ b/model/nextcloud/delete_source.go
@@ -1,0 +1,173 @@
+package nextcloud
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path"
+	"time"
+
+	"github.com/cozy/cozy-stack/model/instance"
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/logger"
+	"github.com/cozy/cozy-stack/pkg/webdav"
+)
+
+// ErrMigrationNotDeletable gates delete-source to the completed status.
+// Failed and canceled migrations may still hold files on Nextcloud that
+// never reached Cozy, and removing the folder would lose them.
+var ErrMigrationNotDeletable = errors.New("nextcloud migration source can only be deleted after a completed migration")
+
+// ErrMigrationSourceAlreadyDeleted is surfaced rather than swallowed so
+// duplicate clicks from the UI show up as bugs instead of silent no-ops.
+var ErrMigrationSourceAlreadyDeleted = errors.New("nextcloud migration source already deleted")
+
+// ErrNextcloudAccountMissing means the single nextcloud account was
+// removed out-of-band between the migration and this cleanup call.
+var ErrNextcloudAccountMissing = errors.New("no nextcloud account configured for this instance")
+
+// DeleteMigrationSource removes the Nextcloud content ingested by the
+// given migration, then empties the user's trashbin so the migrated
+// bytes stop counting against quota.
+//
+// SourcePath == "/" enumerates the WebDAV home and deletes each
+// top-level child: Nextcloud refuses DELETE on the home itself with
+// 403, so a single call would fail. An empty SourcePath is treated as
+// "/" to match legacy docs predating source_path persistence.
+//
+// Error contract (priority order, for errors.Is mapping):
+//
+//   - [ErrMigrationNotFound], [ErrMigrationNotDeletable],
+//     [ErrMigrationSourceAlreadyDeleted],
+//     [ErrNextcloudAccountMissing]: state gates.
+//   - [webdav.ErrInvalidAuth]: stored credentials rejected (401/403).
+//   - [ErrNextcloudUnreachable]: any other Nextcloud-side failure.
+func DeleteMigrationSource(
+	ctx context.Context,
+	inst *instance.Instance,
+	migrationID string,
+) error {
+	log := logger.FromContext(ctx)
+
+	var doc Migration
+	if err := couchdb.GetDoc(inst, consts.NextcloudMigrations, migrationID, &doc); err != nil {
+		if couchdb.IsNotFoundError(err) || couchdb.IsNoDatabaseError(err) {
+			return ErrMigrationNotFound
+		}
+		return fmt.Errorf("load migration %s: %w", migrationID, err)
+	}
+	if doc.Status != MigrationStatusCompleted {
+		log.WithField("status", doc.Status).
+			Infof("Delete-source rejected: migration is not completed")
+		return ErrMigrationNotDeletable
+	}
+	if doc.SourceDeletedAt != nil {
+		log.Infof("Delete-source rejected: source already deleted")
+		return ErrMigrationSourceAlreadyDeleted
+	}
+	sourcePath := doc.SourcePath
+	if sourcePath == "" {
+		sourcePath = "/"
+	}
+
+	acc, err := FindNextcloudAccount(inst)
+	if err != nil {
+		return fmt.Errorf("find nextcloud account: %w", err)
+	}
+	if acc == nil {
+		return ErrNextcloudAccountMissing
+	}
+
+	nc, err := newFromAccountDoc(inst, acc)
+	if err != nil {
+		if errors.Is(err, webdav.ErrInvalidAuth) {
+			return err
+		}
+		return fmt.Errorf("build nextcloud client: %w", err)
+	}
+
+	log = log.WithField("source_path", sourcePath)
+	if sourcePath == "/" {
+		if err := deleteHomeContents(nc, log); err != nil {
+			return err
+		}
+	} else {
+		if err := deleteSinglePath(nc, sourcePath, log); err != nil {
+			return err
+		}
+	}
+	if err := emptyNextcloudTrash(nc, log); err != nil {
+		return err
+	}
+
+	now := time.Now().UTC()
+	doc.SourceDeletedAt = &now
+	if err := couchdb.UpdateDoc(inst, &doc); err != nil {
+		return fmt.Errorf("stamp source_deleted_at: %w", err)
+	}
+	return nil
+}
+
+func deleteSinglePath(nc *NextCloud, sourcePath string, log logger.Logger) error {
+	switch err := nc.Delete(sourcePath); {
+	case err == nil:
+		log.Infof("Nextcloud migration source folder deleted")
+		return nil
+	case errors.Is(err, webdav.ErrNotFound):
+		log.Warnf("Nextcloud migration source folder was already gone")
+		return nil
+	case errors.Is(err, webdav.ErrInvalidAuth):
+		return err
+	default:
+		log.Warnf("Nextcloud delete failed: %s", err)
+		return fmt.Errorf("%w: %w", ErrNextcloudUnreachable, err)
+	}
+}
+
+func deleteHomeContents(nc *NextCloud, log logger.Logger) error {
+	items, err := nc.webdav.List("/files/" + nc.userID + "/")
+	switch {
+	case err == nil:
+	case errors.Is(err, webdav.ErrInvalidAuth):
+		return err
+	case errors.Is(err, webdav.ErrNotFound):
+		log.Warnf("Nextcloud home was already gone")
+		return nil
+	default:
+		log.Warnf("Nextcloud list home failed: %s", err)
+		return fmt.Errorf("%w: list home: %w", ErrNextcloudUnreachable, err)
+	}
+	for _, item := range items {
+		name := path.Base(item.Href)
+		childLog := log.WithField("child", name)
+		switch err := nc.Delete(name); {
+		case err == nil:
+			childLog.Infof("Nextcloud home child deleted")
+		case errors.Is(err, webdav.ErrNotFound):
+			childLog.Warnf("Nextcloud home child was already gone")
+		case errors.Is(err, webdav.ErrInvalidAuth):
+			return err
+		default:
+			childLog.Warnf("Nextcloud delete failed: %s", err)
+			return fmt.Errorf("%w: delete %q: %w", ErrNextcloudUnreachable, name, err)
+		}
+	}
+	return nil
+}
+
+func emptyNextcloudTrash(nc *NextCloud, log logger.Logger) error {
+	switch err := nc.EmptyTrash(); {
+	case err == nil:
+		log.Infof("Nextcloud trash emptied")
+		return nil
+	case errors.Is(err, webdav.ErrNotFound):
+		log.Infof("Nextcloud trash was already empty")
+		return nil
+	case errors.Is(err, webdav.ErrInvalidAuth):
+		return err
+	default:
+		log.Warnf("Nextcloud trash empty failed: %s", err)
+		return fmt.Errorf("%w: empty trash: %w", ErrNextcloudUnreachable, err)
+	}
+}

--- a/model/nextcloud/migration.go
+++ b/model/nextcloud/migration.go
@@ -33,12 +33,15 @@ var ErrMigrationConflict = errors.New("a nextcloud migration is already in progr
 // reducer because it spreads doc.progress and adds to its fields.
 //
 // CancelRequested and CanceledAt are written by the migration service;
-// the Stack round-trips them without modification.
+// the Stack round-trips them without modification. SourcePath and
+// SourceDeletedAt are written only by the Stack (trigger and delete-source
+// respectively); SourceDeletedAt is never cleared once stamped.
 type Migration struct {
 	DocID           string            `json:"_id,omitempty"`
 	DocRev          string            `json:"_rev,omitempty"`
 	Status          string            `json:"status"`
 	TargetDir       string            `json:"target_dir"`
+	SourcePath      string            `json:"source_path,omitempty"`
 	Progress        MigrationProgress `json:"progress"`
 	Errors          []MigrationError  `json:"errors"`
 	Skipped         []SkippedFile     `json:"skipped"`
@@ -46,6 +49,7 @@ type Migration struct {
 	FinishedAt      *time.Time        `json:"finished_at"`
 	CancelRequested bool              `json:"cancel_requested,omitempty"`
 	CanceledAt      *time.Time        `json:"canceled_at,omitempty"`
+	SourceDeletedAt *time.Time        `json:"source_deleted_at,omitempty"`
 }
 
 type MigrationProgress struct {
@@ -96,6 +100,10 @@ func (m *Migration) Clone() couchdb.Doc {
 		t := *m.CanceledAt
 		cloned.CanceledAt = &t
 	}
+	if m.SourceDeletedAt != nil {
+		t := *m.SourceDeletedAt
+		cloned.SourceDeletedAt = &t
+	}
 	return &cloned
 }
 
@@ -121,17 +129,19 @@ var (
 
 // NewPendingMigration returns a fresh Migration document in the pending state.
 // Errors and Skipped are explicit empty slices so the JSON serialization
-// produces "[]" rather than "null" — the migration service consumes them as
-// arrays and would crash on null.
-func NewPendingMigration(targetDir string) *Migration {
+// produces "[]" rather than "null": the migration service consumes them as
+// arrays and would crash on null. sourcePath must be the normalized
+// Nextcloud-side path from the trigger request.
+func NewPendingMigration(targetDir, sourcePath string) *Migration {
 	if targetDir == "" {
 		targetDir = DefaultMigrationTargetDir
 	}
 	return &Migration{
-		Status:    MigrationStatusPending,
-		TargetDir: targetDir,
-		Errors:    []MigrationError{},
-		Skipped:   []SkippedFile{},
+		Status:     MigrationStatusPending,
+		TargetDir:  targetDir,
+		SourcePath: sourcePath,
+		Errors:     []MigrationError{},
+		Skipped:    []SkippedFile{},
 	}
 }
 

--- a/model/nextcloud/nextcloud.go
+++ b/model/nextcloud/nextcloud.go
@@ -82,7 +82,15 @@ func New(inst *instance.Instance, accountID string) (*NextCloud, error) {
 		}
 		return nil, err
 	}
-	account.Decrypt(doc)
+	return newFromAccountDoc(inst, &doc)
+}
+
+// newFromAccountDoc builds a client from an already-fetched account doc,
+// decrypting it in place. Intended for callers that just scanned for the
+// account (e.g. FindNextcloudAccount) and would otherwise pay a second
+// GetDoc inside New.
+func newFromAccountDoc(inst *instance.Instance, doc *couchdb.JSONDoc) (*NextCloud, error) {
+	account.Decrypt(*doc)
 
 	if doc.M == nil || doc.M["account_type"] != "nextcloud" {
 		return nil, ErrInvalidAccount
@@ -113,11 +121,11 @@ func New(inst *instance.Instance, accountID string) (*NextCloud, error) {
 	}
 	nc := &NextCloud{
 		inst:        inst,
-		accountID:   accountID,
+		accountID:   doc.ID(),
 		installRoot: installRoot,
 		webdav:      webdav,
 	}
-	if err := nc.fillUserID(&doc); err != nil {
+	if err := nc.fillUserID(doc); err != nil {
 		return nil, err
 	}
 	return nc, nil

--- a/model/nextcloud/trigger.go
+++ b/model/nextcloud/trigger.go
@@ -122,7 +122,7 @@ func TriggerMigration(
 		return nil, fmt.Errorf("ensure nextcloud account: %w", err)
 	}
 
-	doc := NewPendingMigration(req.TargetDir)
+	doc := NewPendingMigration(req.TargetDir, req.SourcePath)
 	if err := couchdb.CreateDoc(inst, doc); err != nil {
 		log.WithField("account_id", accountID).
 			Errorf("Failed to create migration tracking doc: %s", err)

--- a/web/remote/migration.go
+++ b/web/remote/migration.go
@@ -147,3 +147,46 @@ func mapNextcloudMigrationCancelError(err error) error {
 		return jsonapi.InternalServerError(err)
 	}
 }
+
+// postNextcloudMigrationDeleteSource removes the Nextcloud folder ingested
+// by the given migration. Synchronous because the Stack holds the stored
+// credentials and doing it via the broker would add no resilience over a
+// single WebDAV DELETE the server handles recursively.
+func (h *HTTPHandler) postNextcloudMigrationDeleteSource(c echo.Context) error {
+	if err := middlewares.AllowWholeType(c, permission.POST, consts.NextcloudMigrations); err != nil {
+		return err
+	}
+	inst := middlewares.GetInstance(c)
+	migrationID := c.Param("id")
+	if migrationID == "" {
+		return jsonapi.BadRequest(errors.New("missing migration id"))
+	}
+
+	reqLogger := inst.Logger().WithNamespace(nextcloudMigrationLogNamespace).WithFields(logger.Fields{
+		"migration_id": migrationID,
+	})
+	ctx := logger.WithContext(c.Request().Context(), reqLogger)
+
+	if err := nextcloud.DeleteMigrationSource(ctx, inst, migrationID); err != nil {
+		return mapNextcloudMigrationDeleteSourceError(err)
+	}
+	return c.NoContent(http.StatusNoContent)
+}
+
+func mapNextcloudMigrationDeleteSourceError(err error) error {
+	switch {
+	case errors.Is(err, nextcloud.ErrMigrationNotFound):
+		return jsonapi.NotFound(err)
+	case errors.Is(err, nextcloud.ErrNextcloudAccountMissing):
+		return jsonapi.NotFound(err)
+	case errors.Is(err, nextcloud.ErrMigrationNotDeletable),
+		errors.Is(err, nextcloud.ErrMigrationSourceAlreadyDeleted):
+		return jsonapi.Conflict(err)
+	case errors.Is(err, webdav.ErrInvalidAuth):
+		return jsonapi.Unauthorized(errors.New("nextcloud credentials are invalid"))
+	case errors.Is(err, nextcloud.ErrNextcloudUnreachable):
+		return jsonapi.BadGateway(fmt.Errorf("nextcloud unreachable: %w", err))
+	default:
+		return jsonapi.InternalServerError(err)
+	}
+}

--- a/web/remote/migration_test.go
+++ b/web/remote/migration_test.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/cozy/cozy-stack/model/instance"
 	"github.com/cozy/cozy-stack/model/nextcloud"
@@ -386,7 +388,7 @@ func TestPostNextcloudMigration(t *testing.T) {
 		setup := testutils.NewSetup(t, "ncmigration-conflict")
 		inst := setup.GetTestInstance()
 
-		existing := nextcloud.NewPendingMigration("")
+		existing := nextcloud.NewPendingMigration("", "")
 		existing.Status = nextcloud.MigrationStatusRunning
 		require.NoError(t, couchdb.CreateDoc(inst, existing))
 
@@ -646,7 +648,7 @@ func TestPostNextcloudMigrationCancel(t *testing.T) {
 		setup := testutils.NewSetup(t, "ncmigration-cancel-happy")
 		inst := setup.GetTestInstance()
 
-		doc := nextcloud.NewPendingMigration("")
+		doc := nextcloud.NewPendingMigration("", "")
 		doc.Status = nextcloud.MigrationStatusRunning
 		require.NoError(t, couchdb.CreateDoc(inst, doc))
 
@@ -704,7 +706,7 @@ func TestPostNextcloudMigrationCancel(t *testing.T) {
 			setup := testutils.NewSetup(t, "ncmigration-cancel-"+status)
 			inst := setup.GetTestInstance()
 
-			doc := nextcloud.NewPendingMigration("")
+			doc := nextcloud.NewPendingMigration("", "")
 			doc.Status = status
 			require.NoError(t, couchdb.CreateDoc(inst, doc))
 
@@ -724,7 +726,7 @@ func TestPostNextcloudMigrationCancel(t *testing.T) {
 		setup := testutils.NewSetup(t, "ncmigration-cancel-publishfail")
 		inst := setup.GetTestInstance()
 
-		doc := nextcloud.NewPendingMigration("")
+		doc := nextcloud.NewPendingMigration("", "")
 		doc.Status = nextcloud.MigrationStatusRunning
 		require.NoError(t, couchdb.CreateDoc(inst, doc))
 
@@ -747,7 +749,7 @@ func TestPostNextcloudMigrationCancel(t *testing.T) {
 		setup := testutils.NewSetup(t, "ncmigration-cancel-forbidden")
 		inst := setup.GetTestInstance()
 
-		doc := nextcloud.NewPendingMigration("")
+		doc := nextcloud.NewPendingMigration("", "")
 		doc.Status = nextcloud.MigrationStatusRunning
 		require.NoError(t, couchdb.CreateDoc(inst, doc))
 
@@ -764,5 +766,352 @@ func TestPostNextcloudMigrationCancel(t *testing.T) {
 			Expect().Status(http.StatusForbidden)
 
 		assert.Equal(t, 0, spy.count())
+	})
+}
+
+type nextcloudDeleteMockOptions struct {
+	// deleteStatus is the status returned to a WebDAV DELETE on
+	// /remote.php/dav/files/... Zero means 204 No Content.
+	deleteStatus int
+	// trashStatus is the status returned to a WebDAV DELETE on
+	// /remote.php/dav/trashbin/<user>/trash. Zero means 204.
+	trashStatus int
+	// homeChildren are the top-level entries returned by PROPFIND on
+	// the WebDAV home. Used by the SourcePath="/" flow which lists the
+	// home before deleting each child.
+	homeChildren []string
+}
+
+type nextcloudDeleteMockCounts struct {
+	propfindHome int32
+	deleteFile   int32
+	deleteTrash  int32
+}
+
+// total returns the sum of every WebDAV call observed by the mock.
+// Used by gate-test assertions that expect zero traffic to Nextcloud.
+func (c *nextcloudDeleteMockCounts) total() int32 {
+	return atomic.LoadInt32(&c.propfindHome) +
+		atomic.LoadInt32(&c.deleteFile) +
+		atomic.LoadInt32(&c.deleteTrash)
+}
+
+// startMockNextcloudForDelete stands in for a Nextcloud WebDAV endpoint for
+// the delete-source tests. It only handles DELETE on the files tree: the
+// delete flow never probes OCS because the account is seeded with a cached
+// webdav_user_id.
+func startMockNextcloudForDelete(t *testing.T, opts nextcloudDeleteMockOptions) (url string, counts *nextcloudDeleteMockCounts) {
+	t.Helper()
+	deleteStatus := opts.deleteStatus
+	if deleteStatus == 0 {
+		deleteStatus = http.StatusNoContent
+	}
+	trashStatus := opts.trashStatus
+	if trashStatus == 0 {
+		trashStatus = http.StatusNoContent
+	}
+	counts = &nextcloudDeleteMockCounts{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "PROPFIND" && strings.HasPrefix(r.URL.Path, "/remote.php/dav/files/") && strings.HasSuffix(r.URL.Path, "/"):
+			atomic.AddInt32(&counts.propfindHome, 1)
+			w.Header().Set("Content-Type", "application/xml; charset=utf-8")
+			w.WriteHeader(http.StatusMultiStatus)
+			_, _ = w.Write([]byte(buildHomeMultistatus(r.URL.Path, opts.homeChildren)))
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/remote.php/dav/trashbin/"):
+			atomic.AddInt32(&counts.deleteTrash, 1)
+			w.WriteHeader(trashStatus)
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/remote.php/dav/files/"):
+			atomic.AddInt32(&counts.deleteFile, 1)
+			w.WriteHeader(deleteStatus)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL + "/", counts
+}
+
+// buildHomeMultistatus renders a minimal valid WebDAV multistatus
+// listing the home itself plus the given children. The webdav.List
+// parser only consumes resourcetype + displayname, so we keep the body
+// to that subset.
+func buildHomeMultistatus(homePath string, children []string) string {
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0"?><d:multistatus xmlns:d="DAV:"><d:response><d:href>`)
+	b.WriteString(homePath)
+	b.WriteString(`</d:href><d:propstat><d:prop><d:resourcetype><d:collection/></d:resourcetype></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>`)
+	for _, child := range children {
+		b.WriteString(`<d:response><d:href>`)
+		b.WriteString(homePath)
+		b.WriteString(child)
+		b.WriteString(`/</d:href><d:propstat><d:prop><d:resourcetype><d:collection/></d:resourcetype><d:displayname>`)
+		b.WriteString(child)
+		b.WriteString(`</d:displayname></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>`)
+	}
+	b.WriteString(`</d:multistatus>`)
+	return b.String()
+}
+
+// seedNextcloudAccount upserts the single nextcloud account for the
+// instance with credentials pointing at the given mock URL and a cached
+// webdav_user_id so nextcloud.New skips the OCS probe.
+func seedNextcloudAccount(t *testing.T, inst *instance.Instance, ncURL string) {
+	t.Helper()
+	_, err := nextcloud.EnsureAccount(inst, ncURL, "alice", "app-password-xxx", "alice-webdav")
+	require.NoError(t, err)
+}
+
+// seedCompletedMigration creates a tracking doc in the completed status
+// with the given source path and returns its id.
+func seedCompletedMigration(t *testing.T, inst *instance.Instance, sourcePath string) string {
+	t.Helper()
+	doc := nextcloud.NewPendingMigration("", sourcePath)
+	doc.Status = nextcloud.MigrationStatusCompleted
+	require.NoError(t, couchdb.CreateDoc(inst, doc))
+	return doc.ID()
+}
+
+func TestPostNextcloudMigrationDeleteSource(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	config.UseTestFile(t)
+	testutils.NeedCouchdb(t)
+
+	oldBuildMode := build.BuildMode
+	build.BuildMode = build.ModeDev
+	t.Cleanup(func() { build.BuildMode = oldBuildMode })
+
+	t.Run("HappyPath", func(t *testing.T) {
+		setup := testutils.NewSetup(t, "ncmigration-delete-happy")
+		inst := setup.GetTestInstance()
+
+		ncURL, counts := startMockNextcloudForDelete(t, nextcloudDeleteMockOptions{})
+		seedNextcloudAccount(t, inst, ncURL)
+		migrationID := seedCompletedMigration(t, inst, "/photos")
+
+		ts := setupMigrationRouter(t, inst, migrationPermission(), &spyRabbitMQ{})
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		e.POST("/remote/nextcloud/migration/" + migrationID + "/delete-source").
+			WithHost(inst.Domain).
+			Expect().Status(http.StatusNoContent)
+
+		assert.Equal(t, int32(0), atomic.LoadInt32(&counts.propfindHome),
+			"sub-path delete must not list the home")
+		assert.Equal(t, int32(1), atomic.LoadInt32(&counts.deleteFile), "expected one WebDAV DELETE on the sub-path")
+		assert.Equal(t, int32(1), atomic.LoadInt32(&counts.deleteTrash),
+			"trash must be emptied after the source folder is removed")
+
+		var stored nextcloud.Migration
+		require.NoError(t, couchdb.GetDoc(inst, consts.NextcloudMigrations, migrationID, &stored))
+		assert.Equal(t, nextcloud.MigrationStatusCompleted, stored.Status,
+			"status stays completed; the delete is a post-migration cleanup, not a new state")
+		require.NotNil(t, stored.SourceDeletedAt, "SourceDeletedAt must be stamped")
+		assert.WithinDuration(t, time.Now().UTC(), *stored.SourceDeletedAt, time.Minute)
+	})
+
+	t.Run("UnknownMigrationReturns404", func(t *testing.T) {
+		setup := testutils.NewSetup(t, "ncmigration-delete-unknown")
+		inst := setup.GetTestInstance()
+
+		ts := setupMigrationRouter(t, inst, migrationPermission(), &spyRabbitMQ{})
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		e.POST("/remote/nextcloud/migration/does-not-exist/delete-source").
+			WithHost(inst.Domain).
+			Expect().Status(http.StatusNotFound)
+	})
+
+	for _, status := range []string{
+		nextcloud.MigrationStatusPending,
+		nextcloud.MigrationStatusRunning,
+		nextcloud.MigrationStatusFailed,
+		nextcloud.MigrationStatusCanceled,
+	} {
+		status := status
+		t.Run("NotCompleted_"+status, func(t *testing.T) {
+			setup := testutils.NewSetup(t, "ncmigration-delete-status-"+status)
+			inst := setup.GetTestInstance()
+
+			ncURL, counts := startMockNextcloudForDelete(t, nextcloudDeleteMockOptions{})
+			seedNextcloudAccount(t, inst, ncURL)
+
+			doc := nextcloud.NewPendingMigration("", "/photos")
+			doc.Status = status
+			require.NoError(t, couchdb.CreateDoc(inst, doc))
+
+			ts := setupMigrationRouter(t, inst, migrationPermission(), &spyRabbitMQ{})
+			e := testutils.CreateTestClient(t, ts.URL)
+
+			e.POST("/remote/nextcloud/migration/" + doc.ID() + "/delete-source").
+				WithHost(inst.Domain).
+				Expect().Status(http.StatusConflict)
+
+			assert.Equal(t, int32(0), counts.total(),
+				"non-completed migrations must not reach Nextcloud")
+		})
+	}
+
+	t.Run("AlreadyDeletedReturns409", func(t *testing.T) {
+		setup := testutils.NewSetup(t, "ncmigration-delete-already")
+		inst := setup.GetTestInstance()
+
+		ncURL, counts := startMockNextcloudForDelete(t, nextcloudDeleteMockOptions{})
+		seedNextcloudAccount(t, inst, ncURL)
+
+		doc := nextcloud.NewPendingMigration("", "/photos")
+		doc.Status = nextcloud.MigrationStatusCompleted
+		stamped := time.Now().UTC().Add(-1 * time.Hour)
+		doc.SourceDeletedAt = &stamped
+		require.NoError(t, couchdb.CreateDoc(inst, doc))
+
+		ts := setupMigrationRouter(t, inst, migrationPermission(), &spyRabbitMQ{})
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		e.POST("/remote/nextcloud/migration/" + doc.ID() + "/delete-source").
+			WithHost(inst.Domain).
+			Expect().Status(http.StatusConflict)
+
+		assert.Equal(t, int32(0), counts.total())
+	})
+
+	t.Run("EmptySourcePathDefaultsToRoot", func(t *testing.T) {
+		// Legacy tracking docs (or any doc with an empty source_path) are
+		// treated as a root-level migration, mirroring the trigger which
+		// normalizes an empty source_path to "/". Root deletion enumerates
+		// the home and removes each child because Nextcloud refuses
+		// DELETE on the user's WebDAV home itself.
+		setup := testutils.NewSetup(t, "ncmigration-delete-nopath")
+		inst := setup.GetTestInstance()
+
+		ncURL, counts := startMockNextcloudForDelete(t, nextcloudDeleteMockOptions{
+			homeChildren: []string{"Photos", "Documents"},
+		})
+		seedNextcloudAccount(t, inst, ncURL)
+
+		doc := nextcloud.NewPendingMigration("", "")
+		doc.Status = nextcloud.MigrationStatusCompleted
+		require.NoError(t, couchdb.CreateDoc(inst, doc))
+
+		ts := setupMigrationRouter(t, inst, migrationPermission(), &spyRabbitMQ{})
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		e.POST("/remote/nextcloud/migration/" + doc.ID() + "/delete-source").
+			WithHost(inst.Domain).
+			Expect().Status(http.StatusNoContent)
+
+		assert.Equal(t, int32(1), atomic.LoadInt32(&counts.propfindHome),
+			"root delete must list the home before deleting children")
+		assert.Equal(t, int32(2), atomic.LoadInt32(&counts.deleteFile),
+			"each top-level child must be deleted individually")
+		assert.Equal(t, int32(1), atomic.LoadInt32(&counts.deleteTrash),
+			"trash must be emptied after the children are removed")
+
+		var stored nextcloud.Migration
+		require.NoError(t, couchdb.GetDoc(inst, consts.NextcloudMigrations, doc.ID(), &stored))
+		assert.NotNil(t, stored.SourceDeletedAt)
+	})
+
+	t.Run("NextcloudAlreadyGoneIsIdempotent", func(t *testing.T) {
+		setup := testutils.NewSetup(t, "ncmigration-delete-404")
+		inst := setup.GetTestInstance()
+
+		ncURL, counts := startMockNextcloudForDelete(t, nextcloudDeleteMockOptions{
+			deleteStatus: http.StatusNotFound,
+			trashStatus:  http.StatusNotFound,
+		})
+		seedNextcloudAccount(t, inst, ncURL)
+		migrationID := seedCompletedMigration(t, inst, "/photos")
+
+		ts := setupMigrationRouter(t, inst, migrationPermission(), &spyRabbitMQ{})
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		e.POST("/remote/nextcloud/migration/" + migrationID + "/delete-source").
+			WithHost(inst.Domain).
+			Expect().Status(http.StatusNoContent)
+
+		assert.Equal(t, int32(1), atomic.LoadInt32(&counts.deleteFile))
+		assert.Equal(t, int32(1), atomic.LoadInt32(&counts.deleteTrash),
+			"trash empty must still run even when the folder was already gone")
+
+		var stored nextcloud.Migration
+		require.NoError(t, couchdb.GetDoc(inst, consts.NextcloudMigrations, migrationID, &stored))
+		assert.NotNil(t, stored.SourceDeletedAt,
+			"a folder already gone from Nextcloud still stamps SourceDeletedAt so the UI stops offering the button")
+	})
+
+	t.Run("NextcloudInvalidAuthReturns401", func(t *testing.T) {
+		setup := testutils.NewSetup(t, "ncmigration-delete-401")
+		inst := setup.GetTestInstance()
+
+		ncURL, counts := startMockNextcloudForDelete(t, nextcloudDeleteMockOptions{deleteStatus: http.StatusUnauthorized})
+		seedNextcloudAccount(t, inst, ncURL)
+		migrationID := seedCompletedMigration(t, inst, "/photos")
+
+		ts := setupMigrationRouter(t, inst, migrationPermission(), &spyRabbitMQ{})
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		e.POST("/remote/nextcloud/migration/" + migrationID + "/delete-source").
+			WithHost(inst.Domain).
+			Expect().Status(http.StatusUnauthorized)
+
+		assert.Equal(t, int32(0), atomic.LoadInt32(&counts.deleteTrash),
+			"trash empty must not run when the folder delete was rejected")
+
+		var stored nextcloud.Migration
+		require.NoError(t, couchdb.GetDoc(inst, consts.NextcloudMigrations, migrationID, &stored))
+		assert.Nil(t, stored.SourceDeletedAt,
+			"SourceDeletedAt must not be stamped when Nextcloud rejected the credentials")
+	})
+
+	t.Run("RejectsWithoutPermission", func(t *testing.T) {
+		setup := testutils.NewSetup(t, "ncmigration-delete-forbidden")
+		inst := setup.GetTestInstance()
+
+		ncURL, counts := startMockNextcloudForDelete(t, nextcloudDeleteMockOptions{})
+		seedNextcloudAccount(t, inst, ncURL)
+		migrationID := seedCompletedMigration(t, inst, "/photos")
+
+		pdoc := &permission.Permission{
+			Type:     permission.TypeWebapp,
+			SourceID: consts.Apps + "/" + consts.SettingsSlug,
+		}
+		ts := setupMigrationRouter(t, inst, pdoc, &spyRabbitMQ{})
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		e.POST("/remote/nextcloud/migration/" + migrationID + "/delete-source").
+			WithHost(inst.Domain).
+			Expect().Status(http.StatusForbidden)
+
+		assert.Equal(t, int32(0), counts.total())
+	})
+
+	t.Run("TrashEmptyFailureDoesNotStamp", func(t *testing.T) {
+		setup := testutils.NewSetup(t, "ncmigration-delete-trash-fail")
+		inst := setup.GetTestInstance()
+
+		ncURL, counts := startMockNextcloudForDelete(t, nextcloudDeleteMockOptions{
+			trashStatus: http.StatusInternalServerError,
+		})
+		seedNextcloudAccount(t, inst, ncURL)
+		migrationID := seedCompletedMigration(t, inst, "/photos")
+
+		ts := setupMigrationRouter(t, inst, migrationPermission(), &spyRabbitMQ{})
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		e.POST("/remote/nextcloud/migration/" + migrationID + "/delete-source").
+			WithHost(inst.Domain).
+			Expect().Status(http.StatusBadGateway)
+
+		assert.Equal(t, int32(1), atomic.LoadInt32(&counts.deleteFile))
+		assert.Equal(t, int32(1), atomic.LoadInt32(&counts.deleteTrash))
+
+		var stored nextcloud.Migration
+		require.NoError(t, couchdb.GetDoc(inst, consts.NextcloudMigrations, migrationID, &stored))
+		assert.Nil(t, stored.SourceDeletedAt,
+			"SourceDeletedAt must not be stamped if the trash empty failed: the user can retry to clear quota")
 	})
 }

--- a/web/remote/remote.go
+++ b/web/remote/remote.go
@@ -35,6 +35,7 @@ func (h *HTTPHandler) Register(router *echo.Group) {
 	Routes(router)
 	router.POST("/nextcloud/migration", h.postNextcloudMigration)
 	router.POST("/nextcloud/migration/:id/cancel", h.postNextcloudMigrationCancel)
+	router.POST("/nextcloud/migration/:id/delete-source", h.postNextcloudMigrationDeleteSource)
 }
 
 func allDoctypes(c echo.Context) error {


### PR DESCRIPTION
## Summary

Adds `POST /remote/nextcloud/migration/:id/delete-source`, a synchronous cleanup endpoint the Settings UI calls after a migration completes to remove the Nextcloud-side data the user just imported into their Cozy. It reuses the credentials already stored on the instance's `io.cozy.accounts` document, so the caller never has to hand them back.

The product flow this enables: once the user has finished migrating their Nextcloud account into Cozy Drive, the Settings UI offers a button to wipe their Nextcloud. This endpoint is what that button calls.

## API

`POST /remote/nextcloud/migration/:id/delete-source` (no request body)

| Status | Meaning |
|---|---|
| 204 No Content | Source deleted, trash emptied, `source_deleted_at` stamped on the tracking doc. |
| 401 Unauthorized | Stored Nextcloud credentials were rejected. |
| 404 Not Found | Migration id does not exist, or the Nextcloud account was removed out of band. |
| 409 Conflict | Migration is not in the `completed` status, or the source has already been deleted. |
| 502 Bad Gateway | Nextcloud was reached but returned an unexpected error. The tracking doc is left untouched so the user can retry. |

## Behavior

The endpoint runs three steps end to end before stamping `source_deleted_at`:

1. **Remove the migrated content.** If the migration imported a sub-folder, one DELETE handles it. If the user migrated their whole Nextcloud (`source_path: "/"`, the dominant case), the endpoint lists the WebDAV home with PROPFIND and DELETEs each top-level child individually. See the limitation below for why.
2. **Empty the trash.** Nextcloud moves deleted files to a per-user trashbin where they keep counting against the user's quota until purged. The endpoint empties it so the migrated bytes are actually freed.
3. **Stamp `source_deleted_at`** on the tracking doc so the UI can hide the button and the endpoint refuses repeats.

A Nextcloud 404 at any step is treated as success: the goal is "the content is gone", which it is. The first hard failure aborts before stamping, so a partial cleanup leaves the doc in a state the user can retry from.

Only migrations in the `completed` status are eligible. Failed or canceled migrations may still hold files on Nextcloud that never reached Cozy, and removing them would lose data.

## Why we recurse on `source_path = "/"`

A direct `DELETE` on `/remote.php/dav/files/<user>/` returns 403 from Nextcloud: WebDAV does not let a regular user delete their own home folder. We could either reject `/` and tell the user "we cannot do this", or wipe the home in the way Nextcloud does support, by emptying its contents. We chose the latter because it matches the user's literal intent.

## Limitations

- **Not a full account deletion.** This wipes the user's *files* on Nextcloud, not the Nextcloud *account itself*. Removing the account would need admin OCS Provisioning credentials, which the Stack does not have. If the product later needs that, it is a separate flow.
- **Trash empty is total.** The endpoint clears the entire trashbin, not just items it created. If the user had unrelated items already in their trash, those are wiped too. This matches the "I'm done with Nextcloud" intent of the button but is worth flagging.
- **No parallel deletes.** Top-level children are deleted sequentially. A user with hundreds of folders would feel this; the typical home has well under 20.

## Tests performed

- [x] Unit tests cover the status gate, single-path delete, root recursion, trash empty, idempotent 404, 401 passthrough, and 409-on-repeat paths.
- [x] End-to-end against a real Nextcloud with `source_path: "/"` (account with 11 top-level entries plus one trash item): all entries gone, trash empty, `source_deleted_at` stamped, second call returns 409.