### PR TITLE
fix: prevent partial delegated recipient additions

### DIFF
--- a/docs/sharing.md
+++ b/docs/sharing.md
@@ -928,6 +928,8 @@ HTTP/1.1 204 No Content
 This route allows the sharer to add new recipients (and groups of recipients)
 to a sharing. It can also be used by a recipient when the sharing has
 `open_sharing` set to true if the recipient doesn't have the `read_only` flag.
+Adding a recipient who is already active is idempotent: that recipient is
+ignored, while the other recipients from the same request are still processed.
 
 #### Request
 

--- a/docs/sharing.md
+++ b/docs/sharing.md
@@ -1054,7 +1054,9 @@ recipient invitations. Data for direct recipients should contain an email
 address but if it is not known, an instance URL can also be provided. For
 shared drives, each delegated recipient or group can also carry a `read_only`
 flag, and the owner applies the drive-specific reshare rules when processing
-the request.
+the request. The owner persists the complete member and credential batch before
+sending shortcuts, so immediate auto-acceptance can safely resolve the
+invitation state.
 
 #### Request
 

--- a/model/sharing/invitation.go
+++ b/model/sharing/invitation.go
@@ -115,11 +115,23 @@ func (s *Sharing) updateMemberStatusesWithRetry(inst *instance.Instance) error {
 
 // SendInvitationsToMembers sends mails from a recipient (open_sharing) to
 // their contacts to invite them
-func (s *Sharing) SendInvitationsToMembers(inst *instance.Instance, members []Member, states map[string]string) error {
+func (s *Sharing) SendInvitationsToMembers(
+	inst *instance.Instance,
+	members []Member,
+	invitationStates map[string]string,
+) error {
 	sharer, desc := s.getSharerAndDescription(inst)
 
 	keys := make([]string, 0, len(members))
 	for _, m := range members {
+		if m.Email == "" && m.Instance == "" {
+			return ErrInvitationNotSent
+		}
+		state, ok := delegatedInvitationState(m, invitationStates)
+		if !ok {
+			continue
+		}
+
 		key := m.Email
 		if key == "" {
 			key = m.Instance
@@ -127,10 +139,7 @@ func (s *Sharing) SendInvitationsToMembers(inst *instance.Instance, members []Me
 		// If an instance URL is available, the owner's Cozy has already
 		// created a shortcut, so we don't need to send an invitation.
 		if m.Instance == "" {
-			if m.Email == "" {
-				return ErrInvitationNotSent
-			}
-			link := m.InvitationLink(inst, s, states[key], nil)
+			link := m.InvitationLink(inst, s, state, nil)
 			if err := m.SendMail(inst, s, sharer, desc, link); err != nil {
 				inst.Logger().WithNamespace("sharing").
 					Errorf("Can't send email for %#v: %s", m.Email, err)
@@ -173,6 +182,18 @@ func (s *Sharing) SendInvitationsToMembers(inst *instance.Instance, members []Me
 			return err
 		}
 	}
+}
+
+func delegatedInvitationState(m Member, invitationStates map[string]string) (string, bool) {
+	key := m.Instance
+	if key == "" {
+		key = m.Email
+	}
+	if key == "" {
+		return "", false
+	}
+	state, ok := invitationStates[key]
+	return state, ok && state != ""
 }
 
 func (s *Sharing) getSharerAndDescription(inst *instance.Instance) (string, string) {

--- a/model/sharing/invitation.go
+++ b/model/sharing/invitation.go
@@ -97,19 +97,22 @@ func (s *Sharing) updateMemberStatusesWithRetry(inst *instance.Instance) error {
 		if err == nil || !couchdb.IsConflictError(err) || attempt >= maxRetries {
 			return err
 		}
-		s, err = FindSharing(inst, s.SID)
+		latest, err := FindSharing(inst, s.SID)
 		if err != nil {
 			return err
 		}
 		for i, status := range desiredStatuses {
-			if i >= len(s.Members) {
+			if i >= len(latest.Members) {
 				continue
 			}
-			if s.Members[i].Status == MemberStatusReady {
+			if latest.Members[i].Status == MemberStatusReady {
 				continue
 			}
-			s.Members[i].Status = status
+			latest.Members[i].Status = status
 		}
+		// Keep the caller-owned sharing synchronized with the document used by
+		// the next retry.
+		*s = *latest
 	}
 }
 

--- a/model/sharing/invitation.go
+++ b/model/sharing/invitation.go
@@ -124,9 +124,6 @@ func (s *Sharing) SendInvitationsToMembers(
 
 	keys := make([]string, 0, len(members))
 	for _, m := range members {
-		if m.Email == "" && m.Instance == "" {
-			return ErrInvitationNotSent
-		}
 		state, ok := delegatedInvitationState(m, invitationStates)
 		if !ok {
 			continue

--- a/model/sharing/invitation.go
+++ b/model/sharing/invitation.go
@@ -132,10 +132,7 @@ func (s *Sharing) SendInvitationsToMembers(
 			continue
 		}
 
-		key := m.Email
-		if key == "" {
-			key = m.Instance
-		}
+		key := invitationStateKey(m)
 		// If an instance URL is available, the owner's Cozy has already
 		// created a shortcut, so we don't need to send an invitation.
 		if m.Instance == "" {
@@ -184,11 +181,17 @@ func (s *Sharing) SendInvitationsToMembers(
 	}
 }
 
-func delegatedInvitationState(m Member, invitationStates map[string]string) (string, bool) {
-	key := m.Instance
-	if key == "" {
-		key = m.Email
+// invitationStateKey matches the owner response key: the Cozy instance URL is
+// preferred when available, with the email address as a fallback.
+func invitationStateKey(m Member) string {
+	if m.Instance != "" {
+		return m.Instance
 	}
+	return m.Email
+}
+
+func delegatedInvitationState(m Member, invitationStates map[string]string) (string, bool) {
+	key := invitationStateKey(m)
 	if key == "" {
 		return "", false
 	}

--- a/model/sharing/invitation_test.go
+++ b/model/sharing/invitation_test.go
@@ -54,6 +54,11 @@ func TestDelegatedInvitationState(t *testing.T) {
 			member: Member{Email: "alice@example.test"},
 			states: map[string]string{"alice@example.test": ""},
 		},
+		{
+			name:   "rejects member without address",
+			member: Member{Name: "Alice"},
+			states: map[string]string{},
+		},
 	}
 
 	for _, tt := range tests {

--- a/model/sharing/invitation_test.go
+++ b/model/sharing/invitation_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCleanFilename(t *testing.T) {
@@ -14,6 +15,52 @@ func TestCleanFilename(t *testing.T) {
 	for filename, expected := range cases {
 		t.Run(filename, func(t *testing.T) {
 			assert.Equal(t, expected, cleanFilename(filename))
+		})
+	}
+}
+
+func TestDelegatedInvitationState(t *testing.T) {
+	tests := []struct {
+		name   string
+		member Member
+		states map[string]string
+		state  string
+		ok     bool
+	}{
+		{
+			name:   "uses instance when member has instance and email",
+			member: Member{Email: "alice@example.test", Instance: "https://alice.example.test"},
+			states: map[string]string{
+				"alice@example.test":         "email-state",
+				"https://alice.example.test": "instance-state",
+			},
+			state: "instance-state",
+			ok:    true,
+		},
+		{
+			name:   "falls back to email",
+			member: Member{Email: "alice@example.test"},
+			states: map[string]string{"alice@example.test": "email-state"},
+			state:  "email-state",
+			ok:     true,
+		},
+		{
+			name:   "rejects missing state",
+			member: Member{Email: "alice@example.test"},
+			states: map[string]string{},
+		},
+		{
+			name:   "rejects empty state",
+			member: Member{Email: "alice@example.test"},
+			states: map[string]string{"alice@example.test": ""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state, ok := delegatedInvitationState(tt.member, tt.states)
+			require.Equal(t, tt.ok, ok)
+			require.Equal(t, tt.state, state)
 		})
 	}
 }

--- a/model/sharing/member.go
+++ b/model/sharing/member.go
@@ -389,15 +389,12 @@ func (s *Sharing) SendDelegated(inst *instance.Instance, api *APIDelegateAddCont
 		ParseError: ParseRequestError,
 	}
 	res, err := request.Req(opts)
-	originalRes, originalErr := res, err
+	preRefreshRes, preRefreshErr := res, err
 	if res != nil && res.StatusCode/100 == 4 {
 		res, err = RefreshToken(inst, res, err, s, &s.Members[0], c, opts, body)
 	}
 	if err != nil {
-		if originalRes != nil && originalRes.StatusCode == http.StatusForbidden {
-			return preserveDelegatedRequestError(originalRes.StatusCode, originalErr)
-		}
-		return err
+		return preserveDelegatedResponseError(res, err, preRefreshRes, preRefreshErr)
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
@@ -450,6 +447,21 @@ func (s *Sharing) SendDelegated(inst *instance.Instance, api *APIDelegateAddCont
 		}
 	}
 	return s.SendInvitationsToMembers(inst, api.members, states)
+}
+
+func preserveDelegatedResponseError(
+	res *http.Response,
+	err error,
+	preRefreshRes *http.Response,
+	preRefreshErr error,
+) error {
+	if res != nil && res.StatusCode/100 == 4 {
+		return preserveDelegatedRequestError(res.StatusCode, err)
+	}
+	if preRefreshRes != nil && preRefreshRes.StatusCode/100 == 4 {
+		return preserveDelegatedRequestError(preRefreshRes.StatusCode, preRefreshErr)
+	}
+	return err
 }
 
 func preserveDelegatedRequestError(status int, err error) error {
@@ -1103,13 +1115,13 @@ func (s *Sharing) DelegateRevokeRecipient(inst *instance.Instance, index int) er
 		ParseError: ParseRequestError,
 	}
 	res, err := request.Req(opts)
-	originalRes, originalErr := res, err
+	preRefreshRes, preRefreshErr := res, err
 	if res != nil && res.StatusCode/100 == 4 {
 		res, err = RefreshToken(inst, res, err, s, &s.Members[0], c, opts, nil)
 	}
 	if err != nil {
-		if originalRes != nil && originalRes.StatusCode == http.StatusForbidden {
-			return preserveDelegatedRequestError(originalRes.StatusCode, originalErr)
+		if preRefreshRes != nil && preRefreshRes.StatusCode == http.StatusForbidden {
+			return preserveDelegatedRequestError(preRefreshRes.StatusCode, preRefreshErr)
 		}
 		return err
 	}

--- a/model/sharing/member.go
+++ b/model/sharing/member.go
@@ -390,7 +390,7 @@ func (s *Sharing) SendDelegated(inst *instance.Instance, api *APIDelegateAddCont
 	}
 	res, err := request.Req(opts)
 	preRefreshRes, preRefreshErr := res, err
-	if res != nil && res.StatusCode/100 == 4 {
+	if shouldRetryDelegatedRequest(res) {
 		res, err = RefreshToken(inst, res, err, s, &s.Members[0], c, opts, body)
 	}
 	if err != nil {
@@ -447,6 +447,20 @@ func (s *Sharing) SendDelegated(inst *instance.Instance, api *APIDelegateAddCont
 		}
 	}
 	return s.SendInvitationsToMembers(inst, api.members, states)
+}
+
+// shouldRetryDelegatedRequest restricts replay to authentication and instance
+// relocation responses. Retrying other client errors can duplicate invitations.
+func shouldRetryDelegatedRequest(res *http.Response) bool {
+	if res == nil {
+		return false
+	}
+	switch res.StatusCode {
+	case http.StatusUnauthorized, http.StatusForbidden, http.StatusGone:
+		return true
+	default:
+		return false
+	}
 }
 
 func preserveDelegatedResponseError(

--- a/model/sharing/member_test.go
+++ b/model/sharing/member_test.go
@@ -20,6 +20,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestShouldRetryDelegatedRequest(t *testing.T) {
+	tests := []struct {
+		name     string
+		response *http.Response
+		expected bool
+	}{
+		{name: "missing response"},
+		{name: "unauthorized", response: &http.Response{StatusCode: http.StatusUnauthorized}, expected: true},
+		{name: "forbidden", response: &http.Response{StatusCode: http.StatusForbidden}, expected: true},
+		{name: "moved", response: &http.Response{StatusCode: http.StatusGone}, expected: true},
+		{name: "bad request", response: &http.Response{StatusCode: http.StatusBadRequest}},
+		{name: "conflict", response: &http.Response{StatusCode: http.StatusConflict}},
+		{name: "not found", response: &http.Response{StatusCode: http.StatusNotFound}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, shouldRetryDelegatedRequest(tt.response))
+		})
+	}
+}
+
 func TestPreserveDelegatedResponseError(t *testing.T) {
 	t.Run("prefers the response returned after token refresh", func(t *testing.T) {
 		preRefreshRes := &http.Response{StatusCode: http.StatusUnauthorized}

--- a/model/sharing/member_test.go
+++ b/model/sharing/member_test.go
@@ -2,20 +2,52 @@ package sharing
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 	"sync"
 	"testing"
 
 	"github.com/cozy/cozy-stack/client/auth"
+	"github.com/cozy/cozy-stack/client/request"
 	"github.com/cozy/cozy-stack/model/permission"
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
+	"github.com/cozy/cozy-stack/pkg/jsonapi"
 	"github.com/cozy/cozy-stack/tests/testutils"
 	"github.com/stretchr/testify/require"
 )
+
+func TestPreserveDelegatedResponseError(t *testing.T) {
+	t.Run("prefers the response returned after token refresh", func(t *testing.T) {
+		preRefreshRes := &http.Response{StatusCode: http.StatusUnauthorized}
+		preRefreshErr := &request.Error{Detail: `{"errors":[{"status":"401","title":"Unauthorized"}]}`}
+		res := &http.Response{StatusCode: http.StatusConflict}
+		err := &request.Error{Detail: `{"errors":[{"status":"409","title":"Conflict","detail":"already active"}]}`}
+
+		got := preserveDelegatedResponseError(res, err, preRefreshRes, preRefreshErr)
+
+		var apiErr *jsonapi.Error
+		require.ErrorAs(t, got, &apiErr)
+		require.Equal(t, http.StatusConflict, apiErr.Status)
+		require.Equal(t, "already active", apiErr.Detail)
+	})
+
+	t.Run("falls back to the pre-refresh response when refresh fails", func(t *testing.T) {
+		preRefreshRes := &http.Response{StatusCode: http.StatusForbidden}
+		preRefreshErr := &request.Error{Detail: `{"errors":[{"status":"403","title":"Forbidden","detail":"read only"}]}`}
+		refreshErr := fmt.Errorf("refresh failed")
+
+		got := preserveDelegatedResponseError(nil, refreshErr, preRefreshRes, preRefreshErr)
+
+		var apiErr *jsonapi.Error
+		require.ErrorAs(t, got, &apiErr)
+		require.Equal(t, http.StatusForbidden, apiErr.Status)
+		require.Equal(t, "read only", apiErr.Detail)
+	})
+}
 
 func TestReadOnlyFlagRejectsBrokenRecipientCredentials(t *testing.T) {
 	cases := []struct {

--- a/web/sharings/drives_test.go
+++ b/web/sharings/drives_test.go
@@ -2327,6 +2327,136 @@ func TestSharedDriveDelegatedRecipientAddition(t *testing.T) {
 		require.ElementsMatch(t, []string{"Charlie Mixed", "Erin Mixed"}, sharingInvitationRecipientNames(t, env.betty, sharingID))
 	})
 
+	t.Run("CredentialsArePersistedBeforeCozyAutoAccept", func(t *testing.T) {
+		sharingID := createAcceptedSharedDriveForRecipient(
+			t,
+			env,
+			RecipientInfo{Name: "Betty Auto Accept", Email: "betty@example.net", ReadOnly: false},
+			env.betty,
+			env.tsB.URL,
+		)
+		eOwner, eBetty, _ := env.createClients(t)
+
+		ownerSharing, err := sharing.FindSharing(env.acme, sharingID)
+		require.NoError(t, err)
+		require.NotEmpty(t, ownerSharing.Rules)
+		require.NotEmpty(t, ownerSharing.Rules[0].Values)
+		fileID := createFile(t, eOwner, ownerSharing.Rules[0].Values[0], "auto-accept.txt", env.acmeToken)
+
+		render, _ := statik.NewDirRenderer("../../assets")
+		autoAcceptResult := make(chan error, 1)
+		var invitee *instance.Instance
+		invitee, inviteeToken, inviteeServer := newDriveRecipientTestServer(
+			t,
+			testify(t, "delegated_auto_accept_invitee"),
+			"invitee-auto-accept@example.net",
+			"Invitee Auto Accept",
+			render,
+			map[string]func(*echo.Group){
+				"/sharings": func(g *echo.Group) {
+					g.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
+						return func(c echo.Context) error {
+							if err := next(c); err != nil {
+								return err
+							}
+							if c.Request().Method != http.MethodPut ||
+								c.QueryParam("shortcut") != "true" ||
+								c.Param("sharing-id") != sharingID {
+								return nil
+							}
+
+							recipientSharing, err := sharing.FindSharing(invitee, sharingID)
+							if err == nil && (len(recipientSharing.Members) == 0 || len(recipientSharing.Credentials) == 0) {
+								err = sharing.ErrInvalidSharing
+							}
+							if err == nil {
+								recipientSharing.Members[0].Instance = env.tsA.URL
+								err = couchdb.UpdateDoc(invitee, recipientSharing)
+							}
+							if err == nil {
+								err = sharing.HandleAutoAccept(invitee, &sharing.AutoAcceptMsg{
+									SharingID: sharingID,
+									State:     recipientSharing.Credentials[0].State,
+								})
+							}
+							select {
+							case autoAcceptResult <- err:
+							default:
+							}
+							return nil
+						}
+					})
+					sharings.Routes(g)
+				},
+			},
+		)
+
+		inviteeContact := createContactWithCozy(
+			t,
+			env.betty,
+			"Invitee Auto Accept",
+			"invitee-auto-accept@example.net",
+			inviteeServer.URL,
+		)
+		duplicate := createContactWithCozy(
+			t,
+			env.betty,
+			"Betty Duplicate",
+			"betty@example.net",
+			env.tsB.URL,
+		)
+
+		eBetty.POST("/sharings/"+sharingID+"/recipients").
+			WithHeader("Authorization", "Bearer "+env.bettyToken).
+			WithHeader("Content-Type", jsonAPIContentType).
+			WithBytes(makeAddRecipientsPayload(t, sharingID, "recipients", inviteeContact.ID(), duplicate.ID())).
+			Expect().Status(http.StatusOK)
+
+		select {
+		case err := <-autoAcceptResult:
+			require.NoError(t, err)
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "auto-accept did not run during the shortcut request")
+		}
+
+		require.Eventually(t, func() bool {
+			s, err := sharing.FindSharing(env.acme, sharingID)
+			if err != nil {
+				return false
+			}
+			for _, member := range s.Members {
+				if member.Email == "invitee-auto-accept@example.net" {
+					return member.Status == sharing.MemberStatusReady
+				}
+			}
+			return false
+		}, 5*time.Second, 50*time.Millisecond, "owner should see the auto-accepted recipient as ready")
+
+		require.Eventually(t, func() bool {
+			s, err := sharing.FindSharing(invitee, sharingID)
+			return err == nil && s.Active
+		}, 5*time.Second, 50*time.Millisecond, "invitee sharing should be active")
+
+		require.Eventually(t, func() bool {
+			req, err := http.NewRequestWithContext(
+				context.Background(),
+				http.MethodGet,
+				inviteeServer.URL+"/sharings/drives/"+sharingID+"/"+fileID,
+				nil,
+			)
+			if err != nil {
+				return false
+			}
+			req.Header.Set("Authorization", "Bearer "+inviteeToken)
+			res, err := http.DefaultClient.Do(req)
+			if err != nil {
+				return false
+			}
+			_ = res.Body.Close()
+			return res.StatusCode == http.StatusOK
+		}, 10*time.Second, 100*time.Millisecond, "auto-accepted recipient should access shared files")
+	})
+
 	t.Run("GroupMemberWithoutAddressIsSynchronizedWithoutInvitation", func(t *testing.T) {
 		sharingID := createAcceptedSharedDriveForRecipient(
 			t,

--- a/web/sharings/drives_test.go
+++ b/web/sharings/drives_test.go
@@ -459,6 +459,22 @@ func findSharingMemberByEmail(t *testing.T, inst *instance.Instance, sharingID, 
 	return sharing.Member{}
 }
 
+func findSharingMemberByName(t *testing.T, inst *instance.Instance, sharingID, name string) sharing.Member {
+	t.Helper()
+
+	s, err := sharing.FindSharing(inst, sharingID)
+	require.NoError(t, err)
+
+	for _, member := range s.Members {
+		if member.Name == name {
+			return member
+		}
+	}
+
+	require.FailNowf(t, "member not found", "name %s not found in sharing %s", name, sharingID)
+	return sharing.Member{}
+}
+
 func sharingInvitationRecipientNames(t *testing.T, inst *instance.Instance, sharingID string) []string {
 	t.Helper()
 
@@ -2309,6 +2325,57 @@ func TestSharedDriveDelegatedRecipientAddition(t *testing.T) {
 		}
 		require.Equal(t, 1, bettyCount)
 		require.ElementsMatch(t, []string{"Charlie Mixed", "Erin Mixed"}, sharingInvitationRecipientNames(t, env.betty, sharingID))
+	})
+
+	t.Run("GroupMemberWithoutAddressIsSynchronizedWithoutInvitation", func(t *testing.T) {
+		sharingID := createAcceptedSharedDriveForRecipient(
+			t,
+			env,
+			RecipientInfo{Name: "Betty", Email: "betty@example.net", ReadOnly: false},
+			env.betty,
+			env.tsB.URL,
+		)
+		group := createGroupOnInstance(t, env.betty, "No address group")
+		groupMember := contact.New()
+		groupMember.M["fullname"] = "No Address"
+		groupMember.M["relationships"] = map[string]interface{}{
+			"groups": map[string]interface{}{
+				"data": []interface{}{
+					map[string]interface{}{
+						"_id":   group.ID(),
+						"_type": consts.Groups,
+					},
+				},
+			},
+		}
+		require.NoError(t, couchdb.CreateDoc(env.betty, groupMember))
+
+		eBetty.POST("/sharings/"+sharingID+"/recipients").
+			WithHeader("Authorization", "Bearer "+env.bettyToken).
+			WithHeader("Content-Type", jsonAPIContentType).
+			WithBytes(mustJSON(t, map[string]interface{}{
+				"data": map[string]interface{}{
+					"type": consts.Sharings,
+					"id":   sharingID,
+					"relationships": map[string]interface{}{
+						"recipients": map[string]interface{}{
+							"data": []map[string]interface{}{
+								{"id": group.ID(), "type": consts.Groups},
+							},
+						},
+					},
+				},
+			})).
+			Expect().Status(http.StatusOK)
+
+		for _, inst := range []*instance.Instance{env.acme, env.betty} {
+			member := findSharingMemberByName(t, inst, sharingID, "No Address")
+			require.Equal(t, sharing.MemberStatusMailNotSent, member.Status)
+			require.True(t, member.OnlyInGroups)
+			require.Empty(t, member.Email)
+			require.Empty(t, member.Instance)
+		}
+		require.Empty(t, sharingInvitationRecipientNames(t, env.betty, sharingID))
 	})
 
 	t.Run("ReadOnlyRecipientCanInviteReadOnly", func(t *testing.T) {

--- a/web/sharings/drives_test.go
+++ b/web/sharings/drives_test.go
@@ -459,6 +459,42 @@ func findSharingMemberByEmail(t *testing.T, inst *instance.Instance, sharingID, 
 	return sharing.Member{}
 }
 
+func sharingInvitationRecipientNames(t *testing.T, inst *instance.Instance, sharingID string) []string {
+	t.Helper()
+
+	req := couchdb.AllDocsRequest{}
+	var jobs []job.Job
+	require.NoError(t, couchdb.GetAllDocs(inst, consts.Jobs, &req, &jobs))
+
+	expectedPath := "/sharings/" + sharingID + "/discovery"
+	var names []string
+	for _, j := range jobs {
+		if j.WorkerType != "sendmail" {
+			continue
+		}
+
+		var msg map[string]interface{}
+		require.NoError(t, json.Unmarshal(j.Message, &msg))
+		if msg["template_name"] != "sharing_request" {
+			continue
+		}
+		values, ok := msg["template_values"].(map[string]interface{})
+		require.True(t, ok)
+		link, ok := values["SharingLink"].(string)
+		require.True(t, ok)
+		u, err := url.Parse(link)
+		require.NoError(t, err)
+		if u.Path != expectedPath {
+			continue
+		}
+		require.NotEmpty(t, u.Query().Get("state"))
+		name, ok := msg["recipient_name"].(string)
+		require.True(t, ok)
+		names = append(names, name)
+	}
+	return names
+}
+
 func findSharingMemberIndexByEmail(t *testing.T, inst *instance.Instance, sharingID, email string) int {
 	t.Helper()
 
@@ -2238,6 +2274,41 @@ func TestSharedDriveDelegatedRecipientAddition(t *testing.T) {
 
 		added := findSharingMemberByEmail(t, env.acme, sharingID, "rita@example.net")
 		require.True(t, added.ReadOnly)
+	})
+
+	t.Run("AlreadyActiveRecipientIsIgnoredInMixedBatch", func(t *testing.T) {
+		sharingID := createAcceptedSharedDriveForRecipient(
+			t,
+			env,
+			RecipientInfo{Name: "Betty", Email: "betty@example.net", ReadOnly: false},
+			env.betty,
+			env.tsB.URL,
+		)
+		charlie := createContact(t, env.betty, "Charlie Mixed", "charlie-mixed@example.net")
+		duplicate := createContact(t, env.betty, "Betty Duplicate", "betty@example.net")
+		erin := createContact(t, env.betty, "Erin Mixed", "erin-mixed@example.net")
+
+		eBetty.POST("/sharings/"+sharingID+"/recipients").
+			WithHeader("Authorization", "Bearer "+env.bettyToken).
+			WithHeader("Content-Type", jsonAPIContentType).
+			WithBytes(makeAddRecipientsPayload(t, sharingID, "recipients", charlie.ID(), duplicate.ID(), erin.ID())).
+			Expect().Status(http.StatusOK)
+
+		s, err := sharing.FindSharing(env.acme, sharingID)
+		require.NoError(t, err)
+		require.Len(t, s.Members, 4)
+		require.Equal(t, sharing.MemberStatusReady, findSharingMemberByEmail(t, env.acme, sharingID, "betty@example.net").Status)
+		findSharingMemberByEmail(t, env.acme, sharingID, "charlie-mixed@example.net")
+		findSharingMemberByEmail(t, env.acme, sharingID, "erin-mixed@example.net")
+
+		bettyCount := 0
+		for _, member := range s.Members {
+			if member.Email == "betty@example.net" {
+				bettyCount++
+			}
+		}
+		require.Equal(t, 1, bettyCount)
+		require.ElementsMatch(t, []string{"Charlie Mixed", "Erin Mixed"}, sharingInvitationRecipientNames(t, env.betty, sharingID))
 	})
 
 	t.Run("ReadOnlyRecipientCanInviteReadOnly", func(t *testing.T) {

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -454,6 +454,83 @@ func authorizeDelegatedRecipientAddition(c echo.Context, s *sharing.Sharing, mem
 	return nil
 }
 
+const maxDelegatedRecipientUpdateRetries = 3
+
+// persistDelegatedRecipients stores the complete batch before any shortcut is
+// sent. A trusted recipient can auto-accept while the shortcut request is still
+// in progress, so its credential state must already be visible on the owner.
+func persistDelegatedRecipients(
+	c echo.Context,
+	inst *instance.Instance,
+	s *sharing.Sharing,
+	body *delegatedAddRecipientsBody,
+) (map[string]string, bool, error) {
+	current := s
+	for attempt := 0; ; attempt++ {
+		member, err := requestMember(c, current)
+		if err != nil {
+			return nil, false, wrapErrors(err)
+		}
+		if err = authorizeDelegatedRecipientAddition(c, current, member, body); err != nil {
+			return nil, false, err
+		}
+
+		memberIndex := -1
+		for i, m := range current.Members {
+			if m.Instance == member.Instance {
+				memberIndex = i
+			}
+		}
+		if memberIndex == -1 {
+			return nil, false, jsonapi.InternalServerError(sharing.ErrInvalidSharing)
+		}
+
+		for _, g := range body.Data.Relationships.Groups.Data {
+			g.AddedBy = memberIndex
+			current.Groups = append(current.Groups, g)
+		}
+
+		states := make(map[string]string)
+		hasShortcutInvitations := false
+		for _, m := range body.Data.Relationships.Recipients.Data {
+			state, err := current.AddDelegatedContact(inst, m)
+			if err != nil {
+				// Adding recipients is idempotent: keep processing the batch when a
+				// recipient is already active.
+				if errors.Is(err, sharing.ErrAlreadyAccepted) {
+					continue
+				}
+				if len(m.Groups) > 0 {
+					continue
+				}
+				return nil, false, wrapErrors(err)
+			}
+			if m.Instance != "" {
+				states[m.Instance] = state
+				hasShortcutInvitations = true
+			} else if m.Email != "" {
+				states[m.Email] = state
+			}
+		}
+
+		err = couchdb.UpdateDoc(inst, current)
+		if err == nil {
+			if current != s {
+				*s = *current
+			}
+			return states, hasShortcutInvitations, nil
+		}
+		if !couchdb.IsConflictError(err) || attempt >= maxDelegatedRecipientUpdateRetries {
+			return nil, false, wrapErrors(err)
+		}
+
+		current, err = sharing.FindSharing(inst, s.SID)
+		if err != nil {
+			return nil, false, wrapErrors(err)
+		}
+	}
+}
+
 // AddRecipientsDelegated is used to add members and groups to a sharing on the
 // owner's cozy when it's the recipient's cozy that sends the mail invitation.
 func AddRecipientsDelegated(c echo.Context) error {
@@ -466,67 +543,29 @@ func AddRecipientsDelegated(c echo.Context) error {
 	if !s.Owner || (!s.Open && !s.Drive) {
 		return echo.NewHTTPError(http.StatusForbidden)
 	}
-	member, err := requestMember(c, s)
-	if err != nil {
-		return wrapErrors(err)
-	}
-	memberIndex := -1
-	for i, m := range s.Members {
-		if m.Instance == member.Instance {
-			memberIndex = i
-		}
-	}
-	if memberIndex == -1 {
-		return jsonapi.InternalServerError(sharing.ErrInvalidSharing)
-	}
 
 	var body delegatedAddRecipientsBody
 	if err = json.NewDecoder(c.Request().Body).Decode(&body); err != nil {
 		return jsonapi.BadJSON()
 	}
-	if err = authorizeDelegatedRecipientAddition(c, s, member, &body); err != nil {
+
+	states, hasShortcutInvitations, err := persistDelegatedRecipients(c, inst, s, &body)
+	if err != nil {
 		return err
 	}
 
-	for _, g := range body.Data.Relationships.Groups.Data {
-		g.AddedBy = memberIndex
-		s.Groups = append(s.Groups, g)
-	}
-
-	states := make(map[string]string)
-	for _, m := range body.Data.Relationships.Recipients.Data {
-		state, err := s.AddDelegatedContact(inst, m)
-		if err != nil {
-			// Adding recipients is idempotent: keep processing the batch when a
-			// recipient is already active.
-			if errors.Is(err, sharing.ErrAlreadyAccepted) {
-				continue
-			}
-			if len(m.Groups) > 0 {
-				continue
-			}
-			return wrapErrors(err)
-		}
-		// If we have an URL for the Cozy, we can create a shortcut as an invitation
-		if m.Instance != "" {
-			states[m.Instance] = state
-			var perms *permission.Permission
-			if s.PreviewPath != "" {
-				if perms, err = s.CreatePreviewPermissions(inst); err != nil {
-					return wrapErrors(err)
-				}
-			}
-			if err = s.SendInvitations(inst, perms); err != nil {
+	if hasShortcutInvitations {
+		var perms *permission.Permission
+		if s.PreviewPath != "" {
+			if perms, err = s.CreatePreviewPermissions(inst); err != nil {
 				return wrapErrors(err)
 			}
-		} else if m.Email != "" {
-			states[m.Email] = state
+		}
+		if err = s.SendInvitations(inst, perms); err != nil {
+			return wrapErrors(err)
 		}
 	}
 
-	if err := couchdb.UpdateDoc(inst, s); err != nil {
-		return wrapErrors(err)
-	}
 	cloned := s.Clone().(*sharing.Sharing)
 	go cloned.NotifyRecipients(inst, nil)
 	return c.JSON(http.StatusOK, states)

--- a/web/sharings/sharings.go
+++ b/web/sharings/sharings.go
@@ -497,6 +497,11 @@ func AddRecipientsDelegated(c echo.Context) error {
 	for _, m := range body.Data.Relationships.Recipients.Data {
 		state, err := s.AddDelegatedContact(inst, m)
 		if err != nil {
+			// Adding recipients is idempotent: keep processing the batch when a
+			// recipient is already active.
+			if errors.Is(err, sharing.ErrAlreadyAccepted) {
+				continue
+			}
 			if len(m.Groups) > 0 {
 				continue
 			}


### PR DESCRIPTION
## Bug

When a recipient of an open shared drive adds several members, the request can
partially succeed on the owner while returning a `500` to the initiating
recipient.

Observed staging sequence:

- the recipient starts `POST /sharings/:id/recipients`
- the owner receives `POST /recipients/delegated`
- the owner creates Ivan's shortcut (`201`)
- the owner creates Petr's shortcut (`201`)
- Ivan's automatic acceptance succeeds (`200`)
- Petr's `/answer` callback returns `404` (`The member was not found`) because
  the owner cannot yet match Petr's invitation state to a persisted
  credential/member
- the owner's sharing update fails with a CouchDB `409 Document update conflict`
- the initiating recipient treats this business conflict as an authentication
  failure, refreshes the token, and replays the complete delegated request
- the replay encounters the now-ready Ivan and returns `409 Sharing already
  accepted by this recipient`
- the delegated error is exposed to Drive as a nested `500 Unqualified error`
- Petr receives an email, but cannot access the shared files because the
  credential exchange did not complete

This leaves the sharing inconsistent between instances: the owner can show Petr
as pending while the initiating recipient shows him as revoked or does not
display him.

## Root cause

The owner added members and credentials only in memory, then sent Cozy shortcut
requests before saving the sharing. A trusted recipient can auto-accept
synchronously while its shortcut request is still in progress and call the
owner's `/answer` endpoint. At that point, the new invitation state was not yet
visible in CouchDB. The state existed in Petr's shortcut and was sent back by
his Cozy, but `ProcessAnswer` could not find the matching entry in the owner's
persisted `Sharing.Credentials`, returned `ErrMemberNotFound`, and the HTTP
handler mapped it to `404`.

The auto-accept callback could also update the sharing concurrently. The final
owner-side save then used a stale CouchDB revision and failed with a conflict.
When status persistence retried a conflict, it reloaded the latest document only
into a local pointer, leaving the caller-owned sharing stale.

Finally, `SendDelegated` retried every `4xx` response after refreshing the token.
That is unsafe for this non-idempotent request: `404` and `409` are business
errors, not authentication errors, and replaying the batch can duplicate side
effects or replace the original failure with `Sharing already accepted`.

## Fix

- persist the complete delegated group, member, and credential-state batch
  before sending any shortcut
- retry the owner-side CouchDB update on revision conflicts and return invitation
  states only from the successfully persisted attempt
- treat an already-active recipient as an idempotent no-op and continue
  processing the rest of the batch
- after a status-update conflict, reload the latest sharing, preserve statuses
  that already reached `ready`, apply the desired statuses, and synchronize the
  caller-owned sharing before retrying
- replay delegated requests only for responses that can be resolved by
  refreshing routing/authentication information: `401`, `403`, and `410`
- preserve structured delegated `4xx` errors instead of wrapping them in a
  generic `500`
- create invitation links only for newly persisted, non-empty invitation states,
  while keeping member synchronization independent from that state map
- keep group-only members without an email or Cozy instance synchronized as
  `mail-not-sent`

The invitation-state response is keyed by the recipient's Cozy instance URL
(or email when no instance is available). It contains only the states created
and persisted by this request; it is not a complete state for every member of
the sharing.

## API compatibility

No Drive client API change is required. The existing
`POST /sharings/:sharing-id/recipients` request and delegated response format are
unchanged. The change makes mixed batches idempotent and ensures the response is
returned only after the owner has durably stored the states needed by immediate
auto-accept callbacks.

## Tests

Coverage includes:

- a mixed batch containing an already-active member and new recipients
- a synchronous Cozy auto-accept callback executed during shortcut creation,
  verifying that the owner can resolve the persisted state, the new member
  reaches `ready`, and the shared file is accessible
- group members without an address being synchronized without an invitation
- status persistence after a CouchDB conflict
- delegated retry policy for `401`, `403`, `410`, `404`, and `409`
- preservation of structured errors returned before or after token refresh

The sharing API documentation now also states that adding an already-active
recipient is idempotent and that delegated credentials are persisted before
shortcuts are sent.
