### PR TITLE
Add intent mobile auto-login WebView design

### DIFF
--- a/docs/adr/002-adr-intent-mobile-session-code.md
+++ b/docs/adr/002-adr-intent-mobile-session-code.md
@@ -1,0 +1,216 @@
+# ADR: Mobile intent WebView login via session_code
+
+**Date:** 2026-07-09
+**Status:** Accepted
+**Scope:** cozy-stack (Go)
+
+## Context
+
+The Intent feature lets a client-side app delegate an action (PICK, OPEN, EDIT,
+…) to another installed webapp. On web, the service app is loaded inside an
+iframe and relies on the browser-shared `cozysessid` cookie to be logged in.
+
+On mobile, the caller app is a native app and the service app is loaded in a
+WebView. The cookie is not shared between the native app and the WebView, so the
+service app loads unauthenticated and the intent cannot complete.
+
+The caller app can already exchange an OIDC `id_token` for cozy-stack tokens via
+`POST /auth/token_exchange` (`exchange_type=app`), which returns an app-scoped
+OAuth access token. That token can query the intents API, but it cannot by itself
+log in a WebView — it is a bearer token, not a cookie.
+
+## Goal
+
+Let a mobile caller app open an intent service app in a WebView that is already
+logged in, scoped to that service app, by reusing the existing `session_code`
+primitive.
+
+## Non-goals
+
+- A token-less / cookie-less WebView (that is approach B, not selected).
+- Binding the session cookie to a single intent ID (deliberately not done; see
+  Security).
+- A new session primitive or a new intents API flow.
+
+## Approach
+
+Reuse the flagship `session_code` flow end-to-end. The only new behavior is
+allowing an app-scoped token minted by `token_exchange` to mint a session_code,
+where today `canCreateSessionCode` only accepts a maximal/flagship token or
+passphrase+2FA.
+
+### Data flow
+
+```
+Mobile app                cozy-stack                WebView (service app)
+----------  --------------  ----------------------   ----------------------
+[token_exchange]  ──POST /auth/token_exchange──▶
+                   ◀── app-scoped access_token ──
+[create intent]    ──POST /intents  (Bearer app token)──▶
+                   ◀── intent doc: id + service href ──
+[mint session_code]──POST /auth/session_code (Bearer app token)──▶
+                   ◀── {"session_code": "<code>"} ──
+[open WebView]     ── load https://<serviceSlug>.<inst>/?intent=<id>&session_code=<code> ──▶
+                                                    ServeAppFile:
+                                                    1. CheckAndClearSessionCode → ok
+                                                    2. SetCookieForNewSession(NormalRun)
+                                                    3. redirect to ?intent=<id> (code stripped)
+                                                    4. on reload: relax CSP frame-ancestors
+                                                    5. inject BuildAppToken(serviceSlug, sessID)
+                   ◀── index.html with cozyData.token = <app token> ──
+                                                    cozy-client in WebView uses app token
+                                                    for all API calls (scoped to serviceSlug)
+```
+
+The service-app scoping is achieved by the existing app-token layer:
+`ServeAppFile` injects `inst.BuildAppToken(serviceSlug, sessID)` into the served
+`index.html`, which is a JWT with `subject=serviceSlug` scoped to that app's
+manifest permissions. The cookie is a full user session, but the page only ever
+holds a service-app-scoped token, and `GET /intents/:id` independently enforces
+`intent.Services` on the bearer.
+
+## Implementation
+
+The implementation keeps the existing two-call flow:
+
+- `POST /intents` creates the intent and returns the service href.
+- `POST /auth/session_code` mints a one-time code from an authorized bearer.
+- The mobile app appends `session_code` to the selected service href.
+- `ServeAppFile` consumes the code, creates the cookie, strips only
+  `session_code`, and preserves the remaining query parameters such as
+  `intent`.
+
+### 1. `web/auth/flagship.go` — `canCreateSessionCode`
+
+Add a new branch returning `allowedToCreateSessionCode` when the request is
+authenticated with an app-scoped token from `token_exchange`. This is the only
+behavioral change.
+
+```go
+func canCreateSessionCode(c echo.Context, inst *instance.Instance) canCreateSessionCodeResult {
+    if err := middlewares.AllowMaximal(c); err == nil {
+        return allowedToCreateSessionCode
+    }
+    if isAppTokenExchangeToken(c, inst) {                 // NEW
+        return allowedToCreateSessionCode                 // NEW
+    }
+
+    // …existing passphrase + 2FA path unchanged…
+}
+```
+
+### 2. `web/auth/flagship.go` — new helper `isAppTokenExchangeToken`
+
+Lives next to `canCreateSessionCode` (locality with the only caller). Verifies
+that the bearer token was minted by `token_exchange` for a linked app configured
+on the instance's context.
+
+The implementation uses the OAuth client lookup approach rather than adding a
+new JWT claim: read the decoded access-token claims from the echo context, fetch
+the `oauth.Client`, check that its `SoftwareID` is listed in
+`config.GetOIDCAppTokenExchange(inst.ContextName).Apps`, derive the linked app
+slug, and require that app to be installed. This avoids changing the
+`token_exchange` JWT shape and keeps revoked configuration effective for future
+session-code mints.
+
+### 3. Tests
+
+The authorization tests are colocated in `web/auth/auth_test.go` with the
+existing token_exchange scaffolding:
+
+1. **App-scoped token mints a session_code** — mint an app token via the existing
+   token_exchange helper; `POST /auth/session_code` with that bearer; assert 201
+   + `session_code` present; assert the code is present and single-use in the
+   store.
+2. **Admin token cannot mint a session_code** — token_exchange admin tokens stay
+   rejected by `/auth/session_code`.
+3. **No token cannot mint a session_code** — anonymous requests stay rejected.
+
+The app-serving session_code behavior stays covered in `web/apps/apps_test.go`.
+
+### 4. Docs — `docs/intents.md` (or wherever the intent mobile flow is documented)
+
+Add a section describing the mobile + WebView flow: token_exchange → create
+intent → session_code → load `https://<serviceApp>.<inst>/?intent=<id>&session_
+code=<code>`.
+
+## What is NOT changed
+
+- `model/instance/auth.go:CreateSessionCode` — unchanged.
+- `model/instance/store.go` session_code store — unchanged (single-use,
+  7-day TTL, atomic delete on read).
+- `web/apps/serve.go` — `ServeAppFile` still consumes the existing
+  session_code primitive; it preserves the intent query parameter when stripping
+  `session_code`.
+- `web/intents/intents.go` — create/get handlers unchanged.
+- `model/intent/intents.go:GenerateHref` — unchanged.
+- Flagship flow, magic link, delegated JWT — unchanged.
+
+## Config & gating
+
+No new config flag. The ability to mint a session_code is granted implicitly to
+any token that satisfies `isAppTokenExchangeToken`, i.e. any token minted by
+`token_exchange` for a linked app currently listed in the context's
+`app_token_exchange` config. Revoking an app from `app_token_exchange` revokes
+its ability to mint session_codes going forward.
+
+If a deployer later wants to separate "can exchange id_token" from "can mint
+session_code" per app, add an optional `allow_session_code` field (default
+`true`) under each `OIDCAppTokenExchangeAppConfig` in
+`pkg/config/config/config.go:439`. Deferred to YAGNI until a real need surfaces.
+
+## Session duration
+
+`session.NormalRun` uses a browser-session cookie and the stored session remains
+subject to the normal server-side session lifetime. This matches the existing
+`ServeAppFile` session_code consumer and the flagship flow, so no
+special-casing is needed.
+
+## Security considerations
+
+The design reuses a battle-tested primitive, so the security surface is small
+and mostly inherited.
+
+- **Cookie scope** — `cozysessid` is a full user session on the instance domain
+  (HttpOnly, Secure, SameSite=Lax, scoped to `.instance.tld`). Same risk
+  profile as flagship. Bounded by: single-use session_code (atomic delete in
+  the session-code store on read), 7-day mint TTL, NormalRun session,
+  WebView-only lifecycle.
+- **WebView boundary** — the cookie lives in the WebView's cookie jar, not the
+  mobile app's native storage. If the WebView is destroyed (standard iOS/Android
+  behavior), the cookie is cleared. This is a mobile-side implementation
+  responsibility, not a stack change.
+- **Token elevation** — the app-scoped token gains the ability to mint a user
+  session code. This is an elevation in effect, but the caller already proved
+  OIDC identity to cozy-stack during `token_exchange` (`validateTokenExchange-
+  AppToken`, `web/auth/token_exchange.go:297`), so minting a session_code is a
+  natural follow-on.
+- **Bound to a configured linked app** — `isAppTokenExchangeToken` verifies the
+  token's linked app is in `app_token_exchange` and installed, mirroring
+  `tokenExchangeCheckAppInstance`. Prevents a stray app token from minting codes.
+- **Intent binding (deliberate non-feature)** — the session_code is NOT bound to
+  the intent ID. The minted session is a generic user session; the intent is
+  consumed via `?intent=` which independently enforces `intent.Services` on
+  `GET /intents/:id`. Keeping them decoupled matches the flagship pattern (mint
+  code → use it wherever) and avoids new coupling. Single-use session bound to
+  one intent is approach B, not A.
+- **No CSRF on mint** — `POST /auth/session_code` requires a valid bearer token
+  (not a cookie-CSRF flow); the new branch inherits that.
+- **Audit logging** — log session_code creation with a distinct `source` value
+  (`"app_token_exchange"`) so audit logs distinguish app-token-minted codes from
+  flagship (`"flagship"`) and password (`"password"`) ones.
+
+## Alternatives considered
+
+- **Approach B — Bearer token via `?sharecode=`-style injection (no cookie).**
+  Mint a scoped JWT bound to the intent + service app, pass via `?sharecode=`,
+  reuse `ServeAppFile`'s sharecode path. No cookie ever leaves the stack —
+  strongest isolation. Rejected: more new code (new minting endpoint, new token
+  shape, permission-check adjustments for `GET /intents/:id`), and the
+  cookie-free page cannot use cozy-bar / cross-app navigation. Acceptable
+  trade-off for a focused intent WebView, but A is cheaper and reuses more.
+- **Approach C — Intent-bound scoped session.** Add a `BoundApp` field to the
+  session doc and enforce it in `LoadSession`/`BuildAppToken`. Strongest cookie-
+  level isolation. Rejected: touches the core session model with the largest
+  blast radius; overkill given the app-token layer already scopes API calls in
+  approach A.

