### PR TITLE
fix: avoid revoked note sharing panic

### DIFF
--- a/model/sharing/files.go
+++ b/model/sharing/files.go
@@ -828,7 +828,7 @@ func (s *Sharing) GetNotes(inst *instance.Instance) ([]*vfs.FileDoc, error) {
 					return nil, fmt.Errorf("failed to fetch notes shared by themselves: %w", err)
 				}
 
-				return notes, nil
+				return nonNilFileDocs(notes), nil
 			} else {
 				return nil, nil
 			}
@@ -861,6 +861,16 @@ func (s *Sharing) GetNotes(inst *instance.Instance) ([]*vfs.FileDoc, error) {
 	return nil, nil
 }
 
+func nonNilFileDocs(files []*vfs.FileDoc) []*vfs.FileDoc {
+	docs := files[:0]
+	for _, file := range files {
+		if file != nil {
+			docs = append(docs, file)
+		}
+	}
+	return docs
+}
+
 func (s *Sharing) FixRevokedNotes(inst *instance.Instance) error {
 	docs, err := s.GetNotes(inst)
 	if err != nil {
@@ -869,6 +879,9 @@ func (s *Sharing) FixRevokedNotes(inst *instance.Instance) error {
 
 	var errm error
 	for _, doc := range docs {
+		if doc == nil {
+			continue
+		}
 		// If the note came from another cozy via a sharing that is now revoked, we
 		// may need to recreate the trigger.
 		if err := note.SetupTrigger(inst, doc.ID()); err != nil {

--- a/model/sharing/files_test.go
+++ b/model/sharing/files_test.go
@@ -87,6 +87,21 @@ func TestDriveURLHelpers(t *testing.T) {
 	})
 }
 
+func TestNonNilFileDocs(t *testing.T) {
+	noteFile := &vfs.FileDoc{
+		DocID: "note-file",
+		Mime:  consts.NoteMimeType,
+	}
+	textFile := &vfs.FileDoc{
+		DocID: "text-file",
+		Mime:  "text/plain",
+	}
+
+	docs := nonNilFileDocs([]*vfs.FileDoc{nil, noteFile, textFile})
+
+	assert.Equal(t, []*vfs.FileDoc{noteFile, textFile}, docs)
+}
+
 func TestFiles(t *testing.T) {
 	if testing.Short() {
 		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")


### PR DESCRIPTION
## Summary

- drop nil file docs returned for missing direct-note sharing keys before repairing revoked notes
- keep `FixRevokedNotes` defensive so it skips nil docs instead of calling methods on them

## Bug

Production panics happened on `DELETE /sharings/:sharing-id/recipients/self` while revoking a recipient-side note sharing.

For direct note sharings, `GetNotes` fetches `rule.Values` with CouchDB `_all_docs`. When one of those file ids is already missing or deleted locally, CouchDB still returns a row for the requested key instead of failing the whole request. The stack `GetAllDocs` helper preserves that missing row as `null`, which unmarshals into a nil `*vfs.FileDoc` inside the notes slice.

`FixRevokedNotes` then iterated over that slice and called `doc.ID()` to recreate the note trigger/import images. When `doc` was nil, this caused the nil pointer panic seen in production.

