### PR TITLE
fix: keep sharing news counter for background drive realtime connections

### DIFF
--- a/docs/shared-drives.md
+++ b/docs/shared-drives.md
@@ -1073,6 +1073,12 @@ Recipients are transparently proxied to the owner's instance.
 Get the changes inside a shared drive in real-time from a websocket.
 Identical to [`GET /realtime`](realtime.md), except subscribing to the shared drive is automatically done.
 
+On the recipient side, connecting marks the sharing as seen (its shortcut
+leaves the `new` status counted by `GET /sharings/news`). Background
+consumers that watch a drive without the user looking at it, like the
+dataproxy indexer, must pass the query parameter `background=true` to keep
+the sharing unseen.
+
 This route is currently available only for directory-root shared drives.
 For file-root shared drives, the websocket stream emits only events whose
 target is the root file of the drive. Unrelated file events are filtered out.

--- a/web/sharings/drives_test.go
+++ b/web/sharings/drives_test.go
@@ -4214,6 +4214,82 @@ func TestOpeningPendingSharedDriveShortcutClearsNewsCounter(t *testing.T) {
 	}, 5*time.Second, 100*time.Millisecond, "Betty's opened shared-drive shortcut should be removed after revocation")
 }
 
+func TestBackgroundRealtimeConnectionKeepsSharingNew(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	env := setupSharedDrivesEnv(t)
+	eA, eB, _ := env.createClients(t)
+	sharingID := createDirectRecipientDriveSharing(
+		t,
+		env.acme,
+		eA,
+		env.acmeToken,
+		"Betty Background",
+		"betty@example.net",
+		env.tsB.URL,
+		"Background Realtime Drive",
+		"Drive watched by a background indexer",
+	)
+
+	recipientSharing := waitForSharingOnRecipient(t, env.betty, sharingID)
+	require.NotEmpty(t, recipientSharing.ShortcutID)
+	shortcutID := recipientSharing.ShortcutID
+
+	loginSharingRecipient(t, eB)
+	FakeOwnerInstanceForSharing(t, env.betty, env.tsA.URL, sharingID)
+	require.NotEmpty(t, recipientSharing.Credentials)
+	require.NotEmpty(t, recipientSharing.Credentials[0].State)
+	authorizeLink := fmt.Sprintf(
+		"%s/auth/authorize/sharing?sharing_id=%s&state=%s",
+		env.tsB.URL,
+		sharingID,
+		url.QueryEscape(recipientSharing.Credentials[0].State),
+	)
+	openSharingAuthorize(t, eB, authorizeLink, sharingID)
+
+	// Put the shortcut back in the "new" state, like after an auto-accepted
+	// sharing where the user has not looked at the drive yet.
+	setShortcutSharingStatus(t, env.betty, shortcutID, "new")
+
+	ws := eB.GET("/sharings/drives/"+sharingID+"/realtime").
+		WithQuery("background", "true").
+		WithWebsocketUpgrade().
+		Expect().Status(http.StatusSwitchingProtocols).
+		Websocket()
+	ws.WriteText(fmt.Sprintf(`{"method": "AUTH", "payload": "%s"}`, env.bettyToken))
+	time.Sleep(300 * time.Millisecond)
+	ws.Disconnect()
+
+	count, err := sharing.CountNewShortcuts(env.betty)
+	require.NoError(t, err)
+	require.Equal(t, 1, count, "a background realtime connection should not mark the sharing as seen")
+
+	ws = eB.GET("/sharings/drives/" + sharingID + "/realtime").
+		WithWebsocketUpgrade().
+		Expect().Status(http.StatusSwitchingProtocols).
+		Websocket()
+	defer ws.Disconnect()
+	ws.WriteText(fmt.Sprintf(`{"method": "AUTH", "payload": "%s"}`, env.bettyToken))
+
+	require.Eventually(t, func() bool {
+		count, err := sharing.CountNewShortcuts(env.betty)
+		return err == nil && count == 0
+	}, 5*time.Second, 100*time.Millisecond, "a foreground realtime connection should mark the sharing as seen")
+}
+
+func setShortcutSharingStatus(t *testing.T, inst *instance.Instance, shortcutID, status string) {
+	t.Helper()
+	file, err := inst.VFS().FileByID(shortcutID)
+	require.NoError(t, err)
+	old := file.Clone().(*vfs.FileDoc)
+	meta, ok := file.Metadata["sharing"].(map[string]interface{})
+	require.True(t, ok, "shortcut should carry sharing metadata")
+	meta["status"] = status
+	require.NoError(t, inst.VFS().UpdateFileDoc(old, file))
+}
+
 func TestDirectoryRootSharedDriveOwnerDeletionRevokesRecipient(t *testing.T) {
 	if testing.Short() {
 		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")

--- a/web/sharings/realtime.go
+++ b/web/sharings/realtime.go
@@ -339,12 +339,17 @@ func Ws(c echo.Context) error {
 		return jsonapi.InternalServerError(err)
 	}
 
-	go func() {
-		if err := markSharingAsSeen(inst, s); err != nil {
-			inst.Logger().WithNamespace("sharing").
-				Warnf("markSharingAsSeen failed: %s", err)
-		}
-	}()
+	// Background consumers (like the dataproxy indexer) watch the drive
+	// without the user looking at it, so they must not consume the "new"
+	// status that feeds the sharings news counter.
+	if c.QueryParam("background") != "true" {
+		go func() {
+			if err := markSharingAsSeen(inst, s); err != nil {
+				inst.Logger().WithNamespace("sharing").
+					Warnf("markSharingAsSeen failed: %s", err)
+			}
+		}()
+	}
 
 	// XXX Let's try to avoid one http request by cheating a bit. If the two
 	// instances are on the same domain (same stack), we can watch directly


### PR DESCRIPTION
## Problem
The recipient websocket `/sharings/drives/:id/realtime` marks the sharing as seen on every connection. The dataproxy indexer connects to every accepted drive sharing within seconds to index it, so on auto-accepted sharings the shortcut flips from new to seen before the user ever sees the sharings counter. The recipient never gets the red badge for a newly shared drive.

## Solution
Background consumers now pass `?background=true` to keep the sharing unseen. The default is unchanged, so the drive folder view (and any deployed client) still marks the sharing as seen when the user actually opens the drive. The dataproxy side is in cozy-libs (cozy-realtime grows a `background` option, the search indexer passes it).