--- a/docs/intents.md
+++ b/docs/intents.md
@@ -445,6 +445,65 @@ Content-Type: application/vnd.api+json
 }
 ```
 
+## Mobile + WebView flow
+
+When the client app is a native mobile app and the service app must be loaded in a
+WebView, the browser-shared cookie is not available. The mobile app can authenticate
+the WebView by reusing the existing `session_code` mechanism.
+
+### Flow
+
+```
+Mobile app                cozy-stack                WebView (service app)
+----------  --------------  ----------------------   ----------------------
+[token_exchange]  ──POST /auth/token_exchange──────▶
+                   ◀── app-scoped access_token ────
+[create intent]    ──POST /intents  (Bearer app token)────▶
+                   ◀── intent doc: id + service href ────
+[mint session_code]──POST /auth/session_code (Bearer app token)──▶
+                   ◀── {"session_code": "<code>"} ────
+[open WebView]     ── load https://<service>.<inst>/?intent=<id>&session_code=<code> ────▶
+                                                    ServeAppFile:
+                                                    1. CheckAndClearSessionCode → ok
+                                                    2. SetCookieForNewSession(NormalRun)
+                                                    3. redirect to ?intent=<id> (code stripped)
+                                                    4. on reload: serve app with cozyData.token
+                   ◀── index.html with cozyData.token = <app token> ────
+                                                    cozy-client in WebView uses app token
+                                                    for all API calls (scoped to service slug)
+```
+
+### Prerequisites
+
+- The instance must have OIDC configured with `allow_app_token_exchange: true` and
+  at least one entry under `app_token_exchange` in the context configuration.
+- The caller app must be a linked app listed in that configuration.
+- The service app must be installed on the instance.
+
+### API calls
+
+1. **Token exchange** — `POST /auth/token_exchange` with `exchange_type: "app"` and
+   a valid OIDC `id_token`. Returns an OAuth access token scoped to the linked app.
+2. **Create intent** — `POST /intents` with the app-scoped token. Returns the intent
+   document including the service app's href with `?intent=<id>`.
+3. **Mint session_code** — `POST /auth/session_code` with the same app-scoped token
+   as Bearer. Returns `{"session_code": "<code>"}`.
+4. **Open WebView** — load `https://<serviceSlug>.<instance>/...?intent=<id>&session_code=<code>`.
+   The stack consumes the code, creates a session cookie, and redirects (code
+   stripped). The WebView now has a full user session for the instance domain.
+
+### Security
+
+- The `session_code` is single-use (atomic delete in Redis on read) with a 7-day TTL.
+- The cookie is a `NormalRun` session (browser-session, 30-day max age) cleared
+  when the WebView is destroyed.
+- The service page only receives a service-app-scoped token via `BuildAppToken`;
+  the underlying cookie grants a full user session, but the page code never
+  accesses it directly.
+- Only tokens minted by `token_exchange` for a currently configured linked app
+  can mint session codes. Revoking the app from `app_token_exchange` immediately
+  prevents new session code minting.
+
 ## Annexes
 
 ### Use Cases

