### PR TITLE
exchange OIDC token for app token

### DIFF
--- a/cozy.example.yaml
+++ b/cozy.example.yaml
@@ -385,6 +385,29 @@ deprecated_apps:
 authorized_hosts_for_confirm_auth:
   - sometool.example.org
 
+# Authentication can be configured per context. The keys under "authentication"
+# are context names.
+authentication:
+  beta:
+    disable_password_authentication: false
+    oidc:
+      client_id: aClientID
+      client_secret: s3cret3
+      scope: openid profile
+      redirect_uri: https://oauthcallback.mycozy.cloud/oidc/redirect
+      authorize_url: https://identity-provider/path/to/authorize
+      token_url: https://identity-provider/path/to/token
+      userinfo_url: https://identity-provider/path/to/userinfo
+      userinfo_instance_field: cozy_number
+      id_token_jwk_url: https://identity-provider/path/to/jwk
+      allow_app_token_exchange: true
+      app_token_exchange:
+        # OIDC id_token audience.
+        twake-mail-web:
+          # Must be a Cozy linked application software_id. The local OAuth
+          # scope is derived from this linked app manifest.
+          software_id: registry://mail
+
 notifications:
   # Activate development APIs (iOS only)
   development: false
@@ -506,29 +529,6 @@ contexts:
     # permissions have changed
     additional_platform_apps:
       - superapp
-    # Authentication can be configured per context. This example shows an OIDC
-    # provider that allows a trusted frontend application to exchange its OIDC
-    # id_token for a local Cozy OAuth client/token bound to a linked application.
-    authentication:
-     the-context-name:
-       disable_password_authentication: false
-       oidc:
-         client_id: aClientID
-         client_secret: s3cret3
-         scope: openid profile
-         redirect_uri: https://oauthcallback.mycozy.cloud/oidc/redirect
-         authorize_url: https://identity-provider/path/to/authorize
-         token_url: https://identity-provider/path/to/token
-         userinfo_url: https://identity-provider/path/to/userinfo
-         userinfo_instance_field: cozy_number
-         id_token_jwk_url: https://identity-provider/path/to/jwk
-         allow_app_token_exchange: true
-         app_token_exchange:
-           # OIDC id_token audience.
-           twake-mail-web:
-             # Must be a Cozy linked application software_id. The local OAuth
-             # scope is derived from this linked app manifest.
-             software_id: registry://mail
     # Provides custom logo used in some cozy app (e.g. Home footer)
     # Use type key if you want defined a logo as main
     logos:

--- a/cozy.example.yaml
+++ b/cozy.example.yaml
@@ -506,6 +506,29 @@ contexts:
     # permissions have changed
     additional_platform_apps:
       - superapp
+    # Authentication can be configured per context. This example shows an OIDC
+    # provider that allows a trusted frontend application to exchange its OIDC
+    # id_token for a local Cozy OAuth client/token bound to a linked application.
+    authentication:
+     the-context-name:
+       disable_password_authentication: false
+       oidc:
+         client_id: aClientID
+         client_secret: s3cret3
+         scope: openid profile
+         redirect_uri: https://oauthcallback.mycozy.cloud/oidc/redirect
+         authorize_url: https://identity-provider/path/to/authorize
+         token_url: https://identity-provider/path/to/token
+         userinfo_url: https://identity-provider/path/to/userinfo
+         userinfo_instance_field: cozy_number
+         id_token_jwk_url: https://identity-provider/path/to/jwk
+         allow_app_token_exchange: true
+         app_token_exchange:
+           # OIDC id_token audience.
+           twake-mail-web:
+             # Must be a Cozy linked application software_id. The local OAuth
+             # scope is derived from this linked app manifest.
+             software_id: registry://mail
     # Provides custom logo used in some cozy app (e.g. Home footer)
     # Use type key if you want defined a logo as main
     logos:

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1054,21 +1054,41 @@ Content-Type: application/json
 This endpoint exchanges an external OIDC `id_token` for a normal Cozy OAuth
 client and token pair on the target instance.
 
-It is intended for browser-based admin applications that authenticate with an
-external identity provider, then need to call Cozy APIs directly on an
-organization instance.
+It supports two configured exchanges:
+
+- admin applications that authenticate with an external identity provider, then
+  need to call Cozy APIs directly on an organization instance
+- trusted user applications mapped by OIDC audience to a Cozy linked app, such
+  as `twake-mail-web` to `registry://mail`
 
 The target Cozy instance is the request host. The exchanged `id_token` must:
 
 - be signed by the configured OIDC provider
 - match the configured issuer and audience
+- contain `iat` and `exp` claims
+- contain a `sid` claim so the created OAuth client can be revoked by OIDC
+  backchannel logout
+
+For admin exchanges, the `id_token` must also:
+
 - contain an `org_id` claim equal to the target instance organization id
 - contain an `org_role` claim equal to `owner` or `admin`
+
+For user app exchanges, the `id_token` audience must be present in the
+`oidc.app_token_exchange` stack configuration. The token must also match the
+target Cozy instance using the existing OIDC instance mapping (`sub` to
+`oidc_id` when `allow_custom_instance` is true, otherwise
+`userinfo_instance_field` with prefix/suffix). The returned scope is derived
+from the configured linked app manifest, for example
+`@io.cozy.apps/mail`; caller-provided scopes are rejected.
 
 The request body is JSON:
 
 - `id_token`, the external OIDC token
-- `scope`, a space-separated list of allowed doctypes: `io.cozy.files`, `io.cozy.contacts`, `io.cozy.contacts.groups`
+- `exchange_type`, optional, either `admin` or `app`; when omitted, `admin`
+  is used
+- `scope`, for admin exchanges only, a space-separated list of allowed
+  doctypes: `io.cozy.files`, `io.cozy.contacts`, `io.cozy.contacts.groups`
 
 Example:
 
@@ -1081,6 +1101,15 @@ Accept: application/json
 {
   "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6InRva2VuLWV4Y2hhbmdlIn0...",
   "scope": "io.cozy.files"
+}
+```
+
+Example app exchange:
+
+```json
+{
+  "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6InRva2VuLWV4Y2hhbmdlIn0...",
+  "exchange_type": "app"
 }
 ```
 
@@ -1112,9 +1141,8 @@ The returned OAuth client is a normal Cozy OAuth client:
 - `registration_access_token` can be used with
   `DELETE /auth/register/:client-id` to revoke that exchanged client
 
-When the external `id_token` contains a `sid` claim, the created OAuth client
-is bound to that upstream OIDC session so it can be revoked by OIDC
-backchannel logout.
+The created OAuth client is bound to the upstream OIDC session so it can be
+revoked by OIDC backchannel logout.
 
 ### POST /auth/session_code
 

--- a/docs/delegated-auth.md
+++ b/docs/delegated-auth.md
@@ -50,6 +50,10 @@ authentication:
       allow_custom_instance: false
       allow_oauth_token: false
       id_token_jwk_url: https://identity-provider/path/to/jwk
+      allow_app_token_exchange: true
+      app_token_exchange:
+        twake-mail-web:
+          software_id: registry://mail
 ```
 
 Let's see what it means:
@@ -83,6 +87,15 @@ And in the `oidc` section, we have:
   instance name
 - `allow_oauth_token` must be set to true to enable the
   `POST /oidc/access_token` route (see below for more details).
+- `allow_app_token_exchange` can be set to true to enable user app exchanges
+  on `POST /auth/token_exchange`. The request body must set
+  `exchange_type` to `app` for this exchange.
+- `app_token_exchange` maps an OIDC token audience to a trusted Cozy linked
+  app. The `software_id` must use the `registry://<slug>` format. The stack
+  derives the Cozy OAuth scope from the linked app manifest, so the OIDC
+  provider does not need to expose `registry://...` as an OIDC scope.
+- Token exchange requires a `sid` claim so the created OAuth client can be
+  revoked by OIDC backchannel logout.
 
 With the example config, if the UserInfo response contains `"cozy_number":
 "00001"`, the user can login on the instance `name00001.mycozy.cloud`.

