### PR TITLE
fix: sync shared-drive description on file renames

### DIFF
--- a/model/sharing/update_description.go
+++ b/model/sharing/update_description.go
@@ -3,20 +3,20 @@ package sharing
 import (
 	"github.com/cozy/cozy-stack/model/instance"
 	"github.com/cozy/cozy-stack/model/job"
-	"github.com/cozy/cozy-stack/model/vfs"
 	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
 )
 
-// UpdateSharingDescriptionIfNeeded checks if the given directory is a sharing
-// root and triggers a job to update the sharing description if needed.
-func UpdateSharingDescriptionIfNeeded(inst *instance.Instance, dir *vfs.DirDoc) {
-	// Check if this directory is referenced by any sharings
-	for _, ref := range dir.ReferencedBy {
+// UpdateSharingDescriptionIfNeeded checks if the given references contain
+// sharing references and triggers a job to update the sharing description.
+func UpdateSharingDescriptionIfNeeded(inst *instance.Instance, referencedBy []couchdb.DocReference, newDescription string) {
+	// Check if this file/directory is referenced by any sharings
+	for _, ref := range referencedBy {
 		if ref.Type == consts.Sharings {
-			// This directory is a sharing root, trigger an update job
+			// This file/directory is a sharing root, trigger an update job
 			msg, err := job.NewMessage(&UpdateMsg{
 				SharingID:      ref.ID,
-				NewDescription: dir.DocName,
+				NewDescription: newDescription,
 			})
 			if err != nil {
 				inst.Logger().WithNamespace("sharing").

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -743,11 +743,15 @@ func applyPatch(c echo.Context, fs vfs.VFS, patch *docPatch) (err error) {
 			UpdateDirCozyMetadata(c, dir)
 			dir, err = vfs.ModifyDirMetadata(fs, dir, &patch.DocPatch)
 			if err == nil && patch.Name != nil && oldDirName != *patch.Name {
-				sharing.UpdateSharingDescriptionIfNeeded(middlewares.GetInstance(c), dir)
+				sharing.UpdateSharingDescriptionIfNeeded(middlewares.GetInstance(c), dir.ReferencedBy, dir.DocName)
 			}
 		} else {
+			oldFileName := file.DocName
 			UpdateFileCozyMetadata(c, file, false)
 			file, err = vfs.ModifyFileMetadata(fs, file, &patch.DocPatch)
+			if err == nil && patch.Name != nil && oldFileName != *patch.Name {
+				sharing.UpdateSharingDescriptionIfNeeded(middlewares.GetInstance(c), file.ReferencedBy, file.DocName)
+			}
 		}
 	}
 	if err != nil {
@@ -794,11 +798,15 @@ func applyPatches(c echo.Context, fs vfs.VFS, patches []*docPatch) (errors []*js
 			UpdateDirCozyMetadata(c, dir)
 			dir, errp = vfs.ModifyDirMetadata(fs, dir, &patch.DocPatch)
 			if errp == nil && patch.Name != nil && oldDirName != *patch.Name {
-				sharing.UpdateSharingDescriptionIfNeeded(middlewares.GetInstance(c), dir)
+				sharing.UpdateSharingDescriptionIfNeeded(middlewares.GetInstance(c), dir.ReferencedBy, dir.DocName)
 			}
 		} else if file != nil {
+			oldFileName := file.DocName
 			UpdateFileCozyMetadata(c, file, false)
-			_, errp = vfs.ModifyFileMetadata(fs, file, &patch.DocPatch)
+			file, errp = vfs.ModifyFileMetadata(fs, file, &patch.DocPatch)
+			if errp == nil && patch.Name != nil && oldFileName != *patch.Name {
+				sharing.UpdateSharingDescriptionIfNeeded(middlewares.GetInstance(c), file.ReferencedBy, file.DocName)
+			}
 		}
 		if errp != nil {
 			jsonapiError := wrapVfsErrorJSONAPI(errp)

--- a/web/sharings/drives.go
+++ b/web/sharings/drives.go
@@ -395,20 +395,26 @@ func applyPatch(c echo.Context, fs vfs.VFS, patch *docPatch) (err error) {
 	}
 
 	if dir != nil {
+		oldDirName := dir.DocName
 		files.UpdateDirCozyMetadata(c, dir)
 		dir, err = vfs.ModifyDirMetadata(fs, dir, &patch.DocPatch)
 		if err != nil {
 			return err
 		}
-		if patch.Name != nil {
+		if patch.Name != nil && oldDirName != *patch.Name {
 			// Update sharing description if this directory is a sharing root
-			sharing.UpdateSharingDescriptionIfNeeded(middlewares.GetInstance(c), dir)
+			sharing.UpdateSharingDescriptionIfNeeded(middlewares.GetInstance(c), dir.ReferencedBy, dir.DocName)
 		}
 	} else {
+		oldFileName := file.DocName
 		files.UpdateFileCozyMetadata(c, file, false)
 		file, err = vfs.ModifyFileMetadata(fs, file, &patch.DocPatch)
 		if err != nil {
 			return err
+		}
+		if patch.Name != nil && oldFileName != *patch.Name {
+			// Update sharing description if this file is a file-root sharing root
+			sharing.UpdateSharingDescriptionIfNeeded(middlewares.GetInstance(c), file.ReferencedBy, file.DocName)
 		}
 	}
 

--- a/web/sharings/drives_test.go
+++ b/web/sharings/drives_test.go
@@ -2901,6 +2901,17 @@ func TestFileRootSharedDriveMutationRoutes(t *testing.T) {
 
 		patched.Path("$.data.attributes.name").String().IsEqual("RenamedRoot.txt")
 		patched.Path("$.data.attributes.cozyMetadata.favorite").Boolean().True()
+		require.Eventually(t, func() bool {
+			ownerSharing, err := sharing.FindSharing(env.acme, sharingID)
+			if err != nil || ownerSharing.Description != "RenamedRoot.txt" {
+				return false
+			}
+			recipientSharing, err := sharing.FindSharing(env.betty, sharingID)
+			if err != nil {
+				return false
+			}
+			return recipientSharing.Description == "RenamedRoot.txt"
+		}, 5*time.Second, 50*time.Millisecond)
 
 		eB.PATCH("/sharings/drives/"+sharingID+"/"+rootFileID).
 			WithHeader("Authorization", "Bearer "+env.bettyToken).
@@ -2929,6 +2940,49 @@ func TestFileRootSharedDriveMutationRoutes(t *testing.T) {
 			JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
 			Object().
 			Path("$.data.attributes.trashed").Boolean().False()
+	})
+
+	t.Run("OwnerCanRenameFileRootViaFilesPatch", func(t *testing.T) {
+		eA, _, _ := env.createClients(t)
+
+		rootFileID := createFile(t, eA, "", "OwnerRenamedRoot.txt", env.acmeToken)
+		sharingID, _ := createFileRootSharedDrive(
+			t,
+			env.acme,
+			env.acmeToken,
+			env.tsA.URL,
+			rootFileID,
+			"Owner file-root shared drive",
+			[]RecipientInfo{{Name: "Betty", Email: "betty@example.net", ReadOnly: false}},
+		)
+		acceptSharedDriveForBetty(t, env.acme, env.betty, env.tsA.URL, env.tsB.URL, sharingID)
+
+		newDriveName := testify(t, "Owner renamed file-root via files patch")
+
+		renamed := eA.PATCH("/files/"+rootFileID).
+			WithHeader("Authorization", "Bearer "+env.acmeToken).
+			WithHeader("Content-Type", "application/json").
+			WithBytes([]byte(`{
+				"data": {
+					"type": "io.cozy.files",
+					"id": "` + rootFileID + `",
+					"attributes": {
+						"name": "` + newDriveName + `"
+					}
+				}
+			}`)).
+			Expect().Status(200).
+			JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+			Object()
+		renamed.Path("$.data.attributes.name").String().IsEqual(newDriveName)
+
+		require.Eventually(t, func() bool {
+			s, err := sharing.FindSharing(env.betty, sharingID)
+			if err != nil {
+				return false
+			}
+			return s.Description == newDriveName
+		}, 5*time.Second, 50*time.Millisecond)
 	})
 
 	t.Run("DestroyTrashedRootFile", func(t *testing.T) {


### PR DESCRIPTION
## Context

  Shared-drive names shown in the Sharing tab were not updated in some rename flows.

  Root cause: `share-update` (description sync) was only triggered for directory-root renames.
  For file-root shared drives, renaming via `PATCH /files/:id` or `PATCH /sharings/drives/:sharingID/:fileID` did not always refresh `sharing.description`.

  ## Changes

  - Refactored `UpdateSharingDescriptionIfNeeded` to accept:
    - `referencedBy []couchdb.DocReference`
    - `newDescription string`
  - Triggered description update on **actual rename only** (`oldName != newName`) for:
    - `/files` patch flow (single patch + bulk patch)
    - `/sharings/drives/:sharingID/:fileID` patch flow
  - Kept existing behavior for directory roots and extended it to file roots.
