### PR TITLE
fix: readonly sharing member shouldn't be able to self-promote

### DIFF
--- a/web/sharings/readonly.go
+++ b/web/sharings/readonly.go
@@ -22,7 +22,7 @@ func AddReadOnly(c echo.Context) error {
 	_, err = checkCreatePermissions(c, s)
 	if err != nil {
 		// It can be a delegated call from a member on an open sharing to the owner
-		if err = hasSharingWritePermissions(c); err != nil {
+		if err = authorizeDelegatedReadOnlyChange(c, s); err != nil {
 			return err
 		}
 	}
@@ -76,7 +76,7 @@ func RemoveReadOnly(c echo.Context) error {
 	_, err = checkCreatePermissions(c, s)
 	if err != nil {
 		// It can be a delegated call from a member on an open sharing to the owner
-		if err = hasSharingWritePermissions(c); err != nil {
+		if err = authorizeDelegatedReadOnlyChange(c, s); err != nil {
 			return err
 		}
 	}
@@ -98,6 +98,28 @@ func RemoveReadOnly(c echo.Context) error {
 		}
 	}
 	return c.NoContent(http.StatusNoContent)
+}
+
+func authorizeDelegatedReadOnlyChange(c echo.Context, s *sharing.Sharing) error {
+	if err := hasSharingWritePermissions(c); err != nil {
+		return err
+	}
+
+	if !s.Drive {
+		return nil
+	}
+
+	// A read-only drive member can temporarily hold io.cozy.sharings:ALL to
+	// finish the downgrade protocol, but that scope must not let them promote
+	// themselves or another member to editor.
+	member, err := requestMember(c, s)
+	if err != nil {
+		return wrapErrors(err)
+	}
+	if member.ReadOnly {
+		return echo.NewHTTPError(http.StatusForbidden)
+	}
+	return nil
 }
 
 // UpgradeToReadWrite is used to receive the credentials for pushing updates on

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -4,9 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1610,6 +1612,83 @@ func TestRevokeRecipientDelegationRejectsNonDriveSharing(t *testing.T) {
 	stored, err := sharing.FindSharing(inst, s.SID)
 	require.NoError(t, err)
 	require.Equal(t, sharing.MemberStatusReady, stored.Members[2].Status)
+}
+
+func TestReadOnlyRecipientCannotPromoteSelfToEditor(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	config.UseTestFile(t)
+	build.BuildMode = build.ModeDev
+	testutils.NeedCouchdb(t)
+
+	setup := testutils.NewSetup(t, t.Name()+"_owner")
+	inst := setup.GetTestInstance(&lifecycle.Options{
+		Email:      "owner@example.net",
+		PublicName: "Owner",
+	})
+	ts := setup.GetTestServerMultipleRoutes(map[string]func(*echo.Group){
+		"/sharings": sharings.Routes,
+	})
+	ts.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler
+	t.Cleanup(ts.Close)
+
+	var recipientNotified atomic.Bool
+	recipientTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		recipientNotified.Store(true)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(recipientTS.Close)
+
+	sharingID := "readonly-recipient-promote-self"
+	recipient := sharing.Member{
+		Status:   sharing.MemberStatusReady,
+		Email:    "recipient@example.net",
+		Instance: recipientTS.URL,
+		ReadOnly: true,
+	}
+	cli, err := sharing.CreateOAuthClient(inst, &recipient)
+	require.NoError(t, err)
+	access, err := sharing.CreateAccessToken(inst, cli, sharingID, permission.ALL)
+	require.NoError(t, err)
+
+	s := &sharing.Sharing{
+		SID:    sharingID,
+		Active: true,
+		Owner:  true,
+		Drive:  true,
+		Rules: []sharing.Rule{{
+			Title:   "Shared drive",
+			DocType: consts.Files,
+			Values:  []string{"shared-drive-root"},
+		}},
+		Members: []sharing.Member{
+			{
+				Status:     sharing.MemberStatusOwner,
+				PublicName: "Owner",
+				Email:      "owner@example.net",
+				Instance:   "https://owner.example",
+			},
+			recipient,
+		},
+		Credentials: []sharing.Credentials{{
+			AccessToken:     access,
+			InboundClientID: cli.ClientID,
+			XorKey:          sharing.MakeXorKey(),
+		}},
+	}
+	require.NoError(t, couchdb.CreateNamedDocWithDB(inst, s))
+
+	e := httpexpect.Default(t, ts.URL)
+	e.DELETE("/sharings/"+sharingID+"/recipients/1/readonly").
+		WithHeader("Authorization", "Bearer "+access.AccessToken).
+		Expect().Status(http.StatusForbidden)
+
+	stored, err := sharing.FindSharing(inst, sharingID)
+	require.NoError(t, err)
+	require.True(t, stored.Members[1].ReadOnly)
+	require.False(t, recipientNotified.Load(), "recipient should not receive upgrade credentials")
 }
 
 // createSharingAndGetState creates a sharing and returns its ID and state


### PR DESCRIPTION
 ## Summary

  Prevent read-only shared drive recipients from promoting themselves to editor.

  ## Details

  A read-only shared drive recipient could call the role-change endpoint with a sharing protocol token and remove their own `read_only` flag. The token can legitimately include `io.cozy.sharings:ALL:<sharingID>` during the downgrade
  protocol, but that scope should not imply editor privileges on the shared drive.

