### PR TITLE
Allow token_exchange from client_url_flag app

### DIFF
--- a/docs/apps.md
+++ b/docs/apps.md
@@ -30,6 +30,7 @@ filename for this file: `manifest.webapp`.
 | icon                            | an icon for the home                                                                                                                  |
 | screenshots                     | an array of path to the screenshots of the application                                                                                |
 | category                        | the category of the application                                                                                                       |
+| client_url_flag                 | the name of the feature flag whose value is the client URL to use for intents when the app is not hosted on a cozy subdomain          |
 | short_description               | a short description of the application                                                                                                |
 | long_description                | a long description of the application                                                                                                 |
 | source                          | where the files of the app can be downloaded                                                                                          |

--- a/web/auth/auth.go
+++ b/web/auth/auth.go
@@ -553,7 +553,7 @@ func tokenExchangeOriginAllowed(origin string, inst *instance.Instance) bool {
 	if tokenExchangeAppOriginAllowed(origin, originHost, inst) {
 		return true
 	}
-	if tokenExchangeAppClientURLOriginAllowed(origin, originHost, inst) {
+	if tokenExchangeAppClientURLOriginAllowed(origin, inst) {
 		return true
 	}
 
@@ -583,7 +583,7 @@ func tokenExchangeAppOriginAllowed(origin, originHost string, inst *instance.Ins
 		tokenExchangeAppSlugAllowed(inst.ContextName, appSlug)
 }
 
-func tokenExchangeAppClientURLOriginAllowed(origin, x string, inst *instance.Instance) bool {
+func tokenExchangeAppClientURLOriginAllowed(origin string, inst *instance.Instance) bool {
 	u, err := url.Parse(origin)
 	if err != nil || u.Scheme == "" || u.Host == "" {
 		return false

--- a/web/auth/auth.go
+++ b/web/auth/auth.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cozy/cozy-stack/model/bitwarden/settings"
 	"github.com/cozy/cozy-stack/model/instance"
 	"github.com/cozy/cozy-stack/model/instance/lifecycle"
+	"github.com/cozy/cozy-stack/model/oauth"
 	"github.com/cozy/cozy-stack/model/session"
 	csettings "github.com/cozy/cozy-stack/model/settings"
 	build "github.com/cozy/cozy-stack/pkg/config"
@@ -534,7 +535,9 @@ func tokenExchangeCORS(c echo.Context) bool {
 	return true
 }
 
-// Allow CORS from *.org_domain, and from the owner's SaaS admin panel.
+// Allow CORS from *.org_domain, from Cozy app subdomains of the instance, from
+// org-wide app domains resolved via client_url_flag, and from the owner's SaaS
+// admin panel.
 func tokenExchangeOriginAllowed(origin string, inst *instance.Instance) bool {
 	if inst == nil {
 		return false
@@ -548,6 +551,9 @@ func tokenExchangeOriginAllowed(origin string, inst *instance.Instance) bool {
 		return true
 	}
 	if tokenExchangeAppOriginAllowed(origin, originHost, inst) {
+		return true
+	}
+	if tokenExchangeAppClientURLOriginAllowed(origin, originHost, inst) {
 		return true
 	}
 
@@ -575,6 +581,39 @@ func tokenExchangeAppOriginAllowed(origin, originHost string, inst *instance.Ins
 	return appSlug != "" &&
 		inst.HasDomain(instanceHost) &&
 		tokenExchangeAppSlugAllowed(inst.ContextName, appSlug)
+}
+
+func tokenExchangeAppClientURLOriginAllowed(origin, x string, inst *instance.Instance) bool {
+	u, err := url.Parse(origin)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return false
+	}
+	if u.Scheme != "https" && u.Scheme != "http" {
+		return false
+	}
+
+	appExchangeConfig, err := config.GetOIDCAppTokenExchange(inst.ContextName)
+	if err != nil || !appExchangeConfig.Enabled {
+		return false
+	}
+	for _, appConfig := range appExchangeConfig.Apps {
+		slug := oauth.GetLinkedAppSlug(appConfig.SoftwareID)
+		if slug == "" {
+			continue
+		}
+		clientURL := app.ResolveClientURL(inst, slug)
+		if clientURL == "" {
+			continue
+		}
+		parsed, err := url.Parse(clientURL)
+		if err != nil || parsed.Host == "" {
+			continue
+		}
+		if u.Scheme == parsed.Scheme && u.Host == parsed.Host {
+			return true
+		}
+	}
+	return false
 }
 
 func tokenExchangeAdminPanelOriginAllowed(origin, originHost string, inst *instance.Instance) bool {

--- a/web/auth/auth_test.go
+++ b/web/auth/auth_test.go
@@ -2515,6 +2515,51 @@ func TestTokenExchange(t *testing.T) {
 		require.Equal(t, clientIDValue, boundClients[0].OAuthClientID)
 	})
 
+	t.Run("ExchangesAppTokenFromClientURLFlagOrigin", func(t *testing.T) {
+		const (
+			sid          = "mail-app-sid-client-url-flag"
+			twakeMailURL = "https://mail.stg.lin-saas.com"
+		)
+		testutils.WithFlag(t, testInstance, appTokenClientURLFlag, twakeMailURL)
+		idToken := makeTokenExchangeSignedJWT(t, privateKey, kid, map[string]interface{}{
+			"iss": issuer,
+			"aud": []string{appTokenAudience},
+			"sub": "mail-user",
+			"sid": sid,
+			"iat": time.Now().Unix(),
+			"exp": time.Now().Add(time.Hour).Unix(),
+		})
+
+		resp := e.POST("/auth/token_exchange").
+			WithHost(testInstance.Domain).
+			WithHeader("Accept", "application/json").
+			WithHeader("Origin", twakeMailURL).
+			WithJSON(map[string]string{
+				"id_token":      idToken,
+				"exchange_type": "app",
+			}).
+			Expect().
+			Status(http.StatusOK)
+		resp.Header("Access-Control-Allow-Origin").Equal(twakeMailURL)
+		obj := resp.JSON().Object()
+
+		clientIDValue := obj.Value("client_id").String().Raw()
+		accessToken := obj.Value("access_token").String().Raw()
+		refreshToken := obj.Value("refresh_token").String().Raw()
+		scope := oauth.BuildLinkedAppScope(appTokenAppSlug)
+
+		obj.ValueEqual("token_type", "bearer")
+		obj.ValueEqual("scope", scope)
+		assertValidToken(t, testInstance, accessToken, consts.AccessTokenAudience, clientIDValue, scope)
+		assertValidToken(t, testInstance, refreshToken, consts.RefreshTokenAudience, clientIDValue, scope)
+
+		client, err := oauth.FindClient(testInstance, clientIDValue)
+		require.NoError(t, err)
+		require.Equal(t, appTokenSoftwareID, client.SoftwareID)
+		require.Equal(t, sid, client.OIDCSessionID)
+		require.Equal(t, []string{"https://mail." + testInstance.Domain}, client.RedirectURIs)
+	})
+
 	t.Run("ExchangesAppTokenWithInstanceClaim", func(t *testing.T) {
 		withAppTokenInstanceClaim(t, " workplaceFqdn ")
 		const sid = "mail-app-sid-instance-claim"

--- a/web/auth/auth_test.go
+++ b/web/auth/auth_test.go
@@ -2134,14 +2134,15 @@ func TestTokenExchange(t *testing.T) {
 
 	privateKey, kid, jwksURL := newTokenExchangeSigningKey(t)
 	const (
-		contextName        = "token-exchange-test"
-		clientID           = "cozy-twake-int"
-		appTokenAudience   = "twake-mail-web"
-		appTokenAppSlug    = "mail"
-		appTokenSoftwareID = "registry://mail"
-		issuer             = "https://sign-up.example.com/"
+		contextName           = "token-exchange-test"
+		clientID              = "cozy-twake-int"
+		appTokenAudience      = "twake-mail-web"
+		appTokenAppSlug       = "mail"
+		appTokenSoftwareID    = "registry://mail"
+		appTokenClientURLFlag = "twake_mail_url"
+		issuer                = "https://sign-up.example.com/"
 	)
-	appManifest := makeTokenExchangeAppManifest(appTokenAppSlug)
+	appManifest := makeTokenExchangeAppManifest(appTokenAppSlug, appTokenClientURLFlag)
 	appRegistry := newTokenExchangeRegistry(t, appTokenAppSlug, appManifest)
 	appRegistryURL, err := url.Parse(appRegistry.URL)
 	require.NoError(t, err)
@@ -2293,6 +2294,58 @@ func TestTokenExchange(t *testing.T) {
 		resp.Header("Access-Control-Allow-Methods").Equal(http.MethodPost)
 		resp.Header("Access-Control-Allow-Headers").Equal("content-type")
 		resp.Header("Access-Control-Allow-Credentials").Equal("true")
+	})
+
+	t.Run("AllowsAppClientURLFlagOrigin", func(t *testing.T) {
+		const twakeMailURL = "https://mail.stg.lin-saas.com"
+		testutils.WithFlag(t, testInstance, appTokenClientURLFlag, twakeMailURL)
+
+		resp := e.OPTIONS("/auth/token_exchange").
+			WithHost(testInstance.Domain).
+			WithHeader("Origin", twakeMailURL).
+			WithHeader("Access-Control-Request-Headers", "content-type").
+			Expect().
+			Status(http.StatusNoContent)
+
+		resp.Header("Access-Control-Allow-Origin").Equal(twakeMailURL)
+		resp.Header("Access-Control-Allow-Methods").Equal(http.MethodPost)
+		resp.Header("Access-Control-Allow-Headers").Equal("content-type")
+		resp.Header("Access-Control-Allow-Credentials").Equal("true")
+	})
+
+	t.Run("RejectsAppClientURLFlagOriginWhenFlagInvalid", func(t *testing.T) {
+		const twakeMailURL = "https://mail.stg.lin-saas.com"
+		testutils.WithFlag(t, testInstance, appTokenClientURLFlag, twakeMailURL)
+
+		e.OPTIONS("/auth/token_exchange").
+			WithHost(testInstance.Domain).
+			WithHeader("Origin", "https://chat.stg.lin-saas.com").
+			WithHeader("Access-Control-Request-Headers", "content-type").
+			Expect().
+			Status(http.StatusForbidden).
+			Header("Access-Control-Allow-Origin").Empty()
+	})
+
+	t.Run("RejectsAppClientURLFlagOriginWhenFlagUnset", func(t *testing.T) {
+		e.OPTIONS("/auth/token_exchange").
+			WithHost(testInstance.Domain).
+			WithHeader("Origin", "https://mail.stg.lin-saas.com").
+			WithHeader("Access-Control-Request-Headers", "content-type").
+			Expect().
+			Status(http.StatusForbidden).
+			Header("Access-Control-Allow-Origin").Empty()
+	})
+
+	t.Run("RejectsAppClientURLFlagOriginWhenFlagNotAnUrl", func(t *testing.T) {
+		testutils.WithFlag(t, testInstance, appTokenClientURLFlag, "not-a-url")
+
+		e.OPTIONS("/auth/token_exchange").
+			WithHost(testInstance.Domain).
+			WithHeader("Origin", "https://mail.stg.lin-saas.com").
+			WithHeader("Access-Control-Request-Headers", "content-type").
+			Expect().
+			Status(http.StatusForbidden).
+			Header("Access-Control-Allow-Origin").Empty()
 	})
 
 	t.Run("RejectsAdminPanelPublicDomainSuffixOriginFromDifferentOrg", func(t *testing.T) {
@@ -3010,7 +3063,11 @@ func makeTokenExchangeOIDCConfig(issuer, clientID, jwksURL string) map[string]in
 	}
 }
 
-func makeTokenExchangeAppManifest(slug string) []byte {
+func makeTokenExchangeAppManifest(slug, clientURLFlag string) []byte {
+	var flagField string
+	if clientURLFlag != "" {
+		flagField = fmt.Sprintf(`, "client_url_flag": %q`, clientURLFlag)
+	}
 	return []byte(fmt.Sprintf(`{
   "name": "Mail",
   "name_prefix": "Twake",
@@ -3031,8 +3088,8 @@ func makeTokenExchangeAppManifest(slug string) []byte {
       "type": "io.cozy.contacts",
       "verbs": ["GET"]
     }
-  }
-}`, slug, slug))
+  }%s
+}`, slug, slug, flagField))
 }
 
 func installTokenExchangeWebapp(t *testing.T, inst *instance.Instance, manifestJSON []byte) {


### PR DESCRIPTION
We have the following CORS error when trying a token_exchange from https://mail.stg.lin-saas.com. Let's add the client_url_flag as a CORS origin. See 49d82a5cc1b381c74c17d052cb357afd82551122 for more explanation.

> Access to XMLHttpRequest at 'https://zatteo.stg.lin-saas.com/auth/token_exchange' from origin 'https://mail.stg.lin-saas.com' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: No 'Access-Control-Allow-Origin' header is present on the requested resource.