### PR TITLE
feat: add org fields to the instance show command

### DIFF
--- a/client/instances.go
+++ b/client/instances.go
@@ -30,6 +30,8 @@ type Instance struct {
 	Attrs struct {
 		Domain               string    `json:"domain"`
 		DomainAliases        []string  `json:"domain_aliases,omitempty"`
+		OrgDomain            string    `json:"org_domain,omitempty"`
+		OrgID                string    `json:"org_id,omitempty"`
 		OldDomain            string    `json:"old_domain,omitempty"`
 		Prefix               string    `json:"prefix,omitempty"`
 		Locale               string    `json:"locale"`


### PR DESCRIPTION
 ## Summary

  Expose `org_domain` and `org_id` in the output of `cozy-stack instances show`.

  The admin API already returns these fields from the instance document, but the CLI uses the client-side `Instance` DTO before printing the JSON. Since that DTO did not include the org fields, they were dropped from the final
  command output.
