### PR TITLE
feat: allow safehttp trusted private networks

### DIFF
--- a/cozy.example.yaml
+++ b/cozy.example.yaml
@@ -592,6 +592,18 @@ contexts:
       auto_accept_trusted_contacts: false
       trusted_domains: []
 
+# WARNING: Closed-network deployments only.
+# Allows safehttp callers to reach private CIDRs, bypassing SSRF protections
+# for those addresses (including non-standard ports).
+# This affects sharing, move/import/export, WebDAV, BI, common settings,
+# Bitwarden icon fetching, and all other safehttp-backed outbound calls.
+# Default behavior (empty list) keeps all private addresses blocked.
+# safe_http:
+#   trusted_private_networks:
+#     - 10.0.0.0/8
+#     - 172.16.0.0/12
+#     - 192.168.0.0/16
+
 rabbitmq:
   enabled: true
   nodes:

--- a/pkg/config/config/config.go
+++ b/pkg/config/config/config.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/lock"
 	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/cozy/cozy-stack/pkg/pdf"
+	"github.com/cozy/cozy-stack/pkg/safehttp"
 	"github.com/cozy/cozy-stack/pkg/tlsclient"
 	"github.com/cozy/cozy-stack/pkg/utils"
 	"github.com/cozy/gomail"
@@ -150,6 +151,10 @@ type Config struct {
 	Clouderies     map[string]ClouderyConfig
 
 	RabbitMQ RabbitMQ
+
+	// SafeHTTPTrustedNetworks is a list of private CIDRs that safehttp
+	// callers are allowed to reach. For closed-network deployments only.
+	SafeHTTPTrustedNetworks []string
 
 	RemoteAllowCustomPort bool
 
@@ -1136,6 +1141,11 @@ func UseViper(v *viper.Viper) error {
 	err = v.UnmarshalKey("rabbitmq", &config.RabbitMQ)
 	if err != nil {
 		return fmt.Errorf(`failed to parse the config for "rabbitmq": %w`, err)
+	}
+
+	config.SafeHTTPTrustedNetworks = v.GetStringSlice("safe_http.trusted_private_networks")
+	if err = safehttp.SetTrustedPrivateNetworks(config.SafeHTTPTrustedNetworks); err != nil {
+		return fmt.Errorf("invalid safe_http.trusted_private_networks config: %w", err)
 	}
 
 	// For compatibility

--- a/pkg/config/config/config_test.go
+++ b/pkg/config/config/config_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/cozy/cozy-stack/pkg/prefixer"
+	"github.com/cozy/cozy-stack/pkg/safehttp"
 	"github.com/cozy/gomail"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -302,6 +303,9 @@ func TestConfigUnmarshal(t *testing.T) {
 			"connect": "https://connect-url",
 		},
 	}, cfg.CSPPerContext)
