### PR TITLE
fix: delete owner drive sharing after root deletion

### DIFF
--- a/model/sharing/revoke_trashed.go
+++ b/model/sharing/revoke_trashed.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cozy/cozy-stack/model/instance"
 	"github.com/cozy/cozy-stack/model/vfs"
 	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/prefixer"
 )
 
@@ -38,6 +39,12 @@ func revokeTrashed(db prefixer.Prefixer, sharingID string) {
 	log.Infof("revokeTrashed called for sharing %s", sharingID)
 	if s.Owner {
 		err = s.Revoke(inst)
+		if err == nil && s.Drive {
+			err = couchdb.DeleteDoc(inst, s)
+			if couchdb.IsNotFoundError(err) {
+				err = nil
+			}
+		}
 	} else {
 		err = s.RevokeRecipientBySelf(inst, SharingDirAlreadyTrashed)
 	}

--- a/web/sharings/drives_test.go
+++ b/web/sharings/drives_test.go
@@ -4167,6 +4167,11 @@ func TestDirectoryRootSharedDriveOwnerDeletionRevokesRecipient(t *testing.T) {
 	}, 5*time.Second, 100*time.Millisecond, "Betty should no longer see a shared drive after its owner deletes the root folder")
 
 	require.Eventually(t, func() bool {
+		_, err := sharing.FindSharing(env.acme, sharingID)
+		return couchdb.IsNotFoundError(err)
+	}, 5*time.Second, 100*time.Millisecond, "Owner's sharing document should be deleted after deleting the shared-drive root folder")
+
+	require.Eventually(t, func() bool {
 		_, err := env.betty.VFS().FileByID(shortcutID)
 		return os.IsNotExist(err)
 	}, 5*time.Second, 100*time.Millisecond, "Betty's shared-drive shortcut should be removed after the owner deletes the root folder")
@@ -4222,6 +4227,11 @@ func TestFileRootSharedDriveOwnerDeletionRevokesRecipient(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return !sharedDriveVisibleForBetty()
 	}, 5*time.Second, 100*time.Millisecond, "Betty should no longer see a file-root shared drive after its owner deletes the root file")
+
+	require.Eventually(t, func() bool {
+		_, err := sharing.FindSharing(env.acme, sharingID)
+		return couchdb.IsNotFoundError(err)
+	}, 5*time.Second, 100*time.Millisecond, "Owner's sharing document should be deleted after deleting the shared-drive root file")
 }
 
 // TestSharedDriveRecipientSelfRevocation tests that a recipient can revoke themselves


### PR DESCRIPTION
## Summary
- delete the owner-side drive sharing document after automatic shared-drive root deletion revokes recipients
- keep non-drive and recipient-side revocation behavior unchanged
- assert owner sharing doc deletion for file-root and directory-root shared drives
