### PR TITLE
feat: redirect shared drive invites to target

### DIFF
--- a/model/sharing/files_test.go
+++ b/model/sharing/files_test.go
@@ -1,10 +1,12 @@
 package sharing
 
 import (
+	"net/url"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/cozy/cozy-stack/model/instance"
 	"github.com/cozy/cozy-stack/model/vfs"
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
@@ -13,6 +15,76 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestDriveURLHelpers(t *testing.T) {
+	config.UseTestFile(t)
+	inst := &instance.Instance{Domain: "alice.example.net"}
+
+	t.Run("DirectoryRootTarget", func(t *testing.T) {
+		s := &Sharing{
+			SID:   "sharing-id",
+			Drive: true,
+			Rules: []Rule{{DocType: consts.Files, Values: []string{"folder-id"}}},
+		}
+
+		u := s.DriveTargetURL(inst)
+		assert.Equal(t, "sharing=sharing-id", u.RawQuery)
+		assert.Equal(t, "/shareddrive/sharing-id/folder-id", u.Fragment)
+	})
+
+	t.Run("FileRootTarget", func(t *testing.T) {
+		s := &Sharing{
+			SID:           "sharing-id",
+			Drive:         true,
+			DriveRootType: DriveRootTypeFile,
+			Rules:         []Rule{{DocType: consts.Files, Values: []string{"file-id"}}},
+		}
+
+		u := s.DriveTargetURL(inst)
+		assert.Equal(t, "sharing=sharing-id", u.RawQuery)
+		assert.Equal(t, "/shareddrive/sharing-id/file/file-id", u.Fragment)
+	})
+
+	t.Run("FallbackTarget", func(t *testing.T) {
+		s := &Sharing{
+			SID:   "sharing-id",
+			Drive: true,
+		}
+
+		u := s.DriveTargetURL(inst)
+		assert.Equal(t, "sharing=sharing-id", u.RawQuery)
+		assert.Equal(t, "/folder/"+consts.SharedDrivesDirID, u.Fragment)
+	})
+
+	t.Run("AuthorizeSharingURL", func(t *testing.T) {
+		s := &Sharing{SID: "sharing-id"}
+		u, err := url.Parse(s.AuthorizeSharingURL(inst, "state-id"))
+		require.NoError(t, err)
+
+		assert.Equal(t, "/auth/authorize/sharing", u.Path)
+		assert.Equal(t, "sharing-id", u.Query().Get("sharing_id"))
+		assert.Equal(t, "state-id", u.Query().Get("state"))
+	})
+
+	t.Run("DriveShortcutURL", func(t *testing.T) {
+		s := &Sharing{
+			SID:         "sharing-id",
+			Drive:       true,
+			Credentials: []Credentials{{State: "state-id"}},
+			Rules:       []Rule{{DocType: consts.Files, Values: []string{"folder-id"}}},
+		}
+
+		pendingURL, err := url.Parse(s.driveShortcutURL(inst, false))
+		require.NoError(t, err)
+		assert.Equal(t, "/auth/authorize/sharing", pendingURL.Path)
+		assert.Equal(t, "sharing-id", pendingURL.Query().Get("sharing_id"))
+		assert.Equal(t, "state-id", pendingURL.Query().Get("state"))
+
+		seenURL, err := url.Parse(s.driveShortcutURL(inst, true))
+		require.NoError(t, err)
+		assert.Equal(t, "/shareddrive/sharing-id/folder-id", seenURL.Fragment)
+	})
+}
 
 func TestFiles(t *testing.T) {
 	if testing.Short() {

--- a/model/sharing/invitation.go
+++ b/model/sharing/invitation.go
@@ -384,6 +384,15 @@ func (s *Sharing) CreateDriveShortcut(inst *instance.Instance, seen bool) error 
 	return nil
 }
 
+// AuthorizeSharingURL returns the recipient-side URL that opens the sharing
+// authorization flow.
+func (s *Sharing) AuthorizeSharingURL(inst *instance.Instance, state string) string {
+	return inst.PageURL("/auth/authorize/sharing", url.Values{
+		"sharing_id": {s.SID},
+		"state":      {state},
+	})
+}
+
 func (s *Sharing) driveShortcutURL(inst *instance.Instance, seen bool) string {
 	if !seen && len(s.Credentials) > 0 && s.Credentials[0].State != "" {
 		return s.AuthorizeSharingURL(inst, s.Credentials[0].State)

--- a/model/sharing/invitation.go
+++ b/model/sharing/invitation.go
@@ -307,9 +307,7 @@ func (s *Sharing) CreateDriveShortcut(inst *instance.Instance, seen bool) error 
 	}
 
 	filename := cleanFilename(s.Rules[0].Title) + ".url"
-	u := inst.SubDomain(consts.DriveSlug)
-	u.Fragment = "/folder/" + dir.ID()
-	driveURL := u.String()
+	driveURL := s.driveShortcutURL(inst, seen)
 	body := shortcut.Generate(driveURL)
 	cm := vfs.NewCozyMetadata(s.Members[0].Instance)
 	fileDoc, err := vfs.NewFileDoc(
@@ -384,6 +382,13 @@ func (s *Sharing) CreateDriveShortcut(inst *instance.Instance, seen bool) error 
 		return s.SendShortcutNotification(inst, fileDoc, driveURL)
 	}
 	return nil
+}
+
+func (s *Sharing) driveShortcutURL(inst *instance.Instance, seen bool) string {
+	if !seen && len(s.Credentials) > 0 && s.Credentials[0].State != "" {
+		return s.AuthorizeSharingURL(inst, s.Credentials[0].State)
+	}
+	return s.DriveTargetURL(inst).String()
 }
 
 var illegalChars = []string{"<", ">", ":", `"`, "/", "\\", "|", "?", "*"}
@@ -493,7 +498,9 @@ func (m *Member) SendShortcut(inst *instance.Instance, s *Sharing, link string) 
 
 	v := url.Values{}
 	v.Add("shortcut", "true")
-	v.Add("url", link)
+	if !s.Drive {
+		v.Add("url", link)
+	}
 	u.RawQuery = v.Encode()
 	return m.CreateSharingRequest(inst, s, creds, u)
 }

--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -156,6 +156,36 @@ func (s *Sharing) DriveRootID() (string, error) {
 	return rule.Values[0], nil
 }
 
+// DriveTargetURL returns the Drive URL that opens the shared drive root.
+func (s *Sharing) DriveTargetURL(inst *instance.Instance) *url.URL {
+	u := inst.SubDomain(consts.DriveSlug)
+	u.RawQuery = url.Values{"sharing": {s.SID}}.Encode()
+
+	rootID, err := s.DriveRootID()
+	if err != nil {
+		u.Fragment = "/folder/" + consts.SharedDrivesDirID
+		return u
+	}
+
+	sharingID := url.PathEscape(s.SID)
+	rootID = url.PathEscape(rootID)
+	if s.HasFileDriveRoot() {
+		u.Fragment = "/shareddrive/" + sharingID + "/file/" + rootID
+	} else {
+		u.Fragment = "/shareddrive/" + sharingID + "/" + rootID
+	}
+	return u
+}
+
+// AuthorizeSharingURL returns the recipient-side URL that opens the sharing
+// authorization flow.
+func (s *Sharing) AuthorizeSharingURL(inst *instance.Instance, state string) string {
+	return inst.PageURL("/auth/authorize/sharing", url.Values{
+		"sharing_id": {s.SID},
+		"state":      {state},
+	})
+}
+
 // GetFileDriveRoot returns the root file of a file-root shared drive.
 func (s *Sharing) GetFileDriveRoot(inst *instance.Instance) (*vfs.FileDoc, error) {
 	rootID, err := s.DriveRootID()
@@ -1060,6 +1090,10 @@ func findIntentForRedirect(inst *instance.Instance, webapp *app.WebappManifest, 
 // RedirectAfterAuthorizeURL returns the URL for the redirection after a user
 // has authorized a sharing.
 func (s *Sharing) RedirectAfterAuthorizeURL(inst *instance.Instance) *url.URL {
+	if s.Drive {
+		return s.DriveTargetURL(inst)
+	}
+
 	doctype := s.Rules[0].DocType
 	webapp, _ := app.GetWebappBySlug(inst, s.AppSlug)
 

--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -177,15 +177,6 @@ func (s *Sharing) DriveTargetURL(inst *instance.Instance) *url.URL {
 	return u
 }
 
-// AuthorizeSharingURL returns the recipient-side URL that opens the sharing
-// authorization flow.
-func (s *Sharing) AuthorizeSharingURL(inst *instance.Instance, state string) string {
-	return inst.PageURL("/auth/authorize/sharing", url.Values{
-		"sharing_id": {s.SID},
-		"state":      {state},
-	})
-}
-
 // GetFileDriveRoot returns the root file of a file-root shared drive.
 func (s *Sharing) GetFileDriveRoot(inst *instance.Instance) (*vfs.FileDoc, error) {
 	rootID, err := s.DriveRootID()

--- a/web/auth/oauth.go
+++ b/web/auth/oauth.go
@@ -538,8 +538,14 @@ func (a *AuthorizeHTTPHandler) authorizeSharingForm(c echo.Context) error {
 	}
 
 	s, err := sharing.FindSharing(instance, params.sharingID)
-	if err != nil || s.Owner || s.Active || len(s.Members) < 2 {
+	if err != nil || s.Owner || len(s.Members) < 2 || (s.Active && !s.Drive) {
 		return renderError(c, http.StatusUnauthorized, "Error Invalid sharing")
+	}
+
+	if s.Drive && s.Active {
+		// Invitation emails and shortcuts can still point here after auto-accept.
+		// In that case, this route is used as an "open sharing" link.
+		return c.Redirect(http.StatusSeeOther, s.DriveTargetURL(instance).String())
 	}
 
 	if s.Drive || strings.ToLower(c.QueryParam("shortcut")) == "true" {
@@ -556,9 +562,9 @@ func (a *AuthorizeHTTPHandler) authorizeSharingForm(c echo.Context) error {
 			}
 		}
 		u := instance.SubDomain(consts.DriveSlug)
-		u.RawQuery = "sharing=" + s.SID
+		u.RawQuery = url.Values{"sharing": {s.SID}}.Encode()
 		if s.Drive {
-			u.Fragment = "/folder/" + consts.SharedDrivesDirID
+			u = s.DriveTargetURL(instance)
 		} else {
 			u.Fragment = "/folder/" + consts.SharedWithMeDirID
 		}

--- a/web/auth/oauth.go
+++ b/web/auth/oauth.go
@@ -562,10 +562,10 @@ func (a *AuthorizeHTTPHandler) authorizeSharingForm(c echo.Context) error {
 			}
 		}
 		u := instance.SubDomain(consts.DriveSlug)
-		u.RawQuery = url.Values{"sharing": {s.SID}}.Encode()
 		if s.Drive {
 			u = s.DriveTargetURL(instance)
 		} else {
+			u.RawQuery = url.Values{"sharing": {s.SID}}.Encode()
 			u.Fragment = "/folder/" + consts.SharedWithMeDirID
 		}
 		return c.Redirect(http.StatusSeeOther, u.String())

--- a/web/sharings/drives_test.go
+++ b/web/sharings/drives_test.go
@@ -779,7 +779,7 @@ func submitSharingAuthorize(
 		WithRedirectPolicy(httpexpect.DontFollowRedirects).
 		Expect().Status(http.StatusSeeOther).
 		Header("Location").
-		Contains("/?sharing=" + sharingID)
+		Contains("#/shareddrive/" + sharingID + "/")
 }
 
 func openSharingAuthorize(
@@ -802,7 +802,7 @@ func openSharingAuthorize(
 		Expect().
 		Status(http.StatusSeeOther).
 		Header("Location").
-		Contains("sharing=" + sharingID)
+		Contains("#/shareddrive/" + sharingID + "/")
 }
 
 func waitForSharingOnRecipient(t *testing.T, recipientInstance *instance.Instance, sharingID string) *sharing.Sharing {
@@ -1802,6 +1802,22 @@ func TestDriveAutoAcceptTrusted(t *testing.T) {
 	waitForAutoAcceptJobForSharing(t, env.recipientInstance, sharingID)
 	waitForDriveSharingReadyOnOwner(t, env.eOwner, env.ownerAppToken, sharingID)
 	waitForDriveSharingActiveOnRecipient(t, env.recipientInstance, sharingID)
+
+	loginSharingRecipient(t, env.eRecipient)
+	recipientSharing, err := sharing.FindSharing(env.recipientInstance, sharingID)
+	require.NoError(t, err)
+	require.NotEmpty(t, recipientSharing.Credentials)
+	state := recipientSharing.Credentials[0].State
+	require.NotEmpty(t, state)
+
+	env.eRecipient.GET("/auth/authorize/sharing").
+		WithQuery("sharing_id", sharingID).
+		WithQuery("state", state).
+		WithRedirectPolicy(httpexpect.DontFollowRedirects).
+		Expect().
+		Status(http.StatusSeeOther).
+		Header("Location").
+		Contains("#/shareddrive/" + sharingID + "/")
 }
 
 func TestSendAnswerIsIdempotentAfterStaleConflict(t *testing.T) {
@@ -1887,6 +1903,43 @@ func TestDriveAutoAcceptAfterDiscoveryAuthorizeDoesNotConflict(t *testing.T) {
 	openSharingAuthorize(t, env.eRecipient, authorizeLink, sharingID)
 	waitForDriveSharingReadyOnOwner(t, env.eOwner, env.ownerAppToken, sharingID)
 	waitForDriveSharingActiveOnRecipient(t, env.recipientInstance, sharingID)
+}
+
+func TestFileRootSharedDriveAuthorizeRedirect(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	env := setupSharedDrivesEnv(t)
+	eA, eB, _ := env.createClients(t)
+	rootFileID := createFile(t, eA, "", "SharedDriveRootFile.txt", env.acmeToken)
+	sharingID, _ := createFileRootSharedDrive(
+		t,
+		env.acme,
+		env.acmeToken,
+		env.tsA.URL,
+		rootFileID,
+		"File-root authorize redirect",
+		[]RecipientInfo{{Name: "Betty", Email: "betty@example.net"}},
+	)
+
+	loginSharingRecipient(t, eB)
+	authorizeLink := prepareSharingAuthorizeLink(t, env.acme, "Betty", sharingID, eA, env.tsB.URL)
+	FakeOwnerInstanceForSharing(t, env.betty, env.tsA.URL, sharingID)
+
+	authorizeURL, err := url.Parse(authorizeLink)
+	require.NoError(t, err)
+	state := authorizeURL.Query().Get("state")
+	require.NotEmpty(t, state)
+
+	eB.GET(authorizeURL.Path).
+		WithQuery("sharing_id", sharingID).
+		WithQuery("state", state).
+		WithRedirectPolicy(httpexpect.DontFollowRedirects).
+		Expect().
+		Status(http.StatusSeeOther).
+		Header("Location").
+		Contains("#/shareddrive/" + sharingID + "/file/" + rootFileID)
 }
 
 func TestSharedDriveAcceptance(t *testing.T) {


### PR DESCRIPTION
## Context

Shared-drive invitation links could leave users in the generic shared-drives folder. If auto-accept had already run, the same authorization URL could also be rejected as an already-active sharing instead of opening the target.

## Summary

- Redirect shared-drive invite and shortcut opens to the specific shared drive root instead of the generic shared-drives folder.
- Use existing Cozy Drive routes for folder-root and file-root shared drives.
- Allow the sharing authorization route to act as an open link after auto-accept.

