### PR TITLE
fix: propagate shared drive root rule title on rename

### DIFF
--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -1202,6 +1202,11 @@ func (s *Sharing) GetPreviewURL(inst *instance.Instance, state string) (string, 
 // PatchDescription saves a new description for a sharing.
 func (s *Sharing) PatchDescription(inst *instance.Instance, description string) error {
 	s.Description = description
+	if s.Drive {
+		if rule := s.FirstFilesRule(); rule != nil {
+			rule.Title = description
+		}
+	}
 	if err := couchdb.UpdateDoc(inst, s); err != nil {
 		return err
 	}
@@ -1403,9 +1408,7 @@ func (s *Sharing) UpdateDescriptionSameStack(ownerInst *instance.Instance, recip
 		return err
 	}
 
-	// Update the description directly
-	recipientSharing.Description = description
-	return couchdb.UpdateDoc(recipientInst, recipientSharing)
+	return recipientSharing.PatchDescription(recipientInst, description)
 }
 
 // AddShortcut creates a shortcut for this sharing on the local instance.

--- a/model/sharing/update_description.go
+++ b/model/sharing/update_description.go
@@ -8,7 +8,7 @@ import (
 )
 
 // UpdateSharingDescriptionIfNeeded checks if the given references contain
-// sharing references and triggers a job to update the sharing description.
+// sharing references and triggers a job to update the sharing metadata.
 func UpdateSharingDescriptionIfNeeded(inst *instance.Instance, referencedBy []couchdb.DocReference, newDescription string) {
 	// Check if this file/directory is referenced by any sharings
 	for _, ref := range referencedBy {

--- a/web/sharings/drives_test.go
+++ b/web/sharings/drives_test.go
@@ -3031,14 +3031,16 @@ func TestFileRootSharedDriveMutationRoutes(t *testing.T) {
 		patched.Path("$.data.attributes.cozyMetadata.favorite").Boolean().True()
 		require.Eventually(t, func() bool {
 			ownerSharing, err := sharing.FindSharing(env.acme, sharingID)
-			if err != nil || ownerSharing.Description != "RenamedRoot.txt" {
+			if err != nil || ownerSharing.Description != "RenamedRoot.txt" ||
+				len(ownerSharing.Rules) == 0 || ownerSharing.Rules[0].Title != "RenamedRoot.txt" {
 				return false
 			}
 			recipientSharing, err := sharing.FindSharing(env.betty, sharingID)
 			if err != nil {
 				return false
 			}
-			return recipientSharing.Description == "RenamedRoot.txt"
+			return recipientSharing.Description == "RenamedRoot.txt" &&
+				len(recipientSharing.Rules) > 0 && recipientSharing.Rules[0].Title == "RenamedRoot.txt"
 		}, 5*time.Second, 50*time.Millisecond)
 
 		eB.PATCH("/sharings/drives/"+sharingID+"/"+rootFileID).
@@ -3109,7 +3111,8 @@ func TestFileRootSharedDriveMutationRoutes(t *testing.T) {
 			if err != nil {
 				return false
 			}
-			return s.Description == newDriveName
+			return s.Description == newDriveName &&
+				len(s.Rules) > 0 && s.Rules[0].Title == newDriveName
 		}, 5*time.Second, 50*time.Millisecond)
 	})
 
@@ -3669,11 +3672,58 @@ func TestSharedDriveMetadata(t *testing.T) {
 		renamed.Path("$.data.attributes.name").String().IsEqual(newDriveName)
 
 		require.Eventually(t, func() bool {
-			s, err := sharing.FindSharing(env.betty, env.firstSharingID)
+			ownerSharing, err := sharing.FindSharing(env.acme, env.firstSharingID)
 			if err != nil {
 				return false
 			}
-			return s.Description == newDriveName
+			if ownerSharing.Description != newDriveName ||
+				len(ownerSharing.Rules) == 0 || ownerSharing.Rules[0].Title != newDriveName {
+				return false
+			}
+			recipientSharing, err := sharing.FindSharing(env.betty, env.firstSharingID)
+			if err != nil {
+				return false
+			}
+			return recipientSharing.Description == newDriveName &&
+				len(recipientSharing.Rules) > 0 && recipientSharing.Rules[0].Title == newDriveName
+		}, 5*time.Second, 50*time.Millisecond)
+	})
+
+	t.Run("OwnerCanPatchDriveDescription", func(t *testing.T) {
+		eA, _, _ := env.createClients(t)
+		newDriveName := testify(t, "Renamed shared drive via sharing patch")
+
+		eA.PATCH("/sharings/"+env.firstSharingID).
+			WithHeader("Authorization", "Bearer "+env.acmeToken).
+			WithHeader("Content-Type", "application/vnd.api+json").
+			WithBytes([]byte(`{
+				"data": {
+					"type": "` + consts.Sharings + `",
+					"attributes": {
+						"description": "` + newDriveName + `"
+					}
+				}
+			}`)).
+			Expect().Status(200).
+			JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+			Object().
+			Path("$.data.attributes.description").String().IsEqual(newDriveName)
+
+		require.Eventually(t, func() bool {
+			ownerSharing, err := sharing.FindSharing(env.acme, env.firstSharingID)
+			if err != nil {
+				return false
+			}
+			if ownerSharing.Description != newDriveName ||
+				len(ownerSharing.Rules) == 0 || ownerSharing.Rules[0].Title != newDriveName {
+				return false
+			}
+			recipientSharing, err := sharing.FindSharing(env.betty, env.firstSharingID)
+			if err != nil {
+				return false
+			}
+			return recipientSharing.Description == newDriveName &&
+				len(recipientSharing.Rules) > 0 && recipientSharing.Rules[0].Title == newDriveName
 		}, 5*time.Second, 50*time.Millisecond)
 	})
 }

