### PR TITLE
fix: expose shared file class in drive shortcut target metadata

### DIFF
--- a/model/sharing/files_test.go
+++ b/model/sharing/files_test.go
@@ -121,6 +121,7 @@ func TestFiles(t *testing.T) {
 		assert.Equal(t, consts.Files, target["_type"])
 		assert.Equal(t, DriveRootTypeFile, target["drive_root_type"])
 		assert.Equal(t, "text/plain", target["mime"])
+		assert.Equal(t, "text", target["class"])
 	})
 
 	t.Run("SharingDir", func(t *testing.T) {

--- a/model/sharing/invitation.go
+++ b/model/sharing/invitation.go
@@ -346,7 +346,10 @@ func (s *Sharing) CreateDriveShortcut(inst *instance.Instance, seen bool) error 
 		},
 	}
 	if rule := s.FirstFilesRule(); s.HasFileDriveRoot() && rule != nil && rule.Mime != "" {
-		fileDoc.Metadata["target"].(map[string]interface{})["mime"] = rule.Mime
+		_, class := vfs.ExtractMimeAndClass(rule.Mime)
+		target := fileDoc.Metadata["target"].(map[string]interface{})
+		target["mime"] = rule.Mime
+		target["class"] = class
 	}
 	fileDoc.AddReferencedBy(couchdb.DocReference{
 		ID:   s.SID,


### PR DESCRIPTION
For a file-root sharing, CreateDriveShortcut creates a .url shortcut to materialize the drive on the owner and the recipient. The shortcut mime is fixed to application/internet-shortcut, which forces class shortcut and hides the real class of the shared file (text, spreadsheet, slide).

The mime of the shared file is already exposed in
metadata.target.mime, but the class still has to be re-derived by consumers (e.g. the Drive app) from that mime, which duplicates the mime-to-class mapping that lives in vfs.ExtractMimeAndClass.

Compute the class from the rule mime and store it in metadata.target.class alongside the mime, using the same helper as the rest of the VFS. The change is additive: existing shortcuts without this field keep working, and the replicator already copies metadata.target as-is, so the new field propagates to recipients without any further work.