### PR TITLE
Missing CSP for intent on a non-cozy domain 

### DIFF
--- a/model/app/webapp.go
+++ b/model/app/webapp.go
@@ -209,27 +209,27 @@ func (m *WebappManifest) ClientURLFlag() string { return m.val.ClientURLFlag }
 func ResolveClientURL(ins *instance.Instance, slug string) string {
 	manifest, err := GetWebappBySlug(ins, slug)
 	if err != nil {
-		return defaultClientURL(ins, slug)
+		return DefaultClientURL(ins, slug)
 	}
 	flagKey := manifest.ClientURLFlag()
 	if flagKey == "" {
-		return defaultClientURL(ins, slug)
+		return DefaultClientURL(ins, slug)
 	}
 	flags, err := feature.GetFlags(ins)
 	if err != nil {
-		return defaultClientURL(ins, slug)
+		return DefaultClientURL(ins, slug)
 	}
 	flagValue, ok := flags.M[flagKey].(string)
 	if !ok {
-		return defaultClientURL(ins, slug)
+		return DefaultClientURL(ins, slug)
 	}
 	if _, err := url.ParseRequestURI(flagValue); err != nil {
-		return defaultClientURL(ins, slug)
+		return DefaultClientURL(ins, slug)
 	}
 	return flagValue
 }
 
-func defaultClientURL(ins *instance.Instance, slug string) string {
+func DefaultClientURL(ins *instance.Instance, slug string) string {
 	u := ins.SubDomain(slug)
 	u.Path = ""
 	return u.String()

--- a/web/apps/apps_test.go
+++ b/web/apps/apps_test.go
@@ -344,7 +344,7 @@ func TestApps(t *testing.T) {
 			WithCookie("cozysessid", cozysessID).
 			Expect().Status(200).
 			Header(echo.HeaderContentSecurityPolicy)
-		csp.Contains("frame-ancestors 'self' https://external.example.com;")
+		csp.Contains("frame-ancestors 'self' https://external.example.com https://clienturl-app.cozywithapps.example.net;")
 	})
 
 	t.Run("FaviconWithContext", func(t *testing.T) {

--- a/web/apps/serve.go
+++ b/web/apps/serve.go
@@ -135,6 +135,13 @@ func handleIntent(c echo.Context, i *instance.Instance, slug, intentID string) {
 	from := app.ResolveClientURL(i, parts[1])
 	if !config.GetConfig().CSPDisabled {
 		middlewares.AppendCSPRule(c, "frame-ancestors", from)
+		// When the client app is hosted on a non-cozy domain (via its
+		// client_url_flag), it can itself be framed by its cozy subdomain
+		// parent. frame-ancestors must list every ancestor in the iframe
+		// chain, so also allow the cozy subdomain.
+		if defaultFrom := app.DefaultClientURL(i, parts[1]); defaultFrom != from {
+			middlewares.AppendCSPRule(c, "frame-ancestors", defaultFrom)
+		}
 	}
 }
 


### PR DESCRIPTION
When the client app is hosted on a non-cozy domain (via its client_url_flag), it can itself be framed by its cozy subdomain parent. frame-ancestors must list every ancestor in the iframe chain, so also allow the cozy subdomain.