### PR TITLE
fix: stabilize flaky unit tests in ci

### DIFF
--- a/model/move/sharing_test.go
+++ b/model/move/sharing_test.go
@@ -37,11 +37,6 @@ func TestUpdateSelfMemberInstance(t *testing.T) {
 	setup := testutils.NewSetup(t, t.Name())
 	inst := setup.GetTestInstance()
 
-	// Clean up sharings database
-	_ = couchdb.DeleteDB(inst, consts.Sharings)
-	err := couchdb.CreateDB(inst, consts.Sharings)
-	require.NoError(t, err)
-
 	newInstance := inst.PageURL("", nil)
 	oldDomain := "old-domain.mycozy.cloud"
 
@@ -49,6 +44,7 @@ func TestUpdateSelfMemberInstance(t *testing.T) {
 	inst.OldDomain = oldDomain
 
 	t.Run("UpdateOwnerMemberInstance", func(t *testing.T) {
+		var err error
 		// Create a sharing where we are the owner with old instance URL
 		s := &sharing.Sharing{
 			SID:   uuidv7(),
@@ -85,6 +81,7 @@ func TestUpdateSelfMemberInstance(t *testing.T) {
 	})
 
 	t.Run("UpdateRecipientMemberInstance", func(t *testing.T) {
+		var err error
 		// Create a sharing where we are a recipient with old instance URL
 		s := &sharing.Sharing{
 			SID:   uuidv7(),
@@ -126,6 +123,7 @@ func TestUpdateSelfMemberInstance(t *testing.T) {
 	})
 
 	t.Run("SkipWhenNoOldDomain", func(t *testing.T) {
+		var err error
 		// Clear OldDomain to test skip behavior
 		inst.OldDomain = ""
 
@@ -159,6 +157,7 @@ func TestUpdateSelfMemberInstance(t *testing.T) {
 	})
 
 	t.Run("SkipAlreadyUpdatedSharing", func(t *testing.T) {
+		var err error
 		// Create a sharing where the instance URL is already correct
 		s := &sharing.Sharing{
 			SID:   uuidv7(),
@@ -187,6 +186,7 @@ func TestUpdateSelfMemberInstance(t *testing.T) {
 	})
 
 	t.Run("NoFalsePositiveSubstringMatch", func(t *testing.T) {
+		var err error
 		// Test that a member with a domain containing OldDomain as substring
 		// is NOT matched (e.g., alice-old-domain.mycozy.cloud should not match old-domain.mycozy.cloud)
 		s := &sharing.Sharing{

--- a/web/sharings/drives_test.go
+++ b/web/sharings/drives_test.go
@@ -4471,6 +4471,16 @@ func TestSharedDriveGroupDynamicMembership(t *testing.T) {
 	// Now update the owner's URL in Alice's sharing document
 	FakeOwnerInstanceForSharing(t, aliceInstance, tsOwner.URL, sharingID)
 
+	// The auto-accept job may have already been enqueued and run with the
+	// previous (domain-based) URL, which fails with a DNS error in tests
+	// since the owner's domain does not resolve. Re-enqueue the auto-accept
+	// job with the updated URL so that the sharing is actually accepted.
+	var aliceSharing sharing.Sharing
+	require.NoError(t, couchdb.GetDoc(aliceInstance, consts.Sharings, sharingID, &aliceSharing))
+	if len(aliceSharing.Credentials) > 0 && aliceSharing.Credentials[0].State != "" {
+		require.NoError(t, sharing.EnqueueAutoAccept(aliceInstance, sharingID, aliceSharing.Credentials[0].State))
+	}
+
 	// Step 7: Wait for Alice's sharing to be auto-accepted
 	require.Eventually(t, func() bool {
 		var s sharing.Sharing


### PR DESCRIPTION
## Summary

- Drop the redundant sharings database teardown in TestUpdateSelfMemberInstance that occasionally failed in CI with a CouchDB file_exists error.
- Re-enqueue the auto-accept job in TestSharedDriveGroupDynamicMembership after faking the owner URL so the sharing is accepted via the test server URL even when the original auto-accept job already ran with the unresolvable domain URL.