### PR TITLE
fix: New version of OO requires editorConfig

### DIFF
--- a/model/sharing/open_office.go
+++ b/model/sharing/open_office.go
@@ -58,7 +58,7 @@ type onlyOffice struct {
 			ForceSave bool `json:"forcesave"`
 			GoBack    bool `json:"goback"`
 		} `json:"customization"`
-	} `json:"editor"`
+	} `json:"editorConfig"`
 }
 
 func (o *apiOfficeURL) ID() string                             { return o.FileID }

--- a/web/office/office_test.go
+++ b/web/office/office_test.go
@@ -71,7 +71,7 @@ func TestOffice(t *testing.T) {
 		oo.Value("url").String().NotEmpty()
 		oo.ValueEqual("documentType", "word")
 
-		editor := oo.Value("editor").Object()
+		editor := oo.Value("editorConfig").Object()
 		editor.ValueEqual("mode", "edit")
 		editor.Value("callbackUrl").String().HasSuffix("/office/callback")
 


### PR DESCRIPTION
We're upgrading our OO. Apparently we need this editorConfig instead of config. 