### PR TITLE
test(rabbitmq): bootstrap global CouchDB views in TestMain

### DIFF
--- a/pkg/config/config/config.go
+++ b/pkg/config/config/config.go
@@ -1373,6 +1373,14 @@ func createTestViper() *viper.Viper {
 func UseTestFile(t *testing.T) {
 	t.Helper()
 
+	if err := LoadTestFile(); err != nil {
+		t.Fatalf("fatal error test config file: %s", err)
+	}
+}
+
+// LoadTestFile injects the standard test configuration without requiring
+// testing.T. It is useful from TestMain implementations.
+func LoadTestFile() error {
 	build.BuildMode = build.ModeProd
 	v := createTestViper()
 
@@ -1380,13 +1388,11 @@ func UseTestFile(t *testing.T) {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
 			v = createTestViper()
 		} else {
-			t.Fatalf("fatal error test config file: %s", err)
+			return err
 		}
 	}
 
-	if err := UseViper(v); err != nil {
-		t.Fatalf("fatal error test config file: %s", err)
-	}
+	return UseViper(v)
 }
 
 // FindConfigFile search in the Paths directories for the file with the given

--- a/pkg/rabbitmq/main_test.go
+++ b/pkg/rabbitmq/main_test.go
@@ -1,0 +1,74 @@
+package rabbitmq_test
+
+import (
+	"context"
+	"log"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/cozy/cozy-stack/pkg/config/config"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/spf13/viper"
+)
+
+// TestMain bootstraps the views and indexes that production stacks create
+// at startup via stack.Start → couchdb.InitGlobalDB. Tests in this package
+// call lifecycle.Create / instance.Get directly without going through
+// testutils.NewSetup → GetTestInstance → stack.Start, so they never trigger
+// that init themselves.
+//
+// They've historically relied on the side effect that earlier model/* test
+// packages bootstrap the global DB and that the design doc persists in the
+// shared CouchDB service across test binaries — but Go's test result cache
+// can let those packages be skipped (cached "ok"), and then this implicit
+// dependency breaks. See the CI flake debugged on PR #4716: the second
+// lifecycle.Create call inside TestSyncCreatedOrgContact failed with
+// "CouchDB(not_found): missing" because instance.Service.Get queried
+// _design/domain-and-aliases on the global instances DB and that design
+// doc had never been created.
+//
+// TODO: the more robust fix is to make instance.Service.Get treat any
+// CouchDB "not_found" as ErrNotFound (it currently only handles
+// no_db_file / "Database does not exist."). That would remove the implicit
+// dependency for every package, not just this one. The repercussions on
+// other Get callers haven't been fully audited though, so this localized
+// bootstrap stays in place until that broader change is vetted.
+func TestMain(m *testing.M) {
+	if err := loadTestConfigForMain(); err != nil {
+		log.Fatalf("rabbitmq tests: could not load test config: %s", err)
+	}
+	// Best-effort: if CouchDB is unreachable, individual tests that need it
+	// will fail via testutils.NeedCouchdb(t). We don't want TestMain itself
+	// to hard-fail in environments where CouchDB is intentionally absent.
+	if _, err := couchdb.CheckStatus(context.Background()); err == nil {
+		if err := couchdb.InitGlobalDB(context.Background()); err != nil {
+			log.Printf("rabbitmq tests: could not init global CouchDB: %s", err)
+		}
+	}
+	os.Exit(m.Run())
+}
+
+// loadTestConfigForMain mirrors config.UseTestFile but without the
+// *testing.T plumbing so it can be called from TestMain.
+func loadTestConfigForMain() error {
+	v := viper.New()
+	v.SetConfigName("cozy.test")
+	v.AddConfigPath("$HOME/.cozy")
+	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	v.SetEnvPrefix("cozy")
+	v.AutomaticEnv()
+	v.SetDefault("host", "localhost")
+	v.SetDefault("port", 8080)
+	v.SetDefault("assets", "./assets")
+	v.SetDefault("subdomains", "nested")
+	v.SetDefault("fs.url", "mem://test")
+	v.SetDefault("couchdb.url", "http://localhost:5984/")
+	v.SetDefault("log.level", "info")
+	if err := v.ReadInConfig(); err != nil {
+		if _, isMissing := err.(viper.ConfigFileNotFoundError); !isMissing {
+			return err
+		}
+	}
+	return config.UseViper(v)
+}

--- a/pkg/rabbitmq/main_test.go
+++ b/pkg/rabbitmq/main_test.go
@@ -1,74 +1,12 @@
 package rabbitmq_test
 
 import (
-	"context"
-	"log"
 	"os"
-	"strings"
 	"testing"
 
-	"github.com/cozy/cozy-stack/pkg/config/config"
-	"github.com/cozy/cozy-stack/pkg/couchdb"
-	"github.com/spf13/viper"
+	"github.com/cozy/cozy-stack/tests/testutils"
 )
 
