### PR TITLE
fix: readonly sharing panics on missing credentials

### DIFF
--- a/model/sharing/member.go
+++ b/model/sharing/member.go
@@ -91,6 +91,18 @@ func (m *Member) InstanceHost() string {
 	return u.Host
 }
 
+// InstanceURL returns the parsed Cozy URL of the member.
+func (m *Member) InstanceURL() (*url.URL, bool) {
+	if m == nil || m.Instance == "" {
+		return nil, false
+	}
+	u, err := url.Parse(m.Instance)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return nil, false
+	}
+	return u, true
+}
+
 // Same returns true if the two members are the same.
 func (m *Member) Same(other Member) bool {
 	return m.Name == other.Name &&
@@ -689,9 +701,9 @@ func (c *Credentials) Refresh(inst *instance.Instance, s *Sharing, m *Member) er
 	if c.Client == nil || c.AccessToken == nil {
 		return ErrNoOAuthClient
 	}
-	u, err := url.Parse(m.Instance)
-	if err != nil {
-		return err
+	u, ok := m.InstanceURL()
+	if !ok {
+		return ErrInvalidSharing
 	}
 	r := &auth.Request{
 		Scheme: u.Scheme,
@@ -713,11 +725,64 @@ func (c *Credentials) Refresh(inst *instance.Instance, s *Sharing, m *Member) er
 	return nil
 }
 
+// requireOAuthCredentials checks that an incoming credentials payload carries
+// the embedded credentials, the OAuth client, and a non-empty access token —
+// the fields that downstream code dereferences without further guards.
+func requireOAuthCredentials(creds *APICredentials) error {
+	if creds == nil || creds.Credentials == nil ||
+		creds.Client == nil ||
+		creds.AccessToken == nil ||
+		creds.AccessToken.AccessToken == "" {
+		return ErrInvalidSharing
+	}
+	return nil
+}
+
+// recipientTarget returns what the owner needs to call a recipient:
+// the recipient member, the credentials to authenticate with, and the recipient's URL.
+// It validates everything up front so callers don't hit nil pointer panics later.
+func (s *Sharing) recipientTarget(index int) (*Member, *Credentials, *url.URL, error) {
+	if index <= 0 || index >= len(s.Members) || index-1 >= len(s.Credentials) {
+		return nil, nil, nil, ErrMemberNotFound
+	}
+	m := &s.Members[index]
+	u, ok := m.InstanceURL()
+	if !ok {
+		return nil, nil, nil, ErrInvalidSharing
+	}
+	c := &s.Credentials[index-1]
+	if c.AccessToken == nil {
+		return nil, nil, nil, ErrInvalidSharing
+	}
+	return m, c, u, nil
+}
+
+// ownerTarget returns what a recipient needs to call back to the owner:
+// the owner member, the credentials to authenticate with, and the owner's URL.
+func (s *Sharing) ownerTarget(index int) (*Member, *Credentials, *url.URL, error) {
+	if index <= 0 || index >= len(s.Members) {
+		return nil, nil, nil, ErrMemberNotFound
+	}
+	if len(s.Credentials) != 1 {
+		return nil, nil, nil, ErrInvalidSharing
+	}
+	m := &s.Members[0]
+	u, ok := m.InstanceURL()
+	if !ok {
+		return nil, nil, nil, ErrInvalidSharing
+	}
+	c := &s.Credentials[0]
+	if c.AccessToken == nil {
+		return nil, nil, nil, ErrInvalidSharing
+	}
+	return m, c, u, nil
+}
+
 // AddReadOnlyFlag adds the read-only flag of a recipient, and send
 // an access token with a short validity to let it synchronize its last
 // changes.
 func (s *Sharing) AddReadOnlyFlag(inst *instance.Instance, index int) error {
-	if index <= 0 {
+	if index <= 0 || index >= len(s.Members) {
 		return ErrMemberNotFound
 	}
 	if s.ReadOnlyFlag() {
@@ -726,7 +791,10 @@ func (s *Sharing) AddReadOnlyFlag(inst *instance.Instance, index int) error {
 	if s.Members[index].ReadOnly {
 		return nil
 	}
-	s.Members[index].ReadOnly = true
+	m, c, u, err := s.recipientTarget(index)
+	if err != nil {
+		return err
+	}
 
 	ac := APICredentials{
 		CID:         s.SID,
@@ -736,11 +804,11 @@ func (s *Sharing) AddReadOnlyFlag(inst *instance.Instance, index int) error {
 	// on this cozy), so we have to revoke the client. And we create a new
 	// client for the temporary access token used to synchronize the last
 	// changes (the recipient won't have a refresh token).
-	cli, err := CreateOAuthClient(inst, &s.Members[index])
+	cli, err := CreateOAuthClient(inst, m)
 	if err != nil {
 		return err
 	}
-	s.Credentials[index-1].InboundClientID = cli.ClientID
+	c.InboundClientID = cli.ClientID
 	ac.Credentials.Client = ConvertOAuthClient(cli)
 	scope := consts.Sharings + ":ALL:" + s.SID
 	issuedAt := time.Now().Add(1*time.Hour - consts.AccessTokenValidityDuration)
@@ -755,10 +823,6 @@ func (s *Sharing) AddReadOnlyFlag(inst *instance.Instance, index int) error {
 		Scope: scope,
 	}
 
-	u, err := url.Parse(s.Members[index].Instance)
-	if s.Members[index].Instance == "" || err != nil {
-		return ErrInvalidSharing
-	}
 	data, err := jsonapi.MarshalObject(&ac)
 	if err != nil {
 		return err
@@ -775,14 +839,14 @@ func (s *Sharing) AddReadOnlyFlag(inst *instance.Instance, index int) error {
 		Headers: request.Headers{
 			echo.HeaderAccept:        jsonapi.ContentType,
 			echo.HeaderContentType:   jsonapi.ContentType,
-			echo.HeaderAuthorization: "Bearer " + s.Credentials[index-1].AccessToken.AccessToken,
+			echo.HeaderAuthorization: "Bearer " + c.AccessToken.AccessToken,
 		},
 		Body:       bytes.NewReader(body),
 		ParseError: ParseRequestError,
 	}
 	res, err := request.Req(opts)
 	if res != nil && res.StatusCode/100 == 4 {
-		res, err = RefreshToken(inst, res, err, s, &s.Members[index], &s.Credentials[index-1], opts, body)
+		res, err = RefreshToken(inst, res, err, s, m, c, opts, body)
 	}
 	if err != nil {
 		if res != nil {
@@ -792,17 +856,17 @@ func (s *Sharing) AddReadOnlyFlag(inst *instance.Instance, index int) error {
 	}
 	defer res.Body.Close()
 
+	m.ReadOnly = true
 	return couchdb.UpdateDoc(inst, s)
 }
 
 // DelegateAddReadOnlyFlag is used by a recipient to ask the sharer to
 // add the read-only falg for another member of the sharing.
 func (s *Sharing) DelegateAddReadOnlyFlag(inst *instance.Instance, index int) error {
-	u, err := url.Parse(s.Members[0].Instance)
+	m, c, u, err := s.ownerTarget(index)
 	if err != nil {
 		return err
 	}
-	c := &s.Credentials[0]
 	opts := &request.Options{
 		Method: http.MethodPost,
 		Scheme: u.Scheme,
@@ -815,7 +879,7 @@ func (s *Sharing) DelegateAddReadOnlyFlag(inst *instance.Instance, index int) er
 	}
 	res, err := request.Req(opts)
 	if res != nil && res.StatusCode/100 == 4 {
-		res, err = RefreshToken(inst, res, err, s, &s.Members[0], c, opts, nil)
+		res, err = RefreshToken(inst, res, err, s, m, c, opts, nil)
 	}
 	if err != nil {
 		if res != nil && res.StatusCode == http.StatusBadRequest {
@@ -830,8 +894,11 @@ func (s *Sharing) DelegateAddReadOnlyFlag(inst *instance.Instance, index int) er
 // DowngradeToReadOnly is used to receive credentials on a read-write instance
 // to sync the last changes before going to read-only mode.
 func (s *Sharing) DowngradeToReadOnly(inst *instance.Instance, creds *APICredentials) error {
-	if s.Owner {
+	if s.Owner || len(s.Credentials) != 1 {
 		return ErrInvalidSharing
+	}
+	if err := requireOAuthCredentials(creds); err != nil {
+		return err
 	}
 
 	for i, m := range s.Members {
@@ -867,7 +934,7 @@ func (s *Sharing) DowngradeToReadOnly(inst *instance.Instance, creds *APICredent
 // RemoveReadOnlyFlag removes the read-only flag of a recipient, and send
 // credentials to their cozy so that it can push its changes.
 func (s *Sharing) RemoveReadOnlyFlag(inst *instance.Instance, index int) error {
-	if index <= 0 {
+	if index <= 0 || index >= len(s.Members) {
 		return ErrMemberNotFound
 	}
 	if s.ReadOnlyFlag() {
@@ -876,20 +943,23 @@ func (s *Sharing) RemoveReadOnlyFlag(inst *instance.Instance, index int) error {
 	if !s.Members[index].ReadOnly {
 		return nil
 	}
-	s.Members[index].ReadOnly = false
+	m, c, u, err := s.recipientTarget(index)
+	if err != nil {
+		return err
+	}
 
 	ac := APICredentials{
 		CID: s.SID,
 		Credentials: &Credentials{
-			XorKey: s.Credentials[index-1].XorKey,
+			XorKey: c.XorKey,
 		},
 	}
 	// Create the credentials for the recipient
-	cli, err := CreateOAuthClient(inst, &s.Members[index])
+	cli, err := CreateOAuthClient(inst, m)
 	if err != nil {
 		return err
 	}
-	s.Credentials[index-1].InboundClientID = cli.ClientID
+	c.InboundClientID = cli.ClientID
 	ac.Credentials.Client = ConvertOAuthClient(cli)
 	token, err := CreateAccessToken(inst, cli, s.SID, permission.ALL)
 	if err != nil {
@@ -897,10 +967,6 @@ func (s *Sharing) RemoveReadOnlyFlag(inst *instance.Instance, index int) error {
 	}
 	ac.Credentials.AccessToken = token
 
-	u, err := url.Parse(s.Members[index].Instance)
-	if s.Members[index].Instance == "" || err != nil {
-		return ErrInvalidSharing
-	}
 	data, err := jsonapi.MarshalObject(&ac)
 	if err != nil {
 		return err
@@ -917,27 +983,31 @@ func (s *Sharing) RemoveReadOnlyFlag(inst *instance.Instance, index int) error {
 		Headers: request.Headers{
 			echo.HeaderAccept:        jsonapi.ContentType,
 			echo.HeaderContentType:   jsonapi.ContentType,
-			echo.HeaderAuthorization: "Bearer " + s.Credentials[index-1].AccessToken.AccessToken,
+			echo.HeaderAuthorization: "Bearer " + c.AccessToken.AccessToken,
 		},
 		Body:       bytes.NewReader(body),
 		ParseError: ParseRequestError,
 	}
 	res, err := request.Req(opts)
 	if res != nil && res.StatusCode/100 == 4 {
-		res, err = RefreshToken(inst, res, err, s, &s.Members[index], &s.Credentials[index-1], opts, body)
+		res, err = RefreshToken(inst, res, err, s, m, c, opts, body)
 	}
 	if err != nil {
 		return err
 	}
 	res.Body.Close()
+	m.ReadOnly = false
 	return couchdb.UpdateDoc(inst, s)
 }
 
 // UpgradeToReadWrite is used to receive credentials on a read-only instance
 // to upgrade it to read-write.
 func (s *Sharing) UpgradeToReadWrite(inst *instance.Instance, creds *APICredentials) error {
-	if s.Owner {
+	if s.Owner || len(s.Credentials) != 1 {
 		return ErrInvalidSharing
+	}
+	if err := requireOAuthCredentials(creds); err != nil {
+		return err
 	}
 
 	for i, m := range s.Members {
@@ -960,11 +1030,10 @@ func (s *Sharing) UpgradeToReadWrite(inst *instance.Instance, creds *APICredenti
 // DelegateRemoveReadOnlyFlag is used by a recipient to ask the sharer to
 // remove the read-only falg for another member of the sharing.
 func (s *Sharing) DelegateRemoveReadOnlyFlag(inst *instance.Instance, index int) error {
-	u, err := url.Parse(s.Members[0].Instance)
+	m, c, u, err := s.ownerTarget(index)
 	if err != nil {
 		return err
 	}
-	c := &s.Credentials[0]
 	opts := &request.Options{
 		Method: http.MethodDelete,
 		Scheme: u.Scheme,
@@ -977,7 +1046,7 @@ func (s *Sharing) DelegateRemoveReadOnlyFlag(inst *instance.Instance, index int)
 	}
 	res, err := request.Req(opts)
 	if res != nil && res.StatusCode/100 == 4 {
-		res, err = RefreshToken(inst, res, err, s, &s.Members[0], c, opts, nil)
+		res, err = RefreshToken(inst, res, err, s, m, c, opts, nil)
 	}
 	if err != nil {
 		if res != nil && res.StatusCode == http.StatusBadRequest {

--- a/model/sharing/member_test.go
+++ b/model/sharing/member_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/cozy/cozy-stack/client/auth"
 	"github.com/cozy/cozy-stack/model/permission"
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
@@ -14,6 +15,240 @@ import (
 	"github.com/cozy/cozy-stack/tests/testutils"
 	"github.com/stretchr/testify/require"
 )
+
+func TestReadOnlyFlagRejectsBrokenRecipientCredentials(t *testing.T) {
+	cases := []struct {
+		name     string
+		readOnly bool
+		run      func(*Sharing) error
+	}{
+		{
+			name: "add",
+			run:  func(s *Sharing) error { return s.AddReadOnlyFlag(nil, 1) },
+		},
+		{
+			name:     "remove",
+			readOnly: true,
+			run:      func(s *Sharing) error { return s.RemoveReadOnlyFlag(nil, 1) },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Sharing{
+				SID:   "sharing-id",
+				Owner: true,
+				Members: []Member{
+					{Status: MemberStatusOwner, Instance: "https://owner.example.test"},
+					{Status: MemberStatusReady, Instance: "https://recipient.example.test", ReadOnly: tc.readOnly},
+				},
+				Credentials: []Credentials{{}},
+			}
+
+			err := tc.run(s)
+
+			require.ErrorIs(t, err, ErrInvalidSharing)
+			require.Equal(t, tc.readOnly, s.Members[1].ReadOnly)
+		})
+	}
+}
+
+func TestDelegateReadOnlyFlagRejectsBrokenOwnerCredentials(t *testing.T) {
+	validToken := &auth.AccessToken{AccessToken: "token"}
+	cases := []struct {
+		name    string
+		index   int
+		sharing func() *Sharing
+		wantErr error
+	}{
+		{
+			name:  "invalid index",
+			index: 0,
+			sharing: func() *Sharing {
+				return &Sharing{
+					Members: []Member{
+						{Instance: "https://owner.example.test"},
+						{Instance: "https://recipient.example.test"},
+					},
+					Credentials: []Credentials{{AccessToken: validToken}},
+				}
+			},
+			wantErr: ErrMemberNotFound,
+		},
+		{
+			name:  "missing credentials",
+			index: 1,
+			sharing: func() *Sharing {
+				return &Sharing{
+					Members: []Member{
+						{Instance: "https://owner.example.test"},
+						{Instance: "https://recipient.example.test"},
+					},
+				}
+			},
+			wantErr: ErrInvalidSharing,
+		},
+		{
+			name:  "nil access token",
+			index: 1,
+			sharing: func() *Sharing {
+				return &Sharing{
+					Members: []Member{
+						{Instance: "https://owner.example.test"},
+						{Instance: "https://recipient.example.test"},
+					},
+					Credentials: []Credentials{{Client: &auth.Client{ClientID: "client-id"}}},
+				}
+			},
+			wantErr: ErrInvalidSharing,
+		},
+		{
+			name:  "missing owner instance",
+			index: 1,
+			sharing: func() *Sharing {
+				return &Sharing{
+					Members: []Member{
+						{},
+						{Instance: "https://recipient.example.test"},
+					},
+					Credentials: []Credentials{{AccessToken: validToken}},
+				}
+			},
+			wantErr: ErrInvalidSharing,
+		},
+	}
+
+	methods := map[string]func(*Sharing, int) error{
+		"add":    func(s *Sharing, i int) error { return s.DelegateAddReadOnlyFlag(nil, i) },
+		"remove": func(s *Sharing, i int) error { return s.DelegateRemoveReadOnlyFlag(nil, i) },
+	}
+
+	for _, tc := range cases {
+		for name, run := range methods {
+			t.Run(tc.name+"/"+name, func(t *testing.T) {
+				require.ErrorIs(t, run(tc.sharing(), tc.index), tc.wantErr)
+			})
+		}
+	}
+}
+
+func TestProcessAnswerRejectsBrokenPayloads(t *testing.T) {
+	validToken := &auth.AccessToken{AccessToken: "token"}
+	validClient := &auth.Client{ClientID: "client-id"}
+
+	cases := []struct {
+		name  string
+		creds *APICredentials
+	}{
+		{name: "nil payload"},
+		{name: "missing embedded credentials", creds: &APICredentials{}},
+		{name: "missing client", creds: &APICredentials{Credentials: &Credentials{State: "state", AccessToken: validToken}}},
+		{name: "missing access token", creds: &APICredentials{Credentials: &Credentials{State: "state", Client: validClient}}},
+		{name: "empty access token", creds: &APICredentials{Credentials: &Credentials{State: "state", Client: validClient, AccessToken: &auth.AccessToken{}}}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Sharing{
+				SID:   "sharing-id",
+				Owner: true,
+				Members: []Member{
+					{Status: MemberStatusOwner},
+					{Status: MemberStatusPendingInvitation},
+				},
+				Credentials: []Credentials{{State: "state"}},
+			}
+
+			_, err := s.ProcessAnswer(nil, tc.creds)
+
+			require.ErrorIs(t, err, ErrInvalidSharing)
+			require.Equal(t, MemberStatusPendingInvitation, s.Members[1].Status)
+			require.Nil(t, s.Credentials[0].Client)
+			require.Nil(t, s.Credentials[0].AccessToken)
+		})
+	}
+}
+
+func TestDowngradeToReadOnlyRejectsBrokenPayload(t *testing.T) {
+	validToken := &auth.AccessToken{AccessToken: "token"}
+	validClient := &auth.Client{ClientID: "client-id"}
+	s := &Sharing{
+		Members: []Member{
+			{Instance: "https://owner.example.test"},
+			{Instance: "https://recipient.example.test"},
+		},
+		Credentials: []Credentials{{Client: validClient, AccessToken: validToken}},
+	}
+
+	err := s.DowngradeToReadOnly(nil, &APICredentials{Credentials: &Credentials{Client: validClient}})
+
+	require.ErrorIs(t, err, ErrInvalidSharing)
+	require.False(t, s.Members[1].ReadOnly)
+	require.Same(t, validToken, s.Credentials[0].AccessToken)
+}
+
+func TestUpgradeToReadWriteRejectsBrokenPayload(t *testing.T) {
+	validToken := &auth.AccessToken{AccessToken: "token"}
+	validClient := &auth.Client{ClientID: "client-id"}
+	s := &Sharing{
+		Members: []Member{
+			{Instance: "https://owner.example.test"},
+			{Instance: "https://recipient.example.test", ReadOnly: true},
+		},
+		Credentials: []Credentials{{Client: validClient, AccessToken: validToken}},
+	}
+
+	err := s.UpgradeToReadWrite(nil, &APICredentials{Credentials: &Credentials{Client: validClient}})
+
+	require.ErrorIs(t, err, ErrInvalidSharing)
+	require.True(t, s.Members[1].ReadOnly)
+	require.Same(t, validToken, s.Credentials[0].AccessToken)
+}
+
+func TestCheckSharingCredentialsReportsRecipientGaps(t *testing.T) {
+	s := &Sharing{
+		SID:    "sharing-id",
+		Active: true,
+		Owner:  false,
+		Members: []Member{
+			{Instance: "https://owner.example.test"},
+			{Instance: "https://recipient.example.test"},
+		},
+		Credentials: []Credentials{{}},
+	}
+
+	checks := s.checkSharingCredentials()
+
+	requireCheck(t, checks, "missing_oauth_client", false)
+	requireCheck(t, checks, "missing_access_token", false)
+}
+
+func TestCheckSharingCredentialsReportsOwnerMismatchedCount(t *testing.T) {
+	s := &Sharing{
+		SID:    "sharing-id",
+		Active: true,
+		Owner:  true,
+		Members: []Member{
+			{Status: MemberStatusOwner},
+			{Status: MemberStatusReady, Instance: "https://recipient.example.test"},
+		},
+		Credentials: nil,
+	}
+
+	checks := s.checkSharingCredentials()
+
+	requireCheck(t, checks, "invalid_number_of_credentials", true)
+}
+
+func requireCheck(t *testing.T, checks []map[string]interface{}, typ string, owner bool) {
+	t.Helper()
+	for _, c := range checks {
+		if c["type"] == typ && c["owner"] == owner {
+			return
+		}
+	}
+	require.Failf(t, "missing check", "expected type=%q owner=%t in %#v", typ, owner, checks)
+}
 
 func TestFindMemberByInteractCodeWithDuplicatePermissions(t *testing.T) {
 	if testing.Short() {

--- a/model/sharing/oauth.go
+++ b/model/sharing/oauth.go
@@ -590,12 +590,20 @@ func (s *Sharing) ProcessAnswer(inst *instance.Instance, creds *APICredentials) 
 	if !s.Owner || len(s.Members) != len(s.Credentials)+1 {
 		return nil, ErrInvalidSharing
 	}
+	if err := requireOAuthCredentials(creds); err != nil {
+		return nil, err
+	}
+	if creds.State == "" {
+		return nil, ErrInvalidSharing
+	}
 	for i, c := range s.Credentials {
 		if c.State == creds.State {
-			s.Members[i+1].Status = MemberStatusReady
-			s.Members[i+1].PublicName = creds.PublicName
-			s.Credentials[i].Client = creds.Client
-			s.Credentials[i].AccessToken = creds.AccessToken
+			// Stage member changes on a local copy and only write them back
+			// once OAuth client + access token are minted, so a failure mid-way
+			// leaves the sharing untouched instead of partially mutated.
+			member := s.Members[i+1]
+			member.Status = MemberStatusReady
+			member.PublicName = creds.PublicName
 			ac := APICredentials{
 				CID: s.SID,
 				Credentials: &Credentials{
@@ -603,11 +611,10 @@ func (s *Sharing) ProcessAnswer(inst *instance.Instance, creds *APICredentials) 
 				},
 			}
 			// Create the credentials for the recipient
-			cli, err := CreateOAuthClient(inst, &s.Members[i+1])
+			cli, err := CreateOAuthClient(inst, &member)
 			if err != nil {
-				return &ac, nil
+				return nil, err
 			}
-			s.Credentials[i].InboundClientID = cli.ClientID
 			ac.Credentials.Client = ConvertOAuthClient(cli)
 			var verb permission.VerbSet
 			// In case of read-only, the recipient only needs read access on the
@@ -619,9 +626,14 @@ func (s *Sharing) ProcessAnswer(inst *instance.Instance, creds *APICredentials) 
 			}
 			token, err := CreateAccessToken(inst, cli, s.SID, verb)
 			if err != nil {
-				return &ac, nil
+				return nil, err
 			}
 			ac.Credentials.AccessToken = token
+
+			s.Members[i+1] = member
+			s.Credentials[i].Client = creds.Client
+			s.Credentials[i].AccessToken = creds.AccessToken
+			s.Credentials[i].InboundClientID = cli.ClientID
 
 			// Update the contact to fill the name if missing
 			if email := s.Members[i+1].Email; email != "" {

--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -2045,6 +2045,16 @@ func (s *Sharing) checkSharingCredentials() (checks []map[string]interface{}) {
 	}
 
 	if s.Owner {
+		if len(s.Credentials)+1 != len(s.Members) {
+			checks = append(checks, map[string]interface{}{
+				"id":         s.SID,
+				"type":       "invalid_number_of_credentials",
+				"owner":      true,
+				"nb_members": len(s.Credentials),
+			})
+			return checks
+		}
+
 		for i, m := range s.Members {
 			if i == 0 || m.Status != MemberStatusReady {
 				continue
@@ -2073,16 +2083,6 @@ func (s *Sharing) checkSharingCredentials() (checks []map[string]interface{}) {
 				})
 			}
 		}
-
-		if len(s.Credentials)+1 != len(s.Members) {
-			checks = append(checks, map[string]interface{}{
-				"id":         s.SID,
-				"type":       "invalid_number_of_credentials",
-				"owner":      true,
-				"nb_members": len(s.Credentials),
-			})
-			return checks
-		}
 	} else {
 		if len(s.Credentials) != 1 {
 			checks = append(checks, map[string]interface{}{
@@ -2092,6 +2092,22 @@ func (s *Sharing) checkSharingCredentials() (checks []map[string]interface{}) {
 				"nb_members": len(s.Credentials),
 			})
 			return checks
+		}
+
+		if s.Credentials[0].Client == nil {
+			checks = append(checks, map[string]interface{}{
+				"id":    s.SID,
+				"type":  "missing_oauth_client",
+				"owner": false,
+			})
+		}
+
+		if s.Credentials[0].AccessToken == nil {
+			checks = append(checks, map[string]interface{}{
+				"id":    s.SID,
+				"type":  "missing_access_token",
+				"owner": false,
+			})
 		}
 
 		if s.Credentials[0].InboundClientID == "" {


### PR DESCRIPTION
 ## Summary

  Fixes server panics in sharing readonly transitions when a sharing document has missing OAuth credentials.

  The observed production failures happened on:
  - `POST /sharings/:id/recipients/:index/readonly`
  - `DELETE /sharings/:id/recipients/:index/readonly`

  The panic came from readonly code building an `Authorization` header with `AccessToken.AccessToken` while `AccessToken` could be nil.

  ## Why It Could Happen

  Recipient-side sharing documents can temporarily or permanently have incomplete credentials:
  - a sharing request starts with an empty credential slot before acceptance completes;
  - malformed or partial credential payloads could previously be accepted;
  - `ProcessAnswer` could return success with partial credentials if owner-side OAuth client/token creation failed.

  Those states made later delegated readonly operations dereference nil credentials.

  ## What Changed

  - Added validation before readonly outbound requests on both owner-side and delegated paths.
  - Added `Member.InstanceURL()` to parse member instance URLs without embedding sharing-specific error policy.
  - Validated incoming credential payloads before persisting them in answer, downgrade, and upgrade flows.
  - Changed `ProcessAnswer` to fail instead of returning partial credentials.
  - Extended sharing consistency checks to report missing recipient-side owner client/token.
  - Added regression tests for nil credentials, partial payloads, and consistency diagnostics.
