### PR TITLE
feat/resolve OIDC context by email

### DIFF
--- a/pkg/config/config/config.go
+++ b/pkg/config/config/config.go
@@ -553,6 +553,40 @@ func GetOIDC(contextName string) (map[string]interface{}, bool) {
 	return config, ok
 }
 
+// ErrOIDCDomainConflict is returned when a domain is configured on more than
+// one OIDC context.
+var ErrOIDCDomainConflict = errors.New("multiple OIDC contexts match domain")
+
+// GetOIDCContextByDomain returns the OIDC context configured for a normalized
+// email domain.
+func GetOIDCContextByDomain(domain string) (string, error) {
+	domain = utils.NormalizeDomain(domain)
+	if domain == "" || config.Authentication == nil {
+		return "", nil
+	}
+
+	var match string
+	for contextName, rawAuth := range config.Authentication {
+		auth, ok := rawAuth.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		oidc, ok := auth["oidc"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		configuredDomain, ok := oidc["domain"].(string)
+		if !ok || utils.NormalizeDomain(configuredDomain) != domain {
+			continue
+		}
+		if match != "" && match != contextName {
+			return "", ErrOIDCDomainConflict
+		}
+		match = contextName
+	}
+	return match, nil
+}
+
 // GetFranceConnect returns the FranceConnect config for the given context
 // (with a boolean to say if FranceConnect is enabled).
 func GetFranceConnect(contextName string) (map[string]interface{}, bool) {

--- a/pkg/config/config/config_test.go
+++ b/pkg/config/config/config_test.go
@@ -308,6 +308,66 @@ func TestConfigUnmarshal(t *testing.T) {
 	assert.Equal(t, []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"}, cfg.SafeHTTPTrustedNetworks)
 }
 
+func TestGetOIDCContextByDomain(t *testing.T) {
+	oldConfig := config
+	t.Cleanup(func() {
+		config = oldConfig
+	})
+
+	config = &Config{
+		Authentication: map[string]interface{}{
+			"acme": map[string]interface{}{
+				"oidc": map[string]interface{}{
+					"domain": "acme.fr.",
+				},
+			},
+			"beta": map[string]interface{}{
+				"oidc": map[string]interface{}{
+					"domain": "beta.example",
+				},
+			},
+		},
+	}
+
+	contextName, err := GetOIDCContextByDomain(" ACME.FR ")
+	require.NoError(t, err)
+	assert.Equal(t, "acme", contextName)
+
+	contextName, err = GetOIDCContextByDomain("beta.example")
+	require.NoError(t, err)
+	assert.Equal(t, "beta", contextName)
+
+	contextName, err = GetOIDCContextByDomain("unknown.example")
+	require.NoError(t, err)
+	assert.Empty(t, contextName)
+}
+
+func TestGetOIDCContextByDomainConflict(t *testing.T) {
+	oldConfig := config
+	t.Cleanup(func() {
+		config = oldConfig
+	})
+
+	config = &Config{
+		Authentication: map[string]interface{}{
+			"first": map[string]interface{}{
+				"oidc": map[string]interface{}{
+					"domain": "example.com",
+				},
+			},
+			"second": map[string]interface{}{
+				"oidc": map[string]interface{}{
+					"domain": "example.com",
+				},
+			},
+		},
+	}
+
+	contextName, err := GetOIDCContextByDomain("example.com")
+	assert.ErrorIs(t, err, ErrOIDCDomainConflict)
+	assert.Empty(t, contextName)
+}
+
 func TestUseViper(t *testing.T) {
 	cfg := viper.New()
 	cfg.Set("couchdb.url", "http://db:1234")

--- a/web/oidc/oidc.go
+++ b/web/oidc/oidc.go
@@ -124,8 +124,14 @@ func StartFranceConnect(c echo.Context) error {
 // Sharing is the route to use the SSO to accept a sharing.
 func Sharing(c echo.Context) error {
 	inst := middlewares.GetInstance(c)
+	return RedirectSharingWithContext(c, inst, inst.ContextName, c.QueryParam("sharingID"), c.QueryParam("state"), "")
+}
+
+// RedirectSharingWithContext starts the sharing OIDC flow with the given context.
+// If loginHint is empty, the usual instance login hint is used.
+func RedirectSharingWithContext(c echo.Context, inst *instance.Instance, contextName, sharingID, sharingState, loginHint string) error {
 	conf, err := oidcprovider.LoadConfig(
-		inst.ContextName,
+		contextName,
 		oidcprovider.RequireClientID,
 		oidcprovider.RequireScope,
 		oidcprovider.RequireRedirectURI,
@@ -135,7 +141,10 @@ func Sharing(c echo.Context) error {
 		inst.Logger().WithNamespace("oidc").Infof("Start error: %s", err)
 		return renderError(c, nil, http.StatusNotFound, "Sorry, the context was not found.")
 	}
-	u, err := makeSharingStartURL(inst, c.QueryParam("sharingID"), c.QueryParam("state"), conf, inst.ContextName)
+	if loginHint == "" {
+		loginHint = getLoginHint(inst)
+	}
+	u, err := makeSharingStartURLWithLoginHint(inst, sharingID, sharingState, conf, contextName, loginHint)
 	if err != nil {
 		return renderError(c, nil, http.StatusNotFound, "Sorry, the server is not configured for OpenID Connect.")
 	}
@@ -1217,6 +1226,10 @@ func makeStartURL(inst *instance.Instance, domain, redirect, confirm, oidcContex
 }
 
 func makeSharingStartURL(inst *instance.Instance, sharingID, sharingState string, conf *Config, contextName string) (string, error) {
+	return makeSharingStartURLWithLoginHint(inst, sharingID, sharingState, conf, contextName, getLoginHint(inst))
+}
+
+func makeSharingStartURLWithLoginHint(inst *instance.Instance, sharingID, sharingState string, conf *Config, contextName, loginHint string) (string, error) {
 	u, err := url.Parse(conf.AuthorizeURL)
 	if err != nil {
 		return "", err
@@ -1232,7 +1245,6 @@ func makeSharingStartURL(inst *instance.Instance, sharingID, sharingState string
 	vv.Add("redirect_uri", conf.RedirectURI)
 	vv.Add("state", state.id)
 	vv.Add("nonce", state.Nonce)
-	loginHint := getLoginHint(inst)
 	if loginHint != "" {
 		vv.Add("login_hint", loginHint)
 	}

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -8,6 +8,7 @@ package sharings
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"os"
@@ -30,11 +31,14 @@ import (
 	"github.com/cozy/cozy-stack/pkg/jsonapi"
 	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/cozy/cozy-stack/pkg/safehttp"
+	"github.com/cozy/cozy-stack/pkg/utils"
 	"github.com/cozy/cozy-stack/web/middlewares"
 	weboidc "github.com/cozy/cozy-stack/web/oidc"
 	"github.com/hashicorp/go-multierror"
 	"github.com/labstack/echo/v4"
 )
+
+var errMissingOIDCContextForOrgDomain = errors.New("organization domain instance has no context")
 
 // CreateSharing initializes a new sharing (on the sharer)
 func CreateSharing(c echo.Context) error {
@@ -803,12 +807,38 @@ func discoveryStateForMember(s *sharing.Sharing, currentState string, m *sharing
 	return credentials.State, nil
 }
 
-func oidcContextForMemberEmail(email string) (string, error) {
+func domainFromEmail(email string) string {
 	at := strings.LastIndex(email, "@")
 	if at < 0 || at == len(email)-1 {
+		return ""
+	}
+	return utils.NormalizeDomain(email[at+1:])
+}
+
+func oidcContextForOrgDomain(orgDomain string) (string, error) {
+	instances, err := instance.ListByOrgDomain(orgDomain)
+	if err != nil {
+		return "", err
+	}
+	if len(instances) == 0 {
 		return "", nil
 	}
-	return config.GetOIDCContextByDomain(email[at+1:])
+	contextName := instances[0].ContextName
+	if contextName == "" {
+		return "", fmt.Errorf("%w: %s", errMissingOIDCContextForOrgDomain, instances[0].Domain)
+	}
+	return contextName, nil
+}
+
+func oidcContextForMemberEmail(email string) (string, error) {
+	domain := domainFromEmail(email)
+	if domain == "" {
+		return "", nil
+	}
+	if contextName, err := oidcContextForOrgDomain(domain); err != nil || contextName != "" {
+		return contextName, err
+	}
+	return config.GetOIDCContextByDomain(domain)
 }
 
 // GetDiscovery displays a form where a recipient can give the address of their

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/cozy/cozy-stack/pkg/safehttp"
 	"github.com/cozy/cozy-stack/web/middlewares"
+	weboidc "github.com/cozy/cozy-stack/web/oidc"
 	"github.com/hashicorp/go-multierror"
 	"github.com/labstack/echo/v4"
 )
@@ -802,6 +803,14 @@ func discoveryStateForMember(s *sharing.Sharing, currentState string, m *sharing
 	return credentials.State, nil
 }
 
+func oidcContextForMemberEmail(email string) (string, error) {
+	at := strings.LastIndex(email, "@")
+	if at < 0 || at == len(email)-1 {
+		return "", nil
+	}
+	return config.GetOIDCContextByDomain(email[at+1:])
+}
+
 // GetDiscovery displays a form where a recipient can give the address of their
 // cozy instance
 func GetDiscovery(c echo.Context) error {
@@ -845,6 +854,15 @@ func GetDiscovery(c echo.Context) error {
 			if err == nil {
 				return c.Redirect(http.StatusFound, redirectURL)
 			}
+		}
+	}
+
+	if m.Instance == "" && m.Email != "" {
+		contextName, err := oidcContextForMemberEmail(m.Email)
+		if err != nil {
+			inst.Logger().WithNamespace("oidc").Warnf("Cannot resolve sharing OIDC context from email %q: %s", m.Email, err)
+		} else if contextName != "" {
+			return weboidc.RedirectSharingWithContext(c, inst, contextName, sharingID, state, m.Email)
 		}
 	}
 

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -3,6 +3,7 @@ package sharings_test
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -1421,6 +1422,51 @@ func TestSharings(t *testing.T) {
 		aliceInstance.ContextName = originalContext
 		require.NoError(t, instance.Update(aliceInstance))
 		clearPublicOIDCContext(config.DefaultInstanceContext)
+	})
+
+	t.Run("DiscoveryAutomaticallyRedirectsToCompanyOIDCContext", func(t *testing.T) {
+		conf := config.GetConfig()
+		if conf.Authentication == nil {
+			conf.Authentication = make(map[string]interface{})
+		}
+		companyContextName := "company-domain-oidc"
+		conf.Authentication[companyContextName] = map[string]interface{}{
+			"oidc": map[string]interface{}{
+				"domain":        "example.net",
+				"client_id":     "company-client-id",
+				"client_secret": "company-client-secret",
+				"scope":         "openid profile email",
+				"redirect_uri":  "https://oauthcallback.example.net/oidc/redirect",
+				"authorize_url": "https://idp.company.example/authorize",
+			},
+		}
+		t.Cleanup(func() {
+			delete(conf.Authentication, companyContextName)
+		})
+
+		eA := httpexpect.Default(t, tsA.URL)
+		testSharingID, testState := createSharingAndGetState(t, eA, aliceInstance, aliceAppToken, "company-domain")
+
+		location := eA.GET("/sharings/"+testSharingID+"/discovery").
+			WithQuery("state", testState).
+			WithRedirectPolicy(httpexpect.DontFollowRedirects).
+			Expect().Status(http.StatusSeeOther).
+			Header("Location").NotEmpty().Raw()
+
+		redirectURL, err := url.Parse(location)
+		require.NoError(t, err)
+		assert.Equal(t, "https", redirectURL.Scheme)
+		assert.Equal(t, "idp.company.example", redirectURL.Host)
+		assert.Equal(t, "/authorize", redirectURL.Path)
+
+		query := redirectURL.Query()
+		assert.Equal(t, "code", query.Get("response_type"))
+		assert.Equal(t, "openid profile email", query.Get("scope"))
+		assert.Equal(t, "company-client-id", query.Get("client_id"))
+		assert.Equal(t, "https://oauthcallback.example.net/oidc/redirect", query.Get("redirect_uri"))
+		assert.Equal(t, "bob@example.net", query.Get("login_hint"))
+		assert.NotEmpty(t, query.Get("state"))
+		assert.NotEmpty(t, query.Get("nonce"))
 	})
 }
 

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -1468,6 +1468,98 @@ func TestSharings(t *testing.T) {
 		assert.NotEmpty(t, query.Get("state"))
 		assert.NotEmpty(t, query.Get("nonce"))
 	})
+
+	t.Run("DiscoveryAutomaticallyRedirectsToOrgDomainOIDCContext", func(t *testing.T) {
+		conf := config.GetConfig()
+		if conf.Authentication == nil {
+			conf.Authentication = make(map[string]interface{})
+		}
+		orgContextName := "company-org-oidc"
+		conf.Authentication[orgContextName] = map[string]interface{}{
+			"oidc": map[string]interface{}{
+				"client_id":     "org-client-id",
+				"client_secret": "org-client-secret",
+				"scope":         "openid profile email",
+				"redirect_uri":  "https://oauthcallback.example.net/oidc/redirect",
+				"authorize_url": "https://idp.org.example/authorize",
+			},
+		}
+
+		originalOrgDomain := bobInstance.OrgDomain
+		originalContext := bobInstance.ContextName
+		bobInstance.OrgDomain = "example.net"
+		bobInstance.ContextName = orgContextName
+		require.NoError(t, instance.Update(bobInstance))
+		t.Cleanup(func() {
+			delete(conf.Authentication, orgContextName)
+			bobInstance.OrgDomain = originalOrgDomain
+			bobInstance.ContextName = originalContext
+			require.NoError(t, instance.Update(bobInstance))
+		})
+
+		eA := httpexpect.Default(t, tsA.URL)
+		testSharingID, testState := createSharingAndGetState(t, eA, aliceInstance, aliceAppToken, "org-domain")
+
+		location := eA.GET("/sharings/"+testSharingID+"/discovery").
+			WithQuery("state", testState).
+			WithRedirectPolicy(httpexpect.DontFollowRedirects).
+			Expect().Status(http.StatusSeeOther).
+			Header("Location").NotEmpty().Raw()
+
+		redirectURL, err := url.Parse(location)
+		require.NoError(t, err)
+		assert.Equal(t, "https", redirectURL.Scheme)
+		assert.Equal(t, "idp.org.example", redirectURL.Host)
+		assert.Equal(t, "/authorize", redirectURL.Path)
+
+		query := redirectURL.Query()
+		assert.Equal(t, "code", query.Get("response_type"))
+		assert.Equal(t, "openid profile email", query.Get("scope"))
+		assert.Equal(t, "org-client-id", query.Get("client_id"))
+		assert.Equal(t, "https://oauthcallback.example.net/oidc/redirect", query.Get("redirect_uri"))
+		assert.Equal(t, "bob@example.net", query.Get("login_hint"))
+		assert.NotEmpty(t, query.Get("state"))
+		assert.NotEmpty(t, query.Get("nonce"))
+	})
+
+	t.Run("DiscoveryFallsBackWhenOrgDomainContextIsEmpty", func(t *testing.T) {
+		conf := config.GetConfig()
+		if conf.Authentication == nil {
+			conf.Authentication = make(map[string]interface{})
+		}
+		fallbackContextName := "company-domain-fallback-oidc"
+		conf.Authentication[fallbackContextName] = map[string]interface{}{
+			"oidc": map[string]interface{}{
+				"domain":        "example.net",
+				"client_id":     "fallback-client-id",
+				"client_secret": "fallback-client-secret",
+				"scope":         "openid profile email",
+				"redirect_uri":  "https://oauthcallback.example.net/oidc/redirect",
+				"authorize_url": "https://idp.fallback.example/authorize",
+			},
+		}
+
+		originalOrgDomain := bobInstance.OrgDomain
+		originalContext := bobInstance.ContextName
+		bobInstance.OrgDomain = "example.net"
+		bobInstance.ContextName = ""
+		require.NoError(t, instance.Update(bobInstance))
+		t.Cleanup(func() {
+			delete(conf.Authentication, fallbackContextName)
+			bobInstance.OrgDomain = originalOrgDomain
+			bobInstance.ContextName = originalContext
+			require.NoError(t, instance.Update(bobInstance))
+		})
+
+		eA := httpexpect.Default(t, tsA.URL)
+		testSharingID, testState := createSharingAndGetState(t, eA, aliceInstance, aliceAppToken, "org-domain-empty-context")
+
+		eA.GET("/sharings/"+testSharingID+"/discovery").
+			WithQuery("state", testState).
+			WithRedirectPolicy(httpexpect.DontFollowRedirects).
+			Expect().Status(http.StatusOK).
+			Body().NotContains("idp.fallback.example")
+	})
 }
 
 // createSharingAndGetState creates a sharing and returns its ID and state


### PR DESCRIPTION
 ## Context

  Today, when a user opens a sharing invitation and the stack does not already know their Cozy URL, we show the discovery page. The user has to enter their server address, or use an available OIDC button if one is shown.

  For B2B SaaS users, we already know the invited user email. With this PR, the stack can use that email to find the company/org context and start the right OIDC sharing flow automatically. The expected UX is: user opens the sharing
  link, and if their email domain belongs to a known org with an OIDC context, they are redirected directly to the company SSO instead of filling the discovery form.

  ## Changes

  - Add OIDC context lookup by configured `oidc.domain`.
  - Add automatic sharing discovery redirect to OIDC when the recipient email domain matches a configured OIDC context.
  - Add B2B SaaS support by resolving the recipient email domain against existing instances with the same `org_domain`.
  - For org-domain resolution, use the first matched instance context directly.
  - If the matched org instance has no context, log a warning and fall back to the normal discovery page.
