### PR TITLE
fear: allow token exchange CORS from SaaS admin panels

### DIFF
--- a/pkg/config/config/config.go
+++ b/pkg/config/config/config.go
@@ -588,6 +588,31 @@ func GetPublicOIDCContext(contextName string) string {
 	return ""
 }
 
+// GetPublicDomainSuffix returns the public domain suffix from the specific context
+// or falls back to the default context if not set.
+func GetPublicDomainSuffix(contextName string) string {
+	if config == nil || config.Contexts == nil {
+		return ""
+	}
+
+	if contextName != "" {
+		if suffix := publicDomainSuffixFromContext(contextName); suffix != "" {
+			return suffix
+		}
+	}
+
+	return publicDomainSuffixFromContext(DefaultInstanceContext)
+}
+
+func publicDomainSuffixFromContext(contextName string) string {
+	if ctxData, ok := config.Contexts[contextName].(map[string]interface{}); ok {
+		if publicDomainSuffix, ok := ctxData["public_domain_suffix"].(string); ok {
+			return utils.NormalizeDomain(publicDomainSuffix)
+		}
+	}
+	return ""
+}
+
 // GetPublicOIDC returns the public Twake OIDC configuration from the configured context
 // If contextName is empty, it uses the default context
 func GetPublicOIDC(contextName string) (map[string]interface{}, bool) {

--- a/pkg/config/config/config_test.go
+++ b/pkg/config/config/config_test.go
@@ -392,6 +392,36 @@ func TestCommonSettingsHelpers(t *testing.T) {
 	assert.Len(t, commonSettings, 2)
 }
 
+func TestGetPublicDomainSuffix(t *testing.T) {
+	oldConfig := config
+	t.Cleanup(func() { config = oldConfig })
+
+	config = &Config{
+		Contexts: map[string]interface{}{
+			DefaultInstanceContext: map[string]interface{}{
+				"public_domain_suffix": " STG.LIN-SAAS.COM. ",
+			},
+			"custom": map[string]interface{}{
+				"public_domain_suffix": "Prod.Lin-Saas.COM.",
+			},
+			"blank": map[string]interface{}{
+				"public_domain_suffix": "   ",
+			},
+		},
+	}
+
+	assert.Equal(t, "prod.lin-saas.com", GetPublicDomainSuffix("custom"))
+	assert.Equal(t, "stg.lin-saas.com", GetPublicDomainSuffix("blank"))
+	assert.Equal(t, "stg.lin-saas.com", GetPublicDomainSuffix("missing"))
+	assert.Equal(t, "stg.lin-saas.com", GetPublicDomainSuffix(""))
+
+	config = &Config{}
+	assert.Empty(t, GetPublicDomainSuffix("custom"))
+
+	config = nil
+	assert.Empty(t, GetPublicDomainSuffix("custom"))
+}
+
 func TestRabbitMQConfig(t *testing.T) {
 	// Create a temporary YAML file with RabbitMQ configuration
 	yamlContent := `

--- a/web/auth/auth.go
+++ b/web/auth/auth.go
@@ -528,17 +528,76 @@ func tokenExchangeCORS(c echo.Context) bool {
 	return true
 }
 
-// Allow CORS from *.org_domain
+// Allow CORS from *.org_domain, and from the owner's SaaS admin panel.
 func tokenExchangeOriginAllowed(origin string, inst *instance.Instance) bool {
-	if inst == nil || inst.OrgDomain == "" {
+	if inst == nil {
 		return false
 	}
 	originHost := utils.ExtractInstanceHost(origin)
 	if originHost == "" {
 		return false
 	}
+
+	if tokenExchangeOrgDomainOriginAllowed(originHost, inst) {
+		return true
+	}
+
+	return tokenExchangeAdminPanelOriginAllowed(origin, originHost, inst)
+}
+
+func tokenExchangeOrgDomainOriginAllowed(originHost string, inst *instance.Instance) bool {
 	orgDomain := utils.NormalizeDomain(inst.OrgDomain)
+	if orgDomain == "" {
+		return false
+	}
 	return originHost == orgDomain || strings.HasSuffix(originHost, "."+orgDomain)
+}
+
+func tokenExchangeAdminPanelOriginAllowed(origin, originHost string, inst *instance.Instance) bool {
+	publicDomainSuffix := config.GetPublicDomainSuffix(inst.ContextName)
+	if publicDomainSuffix == "" {
+		return false
+	}
+
+	u, err := url.Parse(origin)
+	if err != nil || u.Scheme != "https" || u.Host == "" {
+		return false
+	}
+
+	suffix := "." + publicDomainSuffix
+	if !strings.HasSuffix(originHost, suffix) {
+		return false
+	}
+
+	adminLabel := strings.TrimSuffix(originHost, suffix)
+	if strings.Contains(adminLabel, ".") || !strings.HasSuffix(adminLabel, "-admin") {
+		return false
+	}
+
+	ownerLabel := strings.TrimSuffix(adminLabel, "-admin")
+	if ownerLabel == "" {
+		return false
+	}
+
+	ownerInst, err := instance.Get(ownerLabel + suffix)
+	if err != nil {
+		return false
+	}
+
+	return tokenExchangeSameOrganization(inst, ownerInst)
+}
+
+func tokenExchangeSameOrganization(targetInst, originInst *instance.Instance) bool {
+	if targetInst == nil || originInst == nil || targetInst.OrgID == "" || originInst.OrgID == "" {
+		return false
+	}
+	if targetInst.OrgID != originInst.OrgID {
+		return false
+	}
+
+	targetOrgDomain := utils.NormalizeDomain(targetInst.OrgDomain)
+	originOrgDomain := utils.NormalizeDomain(originInst.OrgDomain)
+	return targetOrgDomain == "" || originOrgDomain == "" || targetOrgDomain == originOrgDomain
 }
 
 func tokenExchangePreflight(c echo.Context) error {

--- a/web/auth/auth_test.go
+++ b/web/auth/auth_test.go
@@ -2142,6 +2142,12 @@ func TestTokenExchange(t *testing.T) {
 			"oidc": makeTokenExchangeOIDCConfig(issuer, clientID, jwksURL),
 		},
 	}
+	conf.Contexts = map[string]interface{}{
+		config.DefaultInstanceContext: map[string]interface{}{},
+		contextName: map[string]interface{}{
+			"public_domain_suffix": " STG.LIN-SAAS.COM. ",
+		},
+	}
 
 	setup := testutils.NewSetup(t, t.Name())
 
@@ -2151,6 +2157,22 @@ func TestTokenExchange(t *testing.T) {
 		OrgID:       "myorg123",
 		ContextName: contextName,
 		Email:       "token-exchange@example.com",
+	})
+	ownerSetup := testutils.NewSetup(t, t.Name()+"Owner")
+	ownerSetup.GetTestInstance(&lifecycle.Options{
+		Domain:      "theopoizatzatteocorpcc2acd.stg.lin-saas.com",
+		OrgDomain:   testInstance.OrgDomain,
+		OrgID:       testInstance.OrgID,
+		ContextName: contextName,
+		Email:       "owner@example.com",
+	})
+	otherOrgSetup := testutils.NewSetup(t, t.Name()+"OtherOrg")
+	otherOrgSetup.GetTestInstance(&lifecycle.Options{
+		Domain:      "otherowner.stg.lin-saas.com",
+		OrgDomain:   "other.example.com",
+		OrgID:       "otherorg123",
+		ContextName: contextName,
+		Email:       "other-owner@example.com",
 	})
 
 	ts := setup.GetTestServer("/test", fakeAPI, func(r *echo.Echo) *echo.Echo {
@@ -2191,6 +2213,73 @@ func TestTokenExchange(t *testing.T) {
 			resp.Header("Access-Control-Allow-Methods").Equal(http.MethodPost)
 			resp.Header("Access-Control-Allow-Headers").Equal("content-type")
 		}
+	})
+
+	t.Run("AllowsAdminPanelPublicDomainSuffixOrigin", func(t *testing.T) {
+		origin := "https://theopoizatzatteocorpcc2acd-admin.stg.lin-saas.com"
+		resp := e.OPTIONS("/auth/token_exchange").
+			WithHost(testInstance.Domain).
+			WithHeader("Origin", origin).
+			WithHeader("Access-Control-Request-Headers", "content-type").
+			Expect().
+			Status(http.StatusNoContent)
+
+		resp.Header("Access-Control-Allow-Origin").Equal(origin)
+		resp.Header("Access-Control-Allow-Methods").Equal(http.MethodPost)
+		resp.Header("Access-Control-Allow-Headers").Equal("content-type")
+		resp.Header("Access-Control-Allow-Credentials").Equal("true")
+	})
+
+	t.Run("RejectsAdminPanelPublicDomainSuffixOriginFromDifferentOrg", func(t *testing.T) {
+		e.OPTIONS("/auth/token_exchange").
+			WithHost(testInstance.Domain).
+			WithHeader("Origin", "https://otherowner-admin.stg.lin-saas.com").
+			Expect().
+			Status(http.StatusForbidden).
+			Header("Access-Control-Allow-Origin").Empty()
+	})
+
+	t.Run("RejectsNonAdminPublicDomainSuffixOrigin", func(t *testing.T) {
+		e.OPTIONS("/auth/token_exchange").
+			WithHost(testInstance.Domain).
+			WithHeader("Origin", "https://theopoizatzatteocorpcc2acd.stg.lin-saas.com").
+			Expect().
+			Status(http.StatusForbidden).
+			Header("Access-Control-Allow-Origin").Empty()
+	})
+
+	t.Run("RejectsNestedAdminPanelPublicDomainSuffixOrigin", func(t *testing.T) {
+		e.OPTIONS("/auth/token_exchange").
+			WithHost(testInstance.Domain).
+			WithHeader("Origin", "https://workspace.theopoizatzatteocorpcc2acd-admin.stg.lin-saas.com").
+			Expect().
+			Status(http.StatusForbidden).
+			Header("Access-Control-Allow-Origin").Empty()
+	})
+
+	t.Run("RejectsHTTPAdminPanelPublicDomainSuffixOrigin", func(t *testing.T) {
+		e.OPTIONS("/auth/token_exchange").
+			WithHost(testInstance.Domain).
+			WithHeader("Origin", "http://theopoizatzatteocorpcc2acd-admin.stg.lin-saas.com").
+			Expect().
+			Status(http.StatusForbidden).
+			Header("Access-Control-Allow-Origin").Empty()
+	})
+
+	t.Run("RejectsAdminPanelPublicDomainSuffixOriginWhenSuffixUnset", func(t *testing.T) {
+		oldContexts := conf.Contexts
+		conf.Contexts = map[string]interface{}{
+			config.DefaultInstanceContext: map[string]interface{}{},
+			contextName:                   map[string]interface{}{},
+		}
+		defer func() { conf.Contexts = oldContexts }()
+
+		e.OPTIONS("/auth/token_exchange").
+			WithHost(testInstance.Domain).
+			WithHeader("Origin", "https://theopoizatzatteocorpcc2acd-admin.stg.lin-saas.com").
+			Expect().
+			Status(http.StatusForbidden).
+			Header("Access-Control-Allow-Origin").Empty()
 	})
 
 	t.Run("RejectsOtherOrigins", func(t *testing.T) {


### PR DESCRIPTION
 ## Summary
  - Add `public_domain_suffix` context config with default-context fallback.
  - Allow `/auth/token_exchange` CORS from `https://<owner>-admin.<public_domain_suffix>`.
  - Resolve `<owner>.<public_domain_suffix>` and require it to belong to the same organization as the target instance.
  - Keep the existing `*.org_domain` CORS behavior unchanged.