--- a/web/apps/apps_test.go
+++ b/web/apps/apps_test.go
@@ -456,15 +456,17 @@ func TestApps(t *testing.T) {
 			flagship.ClientID, "*", "", time.Now())
 		assert.NoError(t, err)
 
-		// Create the session code
-		code := e.POST("/auth/session_code").
-			WithHost(testInstance.Domain).
-			WithHeader("Authorization", "Bearer "+token).
-			Expect().Status(201).
-			JSON().Object().
-			Value("session_code").String().NotEmpty().Raw()
+		createSessionCode := func() string {
+			return e.POST("/auth/session_code").
+				WithHost(testInstance.Domain).
+				WithHeader("Authorization", "Bearer "+token).
+				Expect().Status(201).
+				JSON().Object().
+				Value("session_code").String().NotEmpty().Raw()
+		}
 
 		// Load a non-public page
+		code := createSessionCode()
 		e.GET("/foo/").
 			WithQuery("session_code", code).
 			WithHost(slug+"."+testInstance.Domain).
@@ -479,6 +481,20 @@ func TestApps(t *testing.T) {
 			WithRedirectPolicy(httpexpect.DontFollowRedirects).
 			Expect().Status(302).
 			Header("Location").Contains("/auth/login")
+
+		redirectCode := createSessionCode()
+		redirect := testutils.CreateTestClient(t, ts.URL).GET("/foo/").
+			WithQuery("intent", "intent-session-code-test").
+			WithQuery("session_code", redirectCode).
+			WithQuery("extra", "drop-me").
+			WithHost(slug + "." + testInstance.Domain).
+			WithRedirectPolicy(httpexpect.DontFollowRedirects).
+			Expect().Status(http.StatusSeeOther)
+
+		redirect.Cookie("cozysessid").Value().NotEmpty()
+		redirect.Header("Location").Contains("intent=intent-session-code-test")
+		redirect.Header("Location").NotContains("session_code")
+		redirect.Header("Location").NotContains("extra")
 	})
 
 	t.Run("ServeAppsWithJWTNotLogged", func(t *testing.T) {

--- a/web/apps/serve.go
+++ b/web/apps/serve.go
@@ -181,7 +181,7 @@ func ServeAppFile(c echo.Context, i *instance.Instance, fs appfs.FileServer, web
 				}
 			}
 			redirect := req.URL
-			redirect.RawQuery = ""
+			redirect.RawQuery = sessionCodeRedirectQuery(redirect.Query()).Encode()
 			return c.Redirect(http.StatusSeeOther, redirect.String())
 		}
 	}
