### PR TITLE
fix: stop unverified email changes via the settings API

### DIFF
--- a/cozy.example.yaml
+++ b/cozy.example.yaml
@@ -481,6 +481,13 @@ contexts:
     # Indicates if debug related features should be enabled in front
     # applications.
     debug: false
+    # URL of the external signup (SaaS) application managing this context. When
+    # set, phone and recovery_email become read-only through PUT /settings/instance
+    # and the POST /settings/email flow is disabled, since the signup app owns the
+    # user profile. The email is always protected from PUT /settings/instance
+    # regardless of this setting (it must go through POST /settings/email or the
+    # CLI).
+    signup_url: https://signup.example.org
     # Redirect to a specific route of Cozy-Home after the onboarding
     # Format: appslug/#/path/to/route
     onboarded_redirection: home/#/discovery/?intro

--- a/model/instance/instance.go
+++ b/model/instance/instance.go
@@ -426,6 +426,19 @@ func (i *Instance) SettingsContext() (map[string]interface{}, bool) {
 	return settings, true
 }
 
+// HasSignup returns true when the instance's context is connected to the
+// external signup (SaaS) application, i.e. when a signup_url is configured for
+// the context. In that case the user profile (email, phone, recovery email) is
+// managed by the signup flow, so the stack must not let those attributes be
+// changed through its own settings endpoints.
+func (i *Instance) HasSignup() bool {
+	if ctxSettings, ok := i.SettingsContext(); ok {
+		signupURL, _ := ctxSettings["signup_url"].(string)
+		return signupURL != ""
+	}
+	return false
+}
+
 // SupportEmailAddress returns the email address that can be used to contact
 // the support.
 func (i *Instance) SupportEmailAddress() string {

--- a/web/settings/instance.go
+++ b/web/settings/instance.go
@@ -123,6 +123,34 @@ func (h *HTTPHandler) updateInstance(c echo.Context) error {
 		delete(doc.M, "context")
 		delete(doc.M, "sponsorships")
 		delete(doc.M, "oidc_id")
+
+		// email and pending_email are never set through this generic update:
+		// changing the email must go through the passphrase-protected
+		// POST /settings/email flow (or the exempt CLI/admin path above), as it
+		// is the delivery address for password-reset, 2FA and magic-link mails.
+		// On signup-managed contexts, phone and recovery_email are additionally
+		// owned by the external signup flow (their RabbitMQ event handlers), so
+		// they are locked too. Restore the stored values so a client cannot set
+		// them directly (e.g. an email to another user's address, bypassing
+		// verification) nor erase them with a partial update. The settings doc is
+		// replaced wholesale on patch, so the stored value is put back rather than
+		// the incoming one merely dropped; a read failure aborts the request
+		// instead of risking a wipe.
+		guarded := []string{"email", "pending_email"}
+		if inst.HasSignup() {
+			guarded = append(guarded, "phone", "recovery_email")
+		}
+		current, err := inst.SettingsDocument()
+		if err != nil {
+			return err
+		}
+		for _, field := range guarded {
+			if v, ok := current.M[field]; ok {
+				doc.M[field] = v
+			} else {
+				delete(doc.M, field)
+			}
+		}
 	}
 
 	if err := lifecycle.Patch(inst, &lifecycle.Options{SettingsObj: doc}); err != nil {

--- a/web/settings/settings.go
+++ b/web/settings/settings.go
@@ -122,6 +122,12 @@ func (h *HTTPHandler) postEmail(c echo.Context) error {
 
 	inst := middlewares.GetInstance(c)
 
+	// On signup-managed contexts the email is owned by the external signup flow,
+	// so it cannot be changed through the stack.
+	if inst.HasSignup() {
+		return jsonapi.NewError(http.StatusForbidden, "email is managed externally and cannot be changed for this instance")
+	}
+
 	err = h.svc.StartEmailUpdate(inst, &csettings.UpdateEmailCmd{
 		Passphrase: []byte(args.Passphrase),
 		Email:      args.Email,

--- a/web/settings/settings_test.go
+++ b/web/settings/settings_test.go
@@ -324,7 +324,9 @@ func TestSettings(t *testing.T) {
 	t.Run("PatchWithBadRevAndChanges", func(t *testing.T) {
 		e := testutils.CreateTestClient(t, tsURL)
 
-		// We are defining a random rev, but make changes in the instance values
+		// We are defining a random rev, but make changes in the instance values.
+		// email is guarded, so the change has to be on an editable settings-doc
+		// field (tz) to still trigger the conflict.
 		rev := "6-2d9b7ef014d10549c2b4e206672d3e44"
 
 		e.PUT("/settings/instance").
@@ -340,7 +342,7 @@ func TestSettings(t *testing.T) {
             "rev": "%s"
           },
           "attributes": {
-            "tz": "Europe/London",
+            "tz": "Asia/Tokyo",
             "email": "alice@example.com",
             "locale": "en"
           }
@@ -626,7 +628,7 @@ func TestSettings(t *testing.T) {
 		instanceRev = meta.Value("rev").String().NotEmpty().Raw()
 
 		attrs := data.Value("attributes").Object()
-		attrs.HasValue("email", "alice@example.org")
+		attrs.HasValue("email", "alice@example.com") // email is guarded: not changeable via PUT
 		attrs.HasValue("tz", "Europe/London")
 		attrs.HasValue("locale", "en")
 		attrs.HasValue("password_defined", true)
@@ -669,7 +671,7 @@ func TestSettings(t *testing.T) {
 		instanceRev = meta.Value("rev").String().NotEmpty().NotEqual(instanceRev).Raw()
 
 		attrs := data.Value("attributes").Object()
-		attrs.HasValue("email", "alice@example.net")
+		attrs.HasValue("email", "alice@example.com") // email is guarded: not changeable via PUT
 		attrs.HasValue("tz", "Europe/Paris")
 		attrs.HasValue("locale", "fr")
 	})
@@ -695,7 +697,7 @@ func TestSettings(t *testing.T) {
 		meta.HasValue("rev", instanceRev)
 
 		attrs := data.Value("attributes").Object()
-		attrs.HasValue("email", "alice@example.net")
+		attrs.HasValue("email", "alice@example.com") // email is guarded: not changeable via PUT
 		attrs.HasValue("tz", "Europe/Paris")
 		attrs.HasValue("locale", "fr")
 	})
@@ -898,7 +900,8 @@ func TestSettings(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.Equal(t, "Antarctica/McMurdo", doc.M["tz"].(string))
-		assert.Equal(t, "alice@expat.eu", doc.M["email"].(string))
+		// email is guarded: the value in the request body is ignored.
+		assert.Equal(t, "alice@example.com", doc.M["email"].(string))
 	})
 
 	t.Run("PatchInstanceAddParam", func(t *testing.T) {
@@ -969,8 +972,94 @@ func TestSettings(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotEqual(t, doc1.Rev(), doc2.Rev())
 		assert.Equal(t, "Europe/Berlin", doc2.M["tz"].(string))
-		_, ok := doc2.M["email"]
-		assert.False(t, ok)
+		// email is guarded: it cannot be removed through a partial update.
+		assert.Equal(t, "alice@example.com", doc2.M["email"].(string))
+	})
+
+	t.Run("UpdateInstanceGuardsEmailButNotPhoneWithoutSignup", func(t *testing.T) {
+		// Without signup, email is still guarded (it must go through the verified
+		// POST /settings/email flow), but phone stays editable.
+		doc, err := testInstance.SettingsDocument()
+		require.NoError(t, err)
+		e := testutils.CreateTestClient(t, tsURL)
+		obj := e.PUT("/settings/instance").
+			WithCookie(sessCookie, "connected").
+			WithHeader("Content-Type", "application/vnd.api+json").
+			WithHeader("Accept", "application/vnd.api+json").
+			WithHeader("Authorization", "Bearer "+token).
+			WithBytes([]byte(fmt.Sprintf(`{
+        "data": {
+          "type": "io.cozy.settings",
+          "id": "io.cozy.settings.instance",
+          "meta": {"rev": "%s"},
+          "attributes": {
+            "email": "attacker@evil.example",
+            "phone": "+33123456789",
+            "tz": "Indian/Mauritius"
+          }
+        }
+      }`, doc.Rev()))).
+			Expect().Status(200).
+			JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+			Object()
+
+		attrs := obj.Value("data").Object().Value("attributes").Object()
+		attrs.HasValue("email", "alice@example.com") // guarded
+		attrs.HasValue("phone", "+33123456789")      // editable without signup
+		attrs.HasValue("tz", "Indian/Mauritius")
+	})
+
+	t.Run("UpdateInstanceGuardsPhoneAndRecoveryWhenSignup", func(t *testing.T) {
+		// With signup, phone and recovery_email are also owned by the signup
+		// flow, so they are locked too (phone keeps the value set just above).
+		conf.Contexts["test-context"] = map[string]interface{}{"signup_url": "https://signup.example.org"}
+		defer delete(conf.Contexts, "test-context")
+
+		doc, err := testInstance.SettingsDocument()
+		require.NoError(t, err)
+		e := testutils.CreateTestClient(t, tsURL)
+		obj := e.PUT("/settings/instance").
+			WithCookie(sessCookie, "connected").
+			WithHeader("Content-Type", "application/vnd.api+json").
+			WithHeader("Accept", "application/vnd.api+json").
+			WithHeader("Authorization", "Bearer "+token).
+			WithBytes([]byte(fmt.Sprintf(`{
+        "data": {
+          "type": "io.cozy.settings",
+          "id": "io.cozy.settings.instance",
+          "meta": {"rev": "%s"},
+          "attributes": {
+            "email": "attacker@evil.example",
+            "phone": "+10000000000",
+            "recovery_email": "attacker-recovery@evil.example",
+            "tz": "Pacific/Auckland"
+          }
+        }
+      }`, doc.Rev()))).
+			Expect().Status(200).
+			JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+			Object()
+
+		attrs := obj.Value("data").Object().Value("attributes").Object()
+		attrs.HasValue("email", "alice@example.com") // guarded
+		attrs.HasValue("phone", "+33123456789")      // guarded on signup: not changed
+		attrs.NotContainsKey("recovery_email")       // guarded on signup: not set
+		attrs.HasValue("tz", "Pacific/Auckland")
+	})
+
+	t.Run("PostEmailBlockedWhenSignupEnabled", func(t *testing.T) {
+		// The dedicated email-change flow is also disabled on signup-managed
+		// contexts.
+		conf.Contexts["test-context"] = map[string]interface{}{"signup_url": "https://signup.example.org"}
+		defer delete(conf.Contexts, "test-context")
+
+		e := testutils.CreateTestClient(t, tsURL)
+		e.POST("/settings/email").
+			WithCookie(sessCookie, "connected").
+			WithHeader("Authorization", "Bearer "+token).
+			WithHeader("Content-Type", "application/json").
+			WithBytes([]byte(`{"passphrase": "MyPassphrase", "email": "new@example.com"}`)).
+			Expect().Status(403)
 	})
 
 	t.Run("FeatureFlags", func(t *testing.T) {


### PR DESCRIPTION
## Problem

The instance email is the delivery address for password-reset, 2FA and magic-link mails, but `PUT /settings/instance` let any caller set it directly, no passphrase, no confirmation. A settings-scoped token could swap the email, trigger the public password reset and take over the account, which is exactly what the verified `POST /settings/email` flow exists to prevent.

## Solution

Non-CLI callers can no longer change `email`/`pending_email` through `PUT /settings/instance`; those go through `POST /settings/email` or the CLI, so other deployments keep working. Contexts wired to the signup app (`signup_url` set) also lock `phone`/`recovery_email` and disable `POST /settings/email`, since the signup flow owns the profile.