### PR TITLE
fix: role changes for pending sharing recipients

### DIFF
--- a/model/sharing/member.go
+++ b/model/sharing/member.go
@@ -760,6 +760,15 @@ func (s *Sharing) recipientTarget(index int) (*Member, *Credentials, *url.URL, e
 	return m, c, u, nil
 }
 
+func (s *Sharing) shouldUpdateReadOnlyFlagWithoutRecipientSync(index int) bool {
+	switch s.Members[index].Status {
+	case MemberStatusMailNotSent, MemberStatusPendingInvitation, MemberStatusSeen:
+		return true
+	default:
+		return false
+	}
+}
+
 // ownerTarget returns what a recipient needs to call back to the owner:
 // the owner member, the credentials to authenticate with, and the owner's URL.
 func (s *Sharing) ownerTarget(index int) (*Member, *Credentials, *url.URL, error) {
@@ -793,6 +802,10 @@ func (s *Sharing) AddReadOnlyFlag(inst *instance.Instance, index int) error {
 	}
 	if s.Members[index].ReadOnly {
 		return nil
+	}
+	if s.shouldUpdateReadOnlyFlagWithoutRecipientSync(index) {
+		s.Members[index].ReadOnly = true
+		return couchdb.UpdateDoc(inst, s)
 	}
 	m, c, u, err := s.recipientTarget(index)
 	if err != nil {
@@ -945,6 +958,10 @@ func (s *Sharing) RemoveReadOnlyFlag(inst *instance.Instance, index int) error {
 	}
 	if !s.Members[index].ReadOnly {
 		return nil
+	}
+	if s.shouldUpdateReadOnlyFlagWithoutRecipientSync(index) {
+		s.Members[index].ReadOnly = false
+		return couchdb.UpdateDoc(inst, s)
 	}
 	m, c, u, err := s.recipientTarget(index)
 	if err != nil {

--- a/model/sharing/member_test.go
+++ b/model/sharing/member_test.go
@@ -3,6 +3,7 @@ package sharing
 import (
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 
@@ -129,6 +130,81 @@ func TestDelegateReadOnlyFlagRejectsBrokenOwnerCredentials(t *testing.T) {
 				require.ErrorIs(t, run(tc.sharing(), tc.index), tc.wantErr)
 			})
 		}
+	}
+}
+
+func TestReadOnlyFlagUpdatesPendingRecipientLocally(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	config.UseTestFile(t)
+	testutils.NeedCouchdb(t)
+	setup := testutils.NewSetup(t, t.Name())
+	inst := setup.GetTestInstance()
+	require.NoError(t, couchdb.ResetDB(inst, consts.Sharings))
+
+	cases := []struct {
+		name     string
+		status   string
+		readOnly bool
+		update   func(*Sharing) error
+		want     bool
+	}{
+		{
+			name:   "add pending invitation",
+			status: MemberStatusPendingInvitation,
+			update: func(s *Sharing) error {
+				return s.AddReadOnlyFlag(inst, 1)
+			},
+			want: true,
+		},
+		{
+			name:     "remove pending invitation",
+			status:   MemberStatusPendingInvitation,
+			readOnly: true,
+			update: func(s *Sharing) error {
+				return s.RemoveReadOnlyFlag(inst, 1)
+			},
+		},
+		{
+			name:   "add seen invitation",
+			status: MemberStatusSeen,
+			update: func(s *Sharing) error {
+				return s.AddReadOnlyFlag(inst, 1)
+			},
+			want: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Sharing{
+				SID:   "sharing-" + strings.ReplaceAll(tc.name, " ", "-"),
+				Owner: true,
+				Members: []Member{
+					{Status: MemberStatusOwner, Instance: "https://owner.example.test"},
+					{
+						Status:   tc.status,
+						Email:    "recipient@example.test",
+						Instance: "https://recipient.example.test",
+						ReadOnly: tc.readOnly,
+					},
+				},
+				Credentials: []Credentials{{State: "state"}},
+			}
+			require.NoError(t, couchdb.CreateNamedDoc(inst, s))
+
+			err := tc.update(s)
+
+			require.NoError(t, err)
+			require.Equal(t, tc.want, s.Members[1].ReadOnly)
+			stored, err := FindSharing(inst, s.SID)
+			require.NoError(t, err)
+			require.Equal(t, tc.status, stored.Members[1].Status)
+			require.Equal(t, tc.want, stored.Members[1].ReadOnly)
+			require.Nil(t, stored.Credentials[0].AccessToken)
+		})
 	}
 }
 

