### PR TITLE
Inline intent doc when fetching an intent index.html

### DIFF
--- a/web/apps/apps.go
+++ b/web/apps/apps.go
@@ -808,7 +808,7 @@ func openWebapp(c echo.Context) error {
 	}
 
 	isLoggedIn := true
-	params := buildServeParams(c, inst, webapp, isLoggedIn, sess.ID())
+	params := buildServeParams(c, inst, webapp, nil, isLoggedIn, sess.ID())
 	obj := &apiOpenParams{
 		slug:   slug,
 		cookie: cookie.String(),

--- a/web/apps/apps_test.go
+++ b/web/apps/apps_test.go
@@ -274,17 +274,37 @@ func TestApps(t *testing.T) {
 		u, err := url.Parse(intent.Services[0].Href)
 		require.NoError(t, err)
 
-		csp := e.GET(u.Path).
+		resp := e.GET(u.Path).
 			WithHost(slug+"."+testInstance.Domain).
 			WithQueryString(u.RawQuery).
 			WithCookie("cozysessid", cozysessID).
-			Expect().Status(200).
-			Header(echo.HeaderContentSecurityPolicy)
+			Expect().Status(200)
+
+		csp := resp.Header(echo.HeaderContentSecurityPolicy)
 		csp.Contains("script-src")
 		csp.Contains("'wasm-unsafe-eval'")
 		csp.Contains("connect-src blob:")
 		csp.Contains("worker-src 'self' blob:;")
 		csp.Contains("frame-ancestors 'self' https://test-app.cozywithapps.example.net;")
+
+		body := resp.Body()
+		body.Contains(`window.__COZY_INTENT__ = JSON.parse(`)
+		body.Contains(intent.ID())
+		body.Contains("PICK")
+		body.Contains("io.cozy.foos")
+		body.Contains("https://test-app.cozywithapps.example.net")
+	})
+
+	t.Run("ServeWithoutIntentDoesNotInline", func(t *testing.T) {
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		body := e.GET("/foo").
+			WithHost(slug+"."+testInstance.Domain).
+			WithCookie("cozysessid", cozysessID).
+			Expect().Status(200).
+			Body()
+
+		body.NotContains(`window.__COZY_INTENT__`)
 	})
 
 	t.Run("ServeWithAnIntentsClientURL", func(t *testing.T) {

--- a/web/apps/apps_test.go
+++ b/web/apps/apps_test.go
@@ -288,7 +288,7 @@ func TestApps(t *testing.T) {
 		csp.Contains("frame-ancestors 'self' https://test-app.cozywithapps.example.net;")
 
 		body := resp.Body()
-		body.Contains(`window.__COZY_INTENT__ = JSON.parse(`)
+		body.Contains(`<script type="application/json" id="cozy-intent">`)
 		body.Contains(intent.ID())
 		body.Contains("PICK")
 		body.Contains("io.cozy.foos")
@@ -304,7 +304,7 @@ func TestApps(t *testing.T) {
 			Expect().Status(200).
 			Body()
 
-		body.NotContains(`window.__COZY_INTENT__`)
+		body.NotContains(`id="cozy-intent"`)
 	})
 
 	t.Run("ServeWithAnIntentsClientURL", func(t *testing.T) {

--- a/web/apps/apps_test.go
+++ b/web/apps/apps_test.go
@@ -367,6 +367,39 @@ func TestApps(t *testing.T) {
 		csp.Contains("frame-ancestors 'self' https://external.example.com https://clienturl-app.cozywithapps.example.net;")
 	})
 
+	t.Run("NoScriptTagBreakoutIntentData", func(t *testing.T) {
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		intent := &intent.Intent{
+			Action: "PICK",
+			Type:   "io.cozy.foos",
+			Client: "io.cozy.apps/" + slug,
+		}
+		err := intent.Save(testInstance)
+		require.NoError(t, err)
+		err = intent.FillServices(testInstance)
+		require.NoError(t, err)
+		require.Len(t, intent.Services, 1)
+		intent.Action = "PICK</script><script>alert('XSS')</script>"
+		err = intent.Save(testInstance)
+		require.NoError(t, err)
+
+		u, err := url.Parse(intent.Services[0].Href)
+		require.NoError(t, err)
+
+		body := e.GET(u.Path).
+			WithHost(slug+"."+testInstance.Domain).
+			WithQueryString(u.RawQuery).
+			WithCookie("cozysessid", cozysessID).
+			Expect().Status(200).
+			Body().Raw()
+
+		// IntentData returns template.HTML (raw, unescaped by html/template).
+		// json.Marshal escapes < to \u003c to prevent </script> breakout
+		// inside the JSON embedded in a <script> block.
+		assert.Contains(t, body, `PICK\u003c/script\u003e`)
+	})
+
 	t.Run("FaviconWithContext", func(t *testing.T) {
 		e := testutils.CreateTestClient(t, ts.URL)
 

--- a/web/apps/serve.go
+++ b/web/apps/serve.go
@@ -638,23 +638,14 @@ func (s serveParams) IntentData() (template.HTML, error) {
 	if err != nil {
 		return "", err
 	}
-	// <script> content is raw text — HTML entities are not decoded by the
-	// browser, so html/template's default JS escaping would corrupt the
-	// JSON. We bypass it with template.HTML and neutralize </script>
-	// breakout ourselves. </ only occurs inside JSON string values, and \/
-	// is a valid JSON escape, so the substitution is parse-equivalent.
-	sanitized := strings.ReplaceAll(string(raw), "</", "<\\/")
-	buf := new(bytes.Buffer)
-	if err := intentTemplate.Execute(buf, template.HTML(sanitized)); err != nil {
-		return "", err
-	}
-	return template.HTML(buf.String()), nil
+	// jsonapi.MarshalObject uses json.Marshal that escapes <, >, & to \u003c, \u003e, \u0026, so the JSON is
+	// safe to embed in a <script> block (no </script> breakout).
+	return template.HTML(`<script type="application/json" id="cozy-intent">` + string(raw) + `</script>`), nil
 }
 
 var clientTemplate *template.Template
 var barTemplate *template.Template
 var warningsTemplate *template.Template
-var intentTemplate *template.Template
 
 // BuildTemplates ensure that cozy-client-js and the bar can be injected in templates
 func BuildTemplates() {
@@ -674,10 +665,6 @@ func BuildTemplates() {
 <meta name="user-action-required" data-title="{{ .Title }}" data-code="{{ .Code }}" data-detail="{{ .Detail }}" {{with .Links}}{{with .Self}}data-links="{{ . }}"{{end}}{{end}} />
 {{end}}
 {{end}}`,
-	))
-
-	intentTemplate = template.Must(template.New("intent-data").Parse(
-		`<script type="application/json" id="cozy-intent">{{.}}</script>`,
 	))
 }
 

--- a/web/apps/serve.go
+++ b/web/apps/serve.go
@@ -113,11 +113,13 @@ func handleAppNotFound(c echo.Context, i *instance.Instance, slug string) error 
 }
 
 // handleIntent will allow iframes from another app if the current app is
-// opened as an intent
-func handleIntent(c echo.Context, i *instance.Instance, slug, intentID string) {
+// opened as an intent. It returns the loaded intent so the caller can inline
+// it into the served page. A nil return means the intent could not be used
+// in that case the caller simply skips inlining, preserving the previous behavior.
+func handleIntent(c echo.Context, i *instance.Instance, slug, intentID string) *intent.Intent {
 	intent := &intent.Intent{}
 	if err := couchdb.GetDoc(i, consts.Intents, intentID, intent); err != nil {
-		return
+		return nil
 	}
 	allowed := false
 	for _, service := range intent.Services {
@@ -126,11 +128,11 @@ func handleIntent(c echo.Context, i *instance.Instance, slug, intentID string) {
 		}
 	}
 	if !allowed {
-		return
+		return nil
 	}
 	parts := strings.SplitN(intent.Client, "/", 2)
 	if len(parts) < 2 || parts[0] != consts.Apps {
-		return
+		return nil
 	}
 	from := app.ResolveClientURL(i, parts[1])
 	if !config.GetConfig().CSPDisabled {
@@ -143,6 +145,7 @@ func handleIntent(c echo.Context, i *instance.Instance, slug, intentID string) {
 			middlewares.AppendCSPRule(c, "frame-ancestors", defaultFrom)
 		}
 	}
+	return intent
 }
 
 // ServeAppFile will serve the requested file using the specified application
@@ -264,9 +267,12 @@ func ServeAppFile(c echo.Context, i *instance.Instance, fs appfs.FileServer, web
 		}
 	}
 
+	var intentDoc *intent.Intent
 	if intentID := c.QueryParam("intent"); intentID != "" {
-		handleIntent(c, i, slug, intentID)
+		intentDoc = handleIntent(c, i, slug, intentID)
 	}
+
+	_ = intentDoc // threaded into serveParams in the next change
 
 	if route.Public && slug == consts.DataProxySlug {
 		// Allow to dataproxy to be embedded in a iframe from the login page of the

--- a/web/apps/serve.go
+++ b/web/apps/serve.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/jsonapi"
 	"github.com/cozy/cozy-stack/pkg/registry"
 	"github.com/cozy/cozy-stack/web/auth"
+	"github.com/cozy/cozy-stack/web/intents"
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/cozy/cozy-stack/web/settings"
 	"github.com/cozy/cozy-stack/web/statik"
@@ -272,8 +273,6 @@ func ServeAppFile(c echo.Context, i *instance.Instance, fs appfs.FileServer, web
 		intentDoc = handleIntent(c, i, slug, intentID)
 	}
 
-	_ = intentDoc // threaded into serveParams in the next change
-
 	if route.Public && slug == consts.DataProxySlug {
 		// Allow to dataproxy to be embedded in a iframe from the login page of the
 		// stack for cleaning.
@@ -296,7 +295,7 @@ func ServeAppFile(c echo.Context, i *instance.Instance, fs appfs.FileServer, web
 	// XXX: Force include Warnings template in all app indexes
 	tmplText := string(buf)
 	if closeTagIdx := strings.Index(tmplText, "</head>"); closeTagIdx >= 0 {
-		tmplText = tmplText[:closeTagIdx] + "\n{{.Warnings}}\n" + tmplText[closeTagIdx:]
+		tmplText = tmplText[:closeTagIdx] + "\n{{.Warnings}}\n{{.IntentData}}\n" + tmplText[closeTagIdx:]
 	} else {
 		needsOpenTag := true
 		if openTagIdx := strings.Index(tmplText, "<head>"); openTagIdx >= 0 {
@@ -313,7 +312,7 @@ func ServeAppFile(c echo.Context, i *instance.Instance, fs appfs.FileServer, web
 				tmplText += "\n<head>"
 			}
 
-			tmplText += "\n{{.Warnings}}\n</head>\n" + after
+			tmplText += "\n{{.Warnings}}\n{{.IntentData}}\n</head>\n" + after
 		}
 	}
 
@@ -335,7 +334,7 @@ func ServeAppFile(c echo.Context, i *instance.Instance, fs appfs.FileServer, web
 			}
 		}
 	}
-	params := buildServeParams(c, i, webapp, isLoggedIn, sessID)
+	params := buildServeParams(c, i, webapp, intentDoc, isLoggedIn, sessID)
 
 	generated := &bytes.Buffer{}
 	if err := tmpl.Execute(generated, params); err != nil {
@@ -365,6 +364,7 @@ func buildServeParams(
 	c echo.Context,
 	inst *instance.Instance,
 	webapp *app.WebappManifest,
+	intentDoc *intent.Intent,
 	isLoggedIn bool,
 	sessID string,
 ) serveParams {
@@ -388,6 +388,7 @@ func buildServeParams(
 		Token:      token,
 		SubDomain:  subdomainsType,
 		Tracking:   tracking,
+		intent:     intentDoc,
 		webapp:     webapp,
 		instance:   inst,
 		isLoggedIn: isLoggedIn,
@@ -496,6 +497,7 @@ type serveParams struct {
 	Token      string
 	SubDomain  string
 	Tracking   bool
+	intent     *intent.Intent
 	webapp     *app.WebappManifest
 	instance   *instance.Instance
 	isLoggedIn bool
@@ -627,9 +629,26 @@ func (s serveParams) Warnings() (template.HTML, error) {
 	return warningsHTML(s.instance, s.isLoggedIn)
 }
 
+func (s serveParams) IntentData() (template.HTML, error) {
+	if s.intent == nil {
+		return "", nil
+	}
+	api := intents.NewAPIIntent(s.intent, s.instance)
+	raw, err := jsonapi.MarshalObject(api)
+	if err != nil {
+		return "", err
+	}
+	buf := new(bytes.Buffer)
+	if err := intentTemplate.Execute(buf, string(raw)); err != nil {
+		return "", err
+	}
+	return template.HTML(buf.String()), nil
+}
+
 var clientTemplate *template.Template
 var barTemplate *template.Template
 var warningsTemplate *template.Template
+var intentTemplate *template.Template
 
 // BuildTemplates ensure that cozy-client-js and the bar can be injected in templates
 func BuildTemplates() {
@@ -649,6 +668,10 @@ func BuildTemplates() {
 <meta name="user-action-required" data-title="{{ .Title }}" data-code="{{ .Code }}" data-detail="{{ .Detail }}" {{with .Links}}{{with .Self}}data-links="{{ . }}"{{end}}{{end}} />
 {{end}}
 {{end}}`,
+	))
+
+	intentTemplate = template.Must(template.New("intent-data").Parse(
+		`<script>window.__COZY_INTENT__ = JSON.parse({{.}})</script>`,
 	))
 }
 

--- a/web/apps/serve.go
+++ b/web/apps/serve.go
@@ -638,8 +638,14 @@ func (s serveParams) IntentData() (template.HTML, error) {
 	if err != nil {
 		return "", err
 	}
+	// <script> content is raw text — HTML entities are not decoded by the
+	// browser, so html/template's default JS escaping would corrupt the
+	// JSON. We bypass it with template.HTML and neutralize </script>
+	// breakout ourselves. </ only occurs inside JSON string values, and \/
+	// is a valid JSON escape, so the substitution is parse-equivalent.
+	sanitized := strings.ReplaceAll(string(raw), "</", "<\\/")
 	buf := new(bytes.Buffer)
-	if err := intentTemplate.Execute(buf, string(raw)); err != nil {
+	if err := intentTemplate.Execute(buf, template.HTML(sanitized)); err != nil {
 		return "", err
 	}
 	return template.HTML(buf.String()), nil
@@ -671,7 +677,7 @@ func BuildTemplates() {
 	))
 
 	intentTemplate = template.Must(template.New("intent-data").Parse(
-		`<script>window.__COZY_INTENT__ = JSON.parse({{.}})</script>`,
+		`<script type="application/json" id="cozy-intent">{{.}}</script>`,
 	))
 }
 

--- a/web/intents/intents.go
+++ b/web/intents/intents.go
@@ -152,6 +152,10 @@ func wrapIntentsError(err error) error {
 	return jsonapi.InternalServerError(err)
 }
 
+func NewAPIIntent(doc *intent.Intent, ins *instance.Instance) *apiIntent {
+	return &apiIntent{doc: doc, ins: ins}
+}
+
 // Routes sets the routing for the intents service
 func Routes(router *echo.Group) {
 	router.POST("", createIntent)

--- a/web/intents/intents_test.go
+++ b/web/intents/intents_test.go
@@ -1,16 +1,19 @@
 package intents
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/cozy/cozy-stack/model/app"
 	"github.com/cozy/cozy-stack/model/instance/lifecycle"
+	"github.com/cozy/cozy-stack/model/intent"
 	"github.com/cozy/cozy-stack/model/oauth"
 	"github.com/cozy/cozy-stack/model/permission"
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/jsonapi"
 	"github.com/cozy/cozy-stack/tests/testutils"
 	"github.com/cozy/cozy-stack/web/errors"
 	"github.com/gavv/httpexpect/v2"
@@ -121,6 +124,29 @@ func TestIntents(t *testing.T) {
 			Object()
 
 		intentID = checkIntentResult(obj, appPerms, true, "https://app.cozy.example.net")
+	})
+
+	t.Run("NewAPIIntentMatchesGetEndpoint", func(t *testing.T) {
+		doc := &intent.Intent{}
+		require.NoError(t, couchdb.GetDoc(ins, consts.Intents, intentID, doc))
+
+		api := NewAPIIntent(doc, ins)
+		raw, err := jsonapi.MarshalObject(api)
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(raw, &got))
+
+		require.Equal(t, "io.cozy.intents", got["type"])
+		require.Equal(t, intentID, got["id"])
+
+		attrs := got["attributes"].(map[string]interface{})
+		require.Equal(t, "PICK", attrs["action"])
+		require.Equal(t, "io.cozy.files", attrs["type"])
+		require.Equal(t, "https://app.cozy.example.net", attrs["client"])
+
+		links := got["links"].(map[string]interface{})
+		require.Equal(t, "/intents/"+intentID, links["self"])
 	})
 
 	t.Run("GetIntent", func(t *testing.T) {


### PR DESCRIPTION
Eliminate the `GET /intents/:id` fetch request that the intent service app (inside the iframe) makes to the stack, by inlining the full intent object into the HTML response when the stack serves the service app's `index.html`.

The stack already loads the intent from CouchDB in `handleIntent()` when serving a page with `?intent=<id>` but currently discards it after setting CSP `frame-ancestors` rules. This change keeps the loaded intent and serializes
it into a `<script>` tag in the `<head>`, so the service app can read it synchronously from `window.__COZY_INTENT__` instead of making a second network round-trip.

**Estimated save:** 1 blocking API call, 233ms (average of 5 call on stg.lin-saas.com)

**Front end:** [github.com/linagora/cozy-libs/pull/3082](https://github.com/linagora/cozy-libs/pull/3082)
