### PR TITLE
feat: support instance_claim for OIDC app token exchange

### DIFF
--- a/cozy.example.yaml
+++ b/cozy.example.yaml
@@ -407,6 +407,8 @@ authentication:
           # Must be a Cozy linked application software_id. The local OAuth
           # scope is derived from this linked app manifest.
           software_id: registry://mail
+          # Optional OIDC claim containing the target Cozy instance domain.
+          instance_claim: workplaceFqdn
 
 notifications:
   # Activate development APIs (iOS only)

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1076,10 +1076,11 @@ For admin exchanges, the `id_token` must also:
 
 For user app exchanges, the `id_token` audience must be present in the
 `oidc.app_token_exchange` stack configuration. The token must also match the
-target Cozy instance using the existing OIDC instance mapping (`sub` to
-`oidc_id` when `allow_custom_instance` is true, otherwise
-`userinfo_instance_field` with prefix/suffix). The returned scope is derived
-from the configured linked app manifest, for example
+target Cozy instance. When the matched app exchange entry sets `instance_claim`,
+that claim must contain the target instance domain. Otherwise the existing OIDC
+instance mapping is used (`sub` to `oidc_id` when `allow_custom_instance` is
+true, otherwise `userinfo_instance_field` with prefix/suffix). The returned
+scope is derived from the configured linked app manifest, for example
 `@io.cozy.apps/mail`; caller-provided scopes are rejected.
 
 The request body is JSON:

--- a/docs/delegated-auth.md
+++ b/docs/delegated-auth.md
@@ -54,6 +54,7 @@ authentication:
       app_token_exchange:
         twake-mail-web:
           software_id: registry://mail
+          instance_claim: workplaceFqdn
 ```
 
 Let's see what it means:
@@ -93,7 +94,9 @@ And in the `oidc` section, we have:
 - `app_token_exchange` maps an OIDC token audience to a trusted Cozy linked
   app. The `software_id` must use the `registry://<slug>` format. The stack
   derives the Cozy OAuth scope from the linked app manifest, so the OIDC
-  provider does not need to expose `registry://...` as an OIDC scope.
+  provider does not need to expose `registry://...` as an OIDC scope. When
+  `instance_claim` is set, the claim must contain the target Cozy instance
+  domain and is used instead of the default OIDC instance mapping.
 - Token exchange requires a `sid` claim so the created OAuth client can be
   revoked by OIDC backchannel logout.
 