--- a/web/sharings/drives_test.go
+++ b/web/sharings/drives_test.go
@@ -459,6 +459,37 @@ func findSharingMemberByEmail(t *testing.T, inst *instance.Instance, sharingID, 
 	return sharing.Member{}
 }
 
+func findSharingMemberIndexByEmail(t *testing.T, inst *instance.Instance, sharingID, email string) int {
+	t.Helper()
+
+	s, err := sharing.FindSharing(inst, sharingID)
+	require.NoError(t, err)
+
+	for i, member := range s.Members {
+		if member.Email == email {
+			return i
+		}
+	}
+
+	require.FailNowf(t, "member not found", "email %s not found in sharing %s", email, sharingID)
+	return -1
+}
+
+func requireOwnerMemberState(
+	t *testing.T,
+	owner *instance.Instance,
+	sharingID string,
+	email string,
+	status string,
+	readOnly bool,
+) {
+	t.Helper()
+
+	member := findSharingMemberByEmail(t, owner, sharingID, email)
+	require.Equal(t, status, member.Status)
+	require.Equal(t, readOnly, member.ReadOnly)
+}
+
 type driveAutoAcceptEnv struct {
 	ownerInstance     *instance.Instance
 	recipientInstance *instance.Instance
@@ -2224,6 +2255,48 @@ func TestSharedDriveDelegatedRecipientRemoval(t *testing.T) {
 		betty := findSharingMemberByEmail(t, env.acme, sharingID, "betty@example.net")
 		require.Equal(t, sharing.MemberStatusReady, betty.Status)
 	})
+}
+
+func TestSharedDriveDelegatedPendingRecipientManagement(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	env := setupSharedDrivesEnv(t)
+	_, eBetty, _ := env.createClients(t)
+
+	sharingID, _, _ := createSharedDrive(
+		t,
+		DriveCreationMethodLegacy,
+		env.acme,
+		env.acmeToken,
+		env.tsA.URL,
+		"Delegated Pending Recipient Management Drive",
+		"Drive for delegated pending recipient management tests",
+		[]RecipientInfo{
+			{Name: "Betty", Email: "betty@example.net", ReadOnly: false},
+			{Name: "Charlie", Email: "charlie@example.net", ReadOnly: false},
+		},
+	)
+	acceptSharedDriveForBetty(t, env.acme, env.betty, env.tsA.URL, env.tsB.URL, sharingID)
+
+	charlieIndex := findSharingMemberIndexByEmail(t, env.acme, sharingID, "charlie@example.net")
+	requireOwnerMemberState(t, env.acme, sharingID, "charlie@example.net", sharing.MemberStatusPendingInvitation, false)
+
+	eBetty.POST(fmt.Sprintf("/sharings/%s/recipients/%d/readonly", sharingID, charlieIndex)).
+		WithHeader("Authorization", "Bearer "+env.bettyToken).
+		Expect().Status(http.StatusNoContent)
+	requireOwnerMemberState(t, env.acme, sharingID, "charlie@example.net", sharing.MemberStatusPendingInvitation, true)
+
+	eBetty.DELETE(fmt.Sprintf("/sharings/%s/recipients/%d/readonly", sharingID, charlieIndex)).
+		WithHeader("Authorization", "Bearer "+env.bettyToken).
+		Expect().Status(http.StatusNoContent)
+	requireOwnerMemberState(t, env.acme, sharingID, "charlie@example.net", sharing.MemberStatusPendingInvitation, false)
+
+	eBetty.DELETE(fmt.Sprintf("/sharings/%s/recipients/%d", sharingID, charlieIndex)).
+		WithHeader("Authorization", "Bearer "+env.bettyToken).
+		Expect().Status(http.StatusNoContent)
+	requireOwnerMemberState(t, env.acme, sharingID, "charlie@example.net", sharing.MemberStatusRevoked, false)
 }
 
 func TestSharedDriveAccess(t *testing.T) {


### PR DESCRIPTION
 ## Summary

  Fixes role updates for sharing recipients whose invitation has been sent but not accepted yet.

  Pending recipients do not have accepted-sharing OAuth credentials, so changing their read-only role must update the owner-side sharing document directly instead of trying to synchronize with the recipient instance.

  ## Changes

  - Persist read-only role changes without recipient sync for `mail-not-sent`, `pending`, and `seen` members.
  - Keep the existing recipient sync flow for `ready` members.
