### PR TITLE
feat: Open CSP for multi-tenant B2B Twake Chat

### DIFF
--- a/web/middlewares/secure.go
+++ b/web/middlewares/secure.go
@@ -307,13 +307,23 @@ func (b cspBuilder) makeCSPHeader(header, cspAllowList string, sources []CSPSour
 			}
 		}
 	}
-	// Add matrix.{org_domain} to frame-src directive if present (for iframes).
-	// OrgDomain is validated to contain only safe characters before being injected into the header.
-	if header == "frame-src" && b.instance != nil && isSafeDomain(b.instance.OrgDomain) {
-		headers = append(headers, "matrix."+b.instance.OrgDomain)
+	// Add org related domains to frame-src directive if present (for iframes).
+	// OrgDomain is validated to contain only safe characters before being
+	// injected into the header.
+	if header == "frame-src" && b.instance != nil {
+		if isSafeDomain(b.instance.OrgDomain) {
+			headers = append(headers, "matrix."+b.instance.OrgDomain)
+		}
+
+		_, domain, found := strings.Cut(b.instance.Domain, ".")
+		if found && isSafeDomain(domain) && isSafeDomain(b.instance.OrgID) {
+			headers = append(headers, "chat-"+b.instance.OrgID+".tc-apps."+domain)
+			headers = append(headers, "auto-login-"+b.instance.OrgID+".tc-apps."+domain)
+		}
 	}
-	// Add api-login-{org_id}.{domain without prefix} to connect-src directive if present.
-	// OrgID, OrgDomain, and domain are all validated before being injected into the header.
+	// Add org related domains to connect-src directive if present.
+	// OrgID, OrgDomain, and domain are all validated before being injected
+	// into the header.
 	if header == "connect-src" && b.instance != nil && isSafeDomain(b.instance.OrgID) {
 		_, domain, found := strings.Cut(b.instance.Domain, ".")
 		if found && isSafeDomain(domain) {
@@ -321,6 +331,8 @@ func (b cspBuilder) makeCSPHeader(header, cspAllowList string, sources []CSPSour
 			headers = append(headers, "api-login-"+orgDomain)
 			headers = append(headers, orgDomain)
 			headers = append(headers, "wss://"+orgDomain)
+			headers = append(headers, "chat-"+b.instance.OrgID+".tc-apps."+domain)
+			headers = append(headers, "auto-login-"+b.instance.OrgID+".tc-apps."+domain)
 		}
 		if isSafeDomain(b.instance.OrgDomain) {
 			orgAltDomain := b.instance.OrgID + "." + b.instance.OrgDomain

--- a/web/middlewares/secure_test.go
+++ b/web/middlewares/secure_test.go
@@ -154,6 +154,10 @@ func TestSecure(t *testing.T) {
 
 		csp := rec.Header().Get(echo.HeaderContentSecurityPolicy)
 
+		// No OrgID set: Twake Chat multi-tenant domains must NOT be present.
+		assert.NotContains(t, csp, "tc-apps",
+			"CSP should NOT contain tc-apps domains when OrgID is empty. Full CSP: %s", csp)
+
 		// Verify that matrix.example.com appears only once (in frame-src)
 		count := strings.Count(csp, "matrix.example.com")
 		assert.Equal(t, 1, count,
@@ -236,6 +240,8 @@ func TestSecure(t *testing.T) {
 		apiLoginDomain := "api-login-myorg123.cozy.example.com"
 		orgInstanceDomain := "myorg123.cozy.example.com"
 		orgInstanceWSDomain := "wss://myorg123.cozy.example.com"
+		chatDomain := "chat-myorg123.tc-apps.cozy.example.com"
+		autoLoginDomain := "auto-login-myorg123.tc-apps.cozy.example.com"
 
 		// Verify that connect-src contains the api-login domain
 		connectSrcIndex := strings.Index(csp, "connect-src ")
@@ -253,6 +259,25 @@ func TestSecure(t *testing.T) {
 			"connect-src should contain %s. Found: %s", orgInstanceDomain, connectSrcContent)
 		assert.Contains(t, connectSrcContent, orgInstanceWSDomain,
 			"connect-src should contain %s. Found: %s", orgInstanceWSDomain, connectSrcContent)
+		assert.Contains(t, connectSrcContent, chatDomain,
+			"connect-src should contain %s. Found: %s", chatDomain, connectSrcContent)
+		assert.Contains(t, connectSrcContent, autoLoginDomain,
+			"connect-src should contain %s. Found: %s", autoLoginDomain, connectSrcContent)
+
+		// Verify that frame-src contains the Twake Chat domains.
+		frameSrcIndex := strings.Index(csp, "frame-src ")
+		assert.NotEqual(t, -1, frameSrcIndex,
+			"frame-src should be present in CSP. Full CSP: %s", csp)
+
+		frameSrcEnd := strings.Index(csp[frameSrcIndex:], ";")
+		assert.NotEqual(t, -1, frameSrcEnd,
+			"frame-src should end with semicolon")
+
+		frameSrcContent := csp[frameSrcIndex : frameSrcIndex+frameSrcEnd]
+		assert.Contains(t, frameSrcContent, chatDomain,
+			"frame-src should contain %s. Found: %s", chatDomain, frameSrcContent)
+		assert.Contains(t, frameSrcContent, autoLoginDomain,
+			"frame-src should contain %s. Found: %s", autoLoginDomain, frameSrcContent)
 
 		// Verify that other directives do NOT contain the api-login domain
 		otherDirectives := []string{
@@ -336,6 +361,8 @@ func TestSecure(t *testing.T) {
 		csp := rec.Header().Get(echo.HeaderContentSecurityPolicy)
 		expectedDomain := "myorg123.example.com"
 		expectedWSDomain := "wss://myorg123.example.com"
+		chatDomain := "chat-myorg123.tc-apps.cozy.example.com"
+		autoLoginDomain := "auto-login-myorg123.tc-apps.cozy.example.com"
 
 		count := strings.Count(csp, expectedDomain)
 		assert.Equal(t, 3, count,
@@ -355,6 +382,25 @@ func TestSecure(t *testing.T) {
 			"connect-src should contain %s. Found: %s", expectedDomain, connectSrcContent)
 		assert.Contains(t, connectSrcContent, expectedWSDomain,
 			"connect-src should contain %s. Found: %s", expectedWSDomain, connectSrcContent)
+		assert.Contains(t, connectSrcContent, chatDomain,
+			"connect-src should contain %s. Found: %s", chatDomain, connectSrcContent)
+		assert.Contains(t, connectSrcContent, autoLoginDomain,
+			"connect-src should contain %s. Found: %s", autoLoginDomain, connectSrcContent)
+
+		// Verify that frame-src contains the Twake Chat domains.
+		frameSrcIndex := strings.Index(csp, "frame-src ")
+		assert.NotEqual(t, -1, frameSrcIndex,
+			"frame-src should be present in CSP. Full CSP: %s", csp)
+
+		frameSrcEnd := strings.Index(csp[frameSrcIndex:], ";")
+		assert.NotEqual(t, -1, frameSrcEnd,
+			"frame-src should end with semicolon")
+
+		frameSrcContent := csp[frameSrcIndex : frameSrcIndex+frameSrcEnd]
+		assert.Contains(t, frameSrcContent, chatDomain,
+			"frame-src should contain %s. Found: %s", chatDomain, frameSrcContent)
+		assert.Contains(t, frameSrcContent, autoLoginDomain,
+			"frame-src should contain %s. Found: %s", autoLoginDomain, frameSrcContent)
 
 		// Verify that img-src also contains the org domain
 		imgSrcIndex := strings.Index(csp, "img-src ")


### PR DESCRIPTION
  We open the `frame-src` and `connect-src` CSP rules for B2B instances
  so users can reach their organization's multi-tenant Twake Chat
  endpoints.

  Fixes #4825 