### PR TITLE
fix: allow delegated drive recipient removal

### DIFF
--- a/model/sharing/member.go
+++ b/model/sharing/member.go
@@ -356,6 +356,9 @@ func (s *Sharing) SendDelegated(inst *instance.Instance, api *APIDelegateAddCont
 	if err != nil {
 		return err
 	}
+	if len(s.Credentials) == 0 {
+		return ErrInvalidSharing
+	}
 	c := &s.Credentials[0]
 	if c.AccessToken == nil {
 		return ErrInvalidSharing
@@ -986,6 +989,48 @@ func (s *Sharing) DelegateRemoveReadOnlyFlag(inst *instance.Instance, index int)
 		return err
 	}
 	res.Body.Close()
+	return nil
+}
+
+// DelegateRevokeRecipient is used by a recipient to ask the sharer to revoke
+// another member of the sharing.
+func (s *Sharing) DelegateRevokeRecipient(inst *instance.Instance, index int) error {
+	u, err := url.Parse(s.Members[0].Instance)
+	if err != nil {
+		return err
+	}
+	if len(s.Credentials) == 0 {
+		return ErrInvalidSharing
+	}
+	c := &s.Credentials[0]
+	if c.AccessToken == nil {
+		return ErrInvalidSharing
+	}
+	opts := &request.Options{
+		Method: http.MethodDelete,
+		Scheme: u.Scheme,
+		Domain: u.Host,
+		Path:   fmt.Sprintf("/sharings/%s/recipients/%d", s.SID, index),
+		Headers: request.Headers{
+			echo.HeaderAuthorization: "Bearer " + c.AccessToken.AccessToken,
+		},
+		ParseError: ParseRequestError,
+	}
+	res, err := request.Req(opts)
+	originalRes, originalErr := res, err
+	if res != nil && res.StatusCode/100 == 4 {
+		res, err = RefreshToken(inst, res, err, s, &s.Members[0], c, opts, nil)
+	}
+	if err != nil {
+		if originalRes != nil && originalRes.StatusCode == http.StatusForbidden {
+			return preserveDelegatedRequestError(originalRes.StatusCode, originalErr)
+		}
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusNoContent {
+		return ErrInternalServerError
+	}
 	return nil
 }
 

--- a/web/sharings/drives_test.go
+++ b/web/sharings/drives_test.go
@@ -2143,6 +2143,68 @@ func TestSharedDriveDelegatedRecipientAddition(t *testing.T) {
 	})
 }
 