--- a/pkg/config/config/config.go
+++ b/pkg/config/config/config.go
@@ -437,8 +437,9 @@ type OIDCAppTokenExchangeConfig struct {
 // OIDCAppTokenExchangeAppConfig contains the linked application allowed for an
 // OIDC token audience.
 type OIDCAppTokenExchangeAppConfig struct {
-	Audience   string
-	SoftwareID string `mapstructure:"software_id"`
+	Audience      string
+	SoftwareID    string `mapstructure:"software_id"`
+	InstanceClaim string `mapstructure:"instance_claim"`
 }
 
 // Worker contains the configuration fields for a specific worker type.
@@ -631,6 +632,7 @@ func GetOIDCAppTokenExchange(contextName string) (OIDCAppTokenExchangeConfig, er
 	for audience, appConfig := range apps {
 		appConfig.Audience = audience
 		appConfig.SoftwareID = strings.TrimSpace(appConfig.SoftwareID)
+		appConfig.InstanceClaim = strings.TrimSpace(appConfig.InstanceClaim)
 		if appConfig.SoftwareID == "" {
 			return cfg, fmt.Errorf("software_id is required for app token exchange audience %q", audience)
 		}

--- a/pkg/config/config/config_test.go
+++ b/pkg/config/config/config_test.go
@@ -258,7 +258,8 @@ func TestConfigUnmarshal(t *testing.T) {
 				"allow_app_token_exchange": true,
 				"app_token_exchange": map[string]interface{}{
 					"twake-mail-web": map[string]interface{}{
-						"software_id": "registry://mail",
+						"software_id":    "registry://mail",
+						"instance_claim": "workplaceFqdn",
 					},
 				},
 			},
@@ -394,7 +395,8 @@ func TestGetOIDCAppTokenExchange(t *testing.T) {
 					"allow_app_token_exchange": true,
 					"app_token_exchange": map[string]interface{}{
 						"twake-mail-web": map[string]interface{}{
-							"software_id": " registry://mail ",
+							"software_id":    " registry://mail ",
+							"instance_claim": " workplaceFqdn ",
 						},
 					},
 				},
@@ -407,6 +409,7 @@ func TestGetOIDCAppTokenExchange(t *testing.T) {
 		require.Contains(t, cfg.Apps, "twake-mail-web")
 		assert.Equal(t, "twake-mail-web", cfg.Apps["twake-mail-web"].Audience)
 		assert.Equal(t, "registry://mail", cfg.Apps["twake-mail-web"].SoftwareID)
+		assert.Equal(t, "workplaceFqdn", cfg.Apps["twake-mail-web"].InstanceClaim)
 	})
 
 	t.Run("disabled when missing", func(t *testing.T) {

--- a/pkg/config/config/testdata/full_config.yaml
+++ b/pkg/config/config/testdata/full_config.yaml
@@ -197,6 +197,7 @@ authentication:
       app_token_exchange:
         twake-mail-web:
           software_id: registry://mail
+          instance_claim: workplaceFqdn
 
 # Public OIDC context name - references the authentication context to use for public Twake accounts
 public_oidc_context: twake_public

--- a/web/auth/auth_test.go
+++ b/web/auth/auth_test.go
@@ -2207,6 +2207,19 @@ func TestTokenExchange(t *testing.T) {
 	require.NoError(t, dynamic.InitDynamicAssetFS(config.FsURL().String()), "Could not init dynamic FS")
 
 	e := testutils.CreateTestClient(t, ts.URL)
+	withAppTokenInstanceClaim := func(t *testing.T, claim string) {
+		appExchange := oidcConfig["app_token_exchange"].(map[string]interface{})
+		appConfig := appExchange[appTokenAudience].(map[string]interface{})
+		previous, hadPrevious := appConfig["instance_claim"]
+		appConfig["instance_claim"] = claim
+		t.Cleanup(func() {
+			if hadPrevious {
+				appConfig["instance_claim"] = previous
+				return
+			}
+			delete(appConfig, "instance_claim")
+		})
+	}
 
 	t.Run("RequiresMandatoryParameters", func(t *testing.T) {
 		e.POST("/auth/token_exchange").
@@ -2447,6 +2460,69 @@ func TestTokenExchange(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, boundClients, 1)
 		require.Equal(t, clientIDValue, boundClients[0].OAuthClientID)
+	})
+
+	t.Run("ExchangesAppTokenWithInstanceClaim", func(t *testing.T) {
+		withAppTokenInstanceClaim(t, " workplaceFqdn ")
+		const sid = "mail-app-sid-instance-claim"
+		idToken := makeTokenExchangeSignedJWT(t, privateKey, kid, map[string]interface{}{
+			"iss":           issuer,
+			"aud":           []string{appTokenAudience},
+			"sub":           "mail-user@on.cozy.lin-saas.com",
+			"sid":           sid,
+			"iat":           time.Now().Unix(),
+			"exp":           time.Now().Add(time.Hour).Unix(),
+			"workplaceFqdn": testInstance.Domain,
+		})
+
+		resp := e.POST("/auth/token_exchange").
+			WithHost(testInstance.Domain).
+			WithHeader("Accept", "application/json").
+			WithHeader("Origin", "https://mail."+testInstance.Domain).
+			WithJSON(map[string]string{
+				"id_token":      idToken,
+				"exchange_type": "app",
+			}).
+			Expect().
+			Status(http.StatusOK)
+		obj := resp.JSON().Object()
+		clientIDValue := obj.Value("client_id").String().Raw()
+		scope := oauth.BuildLinkedAppScope(appTokenAppSlug)
+
+		obj.ValueEqual("token_type", "bearer")
+		obj.ValueEqual("scope", scope)
+		client, err := oauth.FindClient(testInstance, clientIDValue)
+		require.NoError(t, err)
+		require.Equal(t, appTokenSoftwareID, client.SoftwareID)
+		require.Equal(t, sid, client.OIDCSessionID)
+		require.Equal(t, []string{"https://mail." + testInstance.Domain}, client.RedirectURIs)
+	})
+
+	t.Run("RejectsAppTokenWithInstanceClaimMismatch", func(t *testing.T) {
+		withAppTokenInstanceClaim(t, "workplaceFqdn")
+		actualDomain := "other." + testInstance.Domain
+		idToken := makeTokenExchangeSignedJWT(t, privateKey, kid, map[string]interface{}{
+			"iss":           issuer,
+			"aud":           []string{appTokenAudience},
+			"sub":           "mail-user@on.cozy.lin-saas.com",
+			"sid":           "mail-app-sid-instance-claim-mismatch",
+			"iat":           time.Now().Unix(),
+			"exp":           time.Now().Add(time.Hour).Unix(),
+			"workplaceFqdn": actualDomain,
+		})
+
+		e.POST("/auth/token_exchange").
+			WithHost(testInstance.Domain).
+			WithHeader("Accept", "application/json").
+			WithHeader("Origin", "https://mail."+testInstance.Domain).
+			WithJSON(map[string]string{
+				"id_token":      idToken,
+				"exchange_type": "app",
+			}).
+			Expect().
+			Status(http.StatusBadRequest).
+			JSON().Object().
+			ValueEqual("error", "OIDC Domain Mismatch "+testInstance.Domain+" "+actualDomain)
 	})
 
 	t.Run("RejectsAppTokenWithoutExchangeTypeAsAdmin", func(t *testing.T) {

--- a/web/auth/token_exchange.go
+++ b/web/auth/token_exchange.go
@@ -315,10 +315,38 @@ func validateTokenExchangeAppToken(inst *instance.Instance, conf *oidcprovider.C
 	if !ok {
 		return nil, errors.New("invalid token audience")
 	}
-	if err := oidcprovider.CheckClaimsForInstance(conf, inst, claims); err != nil {
+	if err := tokenExchangeCheckAppInstance(conf, inst, claims, *appConfig); err != nil {
 		return nil, err
 	}
 	return appConfig, nil
+}
+
+func tokenExchangeCheckAppInstance(conf *oidcprovider.Config, inst *instance.Instance, claims jwt.MapClaims, appConfig config.OIDCAppTokenExchangeAppConfig) error {
+	if appConfig.InstanceClaim == "" {
+		return oidcprovider.CheckClaimsForInstance(conf, inst, claims)
+	}
+
+	rawDomain, ok := tokenExchangeClaimString(claims, appConfig.InstanceClaim)
+	if !ok || rawDomain == "" {
+		inst.Logger().WithNamespace("oidc").
+			Warnf("Cannot extract instance claim %s", appConfig.InstanceClaim)
+		return oidcprovider.ErrInstanceAuthenticationFailed
+	}
+
+	domain := utils.NormalizeDomain(rawDomain)
+	if domain == "" {
+		inst.Logger().WithNamespace("oidc").
+			Warnf("Cannot extract domain from instance claim %s", appConfig.InstanceClaim)
+		return oidcprovider.ErrInstanceAuthenticationFailed
+	}
+
+	expectedDomain := utils.NormalizeDomain(inst.Domain)
+	if domain != expectedDomain {
+		inst.Logger().WithNamespace("oidc").
+			Errorf("Invalid domains: %s != %s", domain, inst.Domain)
+		return &oidcprovider.InstanceMismatchError{ExpectedDomain: inst.Domain, ActualDomain: domain}
+	}
+	return nil
 }
 
 func createTokenExchangeOAuthClient(c echo.Context, inst *instance.Instance, params tokenExchangeOAuthClientParams) (*oauth.Client, error) {


### PR DESCRIPTION
## Summary

  Add optional `instance_claim` support to OIDC app token exchange configuration.

  When configured for an app token exchange audience, Stack uses that ID token claim as the target Cozy instance domain instead of the default OIDC instance mapping. If`instance_claim` is not configured, the existing behavior is unchanged.

  This allows apps like Twake Mail to keep an app-specific `sub` while still exchanging tokens against the correct Cozy instance.

  ## Changes

  - Add `instance_claim` to `app_token_exchange` config entries.
  - Validate configured instance claims against the target instance domain.
  - Keep existing fallback behavior when `instance_claim` is absent.