@@ -358,6 +358,14 @@ func ServeAppFile(c echo.Context, i *instance.Instance, fs appfs.FileServer, web
 	res.WriteHeader(http.StatusOK)
 	_, err = io.Copy(res, generated)
 	return err
+}
+
+func sessionCodeRedirectQuery(query url.Values) url.Values {
+	redirectQuery := url.Values{}
+	if intentID := query.Get("intent"); intentID != "" {
+		redirectQuery.Set("intent", intentID)
+	}
+	return redirectQuery
 }
 
 func buildServeParams(

--- a/web/auth/auth_test.go
+++ b/web/auth/auth_test.go
@@ -3037,6 +3037,118 @@ func TestTokenExchange(t *testing.T) {
 			JSON().Object().
 			ValueEqual("error", `scope "io.cozy.unknown" is not allowed`)
 	})
+
+	// -----------------------------------------------------------------------
+	// Session code minting via app token exchange tokens
+	// -----------------------------------------------------------------------
+
+	t.Run("AppTokenMintsSessionCode", func(t *testing.T) {
+		const sid = "mail-app-sid-session-code-01"
+		idToken := makeTokenExchangeSignedJWT(t, privateKey, kid, map[string]interface{}{
+			"iss": issuer,
+			"aud": []string{appTokenAudience},
+			"sub": "mail-user",
+			"sid": sid,
+			"iat": time.Now().Unix(),
+			"exp": time.Now().Add(time.Hour).Unix(),
+		})
+
+		resp := e.POST("/auth/token_exchange").
+			WithHost(testInstance.Domain).
+			WithHeader("Accept", "application/json").
+			WithHeader("Origin", "https://mail."+testInstance.Domain).
+			WithJSON(map[string]string{
+				"id_token":      idToken,
+				"exchange_type": "app",
+			}).
+			Expect().
+			Status(http.StatusOK)
+
+		accessToken := resp.JSON().Object().Value("access_token").String().Raw()
+		require.NotEmpty(t, accessToken)
+
+		codeResp := e.POST("/auth/session_code").
+			WithHost(testInstance.Domain).
+			WithHeader("Authorization", "Bearer "+accessToken).
+			Expect().
+			Status(http.StatusCreated).
+			JSON().Object()
+
+		code := codeResp.Value("session_code").String().NotEmpty().Raw()
+		require.NotEmpty(t, code)
+		require.True(t, testInstance.CheckAndClearSessionCode(code))
+		require.False(t, testInstance.CheckAndClearSessionCode(code))
+	})
+
+	t.Run("ForgedAppTokenCannotMintSessionCode", func(t *testing.T) {
+		client := &oauth.Client{
+			RedirectURIs: []string{"https://attacker.example/callback"},
+			ClientName:   "forged-mail-client",
+			SoftwareID:   appTokenSoftwareID,
+		}
+		require.Nil(t, client.Create(testInstance, oauth.SoftwareIDPrevalidated))
+
+		claims := permission.Claims{
+			RegisteredClaims: jwt.RegisteredClaims{
+				Audience:  jwt.ClaimStrings{consts.AccessTokenAudience},
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+				IssuedAt:  jwt.NewNumericDate(time.Now()),
+				Issuer:    testInstance.Domain,
+				Subject:   client.ClientID,
+			},
+			Scope: oauth.BuildLinkedAppScope(appTokenAppSlug),
+		}
+		token := jwt.NewWithClaims(crypto.SigningMethod, claims)
+		forgedAccessToken, err := token.SignedString([]byte("wrong-secret"))
+		require.NoError(t, err)
+
+		e.POST("/auth/session_code").
+			WithHost(testInstance.Domain).
+			WithHeader("Authorization", "Bearer "+forgedAccessToken).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("AdminTokenCannotMintSessionCode", func(t *testing.T) {
+		idToken := makeTokenExchangeSignedJWT(t, privateKey, kid, map[string]interface{}{
+			"iss":        issuer,
+			"aud":        []string{clientID},
+			"sub":        "admin-user",
+			"sid":        "admin-sid-session-code-02",
+			"iat":        time.Now().Unix(),
+			"exp":        time.Now().Add(time.Hour).Unix(),
+			"org_id":     testInstance.OrgID,
+			"org_domain": testInstance.OrgDomain,
+			"org_role":   "owner",
+		})
+
+		resp := e.POST("/auth/token_exchange").
+			WithHost(testInstance.Domain).
+			WithHeader("Accept", "application/json").
+			WithHeader("Origin", "https://admin.example.com").
+			WithJSON(map[string]string{
+				"id_token": idToken,
+				"scope":    "io.cozy.files",
+			}).
+			Expect().
+			Status(http.StatusOK)
+
+		accessToken := resp.JSON().Object().Value("access_token").String().Raw()
+		require.NotEmpty(t, accessToken)
+
+		e.POST("/auth/session_code").
+			WithHost(testInstance.Domain).
+			WithHeader("Authorization", "Bearer "+accessToken).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
+
+	t.Run("NoTokenCannotMintSessionCode", func(t *testing.T) {
+		e.POST("/auth/session_code").
+			WithHost(testInstance.Domain).
+			Expect().
+			Status(http.StatusUnauthorized)
+	})
 }
 
 func getLoginCSRFToken(e *httpexpect.Expect) string {

--- a/web/auth/flagship.go
+++ b/web/auth/flagship.go
@@ -7,9 +7,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cozy/cozy-stack/model/app"
 	"github.com/cozy/cozy-stack/model/instance"
 	"github.com/cozy/cozy-stack/model/instance/lifecycle"
 	"github.com/cozy/cozy-stack/model/oauth"
+	"github.com/cozy/cozy-stack/model/permission"
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
@@ -19,13 +21,23 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
+const (
+	// SessionCodeSourceAppTokenExchange marks session codes minted from app token exchange access tokens.
+	SessionCodeSourceAppTokenExchange = "app_token_exchange"
+	// SessionCodeSourceFlagship marks session codes minted from flagship access tokens.
+	SessionCodeSourceFlagship = "flagship"
+	// SessionCodeSourcePassword marks session codes minted after a password or passphrase check.
+	SessionCodeSourcePassword = "password"
+)
+
 // CreateSessionCode is the handler for creating a session code by the flagship
 // app.
 func CreateSessionCode(c echo.Context) error {
 	inst := middlewares.GetInstance(c)
-	switch canCreateSessionCode(c, inst) {
+	result, source := canCreateSessionCode(c, inst)
+	switch result {
 	case allowedToCreateSessionCode:
-		// OK
+		return ReturnSessionCode(c, http.StatusCreated, inst, source)
 	case need2FAToCreateSessionCode:
 		twoFactorToken, err := lifecycle.SendTwoFactorPasscode(inst)
 		if err != nil {
@@ -40,11 +52,9 @@ func CreateSessionCode(c echo.Context) error {
 			"error": "Not authorized",
 		})
 	}
-
-	return ReturnSessionCode(c, http.StatusCreated, inst)
 }
 
-func ReturnSessionCode(c echo.Context, statusCode int, inst *instance.Instance) error {
+func ReturnSessionCode(c echo.Context, statusCode int, inst *instance.Instance, source string) error {
 	code, err := inst.CreateSessionCode()
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{
@@ -61,6 +71,7 @@ func ReturnSessionCode(c echo.Context, statusCode int, inst *instance.Instance) 
 		ip = strings.Split(req.RemoteAddr, ":")[0]
 	}
 	inst.Logger().WithField("nspace", "loginaudit").
+		WithField("source", source).
 		Infof("New session_code created from %s at %s", ip, time.Now())
 
 	return c.JSON(statusCode, echo.Map{
@@ -82,26 +93,63 @@ const (
 	need2FAToCreateSessionCode
 )
 
-func canCreateSessionCode(c echo.Context, inst *instance.Instance) canCreateSessionCodeResult {
-	if err := middlewares.AllowMaximal(c); err == nil {
-		return allowedToCreateSessionCode
+func canCreateSessionCode(c echo.Context, inst *instance.Instance) (canCreateSessionCodeResult, string) {
+	pdoc, err := middlewares.GetPermission(c)
+	if err == nil {
+		if pdoc.Permissions.IsMaximal() {
+			return allowedToCreateSessionCode, SessionCodeSourceFlagship
+		}
+		if claims, ok := c.Get("claims").(permission.Claims); ok && isAppTokenExchangeToken(inst, pdoc, claims) {
+			return allowedToCreateSessionCode, SessionCodeSourceAppTokenExchange
+		}
 	}
 
 	var args sessionCodeParameters
 	if err := c.Bind(&args); err != nil {
-		return cannotCreateSessionCode
+		return cannotCreateSessionCode, ""
 	}
 	if err := instance.CheckPassphrase(inst, []byte(args.Passphrase)); err != nil {
-		return cannotCreateSessionCode
+		return cannotCreateSessionCode, ""
 	}
 
 	if inst.HasAuthMode(instance.TwoFactorMail) {
 		token := []byte(args.TwoFactorToken)
 		if ok := inst.ValidateTwoFactorPasscode(token, args.TwoFactorCode); !ok {
-			return need2FAToCreateSessionCode
+			return need2FAToCreateSessionCode, ""
 		}
 	}
-	return allowedToCreateSessionCode
+	return allowedToCreateSessionCode, SessionCodeSourcePassword
+}
+
+func isAppTokenExchangeToken(inst *instance.Instance, pdoc *permission.Permission, claims permission.Claims) bool {
+	if pdoc.Type != permission.TypeOauth || pdoc.Client == nil {
+		return false
+	}
+	client, ok := pdoc.Client.(*oauth.Client)
+	if !ok {
+		return false
+	}
+	if len(claims.Audience) != 1 || claims.Audience[0] != consts.AccessTokenAudience {
+		return false
+	}
+	if claims.Subject == "" || claims.Subject != pdoc.SourceID {
+		return false
+	}
+
+	slug := oauth.GetLinkedAppSlug(client.SoftwareID)
+	if slug == "" {
+		return false
+	}
+	if claims.Scope != oauth.BuildLinkedAppScope(slug) {
+		return false
+	}
+	if !tokenExchangeAppSlugAllowed(inst.ContextName, slug) {
+		return false
+	}
+	if _, err := app.GetWebappBySlug(inst, slug); err != nil {
+		return false
+	}
+	return true
 }
 
 func postChallenge(c echo.Context) error {
@@ -237,7 +285,7 @@ func loginFlagship(c echo.Context) error {
 	}
 
 	if !client.Flagship {
-		return ReturnSessionCode(c, http.StatusAccepted, inst)
+		return ReturnSessionCode(c, http.StatusAccepted, inst, SessionCodeSourcePassword)
 	}
 
 	if client.Pending {

--- a/web/auth/magic_link.go
+++ b/web/auth/magic_link.go
@@ -195,7 +195,7 @@ func magicLinkFlagship(c echo.Context) error {
 	}
 
 	if !client.Flagship {
-		return ReturnSessionCode(c, http.StatusAccepted, inst)
+		return ReturnSessionCode(c, http.StatusAccepted, inst, SessionCodeSourcePassword)
 	}
 
 	if client.Pending {

--- a/web/oidc/oidc.go
+++ b/web/oidc/oidc.go
@@ -1068,7 +1068,7 @@ func AccessToken(c echo.Context) error {
 	}
 	if out.Scope == "*" {
 		if !client.Flagship {
-			return auth.ReturnSessionCode(c, http.StatusAccepted, inst)
+			return auth.ReturnSessionCode(c, http.StatusAccepted, inst, auth.SessionCodeSourcePassword)
 		}
 	}
 

--- a/web/settings/passphrase.go
+++ b/web/settings/passphrase.go
@@ -209,7 +209,7 @@ func (h *HTTPHandler) registerPassphraseFlagship(c echo.Context) error {
 		}
 		if !skipCertification {
 			_ = client.SetCreatedAtOnboarding(inst)
-			return auth.ReturnSessionCode(c, http.StatusAccepted, inst)
+			return auth.ReturnSessionCode(c, http.StatusAccepted, inst, auth.SessionCodeSourcePassword)
 		}
 	}
 


### PR DESCRIPTION
~~⚠️ Disclaimer: unreviewed AI code ⚠️~~

Reuse the existing session_code primitive to auto-login the intent service app loaded in a mobile WebView. The only behavioral change is letting an app-scoped token from token_exchange mint a session_code in canCreateSessionCode; every other piece (store, ServeAppFile consumer, intent CSP relaxation, BuildAppToken injection) already exists.