### PR TITLE
fix: parse registry channel from linked app slug

### DIFF
--- a/model/oauth/client.go
+++ b/model/oauth/client.go
@@ -923,7 +923,8 @@ func GetLinkedAppSlug(softwareID string) string {
 	if !IsLinkedApp(softwareID) {
 		return ""
 	}
-	return strings.TrimPrefix(softwareID, "registry://")
+	slug, _, _ := strings.Cut(strings.TrimPrefix(softwareID, "registry://"), "/")
+	return slug
 }
 
 // BuildLinkedAppScope returns a formatted scope for a linked app

--- a/model/oauth/client_test.go
+++ b/model/oauth/client_test.go
@@ -26,6 +26,14 @@ var c = &oauth.Client{
 	CouchID: "my-client-id",
 }
 
+func TestGetLinkedAppSlug(t *testing.T) {
+	assert.Equal(t, "mail", oauth.GetLinkedAppSlug("registry://mail"))
+	assert.Equal(t, "mail", oauth.GetLinkedAppSlug("registry://mail/stable"))
+	assert.Equal(t, "mail", oauth.GetLinkedAppSlug("registry://mail/dev/latest"))
+	assert.Empty(t, oauth.GetLinkedAppSlug("github.com/cozy/mail"))
+	assert.Empty(t, oauth.GetLinkedAppSlug("registry://"))
+}
+
 func TestClient(t *testing.T) {
 	if testing.Short() {
 		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")

--- a/web/auth/token_exchange_test.go
+++ b/web/auth/token_exchange_test.go
@@ -47,6 +47,7 @@ func TestTokenExchangeAssertManifestTrusted(t *testing.T) {
 	}
 
 	assert.NoError(t, tokenExchangeAssertManifestTrusted(mk("registry://mail"), "mail"))
+	assert.NoError(t, tokenExchangeAssertManifestTrusted(mk("registry://mail/stable"), "mail"))
 
 	err := tokenExchangeAssertManifestTrusted(mk(""), "mail")
 	assert.EqualError(t, err, "code=400, message=mail is not a registry application")
@@ -55,5 +56,8 @@ func TestTokenExchangeAssertManifestTrusted(t *testing.T) {
 	assert.EqualError(t, err, "code=400, message=mail is not a registry application")
 
 	err = tokenExchangeAssertManifestTrusted(mk("registry://contacts"), "mail")
+	assert.EqualError(t, err, "code=400, message=mail is not the installed application")
+
+	err = tokenExchangeAssertManifestTrusted(mk("registry://mailbox/stable"), "mail")
 	assert.EqualError(t, err, "code=400, message=mail is not the installed application")
 }


### PR DESCRIPTION
  ## Summary

  Update linked app slug parsing so registry sources with channels resolve to the application slug.

  This fixes OIDC app token exchange for installed apps whose manifest source is stored as `registry://<slug>/<channel>`, for example `registry://mail/stable`, while the token exchange config references `registry://mail`.

  ## Changes

  - Make `oauth.GetLinkedAppSlug` return only the first registry path segment.
  - Accept registry sources such as `registry://mail/stable` as linked app slug `mail`.
  - Keep rejecting different slugs such as `registry://mailbox/stable`.
