### PR TITLE
fix: cozy-app-dev image build and drop debian:10 packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,6 @@ jobs:
       matrix:
         os:
           [
-            "debian:10",
             "debian:11",
             "debian:12",
             "ubuntu:22.04",

--- a/scripts/docker/cozy-app-dev/Dockerfile
+++ b/scripts/docker/cozy-app-dev/Dockerfile
@@ -4,7 +4,7 @@
 
 
 # Multi-stage image: this step builds cozy-stack (and mailhog)
-FROM golang:1.25-bullseye as build
+FROM golang:1.25-bookworm AS build
 WORKDIR /app
 
 # MailHog


### PR DESCRIPTION
## Summary
  - `publish_cozy-app-dev_image` failed because `golang:1.25-bullseye` is not available on Docker Hub.
  - `publish_deb_packages (debian:10)` failed because Debian 10 (buster) repositories are EOL and no longer provide Release metadata.