### PR TITLE
Feat/assistant knowledge base workspace

### DIFF
--- a/model/rag/chat.go
+++ b/model/rag/chat.go
@@ -148,6 +148,34 @@ func (a *chatAssistant) SetID(id string)    { a.DocID = id }
 func (a *chatAssistant) SetRev(rev string)  { a.DocRev = rev }
 func (a *chatAssistant) Clone() couchdb.Doc { c := *a; return &c }
 
+// knowledgeBaseDirID returns the Drive folder scoping the assistant's
+// retrieval, or "" when the assistant has no knowledge base. Only a single
+// folder per assistant is supported: extra io.cozy.files entries are ignored,
+// with a warning so the truncation is at least visible in the logs.
+func (a *chatAssistant) knowledgeBaseDirID(logger logger.Logger) string {
+	if a == nil {
+		return ""
+	}
+	dirID := ""
+	for _, entry := range a.KnowledgeBase {
+		if entry.Doctype != consts.Files || entry.DirID == "" {
+			continue
+		}
+		if dirID == "" {
+			dirID = entry.DirID
+		} else if entry.DirID != dirID {
+			logger.Warnf("assistant %s: multiple knowledge base folders are not supported, ignoring %s", a.DocID, entry.DirID)
+		}
+	}
+	return dirID
+}
+
+// ErrAssistantNotFound is returned when a conversation references an
+// assistant that is gone (deleted, or never created). The query must fail:
+// answering anyway would silently widen a possibly folder-scoped
+// conversation to whole-instance retrieval.
+var ErrAssistantNotFound = errors.New("assistant not found")
+
 func Chat(inst *instance.Instance, payload ChatPayload) (*ChatConversation, error) {
 	var chat ChatConversation
 	err := couchdb.GetDoc(inst, consts.ChatConversations, payload.ChatConversationID, &chat)
@@ -289,10 +317,11 @@ func getSources(event map[string]interface{}) ([]Source, error) {
 }
 
 // assistantForChat loads the assistant bound to the conversation. It returns
-// (nil, nil) when the conversation has no assistant or the assistant was
-// deleted. An error means the caller could not determine how the
-// conversation is configured (e.g. a transient CouchDB error) and MUST NOT
-// proceed as if it were unscoped.
+// (nil, nil) only when the conversation has no assistant at all. An error
+// means either the referenced assistant is gone (ErrAssistantNotFound) or
+// its configuration could not be read (e.g. a transient CouchDB error); in
+// both cases the caller MUST NOT proceed as if the conversation were
+// unscoped.
 func assistantForChat(inst *instance.Instance, chat *ChatConversation) (*chatAssistant, error) {
 	rel, ok := chat.Rels["assistant"]
 	if !ok {
@@ -305,15 +334,13 @@ func assistantForChat(inst *instance.Instance, chat *ChatConversation) (*chatAss
 	}
 	var assistant chatAssistant
 	if err := couchdb.GetDoc(inst, consts.ChatAssistants, assistantID, &assistant); err != nil {
-		// A missing document — or a missing assistants database, which is a
-		// reachable state since the database is only created when a first
-		// assistant doc is saved and Chat() does not check that the
-		// client-supplied assistant id exists — means no knowledge-base
-		// configuration can exist: treat the conversation as unscoped rather
-		// than failing it. Other errors (e.g. a transient CouchDB failure)
-		// keep failing closed: the assistant may exist and be folder-scoped.
+		// The conversation references an assistant that cannot be found
+		// (deleted, or never existed). It may have been scoped to a
+		// knowledge base: degrading to unscoped retrieval would silently
+		// widen it to the whole instance, so surface an explicit error and
+		// let the client deal with the dangling reference.
 		if couchdb.IsNotFoundError(err) {
-			return nil, nil
+			return nil, ErrAssistantNotFound
 		}
 		return nil, err
 	}
@@ -411,7 +438,7 @@ func Query(inst *instance.Instance, logger logger.Logger, query QueryMessage) er
 	if override := buildLLMOverride(inst, assistant); override != nil {
 		metadata["llm_override"] = override
 	}
-	if dirID := knowledgeBaseDirID(assistant, logger); dirID != "" {
+	if dirID := assistant.knowledgeBaseDirID(logger); dirID != "" {
 		if err := ensureWorkspace(inst, logger, dirID); err != nil {
 			logger.Warnf("cannot ensure RAG workspace %s: %s", dirID, err)
 			// A folder-scoped assistant must never answer from the whole

--- a/model/rag/chat.go
+++ b/model/rag/chat.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/cozy/cozy-stack/model/account"
 	"github.com/cozy/cozy-stack/model/instance"
 	"github.com/cozy/cozy-stack/model/job"
+	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/jsonapi"
@@ -117,6 +119,12 @@ type chatAssistant struct {
 	DocID         string                 `json:"_id,omitempty"`
 	DocRev        string                 `json:"_rev,omitempty"`
 	Relationships chatAssistantRelations `json:"relationships,omitempty"`
+	KnowledgeBase []knowledgeBaseEntry   `json:"knowledgeBase,omitempty"`
+}
+
+type knowledgeBaseEntry struct {
+	Doctype string `json:"doctype"`
+	DirID   string `json:"dirId"`
 }
 
 type chatAssistantRelations struct {
@@ -280,25 +288,46 @@ func getSources(event map[string]interface{}) ([]Source, error) {
 	return sources, nil
 }
 
+// assistantForChat loads the assistant bound to the conversation. It returns
+// (nil, nil) when the conversation has no assistant or the assistant was
+// deleted. An error means the caller could not determine how the
+// conversation is configured (e.g. a transient CouchDB error) and MUST NOT
+// proceed as if it were unscoped.
+func assistantForChat(inst *instance.Instance, chat *ChatConversation) (*chatAssistant, error) {
+	rel, ok := chat.Rels["assistant"]
+	if !ok {
+		return nil, nil
+	}
+	relData, _ := rel.Data.(map[string]interface{})
+	assistantID, _ := relData["_id"].(string)
+	if assistantID == "" {
+		return nil, nil
+	}
+	var assistant chatAssistant
+	if err := couchdb.GetDoc(inst, consts.ChatAssistants, assistantID, &assistant); err != nil {
+		// A missing document — or a missing assistants database, which is a
+		// reachable state since the database is only created when a first
+		// assistant doc is saved and Chat() does not check that the
+		// client-supplied assistant id exists — means no knowledge-base
+		// configuration can exist: treat the conversation as unscoped rather
+		// than failing it. Other errors (e.g. a transient CouchDB failure)
+		// keep failing closed: the assistant may exist and be folder-scoped.
+		if couchdb.IsNotFoundError(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &assistant, nil
+}
+
 // buildLLMOverride returns the `metadata.llm_override` map forwarded to
 // OpenRAG when the conversation is bound to an assistant that uses an
 // external provider (OpenAI, Mistral, …). It returns nil to leave the
 // stack's default RAG configuration in place: either no assistant is
 // attached, the provider is the default "openrag", or the linked account
 // could not be resolved.
-func buildLLMOverride(inst *instance.Instance, chat *ChatConversation) map[string]interface{} {
-	rel, ok := chat.Rels["assistant"]
-	if !ok {
-		return nil
-	}
-	relData, _ := rel.Data.(map[string]interface{})
-	assistantID, _ := relData["_id"].(string)
-	if assistantID == "" {
-		return nil
-	}
-
-	var assistant chatAssistant
-	if err := couchdb.GetDoc(inst, consts.ChatAssistants, assistantID, &assistant); err != nil {
+func buildLLMOverride(inst *instance.Instance, assistant *chatAssistant) map[string]interface{} {
+	if assistant == nil {
 		return nil
 	}
 	provider := assistant.Relationships.Provider.Data
@@ -366,8 +395,31 @@ func Query(inst *instance.Instance, logger logger.Logger, query QueryMessage) er
 		}
 		metadata["attachments"] = attachments
 	}
-	if override := buildLLMOverride(inst, &chat); override != nil {
+	msg := chat.Messages[len(chat.Messages)-1]
+	assistant, err := assistantForChat(inst, &chat)
+	if err != nil {
+		// Without the assistant we cannot know whether the conversation is
+		// scoped to a knowledge base, and a folder-scoped assistant must
+		// never silently answer unscoped: surface the error and stop. This
+		// deliberately also fails assistants that only carry an llm_override
+		// (which used to fall back to the stack's default RAG configuration
+		// on such errors): scoping cannot be ruled out without the doc.
+		logger.Warnf("cannot resolve assistant: %s", err)
+		publishError(inst, msg.ID, err)
+		return err
+	}
+	if override := buildLLMOverride(inst, assistant); override != nil {
 		metadata["llm_override"] = override
+	}
+	if dirID := knowledgeBaseDirID(assistant, logger); dirID != "" {
+		if err := ensureWorkspace(inst, logger, dirID); err != nil {
+			logger.Warnf("cannot ensure RAG workspace %s: %s", dirID, err)
+			// A folder-scoped assistant must never answer from the whole
+			// instance: surface the error to the client and stop.
+			publishError(inst, msg.ID, err)
+			return err
+		}
+		metadata["workspace"] = dirID
 	}
 	payload := map[string]interface{}{
 		"model":       fmt.Sprintf("ragondin-%s", inst.Domain),
@@ -385,47 +437,32 @@ func Query(inst *instance.Instance, logger logger.Logger, query QueryMessage) er
 	}
 	res, err := CallRAGQuery(inst, http.MethodPost, body, "v1/chat/completions", echo.MIMEApplicationJSON)
 	if err != nil {
+		publishError(inst, msg.ID, err)
 		return err
 	}
 	if res.StatusCode == http.StatusNotFound {
 		res.Body.Close()
 		checkRes, err := CallRAGQuery(inst, http.MethodGet, nil, fmt.Sprintf("/partition/%s", inst.Domain), echo.MIMEApplicationJSON)
 		if err != nil {
+			publishError(inst, msg.ID, err)
 			return err
 		}
 		checkRes.Body.Close()
 		if checkRes.StatusCode == http.StatusNotFound {
 			logger.Warnf("RAG partition not found, attempting creation")
-			partRes, partErr := CallRAGQuery(inst, http.MethodPost, nil, fmt.Sprintf("/partition/%s", inst.Domain), echo.MIMEApplicationJSON)
-			if partErr != nil {
-				logger.Warnf("Failed to create RAG partition: %s", partErr)
-			} else {
-				partRes.Body.Close()
-				// 409 is treated as success since the partition is already created
-				if (partRes.StatusCode < 200 || partRes.StatusCode >= 300) && partRes.StatusCode != http.StatusConflict {
-					logger.Warnf("Failed to create RAG partition, status: %d", partRes.StatusCode)
-				}
-			}
+			createRAGPartition(inst.RAGServer(), inst.Domain, logger)
 			res, err = CallRAGQuery(inst, http.MethodPost, body, "v1/chat/completions", echo.MIMEApplicationJSON)
 			if err != nil {
+				publishError(inst, msg.ID, err)
 				return err
 			}
 		}
 	}
 	defer res.Body.Close()
-	msg := chat.Messages[len(chat.Messages)-1]
 
 	if res.StatusCode != 200 {
 		ragErr := fmt.Errorf("POST status code: %d", res.StatusCode)
-		errorDoc := couchdb.JSONDoc{
-			Type: consts.ChatEvents,
-			M: map[string]interface{}{
-				"_id":     msg.ID,
-				"object":  "error",
-				"message": ragErr.Error(),
-			},
-		}
-		go realtime.GetHub().Publish(inst, realtime.EventCreate, &errorDoc, nil)
+		publishError(inst, msg.ID, ragErr)
 		return ragErr
 	}
 	var completion string
@@ -438,16 +475,7 @@ func Query(inst *instance.Instance, logger logger.Logger, query QueryMessage) er
 	}
 	if err != nil {
 		// Send error event to client
-		errorDoc := map[string]interface{}{
-			"_id":     msg.ID,
-			"object":  "error",
-			"message": err.Error(),
-		}
-		errorPayload := couchdb.JSONDoc{
-			Type: consts.ChatEvents,
-			M:    errorDoc,
-		}
-		go realtime.GetHub().Publish(inst, realtime.EventCreate, &errorPayload, nil)
+		publishError(inst, msg.ID, err)
 		return err
 	}
 
@@ -488,6 +516,20 @@ func publishSources(inst *instance.Instance, msgID string, sources []Source) {
 	}
 	doc.SetID(msgID)
 	realtime.GetHub().Publish(inst, realtime.EventCreate, &doc, nil)
+}
+
+// publishError sends the `{object:"error"}` chat event, so a client waiting
+// on the realtime feed is never left hanging when the query cannot complete.
+func publishError(inst *instance.Instance, msgID string, err error) {
+	doc := couchdb.JSONDoc{
+		Type: consts.ChatEvents,
+		M: map[string]interface{}{
+			"object":  "error",
+			"message": err.Error(),
+		},
+	}
+	doc.SetID(msgID)
+	go realtime.GetHub().Publish(inst, realtime.EventCreate, &doc, nil)
 }
 
 func publishDone(inst *instance.Instance, msgID string) {
@@ -586,17 +628,41 @@ func handleNonStreamResponse(inst *instance.Instance, msg ChatMessage, body io.R
 	return completion, sources, nil
 }
 
-func CallRAGQuery(inst *instance.Instance, method string, payload []byte, path string, contentType string) (*http.Response, error) {
-	ragServer := inst.RAGServer()
-	if ragServer.URL == "" {
+// ragHTTPClient is the HTTP client used for the openRAG calls. It has no
+// global timeout (chat completions may stream for minutes) but bounds
+// connection establishment and the wait for response headers, so a hung
+// openRAG server cannot pin a rag-query worker — or a rag-index batch and
+// the per-instance lock it holds — forever.
+var ragHTTPClient = &http.Client{
+	Transport: &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           (&net.Dialer{Timeout: 30 * time.Second}).DialContext,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: 5 * time.Minute,
+	},
+}
+
+// callRAG is the instance-free part of CallRAGQuery, split out so the openRAG
+// HTTP mechanics can be unit-tested against an httptest server.
+func callRAG(server config.RAGServer, method string, payload []byte, path string, contentType string) (*http.Response, error) {
+	if server.URL == "" {
 		return nil, errors.New("no RAG server configured")
 	}
-	u, err := url.Parse(ragServer.URL)
+	u, err := url.Parse(server.URL)
 	if err != nil {
 		return nil, err
 	}
 
-	u.Path = path
+	// The path is treated as already percent-encoded: callers escape their
+	// dynamic segments with url.PathEscape (folder and file ids are arbitrary
+	// CouchDB ids and must not be able to break out of their path segment),
+	// and the escaped form must be sent as-is, without double encoding.
+	unescaped, err := url.PathUnescape(path)
+	if err != nil {
+		return nil, err
+	}
+	u.Path = unescaped
+	u.RawPath = path
 	var body io.Reader
 	if payload != nil {
 		body = bytes.NewReader(payload)
@@ -605,9 +671,34 @@ func CallRAGQuery(inst *instance.Instance, method string, payload []byte, path s
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+ragServer.APIKey)
+	req.Header.Add(echo.HeaderAuthorization, "Bearer "+server.APIKey)
 	req.Header.Add("Content-Type", contentType)
-	return http.DefaultClient.Do(req)
+	return ragHTTPClient.Do(req)
+}
+
+func CallRAGQuery(inst *instance.Instance, method string, payload []byte, path string, contentType string) (*http.Response, error) {
+	return callRAG(inst.RAGServer(), method, payload, path, contentType)
+}
+
+// createdOrExists tells whether an openRAG create endpoint reported success,
+// treating 409 (already created concurrently) as success.
+func createdOrExists(statusCode int) bool {
+	return (statusCode >= 200 && statusCode < 300) || statusCode == http.StatusConflict
+}
+
+// createRAGPartition creates the instance's partition on the openRAG server.
+// Best-effort: failures are only logged, and a 409 (partition already
+// created) is treated as success.
+func createRAGPartition(server config.RAGServer, domain string, logger logger.Logger) {
+	res, err := callRAG(server, http.MethodPost, nil, fmt.Sprintf("/partition/%s", domain), echo.MIMEApplicationJSON)
+	if err != nil {
+		logger.Warnf("Failed to create RAG partition: %s", err)
+		return
+	}
+	res.Body.Close()
+	if !createdOrExists(res.StatusCode) {
+		logger.Warnf("Failed to create RAG partition, status: %d", res.StatusCode)
+	}
 }
 
 func foreachSSE(r io.Reader, fn func(event map[string]interface{})) error {

--- a/model/rag/index.go
+++ b/model/rag/index.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 
 	"github.com/cozy/cozy-stack/model/feature"
 	"github.com/cozy/cozy-stack/model/instance"
@@ -55,9 +56,13 @@ func Index(inst *instance.Instance, logger logger.Logger, msg IndexMessage) erro
 		return nil
 	}
 
+	// Lazily loaded on first use, so batches that never reconcile workspace
+	// membership (e.g. deletions only) skip the CouchDB and openRAG queries.
+	kb := sync.OnceValue(func() *kbContext { return loadKBContext(inst, logger) })
+
 	var errj error
 	for _, change := range feed.Results {
-		if err := callRAGIndexer(inst, msg.Doctype, change); err != nil {
+		if err := callRAGIndexer(inst, msg.Doctype, change, kb, logger); err != nil {
 			logger.Warnf("Index error: %s", err)
 			errj = errors.Join(errj, err)
 		}
@@ -71,7 +76,7 @@ func Index(inst *instance.Instance, logger logger.Logger, msg IndexMessage) erro
 	return errj
 }
 
-func callRAGIndexer(inst *instance.Instance, doctype string, change couchdb.Change) error {
+func callRAGIndexer(inst *instance.Instance, doctype string, change couchdb.Change, kb func() *kbContext, logger logger.Logger) error {
 	if strings.HasPrefix(change.DocID, "_design/") {
 		return nil
 	}
@@ -100,6 +105,16 @@ func callRAGIndexer(inst *instance.Instance, doctype string, change couchdb.Chan
 		}
 	}
 	if change.Doc.Get("type") == consts.DirType {
+		// A directory move or rename rewrites the path of the directory and
+		// of all its descendant directories, but never touches the file docs
+		// they contain: those files may have silently entered or left a
+		// knowledge-base folder. Every descendant directory shows up in this
+		// same changes feed, so reconciling the direct file children of each
+		// changed directory covers the whole moved subtree.
+		dirPath, _ := change.Doc.Get("path").(string)
+		if dirPath != "" && !strings.HasPrefix(dirPath, vfs.TrashDirName) {
+			reconcileDirChildren(inst, logger, kb(), change.DocID, dirPath)
+		}
 		return nil
 	}
 
@@ -111,15 +126,9 @@ func callRAGIndexer(inst *instance.Instance, doctype string, change couchdb.Chan
 	if err != nil {
 		return err
 	}
-	u.Path = fmt.Sprintf("/indexer/partition/%s/file/%s", inst.Domain, change.DocID)
 	if change.Deleted || change.Doc.Get("trashed") == true {
 		// Doc deletion
-		req, err := http.NewRequest(http.MethodDelete, u.String(), nil)
-		if err != nil {
-			return err
-		}
-		req.Header.Add(echo.HeaderAuthorization, "Bearer "+ragServer.APIKey)
-		res, err := http.DefaultClient.Do(req)
+		res, err := CallRAGQuery(inst, http.MethodDelete, nil, fmt.Sprintf("/indexer/partition/%s/file/%s", inst.Domain, url.PathEscape(change.DocID)), echo.MIMEApplicationJSON)
 		if err != nil {
 			return err
 		}
@@ -129,13 +138,7 @@ func callRAGIndexer(inst *instance.Instance, doctype string, change couchdb.Chan
 		}
 	} else {
 		md5sum := fmt.Sprintf("%x", change.Doc.Get("md5sum"))
-		u.Path = fmt.Sprintf("/partition/%s/file/%s", inst.Domain, change.DocID)
-		req, err := http.NewRequest(http.MethodGet, u.String(), nil)
-		if err != nil {
-			return err
-		}
-		req.Header.Add(echo.HeaderAuthorization, "Bearer "+ragServer.APIKey)
-		res, err := http.DefaultClient.Do(req)
+		res, err := CallRAGQuery(inst, http.MethodGet, nil, fmt.Sprintf("/partition/%s/file/%s", inst.Domain, url.PathEscape(change.DocID)), echo.MIMEApplicationJSON)
 		if err != nil {
 			return err
 		}
@@ -167,13 +170,14 @@ func callRAGIndexer(inst *instance.Instance, doctype string, change couchdb.Chan
 		default:
 			return fmt.Errorf("GET status code: %d", res.StatusCode)
 		}
+		dirID, _ := change.Doc.Get("dir_id").(string)
 		if !needIndexation {
-			// TODO we should patch the metadata in the vector db when a
-			// file has been moved/renamed.
+			// The content did not change but the file may have been
+			// moved/renamed: keep the knowledge-base workspaces in sync.
+			reconcileMembership(inst, logger, kb(), change.DocID, dirID)
 			return nil
 		}
 
-		dirID, _ := change.Doc.Get("dir_id").(string)
 		name, _ := change.Doc.Get("name").(string)
 		mime, _ := change.Doc.Get("mime").(string)
 		metadataRaw, ok := change.Doc.Get("metadata").(map[string]interface{})
@@ -228,6 +232,22 @@ func callRAGIndexer(inst *instance.Instance, doctype string, change couchdb.Chan
 		}.Encode()
 		u.Path = fmt.Sprintf("/indexer/partition/%s/file/%s", inst.Domain, change.DocID)
 
+		// The streaming goroutine below needs the workspace membership, but
+		// kbContext is not safe for concurrent use: resolve it here, on the
+		// indexing loop, before the goroutine starts.
+		var workspaceIDsJSON string
+		attachUnknown := false
+		if kbc := kb(); !kbc.empty() {
+			if desired, ok := kbc.desiredFor(inst, dirID); !ok {
+				logger.Warnf("cannot resolve parent path for file %s (dir %s): skipping workspace attach", change.DocID, dirID)
+				attachUnknown = true
+			} else if len(desired) > 0 {
+				if wsJSON, err := json.Marshal(desired); err == nil {
+					workspaceIDsJSON = string(wsJSON)
+				}
+			}
+		}
+
 		// Create pipe and writer for file streaming
 		pr, pw := io.Pipe()
 		writer := multipart.NewWriter(pw)
@@ -258,10 +278,17 @@ func callRAGIndexer(inst *instance.Instance, doctype string, change couchdb.Chan
 				_ = pw.CloseWithError(err)
 				return
 			}
+			if workspaceIDsJSON != "" {
+				if err := writer.WriteField("workspace_ids", workspaceIDsJSON); err != nil {
+					_ = pw.CloseWithError(err)
+					return
+				}
+			}
 			defer pw.Close()
 			defer writer.Close()
 		}()
 
+		var req *http.Request
 		if isNewFile {
 			req, err = http.NewRequest(http.MethodPost, u.String(), pr)
 		} else {
@@ -274,7 +301,7 @@ func callRAGIndexer(inst *instance.Instance, doctype string, change couchdb.Chan
 		req.Header.Add(echo.HeaderAuthorization, "Bearer "+ragServer.APIKey)
 		req.Header.Add("Content-Type", writer.FormDataContentType())
 
-		res, err = http.DefaultClient.Do(req)
+		res, err = ragHTTPClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -287,6 +314,16 @@ func callRAGIndexer(inst *instance.Instance, doctype string, change couchdb.Chan
 
 		if res.StatusCode >= 500 {
 			return fmt.Errorf("Status code: %d", res.StatusCode)
+		}
+
+		if (!isNewFile || attachUnknown) && res.StatusCode < 300 {
+			// For an existing file, the content changed but it may also have
+			// been moved/renamed at the same time: keep the knowledge-base
+			// workspaces in sync after a successful re-upload. For a new file
+			// whose membership could not be resolved before the upload
+			// (attachUnknown), this is the only chance to attach it: retry
+			// now that the transient path-resolution error may have cleared.
+			reconcileMembership(inst, logger, kb(), change.DocID, dirID)
 		}
 	}
 	return nil
@@ -354,21 +391,10 @@ func pushJob(inst *instance.Instance, doctype string) error {
 }
 
 func CleanInstance(inst *instance.Instance) error {
-	ragServer := inst.RAGServer()
-	if ragServer.URL == "" {
+	if inst.RAGServer().URL == "" {
 		return nil
 	}
-	u, err := url.Parse(ragServer.URL)
-	if err != nil {
-		return err
-	}
-	u.Path = fmt.Sprintf("/instances/%s", inst.Domain)
-	req, err := http.NewRequest(http.MethodDelete, u.String(), nil)
-	if err != nil {
-		return err
-	}
-	req.Header.Add(echo.HeaderAuthorization, "Bearer "+ragServer.APIKey)
-	res, err := http.DefaultClient.Do(req)
+	res, err := CallRAGQuery(inst, http.MethodDelete, nil, fmt.Sprintf("/instances/%s", inst.Domain), echo.MIMEApplicationJSON)
 	if err != nil {
 		return err
 	}

--- a/model/rag/workspace.go
+++ b/model/rag/workspace.go
@@ -22,28 +22,6 @@ import (
 // single workspace membership backfill request.
 const workspaceBackfillChunkSize = 500
 
-// knowledgeBaseDirID returns the Drive folder scoping the assistant's
-// retrieval, or "" when the assistant has no knowledge base. Only a single
-// folder per assistant is supported: extra io.cozy.files entries are ignored,
-// with a warning so the truncation is at least visible in the logs.
-func knowledgeBaseDirID(assistant *chatAssistant, logger logger.Logger) string {
-	if assistant == nil {
-		return ""
-	}
-	dirID := ""
-	for _, entry := range assistant.KnowledgeBase {
-		if entry.Doctype != consts.Files || entry.DirID == "" {
-			continue
-		}
-		if dirID == "" {
-			dirID = entry.DirID
-		} else if entry.DirID != dirID {
-			logger.Warnf("assistant %s: multiple knowledge base folders are not supported, ignoring %s", assistant.DocID, entry.DirID)
-		}
-	}
-	return dirID
-}
-
 // kbContext carries, for one rag-index batch, the knowledge-base folders
 // declared by assistants. Only folders that already exist as workspaces in
 // openRAG are kept (uploads may only reference existing workspaces). It is
@@ -100,7 +78,7 @@ func loadKBContext(inst *instance.Instance, logger logger.Logger) *kbContext {
 		if err := json.Unmarshal(doc, &assistant); err != nil {
 			return err
 		}
-		dirID := knowledgeBaseDirID(&assistant, logger)
+		dirID := assistant.knowledgeBaseDirID(logger)
 		if dirID == "" {
 			return nil
 		}
@@ -287,12 +265,24 @@ func reconcileMembershipHTTP(server config.RAGServer, domain, fileID string, des
 // folder subtree when needed. An error means the query MUST NOT proceed
 // unscoped.
 func ensureWorkspace(inst *instance.Instance, logger logger.Logger, dirID string) error {
-	// Serialize the concurrent queries racing on the same folder (the
-	// rag-query worker runs several jobs in parallel): without this, two
-	// first-time chats could both create and backfill the workspace, and the
-	// rollback of a failed backfill could delete the workspace the other
-	// query just successfully ensured.
-	mu := config.Lock().ReadWrite(inst, "rag-workspace/"+dirID)
+	// Steady state: the workspace exists for every message but the first
+	// one. Check it outside any lock so the common path stays lock-free.
+	exists, err := workspaceExists(inst.RAGServer(), inst.Domain, dirID)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+	// Creation path: serialize the concurrent queries racing on the same
+	// folder (the rag-query worker runs several jobs in parallel): without
+	// this, two first-time chats could both create and backfill the
+	// workspace, and the rollback of a failed backfill could delete the
+	// workspace the other query just successfully ensured. The backfill of
+	// a large folder can outlive a plain lock's TTL, hence LongOperation,
+	// which keeps refreshing it. ensureWorkspaceHTTP re-checks existence
+	// under the lock, so the loser of the race is a no-op.
+	mu := config.Lock().LongOperation(inst, "rag-workspace/"+dirID)
 	if err := mu.Lock(); err != nil {
 		return err
 	}
@@ -415,22 +405,23 @@ func postWorkspaceFiles(server config.RAGServer, domain, workspaceID string, ids
 // openRAG's endpoint is all-or-nothing: ANY unknown file id in the chunk
 // yields a 404 and adds NONE of the chunk's ids, even the ones that are
 // indexed. When that happens, the chunk's ids are retried one by one so the
-// indexable files are still attached; per-id failures are expected for
+// indexable files are still attached; a per-id 404 is expected for
 // non-indexed files (e.g. an image skipped by the indexer's class flags) and
-// are only logged, not treated as an ensure failure. A 5xx status (chunked
-// or per-id) means the indexer itself failed and is still an ensure failure
-// so the query does not proceed unscoped.
+// only logged. Any other non-2xx status (chunked or per-id) is systemic and
+// is an ensure failure, so the query does not proceed with a silently
+// incomplete workspace.
 func backfillChunk(server config.RAGServer, domain, dirID string, ids []string, logger logger.Logger) error {
 	status, err := postWorkspaceFiles(server, domain, dirID, ids)
 	if err != nil {
 		return err
 	}
 	if status != http.StatusNotFound {
-		if status >= 500 {
-			return fmt.Errorf("workspace backfill status code: %d", status)
-		}
+		// Only a 404 can be a benign per-file condition. Anything else
+		// non-2xx (401/403 auth or permission problems, 5xx failures…) is
+		// systemic: fail the ensure rather than leave a silently incomplete
+		// workspace behind.
 		if status >= 300 {
-			logger.Warnf("workspace backfill chunk rejected (status %d)", status)
+			return fmt.Errorf("workspace backfill status code: %d", status)
 		}
 		return nil
 	}
@@ -454,12 +445,10 @@ func backfillChunk(server config.RAGServer, domain, dirID string, ids []string, 
 			return err
 		}
 		switch {
-		case idStatus >= 500:
-			return fmt.Errorf("workspace backfill status code: %d", idStatus)
 		case idStatus == http.StatusNotFound:
 			logger.Debugf("workspace backfill skipped file %s (not indexed)", id)
 		case idStatus >= 300:
-			logger.Infof("workspace backfill rejected file %s (status %d)", id, idStatus)
+			return fmt.Errorf("workspace backfill status code: %d", idStatus)
 		}
 	}
 	return nil

--- a/model/rag/workspace.go
+++ b/model/rag/workspace.go
@@ -1,0 +1,505 @@
+package rag
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+
+	"github.com/cozy/cozy-stack/model/instance"
+	"github.com/cozy/cozy-stack/model/vfs"
+	"github.com/cozy/cozy-stack/pkg/config/config"
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/logger"
+	"github.com/labstack/echo/v4"
+)
+
+// workspaceBackfillChunkSize is the maximum number of file ids sent in a
+// single workspace membership backfill request.
+const workspaceBackfillChunkSize = 500
+
+// knowledgeBaseDirID returns the Drive folder scoping the assistant's
+// retrieval, or "" when the assistant has no knowledge base. Only a single
+// folder per assistant is supported: extra io.cozy.files entries are ignored,
+// with a warning so the truncation is at least visible in the logs.
+func knowledgeBaseDirID(assistant *chatAssistant, logger logger.Logger) string {
+	if assistant == nil {
+		return ""
+	}
+	dirID := ""
+	for _, entry := range assistant.KnowledgeBase {
+		if entry.Doctype != consts.Files || entry.DirID == "" {
+			continue
+		}
+		if dirID == "" {
+			dirID = entry.DirID
+		} else if entry.DirID != dirID {
+			logger.Warnf("assistant %s: multiple knowledge base folders are not supported, ignoring %s", assistant.DocID, entry.DirID)
+		}
+	}
+	return dirID
+}
+
+// kbContext carries, for one rag-index batch, the knowledge-base folders
+// declared by assistants. Only folders that already exist as workspaces in
+// openRAG are kept (uploads may only reference existing workspaces). It is
+// only ever used from the single goroutine of one rag-index batch and is NOT
+// safe for concurrent use.
+type kbContext struct {
+	folders  map[string]string // dirID -> folder path
+	dirPaths map[string]string // dir_id -> path cache for the batch
+}
+
+func (kb *kbContext) empty() bool { return kb == nil || len(kb.folders) == 0 }
+
+func (kb *kbContext) desiredWorkspaces(parentPath string) []string {
+	// Trashed content never belongs to a workspace, even when the KB folder
+	// itself was moved to the trash.
+	if strings.HasPrefix(parentPath, vfs.TrashDirName) {
+		return nil
+	}
+	var ids []string
+	for dirID, folderPath := range kb.folders {
+		if parentPath == folderPath || strings.HasPrefix(parentPath, folderPath+"/") {
+			ids = append(ids, dirID)
+		}
+	}
+	slices.Sort(ids)
+	return ids
+}
+
+// desiredFor resolves the workspaces that should contain a file whose parent
+// directory is dirID. The boolean is false when the parent path could not be
+// resolved: callers must treat that as "unknown", never as "no membership"
+// (which would incorrectly detach the file from every workspace).
+func (kb *kbContext) desiredFor(inst *instance.Instance, dirID string) ([]string, bool) {
+	parentPath, ok := kb.parentPath(inst, dirID)
+	if !ok {
+		return nil, false
+	}
+	return kb.desiredWorkspaces(parentPath), true
+}
+
+// loadKBContext queries the assistants and the openRAG workspace list once
+// per batch. Any error yields a nil context: indexing proceeds without
+// membership reconciliation (best-effort by design). Note: once the KB
+// folders are known, a failure to list the existing openRAG workspaces also
+// yields nil, so that reconcileMembership does not mistake "we don't know"
+// for "none exist" and delete every current membership.
+func loadKBContext(inst *instance.Instance, logger logger.Logger) *kbContext {
+	kb := &kbContext{
+		folders:  map[string]string{},
+		dirPaths: map[string]string{},
+	}
+	err := couchdb.ForeachDocs(inst, consts.ChatAssistants, func(_ string, doc json.RawMessage) error {
+		var assistant chatAssistant
+		if err := json.Unmarshal(doc, &assistant); err != nil {
+			return err
+		}
+		dirID := knowledgeBaseDirID(&assistant, logger)
+		if dirID == "" {
+			return nil
+		}
+		dir, err := inst.VFS().DirByID(dirID)
+		if err != nil {
+			return nil
+		}
+		kb.folders[dirID] = dir.Fullpath
+		// Files directly inside a KB folder are the common layout: seed the
+		// per-batch path cache so parentPath does not re-fetch this dir.
+		kb.dirPaths[dirID] = dir.Fullpath
+		return nil
+	})
+	if err != nil {
+		if !couchdb.IsNoDatabaseError(err) {
+			logger.Warnf("cannot load assistants for workspace sync: %s", err)
+		}
+		return nil
+	}
+	if len(kb.folders) == 0 {
+		return nil
+	}
+	res, err := CallRAGQuery(inst, http.MethodGet, nil, fmt.Sprintf("/partition/%s/workspaces", inst.Domain), echo.MIMEApplicationJSON)
+	if err != nil {
+		logger.Warnf("cannot list RAG workspaces: %s", err)
+		return nil
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		logger.Warnf("cannot list RAG workspaces: status code %d", res.StatusCode)
+		return nil
+	}
+	var body struct {
+		Workspaces []struct {
+			WorkspaceID string `json:"workspace_id"`
+		} `json:"workspaces"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		logger.Warnf("cannot decode RAG workspaces: %s", err)
+		return nil
+	}
+	existingIDs := make([]string, 0, len(body.Workspaces))
+	for _, ws := range body.Workspaces {
+		existingIDs = append(existingIDs, ws.WorkspaceID)
+	}
+	pruneMissingWorkspaces(kb.folders, existingIDs)
+	if len(kb.folders) == 0 {
+		return nil
+	}
+	return kb
+}
+
+// pruneMissingWorkspaces removes from folders the knowledge-base folders
+// whose workspace does not exist (yet) in openRAG: uploads and reconciliation
+// may only reference existing workspaces (the workspace is created, lazily,
+// by ensureWorkspace on the first chat query).
+func pruneMissingWorkspaces(folders map[string]string, existingIDs []string) {
+	existing := make(map[string]bool, len(existingIDs))
+	for _, id := range existingIDs {
+		existing[id] = true
+	}
+	for dirID := range folders {
+		if !existing[dirID] {
+			delete(folders, dirID)
+		}
+	}
+}
+
+// parentPath resolves and caches the full path of a directory. The boolean
+// return value is false when the path could not be resolved (e.g. a
+// transient VFS/CouchDB error): callers must treat that as "unknown", never
+// as "no ancestors" (which would incorrectly detach the file from every
+// knowledge-base workspace).
+func (kb *kbContext) parentPath(inst *instance.Instance, dirID string) (string, bool) {
+	if p, ok := kb.dirPaths[dirID]; ok {
+		return p, true
+	}
+	dir, err := inst.VFS().DirByID(dirID)
+	if err != nil {
+		return "", false
+	}
+	kb.dirPaths[dirID] = dir.Fullpath
+	return dir.Fullpath, true
+}
+
+// reconcileDirChildren aligns the workspace membership of the direct file
+// children of a directory whose doc changed (typically a move or a rename).
+// Direct children are enough: a moved or renamed subtree puts every
+// descendant directory in the changes feed, so each affected file is seen as
+// the direct child of one of the changed directories. Best-effort: errors
+// are logged.
+func reconcileDirChildren(inst *instance.Instance, logger logger.Logger, kb *kbContext, dirID, dirPath string) {
+	if kb.empty() {
+		return
+	}
+	// The changes feed carries the directory's fresh path: seed the cache so
+	// the per-file reconciliation does not fetch it again.
+	kb.dirPaths[dirID] = dirPath
+	iter := inst.VFS().DirIterator(&vfs.DirDoc{DocID: dirID, Fullpath: dirPath}, nil)
+	for {
+		_, file, err := iter.Next()
+		if errors.Is(err, vfs.ErrIteratorDone) {
+			return
+		}
+		if err != nil {
+			logger.Warnf("cannot list children of dir %s: %s", dirID, err)
+			return
+		}
+		if file == nil || file.Trashed {
+			continue
+		}
+		reconcileMembership(inst, logger, kb, file.DocID, dirID)
+	}
+}
+
+// reconcileMembership aligns one file's workspace membership with the
+// knowledge-base folders containing it. Best-effort: errors are logged.
+func reconcileMembership(inst *instance.Instance, logger logger.Logger, kb *kbContext, fileID, dirID string) {
+	if kb.empty() {
+		return
+	}
+	desired, ok := kb.desiredFor(inst, dirID)
+	if !ok {
+		logger.Warnf("cannot resolve parent path for file %s (dir %s): skipping workspace reconciliation", fileID, dirID)
+		return
+	}
+	reconcileMembershipHTTP(inst.RAGServer(), inst.Domain, fileID, desired, kb.folders, logger)
+}
+
+// reconcileMembershipHTTP is the instance-free part of reconcileMembership,
+// split out so the diff/add/remove behavior can be unit-tested against an
+// httptest server.
+func reconcileMembershipHTTP(server config.RAGServer, domain, fileID string, desired []string, known map[string]string, logger logger.Logger) {
+	res, err := callRAG(server, http.MethodGet, nil, fmt.Sprintf("/partition/%s/files/%s/workspaces", domain, url.PathEscape(fileID)), echo.MIMEApplicationJSON)
+	if err != nil {
+		logger.Warnf("workspace membership check failed for %s: %s", fileID, err)
+		return
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		logger.Warnf("workspace membership check failed for %s: status code %d", fileID, res.StatusCode)
+		return
+	}
+	var body struct {
+		WorkspaceIDs []string `json:"workspace_ids"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		logger.Warnf("workspace membership check failed for %s: %s", fileID, err)
+		return
+	}
+	// openRAG may host workspaces the stack does not manage: they must not
+	// lose this file just because they are absent from `desired`.
+	var actual []string
+	for _, id := range body.WorkspaceIDs {
+		if _, ok := known[id]; ok {
+			actual = append(actual, id)
+		}
+	}
+	toAdd, toRemove := diffMembership(desired, actual)
+	for _, ws := range toAdd {
+		status, err := postWorkspaceFiles(server, domain, ws, []string{fileID})
+		if err != nil {
+			logger.Warnf("workspace add failed for %s in %s: %s", fileID, ws, err)
+		} else if status >= 300 {
+			logger.Warnf("workspace add failed for %s in %s: status code %d", fileID, ws, status)
+		}
+	}
+	for _, ws := range toRemove {
+		r, err := callRAG(server, http.MethodDelete, nil, fmt.Sprintf("/partition/%s/workspaces/%s/files/%s", domain, url.PathEscape(ws), url.PathEscape(fileID)), echo.MIMEApplicationJSON)
+		if err != nil {
+			logger.Warnf("workspace remove failed for %s in %s: %s", fileID, ws, err)
+			continue
+		}
+		r.Body.Close()
+		// 404: the file is already absent from the workspace, fine.
+		if r.StatusCode >= 300 && r.StatusCode != http.StatusNotFound {
+			logger.Warnf("workspace remove failed for %s in %s: status code %d", fileID, ws, r.StatusCode)
+		}
+	}
+}
+
+// ensureWorkspace makes sure the openRAG workspace mirroring the knowledge
+// base folder exists, creating it and backfilling its membership from the
+// folder subtree when needed. An error means the query MUST NOT proceed
+// unscoped.
+func ensureWorkspace(inst *instance.Instance, logger logger.Logger, dirID string) error {
+	// Serialize the concurrent queries racing on the same folder (the
+	// rag-query worker runs several jobs in parallel): without this, two
+	// first-time chats could both create and backfill the workspace, and the
+	// rollback of a failed backfill could delete the workspace the other
+	// query just successfully ensured.
+	mu := config.Lock().ReadWrite(inst, "rag-workspace/"+dirID)
+	if err := mu.Lock(); err != nil {
+		return err
+	}
+	defer mu.Unlock()
+	resolve := func() (string, []string, error) {
+		dir, err := inst.VFS().DirByID(dirID)
+		if err != nil {
+			return "", nil, fmt.Errorf("knowledge base folder %s: %w", dirID, err)
+		}
+		fileIDs, err := listFolderFileIDs(inst, dirID)
+		if err != nil {
+			return "", nil, err
+		}
+		return dir.DocName, fileIDs, nil
+	}
+	return ensureWorkspaceHTTP(inst.RAGServer(), inst.Domain, dirID, resolve, logger)
+}
+
+// ensureWorkspaceHTTP is the instance-free part of ensureWorkspace, split
+// out so the create/backfill/rollback behavior can be unit-tested against an
+// httptest server. `resolve` is a callback rather than precomputed values
+// because it must stay lazy: the workspace already exists for every message
+// but the first one, and resolving eagerly would make each of them pay a VFS
+// lookup and a full folder-subtree walk for nothing.
+func ensureWorkspaceHTTP(server config.RAGServer, domain, dirID string, resolve func() (displayName string, fileIDs []string, err error), logger logger.Logger) error {
+	exists, err := workspaceExists(server, domain, dirID)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+
+	// The partition may not exist yet on a fresh instance (same pattern as
+	// the completion 404 path in Query).
+	createRAGPartition(server, domain, logger)
+
+	displayName, fileIDs, err := resolve()
+	if err != nil {
+		return err
+	}
+
+	createBody, err := json.Marshal(map[string]interface{}{
+		"workspace_id": dirID,
+		"display_name": displayName,
+	})
+	if err != nil {
+		return err
+	}
+	createRes, err := callRAG(server, http.MethodPost, createBody, fmt.Sprintf("/partition/%s/workspaces", domain), echo.MIMEApplicationJSON)
+	if err != nil {
+		return err
+	}
+	createRes.Body.Close()
+	if !createdOrExists(createRes.StatusCode) {
+		return fmt.Errorf("workspace creation status code: %d", createRes.StatusCode)
+	}
+
+	for chunk := range slices.Chunk(fileIDs, workspaceBackfillChunkSize) {
+		if err := backfillChunk(server, domain, dirID, chunk, logger); err != nil {
+			// The workspace was just created but is incomplete, and a later
+			// ensureWorkspace call would see it exists (GET 200) and never
+			// retry the backfill: delete it so the next call starts over.
+			deleteWorkspace(server, domain, dirID, logger)
+			return err
+		}
+	}
+	return nil
+}
+
+// deleteWorkspace best-effort deletes a workspace whose membership backfill
+// failed. If the deletion itself fails, the workspace stays incomplete until
+// an operator or a future ensure path cleans it up: log loudly.
+func deleteWorkspace(server config.RAGServer, domain, dirID string, logger logger.Logger) {
+	res, err := callRAG(server, http.MethodDelete, nil, fmt.Sprintf("/partition/%s/workspaces/%s", domain, url.PathEscape(dirID)), echo.MIMEApplicationJSON)
+	if err != nil {
+		logger.Errorf("cannot rollback incomplete RAG workspace %s: %s", dirID, err)
+		return
+	}
+	res.Body.Close()
+	if res.StatusCode >= 300 && res.StatusCode != http.StatusNotFound {
+		logger.Errorf("cannot rollback incomplete RAG workspace %s: status code %d", dirID, res.StatusCode)
+	}
+}
+
+// workspaceExists tells whether the workspace exists on the openRAG server.
+func workspaceExists(server config.RAGServer, domain, dirID string) (bool, error) {
+	res, err := callRAG(server, http.MethodGet, nil, fmt.Sprintf("/partition/%s/workspaces/%s", domain, url.PathEscape(dirID)), echo.MIMEApplicationJSON)
+	if err != nil {
+		return false, err
+	}
+	res.Body.Close()
+	switch res.StatusCode {
+	case http.StatusOK:
+		return true, nil
+	case http.StatusNotFound:
+		return false, nil
+	default:
+		return false, fmt.Errorf("workspace check status code: %d", res.StatusCode)
+	}
+}
+
+// postWorkspaceFiles posts a batch of file ids to a workspace's /files
+// endpoint and returns the response status code.
+func postWorkspaceFiles(server config.RAGServer, domain, workspaceID string, ids []string) (int, error) {
+	body, err := json.Marshal(map[string]interface{}{"file_ids": ids})
+	if err != nil {
+		return 0, err
+	}
+	path := fmt.Sprintf("/partition/%s/workspaces/%s/files", domain, url.PathEscape(workspaceID))
+	res, err := callRAG(server, http.MethodPost, body, path, echo.MIMEApplicationJSON)
+	if err != nil {
+		return 0, err
+	}
+	res.Body.Close()
+	return res.StatusCode, nil
+}
+
+// backfillChunk posts one backfill chunk of file ids to the workspace.
+// openRAG's endpoint is all-or-nothing: ANY unknown file id in the chunk
+// yields a 404 and adds NONE of the chunk's ids, even the ones that are
+// indexed. When that happens, the chunk's ids are retried one by one so the
+// indexable files are still attached; per-id failures are expected for
+// non-indexed files (e.g. an image skipped by the indexer's class flags) and
+// are only logged, not treated as an ensure failure. A 5xx status (chunked
+// or per-id) means the indexer itself failed and is still an ensure failure
+// so the query does not proceed unscoped.
+func backfillChunk(server config.RAGServer, domain, dirID string, ids []string, logger logger.Logger) error {
+	status, err := postWorkspaceFiles(server, domain, dirID, ids)
+	if err != nil {
+		return err
+	}
+	if status != http.StatusNotFound {
+		if status >= 500 {
+			return fmt.Errorf("workspace backfill status code: %d", status)
+		}
+		if status >= 300 {
+			logger.Warnf("workspace backfill chunk rejected (status %d)", status)
+		}
+		return nil
+	}
+
+	// A 404 can mean "some file id in the chunk is not indexed" (benign) or
+	// "the workspace itself is gone" (the ensure MUST fail so the query does
+	// not proceed scoped to a nonexistent workspace): disambiguate before
+	// falling back to per-id retries.
+	exists, err := workspaceExists(server, domain, dirID)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return fmt.Errorf("workspace %s disappeared during backfill", dirID)
+	}
+
+	// At least one id in the chunk is unknown to openRAG: retry one by one.
+	for _, id := range ids {
+		idStatus, err := postWorkspaceFiles(server, domain, dirID, []string{id})
+		if err != nil {
+			return err
+		}
+		switch {
+		case idStatus >= 500:
+			return fmt.Errorf("workspace backfill status code: %d", idStatus)
+		case idStatus == http.StatusNotFound:
+			logger.Debugf("workspace backfill skipped file %s (not indexed)", id)
+		case idStatus >= 300:
+			logger.Infof("workspace backfill rejected file %s (status %d)", id, idStatus)
+		}
+	}
+	return nil
+}
+
+// listFolderFileIDs walks the folder subtree and returns the ids of the
+// (non-trashed) files it contains.
+func listFolderFileIDs(inst *instance.Instance, dirID string) ([]string, error) {
+	var ids []string
+	fs := inst.VFS()
+	err := vfs.WalkByID(fs, dirID, func(_ string, _ *vfs.DirDoc, file *vfs.FileDoc, err error) error {
+		if err != nil {
+			return err
+		}
+		if file != nil && !file.Trashed {
+			ids = append(ids, file.DocID)
+		}
+		return nil
+	})
+	return ids, err
+}
+
+// diffMembership compares the desired and actual workspace memberships of a
+// file and returns what must be added and removed.
+func diffMembership(desired, actual []string) (toAdd, toRemove []string) {
+	actualSet := make(map[string]bool, len(actual))
+	for _, id := range actual {
+		actualSet[id] = true
+	}
+	desiredSet := make(map[string]bool, len(desired))
+	for _, id := range desired {
+		desiredSet[id] = true
+		if !actualSet[id] {
+			toAdd = append(toAdd, id)
+		}
+	}
+	for _, id := range actual {
+		if !desiredSet[id] {
+			toRemove = append(toRemove, id)
+		}
+	}
+	return toAdd, toRemove
+}

--- a/model/rag/workspace_http_test.go
+++ b/model/rag/workspace_http_test.go
@@ -228,6 +228,38 @@ func TestEnsureWorkspaceHTTP(t *testing.T) {
 		assert.ElementsMatch(t, [][]string{{"file1"}, {"image1"}, {"file2"}}, singleIDBodies)
 	})
 
+	t.Run("backfill 403 is an ensure failure and rolls the workspace back", func(t *testing.T) {
+		// A 4xx other than 404 (e.g. an auth or permission problem) is
+		// systemic: succeeding would leave a silently incomplete workspace.
+		server, rec := newRAGTestServer(t, func(w http.ResponseWriter, req *http.Request) {
+			switch {
+			case req.Method == http.MethodGet && req.URL.Path == "/partition/dom/workspaces/folder1":
+				w.WriteHeader(http.StatusNotFound)
+			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom":
+				w.WriteHeader(http.StatusCreated)
+			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom/workspaces":
+				w.WriteHeader(http.StatusCreated)
+			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom/workspaces/folder1/files":
+				w.WriteHeader(http.StatusForbidden)
+			case req.Method == http.MethodDelete && req.URL.Path == "/partition/dom/workspaces/folder1":
+				w.WriteHeader(http.StatusOK)
+			default:
+				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			}
+		})
+
+		resolve := func() (string, []string, error) { return "My folder", []string{"file1"}, nil }
+		err := ensureWorkspaceHTTP(server, "dom", "folder1", resolve, testLogger())
+		require.Error(t, err)
+		var deletes int
+		for _, rr := range rec.all() {
+			if rr.Method == http.MethodDelete && rr.Path == "/partition/dom/workspaces/folder1" {
+				deletes++
+			}
+		}
+		assert.Equal(t, 1, deletes)
+	})
+
 	t.Run("backfill 404 with a vanished workspace is an ensure failure", func(t *testing.T) {
 		// A chunk 404 normally means "some file id is not indexed" and is
 		// retried per id. But when the workspace itself is gone (e.g. deleted

--- a/model/rag/workspace_http_test.go
+++ b/model/rag/workspace_http_test.go
@@ -1,0 +1,434 @@
+package rag
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/cozy/cozy-stack/pkg/config/config"
+	"github.com/cozy/cozy-stack/pkg/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordedRequest captures one request observed by a test httptest server.
+type recordedRequest struct {
+	Method string
+	Path   string
+	Body   []byte
+}
+
+// requestRecorder is a small thread-safe helper to record and assert on the
+// HTTP requests received by an httptest server.
+type requestRecorder struct {
+	mu       sync.Mutex
+	requests []recordedRequest
+}
+
+func (r *requestRecorder) record(req *http.Request) {
+	body, _ := io.ReadAll(req.Body)
+	req.Body.Close()
+	// Restore the body so the test's own handler can still read it.
+	req.Body = io.NopCloser(bytes.NewReader(body))
+	rr := recordedRequest{Method: req.Method, Path: req.URL.Path, Body: body}
+	r.mu.Lock()
+	r.requests = append(r.requests, rr)
+	r.mu.Unlock()
+}
+
+func (r *requestRecorder) all() []recordedRequest {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]recordedRequest, len(r.requests))
+	copy(out, r.requests)
+	return out
+}
+
+func (r *requestRecorder) countPath(path string) int {
+	n := 0
+	for _, rr := range r.all() {
+		if rr.Path == path {
+			n++
+		}
+	}
+	return n
+}
+
+func testLogger() logger.Logger {
+	return logger.WithNamespace("rag-test")
+}
+
+func newRAGTestServer(t *testing.T, handler http.HandlerFunc) (config.RAGServer, *requestRecorder) {
+	t.Helper()
+	rec := &requestRecorder{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		rec.record(req)
+		handler(w, req)
+	}))
+	t.Cleanup(srv.Close)
+	server := config.RAGServer{URL: srv.URL, APIKey: "test-key"}
+	return server, rec
+}
+
+func decodeFileIDs(t *testing.T, body []byte) []string {
+	t.Helper()
+	var payload struct {
+		FileIDs []string `json:"file_ids"`
+	}
+	require.NoError(t, json.Unmarshal(body, &payload))
+	return payload.FileIDs
+}
+
+// --- ensureWorkspaceHTTP ---------------------------------------------------
+
+func TestEnsureWorkspaceHTTP(t *testing.T) {
+	t.Run("workspace already exists: GET 200 short-circuits", func(t *testing.T) {
+		server, rec := newRAGTestServer(t, func(w http.ResponseWriter, req *http.Request) {
+			assert.Equal(t, http.MethodGet, req.Method)
+			assert.Equal(t, "/partition/example.mycozy.cloud/workspaces/folder1", req.URL.Path)
+			w.WriteHeader(http.StatusOK)
+		})
+
+		resolve := func() (string, []string, error) { return "My folder", []string{"file1"}, nil }
+		err := ensureWorkspaceHTTP(server, "example.mycozy.cloud", "folder1", resolve, testLogger())
+		require.NoError(t, err)
+		assert.Len(t, rec.all(), 1, "no further calls once the workspace is known to exist")
+	})
+
+	t.Run("workspace already exists: resolver is not called (laziness)", func(t *testing.T) {
+		server, rec := newRAGTestServer(t, func(w http.ResponseWriter, req *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		resolverCalled := false
+		resolve := func() (string, []string, error) {
+			resolverCalled = true
+			return "", nil, fmt.Errorf("resolver must not be called on GET 200")
+		}
+		err := ensureWorkspaceHTTP(server, "example.mycozy.cloud", "folder1", resolve, testLogger())
+		require.NoError(t, err)
+		assert.False(t, resolverCalled, "resolver must stay lazy on the GET-200 short-circuit")
+		assert.Len(t, rec.all(), 1)
+	})
+
+	t.Run("workspace missing: creates partition, workspace, and backfills", func(t *testing.T) {
+		server, rec := newRAGTestServer(t, func(w http.ResponseWriter, req *http.Request) {
+			switch {
+			case req.Method == http.MethodGet && req.URL.Path == "/partition/dom/workspaces/folder1":
+				w.WriteHeader(http.StatusNotFound)
+			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom":
+				w.WriteHeader(http.StatusCreated)
+			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom/workspaces":
+				body, _ := io.ReadAll(req.Body)
+				var payload map[string]string
+				require.NoError(t, json.Unmarshal(body, &payload))
+				assert.Equal(t, "folder1", payload["workspace_id"])
+				assert.Equal(t, "My folder", payload["display_name"])
+				w.WriteHeader(http.StatusCreated)
+			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom/workspaces/folder1/files":
+				body, _ := io.ReadAll(req.Body)
+				assert.Equal(t, []string{"file1", "file2"}, decodeFileIDs(t, body))
+				w.WriteHeader(http.StatusOK)
+			default:
+				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			}
+		})
+
+		resolve := func() (string, []string, error) { return "My folder", []string{"file1", "file2"}, nil }
+		err := ensureWorkspaceHTTP(server, "dom", "folder1", resolve, testLogger())
+		require.NoError(t, err)
+		assert.Equal(t, 1, rec.countPath("/partition/dom/workspaces/folder1"))
+		assert.Equal(t, 1, rec.countPath("/partition/dom"))
+		assert.Equal(t, 1, rec.countPath("/partition/dom/workspaces"))
+		assert.Equal(t, 1, rec.countPath("/partition/dom/workspaces/folder1/files"))
+	})
+
+	t.Run("workspace create 409 is tolerated and backfill still runs", func(t *testing.T) {
+		server, _ := newRAGTestServer(t, func(w http.ResponseWriter, req *http.Request) {
+			switch {
+			case req.Method == http.MethodGet && req.URL.Path == "/partition/dom/workspaces/folder1":
+				w.WriteHeader(http.StatusNotFound)
+			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom":
+				w.WriteHeader(http.StatusConflict)
+			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom/workspaces":
+				w.WriteHeader(http.StatusConflict)
+			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom/workspaces/folder1/files":
+				w.WriteHeader(http.StatusOK)
+			default:
+				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			}
+		})
+
+		resolve := func() (string, []string, error) { return "My folder", []string{"file1"}, nil }
+		err := ensureWorkspaceHTTP(server, "dom", "folder1", resolve, testLogger())
+		require.NoError(t, err)
+	})
+
+	t.Run("backfill chunk 404 falls back to per-id retries (CRITICAL fix)", func(t *testing.T) {
+		// openRAG's /files endpoint is all-or-nothing: any unknown id in the
+		// batch 404s and adds NONE of the ids, even the indexable ones. A
+		// single-id post must be attempted for every id in the chunk so
+		// indexable files still get attached.
+		var mu sync.Mutex
+		workspaceExists := false
+		server, rec := newRAGTestServer(t, func(w http.ResponseWriter, req *http.Request) {
+			mu.Lock()
+			defer mu.Unlock()
+			switch {
+			case req.Method == http.MethodGet && req.URL.Path == "/partition/dom/workspaces/folder1":
+				// 404 before creation; 200 for the disambiguation check that
+				// follows the chunk 404.
+				if workspaceExists {
+					w.WriteHeader(http.StatusOK)
+				} else {
+					w.WriteHeader(http.StatusNotFound)
+				}
+			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom":
+				w.WriteHeader(http.StatusCreated)
+			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom/workspaces":
+				workspaceExists = true
+				w.WriteHeader(http.StatusCreated)
+			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom/workspaces/folder1/files":
+				body, _ := io.ReadAll(req.Body)
+				ids := decodeFileIDs(t, body)
+				if len(ids) > 1 {
+					// batch contains the non-indexable "image1": reject all.
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				if ids[0] == "image1" {
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+			default:
+				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			}
+		})
+
+		resolve := func() (string, []string, error) { return "My folder", []string{"file1", "image1", "file2"}, nil }
+		err := ensureWorkspaceHTTP(server, "dom", "folder1", resolve, testLogger())
+		require.NoError(t, err)
+
+		var singleIDBodies [][]string
+		for _, rr := range rec.all() {
+			if rr.Method == http.MethodPost && rr.Path == "/partition/dom/workspaces/folder1/files" {
+				ids := decodeFileIDs(t, rr.Body)
+				if len(ids) == 1 {
+					singleIDBodies = append(singleIDBodies, ids)
+				}
+			}
+		}
+		// one retry per id in the rejected chunk
+		assert.ElementsMatch(t, [][]string{{"file1"}, {"image1"}, {"file2"}}, singleIDBodies)
+	})
+
+	t.Run("backfill 404 with a vanished workspace is an ensure failure", func(t *testing.T) {
+		// A chunk 404 normally means "some file id is not indexed" and is
+		// retried per id. But when the workspace itself is gone (e.g. deleted
+		// concurrently), the ensure must fail so the query does not proceed
+		// scoped to a nonexistent workspace.
+		var mu sync.Mutex
+		created := false
+		server, _ := newRAGTestServer(t, func(w http.ResponseWriter, req *http.Request) {
+			mu.Lock()
+			defer mu.Unlock()
+			switch {
+			case req.Method == http.MethodGet && req.URL.Path == "/partition/dom/workspaces/folder1":
+				// 404 on the initial check AND on the post-chunk-404
+				// disambiguation check: the workspace vanished after its
+				// creation was acknowledged.
+				w.WriteHeader(http.StatusNotFound)
+			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom":
+				w.WriteHeader(http.StatusCreated)
+			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom/workspaces":
+				created = true
+				w.WriteHeader(http.StatusCreated)
+			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom/workspaces/folder1/files":
+				w.WriteHeader(http.StatusNotFound)
+			case req.Method == http.MethodDelete && req.URL.Path == "/partition/dom/workspaces/folder1":
+				// rollback of the failed ensure
+				w.WriteHeader(http.StatusNotFound)
+			default:
+				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			}
+		})
+
+		resolve := func() (string, []string, error) { return "My folder", []string{"file1"}, nil }
+		err := ensureWorkspaceHTTP(server, "dom", "folder1", resolve, testLogger())
+		require.Error(t, err)
+		mu.Lock()
+		assert.True(t, created)
+		mu.Unlock()
+	})
+
+	t.Run("backfill 5xx is an ensure failure and rolls the workspace back", func(t *testing.T) {
+		server, rec := newRAGTestServer(t, func(w http.ResponseWriter, req *http.Request) {
+			switch {
+			case req.Method == http.MethodGet && req.URL.Path == "/partition/dom/workspaces/folder1":
+				w.WriteHeader(http.StatusNotFound)
+			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom":
+				w.WriteHeader(http.StatusCreated)
+			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom/workspaces":
+				w.WriteHeader(http.StatusCreated)
+			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom/workspaces/folder1/files":
+				w.WriteHeader(http.StatusInternalServerError)
+			case req.Method == http.MethodDelete && req.URL.Path == "/partition/dom/workspaces/folder1":
+				w.WriteHeader(http.StatusOK)
+			default:
+				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			}
+		})
+
+		resolve := func() (string, []string, error) { return "My folder", []string{"file1"}, nil }
+		err := ensureWorkspaceHTTP(server, "dom", "folder1", resolve, testLogger())
+		require.Error(t, err)
+
+		var deletes int
+		for _, rr := range rec.all() {
+			if rr.Method == http.MethodDelete && rr.Path == "/partition/dom/workspaces/folder1" {
+				deletes++
+			}
+		}
+		assert.Equal(t, 1, deletes, "the incomplete workspace must be deleted so a later ensure retries the backfill")
+	})
+
+	t.Run("failed backfill is retried from scratch on the next ensure", func(t *testing.T) {
+		// First ensure: the backfill 5xx-fails, the workspace is rolled back.
+		// Second ensure: the GET must see 404 again (not 200) and the whole
+		// create+backfill sequence must rerun and succeed.
+		var mu sync.Mutex
+		workspaceExists := false
+		failBackfill := true
+		server, rec := newRAGTestServer(t, func(w http.ResponseWriter, req *http.Request) {
+			mu.Lock()
+			defer mu.Unlock()
+			switch {
+			case req.Method == http.MethodGet && req.URL.Path == "/partition/dom/workspaces/folder1":
+				if workspaceExists {
+					w.WriteHeader(http.StatusOK)
+				} else {
+					w.WriteHeader(http.StatusNotFound)
+				}
+			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom":
+				w.WriteHeader(http.StatusCreated)
+			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom/workspaces":
+				workspaceExists = true
+				w.WriteHeader(http.StatusCreated)
+			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom/workspaces/folder1/files":
+				if failBackfill {
+					failBackfill = false
+					w.WriteHeader(http.StatusInternalServerError)
+				} else {
+					w.WriteHeader(http.StatusOK)
+				}
+			case req.Method == http.MethodDelete && req.URL.Path == "/partition/dom/workspaces/folder1":
+				workspaceExists = false
+				w.WriteHeader(http.StatusOK)
+			default:
+				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			}
+		})
+
+		resolve := func() (string, []string, error) { return "My folder", []string{"file1"}, nil }
+		require.Error(t, ensureWorkspaceHTTP(server, "dom", "folder1", resolve, testLogger()))
+		require.NoError(t, ensureWorkspaceHTTP(server, "dom", "folder1", resolve, testLogger()))
+
+		assert.Equal(t, 2, rec.countPath("/partition/dom/workspaces"),
+			"the workspace must be re-created by the second ensure")
+		assert.Equal(t, 2, rec.countPath("/partition/dom/workspaces/folder1/files"),
+			"the backfill must rerun after the rollback")
+	})
+}
+
+// --- reconcileMembershipHTTP -----------------------------------------------
+
+func TestReconcileMembershipHTTP(t *testing.T) {
+	t.Run("adds and removes exactly per diff", func(t *testing.T) {
+		server, rec := newRAGTestServer(t, func(w http.ResponseWriter, req *http.Request) {
+			switch {
+			case req.Method == http.MethodGet && req.URL.Path == "/partition/dom/files/file1/workspaces":
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"workspace_ids": []string{"ws-remove", "ws-keep"},
+				})
+			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom/workspaces/ws-add/files":
+				body, _ := io.ReadAll(req.Body)
+				assert.Equal(t, []string{"file1"}, decodeFileIDs(t, body))
+				w.WriteHeader(http.StatusOK)
+			case req.Method == http.MethodDelete && req.URL.Path == "/partition/dom/workspaces/ws-remove/files/file1":
+				w.WriteHeader(http.StatusOK)
+			default:
+				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			}
+		})
+
+		known := map[string]string{"ws-add": "/a", "ws-keep": "/b", "ws-remove": "/c"}
+		reconcileMembershipHTTP(server, "dom", "file1", []string{"ws-keep", "ws-add"}, known, testLogger())
+
+		assert.Equal(t, 1, rec.countPath("/partition/dom/workspaces/ws-add/files"))
+		assert.Equal(t, 1, rec.countPath("/partition/dom/workspaces/ws-remove/files/file1"))
+		assert.Equal(t, 0, rec.countPath("/partition/dom/workspaces/ws-keep/files"))
+	})
+
+	t.Run("foreign workspace in actual membership is never deleted", func(t *testing.T) {
+		// The file's actual openRAG membership includes a workspace id the
+		// stack does not manage (not in `known`). It must be left alone: no
+		// DELETE call for it, even though it is absent from `desired`.
+		server, rec := newRAGTestServer(t, func(w http.ResponseWriter, req *http.Request) {
+			switch {
+			case req.Method == http.MethodGet && req.URL.Path == "/partition/dom/files/file1/workspaces":
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"workspace_ids": []string{"ws-keep", "ws-foreign"},
+				})
+			case req.Method == http.MethodDelete:
+				t.Fatalf("unexpected DELETE for foreign workspace: %s", req.URL.Path)
+			default:
+				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+			}
+		})
+
+		known := map[string]string{"ws-keep": "/b"}
+		reconcileMembershipHTTP(server, "dom", "file1", []string{"ws-keep"}, known, testLogger())
+
+		for _, rr := range rec.all() {
+			assert.NotEqual(t, http.MethodDelete, rr.Method, "no delete should be issued for a foreign workspace")
+		}
+	})
+
+	t.Run("GET failure causes no mutations", func(t *testing.T) {
+		server, rec := newRAGTestServer(t, func(w http.ResponseWriter, req *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+
+		known := map[string]string{"ws-add": "/a"}
+		reconcileMembershipHTTP(server, "dom", "file1", []string{"ws-add"}, known, testLogger())
+
+		assert.Len(t, rec.all(), 1, "only the failed GET, no add/remove calls")
+	})
+}
+
+func TestNilKBContextIsEmpty(t *testing.T) {
+	// loadKBContext returns nil on any error or when no assistant declares a
+	// knowledge base: reconcileMembership relies on empty() to gate that.
+	var kb *kbContext
+	assert.True(t, kb.empty())
+}
+
+func TestDirIDEscaping(t *testing.T) {
+	// Folder ids are arbitrary CouchDB ids (UUIDs, fixed ids like the Drive
+	// root, or anything a client stored): when used as a workspace id they
+	// must stay a single URL path segment, whatever characters they contain.
+	server, _ := newRAGTestServer(t, func(w http.ResponseWriter, req *http.Request) {
+		assert.Equal(t, "/partition/dom/workspaces/kb%2F..%2F1", req.URL.EscapedPath())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	exists, err := workspaceExists(server, "dom", "kb/../1")
+	require.NoError(t, err)
+	assert.True(t, exists)
+}

--- a/model/rag/workspace_test.go
+++ b/model/rag/workspace_test.go
@@ -1,0 +1,69 @@
+package rag
+
+import (
+	"testing"
+
+	"github.com/cozy/cozy-stack/model/vfs"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKnowledgeBaseDirID(t *testing.T) {
+	t.Run("returns the dirId of the io.cozy.files entry", func(t *testing.T) {
+		a := &chatAssistant{KnowledgeBase: []knowledgeBaseEntry{
+			{Doctype: "com.linagora.email", DirID: "nope"},
+			{Doctype: "io.cozy.files", DirID: "folder-1"},
+		}}
+		assert.Equal(t, "folder-1", knowledgeBaseDirID(a, testLogger()))
+	})
+	t.Run("returns empty without knowledge base", func(t *testing.T) {
+		assert.Equal(t, "", knowledgeBaseDirID(&chatAssistant{}, testLogger()))
+		assert.Equal(t, "", knowledgeBaseDirID(nil, testLogger()))
+	})
+	t.Run("only the first files entry is used, extras are ignored", func(t *testing.T) {
+		a := &chatAssistant{KnowledgeBase: []knowledgeBaseEntry{
+			{Doctype: "io.cozy.files", DirID: "folder-1"},
+			{Doctype: "io.cozy.files", DirID: "folder-2"},
+		}}
+		assert.Equal(t, "folder-1", knowledgeBaseDirID(a, testLogger()))
+	})
+}
+
+func TestPruneMissingWorkspaces(t *testing.T) {
+	folders := map[string]string{
+		"kb1": "/Perso/HR",
+		"kb2": "/Projects",
+	}
+	// kb2's workspace does not exist in openRAG: it must never be desired,
+	// so it is pruned from the folder set.
+	pruneMissingWorkspaces(folders, []string{"kb1", "ws-foreign"})
+	assert.Equal(t, map[string]string{"kb1": "/Perso/HR"}, folders)
+
+	pruneMissingWorkspaces(folders, nil)
+	assert.Empty(t, folders)
+}
+
+func TestDiffMembership(t *testing.T) {
+	toAdd, toRemove := diffMembership([]string{"a", "b"}, []string{"b", "c"})
+	assert.Equal(t, []string{"a"}, toAdd)
+	assert.Equal(t, []string{"c"}, toRemove)
+
+	toAdd, toRemove = diffMembership(nil, nil)
+	assert.Empty(t, toAdd)
+	assert.Empty(t, toRemove)
+}
+
+func TestDesiredWorkspaces(t *testing.T) {
+	kb := kbContext{
+		// dirID -> folder path; loadKBContext only keeps folders whose
+		// workspace already exists in openRAG.
+		folders: map[string]string{
+			"kb1": "/Perso/HR",
+			"kb2": "/Projects",
+		},
+	}
+	assert.Equal(t, []string{"kb1"}, kb.desiredWorkspaces("/Perso/HR/contracts"))
+	assert.Equal(t, []string{"kb1"}, kb.desiredWorkspaces("/Perso/HR"))
+	assert.Empty(t, kb.desiredWorkspaces("/Perso/HRX")) // no false prefix match
+	assert.Empty(t, kb.desiredWorkspaces("/Elsewhere"))
+	assert.Empty(t, kb.desiredWorkspaces(vfs.TrashDirName+"/Perso/HR")) // trashed content
+}

--- a/model/rag/workspace_test.go
+++ b/model/rag/workspace_test.go
@@ -13,18 +13,18 @@ func TestKnowledgeBaseDirID(t *testing.T) {
 			{Doctype: "com.linagora.email", DirID: "nope"},
 			{Doctype: "io.cozy.files", DirID: "folder-1"},
 		}}
-		assert.Equal(t, "folder-1", knowledgeBaseDirID(a, testLogger()))
+		assert.Equal(t, "folder-1", a.knowledgeBaseDirID(testLogger()))
 	})
 	t.Run("returns empty without knowledge base", func(t *testing.T) {
-		assert.Equal(t, "", knowledgeBaseDirID(&chatAssistant{}, testLogger()))
-		assert.Equal(t, "", knowledgeBaseDirID(nil, testLogger()))
+		assert.Equal(t, "", (&chatAssistant{}).knowledgeBaseDirID(testLogger()))
+		assert.Equal(t, "", (*chatAssistant)(nil).knowledgeBaseDirID(testLogger()))
 	})
 	t.Run("only the first files entry is used, extras are ignored", func(t *testing.T) {
 		a := &chatAssistant{KnowledgeBase: []knowledgeBaseEntry{
 			{Doctype: "io.cozy.files", DirID: "folder-1"},
 			{Doctype: "io.cozy.files", DirID: "folder-2"},
 		}}
-		assert.Equal(t, "folder-1", knowledgeBaseDirID(a, testLogger()))
+		assert.Equal(t, "folder-1", a.knowledgeBaseDirID(testLogger()))
 	})
 }
 


### PR DESCRIPTION
An assistant (`io.cozy.ai.chat.assistants`) can now declare a knowledge base
pointing to a Drive folder:

```json
{ "knowledgeBase": [{ "doctype": "io.cozy.files", "dirId": "<dir-id>" }] }
```

Chat retrieval for conversations bound to such an assistant is then restricted
to that folder, using openRAG workspaces (a workspace mirrors the folder,
workspace_id = dirId).

**Chat path**

On each query, the stack ensures the workspace exists before forwarding the
completion with metadata.workspace:

- The workspace is created lazily on first use, and its membership is
backfilled from the folder subtree (chunked, with per-id retries when a
chunk contains non-indexed files, and a rollback on failure so the next
query restarts the backfill from scratch).
- Fail closed: if the assistant or the workspace cannot be resolved, the
query surfaces an error to the client rather than silently answering from
the whole instance.
- Concurrent queries on the same folder are serialized with a distributed
lock.

**Index path**

The rag-index worker keeps memberships in sync with the Drive tree:

- new/updated files carry their workspace_ids at upload;
- moves and renames (files, or whole directory subtrees via the changes feed)
are reconciled against the actual openRAG membership (GET + diff);
- the knowledge-base context is loaded once per batch, best-effort: an
indexing batch never fails because of workspace sync.