--- a/web/sharings/replicator.go
+++ b/web/sharings/replicator.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cozy/cozy-stack/model/sharing"
 	"github.com/cozy/cozy-stack/model/vfs"
 	"github.com/cozy/cozy-stack/pkg/consts"
-	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/jsonapi"
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/labstack/echo/v4"
@@ -203,8 +202,7 @@ func UpdateSharingMetadata(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "description is too long (maximum 1000 characters)")
 	}
 
-	s.Description = description
-	if err := couchdb.UpdateDoc(inst, s); err != nil {
+	if err := s.PatchDescription(inst, description); err != nil {
 		return wrapErrors(err)
 	}
 

--- a/web/sharings/replicator_test.go
+++ b/web/sharings/replicator_test.go
@@ -429,6 +429,60 @@ func TestReplicator(t *testing.T) {
 			var updatedSharing sharing.Sharing
 			require.NoError(t, couchdb.GetDoc(replInstance, consts.Sharings, replSharingID, &updatedSharing))
 			assert.Equal(t, newDescription, updatedSharing.Description)
+			require.NotEmpty(t, updatedSharing.Rules)
+			assert.Equal(t, "tests", updatedSharing.Rules[0].Title)
+		})
+
+		t.Run("WithDrive", func(t *testing.T) {
+			rootDir, err := vfs.NewDirDoc(replInstance.VFS(), "Old root name", consts.RootDirID, nil)
+			require.NoError(t, err)
+			require.NoError(t, replInstance.VFS().CreateDir(rootDir))
+			rootID := rootDir.ID()
+			driveSharing := sharing.Sharing{
+				Drive:       true,
+				Description: "Old root name",
+				Rules: []sharing.Rule{{
+					Title:   "Old root name",
+					DocType: consts.Files,
+					Values:  []string{rootID},
+					Add:     sharing.ActionRuleNone,
+					Update:  sharing.ActionRuleNone,
+					Remove:  sharing.ActionRuleNone,
+				}},
+			}
+			require.NoError(t, driveSharing.BeOwner(replInstance, ""))
+			driveSharing.Members = append(driveSharing.Members, sharing.Member{
+				Status:   sharing.MemberStatusReady,
+				Name:     "Drive recipient",
+				Email:    "drive-recipient@example.net",
+				Instance: "https://drive-recipient.example.net/",
+			})
+			driveSharing.Credentials = append(driveSharing.Credentials, sharing.Credentials{})
+			_, err = driveSharing.Create(replInstance)
+			require.NoError(t, err)
+
+			cli, err := sharing.CreateOAuthClient(replInstance, &driveSharing.Members[1])
+			require.NoError(t, err)
+			driveSharing.Credentials[0].Client = sharing.ConvertOAuthClient(cli)
+			token, err := sharing.CreateAccessToken(replInstance, cli, driveSharing.SID, permission.ALL)
+			require.NoError(t, err)
+			driveSharing.Credentials[0].AccessToken = token
+			require.NoError(t, couchdb.UpdateDoc(replInstance, &driveSharing))
+
+			newDescription := "New root name"
+			e.PUT("/sharings/"+driveSharing.SID+"/metadata").
+				WithHeader("Content-Type", "application/json").
+				WithHeader("Authorization", "Bearer "+token.AccessToken).
+				WithJSON(map[string]string{
+					"description": newDescription,
+				}).
+				Expect().Status(204)
+
+			var updatedSharing sharing.Sharing
+			require.NoError(t, couchdb.GetDoc(replInstance, consts.Sharings, driveSharing.SID, &updatedSharing))
+			assert.Equal(t, newDescription, updatedSharing.Description)
+			require.NotEmpty(t, updatedSharing.Rules)
+			assert.Equal(t, newDescription, updatedSharing.Rules[0].Title)
 		})
 
 		t.Run("WithSpecialCharacters", func(t *testing.T) {

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -1067,6 +1067,11 @@ func TestSharings(t *testing.T) {
 	t.Run("PatchSharing", func(t *testing.T) {
 		eA := httpexpect.Default(t, tsA.URL)
 
+		var before sharing.Sharing
+		require.NoError(t, couchdb.GetDoc(aliceInstance, consts.Sharings, sharingID, &before))
+		require.NotEmpty(t, before.Rules)
+		originalRuleTitle := before.Rules[0].Title
+
 		obj := eA.PATCH("/sharings/"+sharingID).
 			WithHeader("Authorization", "Bearer "+aliceAppToken).
 			WithHeader("Content-Type", "application/vnd.api+json").
@@ -1084,6 +1089,11 @@ func TestSharings(t *testing.T) {
 
 		updated := obj.Value("data").Object().Value("attributes").Object().Value("description").String().NotEmpty().Raw()
 		assert.Equal(t, updated, "this is an updated description")
+
+		var s sharing.Sharing
+		require.NoError(t, couchdb.GetDoc(aliceInstance, consts.Sharings, sharingID, &s))
+		require.NotEmpty(t, s.Rules)
+		assert.Equal(t, originalRuleTitle, s.Rules[0].Title)
 	})
 
 	t.Run("DiscoveryTemplateRendering", func(t *testing.T) {


### PR DESCRIPTION
## Summary

  - Update shared-drive root rename propagation to keep `io.cozy.sharings.rules[].title` in sync with `description`
  - Reuse `PatchDescription` for both description-only updates and root rename updates via optional `root_id`
  - Propagate `root_id` through share-update jobs and recipient metadata updates

 ## Why

  Drive’s Sharings tab displays shared-drive entries from sharing rule metadata. When a shared root folder/file was renamed, the stack updated the sharing description but left the root rule title stale, so recipients still saw the old name in Sharings.