### PR TITLE
feat: Resolve client URL via app clientURL or default

### DIFF
--- a/model/app/webapp.go
+++ b/model/app/webapp.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cozy/cozy-stack/model/feature"
 	"github.com/cozy/cozy-stack/model/instance"
 	"github.com/cozy/cozy-stack/model/job"
 	"github.com/cozy/cozy-stack/model/notification"
@@ -93,10 +94,11 @@ type WebappManifest struct {
 		Err              string    `json:"error"`
 
 		// Just readers
-		Name       string `json:"name"`
-		NamePrefix string `json:"name_prefix"`
-		Icon       string `json:"icon"`
-		Editor     string `json:"editor"`
+		Name          string `json:"name"`
+		NamePrefix    string `json:"name_prefix"`
+		Icon          string `json:"icon"`
+		Editor        string `json:"editor"`
+		ClientURLFlag string `json:"client_url_flag"`
 
 		// Fields with complex types
 		Permissions   permission.Set `json:"permissions"`
@@ -194,6 +196,44 @@ func (m *WebappManifest) Icon() string { return m.val.Icon }
 
 // Editor returns the webapp editor.
 func (m *WebappManifest) Editor() string { return m.val.Editor }
+
+// ClientURLFlag returns the name of the feature flag whose value is the
+// client URL to use for postMessage in intents, when the app is not hosted
+// on a cozy subdomain.
+func (m *WebappManifest) ClientURLFlag() string { return m.val.ClientURLFlag }
+
+// ResolveClientURL returns the client URL for an app slug: the value of the
+// feature flag referenced by the app's "client_url_flag" manifest key when present
+// and valid, falling back to the cozy subdomain otherwise. It is used for
+// postMessage targetOrigin in intents and for CSP frame-ancestors.
+func ResolveClientURL(ins *instance.Instance, slug string) string {
+	manifest, err := GetWebappBySlug(ins, slug)
+	if err != nil {
+		return defaultClientURL(ins, slug)
+	}
+	flagKey := manifest.ClientURLFlag()
+	if flagKey == "" {
+		return defaultClientURL(ins, slug)
+	}
+	flags, err := feature.GetFlags(ins)
+	if err != nil {
+		return defaultClientURL(ins, slug)
+	}
+	flagValue, ok := flags.M[flagKey].(string)
+	if !ok {
+		return defaultClientURL(ins, slug)
+	}
+	if _, err := url.ParseRequestURI(flagValue); err != nil {
+		return defaultClientURL(ins, slug)
+	}
+	return flagValue
+}
+
+func defaultClientURL(ins *instance.Instance, slug string) string {
+	u := ins.SubDomain(slug)
+	u.Path = ""
+	return u.String()
+}
 
 // NamePrefix returns the webapp name prefix.
 func (m *WebappManifest) NamePrefix() string { return m.val.NamePrefix }

--- a/web/apps/apps_test.go
+++ b/web/apps/apps_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cozy/cozy-stack/model/instance/lifecycle"
 	"github.com/cozy/cozy-stack/model/intent"
 	"github.com/cozy/cozy-stack/model/oauth"
+	"github.com/cozy/cozy-stack/model/permission"
 	"github.com/cozy/cozy-stack/model/session"
 	"github.com/cozy/cozy-stack/model/stack"
 	"github.com/cozy/cozy-stack/pkg/assets"
@@ -32,6 +33,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/assets/model"
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/filetype"
 	"github.com/cozy/cozy-stack/tests/testutils"
 	"github.com/cozy/cozy-stack/web"
@@ -281,7 +283,67 @@ func TestApps(t *testing.T) {
 		csp.Contains("script-src")
 		csp.Contains("'wasm-unsafe-eval'")
 		csp.Contains("worker-src 'self' blob:;")
-		csp.Contains("frame-ancestors 'self' https://test-app.cozywithapps.example.net/;")
+		csp.Contains("frame-ancestors 'self' https://test-app.cozywithapps.example.net;")
+	})
+
+	t.Run("ServeWithAnIntentsClientURL", func(t *testing.T) {
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		clientURLApp := &couchdb.JSONDoc{
+			Type: consts.Apps,
+			M: map[string]interface{}{
+				"_id":             consts.Apps + "/clienturl-app",
+				"name":            "ClientURLApp",
+				"slug":            "clienturl-app",
+				"source":          "git://github.com/cozy/clienturl.git",
+				"state":           apps.Ready,
+				"client_url_flag": "clienturl_csp_flag",
+				"routes": apps.Routes{
+					"/foo": apps.Route{
+						Folder: "/",
+						Index:  "index.html",
+						Public: false,
+					},
+				},
+				"permissions": permission.Set{},
+				"version":     "1.0.0",
+			},
+		}
+		require.NoError(t, couchdb.CreateNamedDoc(testInstance, clientURLApp))
+		t.Cleanup(func() { _ = couchdb.DeleteDoc(testInstance, clientURLApp) })
+
+		testInstance.FeatureFlags = map[string]interface{}{
+			"clienturl_csp_flag": "https://external.example.com",
+		}
+		require.NoError(t, instance.Update(testInstance))
+		t.Cleanup(func() {
+			testInstance.FeatureFlags = nil
+			_ = instance.Update(testInstance)
+		})
+
+		intent := &intent.Intent{
+			Action: "PICK",
+			Type:   "io.cozy.foos",
+			Client: "io.cozy.apps/clienturl-app",
+		}
+		err := intent.Save(testInstance)
+		require.NoError(t, err)
+		err = intent.FillServices(testInstance)
+		require.NoError(t, err)
+		require.Len(t, intent.Services, 1)
+		err = intent.Save(testInstance)
+		require.NoError(t, err)
+
+		u, err := url.Parse(intent.Services[0].Href)
+		require.NoError(t, err)
+
+		csp := e.GET(u.Path).
+			WithHost(slug+"."+testInstance.Domain).
+			WithQueryString(u.RawQuery).
+			WithCookie("cozysessid", cozysessID).
+			Expect().Status(200).
+			Header(echo.HeaderContentSecurityPolicy)
+		csp.Contains("frame-ancestors 'self' https://external.example.com;")
 	})
 
 	t.Run("FaviconWithContext", func(t *testing.T) {

--- a/web/apps/serve.go
+++ b/web/apps/serve.go
@@ -132,7 +132,7 @@ func handleIntent(c echo.Context, i *instance.Instance, slug, intentID string) {
 	if len(parts) < 2 || parts[0] != consts.Apps {
 		return
 	}
-	from := i.SubDomain(parts[1]).String()
+	from := app.ResolveClientURL(i, parts[1])
 	if !config.GetConfig().CSPDisabled {
 		middlewares.AppendCSPRule(c, "frame-ancestors", from)
 	}

--- a/web/intents/intents.go
+++ b/web/intents/intents.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/cozy/cozy-stack/model/app"
 	"github.com/cozy/cozy-stack/model/instance"
 	"github.com/cozy/cozy-stack/model/intent"
 	"github.com/cozy/cozy-stack/model/permission"
@@ -52,13 +53,15 @@ func (i *apiIntent) MarshalJSON() ([]byte, error) {
 	if len(parts) < 2 {
 		i.doc.Client = ""
 	} else {
-		u := i.ins.SubDomain(parts[1])
-		u.Path = ""
-		i.doc.Client = u.String()
+		i.doc.Client = i.resolveClientURL(parts[1])
 	}
 	res, err := json.Marshal(i.doc)
 	i.doc.Client = was
 	return res, err
+}
+
+func (i *apiIntent) resolveClientURL(slug string) string {
+	return app.ResolveClientURL(i.ins, slug)
 }
 
 func createIntent(c echo.Context) error {

--- a/web/intents/intents_test.go
+++ b/web/intents/intents_test.go
@@ -46,6 +46,20 @@ func TestIntents(t *testing.T) {
 		require.NoError(t, err)
 	}
 	appToken := ins.BuildAppToken("app", "")
+
+	customApp := &couchdb.JSONDoc{
+		Type: consts.Apps,
+		M: map[string]interface{}{
+			"_id":             consts.Apps + "/custom",
+			"slug":            "custom",
+			"client_url_flag": "custom_url_flag",
+		},
+	}
+	require.NoError(t, couchdb.CreateNamedDoc(ins, customApp))
+
+	customAppPerms, err := permission.CreateWebappSet(ins, "custom", permission.Set{}, "1.0.0")
+	require.NoError(t, err)
+	customAppToken := ins.BuildAppToken("custom", "")
 	files := &couchdb.JSONDoc{
 		Type: consts.Apps,
 		M: map[string]interface{}{
@@ -92,7 +106,7 @@ func TestIntents(t *testing.T) {
 			JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
 			Object()
 
-		intentID = checkIntentResult(obj, appPerms, true)
+		intentID = checkIntentResult(obj, appPerms, true, "https://app.cozy.example.net")
 	})
 
 	t.Run("GetIntent", func(t *testing.T) {
@@ -105,7 +119,7 @@ func TestIntents(t *testing.T) {
 			JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
 			Object()
 
-		checkIntentResult(obj, appPerms, true)
+		checkIntentResult(obj, appPerms, true, "https://app.cozy.example.net")
 	})
 
 	t.Run("GetIntentNotFromTheService", func(t *testing.T) {
@@ -138,11 +152,86 @@ func TestIntents(t *testing.T) {
 			JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
 			Object()
 
-		checkIntentResult(obj, appPerms, false)
+		checkIntentResult(obj, appPerms, false, "")
+	})
+
+	t.Run("CreateIntentWithClientURLMatchingFlag", func(t *testing.T) {
+		ins.FeatureFlags = map[string]interface{}{"custom_url_flag": "https://flag.example.com"}
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		obj := e.POST("/intents").
+			WithHeader("Authorization", "Bearer "+customAppToken).
+			WithHeader("Content-Type", "application/vnd.api+json").
+			WithHeader("Accept", "application/vnd.api+json").
+			WithBytes([]byte(`{
+        "data": {
+          "type": "io.cozy.settings",
+          "attributes": {
+            "action": "PICK",
+            "type": "io.cozy.files",
+            "permissions": ["GET"]
+          }
+        }
+      }`)).
+			Expect().Status(200).
+			JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+			Object()
+
+		checkIntentResult(obj, customAppPerms, true, "https://flag.example.com")
+	})
+
+	t.Run("CreateIntentWithClientURLNoMatchingFlag", func(t *testing.T) {
+		ins.FeatureFlags = nil
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		obj := e.POST("/intents").
+			WithHeader("Authorization", "Bearer "+customAppToken).
+			WithHeader("Content-Type", "application/vnd.api+json").
+			WithHeader("Accept", "application/vnd.api+json").
+			WithBytes([]byte(`{
+        "data": {
+          "type": "io.cozy.settings",
+          "attributes": {
+            "action": "PICK",
+            "type": "io.cozy.files",
+            "permissions": ["GET"]
+          }
+        }
+      }`)).
+			Expect().Status(200).
+			JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+			Object()
+
+		checkIntentResult(obj, customAppPerms, true, "https://custom.cozy.example.net")
+	})
+
+	t.Run("CreateIntentWithClientURLInvalidFlagValue", func(t *testing.T) {
+		ins.FeatureFlags = map[string]interface{}{"custom_url_flag": "not-a-url"}
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		obj := e.POST("/intents").
+			WithHeader("Authorization", "Bearer "+customAppToken).
+			WithHeader("Content-Type", "application/vnd.api+json").
+			WithHeader("Accept", "application/vnd.api+json").
+			WithBytes([]byte(`{
+        "data": {
+          "type": "io.cozy.settings",
+          "attributes": {
+            "action": "PICK",
+            "type": "io.cozy.files",
+            "permissions": ["GET"]
+          }
+        }
+      }`)).
+			Expect().Status(200).
+			JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+			Object()
+
+		checkIntentResult(obj, customAppPerms, true, "https://custom.cozy.example.net")
 	})
 }
 
-func checkIntentResult(obj *httpexpect.Object, appPerms *permission.Permission, fromWeb bool) string {
+func checkIntentResult(obj *httpexpect.Object, appPerms *permission.Permission, fromWeb bool, expectedClient string) string {
 	data := obj.Value("data").Object()
 	data.ValueEqual("type", "io.cozy.intents")
 	intentID := data.Value("id").String().NotEmpty().Raw()
@@ -159,7 +248,7 @@ func checkIntentResult(obj *httpexpect.Object, appPerms *permission.Permission, 
 		return intentID
 	}
 
-	attrs.ValueEqual("client", "https://app.cozy.example.net")
+	attrs.ValueEqual("client", expectedClient)
 
 	links := data.Value("links").Object()
 	links.ValueEqual("self", "/intents/"+intentID)


### PR DESCRIPTION
An app can declare a "client_url_flag" key in its manifest. Two paths now:

  Case A — client_url_flag resolves
  Look up the flag value from the instance's feature flags and use
  it as the client URL.

  Case B — subdomain (original behavior, also the fallback)
  Construct https://<user + slug>.<domain> via SubDomain().

This URL is used to specify valid origin when using postMessage in intents. It is required to create an intent from tmail (which is hosted at mail.twake.app and not <user>-mail.twake.app).

Todo:
- [x] validate manifest key name "client_url_flag"
- [x] add manifest key to cozy-twakemail https://github.com/cozy/cozy-twakemail/pull/39
- [x] add manifest key to manifest documentation https://github.com/cozy/cozy-apps-registry/pull/478