--- a/model/oauth/client.go
+++ b/model/oauth/client.go
@@ -393,6 +393,11 @@ const (
 	// sharings by example, as a token is created just after the client
 	// creation.
 	NotPending CreateOptions = iota + 1
+	// SoftwareIDPrevalidated tells Create to skip the registry probe in
+	// CheckSoftwareID. The caller is responsible for proving that the
+	// registry://<slug> SoftwareID is trusted (e.g. by reading the locally
+	// installed manifest).
+	SoftwareIDPrevalidated
 )
 
 func hasOptions(needle CreateOptions, haystack []CreateOptions) bool {
@@ -456,8 +461,10 @@ func (c *Client) Create(i *instance.Instance, opts ...CreateOptions) *ClientRegi
 	if err := c.checkMandatoryFields(i); err != nil {
 		return err
 	}
-	if err := c.CheckSoftwareID(i); err != nil {
-		return err
+	if !hasOptions(SoftwareIDPrevalidated, opts) {
+		if err := c.CheckSoftwareID(i); err != nil {
+			return err
+		}
 	}
 
 	if err := c.ensureClientNameUnicity(i); err != nil {

--- a/model/oidc/provider/instance.go
+++ b/model/oidc/provider/instance.go
@@ -1,0 +1,144 @@
+package provider
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/cozy/cozy-stack/model/instance"
+	"github.com/cozy/cozy-stack/model/instance/lifecycle"
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
+	"github.com/cozy/cozy-stack/pkg/logger"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// ErrInstanceAuthenticationFailed is returned when OIDC claims cannot be
+// interpreted (missing/malformed sub or user info field). It signals an
+// unauthenticated request, not a mismatch.
+var ErrInstanceAuthenticationFailed = errors.New("the authentication has failed")
+
+// InstanceMismatchError is returned when an OIDC token does not match the
+// target Cozy instance.
+type InstanceMismatchError struct {
+	ExpectedDomain string
+	ActualDomain   string
+}
+
+// TranslationKey returns the i18n key for translating this error.
+func (e *InstanceMismatchError) TranslationKey() string {
+	return "OIDC Domain Mismatch %s %s"
+}
+
+// TranslationArgs returns the arguments for the translation.
+func (e *InstanceMismatchError) TranslationArgs() []interface{} {
+	return []interface{}{e.ExpectedDomain, e.ActualDomain}
+}
+
+func (e *InstanceMismatchError) Error() string {
+	return fmt.Sprintf("OIDC Domain Mismatch %s %s", e.ExpectedDomain, e.ActualDomain)
+}
+
+// CheckClaimsForInstance verifies that the given OIDC claims map to the
+// target instance.
+func CheckClaimsForInstance(conf *Config, inst *instance.Instance, claims jwt.MapClaims) error {
+	if conf.AllowCustomInstance {
+		expected := inst.OIDCID
+		if conf.Provider == FranceConnectProvider {
+			expected = inst.FranceConnectID
+		}
+		sub, ok := claims["sub"].(string)
+		if !ok || sub == "" {
+			inst.Logger().WithNamespace("oidc").
+				Errorf("Invalid sub claim: %v != %s", claims["sub"], expected)
+			return ErrInstanceAuthenticationFailed
+		}
+		if sub != expected {
+			inst.Logger().WithNamespace("oidc").
+				Errorf("Invalid sub: %s != %s", sub, expected)
+			return &InstanceMismatchError{ExpectedDomain: inst.Domain, ActualDomain: sub}
+		}
+		return nil
+	}
+
+	domain, err := ExtractDomainFromClaims(conf, claims)
+	if err != nil {
+		inst.Logger().WithNamespace("oidc").Warnf("Cannot extract domain: %s", err)
+		return err
+	}
+	if domain != inst.Domain {
+		inst.Logger().WithNamespace("oidc").
+			Errorf("Invalid domains: %s != %s", domain, inst.Domain)
+		return &InstanceMismatchError{ExpectedDomain: inst.Domain, ActualDomain: domain}
+	}
+	return nil
+}
+
+// ResolveInstanceFromClaims returns the Cozy instance that the given OIDC
+// claims authenticate against.
+func ResolveInstanceFromClaims(contextName string, conf *Config, claims jwt.MapClaims) (*instance.Instance, error) {
+	if conf.AllowCustomInstance {
+		sub, ok := claims["sub"].(string)
+		if !ok || sub == "" {
+			logger.WithNamespace("oidc").
+				Errorf("Invalid sub claim for context %s: %v", contextName, claims["sub"])
+			return nil, ErrInstanceAuthenticationFailed
+		}
+		return FindInstanceBySub(sub, contextName)
+	}
+
+	domain, err := ExtractDomainFromClaims(conf, claims)
+	if err != nil {
+		logger.WithNamespace("oidc").
+			Warnf("Cannot extract domain for context %s: %s", contextName, err)
+		return nil, err
+	}
+	return lifecycle.GetInstance(domain)
+}
+
+// ExtractDomainFromClaims reads the configured user info field from the
+// claims and applies the prefix/suffix transformation to produce an instance
+// domain.
+func ExtractDomainFromClaims(conf *Config, claims jwt.MapClaims) (string, error) {
+	domain, ok := claims[conf.UserInfoField].(string)
+	if !ok {
+		return "", ErrInstanceAuthenticationFailed
+	}
+	return buildInstanceDomain(domain, conf), nil
+}
+
+// buildInstanceDomain normalizes the raw user info value into a Cozy
+// instance domain.
+func buildInstanceDomain(domain string, conf *Config) string {
+	domain = strings.ToLower(domain)
+	domain = strings.ReplaceAll(domain, "-", "")
+	if conf.UserInfoSuffix != "" {
+		domain = strings.ReplaceAll(domain, ".", "")
+	}
+	domain = conf.UserInfoPrefix + domain + conf.UserInfoSuffix
+	return domain
+}
+
+// FindInstanceBySub returns the instance whose `oidc_id` matches the given
+// OIDC subject in the given context, using the `by-oidcid` index.
+func FindInstanceBySub(sub, contextName string) (*instance.Instance, error) {
+	var instances []*instance.Instance
+	req := &couchdb.FindRequest{
+		UseIndex: "by-oidcid",
+		Selector: mango.And(
+			mango.Equal("oidc_id", sub),
+			mango.Equal("context", contextName),
+		),
+		Limit: 1,
+	}
+	err := couchdb.FindDocs(prefixer.GlobalPrefixer, consts.Instances, req, &instances)
+	if err != nil {
+		return nil, err
+	}
+	if len(instances) == 0 {
+		return nil, errors.New("instance not found")
+	}
+	return instances[0], nil
+}

--- a/model/oidc/provider/provider_test.go
+++ b/model/oidc/provider/provider_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cozy/cozy-stack/model/instance"
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/require"
@@ -29,6 +30,52 @@ func TestLoadConfigRequireIssuerOrTokenURL(t *testing.T) {
 
 	_, err := LoadConfig("missing-issuer-and-token-url", RequireIssuerOrTokenURL)
 	require.EqualError(t, err, "The issuer or token_url is missing for this context")
+}
+
+func TestCheckClaimsForInstance(t *testing.T) {
+	inst := &instance.Instance{
+		Domain: "alice.example.net",
+		OIDCID: "alice-sub",
+	}
+
+	err := CheckClaimsForInstance(&Config{AllowCustomInstance: true}, inst, jwt.MapClaims{
+		"sub": "alice-sub",
+	})
+	require.NoError(t, err)
+
+	err = CheckClaimsForInstance(&Config{AllowCustomInstance: true}, inst, jwt.MapClaims{
+		"sub": "bob-sub",
+	})
+	require.EqualError(t, err, "OIDC Domain Mismatch alice.example.net bob-sub")
+
+	domainInst := &instance.Instance{Domain: "name00001.mycozy.cloud"}
+	err = CheckClaimsForInstance(&Config{
+		UserInfoField:  "cozy_number",
+		UserInfoPrefix: "name",
+		UserInfoSuffix: ".mycozy.cloud",
+	}, domainInst, jwt.MapClaims{
+		"cozy_number": "00001",
+	})
+	require.NoError(t, err)
+
+	err = CheckClaimsForInstance(&Config{
+		UserInfoField:  "cozy_number",
+		UserInfoPrefix: "alice",
+		UserInfoSuffix: ".example.net",
+	}, inst, jwt.MapClaims{
+		"cozy_number": "bob",
+	})
+	require.EqualError(t, err, "OIDC Domain Mismatch alice.example.net alicebob.example.net")
+}
+
+func TestBuildInstanceDomain(t *testing.T) {
+	conf := &Config{
+		UserInfoPrefix: "name",
+		UserInfoSuffix: ".mycozy.cloud",
+	}
+
+	require.Equal(t, "name00001.mycozy.cloud", buildInstanceDomain("000-01", conf))
+	require.Equal(t, "nameuserdomain.mycozy.cloud", buildInstanceDomain("user.domain", conf))
 }
 
 func TestVerifyLogoutTokenFailsWhenIssuerCannotBeResolved(t *testing.T) {

--- a/pkg/config/config/config.go
+++ b/pkg/config/config/config.go
@@ -426,6 +426,19 @@ type DeprecatedApp struct {
 	StoreURLs map[string]string `mapstructure:"store_urls"`
 }
 
+// OIDCAppTokenExchangeConfig contains OIDC application token exchange settings.
+type OIDCAppTokenExchangeConfig struct {
+	Enabled bool
+	Apps    map[string]OIDCAppTokenExchangeAppConfig
+}
+
+// OIDCAppTokenExchangeAppConfig contains the linked application allowed for an
+// OIDC token audience.
+type OIDCAppTokenExchangeAppConfig struct {
+	Audience   string
+	SoftwareID string `mapstructure:"software_id"`
+}
+
 // Worker contains the configuration fields for a specific worker type.
 type Worker struct {
 	WorkerType   string
@@ -585,6 +598,47 @@ func GetOIDCContextByDomain(domain string) (string, error) {
 		match = contextName
 	}
 	return match, nil
+}
+
+// GetOIDCAppTokenExchange returns the trusted linked applications allowed to
+// exchange OIDC ID tokens for local OAuth tokens in the given context.
+func GetOIDCAppTokenExchange(contextName string) (OIDCAppTokenExchangeConfig, error) {
+	var cfg OIDCAppTokenExchangeConfig
+	oidc, ok := GetOIDC(contextName)
+	if !ok {
+		return cfg, nil
+	}
+
+	enabled, _ := oidc["allow_app_token_exchange"].(bool)
+	cfg.Enabled = enabled
+	if !enabled {
+		return cfg, nil
+	}
+
+	rawApps, ok := oidc["app_token_exchange"]
+	if !ok {
+		cfg.Apps = map[string]OIDCAppTokenExchangeAppConfig{}
+		return cfg, nil
+	}
+
+	apps := make(map[string]OIDCAppTokenExchangeAppConfig)
+	if err := mapstructure.Decode(rawApps, &apps); err != nil {
+		return cfg, fmt.Errorf("invalid app token exchange configuration: %w", err)
+	}
+
+	for audience, appConfig := range apps {
+		appConfig.Audience = audience
+		appConfig.SoftwareID = strings.TrimSpace(appConfig.SoftwareID)
+		if appConfig.SoftwareID == "" {
+			return cfg, fmt.Errorf("software_id is required for app token exchange audience %q", audience)
+		}
+		if !strings.HasPrefix(appConfig.SoftwareID, "registry://") || strings.TrimPrefix(appConfig.SoftwareID, "registry://") == "" {
+			return cfg, fmt.Errorf("software_id for app token exchange audience %q must be a linked app", audience)
+		}
+		apps[audience] = appConfig
+	}
+	cfg.Apps = apps
+	return cfg, nil
 }
 
 // GetFranceConnect returns the FranceConnect config for the given context

--- a/pkg/config/config/config_test.go
+++ b/pkg/config/config/config_test.go
@@ -242,15 +242,21 @@ func TestConfigUnmarshal(t *testing.T) {
 		"example_oidc": map[string]interface{}{
 			"disable_password_authentication": true,
 			"oidc": map[string]interface{}{
-				"client_id":               "some-id",
-				"client_secret":           "some-secret",
-				"scope":                   "openid",
-				"redirect_uri":            "https://some-redirect-uri",
-				"authorize_url":           "https://some-authorize-url",
-				"token_url":               "https://some-token-url",
-				"userinfo_url":            "https://some-user-info-url",
-				"logout_url":              "https://some-logout-url",
-				"userinfo_instance_field": "instance-field",
+				"client_id":                "some-id",
+				"client_secret":            "some-secret",
+				"scope":                    "openid",
+				"redirect_uri":             "https://some-redirect-uri",
+				"authorize_url":            "https://some-authorize-url",
+				"token_url":                "https://some-token-url",
+				"userinfo_url":             "https://some-user-info-url",
+				"logout_url":               "https://some-logout-url",
+				"userinfo_instance_field":  "instance-field",
+				"allow_app_token_exchange": true,
+				"app_token_exchange": map[string]interface{}{
+					"twake-mail-web": map[string]interface{}{
+						"software_id": "registry://mail",
+					},
+				},
 			},
 		},
 	}, cfg.Authentication)
@@ -373,6 +379,77 @@ func TestUseViper(t *testing.T) {
 	cfg.Set("couchdb.url", "http://db:1234")
 	assert.NoError(t, UseViper(cfg))
 	assert.Equal(t, "http://db:1234/", CouchCluster(prefixer.GlobalCouchCluster).URL.String())
+}
+
+func TestGetOIDCAppTokenExchange(t *testing.T) {
+	t.Run("loads configured linked apps", func(t *testing.T) {
+		UseTestFile(t)
+		GetConfig().Authentication = map[string]interface{}{
+			"mail-context": map[string]interface{}{
+				"oidc": map[string]interface{}{
+					"allow_app_token_exchange": true,
+					"app_token_exchange": map[string]interface{}{
+						"twake-mail-web": map[string]interface{}{
+							"software_id": " registry://mail ",
+						},
+					},
+				},
+			},
+		}
+
+		cfg, err := GetOIDCAppTokenExchange("mail-context")
+		require.NoError(t, err)
+		require.True(t, cfg.Enabled)
+		require.Contains(t, cfg.Apps, "twake-mail-web")
+		assert.Equal(t, "twake-mail-web", cfg.Apps["twake-mail-web"].Audience)
+		assert.Equal(t, "registry://mail", cfg.Apps["twake-mail-web"].SoftwareID)
+	})
+
+	t.Run("disabled when missing", func(t *testing.T) {
+		UseTestFile(t)
+		GetConfig().Authentication = map[string]interface{}{}
+
+		cfg, err := GetOIDCAppTokenExchange("missing-context")
+		require.NoError(t, err)
+		assert.False(t, cfg.Enabled)
+		assert.Nil(t, cfg.Apps)
+	})
+
+	t.Run("requires software id", func(t *testing.T) {
+		UseTestFile(t)
+		GetConfig().Authentication = map[string]interface{}{
+			"mail-context": map[string]interface{}{
+				"oidc": map[string]interface{}{
+					"allow_app_token_exchange": true,
+					"app_token_exchange": map[string]interface{}{
+						"twake-mail-web": map[string]interface{}{},
+					},
+				},
+			},
+		}
+
+		_, err := GetOIDCAppTokenExchange("mail-context")
+		require.EqualError(t, err, `software_id is required for app token exchange audience "twake-mail-web"`)
+	})
+
+	t.Run("requires linked app software id", func(t *testing.T) {
+		UseTestFile(t)
+		GetConfig().Authentication = map[string]interface{}{
+			"mail-context": map[string]interface{}{
+				"oidc": map[string]interface{}{
+					"allow_app_token_exchange": true,
+					"app_token_exchange": map[string]interface{}{
+						"twake-mail-web": map[string]interface{}{
+							"software_id": "mail",
+						},
+					},
+				},
+			},
+		}
+
+		_, err := GetOIDCAppTokenExchange("mail-context")
+		require.EqualError(t, err, `software_id for app token exchange audience "twake-mail-web" must be a linked app`)
+	})
 }
 
 func TestSetup(t *testing.T) {

--- a/pkg/config/config/testdata/full_config.yaml
+++ b/pkg/config/config/testdata/full_config.yaml
@@ -193,6 +193,10 @@ authentication:
       userinfo_url: https://some-user-info-url
       logout_url: https://some-logout-url
       userinfo_instance_field: instance-field
+      allow_app_token_exchange: true
+      app_token_exchange:
+        twake-mail-web:
+          software_id: registry://mail
 
 # Public OIDC context name - references the authentication context to use for public Twake accounts
 public_oidc_context: twake_public

--- a/web/auth/auth.go
+++ b/web/auth/auth.go
@@ -541,6 +541,9 @@ func tokenExchangeOriginAllowed(origin string, inst *instance.Instance) bool {
 	if tokenExchangeOrgDomainOriginAllowed(originHost, inst) {
 		return true
 	}
+	if tokenExchangeAppOriginAllowed(origin, originHost, inst) {
+		return true
+	}
 
 	return tokenExchangeAdminPanelOriginAllowed(origin, originHost, inst)
 }
@@ -551,6 +554,21 @@ func tokenExchangeOrgDomainOriginAllowed(originHost string, inst *instance.Insta
 		return false
 	}
 	return originHost == orgDomain || strings.HasSuffix(originHost, "."+orgDomain)
+}
+
+func tokenExchangeAppOriginAllowed(origin, originHost string, inst *instance.Instance) bool {
+	u, err := url.Parse(origin)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return false
+	}
+	if u.Scheme != "https" && u.Scheme != "http" {
+		return false
+	}
+
+	instanceHost, appSlug, _ := config.SplitCozyHost(originHost)
+	return appSlug != "" &&
+		inst.HasDomain(instanceHost) &&
+		tokenExchangeAppSlugAllowed(inst.ContextName, appSlug)
 }
 
 func tokenExchangeAdminPanelOriginAllowed(origin, originHost string, inst *instance.Instance) bool {
@@ -634,12 +652,20 @@ func tokenExchange(c echo.Context) error {
 	}
 	reqBody.IDToken = strings.TrimSpace(reqBody.IDToken)
 	reqBody.Scope = strings.TrimSpace(reqBody.Scope)
+	reqBody.ExchangeType = strings.TrimSpace(reqBody.ExchangeType)
 	if reqBody.IDToken == "" {
 		return c.JSON(http.StatusBadRequest, echo.Map{
 			"error": "the id_token parameter is mandatory",
 		})
 	}
-	if reqBody.Scope == "" {
+	exchangeType, err := tokenExchangeRequestExchangeType(reqBody.ExchangeType)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, echo.Map{
+			"error": err.Error(),
+		})
+	}
+	reqBody.ExchangeType = exchangeType
+	if exchangeType == tokenExchangeTypeAdmin && reqBody.Scope == "" {
 		return c.JSON(http.StatusBadRequest, echo.Map{
 			"error": "the scope parameter is mandatory",
 		})

--- a/web/auth/auth_test.go
+++ b/web/auth/auth_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cozy/cozy-stack/model/app"
 	"github.com/cozy/cozy-stack/model/instance"
 	"github.com/cozy/cozy-stack/model/instance/lifecycle"
 	"github.com/cozy/cozy-stack/model/oauth"
@@ -2133,13 +2134,29 @@ func TestTokenExchange(t *testing.T) {
 
 	privateKey, kid, jwksURL := newTokenExchangeSigningKey(t)
 	const (
-		contextName = "token-exchange-test"
-		clientID    = "cozy-twake-int"
-		issuer      = "https://sign-up.example.com/"
+		contextName        = "token-exchange-test"
+		clientID           = "cozy-twake-int"
+		appTokenAudience   = "twake-mail-web"
+		appTokenAppSlug    = "mail"
+		appTokenSoftwareID = "registry://mail"
+		issuer             = "https://sign-up.example.com/"
 	)
+	appManifest := makeTokenExchangeAppManifest(appTokenAppSlug)
+	appRegistry := newTokenExchangeRegistry(t, appTokenAppSlug, appManifest)
+	appRegistryURL, err := url.Parse(appRegistry.URL)
+	require.NoError(t, err)
+
+	oidcConfig := makeTokenExchangeOIDCConfig(issuer, clientID, jwksURL)
+	oidcConfig["allow_custom_instance"] = true
+	oidcConfig["allow_app_token_exchange"] = true
+	oidcConfig["app_token_exchange"] = map[string]interface{}{
+		appTokenAudience: map[string]interface{}{
+			"software_id": appTokenSoftwareID,
+		},
+	}
 	conf.Authentication = map[string]interface{}{
 		contextName: map[string]interface{}{
-			"oidc": makeTokenExchangeOIDCConfig(issuer, clientID, jwksURL),
+			"oidc": oidcConfig,
 		},
 	}
 	conf.Contexts = map[string]interface{}{
@@ -2148,6 +2165,10 @@ func TestTokenExchange(t *testing.T) {
 			"public_domain_suffix": " STG.LIN-SAAS.COM. ",
 		},
 	}
+	if conf.Registries == nil {
+		conf.Registries = map[string][]*url.URL{}
+	}
+	conf.Registries[contextName] = []*url.URL{appRegistryURL}
 
 	setup := testutils.NewSetup(t, t.Name())
 
@@ -2157,7 +2178,9 @@ func TestTokenExchange(t *testing.T) {
 		OrgID:       "myorg123",
 		ContextName: contextName,
 		Email:       "token-exchange@example.com",
+		OIDCID:      "mail-user",
 	})
+	installTokenExchangeWebapp(t, testInstance, appManifest)
 	ownerSetup := testutils.NewSetup(t, t.Name()+"Owner")
 	ownerSetup.GetTestInstance(&lifecycle.Options{
 		Domain:      "theopoizatzatteocorpcc2acd.stg.lin-saas.com",
@@ -2196,6 +2219,20 @@ func TestTokenExchange(t *testing.T) {
 			ValueEqual("error", "the id_token parameter is mandatory")
 	})
 
+	t.Run("RejectsInvalidExchangeType", func(t *testing.T) {
+		e.POST("/auth/token_exchange").
+			WithHost(testInstance.Domain).
+			WithHeader("Accept", "application/json").
+			WithJSON(map[string]string{
+				"id_token":      "not-a-token",
+				"exchange_type": "user",
+			}).
+			Expect().
+			Status(http.StatusBadRequest).
+			JSON().Object().
+			ValueEqual("error", `exchange_type "user" is not allowed`)
+	})
+
 	t.Run("AllowsOrgDomainOrigins", func(t *testing.T) {
 		for _, origin := range []string{
 			"https://example.com",
@@ -2217,6 +2254,21 @@ func TestTokenExchange(t *testing.T) {
 
 	t.Run("AllowsAdminPanelPublicDomainSuffixOrigin", func(t *testing.T) {
 		origin := "https://theopoizatzatteocorpcc2acd-admin.stg.lin-saas.com"
+		resp := e.OPTIONS("/auth/token_exchange").
+			WithHost(testInstance.Domain).
+			WithHeader("Origin", origin).
+			WithHeader("Access-Control-Request-Headers", "content-type").
+			Expect().
+			Status(http.StatusNoContent)
+
+		resp.Header("Access-Control-Allow-Origin").Equal(origin)
+		resp.Header("Access-Control-Allow-Methods").Equal(http.MethodPost)
+		resp.Header("Access-Control-Allow-Headers").Equal("content-type")
+		resp.Header("Access-Control-Allow-Credentials").Equal("true")
+	})
+
+	t.Run("AllowsAppSubdomainOriginWhenAppExchangeEnabled", func(t *testing.T) {
+		origin := "https://mail." + testInstance.Domain
 		resp := e.OPTIONS("/auth/token_exchange").
 			WithHost(testInstance.Domain).
 			WithHeader("Origin", origin).
@@ -2297,6 +2349,7 @@ func TestTokenExchange(t *testing.T) {
 			"aud":        []string{clientID},
 			"azp":        clientID,
 			"sub":        "admin-user",
+			"sid":        "admin-user-sid",
 			"iat":        time.Now().Unix(),
 			"exp":        time.Now().Add(time.Hour).Unix(),
 			"org_id":     testInstance.OrgID,
@@ -2339,6 +2392,184 @@ func TestTokenExchange(t *testing.T) {
 		require.Equal(t, clientSecretValue, client.ClientSecret)
 		require.False(t, client.Pending)
 		require.Equal(t, []string{"https://admin.example.com"}, client.RedirectURIs)
+	})
+
+	t.Run("ExchangesAppTokenWithLinkedAppScope", func(t *testing.T) {
+		const sid = "mail-app-sid-123"
+		idToken := makeTokenExchangeSignedJWT(t, privateKey, kid, map[string]interface{}{
+			"iss": issuer,
+			"aud": []string{appTokenAudience},
+			"sub": "mail-user",
+			"sid": sid,
+			"iat": time.Now().Unix(),
+			"exp": time.Now().Add(time.Hour).Unix(),
+		})
+
+		resp := e.POST("/auth/token_exchange").
+			WithHost(testInstance.Domain).
+			WithHeader("Accept", "application/json").
+			WithHeader("Origin", "https://mail."+testInstance.Domain).
+			WithJSON(map[string]string{
+				"id_token":      idToken,
+				"exchange_type": "app",
+			}).
+			Expect().
+			Status(http.StatusOK)
+		resp.Header("Cache-Control").Equal("no-store")
+		resp.Header("Pragma").Equal("no-cache")
+		resp.Header("Access-Control-Allow-Origin").Equal("https://mail." + testInstance.Domain)
+		obj := resp.JSON().Object()
+
+		clientIDValue := obj.Value("client_id").String().Raw()
+		clientSecretValue := obj.Value("client_secret").String().Raw()
+		registrationToken := obj.Value("registration_access_token").String().Raw()
+		accessToken := obj.Value("access_token").String().Raw()
+		refreshToken := obj.Value("refresh_token").String().Raw()
+		scope := oauth.BuildLinkedAppScope(appTokenAppSlug)
+
+		obj.ValueEqual("token_type", "bearer")
+		obj.ValueEqual("scope", scope)
+		require.NotEmpty(t, clientIDValue)
+		require.NotEmpty(t, clientSecretValue)
+		require.NotEmpty(t, registrationToken)
+		assertValidToken(t, testInstance, accessToken, consts.AccessTokenAudience, clientIDValue, scope)
+		assertValidToken(t, testInstance, refreshToken, consts.RefreshTokenAudience, clientIDValue, scope)
+
+		client, err := oauth.FindClient(testInstance, clientIDValue)
+		require.NoError(t, err)
+		require.Equal(t, appTokenSoftwareID, client.SoftwareID)
+		require.Equal(t, "Twake Mail", client.ClientName)
+		require.Equal(t, sid, client.OIDCSessionID)
+		require.False(t, client.Pending)
+		require.Equal(t, []string{"https://mail." + testInstance.Domain}, client.RedirectURIs)
+
+		boundClients, err := oidcbinding.ListOAuthClients(contextName, sid)
+		require.NoError(t, err)
+		require.Len(t, boundClients, 1)
+		require.Equal(t, clientIDValue, boundClients[0].OAuthClientID)
+	})
+
+	t.Run("RejectsAppTokenWithoutExchangeTypeAsAdmin", func(t *testing.T) {
+		idToken := makeTokenExchangeSignedJWT(t, privateKey, kid, map[string]interface{}{
+			"iss": issuer,
+			"aud": []string{appTokenAudience},
+			"sub": "mail-user",
+			"sid": "mail-app-sid-default-admin",
+			"iat": time.Now().Unix(),
+			"exp": time.Now().Add(time.Hour).Unix(),
+		})
+
+		e.POST("/auth/token_exchange").
+			WithHost(testInstance.Domain).
+			WithHeader("Accept", "application/json").
+			WithHeader("Origin", "https://mail."+testInstance.Domain).
+			WithJSON(map[string]string{
+				"id_token": idToken,
+				"scope":    "io.cozy.files",
+			}).
+			Expect().
+			Status(http.StatusBadRequest).
+			JSON().Object().
+			ValueEqual("error", "invalid token audience")
+	})
+
+	t.Run("RejectsAppTokenScopeParameter", func(t *testing.T) {
+		idToken := makeTokenExchangeSignedJWT(t, privateKey, kid, map[string]interface{}{
+			"iss": issuer,
+			"aud": []string{appTokenAudience},
+			"sub": "mail-user",
+			"sid": "mail-app-sid-scope",
+			"iat": time.Now().Unix(),
+			"exp": time.Now().Add(time.Hour).Unix(),
+		})
+
+		e.POST("/auth/token_exchange").
+			WithHost(testInstance.Domain).
+			WithHeader("Accept", "application/json").
+			WithHeader("Origin", "https://mail."+testInstance.Domain).
+			WithJSON(map[string]string{
+				"id_token":      idToken,
+				"scope":         "io.cozy.files",
+				"exchange_type": "app",
+			}).
+			Expect().
+			Status(http.StatusBadRequest).
+			JSON().Object().
+			ValueEqual("error", "scope is not allowed for app token exchange")
+	})
+
+	t.Run("RejectsAppTokenWithoutSID", func(t *testing.T) {
+		idToken := makeTokenExchangeSignedJWT(t, privateKey, kid, map[string]interface{}{
+			"iss": issuer,
+			"aud": []string{appTokenAudience},
+			"sub": "mail-user",
+			"iat": time.Now().Unix(),
+			"exp": time.Now().Add(time.Hour).Unix(),
+		})
+
+		e.POST("/auth/token_exchange").
+			WithHost(testInstance.Domain).
+			WithHeader("Accept", "application/json").
+			WithHeader("Origin", "https://mail."+testInstance.Domain).
+			WithJSON(map[string]string{
+				"id_token":      idToken,
+				"exchange_type": "app",
+			}).
+			Expect().
+			Status(http.StatusBadRequest).
+			JSON().Object().
+			ValueEqual("error", "sid claim is required")
+	})
+
+	t.Run("RejectsAppTokenWithOIDCIDMismatch", func(t *testing.T) {
+		idToken := makeTokenExchangeSignedJWT(t, privateKey, kid, map[string]interface{}{
+			"iss": issuer,
+			"aud": []string{appTokenAudience},
+			"sub": "other-mail-user",
+			"sid": "mail-app-sid-oidc-id",
+			"iat": time.Now().Unix(),
+			"exp": time.Now().Add(time.Hour).Unix(),
+		})
+
+		e.POST("/auth/token_exchange").
+			WithHost(testInstance.Domain).
+			WithHeader("Accept", "application/json").
+			WithHeader("Origin", "https://mail."+testInstance.Domain).
+			WithJSON(map[string]string{
+				"id_token":      idToken,
+				"exchange_type": "app",
+			}).
+			Expect().
+			Status(http.StatusBadRequest).
+			JSON().Object().
+			ValueEqual("error", "OIDC Domain Mismatch "+testInstance.Domain+" other-mail-user")
+	})
+
+	t.Run("RejectsAppTokenWhenAppExchangeDisabled", func(t *testing.T) {
+		oidcConfig["allow_app_token_exchange"] = false
+		defer func() { oidcConfig["allow_app_token_exchange"] = true }()
+
+		idToken := makeTokenExchangeSignedJWT(t, privateKey, kid, map[string]interface{}{
+			"iss": issuer,
+			"aud": []string{appTokenAudience},
+			"sub": "mail-user",
+			"sid": "mail-app-sid-disabled",
+			"iat": time.Now().Unix(),
+			"exp": time.Now().Add(time.Hour).Unix(),
+		})
+
+		e.POST("/auth/token_exchange").
+			WithHost(testInstance.Domain).
+			WithHeader("Accept", "application/json").
+			WithHeader("Origin", "https://admin.example.com").
+			WithJSON(map[string]string{
+				"id_token":      idToken,
+				"exchange_type": "app",
+			}).
+			Expect().
+			Status(http.StatusBadRequest).
+			JSON().Object().
+			ValueEqual("error", "this endpoint is not enabled")
 	})
 
 	t.Run("BindsExchangedClientToOIDCSID", func(t *testing.T) {
@@ -2385,6 +2616,7 @@ func TestTokenExchange(t *testing.T) {
 			"iss":        issuer,
 			"aud":        []string{clientID},
 			"sub":        "admin-user-role",
+			"sid":        "admin-user-role-sid",
 			"iat":        time.Now().Unix(),
 			"exp":        time.Now().Add(time.Hour).Unix(),
 			"org_id":     testInstance.OrgID,
@@ -2409,6 +2641,7 @@ func TestTokenExchange(t *testing.T) {
 			"iss":        issuer,
 			"aud":        []string{clientID},
 			"sub":        "admin-user-revoke",
+			"sid":        "admin-user-revoke-sid",
 			"iat":        time.Now().Unix(),
 			"exp":        time.Now().Add(time.Hour).Unix(),
 			"org_id":     testInstance.OrgID,
@@ -2447,6 +2680,7 @@ func TestTokenExchange(t *testing.T) {
 			"iss":        issuer,
 			"aud":        []string{clientID},
 			"sub":        "admin-user-1",
+			"sid":        "admin-user-1-sid",
 			"iat":        time.Now().Unix(),
 			"exp":        time.Now().Add(time.Hour).Unix(),
 			"org_id":     testInstance.OrgID,
@@ -2457,6 +2691,7 @@ func TestTokenExchange(t *testing.T) {
 			"iss":        issuer,
 			"aud":        []string{clientID},
 			"sub":        "admin-user-2",
+			"sid":        "admin-user-2-sid",
 			"iat":        time.Now().Unix(),
 			"exp":        time.Now().Add(time.Hour).Unix(),
 			"org_id":     testInstance.OrgID,
@@ -2523,11 +2758,38 @@ func TestTokenExchange(t *testing.T) {
 			ValueEqual("error", "invalid token")
 	})
 
+	t.Run("RejectsAdminTokenWithoutSID", func(t *testing.T) {
+		idToken := makeTokenExchangeSignedJWT(t, privateKey, kid, map[string]interface{}{
+			"iss":        issuer,
+			"aud":        []string{clientID},
+			"sub":        "admin-user-without-sid",
+			"iat":        time.Now().Unix(),
+			"exp":        time.Now().Add(time.Hour).Unix(),
+			"org_id":     testInstance.OrgID,
+			"org_domain": testInstance.OrgDomain,
+			"org_role":   "owner",
+		})
+
+		e.POST("/auth/token_exchange").
+			WithHost(testInstance.Domain).
+			WithHeader("Accept", "application/json").
+			WithHeader("Origin", "https://admin.example.com").
+			WithJSON(map[string]string{
+				"id_token": idToken,
+				"scope":    "io.cozy.files",
+			}).
+			Expect().
+			Status(http.StatusBadRequest).
+			JSON().Object().
+			ValueEqual("error", "sid claim is required")
+	})
+
 	t.Run("RejectsMissingAdminAuthorization", func(t *testing.T) {
 		idToken := makeTokenExchangeSignedJWT(t, privateKey, kid, map[string]interface{}{
 			"iss":        issuer,
 			"aud":        []string{clientID},
 			"sub":        "member-user",
+			"sid":        "member-user-sid",
 			"iat":        time.Now().Unix(),
 			"exp":        time.Now().Add(time.Hour).Unix(),
 			"org_id":     testInstance.OrgID,
@@ -2553,6 +2815,7 @@ func TestTokenExchange(t *testing.T) {
 			"iss":        issuer,
 			"aud":        []string{clientID},
 			"sub":        "admin-user",
+			"sid":        "admin-user-org-mismatch-sid",
 			"iat":        time.Now().Unix(),
 			"exp":        time.Now().Add(time.Hour).Unix(),
 			"org_id":     "other-org",
@@ -2579,6 +2842,7 @@ func TestTokenExchange(t *testing.T) {
 			"iss":        issuer,
 			"aud":        []string{clientID},
 			"sub":        "admin-user",
+			"sid":        "admin-user-invalid-scope-sid",
 			"iat":        time.Now().Unix(),
 			"exp":        time.Now().Add(time.Hour).Unix(),
 			"org_id":     testInstance.OrgID,
@@ -2668,6 +2932,68 @@ func makeTokenExchangeOIDCConfig(issuer, clientID, jwksURL string) map[string]in
 		"userinfo_instance_field": "workplaceFqdn",
 		"id_token_jwk_url":        jwksURL,
 	}
+}
+
+func makeTokenExchangeAppManifest(slug string) []byte {
+	return []byte(fmt.Sprintf(`{
+  "name": "Mail",
+  "name_prefix": "Twake",
+  "slug": %q,
+  "source": "registry://%s",
+  "version": "1.0.0",
+  "type": "webapp",
+  "routes": {
+    "/": {
+      "folder": "/",
+      "index": "index.html",
+      "public": false
+    }
+  },
+  "permissions": {
+    "contacts": {
+      "description": "Required to display the avatar",
+      "type": "io.cozy.contacts",
+      "verbs": ["GET"]
+    }
+  }
+}`, slug, slug))
+}
+
+func installTokenExchangeWebapp(t *testing.T, inst *instance.Instance, manifestJSON []byte) {
+	t.Helper()
+
+	var manifest app.WebappManifest
+	require.NoError(t, json.Unmarshal(manifestJSON, &manifest))
+	require.NoError(t, manifest.Create(inst))
+}
+
+func newTokenExchangeRegistry(t *testing.T, slug string, manifestJSON []byte) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/registry/" + slug, "/registry/" + slug + "/":
+			_, _ = fmt.Fprintf(w, `{"slug":%q,"type":"webapp"}`, slug)
+		case "/registry/" + slug + "/stable/latest":
+			version := map[string]interface{}{
+				"slug":       slug,
+				"version":    "1.0.0",
+				"url":        "https://example.com/" + slug + ".tar.gz",
+				"sha256":     "00",
+				"created_at": time.Now().Format(time.RFC3339),
+				"size":       "0",
+				"manifest":   json.RawMessage(manifestJSON),
+			}
+			if err := json.NewEncoder(w).Encode(version); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server
 }
 
 func makeTokenExchangeSignedJWT(t *testing.T, privateKey *rsa.PrivateKey, kid string, claims map[string]interface{}) string {

--- a/web/auth/token_exchange.go
+++ b/web/auth/token_exchange.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cozy/cozy-stack/model/app"
 	"github.com/cozy/cozy-stack/model/instance"
 	"github.com/cozy/cozy-stack/model/oauth"
 	oidcbinding "github.com/cozy/cozy-stack/model/oidc/binding"
@@ -25,6 +26,8 @@ import (
 const (
 	tokenExchangeAdminRole             = "admin"
 	tokenExchangeOwnerRole             = "owner"
+	tokenExchangeTypeAdmin             = "admin"
+	tokenExchangeTypeApp               = "app"
 	tokenExchangeOAuthClientName       = "Twake Admin Panel"
 	tokenExchangeOAuthClientSoftwareID = "twake-admin-panel"
 )
@@ -37,9 +40,14 @@ var tokenExchangeAllowedScopes = map[string]struct{}{
 	"io.cozy.sharings":        {},
 }
 
+// errTokenExchangeDisabled is returned to clients when token exchange is not
+// configured for the instance.
+var errTokenExchangeDisabled = errors.New("this endpoint is not enabled")
+
 type tokenExchangeRequest struct {
-	IDToken string `json:"id_token"`
-	Scope   string `json:"scope"`
+	IDToken      string `json:"id_token"`
+	Scope        string `json:"scope"`
+	ExchangeType string `json:"exchange_type"`
 }
 
 type tokenExchangeResponse struct {
@@ -49,29 +57,126 @@ type tokenExchangeResponse struct {
 	RegistrationToken string `json:"registration_access_token"`
 }
 
+type tokenExchangeValidatedToken struct {
+	Claims    jwt.MapClaims
+	AppConfig *config.OIDCAppTokenExchangeAppConfig
+}
+
+// tokenExchangeOAuthClientParams carries the per-exchange information needed
+// to register a Cozy OAuth client.
+type tokenExchangeOAuthClientParams struct {
+	AppSlug    string
+	ClientName string
+	SoftwareID string
+	// SoftwareIDPrevalidated lets the trusted internal app-exchange path skip
+	// the registry probe in CheckSoftwareID once the installed manifest has
+	// already been verified locally.
+	SoftwareIDPrevalidated bool
+}
+
+// executeTokenExchange runs the token exchange flow for a request
 func executeTokenExchange(c echo.Context, inst *instance.Instance, req tokenExchangeRequest) (*tokenExchangeResponse, error) {
-	claims, err := validateTokenExchangeIDToken(inst, req.IDToken)
+	validated, err := validateTokenExchangeIDToken(inst, req.IDToken, req.ExchangeType)
 	if err != nil {
 		return nil, echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
-	if err := validateTokenExchangeScope(req.Scope); err != nil {
-		return nil, echo.NewHTTPError(http.StatusBadRequest, err.Error())
-	}
 
-	client, err := createTokenExchangeOAuthClient(c, inst)
+	var client *oauth.Client
+	var scope string
+	if req.ExchangeType == tokenExchangeTypeApp {
+		if validated.AppConfig == nil {
+			return nil, echo.NewHTTPError(http.StatusBadRequest, "invalid token audience")
+		}
+		client, scope, err = executeTokenExchangeApp(c, inst, req, *validated.AppConfig)
+	} else {
+		client, scope, err = executeTokenExchangeAdmin(c, inst, req)
+	}
 	if err != nil {
 		return nil, err
 	}
+
 	defer LockOAuthClient(inst, client.ClientID)()
 
-	if err := bindTokenExchangeOIDCSession(inst, client, claims); err != nil {
+	if err := bindTokenExchangeOIDCSession(inst, client, validated.Claims); err != nil {
 		if delErr := client.Delete(inst); delErr != nil {
-			inst.Logger().WithNamespace("token_exchange").Warnf("Cannot delete orphaned OAuth client %s: %s", client.CouchID, delErr.Description)
+			inst.Logger().WithNamespace("oidc").Warnf("Cannot delete orphaned OAuth client %s: %s", client.CouchID, delErr.Description)
 		}
 		return nil, err
 	}
 
-	return buildTokenExchangeResponse(inst, client, req.Scope)
+	return buildTokenExchangeResponse(inst, client, scope)
+}
+
+func executeTokenExchangeAdmin(c echo.Context, inst *instance.Instance, req tokenExchangeRequest) (*oauth.Client, string, error) {
+	if err := validateTokenExchangeScope(req.Scope); err != nil {
+		return nil, "", echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+
+	client, err := createTokenExchangeOAuthClient(c, inst, tokenExchangeOAuthClientParams{
+		ClientName: tokenExchangeOAuthClientName,
+		SoftwareID: tokenExchangeOAuthClientSoftwareID,
+	})
+	if err != nil {
+		return nil, "", err
+	}
+	return client, req.Scope, nil
+}
+
+func executeTokenExchangeApp(c echo.Context, inst *instance.Instance, req tokenExchangeRequest, appConfig config.OIDCAppTokenExchangeAppConfig) (*oauth.Client, string, error) {
+	if req.Scope != "" {
+		return nil, "", echo.NewHTTPError(http.StatusBadRequest, "scope is not allowed for app token exchange")
+	}
+
+	slug := oauth.GetLinkedAppSlug(appConfig.SoftwareID)
+	if slug == "" {
+		return nil, "", echo.NewHTTPError(http.StatusBadRequest, "software_id must be a linked app")
+	}
+	manifest, err := app.GetWebappBySlug(inst, slug)
+	if err != nil {
+		return nil, "", echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("%s is not installed", slug))
+	}
+	if err := tokenExchangeAssertManifestTrusted(manifest, slug); err != nil {
+		return nil, "", err
+	}
+	client, err := createTokenExchangeOAuthClient(c, inst, tokenExchangeOAuthClientParams{
+		AppSlug:                slug,
+		ClientName:             tokenExchangeLinkedAppClientName(manifest, slug),
+		SoftwareID:             appConfig.SoftwareID,
+		SoftwareIDPrevalidated: true,
+	})
+	if err != nil {
+		return nil, "", err
+	}
+
+	return client, oauth.BuildLinkedAppScope(slug), nil
+}
+
+// tokenExchangeAssertManifestTrusted confirms the locally installed manifest
+// really came from the registry path the config maps the audience to. This
+// is the local equivalent of CheckSoftwareID's registry probe, and lets the
+// flow proceed when the registry is unreachable.
+func tokenExchangeAssertManifestTrusted(manifest *app.WebappManifest, slug string) error {
+	source := strings.TrimSpace(manifest.Source())
+	if !strings.HasPrefix(source, "registry://") {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("%s is not a registry application", slug))
+	}
+	if oauth.GetLinkedAppSlug(source) != slug {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("%s is not the installed application", slug))
+	}
+	return nil
+}
+
+func tokenExchangeRequestExchangeType(raw string) (string, error) {
+	exchangeType := strings.TrimSpace(raw)
+	if exchangeType == "" {
+		return tokenExchangeTypeAdmin, nil
+	}
+	switch exchangeType {
+	case tokenExchangeTypeAdmin, tokenExchangeTypeApp:
+		return exchangeType, nil
+	default:
+		return "", fmt.Errorf("exchange_type %q is not allowed", raw)
+	}
 }
 
 func validateTokenExchangeScope(scope string) error {
@@ -86,18 +191,19 @@ func validateTokenExchangeScope(scope string) error {
 	return nil
 }
 
-func validateTokenExchangeIDToken(inst *instance.Instance, raw string) (jwt.MapClaims, error) {
+func validateTokenExchangeIDToken(inst *instance.Instance, raw, exchangeType string) (*tokenExchangeValidatedToken, error) {
 	if inst == nil {
 		return nil, errors.New("instance is missing")
 	}
 	conf, err := oidcprovider.LoadConfig(
 		inst.ContextName,
-		oidcprovider.RequireClientID,
 		oidcprovider.RequireIDTokenKeyURL,
 		oidcprovider.RequireIssuerOrTokenURL,
 	)
-	if err != nil || !conf.AllowOAuthToken {
-		return nil, errors.New("this endpoint is not enabled")
+	if err != nil {
+		inst.Logger().WithNamespace("oidc").
+			Warnf("token exchange disabled: OIDC config invalid for context %s: %s", inst.ContextName, err)
+		return nil, errTokenExchangeDisabled
 	}
 
 	claims, err := oidcprovider.VerifyIDToken(raw, conf)
@@ -107,15 +213,12 @@ func validateTokenExchangeIDToken(inst *instance.Instance, raw string) (jwt.MapC
 
 	expectedIssuer, err := oidcprovider.GetIssuer(inst.ContextName, conf)
 	if err != nil {
-		inst.Logger().WithNamespace("token_exchange").Errorf("Cannot get OIDC issuer for context %s: %s", inst.ContextName, err)
+		inst.Logger().WithNamespace("oidc").Errorf("Cannot get OIDC issuer for context %s: %s", inst.ContextName, err)
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "internal server error")
 	}
 	issuer, err := claims.GetIssuer()
 	if err != nil || issuer == "" || issuer != expectedIssuer {
 		return nil, errors.New("invalid token issuer")
-	}
-	if !tokenExchangeAudienceMatches(claims, conf.ClientID) {
-		return nil, errors.New("invalid token audience")
 	}
 	issuedAt, err := claims.GetIssuedAt()
 	if err != nil || issuedAt == nil {
@@ -124,29 +227,102 @@ func validateTokenExchangeIDToken(inst *instance.Instance, raw string) (jwt.MapC
 	if issuedAt.Time.After(time.Now().Add(5 * time.Minute)) {
 		return nil, errors.New("invalid token")
 	}
+	expiresAt, err := claims.GetExpirationTime()
+	if err != nil || expiresAt == nil {
+		return nil, errors.New("invalid token")
+	}
+	if time.Now().After(expiresAt.Time) {
+		return nil, errors.New("invalid token")
+	}
+	sid, _ := tokenExchangeClaimString(claims, "sid")
+	if sid == "" {
+		return nil, errors.New("sid claim is required")
+	}
+
+	validated := &tokenExchangeValidatedToken{
+		Claims: claims,
+	}
+	switch exchangeType {
+	case tokenExchangeTypeAdmin:
+		if err := validateTokenExchangeAdminToken(inst, conf, claims); err != nil {
+			return nil, err
+		}
+	case tokenExchangeTypeApp:
+		appConfig, err := validateTokenExchangeAppToken(inst, conf, claims)
+		if err != nil {
+			return nil, err
+		}
+		validated.AppConfig = appConfig
+	default:
+		return nil, fmt.Errorf("exchange_type %q is not allowed", exchangeType)
+	}
+	return validated, nil
+}
+
+func validateTokenExchangeAdminToken(inst *instance.Instance, conf *oidcprovider.Config, claims jwt.MapClaims) error {
+	if !conf.AllowOAuthToken {
+		inst.Logger().WithNamespace("oidc").
+			Warnf("admin token exchange disabled for context %s: allow_oauth_token=false", inst.ContextName)
+		return errTokenExchangeDisabled
+	}
+	if conf.ClientID == "" {
+		inst.Logger().WithNamespace("oidc").
+			Warnf("admin token exchange disabled for context %s: missing client_id in OIDC config", inst.ContextName)
+		return errTokenExchangeDisabled
+	}
+	if !tokenExchangeAudienceMatches(claims, conf.ClientID) {
+		return errors.New("invalid token audience")
+	}
 	if !tokenExchangeHasAdminRole(claims) {
-		return nil, errors.New("admin authorization is required")
+		return errors.New("admin authorization is required")
 	}
 
 	orgID, _ := tokenExchangeClaimString(claims, "org_id")
 	if orgID == "" || subtle.ConstantTimeCompare([]byte(orgID), []byte(inst.OrgID)) == 0 {
-		return nil, errors.New("org_id mismatch")
+		return errors.New("org_id mismatch")
 	}
 	if inst.OrgDomain != "" {
 		orgDomain, ok := tokenExchangeClaimString(claims, "org_domain")
 		if !ok || orgDomain == "" {
-			return nil, errors.New("org_domain claim is required")
+			return errors.New("org_domain claim is required")
 		}
 		if subtle.ConstantTimeCompare([]byte(orgDomain), []byte(inst.OrgDomain)) == 0 {
-			return nil, errors.New("org_domain mismatch")
+			return errors.New("org_domain mismatch")
 		}
 	}
 
-	return claims, nil
+	return nil
 }
 
-func createTokenExchangeOAuthClient(c echo.Context, inst *instance.Instance) (*oauth.Client, error) {
-	redirectURI, err := tokenExchangeRedirectURI(c, inst)
+func validateTokenExchangeAppToken(inst *instance.Instance, conf *oidcprovider.Config, claims jwt.MapClaims) (*config.OIDCAppTokenExchangeAppConfig, error) {
+	appExchangeConfig, err := config.GetOIDCAppTokenExchange(inst.ContextName)
+	if err != nil {
+		inst.Logger().WithNamespace("oidc").
+			Warnf("app token exchange config invalid for context %s: %s", inst.ContextName, err)
+		return nil, errTokenExchangeDisabled
+	}
+	if !appExchangeConfig.Enabled {
+		inst.Logger().WithNamespace("oidc").
+			Warnf("app token exchange disabled for context %s: allow_app_token_exchange=false", inst.ContextName)
+		return nil, errTokenExchangeDisabled
+	}
+	if len(appExchangeConfig.Apps) == 0 {
+		inst.Logger().WithNamespace("oidc").
+			Warnf("app token exchange disabled for context %s: no app_token_exchange entries configured", inst.ContextName)
+		return nil, errTokenExchangeDisabled
+	}
+	appConfig, ok := tokenExchangeMatchingAppConfig(claims, appExchangeConfig.Apps)
+	if !ok {
+		return nil, errors.New("invalid token audience")
+	}
+	if err := oidcprovider.CheckClaimsForInstance(conf, inst, claims); err != nil {
+		return nil, err
+	}
+	return appConfig, nil
+}
+
+func createTokenExchangeOAuthClient(c echo.Context, inst *instance.Instance, params tokenExchangeOAuthClientParams) (*oauth.Client, error) {
+	redirectURI, err := tokenExchangeRedirectURI(c, inst, params.AppSlug)
 	if err != nil {
 		return nil, echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
@@ -156,11 +332,15 @@ func createTokenExchangeOAuthClient(c echo.Context, inst *instance.Instance) (*o
 
 	client := &oauth.Client{
 		RedirectURIs: []string{redirectURI},
-		ClientName:   tokenExchangeOAuthClientName,
+		ClientName:   params.ClientName,
 		ClientKind:   "browser",
-		SoftwareID:   tokenExchangeOAuthClientSoftwareID,
+		SoftwareID:   params.SoftwareID,
 	}
-	if regErr := client.Create(inst); regErr != nil {
+	var opts []oauth.CreateOptions
+	if params.SoftwareIDPrevalidated {
+		opts = append(opts, oauth.SoftwareIDPrevalidated)
+	}
+	if regErr := client.Create(inst, opts...); regErr != nil {
 		return nil, echo.NewHTTPError(regErr.Code, regErr.Description)
 	}
 
@@ -170,6 +350,18 @@ func createTokenExchangeOAuthClient(c echo.Context, inst *instance.Instance) (*o
 	}
 	storedClient.RegistrationToken = client.RegistrationToken
 	return storedClient, nil
+}
+
+func tokenExchangeLinkedAppClientName(manifest *app.WebappManifest, slug string) string {
+	name := strings.TrimSpace(manifest.Name())
+	if name == "" {
+		return slug
+	}
+	prefix := strings.TrimSpace(manifest.NamePrefix())
+	if prefix == "" {
+		return name
+	}
+	return prefix + " " + name
 }
 
 func bindTokenExchangeOIDCSession(inst *instance.Instance, client *oauth.Client, claims jwt.MapClaims) error {
@@ -221,7 +413,7 @@ func buildTokenExchangeResponse(inst *instance.Instance, client *oauth.Client, s
 
 	client.LastRefreshedAt = time.Now()
 	if err := couchdb.UpdateDoc(inst, client); err != nil {
-		inst.Logger().WithNamespace("token_exchange").Warnf("Cannot update LastRefreshedAt for client %s: %s", client.CouchID, err)
+		inst.Logger().WithNamespace("oidc").Warnf("Cannot update LastRefreshedAt for client %s: %s", client.CouchID, err)
 	}
 
 	return out, nil
@@ -241,6 +433,35 @@ func tokenExchangeAudienceMatches(claims jwt.MapClaims, clientID string) bool {
 	return azp == clientID
 }
 
+// tokenExchangeMatchingAppConfig returns the first app exchange config whose
+// configured audience appears in the token's `aud` claim. If multiple audiences
+// match, the order in the token's `aud` slice wins.
+func tokenExchangeMatchingAppConfig(claims jwt.MapClaims, appConfigs map[string]config.OIDCAppTokenExchangeAppConfig) (*config.OIDCAppTokenExchangeAppConfig, bool) {
+	audiences, err := claims.GetAudience()
+	if err != nil {
+		return nil, false
+	}
+	for _, audience := range audiences {
+		if appConfig, ok := appConfigs[audience]; ok {
+			return &appConfig, true
+		}
+	}
+	return nil, false
+}
+
+func tokenExchangeAppSlugAllowed(contextName, slug string) bool {
+	appExchangeConfig, err := config.GetOIDCAppTokenExchange(contextName)
+	if err != nil || !appExchangeConfig.Enabled {
+		return false
+	}
+	for _, appConfig := range appExchangeConfig.Apps {
+		if oauth.GetLinkedAppSlug(appConfig.SoftwareID) == slug {
+			return true
+		}
+	}
+	return false
+}
+
 func tokenExchangeHasAdminRole(claims jwt.MapClaims) bool {
 	orgRole, ok := tokenExchangeClaimString(claims, "org_role")
 	return ok && (strings.EqualFold(orgRole, tokenExchangeAdminRole) ||
@@ -256,8 +477,26 @@ func tokenExchangeClaimString(claims jwt.MapClaims, key string) (string, bool) {
 	return value, ok
 }
 
-func tokenExchangeRedirectURI(c echo.Context, inst *instance.Instance) (string, error) {
-	if origin := c.Request().Header.Get(echo.HeaderOrigin); origin != "" {
+// tokenExchangeRedirectURI returns the redirect URI to attach to the
+// exchanged OAuth client.
+//
+// For app exchanges (appSlug != ""), the redirect URI is always the app's
+// own subdomain on this instance: callers cannot influence it via the
+// Origin header because executeTokenExchangeApp has already enforced that
+// the Origin (if any) is exactly that subdomain.
+//
+// For admin exchanges, the Origin header is honoured when it points
+// somewhere other than the instance itself, which lets the admin panel host
+// its own redirect target.
+func tokenExchangeRedirectURI(c echo.Context, inst *instance.Instance, appSlug string) (string, error) {
+	if inst != nil && appSlug != "" {
+		u := inst.SubDomain(appSlug)
+		u.Path = ""
+		return u.String(), nil
+	}
+
+	origin := c.Request().Header.Get(echo.HeaderOrigin)
+	if origin != "" && inst != nil {
 		u, err := url.Parse(origin)
 		if err == nil && u.Scheme != "" && u.Host != "" && utils.StripPort(u.Host) != inst.Domain {
 			u.Path = ""

--- a/web/auth/token_exchange_test.go
+++ b/web/auth/token_exchange_test.go
@@ -1,9 +1,12 @@
 package auth
 
 import (
+	"net/url"
 	"testing"
 
+	"github.com/cozy/cozy-stack/model/app"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidateTokenExchangeScope(t *testing.T) {
@@ -12,4 +15,45 @@ func TestValidateTokenExchangeScope(t *testing.T) {
 	assert.Error(t, validateTokenExchangeScope("io.cozy.files\tio.cozy.contacts\tio.cozy.contacts.groups\tio.cozy.apps\tio.cozy.sharings"))
 	assert.NoError(t, validateTokenExchangeScope("io.cozy.files"))
 	assert.NoError(t, validateTokenExchangeScope("io.cozy.files io.cozy.contacts io.cozy.contacts.groups io.cozy.apps io.cozy.sharings"))
+}
+
+func TestTokenExchangeRequestExchangeType(t *testing.T) {
+	exchangeType, err := tokenExchangeRequestExchangeType("")
+	assert.NoError(t, err)
+	assert.Equal(t, tokenExchangeTypeAdmin, exchangeType)
+
+	exchangeType, err = tokenExchangeRequestExchangeType("admin")
+	assert.NoError(t, err)
+	assert.Equal(t, tokenExchangeTypeAdmin, exchangeType)
+
+	exchangeType, err = tokenExchangeRequestExchangeType(" app ")
+	assert.NoError(t, err)
+	assert.Equal(t, tokenExchangeTypeApp, exchangeType)
+
+	_, err = tokenExchangeRequestExchangeType("user")
+	assert.EqualError(t, err, `exchange_type "user" is not allowed`)
+}
+
+func TestTokenExchangeAssertManifestTrusted(t *testing.T) {
+	mk := func(source string) *app.WebappManifest {
+		m := &app.WebappManifest{}
+		m.SetSlug("mail")
+		if source != "" {
+			u, err := url.Parse(source)
+			require.NoError(t, err)
+			m.SetSource(u)
+		}
+		return m
+	}
+
+	assert.NoError(t, tokenExchangeAssertManifestTrusted(mk("registry://mail"), "mail"))
+
+	err := tokenExchangeAssertManifestTrusted(mk(""), "mail")
+	assert.EqualError(t, err, "code=400, message=mail is not a registry application")
+
+	err = tokenExchangeAssertManifestTrusted(mk("git://example.com/mail"), "mail")
+	assert.EqualError(t, err, "code=400, message=mail is not a registry application")
+
+	err = tokenExchangeAssertManifestTrusted(mk("registry://contacts"), "mail")
+	assert.EqualError(t, err, "code=400, message=mail is not the installed application")
 }

--- a/web/oidc/oidc.go
+++ b/web/oidc/oidc.go
@@ -23,10 +23,8 @@ import (
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
-	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
 	"github.com/cozy/cozy-stack/pkg/limits"
 	"github.com/cozy/cozy-stack/pkg/logger"
-	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/cozy/cozy-stack/web/auth"
 	"github.com/cozy/cozy-stack/web/bitwarden"
 	"github.com/cozy/cozy-stack/web/middlewares"
@@ -38,7 +36,7 @@ import (
 var (
 	ErrInvalidToken         = errors.New("invalid token")
 	ErrInvalidConfiguration = errors.New("invalid configuration")
-	ErrAuthenticationFailed = errors.New("the authentication has failed")
+	ErrAuthenticationFailed = oidcprovider.ErrInstanceAuthenticationFailed
 	ErrFranceConnectFailed  = errors.New("the FranceConnect authentication has failed")
 	ErrIdentityProvider     = errors.New("error from the identity provider")
 	ErrAmbiguousLogout      = errors.New("ambiguous logout context")
@@ -46,24 +44,7 @@ var (
 
 // DomainMismatchError is returned when the user tries to connect to an
 // instance but has an active OIDC session for a different instance/account.
-type DomainMismatchError struct {
-	ExpectedDomain string // The instance the user is trying to access
-	ActualDomain   string // The instance from the OIDC token
-}
-
-// TranslationKey returns the i18n key for translating this error.
-func (e *DomainMismatchError) TranslationKey() string {
-	return "OIDC Domain Mismatch %s %s"
-}
-
-// TranslationArgs returns the arguments for the translation.
-func (e *DomainMismatchError) TranslationArgs() []interface{} {
-	return []interface{}{e.ExpectedDomain, e.ActualDomain}
-}
-
-func (e *DomainMismatchError) Error() string {
-	return fmt.Sprintf("OIDC Domain Mismatch %s %s", e.ExpectedDomain, e.ActualDomain)
-}
+type DomainMismatchError = oidcprovider.InstanceMismatchError
 
 // extractSessionID extracts the session ID (sid) from an id_token.
 func extractSessionID(idToken string) string {
@@ -287,9 +268,9 @@ func Redirect(c echo.Context) error {
 			logger.WithNamespace("oidc").Errorf("Missing sub")
 			return ErrAuthenticationFailed
 		}
-		domain, err := extractDomain(conf, params)
+		domain, err := oidcprovider.ExtractDomainFromClaims(conf, params)
 		if err == ErrAuthenticationFailed && conf.AllowCustomInstance {
-			inst, err := findInstanceBySub(sub, state.OIDCContext)
+			inst, err := oidcprovider.FindInstanceBySub(sub, state.OIDCContext)
 			if err != nil {
 				return renderError(c, nil, http.StatusNotFound, "Sorry, the twake was not found.")
 			}
@@ -478,7 +459,7 @@ func acceptSharing(c echo.Context, ownerInst *instance.Instance, conf *Config, t
 			"OIDC sharing lookup by oidc_id: oidc_id=%q context=%s",
 			sub, state.OIDCContext,
 		)
-		memberInst, err = findInstanceBySub(sub, state.OIDCContext)
+		memberInst, err = oidcprovider.FindInstanceBySub(sub, state.OIDCContext)
 		if err != nil {
 			oidcLog.Warnf(
 				"OIDC sharing lookup by oidc_id failed: oidc_id=%q context=%s error=%s",
@@ -488,7 +469,7 @@ func acceptSharing(c echo.Context, ownerInst *instance.Instance, conf *Config, t
 	}
 	if memberInst == nil {
 		// Fall back to domain extraction from user info
-		domain, err := extractDomain(conf, params)
+		domain, err := oidcprovider.ExtractDomainFromClaims(conf, params)
 		if err == nil {
 			oidcLog.Infof("OIDC sharing lookup by domain: domain=%s", domain)
 			memberInst, err = lifecycle.GetInstance(domain)
@@ -503,7 +484,7 @@ func acceptSharing(c echo.Context, ownerInst *instance.Instance, conf *Config, t
 				"OIDC sharing lookup domain extraction failed, retrying oidc_id lookup: oidc_id=%q context=%s error=%s",
 				sub, state.OIDCContext, err,
 			)
-			memberInst, err = findInstanceBySub(sub, state.OIDCContext)
+			memberInst, err = oidcprovider.FindInstanceBySub(sub, state.OIDCContext)
 			if err != nil {
 				oidcLog.Infof(
 					"OIDC sharing lookup retry by oidc_id failed: oidc_id=%q context=%s error=%s",
@@ -936,27 +917,11 @@ func applyLogoutForContext(verified logoutContext) error {
 }
 
 func resolveLogoutInstance(contextName string, conf *Config, claims jwt.MapClaims) (*instance.Instance, error) {
-	if conf.AllowCustomInstance {
-		sub, ok := claims["sub"].(string)
-		if !ok {
-			return nil, errors.New("invalid claims")
-		}
-		logger.WithNamespace("oidc").Debugf(
-			"Resolving logout instance by subject for context %s",
-			contextName,
-		)
-		return findInstanceBySub(sub, contextName)
-	}
-
-	domain, ok := claims[conf.UserInfoField].(string)
-	if !ok {
-		return nil, errors.New("invalid claims")
-	}
 	logger.WithNamespace("oidc").Debugf(
-		"Resolving logout instance by %s for context %s",
-		conf.UserInfoField, contextName,
+		"Resolving logout instance for context %s using OIDC instance mapping",
+		contextName,
 	)
-	return lifecycle.GetInstance(buildDomain(domain, conf))
+	return oidcprovider.ResolveInstanceFromClaims(contextName, conf, claims)
 }
 
 func audienceContains(audiences []string, clientID string) bool {
@@ -1325,7 +1290,7 @@ func getDomainFromUserInfo(conf *Config, token string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return extractDomain(conf, params)
+	return oidcprovider.ExtractDomainFromClaims(conf, params)
 }
 
 func checkDomainFromUserInfo(conf *Config, inst *instance.Instance, token string) error {
@@ -1334,39 +1299,17 @@ func checkDomainFromUserInfo(conf *Config, inst *instance.Instance, token string
 		return err
 	}
 
-	if conf.AllowCustomInstance {
-		sub, ok := params["sub"].(string)
-		expected := inst.OIDCID
-		if conf.Provider == oidcprovider.FranceConnectProvider {
-			expected = inst.FranceConnectID
+	err = oidcprovider.CheckClaimsForInstance(conf, inst, params)
+	if err != nil && conf.Provider == oidcprovider.FranceConnectProvider {
+		if errors.Is(err, ErrAuthenticationFailed) {
+			return ErrFranceConnectFailed
 		}
-		if !ok || sub == "" {
-			inst.Logger().WithNamespace("oidc").Errorf("Invalid sub: %s != %s", sub, expected)
-			if conf.Provider == oidcprovider.FranceConnectProvider {
-				return ErrFranceConnectFailed
-			}
-			return ErrAuthenticationFailed
+		var mismatch *oidcprovider.InstanceMismatchError
+		if errors.As(err, &mismatch) {
+			return ErrFranceConnectFailed
 		}
-		if sub != expected {
-			inst.Logger().WithNamespace("oidc").Errorf("Invalid sub: %s != %s", sub, expected)
-			if conf.Provider == oidcprovider.FranceConnectProvider {
-				return ErrFranceConnectFailed
-			}
-			return &DomainMismatchError{ExpectedDomain: inst.Domain, ActualDomain: sub}
-		}
-		return nil
 	}
-
-	domain, err := extractDomain(conf, params)
-	if err != nil {
-		logger.WithNamespace("oidc").Warnf("Cannot extract domain: %s", err)
-		return err
-	}
-	if domain != inst.Domain {
-		logger.WithNamespace("oidc").Errorf("Invalid domains: %s != %s", domain, inst.Domain)
-		return &DomainMismatchError{ExpectedDomain: inst.Domain, ActualDomain: domain}
-	}
-	return nil
+	return err
 }
 
 func getUserInfo(conf *Config, token string) (map[string]interface{}, error) {
@@ -1396,46 +1339,6 @@ func getUserInfo(conf *Config, token string) (map[string]interface{}, error) {
 		return nil, ErrIdentityProvider
 	}
 	return params, nil
-}
-
-func extractDomain(conf *Config, params map[string]interface{}) (string, error) {
-	domain, ok := params[conf.UserInfoField].(string)
-	if !ok {
-		return "", ErrAuthenticationFailed
-	}
-	return buildDomain(domain, conf), nil
-}
-
-func buildDomain(domain string, conf *Config) string {
-	domain = strings.ToLower(domain)             // The domain is case insensitive
-	domain = strings.ReplaceAll(domain, "-", "") // We don't want - in cozy instance
-	if conf.UserInfoSuffix != "" {
-		// When we have a suffix, it means that the data from user infos is
-		// just the slug, and we don't . in the slug
-		domain = strings.ReplaceAll(domain, ".", "")
-	}
-	domain = conf.UserInfoPrefix + domain + conf.UserInfoSuffix
-	return domain
-}
-
-func findInstanceBySub(sub, contextName string) (*instance.Instance, error) {
-	var instances []*instance.Instance
-	req := &couchdb.FindRequest{
-		UseIndex: "by-oidcid",
-		Selector: mango.And(
-			mango.Equal("oidc_id", sub),
-			mango.Equal("context", contextName),
-		),
-		Limit: 1,
-	}
-	err := couchdb.FindDocs(prefixer.GlobalPrefixer, consts.Instances, req, &instances)
-	if err != nil {
-		return nil, err
-	}
-	if len(instances) == 0 {
-		return nil, errors.New("instance not found")
-	}
-	return instances[0], nil
 }
 
 func checkIDToken(conf *Config, inst *instance.Instance, idToken string) error {
@@ -1561,7 +1464,7 @@ func GetDelegatedCode(c echo.Context) error {
 		}
 		s = sub
 	} else {
-		domain, err := extractDomain(conf, params)
+		domain, err := oidcprovider.ExtractDomainFromClaims(conf, params)
 		if err != nil {
 			logger.WithNamespace("oidc").Warnf("Cannot extract domain: %s", err)
 			return err


### PR DESCRIPTION
 ## Summary

  Adds OIDC app token exchange support to `/auth/token_exchange`.

  This lets a trusted frontend app, like Twake Mail, exchange an external OIDC `id_token` for a local Cozy OAuth client and access/refresh tokens, and initialize cozy-client

  ## Changes

  - Adds `exchange_type` to `/auth/token_exchange`.
    - Missing value keeps the existing admin exchange behavior.
    - `exchange_type: "app"` enables app token exchange.
  - Adds OIDC config for trusted app exchanges:
    - `allow_app_token_exchange`
    - `app_token_exchange`
  - Maps an OIDC token audience, like `twake-mail-web`, to a Cozy linked app, like `registry://mail`.
  - Derives the local OAuth scope from the linked app manifest instead of accepting caller-provided scopes.
 
