### PR TITLE
feat: add CSP support for Wasm and blob workers

### DIFF
--- a/web/apps/apps_test.go
+++ b/web/apps/apps_test.go
@@ -272,13 +272,16 @@ func TestApps(t *testing.T) {
 		u, err := url.Parse(intent.Services[0].Href)
 		require.NoError(t, err)
 
-		e.GET(u.Path).
+		csp := e.GET(u.Path).
 			WithHost(slug+"."+testInstance.Domain).
 			WithQueryString(u.RawQuery).
 			WithCookie("cozysessid", cozysessID).
 			Expect().Status(200).
-			Header(echo.HeaderContentSecurityPolicy).
-			Contains("frame-ancestors 'self' https://test-app.cozywithapps.example.net/;")
+			Header(echo.HeaderContentSecurityPolicy)
+		csp.Contains("script-src")
+		csp.Contains("'wasm-unsafe-eval'")
+		csp.Contains("worker-src 'self' blob:;")
+		csp.Contains("frame-ancestors 'self' https://test-app.cozywithapps.example.net/;")
 	})
 
 	t.Run("FaviconWithContext", func(t *testing.T) {

--- a/web/middlewares/secure.go
+++ b/web/middlewares/secure.go
@@ -80,6 +80,9 @@ const (
 	// CSPUnsafeInline is the  'unsafe-inline' option. It allows to have inline
 	// styles or scripts to be injected in the page.
 	CSPUnsafeInline
+	// CSPWasmUnsafeEval allows WebAssembly compilation without allowing
+	// JavaScript eval-like sinks.
+	CSPWasmUnsafeEval
 	// CSPAllowList inserts a allowList of domains.
 	CSPAllowList
 )
@@ -114,7 +117,7 @@ func Secure(conf *SecureConfig) echo.MiddlewareFunc {
 	conf.CSPStyleSrc, conf.CSPStyleSrcAllowList =
 		validCSPList(conf.CSPStyleSrc, conf.CSPDefaultSrc, conf.CSPStyleSrcAllowList)
 	conf.CSPWorkerSrc, conf.CSPWorkerSrcAllowList =
-		validCSPList(conf.CSPWorkerSrc, conf.CSPDefaultSrc, conf.CSPWorkerSrcAllowList)
+		validCSPList(conf.CSPWorkerSrc, nil, conf.CSPWorkerSrcAllowList)
 	conf.CSPFormAction, conf.CSPFormActionAllowList =
 		validCSPList(conf.CSPFormAction, nil, conf.CSPFormActionAllowList)
 
@@ -272,6 +275,8 @@ func (b cspBuilder) makeCSPHeader(header, cspAllowList string, sources []CSPSour
 			headers[i] = "*"
 		case CSPUnsafeInline:
 			headers[i] = "'unsafe-inline'"
+		case CSPWasmUnsafeEval:
+			headers[i] = "'wasm-unsafe-eval'"
 		case CSPAllowList:
 			headers[i] = cspAllowList
 		}

--- a/web/middlewares/secure_test.go
+++ b/web/middlewares/secure_test.go
@@ -80,10 +80,21 @@ func TestSecure(t *testing.T) {
 		})(echo.NotFoundHandler)
 		_ = h4(c4)
 
+		e5 := echo.New()
+		req5, _ := http.NewRequest(echo.GET, "http://app.cozy.local/", nil)
+		rec5 := httptest.NewRecorder()
+		c5 := e5.NewContext(req5, rec5)
+		h5 := Secure(&SecureConfig{
+			CSPScriptSrc: []CSPSource{CSPWasmUnsafeEval},
+			CSPWorkerSrc: []CSPSource{CSPSrcSelf, CSPSrcBlob},
+		})(echo.NotFoundHandler)
+		_ = h5(c5)
+
 		assert.Equal(t, "", rec1.Header().Get(echo.HeaderContentSecurityPolicy))
 		assert.Equal(t, "script-src 'self';frame-src *;", rec2.Header().Get(echo.HeaderContentSecurityPolicy))
 		assert.Equal(t, "script-src https://*.cozy.local;frame-src *;connect-src https://cozy.local 'self';", rec3.Header().Get(echo.HeaderContentSecurityPolicy))
 		assert.Equal(t, "script-src 'self';frame-src * https://example.net;connect-src https://example.com;", rec4.Header().Get(echo.HeaderContentSecurityPolicy))
+		assert.Equal(t, "script-src 'wasm-unsafe-eval';worker-src 'self' blob:;", rec5.Header().Get(echo.HeaderContentSecurityPolicy))
 	})
 
 	t.Run("AppendCSPRule", func(t *testing.T) {

--- a/web/routing.go
+++ b/web/routing.go
@@ -120,11 +120,13 @@ func SetupAppsHandler(appsHandler echo.HandlerFunc) echo.HandlerFunc {
 		secure := middlewares.Secure(&middlewares.SecureConfig{
 			HSTSMaxAge:        hstsMaxAge,
 			CSPDefaultSrc:     []middlewares.CSPSource{middlewares.CSPSrcSelf, middlewares.CSPSrcParent, middlewares.CSPSrcWS},
+			CSPScriptSrc:      []middlewares.CSPSource{middlewares.CSPWasmUnsafeEval},
 			CSPStyleSrc:       []middlewares.CSPSource{middlewares.CSPUnsafeInline},
 			CSPFontSrc:        []middlewares.CSPSource{middlewares.CSPSrcData},
 			CSPImgSrc:         []middlewares.CSPSource{middlewares.CSPSrcData, middlewares.CSPSrcBlob},
 			CSPObjectSrc:      []middlewares.CSPSource{middlewares.CSPSrcNone},
 			CSPFrameSrc:       []middlewares.CSPSource{middlewares.CSPSrcSiblings},
+			CSPWorkerSrc:      []middlewares.CSPSource{middlewares.CSPSrcSelf, middlewares.CSPSrcBlob},
 			CSPFrameAncestors: []middlewares.CSPSource{middlewares.CSPSrcSelf},
 			CSPBaseURI:        []middlewares.CSPSource{middlewares.CSPSrcSelf},
 			CSPFormAction:     []middlewares.CSPSource{middlewares.CSPSrcParent},


### PR DESCRIPTION
## Summary
  - Add `'wasm-unsafe-eval'` to hosted app `script-src` CSP so apps can compile WebAssembly without enabling JavaScript `unsafe-eval`.
  - Add explicit `worker-src 'self' blob:` so apps can create same-origin and blob workers.
  - Keep `worker-src` from inheriting broader `default-src` sources when explicitly configured.