-// TestMain bootstraps the views and indexes that production stacks create
-// at startup via stack.Start → couchdb.InitGlobalDB. Tests in this package
-// call lifecycle.Create / instance.Get directly without going through
-// testutils.NewSetup → GetTestInstance → stack.Start, so they never trigger
-// that init themselves.
-//
-// They've historically relied on the side effect that earlier model/* test
-// packages bootstrap the global DB and that the design doc persists in the
-// shared CouchDB service across test binaries — but Go's test result cache
-// can let those packages be skipped (cached "ok"), and then this implicit
-// dependency breaks. See the CI flake debugged on PR #4716: the second
-// lifecycle.Create call inside TestSyncCreatedOrgContact failed with
-// "CouchDB(not_found): missing" because instance.Service.Get queried
-// _design/domain-and-aliases on the global instances DB and that design
-// doc had never been created.
-//
-// TODO: the more robust fix is to make instance.Service.Get treat any
-// CouchDB "not_found" as ErrNotFound (it currently only handles
-// no_db_file / "Database does not exist."). That would remove the implicit
-// dependency for every package, not just this one. The repercussions on
-// other Get callers haven't been fully audited though, so this localized
-// bootstrap stays in place until that broader change is vetted.
 func TestMain(m *testing.M) {
-	if err := loadTestConfigForMain(); err != nil {
-		log.Fatalf("rabbitmq tests: could not load test config: %s", err)
-	}
-	// Best-effort: if CouchDB is unreachable, individual tests that need it
-	// will fail via testutils.NeedCouchdb(t). We don't want TestMain itself
-	// to hard-fail in environments where CouchDB is intentionally absent.
-	if _, err := couchdb.CheckStatus(context.Background()); err == nil {
-		if err := couchdb.InitGlobalDB(context.Background()); err != nil {
-			log.Printf("rabbitmq tests: could not init global CouchDB: %s", err)
-		}
-	}
-	os.Exit(m.Run())
-}
-
-// loadTestConfigForMain mirrors config.UseTestFile but without the
-// *testing.T plumbing so it can be called from TestMain.
-func loadTestConfigForMain() error {
-	v := viper.New()
-	v.SetConfigName("cozy.test")
-	v.AddConfigPath("$HOME/.cozy")
-	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
-	v.SetEnvPrefix("cozy")
-	v.AutomaticEnv()
-	v.SetDefault("host", "localhost")
-	v.SetDefault("port", 8080)
-	v.SetDefault("assets", "./assets")
-	v.SetDefault("subdomains", "nested")
-	v.SetDefault("fs.url", "mem://test")
-	v.SetDefault("couchdb.url", "http://localhost:5984/")
-	v.SetDefault("log.level", "info")
-	if err := v.ReadInConfig(); err != nil {
-		if _, isMissing := err.(viper.ConfigFileNotFoundError); !isMissing {
-			return err
-		}
-	}
-	return config.UseViper(v)
+	os.Exit(testutils.RunTestMainWithCouchDB(m))
 }

--- a/tests/testutils/test_utils.go
+++ b/tests/testutils/test_utils.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"log"
 	"net/http/httptest"
 	"net/url"
 	"path"
@@ -85,6 +86,24 @@ func NeedCouchdb(t *testing.T) {
 	if _, err := couchdb.CheckStatus(context.Background()); err != nil {
 		t.Fatal("This test need couchdb to run.")
 	}
+}
+
+// RunTestMainWithCouchDB loads the standard test configuration and initializes
+// global CouchDB views when CouchDB is available.
+func RunTestMainWithCouchDB(m *testing.M) int {
+	if err := config.LoadTestFile(); err != nil {
+		log.Printf("test setup: could not load test config: %s", err)
+		return 1
+	}
+
+	ctx := context.Background()
+	if _, err := couchdb.CheckStatus(ctx); err == nil {
+		if err := couchdb.InitGlobalDB(ctx); err != nil {
+			log.Printf("test setup: could not initialize global CouchDB: %s", err)
+		}
+	}
+
+	return m.Run()
 }
 
 // TODO can be used as a reminder to do something in the future. The test that


### PR DESCRIPTION
## Background — how we ran into this

While debugging CI failures on #4716 (S3 VFS backend), the `test (1.25.x, 3.2.3)` job kept failing with this signature, deterministically across reruns:

```
--- FAIL: TestSyncCreatedOrgContact/CreatesExternalContactsForOtherMembers
    org_contacts_test.go:28:
        Error Trace:    pkg/rabbitmq/rabbitmq_test.go:1070
                        pkg/rabbitmq/org_contacts_test.go:28
        Received unexpected error:
            CouchDB(not_found): missing
--- FAIL: TestSyncCreatedOrgContact/SkipsExistingExternalContact
    ...
--- FAIL: TestSyncDeletedOrgContact/...
```

The same source built **green on `test (1.26.x, 3.3.3)`** in the same workflow run, and crucially had been **green on `test (1.25.x, 3.2.3)` on the immediately preceding commit** (only diff: a single trailing newline removal in an unrelated file). Reruns on fresh GitHub-hosted runners reproduced the failure identically. After purging the PR's `actions/setup-go` caches and re-running, both jobs went green.

