### PR TITLE
feat: allow user.created without hash with external OIDC

### DIFF
--- a/pkg/rabbitmq/handlers.go
+++ b/pkg/rabbitmq/handlers.go
@@ -173,39 +173,8 @@ func (h *UserCreatedHandler) Handle(ctx context.Context, d amqp.Delivery) error 
 		log.Debugf("user.created: no domain provided, using default: %s", DefaultDomain)
 		msg.Domain = DefaultDomain
 	}
-	if msg.Hash == "" {
-		return fmt.Errorf("user.created: missing passphrase hash")
-	}
 	if msg.WorkplaceFqdn == "" {
 		return fmt.Errorf("user.created: missing workplaceFqdn")
-	}
-	if msg.Iterations <= 0 {
-		return fmt.Errorf("user.created: missing iterations")
-	}
-	log.Debugf("user.created: message validation passed for TwakeID: %s", msg.TwakeID)
-
-	decoded, err := decodePassword(msg.Hash)
-	if err != nil {
-		return err
-	}
-
-	params := lifecycle.PassParameters{
-		Pass:       decoded,
-		Iterations: msg.Iterations,
-	}
-
-	if msg.Key != "" {
-		log.Debugf("user.created: setting key parameter for TwakeID: %s", msg.TwakeID)
-		params.Key = msg.Key
-	}
-
-	// if one of the keys is missing, do not update any of the keys
-	if msg.PublicKey != "" && msg.PrivateKey != "" {
-		log.Debugf("user.created: setting public/private key parameters for TwakeID: %s", msg.TwakeID)
-		params.PublicKey = msg.PublicKey
-		params.PrivateKey = msg.PrivateKey
-	} else {
-		log.Debugf("user.created: skipping key parameters (incomplete pair) for TwakeID: %s", msg.TwakeID)
 	}
 
 	log.Debugf("user.created: looking for instance for domain: %s", msg.WorkplaceFqdn)
@@ -213,11 +182,46 @@ func (h *UserCreatedHandler) Handle(ctx context.Context, d amqp.Delivery) error 
 	if err != nil {
 		return fmt.Errorf("user.created: get instance: %w", err)
 	}
+	log.Debugf("user.created: message validation passed for TwakeID: %s", msg.TwakeID)
 
