### PR TITLE
fix: update shared drive target URLs

### DIFF
--- a/model/sharing/files_test.go
+++ b/model/sharing/files_test.go
@@ -28,7 +28,7 @@ func TestDriveURLHelpers(t *testing.T) {
 		}
 
 		u := s.DriveTargetURL(inst)
-		assert.Equal(t, "sharing=sharing-id", u.RawQuery)
+		assert.Empty(t, u.RawQuery)
 		assert.Equal(t, "/shareddrive/sharing-id/folder-id", u.Fragment)
 	})
 
@@ -41,8 +41,8 @@ func TestDriveURLHelpers(t *testing.T) {
 		}
 
 		u := s.DriveTargetURL(inst)
-		assert.Equal(t, "sharing=sharing-id", u.RawQuery)
-		assert.Equal(t, "/shareddrive/sharing-id/file/file-id", u.Fragment)
+		assert.Empty(t, u.RawQuery)
+		assert.Equal(t, "/sharings/shareddrive/sharing-id/file/file-id", u.Fragment)
 	})
 
 	t.Run("FallbackTarget", func(t *testing.T) {
@@ -52,7 +52,7 @@ func TestDriveURLHelpers(t *testing.T) {
 		}
 
 		u := s.DriveTargetURL(inst)
-		assert.Equal(t, "sharing=sharing-id", u.RawQuery)
+		assert.Empty(t, u.RawQuery)
 		assert.Equal(t, "/folder/"+consts.SharedDrivesDirID, u.Fragment)
 	})
 
@@ -82,6 +82,7 @@ func TestDriveURLHelpers(t *testing.T) {
 
 		seenURL, err := url.Parse(s.driveShortcutURL(inst, true))
 		require.NoError(t, err)
+		assert.Empty(t, seenURL.RawQuery)
 		assert.Equal(t, "/shareddrive/sharing-id/folder-id", seenURL.Fragment)
 	})
 }

--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -168,7 +168,6 @@ func (s *Sharing) DriveRootID() (string, error) {
 // DriveTargetURL returns the Drive URL that opens the shared drive root.
 func (s *Sharing) DriveTargetURL(inst *instance.Instance) *url.URL {
 	u := inst.SubDomain(consts.DriveSlug)
-	u.RawQuery = url.Values{"sharing": {s.SID}}.Encode()
 
 	rootID, err := s.DriveRootID()
 	if err != nil {
@@ -179,7 +178,7 @@ func (s *Sharing) DriveTargetURL(inst *instance.Instance) *url.URL {
 	sharingID := url.PathEscape(s.SID)
 	rootID = url.PathEscape(rootID)
 	if s.HasFileDriveRoot() {
-		u.Fragment = "/shareddrive/" + sharingID + "/file/" + rootID
+		u.Fragment = "/sharings/shareddrive/" + sharingID + "/file/" + rootID
 	} else {
 		u.Fragment = "/shareddrive/" + sharingID + "/" + rootID
 	}

--- a/web/sharings/drives_test.go
+++ b/web/sharings/drives_test.go
@@ -779,6 +779,31 @@ func submitSharingDiscovery(
 	return redirectHeader.NotEmpty().Raw()
 }
 
+func assertSharedDriveRedirectLocation(t *testing.T, location, sharingID string) {
+	t.Helper()
+
+	u, err := url.Parse(location)
+	require.NoError(t, err)
+
+	folderPrefix := "/shareddrive/" + sharingID + "/"
+	filePrefix := "/sharings/shareddrive/" + sharingID + "/file/"
+	switch {
+	case strings.HasPrefix(u.Fragment, folderPrefix):
+		require.NotEmpty(t, strings.TrimPrefix(u.Fragment, folderPrefix), "folder redirect should include a root folder id")
+	case strings.HasPrefix(u.Fragment, filePrefix):
+		require.NotEmpty(t, strings.TrimPrefix(u.Fragment, filePrefix), "file redirect should include a root file id")
+	default:
+		require.Failf(
+			t,
+			"unexpected shared drive redirect",
+			"expected Location %q fragment to start with %q or %q",
+			location,
+			folderPrefix,
+			filePrefix,
+		)
+	}
+}
+
 func submitSharingAuthorize(
 	t *testing.T,
 	eRecipient *httpexpect.Expect,
@@ -793,7 +818,7 @@ func submitSharingAuthorize(
 	state := authorizeURL.Query().Get("state")
 	require.NotEmpty(t, state)
 
-	eRecipient.POST(authorizeURL.Path).
+	location := eRecipient.POST(authorizeURL.Path).
 		WithFormField("sharing_id", sharingID).
 		WithFormField("state", state).
 		WithFormField("csrf_token", csrfToken).
@@ -801,7 +826,8 @@ func submitSharingAuthorize(
 		WithRedirectPolicy(httpexpect.DontFollowRedirects).
 		Expect().Status(http.StatusSeeOther).
 		Header("Location").
-		Contains("#/shareddrive/" + sharingID + "/")
+		Raw()
+	assertSharedDriveRedirectLocation(t, location, sharingID)
 }
 
 func openSharingAuthorize(
@@ -817,14 +843,15 @@ func openSharingAuthorize(
 	state := authorizeURL.Query().Get("state")
 	require.NotEmpty(t, state)
 
-	eRecipient.GET(authorizeURL.Path).
+	location := eRecipient.GET(authorizeURL.Path).
 		WithQuery("sharing_id", sharingID).
 		WithQuery("state", state).
 		WithRedirectPolicy(httpexpect.DontFollowRedirects).
 		Expect().
 		Status(http.StatusSeeOther).
 		Header("Location").
-		Contains("#/shareddrive/" + sharingID + "/")
+		Raw()
+	assertSharedDriveRedirectLocation(t, location, sharingID)
 }
 
 func waitForSharingOnRecipient(t *testing.T, recipientInstance *instance.Instance, sharingID string) *sharing.Sharing {
@@ -1832,14 +1859,15 @@ func TestDriveAutoAcceptTrusted(t *testing.T) {
 	state := recipientSharing.Credentials[0].State
 	require.NotEmpty(t, state)
 
-	env.eRecipient.GET("/auth/authorize/sharing").
+	location := env.eRecipient.GET("/auth/authorize/sharing").
 		WithQuery("sharing_id", sharingID).
 		WithQuery("state", state).
 		WithRedirectPolicy(httpexpect.DontFollowRedirects).
 		Expect().
 		Status(http.StatusSeeOther).
 		Header("Location").
-		Contains("#/shareddrive/" + sharingID + "/")
+		Raw()
+	assertSharedDriveRedirectLocation(t, location, sharingID)
 }
 
 func TestSendAnswerIsIdempotentAfterStaleConflict(t *testing.T) {

--- a/web/sharings/drives_test.go
+++ b/web/sharings/drives_test.go
@@ -1961,7 +1961,7 @@ func TestFileRootSharedDriveAuthorizeRedirect(t *testing.T) {
 		Expect().
 		Status(http.StatusSeeOther).
 		Header("Location").
-		Contains("#/shareddrive/" + sharingID + "/file/" + rootFileID)
+		Contains("#/sharings/shareddrive/" + sharingID + "/file/" + rootFileID)
 }
 
 func TestSharedDriveAcceptance(t *testing.T) {


### PR DESCRIPTION
## Summary

  - Update `DriveTargetURL` to stop adding the `?sharing=<id>` query parameter.
  - Change file-root shared drive redirects to `#/sharings/shareddrive/<sharing_id>/file/<file_id>`.