+
+	// SafeHTTP
+	assert.Equal(t, []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"}, cfg.SafeHTTPTrustedNetworks)
 }
 
 func TestUseViper(t *testing.T) {
@@ -512,4 +516,36 @@ rabbitmq:
 	assert.Equal(t, []string{"settings.admin.*"}, queue2b.Bindings)
 	assert.Equal(t, 8, queue2b.Prefetch)
 	assert.Equal(t, 2, queue2b.DeliveryLimit)
+}
+
+func TestSafeHTTPConfig(t *testing.T) {
+	t.Cleanup(func() { _ = safehttp.SetTrustedPrivateNetworks(nil) })
+
+	t.Run("valid CIDRs map through UseViper", func(t *testing.T) {
+		cfg := viper.New()
+		cfg.Set("safe_http.trusted_private_networks", []string{"10.0.0.0/8", "172.16.0.0/12"})
+		require.NoError(t, UseViper(cfg))
+		assert.Equal(t, []string{"10.0.0.0/8", "172.16.0.0/12"}, GetConfig().SafeHTTPTrustedNetworks)
+	})
+
+	t.Run("invalid CIDR makes UseViper fail", func(t *testing.T) {
+		cfg := viper.New()
+		cfg.Set("safe_http.trusted_private_networks", []string{"not-a-cidr"})
+		err := UseViper(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid safe_http.trusted_private_networks config")
+	})
+
+	t.Run("empty config keeps strict defaults", func(t *testing.T) {
+		cfg := viper.New()
+		require.NoError(t, UseViper(cfg))
+		assert.Empty(t, GetConfig().SafeHTTPTrustedNetworks)
+	})
+
+	t.Run("missing key keeps strict defaults", func(t *testing.T) {
+		cfg := viper.New()
+		cfg.Set("host", "localhost")
+		require.NoError(t, UseViper(cfg))
+		assert.Empty(t, GetConfig().SafeHTTPTrustedNetworks)
+	})
 }

--- a/pkg/config/config/testdata/full_config.yaml
+++ b/pkg/config/config/testdata/full_config.yaml
@@ -115,6 +115,12 @@ clouderies:
       url: https://manager-url
       token: manager-token
 
+safe_http:
+  trusted_private_networks:
+    - 10.0.0.0/8
+    - 172.16.0.0/12
+    - 192.168.0.0/16
+
 rabbitmq:
   enabled: true
   nodes:

--- a/pkg/safehttp/client.go
+++ b/pkg/safehttp/client.go
@@ -2,17 +2,48 @@
 // not trusted (user inputs). It will avoid SSRF by ensuring that the IP
 // address which will connect is not a private address, or loopback. It also
 // checks that the port is 80 or 443, not anything else.
+//
+// Operators can configure trusted private networks (CIDRs) to allow safehttp
+// callers to reach private addresses in closed-network deployments.
 package safehttp
 
 import (
 	"fmt"
 	"net"
 	"net/http"
+	"sync/atomic"
 	"syscall"
 	"time"
 
 	build "github.com/cozy/cozy-stack/pkg/config"
 )
+
+// trustedPrivateNetworks holds the parsed CIDRs that are allowed to bypass
+// private-IP and port restrictions. Set once at startup via
+// SetTrustedPrivateNetworks. Stored as an atomic.Value to avoid data races
+// between config/test setup and concurrent outbound requests.
+var trustedPrivateNetworks atomic.Value // holds []*net.IPNet
+
+// SetTrustedPrivateNetworks parses the given CIDR strings and stores them for
+// use by safeControl. It should be called once at startup. If any CIDR is
+// invalid, it returns an error and does not update the allowlist.
+func SetTrustedPrivateNetworks(cidrs []string) error {
+	nets := make([]*net.IPNet, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		_, ipnet, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return fmt.Errorf("invalid trusted private network CIDR %q: %w", cidr, err)
+		}
+		nets = append(nets, ipnet)
+	}
+	trustedPrivateNetworks.Store(nets)
+	return nil
+}
+
+func loadTrustedNetworks() []*net.IPNet {
+	nets, _ := trustedPrivateNetworks.Load().([]*net.IPNet)
+	return nets
+}
 
 var safeDialer = &net.Dialer{
 	Timeout:   30 * time.Second,
@@ -81,6 +112,14 @@ func safeControl(network string, address string, conn syscall.RawConn) error {
 		return fmt.Errorf("%s is not a valid IP address", host)
 	}
 
+	// Trusted private networks bypass private-IP, loopback, and port
+	// restrictions only for private or loopback destinations. This is for
+	// closed-network deployments where internal services run on private
+	// addresses and non-standard ports.
+	if (ipaddress.IsPrivate() || ipaddress.IsLoopback()) && isInTrustedNetwork(ipaddress) {
+		return nil
+	}
+
 	if ipaddress.IsPrivate() {
 		return fmt.Errorf("%s is not a public IP address", ipaddress)
 	}
@@ -101,4 +140,13 @@ func safeControl(network string, address string, conn syscall.RawConn) error {
 	}
 
 	return nil
+}
+
+func isInTrustedNetwork(ip net.IP) bool {
+	for _, ipnet := range loadTrustedNetworks() {
+		if ipnet.Contains(ip) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/safehttp/client_test.go
+++ b/pkg/safehttp/client_test.go
@@ -23,3 +23,128 @@ func TestDefaultClient(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "is not a safe port")
 }
+
+func TestSetTrustedPrivateNetworks(t *testing.T) {
+	t.Run("invalid CIDR returns error", func(t *testing.T) {
+		err := SetTrustedPrivateNetworks([]string{"not-a-cidr"})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid trusted private network CIDR")
+	})
+
+	t.Run("valid CIDRs are accepted", func(t *testing.T) {
+		err := SetTrustedPrivateNetworks([]string{"10.0.0.0/8", "192.168.0.0/16"})
+		assert.NoError(t, err)
+		t.Cleanup(resetTrustedNetworks)
+	})
+
+	t.Run("invalid CIDR does not change existing allowlist", func(t *testing.T) {
+		err := SetTrustedPrivateNetworks([]string{"10.0.0.0/8"})
+		require.NoError(t, err)
+		require.Len(t, loadTrustedNetworks(), 1)
+
+		err = SetTrustedPrivateNetworks([]string{"bad"})
+		require.Error(t, err)
+		// The previous valid config is still in place.
+		assert.Len(t, loadTrustedNetworks(), 1)
+		t.Cleanup(resetTrustedNetworks)
+	})
+
+	t.Run("empty list clears allowlist", func(t *testing.T) {
+		err := SetTrustedPrivateNetworks([]string{"10.0.0.0/8"})
+		require.NoError(t, err)
+
+		err = SetTrustedPrivateNetworks([]string{})
+		require.NoError(t, err)
+		assert.Empty(t, loadTrustedNetworks())
+	})
+}
+
+func resetTrustedNetworks() {
+	_ = SetTrustedPrivateNetworks(nil)
+}
+
+func TestSafeControl(t *testing.T) {
+	build.BuildMode = build.ModeProd
+	t.Cleanup(resetTrustedNetworks)
+
+	t.Run("private IP blocked by default", func(t *testing.T) {
+		err := safeControl("tcp4", "192.168.1.1:80", nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "is not a public IP address")
+	})
+
+	t.Run("loopback blocked by default", func(t *testing.T) {
+		err := safeControl("tcp4", "127.0.0.1:80", nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "is not a public IP address")
+	})
+
+	t.Run("private IP allowed when inside configured CIDR", func(t *testing.T) {
+		require.NoError(t, SetTrustedPrivateNetworks([]string{"192.168.0.0/16"}))
+		err := safeControl("tcp4", "192.168.1.1:80", nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("private IP on non-standard port allowed when inside configured CIDR", func(t *testing.T) {
+		require.NoError(t, SetTrustedPrivateNetworks([]string{"10.0.0.0/8"}))
+		err := safeControl("tcp4", "10.0.0.1:8080", nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("private IP outside configured CIDR remains blocked", func(t *testing.T) {
+		require.NoError(t, SetTrustedPrivateNetworks([]string{"10.0.0.0/8"}))
+		err := safeControl("tcp4", "192.168.1.1:80", nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "is not a public IP address")
+	})
+
+	t.Run("loopback allowed only if explicitly configured", func(t *testing.T) {
+		require.NoError(t, SetTrustedPrivateNetworks([]string{"192.168.0.0/16"}))
+		err := safeControl("tcp4", "127.0.0.1:80", nil)
+		assert.Error(t, err)
+
+		require.NoError(t, SetTrustedPrivateNetworks([]string{"127.0.0.0/8"}))
+		err = safeControl("tcp4", "127.0.0.1:80", nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("link-local remains blocked even with trusted networks", func(t *testing.T) {
+		require.NoError(t, SetTrustedPrivateNetworks([]string{"0.0.0.0/0"}))
+		err := safeControl("tcp4", "169.254.1.1:80", nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "is not a valid IP address")
+	})
+
+	t.Run("unspecified address remains blocked even with trusted networks", func(t *testing.T) {
+		require.NoError(t, SetTrustedPrivateNetworks([]string{"0.0.0.0/0"}))
+		err := safeControl("tcp4", "0.0.0.0:80", nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "is not a valid IP address")
+	})
+
+	t.Run("unsupported network type rejected", func(t *testing.T) {
+		err := safeControl("udp", "10.0.0.1:80", nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "is not a safe network type")
+	})
+
+	t.Run("public IP on non-standard port still blocked", func(t *testing.T) {
+		require.NoError(t, SetTrustedPrivateNetworks([]string{"10.0.0.0/8"}))
+		err := safeControl("tcp4", "8.8.8.8:8080", nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "is not a safe port number")
+	})
+
+	t.Run("public IP on non-standard port blocked even with broad trusted CIDR", func(t *testing.T) {
+		require.NoError(t, SetTrustedPrivateNetworks([]string{"0.0.0.0/0"}))
+		err := safeControl("tcp4", "8.8.8.8:8080", nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "is not a safe port number")
+	})
+
+	t.Run("IPv6 private address with matching CIDR", func(t *testing.T) {
+		require.NoError(t, SetTrustedPrivateNetworks([]string{"::1/128"}))
+		err := safeControl("tcp6", "[::1]:8080", nil)
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
## Context

Some deployments run Cozy services on a closed private network. In those setups, safehttp currently blocks calls to internal services because their hosts resolve to private IPs.

This adds an explicit opt-in allowlist for those deployments. By default nothing changes: private IPs are still blocked unless an operator configures trusted private CIDRs.

## Changes

- Add `safe_http.trusted_private_networks` to the global config.
- Load and validate the configured CIDRs at startup.
- Allow safehttp calls to private or loopback IPs inside those CIDRs, including custom ports.
- Keep public custom ports, link-local addresses, unspecified addresses, malformed addresses, and unsupported networks blocked.