+func TestSharedDriveDelegatedRecipientRemoval(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	env := setupSharedDrivesEnv(t)
+	eA, eBetty, eDave := env.createClients(t)
+
+	t.Run("WriteRecipientCanRemoveAnotherRecipient", func(t *testing.T) {
+		sharingID, rootDirID, _ := createSharedDrive(
+			t,
+			DriveCreationMethodLegacy,
+			env.acme,
+			env.acmeToken,
+			env.tsA.URL,
+			"Delegated Recipient Removal Drive",
+			"Drive for delegated recipient removal tests",
+			nil,
+		)
+		acceptSharedDriveForBetty(t, env.acme, env.betty, env.tsA.URL, env.tsB.URL, sharingID)
+		acceptSharedDrive(t, env.acme, env.dave, "Dave", env.tsA.URL, env.tsD.URL, sharingID)
+		fileID := createFile(t, eA, rootDirID, "DelegatedRemoval.txt", env.acmeToken)
+
+		eDave.GET("/sharings/drives/"+sharingID+"/"+fileID).
+			WithHeader("Authorization", "Bearer "+env.daveToken).
+			Expect().Status(http.StatusOK)
+
+		eBetty.DELETE("/sharings/"+sharingID+"/recipients/2").
+			WithHeader("Authorization", "Bearer "+env.bettyToken).
+			Expect().Status(http.StatusNoContent)
+
+		removed := findSharingMemberByEmail(t, env.acme, sharingID, "dave@example.net")
+		require.Equal(t, sharing.MemberStatusRevoked, removed.Status)
+
+		eDave.GET("/sharings/drives/"+sharingID+"/"+fileID).
+			WithHeader("Authorization", "Bearer "+env.daveToken).
+			Expect().Status(http.StatusForbidden)
+	})
+
+	t.Run("ReadOnlyRecipientCannotRemoveAnotherRecipient", func(t *testing.T) {
+		sharingID, _, _ := createSharedDrive(
+			t,
+			DriveCreationMethodLegacy,
+			env.acme,
+			env.acmeToken,
+			env.tsA.URL,
+			"Delegated Recipient Removal Read Only Drive",
+			"Drive for read-only delegated recipient removal tests",
+			nil,
+		)
+		acceptSharedDriveForBetty(t, env.acme, env.betty, env.tsA.URL, env.tsB.URL, sharingID)
+		acceptSharedDrive(t, env.acme, env.dave, "Dave", env.tsA.URL, env.tsD.URL, sharingID)
+
+		eDave.DELETE("/sharings/"+sharingID+"/recipients/1").
+			WithHeader("Authorization", "Bearer "+env.daveToken).
+			Expect().Status(http.StatusForbidden)
+
+		betty := findSharingMemberByEmail(t, env.acme, sharingID, "betty@example.net")
+		require.Equal(t, sharing.MemberStatusReady, betty.Status)
+	})
+}
+
 func TestSharedDriveAccess(t *testing.T) {
 	if testing.Short() {
 		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")

--- a/web/sharings/revoke.go
+++ b/web/sharings/revoke.go
@@ -38,10 +38,6 @@ func RevokeRecipient(c echo.Context) error {
 	if err != nil {
 		return wrapErrors(err)
 	}
-	_, err = checkCreatePermissions(c, s)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusForbidden)
-	}
 	index, err := strconv.Atoi(c.Param("index"))
 	if err != nil {
 		return jsonapi.InvalidParameter("index", err)
@@ -49,11 +45,39 @@ func RevokeRecipient(c echo.Context) error {
 	if index == 0 || index >= len(s.Members) {
 		return jsonapi.InvalidParameter("index", errors.New("Invalid index"))
 	}
-	if err = s.RevokeRecipient(inst, index); err != nil {
+	if err = authorizeRevokeRecipient(c, s); err != nil {
+		return err
+	}
+	if s.Owner {
+		if err = s.RevokeRecipient(inst, index); err != nil {
+			return wrapErrors(err)
+		}
+		go s.NotifyRecipients(inst, nil)
+		return c.NoContent(http.StatusNoContent)
+	}
+	if !s.Drive {
+		return echo.NewHTTPError(http.StatusForbidden)
+	}
+	if err = s.DelegateRevokeRecipient(inst, index); err != nil {
 		return wrapErrors(err)
 	}
-	go s.NotifyRecipients(inst, nil)
 	return c.NoContent(http.StatusNoContent)
+}
+
+func authorizeRevokeRecipient(c echo.Context, s *sharing.Sharing) error {
+	if _, err := checkCreatePermissions(c, s); err == nil {
+		return nil
+	}
+	if !s.Owner || !s.Drive {
+		return echo.NewHTTPError(http.StatusForbidden)
+	}
+	if err := hasSharingWritePermissions(c); err != nil {
+		return err
+	}
+	if _, err := requestMember(c, s); err != nil {
+		return wrapErrors(err)
+	}
+	return nil
 }
 
 // RevokeGroup is used by the owner to revoke a group

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -1562,6 +1562,56 @@ func TestSharings(t *testing.T) {
 	})
 }
 
+func TestRevokeRecipientDelegationRejectsNonDriveSharing(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	config.UseTestFile(t)
+	build.BuildMode = build.ModeDev
+	testutils.NeedCouchdb(t)
+
+	setup := testutils.NewSetup(t, t.Name()+"_recipient")
+	inst := setup.GetTestInstance(&lifecycle.Options{
+		Email:      "recipient@example.net",
+		PublicName: "Recipient",
+	})
+	token := generateAppToken(inst, "testapp", iocozytests)
+	ts := setup.GetTestServerMultipleRoutes(map[string]func(*echo.Group){
+		"/sharings": sharings.Routes,
+	})
+	ts.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler
+	t.Cleanup(ts.Close)
+
+	s := &sharing.Sharing{
+		SID:    "non-open-delegated-revoke",
+		Active: true,
+		Open:   true,
+		Owner:  false,
+		Rules: []sharing.Rule{{
+			Title:   "test",
+			DocType: iocozytests,
+			Values:  []string{"doc1"},
+		}},
+		Members: []sharing.Member{
+			{Status: sharing.MemberStatusOwner, Email: "owner@example.net", Instance: "https://owner.example"},
+			{Status: sharing.MemberStatusReady, Email: "recipient@example.net", Instance: "https://recipient.example"},
+			{Status: sharing.MemberStatusReady, Email: "other@example.net", Instance: "https://other.example"},
+		},
+		Credentials: []sharing.Credentials{{}},
+	}
+	require.NoError(t, couchdb.CreateNamedDocWithDB(inst, s))
+
+	e := httpexpect.Default(t, ts.URL)
+	e.DELETE("/sharings/"+s.SID+"/recipients/2").
+		WithHeader("Authorization", "Bearer "+token).
+		Expect().Status(http.StatusForbidden)
+
+	stored, err := sharing.FindSharing(inst, s.SID)
+	require.NoError(t, err)
+	require.Equal(t, sharing.MemberStatusReady, stored.Members[2].Status)
+}
+
 // createSharingAndGetState creates a sharing and returns its ID and state
 func createSharingAndGetState(t *testing.T, e *httpexpect.Expect, inst *instance.Instance, token, value string) (string, string) {
 	t.Helper()


### PR DESCRIPTION
## Summary

- allow write-capable shared-drive recipients to remove another recipient through the existing recipient removal endpoint
- delegate recipient-side removal requests to the owner sharing using the existing sharing OAuth token refresh pattern
- keep direct delegated recipient removal forbidden for non-drive sharings, including open sharings

## Root cause

`DELETE /sharings/:sharing-id/recipients/:index` was owner-side only. A write-capable recipient could pass local permissions, but the local recipient-side sharing has `owner: false`, so the model returned `ErrInvalidSharing` and the API responded with 400.

## Validation

- `go test ./web/sharings -run 'TestSharedDriveDelegatedRecipientRemoval|TestRevokeRecipientDelegationRejectsNonDriveSharing'`\n- `go test ./web/sharings`\n- `go test ./model/sharing`