### PR TITLE
fix: degrade settings when the cloudery legal notice fetch fails

### DIFF
--- a/web/settings/instance.go
+++ b/web/settings/instance.go
@@ -82,11 +82,10 @@ func (h *HTTPHandler) getInstance(c echo.Context) error {
 		return err
 	}
 
-	url, err := h.svc.GetLegalNoticeUrl(inst)
-	if err != nil {
-		return err
-	}
-	if url != "" {
+	if url, err := h.svc.GetLegalNoticeUrl(inst); err != nil {
+		inst.Logger().WithNamespace("settings").
+			Warnf("Failed to fetch the legal notice URL from the cloudery: %s", err)
+	} else if url != "" {
 		doc.M["legal_notice_url"] = url
 	}
 

--- a/web/settings/settings_test.go
+++ b/web/settings/settings_test.go
@@ -637,6 +637,22 @@ func TestSettings(t *testing.T) {
 		attrs.HasValue("org_id", "test-org-id-456")
 	})
 
+	t.Run("GetInstanceDegradesWhenLegalNoticeFails", func(t *testing.T) {
+		e := testutils.CreateTestClient(t, tsURL)
+		svc.On("GetLegalNoticeUrl", testInstance).
+			Return("", fmt.Errorf("cloudery is down")).Once()
+
+		obj := e.GET("/settings/instance").
+			WithCookie(sessCookie, "connected").
+			WithHeader("Authorization", "Bearer "+token).
+			Expect().Status(200).
+			JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+			Object()
+
+		attrs := obj.Value("data").Object().Value("attributes").Object()
+		attrs.NotContainsKey("legal_notice_url")
+	})
+
 	t.Run("UpdateInstance", func(t *testing.T) {
 		e := testutils.CreateTestClient(t, tsURL)
 


### PR DESCRIPTION
## Summary

- Stop propagating the cloudery error from the optional `legal_notice_url` fetch in `GET /settings/instance`; log it and omit the field so the route keeps returning the locally-available settings when the cloudery is down.
- Add a test asserting the route returns 200 without `legal_notice_url` when `GetLegalNoticeUrl` errors.