### PR TITLE
fix: delete drive sharing after last member removal

### DIFF
--- a/model/sharing/group.go
+++ b/model/sharing/group.go
@@ -106,6 +106,16 @@ func (s *Sharing) RevokeGroup(inst *instance.Instance, index int) error {
 	}
 
 	s.Groups[index].Revoked = true
+	if s.Drive {
+		if errm != nil {
+			if err := couchdb.UpdateDoc(inst, s); err != nil {
+				errm = multierror.Append(errm, err)
+			}
+			return errm
+		}
+		return s.NoMoreRecipient(inst)
+	}
+
 	if err := couchdb.UpdateDoc(inst, s); err != nil {
 		errm = multierror.Append(errm, err)
 	}

--- a/model/sharing/group_test.go
+++ b/model/sharing/group_test.go
@@ -232,6 +232,137 @@ func TestGroups(t *testing.T) {
 		assert.Equal(t, s.Members[3].Groups, []int{1})
 		assert.Equal(t, s.Members[3].Status, MemberStatusPendingInvitation)
 	})
+
+	t.Run("RemoveLastDriveGroupMemberKeepsSharing", func(t *testing.T) {
+		now := time.Now()
+		team := createGroup(t, inst, "Drive Team")
+		alice := createContactInGroups(t, inst, "DriveAlice", []string{team.ID()})
+
+		s := &Sharing{
+			Active:      true,
+			Owner:       true,
+			Drive:       true,
+			Description: "Just testing drive groups",
+			Members: []Member{
+				{Status: MemberStatusOwner, Name: "Alice", Email: "alice@cozy.tools"},
+			},
+			Rules: []Rule{
+				{
+					Title:   "Just testing drive groups",
+					DocType: consts.Files,
+					Values:  []string{uuidv7()},
+				},
+			},
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+		require.NoError(t, couchdb.CreateDoc(inst, s))
+		sid := s.SID
+		require.NoError(t, s.AddGroup(inst, team.ID(), false))
+		require.NoError(t, couchdb.UpdateDoc(inst, s))
+
+		require.Len(t, s.Members, 2)
+		require.Equal(t, s.Members[1].Name, "DriveAlice")
+		assert.True(t, s.Members[1].OnlyInGroups)
+		assert.Equal(t, []int{0}, s.Members[1].Groups)
+
+		msg := job.ShareGroupMessage{
+			ContactID:     alice.ID(),
+			GroupsRemoved: []string{team.ID()},
+		}
+		require.NoError(t, UpdateGroups(inst, msg))
+
+		s = &Sharing{}
+		require.NoError(t, couchdb.GetDoc(inst, consts.Sharings, sid, s))
+
+		require.Len(t, s.Members, 2)
+		assert.True(t, s.Active)
+		assert.Equal(t, MemberStatusRevoked, s.Members[1].Status)
+		assert.Empty(t, s.Members[1].Groups)
+		require.Len(t, s.Groups, 1)
+		assert.False(t, s.Groups[0].Revoked)
+	})
+
+	t.Run("RevokeLastDriveGroupDeletesSharing", func(t *testing.T) {
+		team := createGroup(t, inst, "Drive Group")
+		_ = createContactInGroups(t, inst, "DriveGroupAlice", []string{team.ID()})
+		s := createDriveSharingForGroupTest(t, inst, "Drive group revoke")
+		sid := s.SID
+		require.NoError(t, s.AddGroup(inst, team.ID(), false))
+		require.NoError(t, couchdb.UpdateDoc(inst, s))
+
+		require.Len(t, s.Members, 2)
+		require.Len(t, s.Groups, 1)
+		require.NoError(t, s.RevokeGroup(inst, 0))
+
+		deleted := &Sharing{}
+		err := couchdb.GetDoc(inst, consts.Sharings, sid, deleted)
+		require.Error(t, err)
+		assert.True(t, couchdb.IsNotFoundError(err), "expected deleted sharing, got %v", err)
+	})
+
+	t.Run("RevokeEmptyLastDriveGroupDeletesSharing", func(t *testing.T) {
+		team := createGroup(t, inst, "Empty Drive Group")
+		s := createDriveSharingForGroupTest(t, inst, "Empty drive group revoke")
+		sid := s.SID
+		require.NoError(t, s.AddGroup(inst, team.ID(), false))
+		require.NoError(t, couchdb.UpdateDoc(inst, s))
+
+		require.Len(t, s.Members, 1)
+		require.Len(t, s.Groups, 1)
+		require.NoError(t, s.RevokeGroup(inst, 0))
+
+		deleted := &Sharing{}
+		err := couchdb.GetDoc(inst, consts.Sharings, sid, deleted)
+		require.Error(t, err)
+		assert.True(t, couchdb.IsNotFoundError(err), "expected deleted sharing, got %v", err)
+	})
+
+	t.Run("RevokeDriveGroupKeepsSharingWhenAnotherGroupRemains", func(t *testing.T) {
+		team := createGroup(t, inst, "First Empty Drive Group")
+		otherTeam := createGroup(t, inst, "Second Empty Drive Group")
+		s := createDriveSharingForGroupTest(t, inst, "Remaining drive group")
+		sid := s.SID
+		require.NoError(t, s.AddGroup(inst, team.ID(), false))
+		require.NoError(t, s.AddGroup(inst, otherTeam.ID(), false))
+		require.NoError(t, couchdb.UpdateDoc(inst, s))
+
+		require.Len(t, s.Members, 1)
+		require.Len(t, s.Groups, 2)
+		require.NoError(t, s.RevokeGroup(inst, 0))
+
+		stored := &Sharing{}
+		require.NoError(t, couchdb.GetDoc(inst, consts.Sharings, sid, stored))
+		assert.True(t, stored.Active)
+		require.Len(t, stored.Groups, 2)
+		assert.True(t, stored.Groups[0].Revoked)
+		assert.False(t, stored.Groups[1].Revoked)
+	})
+}
+
+func createDriveSharingForGroupTest(t *testing.T, inst *instance.Instance, description string) *Sharing {
+	t.Helper()
+	now := time.Now()
+	s := &Sharing{
+		Active:      true,
+		Owner:       true,
+		Drive:       true,
+		Description: description,
+		Members: []Member{
+			{Status: MemberStatusOwner, Name: "Alice", Email: "alice@cozy.tools"},
+		},
+		Rules: []Rule{
+			{
+				Title:   description,
+				DocType: consts.Files,
+				Values:  []string{uuidv7()},
+			},
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	require.NoError(t, couchdb.CreateDoc(inst, s))
+	return s
 }
 
 func createGroup(t *testing.T, inst *instance.Instance, name string) *contact.Group {

--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -636,6 +636,9 @@ func (s *Sharing) Revoke(inst *instance.Instance) error {
 	if err := couchdb.UpdateDoc(inst, s); err != nil {
 		return err
 	}
+	if s.Drive && errm == nil {
+		return s.deleteRevokedDriveSharing(inst)
+	}
 	return errm
 }
 
@@ -892,7 +895,23 @@ func (s *Sharing) RevokeRecipientByNotification(inst *instance.Instance, m *Memb
 // NoMoreRecipient cleans up the sharing if there is no more active recipient
 func (s *Sharing) NoMoreRecipient(inst *instance.Instance) error {
 	if s.Drive {
-		return couchdb.UpdateDoc(inst, s)
+		if s.hasRemainingRecipients() {
+			return couchdb.UpdateDoc(inst, s)
+		}
+		if err := s.RemoveTriggers(inst); err != nil {
+			return err
+		}
+		if err := RemoveSharedRefs(inst, s.SID); err != nil {
+			return err
+		}
+		if err := s.RevokeInteractPermissions(inst); err != nil {
+			return err
+		}
+		s.Active = false
+		if err := couchdb.UpdateDoc(inst, s); err != nil {
+			return err
+		}
+		return s.deleteRevokedDriveSharing(inst)
 	}
 	for _, m := range s.Members {
 		if m.Status == MemberStatusReady {
@@ -907,6 +926,31 @@ func (s *Sharing) NoMoreRecipient(inst *instance.Instance) error {
 		return err
 	}
 	return RemoveSharedRefs(inst, s.SID)
+}
+
+func (s *Sharing) hasRemainingRecipients() bool {
+	for i, m := range s.Members {
+		if i > 0 && m.Status != MemberStatusRevoked {
+			return true
+		}
+	}
+	for _, g := range s.Groups {
+		if !g.Revoked {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Sharing) deleteRevokedDriveSharing(inst *instance.Instance) error {
+	if !s.Drive {
+		return nil
+	}
+	err := couchdb.DeleteDoc(inst, s)
+	if couchdb.IsNotFoundError(err) {
+		return nil
+	}
+	return err
 }
 
 // FindSharing retrieves a sharing document from its ID

--- a/web/sharings/drives_test.go
+++ b/web/sharings/drives_test.go
@@ -4100,6 +4100,45 @@ func TestSharedDriveRevocation(t *testing.T) {
 			WithHeader("Authorization", "Bearer "+env.bettyToken).
 			Expect().Status(403)
 	})
+
+	t.Run("RemoveRemainingRecipient", func(t *testing.T) {
+		eA, _, _ := env.createClients(t)
+
+		eA.DELETE("/sharings/"+sharingID+"/recipients/2").
+			WithHeader("Authorization", "Bearer "+env.acmeToken).
+			Expect().Status(204)
+	})
+
+	t.Run("OwnerSharingIsDeleted", func(t *testing.T) {
+		require.Eventually(t, func() bool {
+			_, err := sharing.FindSharing(env.acme, sharingID)
+			return couchdb.IsNotFoundError(err)
+		}, 5*time.Second, 100*time.Millisecond, "Owner's drive sharing document should be deleted after the last recipient is revoked")
+	})
+
+	t.Run("RevokeAllRecipientsDeletesOwnerSharing", func(t *testing.T) {
+		allSharingID, _, _ := createSharedDrive(
+			t,
+			DriveCreationMethodLegacy,
+			env.acme,
+			env.acmeToken,
+			env.tsA.URL,
+			"Revoke All Recipients Drive",
+			"Drive for testing full revocation",
+			[]RecipientInfo{{Name: "Betty", Email: "betty@example.net", ReadOnly: false}},
+		)
+		acceptSharedDriveForBetty(t, env.acme, env.betty, env.tsA.URL, env.tsB.URL, allSharingID)
+
+		eA, _, _ := env.createClients(t)
+		eA.DELETE("/sharings/"+allSharingID+"/recipients").
+			WithHeader("Authorization", "Bearer "+env.acmeToken).
+			Expect().Status(204)
+
+		require.Eventually(t, func() bool {
+			_, err := sharing.FindSharing(env.acme, allSharingID)
+			return couchdb.IsNotFoundError(err)
+		}, 5*time.Second, 100*time.Millisecond, "Owner's drive sharing document should be deleted after revoking all recipients")
+	})
 }
 
 func TestDirectoryRootSharedDriveOwnerDeletionRevokesRecipient(t *testing.T) {


### PR DESCRIPTION
## Summary
- delete owner-side drive sharing documents once all recipients are revoked
- keep drive sharing documents when at least one recipient remains
- cover both last-recipient removal and bulk recipient revocation

