### PR TITLE
fix: 409 conflict after auto accept of a shared drive

### DIFF
--- a/model/sharing/invitation.go
+++ b/model/sharing/invitation.go
@@ -72,10 +72,45 @@ func (s *Sharing) SendInvitations(inst *instance.Instance, perms *permission.Per
 		})
 	}
 	errg := g.Wait()
-	if err := couchdb.UpdateDoc(inst, s); err != nil {
+	if err := s.updateMemberStatusesWithRetry(inst); err != nil {
 		return err
 	}
 	return errg
+}
+
+// updateMemberStatusesWithRetry persists the current member statuses to
+// CouchDB, retrying on conflict. A conflict can happen when ProcessAnswer
+// updates the sharing concurrently (e.g. during auto-accept).
+// On retry, the document is reloaded and statuses are re-applied, but
+// members already in Ready state are never downgraded.
+func (s *Sharing) updateMemberStatusesWithRetry(inst *instance.Instance) error {
+	desiredStatuses := make(map[int]string, len(s.Members))
+	for i, m := range s.Members {
+		if i > 0 {
+			desiredStatuses[i] = m.Status
+		}
+	}
+
+	maxRetries := 3
+	for attempt := 0; ; attempt++ {
+		err := couchdb.UpdateDoc(inst, s)
+		if err == nil || !couchdb.IsConflictError(err) || attempt >= maxRetries {
+			return err
+		}
+		s, err = FindSharing(inst, s.SID)
+		if err != nil {
+			return err
+		}
+		for i, status := range desiredStatuses {
+			if i >= len(s.Members) {
+				continue
+			}
+			if s.Members[i].Status == MemberStatusReady {
+				continue
+			}
+			s.Members[i].Status = status
+		}
+	}
 }
 
 // SendInvitationsToMembers sends mails from a recipient (open_sharing) to


### PR DESCRIPTION
## Summary
 - AddGroupsAndContacts adds Bob, saves doc (rev 1)
 - SendInvitations starts → SendShortcut → sends sharing request to Bob's cozy
 - Bob's cozy auto-accepts (trusted sender) → calls back POST /sharings/:id/answer on your cozy
 - ProcessAnswer on your cozy updates the sharing doc (rev 1 → 2) — member status becomes Ready
 - Meanwhile, SendInvitations finishes the goroutine and calls couchdb.UpdateDoc(inst, s) with stale rev 1 → CouchDB 409  

The sharing actually worked, the member was added and accepted, but the response to the client is 409 because of the stale revision.