### PR TITLE
Allow shared drive writers to manage links

### DIFF
--- a/cozy.example.yaml
+++ b/cozy.example.yaml
@@ -564,6 +564,9 @@ contexts:
       trusted_domains:
         - example.com
         - mycompany.twake.app
+      # Allow shared drive members with write access to update or revoke
+      # share-by-link permissions created by other members (default: false)
+      allow_writers_to_manage_links: false
     # Antivirus configuration for scanning uploaded files using ClamAV
     antivirus:
       # Enable or disable antivirus scanning

--- a/pkg/config/config/config.go
+++ b/pkg/config/config/config.go
@@ -328,6 +328,7 @@ type SharingConfig struct {
 	AutoAcceptTrusted         bool     `mapstructure:"auto_accept_trusted"`
 	AutoAcceptTrustedContacts bool     `mapstructure:"auto_accept_trusted_contacts"`
 	TrustedDomains            []string `mapstructure:"trusted_domains"`
+	AllowWritersToManageLinks bool     `mapstructure:"allow_writers_to_manage_links"`
 }
 
 // GetSharingConfig returns the sharing configuration for a given context.
@@ -339,6 +340,7 @@ func GetSharingConfig(contextName string) SharingConfig {
 		AutoAcceptTrusted:         false,
 		AutoAcceptTrustedContacts: false,
 		TrustedDomains:            []string{},
+		AllowWritersToManageLinks: false,
 	}
 
 	if config == nil || config.Contexts == nil {

--- a/pkg/config/config/config_test.go
+++ b/pkg/config/config/config_test.go
@@ -130,6 +130,7 @@ func TestConfigUnmarshal(t *testing.T) {
 	myContextSharing := GetSharingConfig("my-context")
 	assert.Equal(t, true, myContextSharing.AutoAcceptTrusted)
 	assert.Equal(t, []string{"linagora.com"}, myContextSharing.TrustedDomains)
+	assert.Equal(t, true, myContextSharing.AllowWritersToManageLinks)
 
 	// Test GetAntivirusConfig for my-context (includes duration parsing)
 	myContextAntivirus := GetAntivirusConfig("my-context")
@@ -149,10 +150,12 @@ func TestConfigUnmarshal(t *testing.T) {
 	// Test GetSharingConfig for default context
 	defaultSharing := GetSharingConfig("default")
 	assert.Equal(t, true, defaultSharing.AutoAcceptTrusted)
+	assert.Equal(t, false, defaultSharing.AllowWritersToManageLinks)
 
 	// Test GetSharingConfig for non-existent context falls back to default
 	fallbackSharing := GetSharingConfig("non-existent")
 	assert.Equal(t, true, fallbackSharing.AutoAcceptTrusted)
+	assert.Equal(t, false, fallbackSharing.AllowWritersToManageLinks)
 
 	// Contexts
 	assert.EqualValues(t, map[string]interface{}{
@@ -169,8 +172,9 @@ func TestConfigUnmarshal(t *testing.T) {
 				map[string]interface{}{"home_hidden_apps": []interface{}{"foobar"}},
 			},
 			"sharing": map[string]interface{}{
-				"auto_accept_trusted": true,
-				"trusted_domains":     []interface{}{"linagora.com"},
+				"auto_accept_trusted":           true,
+				"allow_writers_to_manage_links": true,
+				"trusted_domains":               []interface{}{"linagora.com"},
 			},
 			"antivirus": map[string]interface{}{
 				"enabled":       true,

--- a/pkg/config/config/testdata/full_config.yaml
+++ b/pkg/config/config/testdata/full_config.yaml
@@ -277,6 +277,7 @@ contexts:
             type: secondary
     sharing:
       auto_accept_trusted: true
+      allow_writers_to_manage_links: true
       trusted_domains:
         - linagora.com
     antivirus:

--- a/web/sharings/drives.go
+++ b/web/sharings/drives.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cozy/cozy-stack/model/permission"
 	"github.com/cozy/cozy-stack/model/sharing"
 	"github.com/cozy/cozy-stack/model/vfs"
+	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/crypto"
@@ -932,6 +933,7 @@ func CheckSharedDrivePermissionMutationAuthorization(
 	callerDomain string,
 	identityResolved bool,
 	callerReadOnly bool,
+	allowWritersToManageLinks bool,
 ) error {
 	// Public share tokens are never allowed to mutate permissions.
 	if actorPerm != nil &&
@@ -951,8 +953,13 @@ func CheckSharedDrivePermissionMutationAuthorization(
 		creatorDomain := existingPerm.Metadata.UpdatedByApps[0].Instance
 		isCreator = creatorDomain == callerDomain
 	}
+	isSharedDriveWriter := allowWritersToManageLinks &&
+		actorPerm != nil &&
+		actorPerm.Type == permission.TypeShareInteract &&
+		identityResolved &&
+		!callerReadOnly
 
-	if !isOwner && !isCreator {
+	if !isOwner && !isCreator && !isSharedDriveWriter {
 		if actorPerm != nil && actorPerm.Type == permission.TypeShareInteract && !identityResolved {
 			return jsonapi.Forbidden(errors.New("cannot verify caller identity for this shared-drive token"))
 		}
@@ -1046,6 +1053,7 @@ func prepareSharedDrivePermissionMutation(
 		ctx.callerDomain,
 		ctx.identityResolved,
 		ctx.callerReadOnly,
+		config.GetSharingConfig(inst.ContextName).AllowWritersToManageLinks,
 	); err != nil {
 		return nil, err
 	}

--- a/web/sharings/drives_permissions_test.go
+++ b/web/sharings/drives_permissions_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cozy/cozy-stack/model/instance"
 	"github.com/cozy/cozy-stack/model/sharing"
+	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/gavv/httpexpect/v2"
 	"github.com/stretchr/testify/require"
@@ -207,6 +208,39 @@ func makeSharedDrivePatchPayload(t *testing.T, attrs map[string]interface{}) []b
 			"type":       consts.Permissions,
 			"attributes": attrs,
 		},
+	})
+}
+
+func allowWritersToManageLinksForTest(t *testing.T) {
+	t.Helper()
+
+	cfg := config.GetConfig()
+	prevContexts := cfg.Contexts
+	contexts := make(map[string]interface{}, len(prevContexts)+1)
+	for k, v := range prevContexts {
+		contexts[k] = v
+	}
+
+	defaultContext := map[string]interface{}{}
+	if raw, ok := contexts[config.DefaultInstanceContext].(map[string]interface{}); ok {
+		for k, v := range raw {
+			defaultContext[k] = v
+		}
+	}
+
+	sharingConfig := map[string]interface{}{}
+	if raw, ok := defaultContext["sharing"].(map[string]interface{}); ok {
+		for k, v := range raw {
+			sharingConfig[k] = v
+		}
+	}
+	sharingConfig["allow_writers_to_manage_links"] = true
+	defaultContext["sharing"] = sharingConfig
+	contexts[config.DefaultInstanceContext] = defaultContext
+	cfg.Contexts = contexts
+
+	t.Cleanup(func() {
+		cfg.Contexts = prevContexts
 	})
 }
 
@@ -789,6 +823,64 @@ func TestSharedDriveShareByLinkPatch(t *testing.T) {
 		)
 
 		deleteSharedDrivePermissionExpectStatus(t, eBetty, f.sharingID, permID, bettyToken, http.StatusNoContent)
+	})
+
+	t.Run("WriterCannotPatchPermissionCreatedByOwnerWithoutConfig", func(t *testing.T) {
+		eBetty, bettyToken := f.newBettyClient(t)
+		payload := makeSharedDrivePermissionPayload(t, consts.Files, []string{f.fileID}, "", nil)
+		permID, _ := createSharedDrivePermission(
+			t, f.eOwner, f.sharingID, f.ownerAppToken, "owner-patch-link", "", payload,
+		)
+
+		patchSharedDrivePermissionExpectStatus(
+			t,
+			eBetty,
+			f.sharingID,
+			permID,
+			bettyToken,
+			makeSharedDrivePatchPayload(t, map[string]interface{}{"password": "secret"}),
+			http.StatusForbidden,
+		)
+
+		deleteSharedDrivePermissionExpectStatus(t, f.eOwner, f.sharingID, permID, f.ownerAppToken, http.StatusNoContent)
+	})
+
+	t.Run("WriterCanPatchPermissionCreatedByOwnerWithConfig", func(t *testing.T) {
+		allowWritersToManageLinksForTest(t)
+		eBetty, bettyToken := f.newBettyClient(t)
+		payload := makeSharedDrivePermissionPayload(t, consts.Files, []string{f.fileID}, "", nil)
+		permID, _ := createSharedDrivePermission(
+			t, f.eOwner, f.sharingID, f.ownerAppToken, "owner-patch-enabled-link", "", payload,
+		)
+
+		patchedObj := patchSharedDrivePermissionExpectStatus(
+			t,
+			eBetty,
+			f.sharingID,
+			permID,
+			bettyToken,
+			makeSharedDrivePatchPayload(t, map[string]interface{}{
+				"password":   "secret",
+				"expires_at": "2030-01-01T00:00:00Z",
+				"permissions": map[string]interface{}{
+					"files": map[string]interface{}{
+						"type":   consts.Files,
+						"verbs":  []string{"GET", "POST"},
+						"values": []string{f.fileID},
+					},
+				},
+			}),
+			http.StatusOK,
+		)
+		attrs := patchedObj.Value("data").Object().Value("attributes").Object()
+		attrs.Value("password").Boolean().IsTrue()
+		attrs.Value("expires_at").String().IsEqual("2030-01-01T00:00:00Z")
+		attrs.Value("permissions").Object().
+			Value("files").Object().
+			Value("verbs").Array().
+			Contains("POST")
+
+		deleteSharedDrivePermissionExpectStatus(t, f.eOwner, f.sharingID, permID, f.ownerAppToken, http.StatusNoContent)
 	})
 
 	t.Run("PublicShareTokenCannotPatchPermission", func(t *testing.T) {
@@ -1439,7 +1531,7 @@ func TestSharedDriveShareByLinkRevoke(t *testing.T) {
 		deleteSharedDrivePermissionExpectStatus(t, eBetty, f.sharingID, permID, bettyToken, http.StatusNoContent)
 	})
 
-	t.Run("NonCreatorCannotRevokePermission", func(t *testing.T) {
+	t.Run("WriterCannotRevokePermissionWithoutConfig", func(t *testing.T) {
 		eBetty, bettyToken := f.newBettyClient(t)
 		payload := makeSharedDrivePermissionPayload(t, consts.Files, []string{f.fileID}, "", nil)
 		permID, _ := createSharedDrivePermission(
@@ -1448,6 +1540,17 @@ func TestSharedDriveShareByLinkRevoke(t *testing.T) {
 
 		deleteSharedDrivePermissionExpectStatus(t, eBetty, f.sharingID, permID, bettyToken, http.StatusForbidden)
 		deleteSharedDrivePermissionExpectStatus(t, f.eOwner, f.sharingID, permID, f.ownerAppToken, http.StatusNoContent)
+	})
+
+	t.Run("WriterCanRevokePermissionCreatedByOwnerWithConfig", func(t *testing.T) {
+		allowWritersToManageLinksForTest(t)
+		eBetty, bettyToken := f.newBettyClient(t)
+		payload := makeSharedDrivePermissionPayload(t, consts.Files, []string{f.fileID}, "", nil)
+		permID, _ := createSharedDrivePermission(
+			t, f.eOwner, f.sharingID, f.ownerAppToken, "owner-revoke-enabled-link", "", payload,
+		)
+
+		deleteSharedDrivePermissionExpectStatus(t, eBetty, f.sharingID, permID, bettyToken, http.StatusNoContent)
 	})
 
 	t.Run("ReadOnlyRecipientCanRevokeOwnPermission", func(t *testing.T) {

--- a/web/sharings/drives_permissions_unit_test.go
+++ b/web/sharings/drives_permissions_unit_test.go
@@ -131,6 +131,7 @@ func TestCheckSharedDrivePermissionMutationAuthorization(t *testing.T) {
 			"",
 			false,
 			false,
+			false,
 		)
 		require.NoError(t, err)
 	})
@@ -147,6 +148,24 @@ func TestCheckSharedDrivePermissionMutationAuthorization(t *testing.T) {
 			"creator.example",
 			true,
 			false,
+			false,
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("AllowsWritableMemberWithConfig", func(t *testing.T) {
+		s := &modelsharing.Sharing{Owner: false}
+		target := permissionWithCreatorDomain("creator.example")
+		current := &permission.Permission{Type: permission.TypeShareInteract}
+
+		err := sharingsweb.CheckSharedDrivePermissionMutationAuthorization(
+			s,
+			target,
+			current,
+			"writer.example",
+			true,
+			false,
+			true,
 		)
 		require.NoError(t, err)
 	})
@@ -166,6 +185,7 @@ func TestCheckSharedDrivePermissionMutationAuthorization(t *testing.T) {
 			"creator.example",
 			true,
 			true,
+			false,
 		)
 		require.NoError(t, err)
 	})
@@ -185,6 +205,7 @@ func TestCheckSharedDrivePermissionMutationAuthorization(t *testing.T) {
 			"creator.example",
 			true,
 			true,
+			true,
 		)
 		assertJSONAPIError(t, err, http.StatusForbidden, "write access denied")
 	})
@@ -201,6 +222,7 @@ func TestCheckSharedDrivePermissionMutationAuthorization(t *testing.T) {
 			"",
 			false,
 			false,
+			true,
 		)
 		assertJSONAPIError(t, err, http.StatusForbidden, "public share token cannot modify")
 	})
@@ -217,6 +239,7 @@ func TestCheckSharedDrivePermissionMutationAuthorization(t *testing.T) {
 			"",
 			false,
 			false,
+			true,
 		)
 		assertJSONAPIError(t, err, http.StatusForbidden, "public share token cannot modify")
 	})
@@ -233,11 +256,12 @@ func TestCheckSharedDrivePermissionMutationAuthorization(t *testing.T) {
 			"",
 			false,
 			false,
+			true,
 		)
 		assertJSONAPIError(t, err, http.StatusForbidden, "cannot verify caller identity")
 	})
 
