### PR TITLE
fix: resolve same-stack sharing peers by local instance lookup

### DIFF
--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/metadata"
 	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/cozy/cozy-stack/pkg/realtime"
+	"github.com/cozy/cozy-stack/pkg/utils"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/labstack/echo/v4"
 )
@@ -1350,20 +1351,19 @@ func (s *Sharing) ReplicateDescriptionChange(inst *instance.Instance) {
 			continue
 		}
 
-		// Optimization: use direct database update for recipients on the same stack
-		if IsSameStack(inst, m.Instance) {
-			err = s.UpdateDescriptionSameStack(inst, m.Instance, s.Description)
-			if err != nil {
-				inst.Logger().WithNamespace("sharing").
-					Warnf("Can't update description directly for same-stack recipient %s: %s", m.Instance, err)
-				errors = append(errors, fmt.Errorf("failed to update same-stack recipient %s: %w", m.Instance, err))
+		if recipientInst := LocalInstanceFromURL(m.Instance); recipientInst != nil {
+			recipientSharing, localErr := FindSharing(recipientInst, s.SID)
+			if localErr == nil {
+				localErr = recipientSharing.PatchDescription(recipientInst, s.Description)
+			}
+			if localErr == nil {
+				successCount++
 				continue
 			}
-			successCount++
-			continue
+			inst.Logger().WithNamespace("sharing").
+				Warnf("Same-stack update failed for %s, falling through to HTTP: %s", m.Instance, localErr)
 		}
 
-		// Fall back to HTTP request for cross-stack recipients
 		opts := &request.Options{
 			Method: http.MethodPut,
 			Scheme: u.Scheme,
@@ -1411,48 +1411,35 @@ func shouldReplicateDescriptionChange(i int, m Member) bool {
 	return i > 0 && m.Status == MemberStatusReady && m.Instance != ""
 }
 
-// IsSameStack checks if the recipient instance is on the same stack as the owner instance
-func IsSameStack(ownerInst *instance.Instance, recipientURL string) bool {
-	u, err := url.Parse(recipientURL)
-	if err != nil {
-		return false
+// LocalInstanceFromURL returns the local instance for the given URL, or nil.
+func LocalInstanceFromURL(rawURL string) *instance.Instance {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return nil
 	}
-
-	// Extract port from both domains for comparison
-	var ownerPort, recipientPort string
-	ownerParts := strings.SplitN(ownerInst.Domain, ":", 2)
-	if len(ownerParts) > 1 {
-		ownerPort = ownerParts[1]
-	}
-	recipientParts := strings.SplitN(u.Host, ":", 2)
-	if len(recipientParts) > 1 {
-		recipientPort = recipientParts[1]
-	}
-
-	// Same stack if ports match (both instances running on same port)
-	return ownerPort == recipientPort
+	return LocalInstanceFromHost(u.Host)
 }
 
-// UpdateDescriptionSameStack directly updates the sharing description for recipients on the same stack
-func (s *Sharing) UpdateDescriptionSameStack(ownerInst *instance.Instance, recipientURL string, description string) error {
-	u, err := url.Parse(recipientURL)
-	if err != nil {
-		return err
+// LocalInstanceFromHost returns the local instance for the given host, or nil.
+// The host may include a port (e.g. "example.com:8080"). The exact host is
+// tried first, then a normalized host without port is tried as a fallback.
+func LocalInstanceFromHost(host string) *instance.Instance {
+	if host == "" {
+		return nil
+	}
+	if inst, err := lifecycle.GetInstance(host); err == nil {
+		return inst
 	}
 
-	// Get the recipient instance directly from the same stack
-	recipientInst, err := lifecycle.GetInstance(u.Host)
-	if err != nil {
-		return err
+	domain := utils.ExtractInstanceHost(host)
+	if domain == "" || domain == host {
+		return nil
 	}
-
-	// Find the sharing document on the recipient's instance
-	recipientSharing, err := FindSharing(recipientInst, s.SID)
+	inst, err := lifecycle.GetInstance(domain)
 	if err != nil {
-		return err
+		return nil
 	}
-
-	return recipientSharing.PatchDescription(recipientInst, description)
+	return inst
 }
 
 // AddShortcut creates a shortcut for this sharing on the local instance.

--- a/model/sharing/upload.go
+++ b/model/sharing/upload.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/cozy/cozy-stack/client/request"
 	"github.com/cozy/cozy-stack/model/instance"
-	"github.com/cozy/cozy-stack/model/instance/lifecycle"
 	"github.com/cozy/cozy-stack/model/vfs"
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
@@ -349,8 +348,7 @@ func (s *Sharing) uploadFile(inst *instance.Instance, m *Member, file map[string
 		return ErrInternalServerError
 	}
 
-	dstInstance, err := lifecycle.GetInstance(m.InstanceHost())
-	if err == nil && onSameStack(inst, dstInstance) {
+	if dstInstance := LocalInstanceFromHost(m.InstanceHost()); dstInstance != nil && uploadStoreIsShared() {
 		err := s.optimizedUploadFile(inst, dstInstance, m, fileDoc, file, resBody)
 		if err != nil {
 			inst.Logger().WithNamespace("upload").
@@ -389,19 +387,6 @@ func (s *Sharing) uploadFile(inst *instance.Instance, m *Member, file map[string
 	}
 	res2.Body.Close()
 	return nil
-}
-
-func onSameStack(src, dst *instance.Instance) bool {
-	var srcPort, dstPort string
-	parts := strings.SplitN(src.Domain, ":", 2)
-	if len(parts) > 1 {
-		srcPort = parts[1]
-	}
-	parts = strings.SplitN(dst.Domain, ":", 2)
-	if len(parts) > 1 {
-		dstPort = parts[1]
-	}
-	return srcPort == dstPort
 }
 
 func (s *Sharing) optimizedUploadFile(

--- a/model/sharing/upload_store.go
+++ b/model/sharing/upload_store.go
@@ -18,6 +18,7 @@ import (
 type UploadStore interface {
 	Get(db prefixer.Prefixer, key string) (*FileDocWithRevisions, error)
 	Save(db prefixer.Prefixer, doc *FileDocWithRevisions) (string, error)
+	IsShared() bool
 }
 
 // uploadStoreTTL is the time an entry stay alive
@@ -46,6 +47,10 @@ func getStore() UploadStore {
 	return globalStore
 }
 
+func uploadStoreIsShared() bool {
+	return getStore().IsShared()
+}
+
 type memRef struct {
 	val *FileDocWithRevisions
 	exp time.Time
@@ -60,6 +65,10 @@ func newMemStore() UploadStore {
 type memStore struct {
 	mu   sync.Mutex
 	vals map[string]*memRef
+}
+
+func (s *memStore) IsShared() bool {
+	return false
 }
 
 func (s *memStore) cleaner() {
@@ -101,6 +110,10 @@ func (s *memStore) Save(db prefixer.Prefixer, doc *FileDocWithRevisions) (string
 type redisStore struct {
 	c   redis.UniversalClient
 	ctx context.Context
+}
+
+func (s *redisStore) IsShared() bool {
+	return true
 }
 
 func (s *redisStore) Get(db prefixer.Prefixer, key string) (*FileDocWithRevisions, error) {

--- a/model/sharing/upload_store_test.go
+++ b/model/sharing/upload_store_test.go
@@ -1,0 +1,12 @@
+package sharing
+
+import "testing"
+
+func TestUploadStoreIsShared(t *testing.T) {
+	if (&memStore{}).IsShared() {
+		t.Fatal("memory upload store must not be shared")
+	}
+	if !(&redisStore{}).IsShared() {
+		t.Fatal("redis upload store must be shared")
+	}
+}

--- a/web/sharings/move.go
+++ b/web/sharings/move.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cozy/cozy-stack/client"
 	"github.com/cozy/cozy-stack/client/request"
 	"github.com/cozy/cozy-stack/model/instance"
-	"github.com/cozy/cozy-stack/model/instance/lifecycle"
 	"github.com/cozy/cozy-stack/model/sharing"
 	"github.com/cozy/cozy-stack/model/vfs"
 	"github.com/cozy/cozy-stack/pkg/consts"
@@ -134,13 +133,19 @@ func MoveHandler(c echo.Context) error {
 		return err
 	}
 
-	sourceInstance, err := resolveInstanceOrCurrent(req.Source.Instance, inst)
-	if err != nil {
-		return err
+	sourceInstance := inst
+	if req.Source.Instance != "" {
+		if err := validateInstanceURL(req.Source.Instance); err != nil {
+			return err
+		}
+		sourceInstance = LocalInstanceFromURL(req.Source.Instance)
 	}
-	destInstance, err := resolveInstanceOrCurrent(req.Dest.Instance, inst)
-	if err != nil {
-		return err
+	destInstance := inst
+	if req.Dest.Instance != "" {
+		if err := validateInstanceURL(req.Dest.Instance); err != nil {
+			return err
+		}
+		destInstance = LocalInstanceFromURL(req.Dest.Instance)
 	}
 
 	moveDirectory := req.Source.DirID != ""
@@ -157,7 +162,7 @@ func MoveHandler(c echo.Context) error {
 		if err := validateFileBackedDriveMoveCopy(req, sourceSharing, destSharing); err != nil {
 			return err
 		}
-		if OnSameStackCheck(sourceInstance, destInstance) {
+		if sourceInstance != nil && destInstance != nil {
 			if moveDirectory {
 				return moveDirSameStack(c, sourceInstance, destInstance, req.Source.DirID, req.Dest.DirID, destSharing, req.Copy)
 			} else {
@@ -177,7 +182,7 @@ func MoveHandler(c echo.Context) error {
 		if err := validateFileBackedDriveMoveCopy(req, s, nil); err != nil {
 			return err
 		}
-		if OnSameStackCheck(sourceInstance, destInstance) {
+		if sourceInstance != nil && destInstance != nil {
 			if moveDirectory {
 				return moveDirSameStack(c, sourceInstance, destInstance, req.Source.DirID, req.Dest.DirID, nil, req.Copy)
 			} else {
@@ -185,9 +190,9 @@ func MoveHandler(c echo.Context) error {
 			}
 		} else {
 			if moveDirectory {
-				return moveDirFromSharedDrive(c, destInstance, req.Source.Instance, req.Source.DirID, req.Dest.DirID, s, req.Copy)
+				return moveDirFromSharedDrive(c, inst, req.Source.Instance, req.Source.DirID, req.Dest.DirID, s, req.Copy)
 			}
-			return moveFileFromSharedDrive(c, destInstance, req.Source.Instance, req.Source.FileID, req.Dest.DirID, s, req.Copy)
+			return moveFileFromSharedDrive(c, inst, req.Source.Instance, req.Source.FileID, req.Dest.DirID, s, req.Copy)
 		}
 	} else if req.Source.Instance == "" && req.Dest.Instance != "" {
 		s, err := checkSharedDrivePermission(inst, req.Dest.SharingID, true)
@@ -197,7 +202,7 @@ func MoveHandler(c echo.Context) error {
 		if err := validateFileBackedDriveMoveCopy(req, nil, s); err != nil {
 			return err
 		}
-		if OnSameStackCheck(sourceInstance, destInstance) {
+		if sourceInstance != nil && destInstance != nil {
 			if moveDirectory {
 				return moveDirSameStack(c, sourceInstance, destInstance, req.Source.DirID, req.Dest.DirID, s, req.Copy)
 			} else {
@@ -205,9 +210,9 @@ func MoveHandler(c echo.Context) error {
 			}
 		} else {
 			if moveDirectory {
-				return moveDirToSharedDrive(c, sourceInstance, req.Source.DirID, req.Dest.DirID, s, req.Copy)
+				return moveDirToSharedDrive(c, inst, req.Source.DirID, req.Dest.DirID, s, req.Copy)
 			}
-			return moveFileToSharedDrive(c, sourceInstance, req.Dest.DirID, req.Source.FileID, s, req.Copy)
+			return moveFileToSharedDrive(c, inst, req.Dest.DirID, req.Source.FileID, s, req.Copy)
 		}
 	} else {
 		return jsonapi.BadRequest(errors.New("to move files inside personal drive use patch function"))
@@ -868,50 +873,16 @@ func moveFileBetweenSharedDrives(c echo.Context, sourceInstanceURL, fileID strin
 	return respondRemoteUpload(c, uploaded, destSharing.ID())
 }
 
-func getInstanceIdentifierFromURL(urlStr string) (*instance.Instance, error) {
-	u, err := url.Parse(urlStr)
-	if err != nil {
-		return nil, err
-	}
-	// Try to get the real instance first (for same-stack operations)
-	inst, err := lifecycle.GetInstance(u.Host)
-	if err == nil {
-		return inst, nil
-	}
-	// If not found locally, return a minimal instance (for cross-stack operations)
-	return &instance.Instance{Domain: u.Host}, nil
-}
+// LocalInstanceFromURL allows tests to replace same-stack detection.
+var LocalInstanceFromURL = sharing.LocalInstanceFromURL
 
-// resolveInstanceOrCurrent returns the instance resolved from the given URL,
-// or the provided current instance when the URL is empty. Invalid URLs are
-// reported as a BadRequest error suitable for handlers.
-func resolveInstanceOrCurrent(urlStr string, current *instance.Instance) (*instance.Instance, error) {
-	if urlStr == "" {
-		return current, nil
+func validateInstanceURL(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return jsonapi.BadRequest(errors.New("invalid instance URL"))
 	}
-	inst, err := getInstanceIdentifierFromURL(urlStr)
-	if err != nil {
-		return nil, jsonapi.BadRequest(errors.New("invalid instance URL"))
-	}
-	return inst, nil
+	return nil
 }
-
-func onSameStack(src, dst *instance.Instance) bool {
-	var srcPort, dstPort string
-	parts := strings.SplitN(src.Domain, ":", 2)
-	if len(parts) > 1 {
-		srcPort = parts[1]
-	}
-	parts = strings.SplitN(dst.Domain, ":", 2)
-	if len(parts) > 1 {
-		dstPort = parts[1]
-	}
-	return srcPort == dstPort
-}
-
-// OnSameStackCheck allows tests to replace same-stack detection logic.
-// Default points to onSameStack; tests may replace it.
-var OnSameStackCheck = onSameStack
 
 // NewRemoteClient allows tests to inject custom client behavior for cross-stack operations.
 var NewRemoteClient = func(u *url.URL, bearerToken string) *client.Client {

--- a/web/sharings/move_test.go
+++ b/web/sharings/move_test.go
@@ -128,13 +128,15 @@ func setupSharedDrivesEnvWithOwnerOptions(t *testing.T, ownerOptions *lifecycle.
 
 func forceCrossStack(t *testing.T, baseURL string) func() {
 	t.Helper()
-	prevSameStack := sharings.OnSameStackCheck
+	prevLocal := sharings.LocalInstanceFromURL
 	prevClient := sharings.NewRemoteClient
 	u, _ := url.Parse(baseURL)
-	sharings.OnSameStackCheck = func(_, _ *instance.Instance) bool { return false }
+	sharings.LocalInstanceFromURL = func(rawURL string) *instance.Instance {
+		return nil
+	}
 	sharings.NewRemoteClient = mockAcmeClient(u)
 	return func() {
-		sharings.OnSameStackCheck = prevSameStack
+		sharings.LocalInstanceFromURL = prevLocal
 		sharings.NewRemoteClient = prevClient
 	}
 }
@@ -1008,6 +1010,24 @@ func TestSharedDrivesMove(t *testing.T) {
 		_ = postMoveExpectStatus(t, eB, env.bettyToken, `{
 			  "source": {"file_id": "`+fileID+`"},
 			  "dest": {"dir_id": "`+env.productDirID+`"}
+		}`, 400)
+	})
+
+	t.Run("BadRequest_InvalidSourceInstanceURL", func(t *testing.T) {
+		_, eB, _ := env.createClients(t)
+		fileID := createFile(t, eB, "", "file-bad-src-url.txt", env.bettyToken)
+		_ = postMoveExpectStatus(t, eB, env.bettyToken, `{
+			  "source": {"instance": "not-a-url", "file_id": "`+fileID+`", "sharing_id": "`+env.firstSharingID+`"},
+			  "dest": {"dir_id": "`+env.productDirID+`"}
+		}`, 400)
+	})
+
+	t.Run("BadRequest_InvalidDestInstanceURL", func(t *testing.T) {
+		_, eB, _ := env.createClients(t)
+		fileID := createFile(t, eB, "", "file-bad-dst-url.txt", env.bettyToken)
+		_ = postMoveExpectStatus(t, eB, env.bettyToken, `{
+			  "source": {"file_id": "`+fileID+`"},
+			  "dest": {"instance": "://broken", "dir_id": "`+env.productDirID+`", "sharing_id": "`+env.firstSharingID+`"}
 		}`, 400)
 	})
 


### PR DESCRIPTION
## Context

Some sharing flows need to know when two Cozy instances are served by the same cozy-stack process.

The old same-stack check only compared ports. In production, instance URLs usually do not include a port, so the check could give wrong results. This affected sharing flows like auto-acceptance and description updates: instances that should have been handled locally could be treated as remote, and remote recipients could also be wrongly sent through the local path.

For description updates, this was especially problematic: when the local update path failed, the code did not fall back to the HTTP path, so the update was not sent.

## Changes

- Replace port-based same-stack checks with local instance lookup.
- Add helpers to resolve a local instance from a sharing URL or host.
- Use the local path only when the target instance really exists on this stack.
- Fall back to HTTP when a local description update fails.
- Remove fake remote `instance.Instance` values from shared-drive move logic.
