### PR TITLE
feat: Allow io.cozy.contacts and io.cozy.contacts.groups in token exc…

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1068,7 +1068,7 @@ The target Cozy instance is the request host. The exchanged `id_token` must:
 The request body is JSON:
 
 - `id_token`, the external OIDC token
-- `scope`, currently limited to `io.cozy.files`
+- `scope`, a space-separated list of allowed doctypes: `io.cozy.files`, `io.cozy.contacts`, `io.cozy.contacts.groups`
 
 Example:
 

--- a/web/auth/auth_test.go
+++ b/web/auth/auth_test.go
@@ -2503,12 +2503,12 @@ func TestTokenExchange(t *testing.T) {
 			WithHeader("Origin", "https://admin.example.com").
 			WithJSON(map[string]string{
 				"id_token": idToken,
-				"scope":    "io.cozy.contacts",
+				"scope":    "io.cozy.unknown",
 			}).
 			Expect().
 			Status(http.StatusBadRequest).
 			JSON().Object().
-			ValueEqual("error", "invalid scope")
+			ValueEqual("error", `scope "io.cozy.unknown" is not allowed`)
 	})
 }
 

--- a/web/auth/token_exchange.go
+++ b/web/auth/token_exchange.go
@@ -25,10 +25,15 @@ import (
 const (
 	tokenExchangeAdminRole             = "admin"
 	tokenExchangeOwnerRole             = "owner"
-	tokenExchangeAllowedScope          = "io.cozy.files"
 	tokenExchangeOAuthClientName       = "Twake Admin Panel"
 	tokenExchangeOAuthClientSoftwareID = "twake-admin-panel"
 )
+
+var tokenExchangeAllowedScopes = map[string]struct{}{
+	"io.cozy.files":           {},
+	"io.cozy.contacts":        {},
+	"io.cozy.contacts.groups": {},
+}
 
 type tokenExchangeRequest struct {
 	IDToken string `json:"id_token"`
@@ -47,8 +52,8 @@ func executeTokenExchange(c echo.Context, inst *instance.Instance, req tokenExch
 	if err != nil {
 		return nil, echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
-	if req.Scope != tokenExchangeAllowedScope {
-		return nil, echo.NewHTTPError(http.StatusBadRequest, "invalid scope")
+	if err := validateTokenExchangeScope(req.Scope); err != nil {
+		return nil, echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
 	client, err := createTokenExchangeOAuthClient(c, inst)
@@ -65,6 +70,18 @@ func executeTokenExchange(c echo.Context, inst *instance.Instance, req tokenExch
 	}
 
 	return buildTokenExchangeResponse(inst, client, req.Scope)
+}
+
+func validateTokenExchangeScope(scope string) error {
+	if scope == "" {
+		return errors.New("scope is required")
+	}
+	for _, s := range strings.Split(scope, " ") {
+		if _, ok := tokenExchangeAllowedScopes[s]; !ok {
+			return fmt.Errorf("scope %q is not allowed", s)
+		}
+	}
+	return nil
 }
 
 func validateTokenExchangeIDToken(inst *instance.Instance, raw string) (jwt.MapClaims, error) {

--- a/web/auth/token_exchange_test.go
+++ b/web/auth/token_exchange_test.go
@@ -1,0 +1,15 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateTokenExchangeScope(t *testing.T) {
+	assert.Error(t, validateTokenExchangeScope(""))
+	assert.Error(t, validateTokenExchangeScope("io.cozy.unknown"))
+	assert.Error(t, validateTokenExchangeScope("io.cozy.files\tio.cozy.contacts\tio.cozy.contacts.groups"))
+	assert.NoError(t, validateTokenExchangeScope("io.cozy.files"))
+	assert.NoError(t, validateTokenExchangeScope("io.cozy.files io.cozy.contacts io.cozy.contacts.groups"))
+}


### PR DESCRIPTION
…hange

Replace the single allowed scope constant with an allowlist and a validateTokenExchangeScope function that accepts any space-separated combination of io.cozy.files, io.cozy.contacts, and io.cozy.contacts.groups.