### PR TITLE
fix: add blob: to app connect-src csp

### DIFF
--- a/web/apps/apps_test.go
+++ b/web/apps/apps_test.go
@@ -280,6 +280,7 @@ func TestApps(t *testing.T) {
 			Header(echo.HeaderContentSecurityPolicy)
 		csp.Contains("script-src")
 		csp.Contains("'wasm-unsafe-eval'")
+		csp.Contains("connect-src blob:")
 		csp.Contains("worker-src 'self' blob:;")
 		csp.Contains("frame-ancestors 'self' https://test-app.cozywithapps.example.net/;")
 	})

--- a/web/middlewares/secure_test.go
+++ b/web/middlewares/secure_test.go
@@ -85,8 +85,9 @@ func TestSecure(t *testing.T) {
 		rec5 := httptest.NewRecorder()
 		c5 := e5.NewContext(req5, rec5)
 		h5 := Secure(&SecureConfig{
-			CSPScriptSrc: []CSPSource{CSPWasmUnsafeEval},
-			CSPWorkerSrc: []CSPSource{CSPSrcSelf, CSPSrcBlob},
+			CSPScriptSrc:  []CSPSource{CSPWasmUnsafeEval},
+			CSPConnectSrc: []CSPSource{CSPSrcBlob},
+			CSPWorkerSrc:  []CSPSource{CSPSrcSelf, CSPSrcBlob},
 		})(echo.NotFoundHandler)
 		_ = h5(c5)
 
@@ -94,7 +95,7 @@ func TestSecure(t *testing.T) {
 		assert.Equal(t, "script-src 'self';frame-src *;", rec2.Header().Get(echo.HeaderContentSecurityPolicy))
 		assert.Equal(t, "script-src https://*.cozy.local;frame-src *;connect-src https://cozy.local 'self';", rec3.Header().Get(echo.HeaderContentSecurityPolicy))
 		assert.Equal(t, "script-src 'self';frame-src * https://example.net;connect-src https://example.com;", rec4.Header().Get(echo.HeaderContentSecurityPolicy))
-		assert.Equal(t, "script-src 'wasm-unsafe-eval';worker-src 'self' blob:;", rec5.Header().Get(echo.HeaderContentSecurityPolicy))
+		assert.Equal(t, "script-src 'wasm-unsafe-eval';connect-src blob:;worker-src 'self' blob:;", rec5.Header().Get(echo.HeaderContentSecurityPolicy))
 	})
 
 	t.Run("AppendCSPRule", func(t *testing.T) {

--- a/web/routing.go
+++ b/web/routing.go
@@ -121,6 +121,7 @@ func SetupAppsHandler(appsHandler echo.HandlerFunc) echo.HandlerFunc {
 			HSTSMaxAge:        hstsMaxAge,
 			CSPDefaultSrc:     []middlewares.CSPSource{middlewares.CSPSrcSelf, middlewares.CSPSrcParent, middlewares.CSPSrcWS},
 			CSPScriptSrc:      []middlewares.CSPSource{middlewares.CSPWasmUnsafeEval},
+			CSPConnectSrc:     []middlewares.CSPSource{middlewares.CSPSrcBlob},
 			CSPStyleSrc:       []middlewares.CSPSource{middlewares.CSPUnsafeInline},
 			CSPFontSrc:        []middlewares.CSPSource{middlewares.CSPSrcData},
 			CSPImgSrc:         []middlewares.CSPSource{middlewares.CSPSrcData, middlewares.CSPSrcBlob},


### PR DESCRIPTION
## Summary

Hosted apps can create blob workers since `worker-src 'self' blob:` was added (#4804), but the `connect-src` directive only inherited `default-src` (`self`, parent, ws). Fetching/connecting to a `blob:` URL from a hosted app was therefore blocked with:

```
Connecting to 'blob:https://<app>.example.com/...' violates the following Content Security Policy directive: "connect-src ... 'self' https://<parent> wss://<parent>".
```

This adds `blob:` to the hosted-app `connect-src`, mirroring the existing `img-src` and `worker-src` handling.
