### PR TITLE
feat: add shared-drive versions proxy endpoint

### DIFF
--- a/docs/shared-drives.md
+++ b/docs/shared-drives.md
@@ -1017,6 +1017,16 @@ another string called the `version-id`, separated by a `/`. So, when a route
 makes reference to `/something/:file-id/:version-id`, you can use the identifier
 of the version document (without having to prepend the file identifier).
 
+### POST /sharings/drives/:id/:file-id/versions
+
+Create a new version of a file, with the same content but new metadata.
+
+Identical call to [`POST /files/:file-id/versions`](files.md#post-filesfile-idversions)
+but over a shared drive. See there for request and response examples, the only
+difference is the URL.
+
+For file-root shared drives, this route is supported for the root file.
+
 ### GET /sharings/drives/:id/download/:file-id/:version-id
 
 Downloads an old version of the file content.

--- a/web/sharings/drives.go
+++ b/web/sharings/drives.go
@@ -287,6 +287,14 @@ func ReadFileContentFromVersion(c echo.Context, inst *instance.Instance, s *shar
 	return files.ReadFileContentFromVersion(c)
 }
 
+// CopyVersionHandler handles POST requests on /sharings/drives/:id/:file-id/versions.
+//
+// It can be used to create a new version of a file, with the same content but
+// new metadata.
+func CopyVersionHandler(c echo.Context, inst *instance.Instance, s *sharing.Sharing) error {
+	return files.CopyVersionHandler(c)
+}
+
 // GetDirSize returns the size of a directory (the sum of the size of the files
 // in this directory, including those in subdirectories).
 func GetDirSize(c echo.Context, inst *instance.Instance, s *sharing.Sharing) error {
@@ -1263,6 +1271,7 @@ func drivesRoutes(router *echo.Group) {
 
 	drive.HEAD("/download/:file-id/:version-id", proxy(ReadFileContentFromVersion, true))
 	drive.GET("/download/:file-id/:version-id", proxy(ReadFileContentFromVersion, true))
+	drive.POST("/:file-id/versions", proxy(CopyVersionHandler, true))
 
 	drive.GET("/_changes", proxy(ChangesFeed, true))
 

--- a/web/sharings/drives_test.go
+++ b/web/sharings/drives_test.go
@@ -2853,6 +2853,33 @@ func TestFileRootSharedDriveMutationRoutes(t *testing.T) {
 			Expect().Status(200).
 			Body().IsEqual("bar")
 
+		versioned := eB.POST("/sharings/drives/"+sharingID+"/"+rootFileID+"/versions").
+			WithQuery("Tags", "checkpoint").
+			WithHeader("Authorization", "Bearer "+env.bettyToken).
+			WithHeader("Content-Type", "application/json").
+			WithBytes([]byte(`{
+					"data": {
+						"type": "io.cozy.files.metadata",
+						"attributes": {
+							"label": "root-version"
+						}
+					}
+				}`)).
+			Expect().Status(200).
+			JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+			Object()
+
+		versionedAttrs := versioned.Path("$.data.attributes").Object()
+		versionedTags := versionedAttrs.Value("tags").Array()
+		versionedTags.Length().Equal(1)
+		versionedTags.First().String().IsEqual("checkpoint")
+		versionedAttrs.Value("metadata").Object().ValueEqual("label", "root-version")
+
+		eB.GET("/sharings/drives/"+sharingID+"/download/"+rootFileID).
+			WithHeader("Authorization", "Bearer "+env.bettyToken).
+			Expect().Status(200).
+			Body().IsEqual("bar")
+
 		patched := eB.PATCH("/sharings/drives/"+sharingID+"/"+rootFileID).
 			WithHeader("Authorization", "Bearer "+env.bettyToken).
 			WithHeader("Content-Type", "application/json").


### PR DESCRIPTION
## Summary
`POST /sharings/drives/:id/:file-id/versions` with the same proxy pattern/signature as other shared-drive handlers, delegating to files.CopyVersionHandler