### PR TITLE
add trailing slash to restore_path for trashed directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ tmp
 /debian/tmp/
 /.gocache
 /.idea
+.opencode

--- a/model/vfs/directory.go
+++ b/model/vfs/directory.go
@@ -300,7 +300,7 @@ func TrashDir(fs VFS, olddoc *DirDoc) (*DirDoc, error) {
 	}
 
 	trashDirID := consts.TrashDirID
-	restorePath := path.Dir(oldpath)
+	restorePath := path.Dir(oldpath) + "/"
 
 	var newdoc *DirDoc
 	err = tryOrUseSuffix(olddoc.DocName, conflictFormat, func(name string) error {

--- a/model/vfs/file.go
+++ b/model/vfs/file.go
@@ -406,7 +406,7 @@ func TrashFile(fs VFS, olddoc *FileDoc) (*FileDoc, error) {
 	}
 
 	var newdoc *FileDoc
-	restorePath := path.Dir(oldpath)
+	restorePath := path.Dir(oldpath) + "/"
 	err = tryOrUseSuffix(olddoc.DocName, conflictFormat, func(name string) error {
 		newdoc = olddoc.Clone().(*FileDoc)
 		newdoc.DirID = consts.TrashDirID


### PR DESCRIPTION
Add a trailing `/` to `restore_path` (path of the parent folder) when trashing files and directories. This prevents false positives when querying the trash of shared drives with similar names — without it, a `$gte: "/Shared Drives/Test"` query also captures files from `"/Shared Drives/Test 2/..."`.

No impact on `RestoreDir` / `RestoreFile` — `DirByPath` uses `path.Clean` which strips trailing slashes, and `path.Join` normalizes paths.

App must change fetch from 
```
    Q(FILES_DOCTYPE)
      .where({
        dir_id: TRASH_DIR_ID,
        type,
        name: { $gt: null },
        restore_path: { $gte: path, $lt: path + '\ufff0' }
      })
```
to
```
    Q(FILES_DOCTYPE)
      .where({
        dir_id: TRASH_DIR_ID,
        type,
        name: { $gt: null },
        restore_path: { $gte: path + '/', $lt: path + '\ufff0' }
```