### PR TITLE
fix: stale shared drive references

### DIFF
--- a/model/sharing/files.go
+++ b/model/sharing/files.go
@@ -357,6 +357,58 @@ func (s *Sharing) AddReferenceForSharing(inst *instance.Instance, rule *Rule) er
 	return fs.UpdateFileDoc(olddoc, file)
 }
 
+// RemoveReferenceForSharing removes the reference to the sharing from its root
+// file or folder. It is a no-op when the root is already gone.
+func (s *Sharing) RemoveReferenceForSharing(inst *instance.Instance, rule *Rule) error {
+	if rule == nil || rule.Selector == couchdb.SelectorReferencedBy || len(rule.Values) == 0 {
+		return nil
+	}
+
+	indexer := vfs.NewCouchdbIndexer(inst)
+	parts := strings.Split(rule.Values[0], "/")
+	dir, file, err := indexer.DirOrFileByID(parts[len(parts)-1])
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) || couchdb.IsNotFoundError(err) {
+			return nil
+		}
+		inst.Logger().WithNamespace("sharing").
+			Warnf("RemoveReferenceForSharing failed to find root: %s", err)
+		return err
+	}
+	if dir == nil && file == nil {
+		return nil
+	}
+
+	ref := couchdb.DocReference{
+		ID:   s.SID,
+		Type: consts.Sharings,
+	}
+
+	if dir != nil {
+		newdoc := dir.Clone().(*vfs.DirDoc)
+		before := len(newdoc.ReferencedBy)
+		newdoc.RemoveReferencedBy(ref)
+		if len(newdoc.ReferencedBy) == before {
+			return nil
+		}
+		if newdoc.CozyMetadata != nil {
+			newdoc.CozyMetadata.UpdatedAt = time.Now()
+		}
+		return indexer.UpdateDirDoc(dir, newdoc)
+	}
+
+	newdoc := file.Clone().(*vfs.FileDoc)
+	before := len(newdoc.ReferencedBy)
+	newdoc.RemoveReferencedBy(ref)
+	if len(newdoc.ReferencedBy) == before {
+		return nil
+	}
+	if newdoc.CozyMetadata != nil {
+		newdoc.CozyMetadata.UpdatedAt = time.Now()
+	}
+	return indexer.UpdateFileDoc(file, newdoc)
+}
+
 // ValidateDriveRoot validates that a file or folder can be used to create a
 // shared drive.
 func ValidateDriveRoot(inst *instance.Instance, rootID string) (*vfs.DirDoc, *vfs.FileDoc, error) {

--- a/model/sharing/files.go
+++ b/model/sharing/files.go
@@ -273,10 +273,7 @@ func (s *Sharing) CreateDirForSharing(inst *instance.Instance, rule *Rule, paren
 	}
 	parts := strings.Split(rule.Values[0], "/")
 	dir.DocID = parts[len(parts)-1]
-	dir.AddReferencedBy(couchdb.DocReference{
-		ID:   s.SID,
-		Type: consts.Sharings,
-	})
+	dir.AddReferencedBy(s.DocReference())
 	dir.CozyMetadata = vfs.NewCozyMetadata(inst.PageURL("/", nil))
 	basename := dir.DocName
 	for i := 2; i < 20; i++ {
@@ -286,10 +283,7 @@ func (s *Sharing) CreateDirForSharing(inst *instance.Instance, rule *Rule, paren
 		if couchdb.IsConflictError(err) || errors.Is(err, os.ErrExist) {
 			doc, err := fs.DirByID(dir.DocID)
 			if err == nil {
-				doc.AddReferencedBy(couchdb.DocReference{
-					ID:   s.SID,
-					Type: consts.Sharings,
-				})
+				doc.AddReferencedBy(s.DocReference())
 				_ = couchdb.UpdateDoc(inst, doc)
 				return doc, nil
 			}
@@ -319,15 +313,12 @@ func (s *Sharing) AddReferenceForSharing(inst *instance.Instance, rule *Rule) er
 
 	if dir != nil {
 		for _, ref := range dir.ReferencedBy {
-			if ref.Type == consts.Sharings && ref.ID == s.SID {
+			if ref == s.DocReference() {
 				return nil
 			}
 		}
 		olddoc := dir.Clone().(*vfs.DirDoc)
-		dir.AddReferencedBy(couchdb.DocReference{
-			ID:   s.SID,
-			Type: consts.Sharings,
-		})
+		dir.AddReferencedBy(s.DocReference())
 		if dir.CozyMetadata == nil {
 			dir.CozyMetadata = vfs.NewCozyMetadata(inst.PageURL("/", nil))
 		} else {
@@ -340,15 +331,12 @@ func (s *Sharing) AddReferenceForSharing(inst *instance.Instance, rule *Rule) er
 		return nil
 	}
 	for _, ref := range file.ReferencedBy {
-		if ref.Type == consts.Sharings && ref.ID == s.SID {
+		if ref == s.DocReference() {
 			return nil
 		}
 	}
 	olddoc := file.Clone().(*vfs.FileDoc)
-	file.AddReferencedBy(couchdb.DocReference{
-		ID:   s.SID,
-		Type: consts.Sharings,
-	})
+	file.AddReferencedBy(s.DocReference())
 	if file.CozyMetadata == nil {
 		file.CozyMetadata = vfs.NewCozyMetadata(inst.PageURL("/", nil))
 	} else {
@@ -379,10 +367,7 @@ func (s *Sharing) RemoveReferenceForSharing(inst *instance.Instance, rule *Rule)
 		return nil
 	}
 
-	ref := couchdb.DocReference{
-		ID:   s.SID,
-		Type: consts.Sharings,
-	}
+	ref := s.DocReference()
 
 	if dir != nil {
 		newdoc := dir.Clone().(*vfs.DirDoc)
@@ -595,10 +580,7 @@ func (s *Sharing) RemoveSharingDir(inst *instance.Instance) error {
 		return err
 	}
 	olddoc := dir.Clone().(*vfs.DirDoc)
-	dir.RemoveReferencedBy(couchdb.DocReference{
-		ID:   s.SID,
-		Type: consts.Sharings,
-	})
+	dir.RemoveReferencedBy(s.DocReference())
 	if dir.CozyMetadata == nil {
 		dir.CozyMetadata = vfs.NewCozyMetadata(inst.PageURL("/", nil))
 	} else {

--- a/model/sharing/invitation.go
+++ b/model/sharing/invitation.go
@@ -351,10 +351,7 @@ func (s *Sharing) CreateDriveShortcut(inst *instance.Instance, seen bool) error 
 		target["mime"] = rule.Mime
 		target["class"] = class
 	}
-	fileDoc.AddReferencedBy(couchdb.DocReference{
-		ID:   s.SID,
-		Type: consts.Sharings,
-	})
+	fileDoc.AddReferencedBy(s.DocReference())
 
 	fileDoc, err = s.createOrUpdateShortcut(inst, fileDoc, body)
 	if err != nil {
@@ -426,10 +423,7 @@ func (s *Sharing) CreateShortcut(inst *instance.Instance, previewURL string, see
 			"mime":  s.Rules[0].Mime,
 		},
 	}
-	fileDoc.AddReferencedBy(couchdb.DocReference{
-		ID:   s.SID,
-		Type: consts.Sharings,
-	})
+	fileDoc.AddReferencedBy(s.DocReference())
 
 	fileDoc, err = s.createOrUpdateShortcut(inst, fileDoc, body)
 	if err != nil {

--- a/model/sharing/revoke_trashed.go
+++ b/model/sharing/revoke_trashed.go
@@ -38,7 +38,7 @@ func revokeTrashed(db prefixer.Prefixer, sharingID string) {
 	log := inst.Logger().WithNamespace("sharing")
 	log.Infof("revokeTrashed called for sharing %s", sharingID)
 	if s.Owner {
-		err = s.Revoke(inst)
+		err = s.revoke(inst, revokeOptions{removeRootReference: false})
 		if err == nil && s.Drive {
 			err = couchdb.DeleteDoc(inst, s)
 			if couchdb.IsNotFoundError(err) {

--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -96,6 +96,14 @@ func (s *Sharing) Rev() string { return s.SRev }
 // DocType returns the sharing document type
 func (s *Sharing) DocType() string { return consts.Sharings }
 
+// DocReference returns the CouchDB reference for the sharing.
+func (s *Sharing) DocReference() couchdb.DocReference {
+	return couchdb.DocReference{
+		ID:   s.SID,
+		Type: s.DocType(),
+	}
+}
+
 // SetID changes the sharing qualified identifier
 func (s *Sharing) SetID(id string) { s.SID = id }
 

--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -600,6 +600,17 @@ func (s *Sharing) CreateRequest(inst *instance.Instance) error {
 // Revoke remove the credentials for all members, contact them, removes the
 // triggers and set the active flag to false.
 func (s *Sharing) Revoke(inst *instance.Instance) error {
+	return s.revoke(inst, revokeOptions{removeRootReference: true})
+}
+
+// revokeOptions keeps the revoke steps explicit for special callers. When the
+// shared root is already being trashed, the VFS update removes referenced_by,
+// so revoke must not update the root document again.
+type revokeOptions struct {
+	removeRootReference bool
+}
+
+func (s *Sharing) revoke(inst *instance.Instance, opts revokeOptions) error {
 	var errm error
 
 	if !s.Owner {
@@ -618,6 +629,11 @@ func (s *Sharing) Revoke(inst *instance.Instance) error {
 	}
 	if err := RemoveSharedRefs(inst, s.SID); err != nil {
 		return err
+	}
+	if opts.removeRootReference {
+		if err := s.RemoveReferenceForSharing(inst, s.FirstFilesRule()); err != nil {
+			return err
+		}
 	}
 	if s.PreviewPath != "" {
 		if err := s.RevokePreviewPermissions(inst); err != nil {
@@ -904,6 +920,9 @@ func (s *Sharing) NoMoreRecipient(inst *instance.Instance) error {
 		if err := RemoveSharedRefs(inst, s.SID); err != nil {
 			return err
 		}
+		if err := s.RemoveReferenceForSharing(inst, s.FirstFilesRule()); err != nil {
+			return err
+		}
 		if err := s.RevokeInteractPermissions(inst); err != nil {
 			return err
 		}
@@ -919,6 +938,9 @@ func (s *Sharing) NoMoreRecipient(inst *instance.Instance) error {
 		}
 	}
 	if err := s.RemoveTriggers(inst); err != nil {
+		return err
+	}
+	if err := s.RemoveReferenceForSharing(inst, s.FirstFilesRule()); err != nil {
 		return err
 	}
 	s.Active = false

--- a/model/sharing/upload.go
+++ b/model/sharing/upload.go
@@ -714,11 +714,7 @@ func (s *Sharing) UploadNewFile(
 	ref.Infos[s.SID] = SharedInfo{Rule: ruleIndex, Binary: true}
 	newdoc.ReferencedBy = buildReferencedBy(target.FileDoc, nil, rule)
 	if addReferencedBy {
-		ref := couchdb.DocReference{
-			ID:   s.SID,
-			Type: consts.Sharings,
-		}
-		newdoc.ReferencedBy = append(newdoc.ReferencedBy, ref)
+		newdoc.ReferencedBy = append(newdoc.ReferencedBy, s.DocReference())
 	}
 
 	err = create(fs, newdoc, nil)

--- a/web/sharings/drives_test.go
+++ b/web/sharings/drives_test.go
@@ -373,6 +373,28 @@ func createFileRootSharedDrive(
 	return
 }
 
+func requireNoDirSharingReference(t *testing.T, inst *instance.Instance, dirID, sharingID string) {
+	t.Helper()
+
+	dir, err := inst.VFS().DirByID(dirID)
+	require.NoError(t, err)
+	require.NotContains(t, dir.ReferencedBy, couchdb.DocReference{
+		ID:   sharingID,
+		Type: consts.Sharings,
+	})
+}
+
+func requireNoFileSharingReference(t *testing.T, inst *instance.Instance, fileID, sharingID string) {
+	t.Helper()
+
+	file, err := inst.VFS().FileByID(fileID)
+	require.NoError(t, err)
+	require.NotContains(t, file.ReferencedBy, couchdb.DocReference{
+		ID:   sharingID,
+		Type: consts.Sharings,
+	})
+}
+
 func makeAddRecipientsPayload(t *testing.T, sharingID, relationshipName string, contactIDs ...string) []byte {
 	t.Helper()
 
@@ -4116,8 +4138,30 @@ func TestSharedDriveRevocation(t *testing.T) {
 		}, 5*time.Second, 100*time.Millisecond, "Owner's drive sharing document should be deleted after the last recipient is revoked")
 	})
 
+	t.Run("OwnerRootReferenceIsRemoved", func(t *testing.T) {
+		requireNoDirSharingReference(t, env.acme, rootDirID, sharingID)
+	})
+
+	t.Run("OwnerRootCanBeSharedAgain", func(t *testing.T) {
+		eA, _, _ := env.createClients(t)
+
+		eA.POST("/sharings/drives").
+			WithHeader("Authorization", "Bearer "+env.acmeToken).
+			WithHeader("Content-Type", "application/vnd.api+json").
+			WithBytes([]byte(fmt.Sprintf(`{
+				"data": {
+					"type": "%s",
+					"attributes": {
+						"description": "Recreated drive after recipient revocation",
+						"folder_id": "%s"
+					}
+				}
+			}`, consts.Sharings, rootDirID))).
+			Expect().Status(http.StatusCreated)
+	})
+
 	t.Run("RevokeAllRecipientsDeletesOwnerSharing", func(t *testing.T) {
-		allSharingID, _, _ := createSharedDrive(
+		allSharingID, allRootDirID, _ := createSharedDrive(
 			t,
 			DriveCreationMethodLegacy,
 			env.acme,
@@ -4138,7 +4182,55 @@ func TestSharedDriveRevocation(t *testing.T) {
 			_, err := sharing.FindSharing(env.acme, allSharingID)
 			return couchdb.IsNotFoundError(err)
 		}, 5*time.Second, 100*time.Millisecond, "Owner's drive sharing document should be deleted after revoking all recipients")
+
+		requireNoDirSharingReference(t, env.acme, allRootDirID, allSharingID)
 	})
+}
+
+func TestFileRootSharedDriveLastRecipientRemovalCleansReference(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	env := setupSharedDrivesEnv(t)
+	eA, _, _ := env.createClients(t)
+
+	rootFileID := createFile(t, eA, "", "FileRootRevocationReference.txt", env.acmeToken)
+	sharingID, _ := createFileRootSharedDrive(
+		t,
+		env.acme,
+		env.acmeToken,
+		env.tsA.URL,
+		rootFileID,
+		"File root drive for reference cleanup",
+		[]RecipientInfo{{Name: "Betty", Email: "betty@example.net", ReadOnly: false}},
+	)
+	acceptSharedDriveForBetty(t, env.acme, env.betty, env.tsA.URL, env.tsB.URL, sharingID)
+
+	eA.DELETE("/sharings/"+sharingID+"/recipients/1").
+		WithHeader("Authorization", "Bearer "+env.acmeToken).
+		Expect().Status(http.StatusNoContent)
+
+	require.Eventually(t, func() bool {
+		_, err := sharing.FindSharing(env.acme, sharingID)
+		return couchdb.IsNotFoundError(err)
+	}, 5*time.Second, 100*time.Millisecond, "Owner's file-root drive sharing document should be deleted after the last recipient is revoked")
+
+	requireNoFileSharingReference(t, env.acme, rootFileID, sharingID)
+
+	eA.POST("/sharings/drives").
+		WithHeader("Authorization", "Bearer "+env.acmeToken).
+		WithHeader("Content-Type", "application/vnd.api+json").
+		WithBytes([]byte(fmt.Sprintf(`{
+			"data": {
+				"type": "%s",
+				"attributes": {
+					"description": "Recreated file root drive after recipient revocation",
+					"file_id": "%s"
+				}
+			}
+		}`, consts.Sharings, rootFileID))).
+		Expect().Status(http.StatusCreated)
 }
 
 func TestOpeningPendingSharedDriveShortcutClearsNewsCounter(t *testing.T) {


### PR DESCRIPTION
## Summary
- remove stale root `referenced_by` entries when sharings are fully revoked
- clean both directory-root and file-root shared drive references
- add regressions proving roots can be shared again after final recipient removal

## Root cause
Deleting a drive sharing after the last recipient was removed deleted the `io.cozy.sharings` document, but did not remove its id from the owner root file or folder `referenced_by`. That stale reference made later `POST /sharings/drives` fail with 409.