That ruled out a normal flake and pointed at cache-shaped state.

## Root cause

`pkg/rabbitmq` tests call `lifecycle.Create` / `instance.Get` directly. They never go through `testutils.NewSetup` → `GetTestInstance` → `stack.Start`, so they never trigger `couchdb.InitGlobalDB`, which is the only function in the codebase that creates the design doc backing the `domain-and-aliases` view on the global `instances` DB.

```
$ grep -rn "InitGlobalDB" pkg/ model/
pkg/couchdb/index.go      (definition)
model/stack/main.go       (only caller)
```

So the implicit assumption these tests have been making is:

1. `go test ./...` runs packages in lexicographic order, so `model/move`, `model/sharing`, etc. run before `pkg/rabbitmq`.
2. Those earlier packages do go through `NewSetup`/`GetTestInstance`, which calls `stack.Start` and therefore `InitGlobalDB`.
3. The design doc lives in the **shared** CouchDB service for the run, so it survives across test binaries and is there when `pkg/rabbitmq` queries it.

`actions/setup-go@v5 cache: true` caches `~/.cache/go-build`, which contains `go test`'s **result cache**. When the cache is warm and a package's inputs haven't changed, Go reports `(cached) ok` for it without re-running the test binary — so the side effect of creating the design doc never happens. The CouchDB service in the new run is fresh (its container is per-job), so the design doc is genuinely absent.

Then in `instance.Service.Get`:

```go
err := couchdb.ExecView(prefixer.GlobalPrefixer, couchdb.DomainAndAliasesView, ...)
if couchdb.IsNoDatabaseError(err) {
    return nil, ErrNotFound
}
if err != nil {
    return nil, err   // <-- propagates "not_found: missing" from the missing design doc
}
```

`IsNoDatabaseError` only matches `Reason == "no_db_file"` or `"Database does not exist."`. A missing **design doc** comes back as `404 not_found "missing"`, which falls through to the raw-error branch. `lifecycle.Create` does not unwrap that as `ErrNotFound`, propagates it, and the second `lifecycle.Create` call in the test (the first `bob := createInstanceInOrg(...)` after `target := ...`) fails.

This explains every detail of the observed symptom:

- Failure is on the **second** `createInstanceInOrg` call: the first creates the global DB lazily via `CreateDoc` (which `IsNoDatabaseError` does handle), the second hits the now-existing DB but missing-design-doc path.
- It's deterministic across reruns: same cache → same skipped packages → same missing side effect.
- 1.25 vs 1.26 split: each Go version has its own cache key (`setup-go-...-go-1.25.9-...` vs `...-go-1.26.3-...`), and the two caches were in different states.
- Cache purge fixes it: forces `model/*` to actually re-run, recreating the design doc.

## Fix in this PR

Add a `TestMain` in `pkg/rabbitmq` that bootstraps the global views the same way production does, removing the cross-package implicit dependency for this package:

```go
func TestMain(m *testing.M) {
    if err := loadTestConfigForMain(); err != nil { log.Fatalf(...) }
    if _, err := couchdb.CheckStatus(ctx); err == nil {
        if err := couchdb.InitGlobalDB(ctx); err != nil { log.Printf(...) }
    }
    os.Exit(m.Run())
}
```

`loadTestConfigForMain` is a small in-file replica of `config.UseTestFile`'s setup, since `UseTestFile` requires a `*testing.T` we don't have inside `TestMain`. CouchDB unreachability is tolerated (logged) so this `TestMain` doesn't hard-fail in environments where CouchDB is intentionally absent — individual tests that need it will still fail through `testutils.NeedCouchdb(t)` as before.

## Why not the broader fix

A more robust change would live in `model/instance/service.go`:

```diff
-   if couchdb.IsNoDatabaseError(err) {
+   if couchdb.IsNotFoundError(err) {
        return nil, ErrNotFound
    }
```

`IsNotFoundError` is a strict superset of `IsNoDatabaseError` and would treat a missing design doc as "no instance with that domain", which is what every caller of `instance.Get` already wants. That removes the implicit dependency for every test package, not just this one.

We deliberately don't ship that change here: the repercussions on other `Get` callers haven't been fully audited (e.g. it would silently hide a deployment-time view rename), and we wanted the immediate CI fix decoupled from a behavior-shift in core instance lookup. The `TestMain` carries a `TODO` pointing at this follow-up.

## Test plan

- [ ] CI on this branch: `pkg/rabbitmq` tests pass on both `test (1.25.x, 3.2.3)` and `test (1.26.x, 3.3.3)` from a clean runner.
- [ ] Re-run the same CI job to verify it stays green even when `model/*` is cache-skipped (which is what cached reruns simulate).
- [ ] Confirm `connection_test.go` / `publisher_test.go` (which don't need CouchDB) still run unaffected when CouchDB is absent locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)