### PR TITLE
feat(sharing): propagate group colors

### DIFF
--- a/docs/sharing-design.md
+++ b/docs/sharing-design.md
@@ -503,6 +503,7 @@ care of it later.
 -   A list of `groups`, with for each one:
     - `id`, the identifier of the io.cozy.contacts.groups
     - `name`, the name of the group
+    - `color`, the customized color of the group, when set
     - `addedBy`, the index of the member that has added the group
     - `read_only`, a flag to tell if the group is restricted to read-only mode
     - `revoked`, a flag set to true when the group is revoked from the sharing

--- a/docs/sharing.md
+++ b/docs/sharing.md
@@ -153,6 +153,7 @@ Content-Type: application/vnd.api+json
         {
           "id": "51bbc980acb0013cb5f618c04daba326",
           "name": "G. people",
+          "color": "#22AA55",
           "addedBy": 0
         }
       ],

--- a/model/contact/group.go
+++ b/model/contact/group.go
@@ -32,6 +32,12 @@ func (g *Group) Name() string {
 	return name
 }
 
+// Color returns the color of the group.
+func (g *Group) Color() string {
+	color, _ := g.Get("color").(string)
+	return color
+}
+
 // FindGroup returns the group of contacts stored in database from a given ID
 func FindGroup(db prefixer.Prefixer, groupID string) (*Group, error) {
 	doc := &Group{}

--- a/model/job/trigger_share_group.go
+++ b/model/job/trigger_share_group.go
@@ -64,11 +64,11 @@ func (t *ShareGroupTrigger) matchGroup(e *realtime.Event) *ShareGroupMessage {
 	if e.Verb != realtime.EventUpdate {
 		return nil
 	}
-	newdoc, ok := e.Doc.(*couchdb.JSONDoc)
+	newdoc, ok := groupJSONDoc(e.Doc)
 	if !ok {
 		return nil
 	}
-	olddoc, ok := e.OldDoc.(*couchdb.JSONDoc)
+	olddoc, ok := groupJSONDoc(e.OldDoc)
 	if !ok {
 		return nil
 	}
@@ -78,6 +78,22 @@ func (t *ShareGroupTrigger) matchGroup(e *realtime.Event) *ShareGroupMessage {
 		return nil
 	}
 	return &ShareGroupMessage{RenamedGroup: newdoc}
+}
+
+// groupJSONDoc returns the generic document embedded in each supported group
+// event representation. couchdb.UpdateDoc keeps the old document in the
+// caller's concrete type (*contact.Group), while RTEvent clones the new
+// document through JSONDoc.Clone and publishes it as *couchdb.JSONDoc. Both
+// values represent the same doctype and must be normalized before comparison.
+func groupJSONDoc(doc realtime.Doc) (*couchdb.JSONDoc, bool) {
+	switch doc := doc.(type) {
+	case *couchdb.JSONDoc:
+		return doc, true
+	case *contact.Group:
+		return &doc.JSONDoc, true
+	default:
+		return nil, false
+	}
 }
 
 func (t *ShareGroupTrigger) matchContact(e *realtime.Event) *ShareGroupMessage {

--- a/model/job/trigger_share_group.go
+++ b/model/job/trigger_share_group.go
@@ -72,7 +72,9 @@ func (t *ShareGroupTrigger) matchGroup(e *realtime.Event) *ShareGroupMessage {
 	if !ok {
 		return nil
 	}
-	if newdoc.M["name"] == olddoc.M["name"] {
+	newGroup := &contact.Group{JSONDoc: *newdoc}
+	oldGroup := &contact.Group{JSONDoc: *olddoc}
+	if newGroup.Name() == oldGroup.Name() && newGroup.Color() == oldGroup.Color() {
 		return nil
 	}
 	return &ShareGroupMessage{RenamedGroup: newdoc}

--- a/model/job/trigger_share_group_test.go
+++ b/model/job/trigger_share_group_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/cozy/cozy-stack/model/contact"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/realtime"
@@ -64,6 +65,28 @@ func TestShareGroupTrigger(t *testing.T) {
 			Verb:   realtime.EventUpdate,
 		})
 		require.NotNil(t, msg)
+	})
+
+	t.Run("The RabbitMQ group update has a typed old document", func(t *testing.T) {
+		oldGroup := contact.NewGroup()
+		oldGroup.SetID("id-marketing")
+		oldGroup.SetRev("1-abcdef")
+		oldGroup.Type = consts.Groups
+		oldGroup.M["name"] = "Marketing"
+		oldGroup.M["color"] = "#3367D6"
+
+		updated := oldGroup.JSONDoc.Clone().(*couchdb.JSONDoc)
+		updated.SetRev("2-abcdef")
+		updated.M["color"] = "#A142F4"
+
+		msg := trigger.match(&realtime.Event{
+			Doc:    updated,
+			OldDoc: oldGroup,
+			Verb:   realtime.EventUpdate,
+		})
+
+		require.NotNil(t, msg)
+		require.Same(t, updated, msg.RenamedGroup)
 	})
 
 	t.Run("The contact becomes invitable", func(t *testing.T) {

--- a/model/job/trigger_share_group_test.go
+++ b/model/job/trigger_share_group_test.go
@@ -14,6 +14,58 @@ import (
 func TestShareGroupTrigger(t *testing.T) {
 	trigger := &ShareGroupTrigger{}
 
+	t.Run("The group name or color changes", func(t *testing.T) {
+		group := &couchdb.JSONDoc{
+			Type: consts.Groups,
+			M: map[string]interface{}{
+				"_id":  "id-friends",
+				"_rev": "1-abcdef",
+				"name": "Friends",
+			},
+		}
+
+		unrelatedUpdate := group.Clone().(*couchdb.JSONDoc)
+		unrelatedUpdate.M["description"] = "Friends from school"
+		unrelatedUpdate.M["_rev"] = "2-abcdef"
+		msg := trigger.match(&realtime.Event{
+			Doc:    unrelatedUpdate,
+			OldDoc: group,
+			Verb:   realtime.EventUpdate,
+		})
+		require.Nil(t, msg)
+
+		colored := unrelatedUpdate.Clone().(*couchdb.JSONDoc)
+		colored.M["color"] = "#22AA55"
+		colored.M["_rev"] = "3-abcdef"
+		msg = trigger.match(&realtime.Event{
+			Doc:    colored,
+			OldDoc: unrelatedUpdate,
+			Verb:   realtime.EventUpdate,
+		})
+		require.NotNil(t, msg)
+		require.Same(t, colored, msg.RenamedGroup)
+
+		withoutColor := colored.Clone().(*couchdb.JSONDoc)
+		delete(withoutColor.M, "color")
+		withoutColor.M["_rev"] = "4-abcdef"
+		msg = trigger.match(&realtime.Event{
+			Doc:    withoutColor,
+			OldDoc: colored,
+			Verb:   realtime.EventUpdate,
+		})
+		require.NotNil(t, msg)
+
+		renamed := withoutColor.Clone().(*couchdb.JSONDoc)
+		renamed.M["name"] = "Best friends"
+		renamed.M["_rev"] = "5-abcdef"
+		msg = trigger.match(&realtime.Event{
+			Doc:    renamed,
+			OldDoc: withoutColor,
+			Verb:   realtime.EventUpdate,
+		})
+		require.NotNil(t, msg)
+	})
+
 	t.Run("The contact becomes invitable", func(t *testing.T) {
 		justName := &couchdb.JSONDoc{
 			Type: consts.Contacts,

--- a/model/sharing/group.go
+++ b/model/sharing/group.go
@@ -25,6 +25,7 @@ import (
 type Group struct {
 	ID       string `json:"id,omitempty"`
 	Name     string `json:"name"`
+	Color    string `json:"color,omitempty"`
 	AddedBy  int    `json:"addedBy"` // The index of the member who added the group
 	ReadOnly bool   `json:"read_only"`
 	Revoked  bool   `json:"revoked,omitempty"`
@@ -64,7 +65,13 @@ func (s *Sharing) AddGroup(inst *instance.Instance, groupID string, readOnly boo
 		}
 	}
 
-	g := Group{ID: groupID, Name: group.Name(), AddedBy: 0, ReadOnly: readOnly}
+	g := Group{
+		ID:       groupID,
+		Name:     group.Name(),
+		Color:    group.Color(),
+		AddedBy:  0,
+		ReadOnly: readOnly,
+	}
 	s.Groups = append(s.Groups, g)
 	return nil
 }
@@ -127,7 +134,7 @@ func (s *Sharing) RevokeGroup(inst *instance.Instance, index int) error {
 // sharings.
 func UpdateGroups(inst *instance.Instance, msg job.ShareGroupMessage) error {
 	if msg.RenamedGroup != nil {
-		return updateRenamedGroup(inst, msg.RenamedGroup)
+		return updateGroupMetadata(inst, msg.RenamedGroup)
 	}
 
 	var c *contact.Contact
@@ -189,25 +196,25 @@ func UpdateGroups(inst *instance.Instance, msg job.ShareGroupMessage) error {
 	return errm
 }
 
-func updateRenamedGroup(inst *instance.Instance, doc *couchdb.JSONDoc) error {
+func updateGroupMetadata(inst *instance.Instance, doc *couchdb.JSONDoc) error {
 	sharings, err := FindActive(inst)
 	if err != nil {
 		return err
 	}
 
+	updatedGroup := &contact.Group{JSONDoc: *doc}
 	var errm error
 	for _, s := range sharings {
 		for idx, group := range s.Groups {
 			if group.ID == doc.ID() {
-				if name, ok := doc.M["name"].(string); ok {
-					group.Name = name
-					s.Groups[idx] = group
-					if err := couchdb.UpdateDoc(inst, s); err != nil {
-						errm = multierror.Append(errm, err)
-					}
-					cloned := s.Clone().(*Sharing)
-					go cloned.NotifyRecipients(inst, nil)
+				group.Name = updatedGroup.Name()
+				group.Color = updatedGroup.Color()
+				s.Groups[idx] = group
+				if err := couchdb.UpdateDoc(inst, s); err != nil {
+					errm = multierror.Append(errm, err)
 				}
+				cloned := s.Clone().(*Sharing)
+				go cloned.NotifyRecipients(inst, nil)
 			}
 		}
 	}

--- a/model/sharing/group.go
+++ b/model/sharing/group.go
@@ -207,7 +207,9 @@ func updateGroupMetadata(inst *instance.Instance, doc *couchdb.JSONDoc) error {
 	for _, s := range sharings {
 		for idx, group := range s.Groups {
 			if group.ID == doc.ID() {
-				group.Name = updatedGroup.Name()
+				if name, ok := doc.M["name"].(string); ok {
+					group.Name = name
+				}
 				group.Color = updatedGroup.Color()
 				s.Groups[idx] = group
 				if err := couchdb.UpdateDoc(inst, s); err != nil {

--- a/model/sharing/group_test.go
+++ b/model/sharing/group_test.go
@@ -155,11 +155,22 @@ func TestGroups(t *testing.T) {
 		require.Equal(t, "Brand marketing", stored.Groups[0].Name)
 		require.Equal(t, "#A142F4", stored.Groups[0].Color)
 
+		updated.M["name"] = 42
+		updated.M["color"] = "#0F9D58"
+		require.NoError(t, UpdateGroups(inst, job.ShareGroupMessage{RenamedGroup: updated}))
+
+		stored, err = FindSharing(inst, s.ID())
+		require.NoError(t, err)
+		require.Equal(t, "Brand marketing", stored.Groups[0].Name)
+		require.Equal(t, "#0F9D58", stored.Groups[0].Color)
+
+		delete(updated.M, "name")
 		delete(updated.M, "color")
 		require.NoError(t, UpdateGroups(inst, job.ShareGroupMessage{RenamedGroup: updated}))
 
 		stored, err = FindSharing(inst, s.ID())
 		require.NoError(t, err)
+		require.Equal(t, "Brand marketing", stored.Groups[0].Name)
 		require.Empty(t, stored.Groups[0].Color)
 	})
 

--- a/model/sharing/group_test.go
+++ b/model/sharing/group_test.go
@@ -1,6 +1,7 @@
 package sharing
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
@@ -19,6 +20,22 @@ import (
 	_ "github.com/cozy/cozy-stack/worker/mails"
 )
 
+func TestGroupColorJSON(t *testing.T) {
+	data, err := json.Marshal(Group{
+		ID:    "group-id",
+		Name:  "Marketing",
+		Color: "#22AA55",
+	})
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"id": "group-id",
+		"name": "Marketing",
+		"color": "#22AA55",
+		"addedBy": 0,
+		"read_only": false
+	}`, string(data))
+}
+
 func TestGroups(t *testing.T) {
 	if testing.Short() {
 		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
@@ -35,6 +52,8 @@ func TestGroups(t *testing.T) {
 	t.Run("RevokeGroup", func(t *testing.T) {
 		now := time.Now()
 		friends := createGroup(t, inst, "Friends")
+		friends.M["color"] = "#22AA55"
+		require.NoError(t, couchdb.UpdateDoc(inst, friends))
 		football := createGroup(t, inst, "Football")
 		bob := createContactInGroups(t, inst, "Bob", []string{friends.ID()})
 		_ = createContactInGroups(t, inst, "Charlie", []string{friends.ID(), football.ID()})
@@ -76,6 +95,7 @@ func TestGroups(t *testing.T) {
 
 		require.Len(t, s.Groups, 2)
 		require.Equal(t, s.Groups[0].Name, "Friends")
+		require.Equal(t, "#22AA55", s.Groups[0].Color)
 		assert.False(t, s.Groups[0].Revoked)
 		require.Equal(t, s.Groups[1].Name, "Football")
 		assert.False(t, s.Groups[1].Revoked)
@@ -107,6 +127,40 @@ func TestGroups(t *testing.T) {
 		require.Len(t, s.Groups, 2)
 		assert.True(t, s.Groups[0].Revoked)
 		assert.True(t, s.Groups[1].Revoked)
+	})
+
+	t.Run("UpdateGroupMetadata", func(t *testing.T) {
+		group := createGroup(t, inst, "Marketing")
+		group.M["color"] = "#3367D6"
+		require.NoError(t, couchdb.UpdateDoc(inst, group))
+
+		s := &Sharing{
+			Active: true,
+			Groups: []Group{{
+				ID:    group.ID(),
+				Name:  group.Name(),
+				Color: group.Color(),
+			}},
+		}
+		require.NoError(t, couchdb.CreateDoc(inst, s))
+
+		updated := group.JSONDoc.Clone().(*couchdb.JSONDoc)
+		updated.M["name"] = "Brand marketing"
+		updated.M["color"] = "#A142F4"
+		require.NoError(t, UpdateGroups(inst, job.ShareGroupMessage{RenamedGroup: updated}))
+
+		stored, err := FindSharing(inst, s.ID())
+		require.NoError(t, err)
+		require.Len(t, stored.Groups, 1)
+		require.Equal(t, "Brand marketing", stored.Groups[0].Name)
+		require.Equal(t, "#A142F4", stored.Groups[0].Color)
+
+		delete(updated.M, "color")
+		require.NoError(t, UpdateGroups(inst, job.ShareGroupMessage{RenamedGroup: updated}))
+
+		stored, err = FindSharing(inst, s.ID())
+		require.NoError(t, err)
+		require.Empty(t, stored.Groups[0].Color)
 	})
 
 	t.Run("UpdateGroups", func(t *testing.T) {

--- a/model/sharing/member.go
+++ b/model/sharing/member.go
@@ -334,7 +334,12 @@ func (s *Sharing) DelegateAddContactsAndGroups(inst *instance.Instance, groupIDs
 		if err != nil {
 			return err
 		}
-		g := Group{ID: groupID, Name: group.Name(), ReadOnly: readOnly}
+		g := Group{
+			ID:       groupID,
+			Name:     group.Name(),
+			Color:    group.Color(),
+			ReadOnly: readOnly,
+		}
 		api.groups = append(api.groups, g)
 
 		contacts, err := group.GetAllContacts(inst)

--- a/web/sharings/drives_test.go
+++ b/web/sharings/drives_test.go
@@ -2508,6 +2508,50 @@ func TestSharedDriveDelegatedRecipientAddition(t *testing.T) {
 		require.Empty(t, sharingInvitationRecipientNames(t, env.betty, sharingID))
 	})
 
+	t.Run("GroupColorIsPropagated", func(t *testing.T) {
+		sharingID := createAcceptedSharedDriveForRecipient(
+			t,
+			env,
+			RecipientInfo{Name: "Betty", Email: "betty@example.net", ReadOnly: false},
+			env.betty,
+			env.tsB.URL,
+		)
+		group := createGroupOnInstance(t, env.betty, "Marketing")
+		group.M["color"] = "#3367D6"
+		require.NoError(t, couchdb.UpdateDoc(env.betty, group))
+		createContactInGroupWithCozy(
+			t,
+			env.betty,
+			group,
+			"Charlie Group",
+			"charlie-group@example.net",
+			"",
+		)
+
+		eBetty.POST("/sharings/"+sharingID+"/recipients").
+			WithHeader("Authorization", "Bearer "+env.bettyToken).
+			WithHeader("Content-Type", jsonAPIContentType).
+			WithBytes(mustJSON(t, map[string]interface{}{
+				"data": map[string]interface{}{
+					"type": consts.Sharings,
+					"id":   sharingID,
+					"relationships": map[string]interface{}{
+						"recipients": map[string]interface{}{
+							"data": []map[string]interface{}{
+								{"id": group.ID(), "type": consts.Groups},
+							},
+						},
+					},
+				},
+			})).
+			Expect().Status(http.StatusOK)
+
+		ownerSharing, err := sharing.FindSharing(env.acme, sharingID)
+		require.NoError(t, err)
+		require.NotEmpty(t, ownerSharing.Groups)
+		require.Equal(t, "#3367D6", ownerSharing.Groups[len(ownerSharing.Groups)-1].Color)
+	})
+
 	t.Run("ReadOnlyRecipientCanInviteReadOnly", func(t *testing.T) {
 		sharingID := createAcceptedSharedDriveForRecipient(
 			t,

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -296,6 +296,8 @@ func TestSharings(t *testing.T) {
 
 		group := createGroup(t, aliceInstance, "friends")
 		require.NotNil(t, group)
+		group.M["color"] = "#22AA55"
+		require.NoError(t, couchdb.UpdateDoc(aliceInstance, group))
 		fionaContact := addContactToGroup(t, aliceInstance, group, "Fiona")
 		require.NotNil(t, fionaContact)
 		gabyContact := addContactToGroup(t, aliceInstance, group, "Gaby")
@@ -361,6 +363,7 @@ func TestSharings(t *testing.T) {
 		g := groups.Value(0).Object()
 		g.HasValue("id", group.ID())
 		g.HasValue("name", "friends")
+		g.HasValue("color", "#22AA55")
 		g.HasValue("addedBy", 0)
 	})
 


### PR DESCRIPTION
## Summary

- Include contact group colors in sharing group attributes.
- Propagate group color changes to active sharings and recipients.
- Cover direct and delegated sharing flows and document the field.
