### PR TITLE
feat: mark org contacts created on user.created as trusted

### DIFF
--- a/model/contact/contacts.go
+++ b/model/contact/contacts.go
@@ -326,11 +326,12 @@ func CreateMyself(inst *instance.Instance, settings *couchdb.JSONDoc) (*Contact,
 
 // CreateOptions describes the input used to create a contact.
 type CreateOptions struct {
-	Email    string
-	Name     string
-	CozyURL  string
-	Phone    string
-	External bool
+	Email             string
+	Name              string
+	CozyURL           string
+	Phone             string
+	External          bool
+	TrustedForSharing bool
 }
 
 // Create creates a contact from the provided options.
@@ -372,6 +373,9 @@ func Create(db prefixer.Prefixer, opts CreateOptions) (*Contact, error) {
 		doc.JSONDoc.M["metadata"] = map[string]interface{}{
 			"external": true,
 		}
+	}
+	if opts.TrustedForSharing {
+		doc.JSONDoc.M[TrustedForSharingKey] = true
 	}
 
 	index := email

--- a/pkg/rabbitmq/org_contacts.go
+++ b/pkg/rabbitmq/org_contacts.go
@@ -62,11 +62,12 @@ func SyncCreatedOrgContact(ctx context.Context, target *instance.Instance, msg U
 		}
 
 		if _, err := contact.Create(inst, contact.CreateOptions{
-			Email:    email,
-			Name:     name,
-			CozyURL:  targetURL,
-			Phone:    msg.Mobile,
-			External: true,
+			Email:             email,
+			Name:              name,
+			CozyURL:           targetURL,
+			Phone:             msg.Mobile,
+			External:          true,
+			TrustedForSharing: true,
 		}); err != nil {
 			wrappedErr := fmt.Errorf("user.created: create contact for %s in %s: %w", email, inst.Domain, err)
 			log.Errorf("%v", wrappedErr)
@@ -207,11 +208,12 @@ func externalOrgContactFromInstance(inst *instance.Instance) (contact.CreateOpti
 	phone, _ := settings.M["phone"].(string)
 
 	return contact.CreateOptions{
-		Email:    email,
-		Name:     name,
-		CozyURL:  inst.PageURL("", nil),
-		Phone:    phone,
-		External: true,
+		Email:             email,
+		Name:              name,
+		CozyURL:           inst.PageURL("", nil),
+		Phone:             phone,
+		External:          true,
+		TrustedForSharing: true,
 	}, nil
 }
 

--- a/pkg/rabbitmq/org_contacts_test.go
+++ b/pkg/rabbitmq/org_contacts_test.go
@@ -51,6 +51,7 @@ func TestSyncCreatedOrgContact(t *testing.T) {
 				bobFoundManual = true
 				require.Equal(t, "Existing Alice", doc.PrimaryName())
 				require.False(t, doc.IsExternal())
+				require.False(t, doc.IsTrusted())
 				continue
 			}
 			if doc.IsExternal() {
@@ -58,6 +59,7 @@ func TestSyncCreatedOrgContact(t *testing.T) {
 				require.Equal(t, "Alice", doc.PrimaryName())
 				require.Equal(t, "+33123456789", doc.PrimaryPhoneNumber())
 				require.Equal(t, targetURL, doc.PrimaryCozyURL())
+				require.True(t, doc.IsTrusted())
 			}
 		}
 		require.True(t, bobFoundManual)
@@ -70,6 +72,7 @@ func TestSyncCreatedOrgContact(t *testing.T) {
 		require.Equal(t, "Alice", carolContacts[0].PrimaryName())
 		require.Equal(t, "+33123456789", carolContacts[0].PrimaryPhoneNumber())
 		require.Equal(t, targetURL, carolContacts[0].PrimaryCozyURL())
+		require.True(t, carolContacts[0].IsTrusted())
 
 		targetContacts, err := contact.FindAllByEmail(target, "alice@example.com")
 		if err == nil {
@@ -87,6 +90,7 @@ func TestSyncCreatedOrgContact(t *testing.T) {
 		require.Equal(t, "Bob", targetBobContacts[0].PrimaryName())
 		require.Equal(t, "+33987654321", targetBobContacts[0].PrimaryPhoneNumber())
 		require.Equal(t, bobURL, targetBobContacts[0].PrimaryCozyURL())
+		require.True(t, targetBobContacts[0].IsTrusted())
 
 		targetCarolContacts, err := contact.FindAllByEmail(target, "carol@example.com")
 		require.NoError(t, err)
@@ -94,6 +98,7 @@ func TestSyncCreatedOrgContact(t *testing.T) {
 		require.True(t, targetCarolContacts[0].IsExternal())
 		require.Equal(t, "Carol", targetCarolContacts[0].PrimaryName())
 		require.Equal(t, carolURL, targetCarolContacts[0].PrimaryCozyURL())
+		require.True(t, targetCarolContacts[0].IsTrusted())
 	})
 
 	t.Run("SkipsExistingExternalContact", func(t *testing.T) {
@@ -125,12 +130,14 @@ func TestSyncCreatedOrgContact(t *testing.T) {
 		require.True(t, bobContacts[0].IsExternal())
 		require.Equal(t, "Old Alice", bobContacts[0].PrimaryName())
 		require.Equal(t, "https://old.example", bobContacts[0].PrimaryCozyURL())
+		require.False(t, bobContacts[0].IsTrusted())
 
 		carolContacts, err := contact.FindAllByEmail(carol, "alice@example.com")
 		require.NoError(t, err)
 		require.Len(t, carolContacts, 1)
 		require.True(t, carolContacts[0].IsExternal())
 		require.Equal(t, targetURL, carolContacts[0].PrimaryCozyURL())
+		require.True(t, carolContacts[0].IsTrusted())
 	})
 
 	t.Run("FailsOnMultipleExternalContactsForEmail", func(t *testing.T) {
@@ -182,6 +189,7 @@ func TestSyncCreatedOrgContact(t *testing.T) {
 		require.Len(t, carolContacts, 1)
 		require.True(t, carolContacts[0].IsExternal())
 		require.Equal(t, target.PageURL("", nil), carolContacts[0].PrimaryCozyURL())
+		require.True(t, carolContacts[0].IsTrusted())
 	})
 
 	t.Run("MissingInternalEmail", func(t *testing.T) {

--- a/pkg/rabbitmq/rabbitmq_test.go
+++ b/pkg/rabbitmq/rabbitmq_test.go
@@ -414,7 +414,7 @@ func TestHandlers(t *testing.T) {
 				return false
 			}
 			for _, doc := range matches {
-				if doc.IsExternal() {
+				if doc.IsExternal() && doc.IsTrusted() {
 					return true
 				}
 			}


### PR DESCRIPTION
## Summary
Make contacts created by the `user.created` organization sync trusted for sharing, so trusted-contact auto-accept works immediately.