### PR TITLE
feat: Intent client empty when using a token from token_exchange

### DIFF
--- a/web/intents/intents.go
+++ b/web/intents/intents.go
@@ -65,6 +65,23 @@ func (i *apiIntent) resolveClientURL(slug string) string {
 	return app.ResolveClientURL(i.ins, slug)
 }
 
+func RequestAppSourceID(pdoc *permission.Permission) string {
+	if pdoc.Type != permission.TypeOauth {
+		return pdoc.SourceID
+	}
+
+	oc, ok := pdoc.Client.(*oauth.Client)
+	if !ok {
+		return pdoc.SourceID
+	}
+
+	if slug := oauth.GetLinkedAppSlug(oc.SoftwareID); slug != "" {
+		return consts.Apps + "/" + slug
+	}
+
+	return pdoc.SourceID
+}
+
 func createIntent(c echo.Context) error {
 	pdoc, err := middlewares.GetPermission(c)
 	if err != nil {
@@ -81,12 +98,7 @@ func createIntent(c echo.Context) error {
 	if intent.Type == "" {
 		return jsonapi.InvalidParameter("type", errors.New("Type is missing"))
 	}
-	intent.Client = pdoc.SourceID
-	if oc, ok := pdoc.Client.(*oauth.Client); ok {
-		if slug := oauth.GetLinkedAppSlug(oc.SoftwareID); slug != "" {
-			intent.Client = consts.Apps + "/" + slug
-		}
-	}
+	intent.Client = RequestAppSourceID(pdoc)
 	intent.SetID("")
 	intent.SetRev("")
 	intent.Services = nil

--- a/web/intents/intents.go
+++ b/web/intents/intents.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cozy/cozy-stack/model/app"
 	"github.com/cozy/cozy-stack/model/instance"
 	"github.com/cozy/cozy-stack/model/intent"
+	"github.com/cozy/cozy-stack/model/oauth"
 	"github.com/cozy/cozy-stack/model/permission"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
@@ -81,6 +82,11 @@ func createIntent(c echo.Context) error {
 		return jsonapi.InvalidParameter("type", errors.New("Type is missing"))
 	}
 	intent.Client = pdoc.SourceID
+	if oc, ok := pdoc.Client.(*oauth.Client); ok {
+		if slug := oauth.GetLinkedAppSlug(oc.SoftwareID); slug != "" {
+			intent.Client = consts.Apps + "/" + slug
+		}
+	}
 	intent.SetID("")
 	intent.SetRev("")
 	intent.Services = nil

--- a/web/intents/intents_test.go
+++ b/web/intents/intents_test.go
@@ -2,6 +2,7 @@ package intents
 
 import (
 	"testing"
+	"time"
 
 	"github.com/cozy/cozy-stack/model/app"
 	"github.com/cozy/cozy-stack/model/instance/lifecycle"
@@ -15,7 +16,6 @@ import (
 	"github.com/gavv/httpexpect/v2"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/require"
-	"time"
 )
 
 func TestIntents(t *testing.T) {
@@ -175,9 +175,9 @@ func TestIntents(t *testing.T) {
 		oauthClient := &oauth.Client{
 			ClientName:   "test-oauth-linked-app",
 			RedirectURIs: []string{"https://foobar"},
-			SoftwareID:   "registry://drive",
+			SoftwareID:   "registry://drive/stable",
 		}
-		require.Nil(t, oauthClient.Create(ins))
+		require.Nil(t, oauthClient.Create(ins, oauth.SoftwareIDPrevalidated))
 
 		// Issue an OAuth access token (AccessTokenAudience) for that client,
 		// with the linked-app scope so GetForOauth translates it via the

--- a/web/intents/intents_test.go
+++ b/web/intents/intents_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cozy/cozy-stack/model/app"
 	"github.com/cozy/cozy-stack/model/instance/lifecycle"
+	"github.com/cozy/cozy-stack/model/oauth"
 	"github.com/cozy/cozy-stack/model/permission"
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
@@ -14,6 +15,7 @@ import (
 	"github.com/gavv/httpexpect/v2"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/require"
+	"time"
 )
 
 func TestIntents(t *testing.T) {
@@ -80,6 +82,18 @@ func TestIntents(t *testing.T) {
 		require.NoError(t, err)
 	}
 	filesToken := ins.BuildAppToken("files", "")
+
+	driveApp := &couchdb.JSONDoc{
+		Type: consts.Apps,
+		M: map[string]interface{}{
+			"_id":  consts.Apps + "/drive",
+			"slug": "drive",
+		},
+	}
+	require.NoError(t, couchdb.CreateNamedDoc(ins, driveApp))
+	if _, err := permission.CreateWebappSet(ins, "drive", permission.Set{}, "1.0.0"); err != nil {
+		require.NoError(t, err)
+	}
 
 	ts := setup.GetTestServer("/intents", Routes)
 	ts.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler
@@ -153,6 +167,46 @@ func TestIntents(t *testing.T) {
 			Object()
 
 		checkIntentResult(obj, appPerms, false, "")
+	})
+
+	t.Run("CreateIntentWithOAuthLinkedApp", func(t *testing.T) {
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		oauthClient := &oauth.Client{
+			ClientName:   "test-oauth-linked-app",
+			RedirectURIs: []string{"https://foobar"},
+			SoftwareID:   "registry://drive",
+		}
+		require.Nil(t, oauthClient.Create(ins))
+
+		// Issue an OAuth access token (AccessTokenAudience) for that client,
+		// with the linked-app scope so GetForOauth translates it via the
+		// "drive" manifest.
+		tok, err := ins.MakeJWT(consts.AccessTokenAudience,
+			oauthClient.ClientID, "@io.cozy.apps/drive", "", time.Now())
+		require.NoError(t, err)
+
+		obj := e.POST("/intents").
+			WithHeader("Authorization", "Bearer "+tok).
+			WithHeader("Content-Type", "application/vnd.api+json").
+			WithHeader("Accept", "application/vnd.api+json").
+			WithBytes([]byte(`{
+        "data": {
+          "type": "io.cozy.settings",
+          "attributes": {
+            "action": "PICK",
+            "type": "io.cozy.files",
+            "permissions": ["GET"]
+          }
+        }
+      }`)).
+			Expect().Status(200).
+			JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+			Object()
+
+		data := obj.Value("data").Object()
+		attrs := data.Value("attributes").Object()
+		attrs.ValueEqual("client", "https://drive.cozy.example.net")
 	})
 
 	t.Run("CreateIntentWithClientURLMatchingFlag", func(t *testing.T) {


### PR DESCRIPTION
AI report

## The bug

When an app uses an OAuth access token obtained from `POST /auth/token_exchange` to
create an intent, the `client` field in the JSON-API response is `""` instead of
the resolved client URL.

## Root cause

The chain from token → intent response:

### 1. JWT subject is the OAuth client CouchID

`model/oauth/client.go:834`

```go
func (c *Client) CreateJWT(i *instance.Instance, audience, scope string) (string, error) {
    token, err := crypto.NewJWT(i.OAuthSecret, permission.Claims{
        RegisteredClaims: jwt.RegisteredClaims{
            Subject:  c.CouchID,   // ← UUID, e.g. "c1a2b3c4d5e67890abcdef0123456789"
            ...
        },
        Scope: scope,
    })
```

`CouchID` is a UUID — no `/` character.

### 2. SourceID is set to claims.Subject

`web/middlewares/permissions.go:128-133`

```go
func GetForOauth(instance *instance.Instance, claims *permission.Claims, client *oauth.Client) (*permission.Permission, error) {
    pdoc := &permission.Permission{
        Type:     permission.TypeOauth,
        SourceID: claims.Subject,  // ← the UUID, no "/"
        Client:   client,
    }
}
```

### 3. Intent.Client is set to SourceID

`web/intents/intents.go:83`

```go
intent.Client = pdoc.SourceID  // ← "c1a2b3c4d5e67890abcdef0123456789"
```

### 4. MarshalJSON splits on "/" — finds nothing

`web/intents/intents.go:50-57`

```go
func (i *apiIntent) MarshalJSON() ([]byte, error) {
    was := i.doc.Client
    parts := strings.SplitN(i.doc.Client, "/", 2)
    if len(parts) < 2 {
        i.doc.Client = ""   // ← always hit for OAuth tokens
    } else {
        i.doc.Client = i.resolveClientURL(parts[1])  // ← never reached
    }
    res, err := json.Marshal(i.doc)
    i.doc.Client = was
    return res, err
}
```

Since the UUID has no `/`, `strings.SplitN` returns a single-element slice,
`len(parts) < 2` is true, and `client` is set to `""`. The `resolveClientURL`
call (which would use `client_url_flag` from the manifest) is never reached.

## SourceID per token type

| Token audience | SourceID | Has `/`? | MarshalJSON result |
|---|---|---|---|
| `AppAudience` (webapp token) | `consts.Apps + "/" + slug` → `io.cozy.apps/mydrive` | yes | resolves correctly |
| `KonnectorAudience` | `consts.Konnectors + "/" + slug` | yes | resolves correctly |
| `AccessTokenAudience` (OAuth token) | `claims.Subject` = OAuth `CouchID` (UUID) | **no** | **`""`** |
| `CLIAudience` | unset/empty | no | `""` |
| Register token | unset/empty | no | `""` |

For webapp tokens, `SourceID` is built as `docType + "/" + slug` in
`createAppSet` (`model/permission/permissions.go:613`). For OAuth tokens,
`SourceID` is just `claims.Subject` — the OAuth client's CouchDB doc ID, which
is a UUID with no `/`.

## What needs to happen for OAuth tokens

`MarshalJSON` in `web/intents/intents.go` needs to handle the OAuth case. When
`SourceID` has no `/`, it should:

1. Retrieve the OAuth client from `claims.Subject` (the CouchID)
2. Find the app linked to that OAuth client (via the client's `SoftwareID` or
   linked app scope)
3. Use the app's slug to call `resolveClientURL(slug)`, which will pick up
   the `client_url_flag` from the manifest

The relevant helpers already exist:

- `oauth.FindClient(inst, clientID)` in `model/oauth/client.go`
- `oauth.GetLinkedAppSlug(softwareID)` to extract the slug from a software ID
- `app.ResolveClientURL(inst, slug)` to resolve the URL from the manifest's
   `client_url_flag` or fall back to subdomain