-	t.Run("RejectsNonOwnerNonCreator", func(t *testing.T) {
+	t.Run("RejectsNonOwnerNonCreatorWithoutConfig", func(t *testing.T) {
 		s := &modelsharing.Sharing{Owner: false}
 		target := permissionWithCreatorDomain("creator.example")
 		current := &permission.Permission{Type: permission.TypeWebapp}
@@ -249,6 +273,27 @@ func TestCheckSharedDrivePermissionMutationAuthorization(t *testing.T) {
 			"other.example",
 			true,
 			false,
+			false,
+		)
+		assertJSONAPIError(t, err, http.StatusForbidden, "only creator or owner can modify")
+	})
+
+	t.Run("RejectsReadOnlyNonCreatorWithConfig", func(t *testing.T) {
+		s := &modelsharing.Sharing{Owner: false}
+		target := permissionWithCreatorDomain("creator.example")
+		target.Permissions = permission.Set{
+			{Type: "io.cozy.files", Verbs: permission.Verbs(permission.GET)},
+		}
+		current := &permission.Permission{Type: permission.TypeShareInteract}
+
+		err := sharingsweb.CheckSharedDrivePermissionMutationAuthorization(
+			s,
+			target,
+			current,
+			"readonly.example",
+			true,
+			true,
+			true,
 		)
 		assertJSONAPIError(t, err, http.StatusForbidden, "only creator or owner can modify")
 	})


### PR DESCRIPTION
## Summary
- add contexts.<context>.sharing.allow_writers_to_manage_links with a safe default of false
- allow resolved non-read-only shared-drive members to patch or revoke links created by others when the flag is enabled
- preserve owner-or-creator default behavior plus public-token and read-only restrictions