-	if err := lifecycle.ForceUpdatePassphraseWithSHash(inst, params.Pass, params); err != nil {
-		return fmt.Errorf("user.created: update passphrase: %w", err)
+	if msg.Hash == "" {
+		if !inst.HasForcedOIDC() {
+			return fmt.Errorf("user.created: missing passphrase hash")
+		}
+		log.Infof("user.created: skipping passphrase update for instance %s (forced OIDC context: %s)", inst.Domain, inst.ContextName)
+	} else {
+		if msg.Iterations <= 0 {
+			return fmt.Errorf("user.created: missing iterations")
+		}
+		decoded, err := decodePassword(msg.Hash)
+		if err != nil {
+			return err
+		}
+
+		params := lifecycle.PassParameters{
+			Pass:       decoded,
+			Iterations: msg.Iterations,
+		}
+
+		if msg.Key != "" {
+			log.Debugf("user.created: setting key parameter for TwakeID: %s", msg.TwakeID)
+			params.Key = msg.Key
+		}
+
+		// if one of the keys is missing, do not update any of the keys
+		if msg.PublicKey != "" && msg.PrivateKey != "" {
+			log.Debugf("user.created: setting public/private key parameters for TwakeID: %s", msg.TwakeID)
+			params.PublicKey = msg.PublicKey
+			params.PrivateKey = msg.PrivateKey
+		} else {
+			log.Debugf("user.created: skipping key parameters (incomplete pair) for TwakeID: %s", msg.TwakeID)
+		}
+
+		if err := lifecycle.ForceUpdatePassphraseWithSHash(inst, params.Pass, params); err != nil {
+			return fmt.Errorf("user.created: update passphrase: %w", err)
+		}
+		log.Infof("user.created: successfully updated passphrase for instance: %s (PasswordDefined: %v)", inst.Domain, inst.PasswordDefined)
 	}
-	log.Infof("user.created: successfully updated passphrase for instance: %s (PasswordDefined: %v)", inst.Domain, inst.PasswordDefined)
 
 	if msg.OrganizationDomain != "" {
 		if err := SyncCreatedOrgContact(ctx, inst, msg); err != nil {

--- a/pkg/rabbitmq/rabbitmq_test.go
+++ b/pkg/rabbitmq/rabbitmq_test.go
@@ -337,6 +337,97 @@ func TestHandlers(t *testing.T) {
 		require.Equal(t, prevPriv, bw.PrivateKey)
 	})
 
+	t.Run("CreateUserWithoutHashInForcedOIDCContext", func(t *testing.T) {
+		setup := setUpRabbitMQConfig(t, MQ, "CreateUserWithoutHashInForcedOIDCContext")
+		cfg := config.GetConfig()
+		prevAuthentication := cfg.Authentication
+		const oidcContext = "oidc-no-password-context"
+		cfg.Authentication = map[string]interface{}{
+			oidcContext: map[string]interface{}{
+				"disable_password_authentication": true,
+			},
+		}
+		t.Cleanup(func() {
+			cfg.Authentication = prevAuthentication
+		})
+
+		suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+		orgDomain := "no-hash-org-" + suffix + ".example"
+		orgID := "org-no-hash-" + suffix
+		targetEmail := "target-" + suffix + "@example.com"
+		target := setup.GetTestInstance(&lifecycle.Options{
+			Domain:      "no-hash-target-" + suffix + ".local",
+			ContextName: oidcContext,
+			OrgDomain:   orgDomain,
+			OrgID:       orgID,
+			Email:       targetEmail,
+			PublicName:  "Target User",
+		})
+		other := createInstanceInOrg(
+			t,
+			"no-hash-other-"+suffix+".local",
+			orgDomain,
+			orgID,
+			"other-"+suffix+"@example.com",
+			"Other User",
+		)
+
+		initialHash := string(target.PassphraseHash)
+		require.NotEmpty(t, initialHash)
+		require.NotNil(t, target.PasswordDefined)
+		require.False(t, *target.PasswordDefined)
+
+		ch, err := getChannel(t, MQ)
+		require.NoError(t, err)
+
+		slug, _ := SplitDomain(t, target.Domain)
+		msg := rabbitmq.UserCreatedMessage{
+			TwakeID:            slug,
+			Mobile:             "+33700000000",
+			InternalEmail:      targetEmail,
+			Timestamp:          time.Now().Unix(),
+			WorkplaceFqdn:      target.Domain,
+			OrganizationID:     orgID,
+			OrganizationDomain: orgDomain,
+		}
+		body, err := json.Marshal(msg)
+		require.NoError(t, err)
+
+		err = ch.PublishWithContext(
+			testCtx(t),
+			"auth",
+			"user.created",
+			false,
+			false,
+			amqp.Publishing{
+				DeliveryMode: amqp.Persistent,
+				ContentType:  "application/json",
+				Body:         body,
+				MessageId:    fmt.Sprintf("%d", time.Now().UnixNano()),
+			},
+		)
+		require.NoError(t, err)
+
+		testutils.WaitForOrFail(t, 10*time.Second, func() bool {
+			matches, err := contact.FindAllByEmail(other, targetEmail)
+			if err != nil {
+				return false
+			}
+			for _, doc := range matches {
+				if doc.IsExternal() {
+					return true
+				}
+			}
+			return false
+		})
+
+		updated, err := lifecycle.GetInstance(target.Domain)
+		require.NoError(t, err)
+		require.Equal(t, initialHash, string(updated.PassphraseHash))
+		require.NotNil(t, updated.PasswordDefined)
+		require.False(t, *updated.PasswordDefined)
+	})
+
 	t.Run("DeleteUserHandler", func(t *testing.T) {
 		setup := setUpRabbitMQConfig(t, MQ, "DeleteUserHandler")
 		_ = setup.GetTestInstance()


### PR DESCRIPTION
 Make `hash` optional in the `user.created` RabbitMQ handler when the target
  instance context has `disable_password_authentication=true` (forced OIDC)