### PR TITLE
feat: preserve revoked org drive sharing documents

### DIFF
--- a/model/sharing/group_test.go
+++ b/model/sharing/group_test.go
@@ -301,6 +301,29 @@ func TestGroups(t *testing.T) {
 		assert.True(t, couchdb.IsNotFoundError(err), "expected deleted sharing, got %v", err)
 	})
 
+	t.Run("RevokeLastOrgDriveGroupKeepsInactiveSharing", func(t *testing.T) {
+		team := createGroup(t, inst, "Org Drive Group")
+		_ = createContactInGroups(t, inst, "OrgDriveGroupAlice", []string{team.ID()})
+		s := createDriveSharingForGroupTest(t, inst, "Org drive group revoke")
+		s.OrgDrive = true
+		sid := s.SID
+		require.NoError(t, s.AddGroup(inst, team.ID(), false))
+		require.NoError(t, couchdb.UpdateDoc(inst, s))
+
+		require.Len(t, s.Members, 2)
+		require.Len(t, s.Groups, 1)
+		require.NoError(t, s.RevokeGroup(inst, 0))
+
+		stored := &Sharing{}
+		require.NoError(t, couchdb.GetDoc(inst, consts.Sharings, sid, stored))
+		assert.False(t, stored.Active)
+		assert.True(t, stored.OrgDrive)
+		require.Len(t, stored.Members, 2)
+		assert.Equal(t, MemberStatusRevoked, stored.Members[1].Status)
+		require.Len(t, stored.Groups, 1)
+		assert.True(t, stored.Groups[0].Revoked)
+	})
+
 	t.Run("RevokeEmptyLastDriveGroupDeletesSharing", func(t *testing.T) {
 		team := createGroup(t, inst, "Empty Drive Group")
 		s := createDriveSharingForGroupTest(t, inst, "Empty drive group revoke")

--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -995,7 +995,7 @@ func (s *Sharing) hasRemainingRecipients() bool {
 }
 
 func (s *Sharing) deleteRevokedDriveSharing(inst *instance.Instance) error {
-	if !s.Drive {
+	if !s.Drive || s.OrgDrive {
 		return nil
 	}
 	err := couchdb.DeleteDoc(inst, s)

--- a/web/sharings/drives_test.go
+++ b/web/sharings/drives_test.go
@@ -2819,6 +2819,21 @@ func TestOrgDriveFlag(t *testing.T) {
 		recipientOrgDrive, err := getOrgDriveFlag(env.tsB.URL, env.bettyToken)
 		return err == nil && recipientOrgDrive
 	}, 10*time.Second, 200*time.Millisecond, "recipient sharing should preserve org_drive")
+
+	eOwner.DELETE("/sharings/"+sharingID+"/recipients").
+		WithHeader("Authorization", "Bearer "+env.acmeToken).
+		Expect().Status(http.StatusNoContent)
+
+	var revoked sharing.Sharing
+	require.Eventually(t, func() bool {
+		if err := couchdb.GetDoc(env.acme, consts.Sharings, sharingID, &revoked); err != nil {
+			return false
+		}
+		return revoked.OrgDrive && !revoked.Active
+	}, 5*time.Second, 100*time.Millisecond, "owner org-drive sharing should be kept inactive after revocation")
+	require.Len(t, revoked.Members, 2)
+	assert.Equal(t, sharing.MemberStatusRevoked, revoked.Members[1].Status)
+	requireNoDirSharingReference(t, env.acme, folderID, sharingID)
 }
 
 func TestSharedDriveTrashAttribution(t *testing.T) {


### PR DESCRIPTION
## Summary
  Keep revoked drive sharing documents when `org_drive=true`
 