### PR TITLE
feat(sharings): Add effective access resolver

### DIFF
--- a/model/sharing/effective_access.go
+++ b/model/sharing/effective_access.go
@@ -1,0 +1,271 @@
+package sharing
+
+import (
+	"os"
+	"path"
+
+	"github.com/cozy/cozy-stack/model/instance"
+	"github.com/cozy/cozy-stack/model/permission"
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
+)
+
+// SharingScope describes a single sharing scope that applies to a target file
+// or folder. It is produced by AccessResolver.scopesFor and consumed by
+// Resolve to aggregate an EffectiveAccess. ReadOnly reflects the current
+// instance's membership for that scope (via Sharing.MemberFor).
+type SharingScope struct {
+	SharingID  string
+	RootID     string
+	RootPath   string
+	AccessMode string
+	ReadOnly   bool
+}
+
+// EffectiveAccess is the merged result of all applicable additive sharing
+// scopes for a target, from the perspective of the current instance. CanRead
+// is true if the instance is a member of at least one applicable scope;
+// CanWrite is true if at least one such scope grants write (highest right
+// wins).
+type EffectiveAccess struct {
+	CanRead          bool
+	CanWrite         bool
+	SourceSharingIDs []string
+}
+
+// Can reports whether the effective access satisfies the given verb. GET
+// requires CanRead; POST, PUT, PATCH and DELETE require CanWrite.
+func (ea *EffectiveAccess) Can(verb permission.Verb) bool {
+	if ea == nil {
+		return false
+	}
+	switch verb {
+	case permission.GET:
+		return ea.CanRead
+	case permission.POST, permission.PUT, permission.PATCH, permission.DELETE:
+		return ea.CanWrite
+	}
+	return false
+}
+
+// AccessResolver computes the effective access for a target file or folder,
+// covering the target itself (if shared) plus all shared ancestors on its
+// path, filtered to scopes where the current instance is a member.
+type AccessResolver struct {
+	inst *instance.Instance
+}
+
+// NewAccessResolver builds an AccessResolver bound to an instance.
+func NewAccessResolver(inst *instance.Instance) *AccessResolver {
+	return &AccessResolver{inst: inst}
+}
+
+// Resolve returns the effective access for the given file or folder. The
+// target's own share (if it is a shared file) and the shares of every
+// ancestor directory are all considered. Scopes where the current instance
+// is not a member are ignored. The highest permission wins: CanRead if at
+// least one applicable scope, CanWrite if at least one non-read-only scope.
+func (r *AccessResolver) Resolve(targetID string) (*EffectiveAccess, error) {
+	scopes, err := r.scopesFor(targetID)
+	if err != nil {
+		return nil, err
+	}
+	ea := &EffectiveAccess{SourceSharingIDs: make([]string, 0, len(scopes))}
+	for _, sc := range scopes {
+		ea.SourceSharingIDs = append(ea.SourceSharingIDs, sc.SharingID)
+		ea.CanRead = true
+		if !sc.ReadOnly {
+			ea.CanWrite = true
+		}
+	}
+	return ea, nil
+}
+
+// scopesFor loads the target, builds ancestor paths, finds shared roots on
+// the path, adds the target's own file share if any, bulk-loads sharings,
+// filters to active additive ones where the current instance is a member,
+// and returns the resulting scopes.
+func (r *AccessResolver) scopesFor(targetID string) ([]SharingScope, error) {
+	fs := r.inst.VFS()
+
+	dir, file, err := fs.DirOrFileByID(targetID)
+	if err != nil {
+		return nil, err
+	}
+	if dir == nil && file == nil {
+		return nil, os.ErrNotExist
+	}
+
+	var targetPath string
+	if dir != nil {
+		targetPath = dir.Fullpath
+	} else {
+		targetPath, err = file.Path(fs)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	ancestorPaths := r.ancestorPaths(targetPath, dir != nil)
+
+	// XXX: single find via dir-by-path + Go-side referenced_by filter, rather
+	// than a dedicated shared-folder-roots-by-path view — one fewer view to
+	// maintain while N ancestors is small.
+	paths := make([]any, len(ancestorPaths))
+	for i, p := range ancestorPaths {
+		paths[i] = p
+	}
+	type sharedRootDoc struct {
+		ID           string                 `json:"_id"`
+		Path         string                 `json:"path"`
+		ReferencedBy []couchdb.DocReference `json:"referenced_by"`
+	}
+	var roots []sharedRootDoc
+	if len(paths) > 0 {
+		req := &couchdb.FindRequest{
+			UseIndex: "dir-by-path",
+			Selector: mango.And(
+				mango.In("path", paths),
+				mango.Equal("type", consts.DirType),
+				mango.Exists(couchdb.SelectorReferencedBy),
+			),
+			Fields: []string{"_id", "path", "referenced_by"},
+			Limit:  len(paths),
+		}
+		if err := couchdb.FindDocs(r.inst, consts.Files, req, &roots); err != nil {
+			return nil, err
+		}
+	}
+
+	// Collect (sharingID -> {rootID, rootPath}) from ancestor dir roots.
+	type rootInfo struct {
+		RootID   string
+		RootPath string
+	}
+	rootBySharing := make(map[string]rootInfo)
+	for _, root := range roots {
+		for _, ref := range root.ReferencedBy {
+			if ref.Type == consts.Sharings {
+				if _, ok := rootBySharing[ref.ID]; !ok {
+					rootBySharing[ref.ID] = rootInfo{RootID: root.ID, RootPath: root.Path}
+				}
+			}
+		}
+	}
+
+	// XXX: DirType selector excludes the file from the Mango find; its
+	// own scopes are added by hand so file shares stay additive at the target
+	// level.
+	if file != nil {
+		for _, ref := range file.ReferencedBy {
+			if ref.Type == consts.Sharings {
+				if _, ok := rootBySharing[ref.ID]; !ok {
+					rootBySharing[ref.ID] = rootInfo{RootID: file.DocID, RootPath: targetPath}
+				}
+			}
+		}
+	}
+
+	if len(rootBySharing) == 0 {
+		return nil, nil
+	}
+
+	sharingIDs := make([]string, 0, len(rootBySharing))
+	for id := range rootBySharing {
+		sharingIDs = append(sharingIDs, id)
+	}
+
+	sharings, err := r.loadSharings(sharingIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	scopes := make([]SharingScope, 0, len(sharings))
+	for _, s := range sharings {
+		info, ok := rootBySharing[s.SID]
+		if !ok {
+			continue
+		}
+		member := s.MemberFor(r.inst)
+		if member == nil {
+			continue
+		}
+		scopes = append(scopes, SharingScope{
+			SharingID:  s.SID,
+			RootID:     info.RootID,
+			RootPath:   info.RootPath,
+			AccessMode: s.EffectiveAccessMode(),
+			ReadOnly:   member.ReadOnly,
+		})
+	}
+	return scopes, nil
+}
+
+// ancestorPaths returns the directory paths to query for shared roots. When
+// the target is a directory, its own path is included (a dir can be a shared
+// root). When the target is a file, only its parent directories are included.
+func (r *AccessResolver) ancestorPaths(targetPath string, targetIsDir bool) []string {
+	var paths []string
+	current := path.Clean(targetPath)
+	if !targetIsDir {
+		current = path.Dir(current)
+	}
+	for {
+		if current == "" || current == "." {
+			break
+		}
+		paths = append(paths, current)
+		if current == "/" {
+			break
+		}
+		parent := path.Dir(current)
+		if parent == current {
+			break
+		}
+		current = parent
+	}
+	return paths
+}
+
+// loadSharings bulk-loads sharings by ID and keeps only the active additive
+// ones. limited_access sharings are dropped in v1. Membership filtering is
+// done by the caller (scopesFor) so this helper stays reusable.
+func (r *AccessResolver) loadSharings(ids []string) ([]*Sharing, error) {
+	sharings, err := FindSharings(r.inst, ids)
+	if err != nil {
+		return nil, err
+	}
+	kept := make([]*Sharing, 0, len(sharings))
+	for _, s := range sharings {
+		if s == nil {
+			continue
+		}
+		if !s.Active {
+			continue
+		}
+		if s.EffectiveAccessMode() != AccessModeAdditive {
+			continue
+		}
+		kept = append(kept, s)
+	}
+	return kept, nil
+}
+
+// NearestRestrictiveBoundary returns the closest limited_access boundary
+// applying to the target. v1 has no limited_access mode, so it always
+// returns nil.
+//
+// XXX: reserved for limited_access). v1 returns no boundary; upgrade path is
+// to walk ancestors and stop at the first limited_access scope.
+func (r *AccessResolver) NearestRestrictiveBoundary(targetID string) (*SharingScope, error) {
+	return nil, nil
+}
+
+// ChildSharedRootsUnder returns shared roots nested under the given folder.
+// v1 has no caller for it yet, so it returns nil.
+//
+// XXX: reserved for recursive move/copy/delete.
+func (r *AccessResolver) ChildSharedRootsUnder(folderID string) ([]SharingScope, error) {
+	return nil, nil
+}

--- a/model/sharing/effective_access_test.go
+++ b/model/sharing/effective_access_test.go
@@ -1,0 +1,474 @@
+package sharing
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/cozy/cozy-stack/model/instance"
+	"github.com/cozy/cozy-stack/model/permission"
+	"github.com/cozy/cozy-stack/pkg/config/config"
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/tests/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccessResolver_AncestorsOnly(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+	config.UseTestFile(t)
+	testutils.NeedCouchdb(t)
+	setup := testutils.NewSetup(t, t.Name())
+	inst := setup.GetTestInstance()
+	fs := inst.VFS()
+
+	tree := H{"parent/": H{"child/": H{}}}
+	parent := createTree(t, fs, tree, consts.RootDirID)
+	child, err := fs.DirByPath(parent.Fullpath + "/child")
+	require.NoError(t, err)
+
+	s := createActiveDirSharing(t, inst, parent.ID())
+
+	resolver := NewAccessResolver(inst)
+	scopes, err := resolver.scopesFor(child.ID())
+	require.NoError(t, err)
+	require.Len(t, scopes, 1)
+	assert.Equal(t, s.SID, scopes[0].SharingID)
+	assert.Equal(t, parent.ID(), scopes[0].RootID)
+	assert.Equal(t, parent.Fullpath, scopes[0].RootPath)
+
+	ea, err := resolver.Resolve(child.ID())
+	require.NoError(t, err)
+	assert.True(t, ea.CanRead)
+	assert.True(t, ea.CanWrite)
+	assert.True(t, ea.Can(permission.GET))
+	assert.True(t, ea.Can(permission.PUT))
+}
+
+func TestAccessResolver_SelfAndAncestor(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+	config.UseTestFile(t)
+	testutils.NeedCouchdb(t)
+	setup := testutils.NewSetup(t, t.Name())
+	inst := setup.GetTestInstance()
+	fs := inst.VFS()
+
+	tree := H{"parent/": H{"child/": H{}}}
+	parent := createTree(t, fs, tree, consts.RootDirID)
+	child, err := fs.DirByPath(parent.Fullpath + "/child")
+	require.NoError(t, err)
+
+	sParent := createActiveDirSharing(t, inst, parent.ID())
+	sChild := createActiveDirSharing(t, inst, child.ID())
+
+	resolver := NewAccessResolver(inst)
+	scopes, err := resolver.scopesFor(child.ID())
+	require.NoError(t, err)
+	require.Len(t, scopes, 2)
+	got := map[string]SharingScope{}
+	for _, sc := range scopes {
+		got[sc.SharingID] = sc
+	}
+	assert.Contains(t, got, sParent.SID)
+	assert.Contains(t, got, sChild.SID)
+	assert.Equal(t, child.ID(), got[sChild.SID].RootID)
+}
+
+func TestAccessResolver_SkipsInactive(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+	config.UseTestFile(t)
+	testutils.NeedCouchdb(t)
+	setup := testutils.NewSetup(t, t.Name())
+	inst := setup.GetTestInstance()
+	fs := inst.VFS()
+
+	tree := H{"parent/": H{"child/": H{}}}
+	parent := createTree(t, fs, tree, consts.RootDirID)
+	child, err := fs.DirByPath(parent.Fullpath + "/child")
+	require.NoError(t, err)
+
+	s := createActiveDirSharing(t, inst, parent.ID())
+	s.Active = false
+	require.NoError(t, couchdb.UpdateDoc(inst, s))
+
+	resolver := NewAccessResolver(inst)
+	scopes, err := resolver.scopesFor(child.ID())
+	require.NoError(t, err)
+	assert.Empty(t, scopes)
+}
+
+func TestAccessResolver_SkipsLimitedAccess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+	config.UseTestFile(t)
+	testutils.NeedCouchdb(t)
+	setup := testutils.NewSetup(t, t.Name())
+	inst := setup.GetTestInstance()
+	fs := inst.VFS()
+
+	tree := H{"parent/": H{"child/": H{}}}
+	parent := createTree(t, fs, tree, consts.RootDirID)
+	child, err := fs.DirByPath(parent.Fullpath + "/child")
+	require.NoError(t, err)
+
+	s := createActiveDirSharing(t, inst, parent.ID())
+	s.AccessMode = AccessModeLimitedAccess
+	require.NoError(t, couchdb.UpdateDoc(inst, s))
+
+	resolver := NewAccessResolver(inst)
+	scopes, err := resolver.scopesFor(child.ID())
+	require.NoError(t, err)
+	assert.Empty(t, scopes)
+}
+
+func TestAccessResolver_FileTargetWithOwnShare(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+	config.UseTestFile(t)
+	testutils.NeedCouchdb(t)
+	setup := testutils.NewSetup(t, t.Name())
+	inst := setup.GetTestInstance()
+	fs := inst.VFS()
+
+	tree := H{"parent/": H{"file.txt": nil}}
+	parent := createTree(t, fs, tree, consts.RootDirID)
+	file, err := fs.FileByPath(parent.Fullpath + "/file.txt")
+	require.NoError(t, err)
+
+	s := createActiveFileSharing(t, inst, file.ID())
+
+	resolver := NewAccessResolver(inst)
+	scopes, err := resolver.scopesFor(file.ID())
+	require.NoError(t, err)
+	require.Len(t, scopes, 1)
+	assert.Equal(t, s.SID, scopes[0].SharingID)
+	assert.Equal(t, file.ID(), scopes[0].RootID)
+}
+
+func TestAccessResolver_FileTargetInSharedDir(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+	config.UseTestFile(t)
+	testutils.NeedCouchdb(t)
+	setup := testutils.NewSetup(t, t.Name())
+	inst := setup.GetTestInstance()
+	fs := inst.VFS()
+
+	tree := H{"parent/": H{"file.txt": nil}}
+	parent := createTree(t, fs, tree, consts.RootDirID)
+	file, err := fs.FileByPath(parent.Fullpath + "/file.txt")
+	require.NoError(t, err)
+
+	s := createActiveDirSharing(t, inst, parent.ID())
+
+	resolver := NewAccessResolver(inst)
+	scopes, err := resolver.scopesFor(file.ID())
+	require.NoError(t, err)
+	require.Len(t, scopes, 1)
+	assert.Equal(t, s.SID, scopes[0].SharingID)
+	assert.Equal(t, parent.ID(), scopes[0].RootID)
+}
+
+func TestAccessResolver_FileTargetAdditive(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+	config.UseTestFile(t)
+	testutils.NeedCouchdb(t)
+	setup := testutils.NewSetup(t, t.Name())
+	inst := setup.GetTestInstance()
+	fs := inst.VFS()
+
+	tree := H{"parent/": H{"file.txt": nil}}
+	parent := createTree(t, fs, tree, consts.RootDirID)
+	file, err := fs.FileByPath(parent.Fullpath + "/file.txt")
+	require.NoError(t, err)
+
+	sParent := createActiveDirSharing(t, inst, parent.ID())
+	sFile := createActiveFileSharing(t, inst, file.ID())
+
+	resolver := NewAccessResolver(inst)
+	scopes, err := resolver.scopesFor(file.ID())
+	require.NoError(t, err)
+	require.Len(t, scopes, 2)
+	got := map[string]SharingScope{}
+	for _, sc := range scopes {
+		got[sc.SharingID] = sc
+	}
+	assert.Contains(t, got, sParent.SID)
+	assert.Contains(t, got, sFile.SID)
+	assert.Equal(t, file.ID(), got[sFile.SID].RootID)
+	assert.Equal(t, parent.ID(), got[sParent.SID].RootID)
+}
+
+func TestAccessResolver_NotFound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+	config.UseTestFile(t)
+	testutils.NeedCouchdb(t)
+	setup := testutils.NewSetup(t, t.Name())
+	inst := setup.GetTestInstance()
+
+	resolver := NewAccessResolver(inst)
+	ea, err := resolver.Resolve("does-not-exist")
+	require.Error(t, err)
+	assert.True(t, os.IsNotExist(err))
+	assert.Nil(t, ea)
+}
+
+func TestAccessResolver_NearestRestrictiveBoundaryStub(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+	config.UseTestFile(t)
+	testutils.NeedCouchdb(t)
+	setup := testutils.NewSetup(t, t.Name())
+	inst := setup.GetTestInstance()
+
+	resolver := NewAccessResolver(inst)
+	b, err := resolver.NearestRestrictiveBoundary("whatever")
+	require.NoError(t, err)
+	assert.Nil(t, b)
+
+	roots, err := resolver.ChildSharedRootsUnder("whatever")
+	require.NoError(t, err)
+	assert.Nil(t, roots)
+}
+
+func TestAccessResolver_ReadOnlyRecipient(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+	config.UseTestFile(t)
+	testutils.NeedCouchdb(t)
+	setup := testutils.NewSetup(t, t.Name())
+	inst := setup.GetTestInstance()
+	fs := inst.VFS()
+
+	tree := H{"parent/": H{"child/": H{}}}
+	parent := createTree(t, fs, tree, consts.RootDirID)
+	child, err := fs.DirByPath(parent.Fullpath + "/child")
+	require.NoError(t, err)
+
+	createActiveRecipientSharing(t, inst, parent.ID(), true)
+
+	resolver := NewAccessResolver(inst)
+	ea, err := resolver.Resolve(child.ID())
+	require.NoError(t, err)
+	assert.True(t, ea.CanRead)
+	assert.False(t, ea.CanWrite)
+	assert.True(t, ea.Can(permission.GET))
+	assert.False(t, ea.Can(permission.PUT))
+}
+
+func TestAccessResolver_HighestChildScopeWins(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+	config.UseTestFile(t)
+	testutils.NeedCouchdb(t)
+	setup := testutils.NewSetup(t, t.Name())
+	inst := setup.GetTestInstance()
+	fs := inst.VFS()
+
+	tree := H{"parent/": H{"child/": H{}}}
+	parent := createTree(t, fs, tree, consts.RootDirID)
+	child, err := fs.DirByPath(parent.Fullpath + "/child")
+	require.NoError(t, err)
+
+	createActiveRecipientSharing(t, inst, parent.ID(), true)
+	createActiveRecipientSharing(t, inst, child.ID(), false)
+
+	resolver := NewAccessResolver(inst)
+	ea, err := resolver.Resolve(child.ID())
+	require.NoError(t, err)
+	assert.True(t, ea.CanRead)
+	assert.True(t, ea.CanWrite)
+	assert.True(t, ea.Can(permission.GET))
+	assert.True(t, ea.Can(permission.PUT))
+	assert.Len(t, ea.SourceSharingIDs, 2)
+}
+
+func TestAccessResolver_HighestParentScopeWins(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+	config.UseTestFile(t)
+	testutils.NeedCouchdb(t)
+	setup := testutils.NewSetup(t, t.Name())
+	inst := setup.GetTestInstance()
+	fs := inst.VFS()
+
+	tree := H{"parent/": H{"child/": H{}}}
+	parent := createTree(t, fs, tree, consts.RootDirID)
+	child, err := fs.DirByPath(parent.Fullpath + "/child")
+	require.NoError(t, err)
+
+	createActiveRecipientSharing(t, inst, parent.ID(), false)
+	createActiveRecipientSharing(t, inst, child.ID(), true)
+
+	resolver := NewAccessResolver(inst)
+	ea, err := resolver.Resolve(child.ID())
+	require.NoError(t, err)
+	assert.True(t, ea.CanRead)
+	assert.True(t, ea.CanWrite)
+	assert.True(t, ea.Can(permission.GET))
+	assert.True(t, ea.Can(permission.PUT))
+	assert.Len(t, ea.SourceSharingIDs, 2)
+}
+
+func TestAccessResolver_NotAMember(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+	config.UseTestFile(t)
+	testutils.NeedCouchdb(t)
+	setup := testutils.NewSetup(t, t.Name())
+	inst := setup.GetTestInstance()
+	fs := inst.VFS()
+
+	tree := H{"parent/": H{"child/": H{}}}
+	parent := createTree(t, fs, tree, consts.RootDirID)
+	child, err := fs.DirByPath(parent.Fullpath + "/child")
+	require.NoError(t, err)
+
+	createActiveRecipientSharing(t, inst, parent.ID(), false, "https://someone-else.cozy.tools")
+
+	resolver := NewAccessResolver(inst)
+	ea, err := resolver.Resolve(child.ID())
+	require.NoError(t, err)
+	assert.False(t, ea.CanRead)
+	assert.False(t, ea.CanWrite)
+	assert.False(t, ea.Can(permission.GET))
+	assert.Empty(t, ea.SourceSharingIDs)
+}
+
+func TestAccessResolver_RevokedMemberSkipped(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+	config.UseTestFile(t)
+	testutils.NeedCouchdb(t)
+	setup := testutils.NewSetup(t, t.Name())
+	inst := setup.GetTestInstance()
+	fs := inst.VFS()
+
+	tree := H{"parent/": H{"child/": H{}}}
+	parent := createTree(t, fs, tree, consts.RootDirID)
+	child, err := fs.DirByPath(parent.Fullpath + "/child")
+	require.NoError(t, err)
+
+	s := createActiveRecipientSharing(t, inst, parent.ID(), false)
+	s.Members[1].Status = MemberStatusRevoked
+	require.NoError(t, couchdb.UpdateDoc(inst, s))
+
+	resolver := NewAccessResolver(inst)
+	ea, err := resolver.Resolve(child.ID())
+	require.NoError(t, err)
+	assert.False(t, ea.CanRead)
+	assert.False(t, ea.CanWrite)
+	assert.Empty(t, ea.SourceSharingIDs)
+}
+
+// createActiveDirSharing creates and persists an active additive sharing owned
+// by the current instance (owner → write access), with a directory root.
+func createActiveDirSharing(t *testing.T, inst *instance.Instance, rootID string) *Sharing {
+	t.Helper()
+	return createSharing(t, inst, rootID, true, false, DriveRootTypeDirectory, "")
+}
+
+// createActiveFileSharing creates and persists an active additive sharing
+// owned by the current instance, with a single-file root.
+func createActiveFileSharing(t *testing.T, inst *instance.Instance, rootID string) *Sharing {
+	t.Helper()
+	return createSharing(t, inst, rootID, true, false, DriveRootTypeFile, "")
+}
+
+// createActiveRecipientSharing creates and persists an active additive sharing
+// where the current instance is a recipient (not the owner). readOnly sets the
+// recipient's ReadOnly flag. When memberInstance is empty, the member's
+// Instance is set to the current instance's domain; otherwise the given
+// memberInstance is used (to simulate a non-member).
+func createActiveRecipientSharing(t *testing.T, inst *instance.Instance, rootID string, readOnly bool, memberInstance ...string) *Sharing {
+	t.Helper()
+	mi := ""
+	if len(memberInstance) > 0 {
+		mi = memberInstance[0]
+	}
+	return createSharing(t, inst, rootID, false, readOnly, DriveRootTypeDirectory, mi)
+}
+
+func createSharing(t *testing.T, inst *instance.Instance, rootID string, owner bool, readOnly bool, rootType string, recipientInstance string) *Sharing {
+	t.Helper()
+	now := time.Now()
+
+	var members []Member
+	if owner {
+		name, err := inst.SettingsPublicName()
+		require.NoError(t, err)
+		email, err := inst.SettingsEMail()
+		require.NoError(t, err)
+
+		members = []Member{
+			{
+				Status:   MemberStatusOwner,
+				Name:     name,
+				Email:    email,
+				Instance: "https://" + inst.Domain,
+			},
+		}
+	} else {
+		instVal := recipientInstance
+		if instVal == "" {
+			instVal = "https://" + inst.Domain
+		}
+
+		members = []Member{
+			{
+				Status:   MemberStatusOwner,
+				Name:     "Alice",
+				Email:    "alice@cozy.tools",
+				Instance: "https://owner.cozy.tools",
+			},
+			{
+				Status:   MemberStatusReady,
+				Name:     inst.Domain,
+				Instance: instVal,
+				ReadOnly: readOnly,
+			},
+		}
+	}
+
+	s := &Sharing{
+		Active:        true,
+		Owner:         owner,
+		Drive:         true,
+		DriveRootType: rootType,
+		AppSlug:       "test",
+		AccessMode:    AccessModeAdditive,
+		Members:       members,
+		Rules: []Rule{
+			{
+				Title:   "test",
+				DocType: consts.Files,
+				Values:  []string{rootID},
+			},
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	require.NoError(t, couchdb.CreateDoc(inst, s))
+	require.NoError(t, s.AddReferenceForSharing(inst, &s.Rules[0]))
+	return s
+}

--- a/model/sharing/member.go
+++ b/model/sharing/member.go
@@ -629,6 +629,41 @@ func (s *Sharing) FindMemberByState(state string) (*Member, error) {
 	return nil, ErrMemberNotFound
 }
 
+// MemberFor returns the member of the sharing that corresponds to the given
+// instance (the owner entry on the owner's Cozy, the matching recipient
+// entry on a recipient's Cozy), or nil if the instance is not a member.
+// Revoked members are not returned.
+func (s *Sharing) MemberFor(inst *instance.Instance) *Member {
+	if s.Owner {
+		if len(s.Members) == 0 {
+			return nil
+		}
+		return &s.Members[0]
+	}
+	currDomain := inst.Domain
+	if i := strings.IndexByte(currDomain, ':'); i >= 0 {
+		currDomain = currDomain[:i]
+	}
+	currEmail, _ := inst.SettingsEMail()
+	for i := range s.Members {
+		m := &s.Members[i]
+		if m.Status == MemberStatusRevoked {
+			continue
+		}
+		memberHost := m.InstanceHost()
+		if memberHost == "" {
+			continue
+		}
+		if memberHost == inst.Domain || memberHost == currDomain {
+			return m
+		}
+		if currEmail != "" && m.Email == currEmail {
+			return m
+		}
+	}
+	return nil
+}
+
 // FindMemberBySharecode returns the member that is linked to the sharing by
 // the given sharecode
 func (s *Sharing) FindMemberBySharecode(db prefixer.Prefixer, sharecode string) (*Member, error) {

--- a/model/sharing/member_test.go
+++ b/model/sharing/member_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
 	"github.com/cozy/cozy-stack/pkg/jsonapi"
 	"github.com/cozy/cozy-stack/tests/testutils"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -515,4 +516,68 @@ func TestGetInteractCodeConcurrentCalls(t *testing.T) {
 	require.NoError(t, couchdb.FindDocs(inst, consts.Permissions, &req, &perms))
 	require.Len(t, perms, 1)
 	require.Equal(t, permission.ShareInteractPermissionID(sharingID), perms[0].ID())
+}
+
+func TestMemberFor(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+	config.UseTestFile(t)
+	testutils.NeedCouchdb(t)
+	setup := testutils.NewSetup(t, t.Name())
+	inst := setup.GetTestInstance()
+
+	t.Run("Owner", func(t *testing.T) {
+		s := &Sharing{
+			Owner: true,
+			Members: []Member{
+				{Status: MemberStatusOwner, Name: "Alice", Email: "alice@cozy.tools"},
+			},
+		}
+		m := s.MemberFor(inst)
+		if assert.NotNil(t, m) {
+			assert.Equal(t, MemberStatusOwner, m.Status)
+		}
+	})
+
+	t.Run("OwnerNoMembers", func(t *testing.T) {
+		s := &Sharing{Owner: true}
+		assert.Nil(t, s.MemberFor(inst))
+	})
+
+	t.Run("RecipientByDomain", func(t *testing.T) {
+		s := &Sharing{
+			Owner: false,
+			Members: []Member{
+				{Status: MemberStatusOwner, Instance: "https://owner.cozy.tools"},
+				{Status: MemberStatusReady, Instance: "https://" + inst.Domain, ReadOnly: true},
+			},
+		}
+		m := s.MemberFor(inst)
+		if assert.NotNil(t, m) {
+			assert.True(t, m.ReadOnly)
+		}
+	})
+
+	t.Run("NotAMember", func(t *testing.T) {
+		s := &Sharing{
+			Owner: false,
+			Members: []Member{
+				{Status: MemberStatusOwner, Instance: "https://owner.cozy.tools"},
+				{Status: MemberStatusReady, Instance: "https://charlie.cozy.tools"},
+			},
+		}
+		assert.Nil(t, s.MemberFor(inst))
+	})
+
+	t.Run("RevokedMemberSkipped", func(t *testing.T) {
+		s := &Sharing{
+			Owner: false,
+			Members: []Member{
+				{Status: MemberStatusOwner, Instance: "https://owner.cozy.tools"},
+				{Status: MemberStatusRevoked, Instance: "https://" + inst.Domain, ReadOnly: false},
+			},
+		}
+		assert.Nil(t, s.MemberFor(inst))
+	})
 }

--- a/model/sharing/oauth.go
+++ b/model/sharing/oauth.go
@@ -108,6 +108,7 @@ func (m *Member) CreateSharingRequest(inst *instance.Instance, s *Sharing, c *Cr
 			Active:        false,
 			Owner:         false,
 			Open:          s.Open,
+			AccessMode:    s.AccessMode,
 			Description:   s.Description,
 			AppSlug:       s.AppSlug,
 			PreviewPath:   s.PreviewPath,

--- a/model/sharing/oauth_test.go
+++ b/model/sharing/oauth_test.go
@@ -1,0 +1,90 @@
+package sharing
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/cozy/cozy-stack/model/instance"
+	build "github.com/cozy/cozy-stack/pkg/config"
+	"github.com/cozy/cozy-stack/pkg/config/config"
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateSharingRequestPropagatesAccessMode(t *testing.T) {
+	config.UseTestFile(t)
+	inst := &instance.Instance{Domain: "alice.example.net"}
+
+	// safehttp blocks loopback addresses outside dev mode; enable it so the
+	// in-memory httptest server is reachable.
+	oldBuildMode := build.BuildMode
+	build.BuildMode = build.ModeDev
+	t.Cleanup(func() { build.BuildMode = oldBuildMode })
+
+	newSharing := func(accessMode string) *Sharing {
+		return &Sharing{
+			SID:        "sharing-access-mode-test-" + accessMode,
+			AppSlug:    "testapp",
+			AccessMode: accessMode,
+			Rules: []Rule{{
+				Title:   "contacts",
+				DocType: consts.Contacts,
+				Values:  []string{"io.cozy.contacts"},
+			}},
+			Members:     []Member{{Email: "bob@example.net", Instance: "recipient"}},
+			Credentials: []Credentials{{XorKey: []byte{0x01, 0x02}, State: "state-" + accessMode}},
+		}
+	}
+
+	startCaptureServer := func() (*httptest.Server, chan []byte) {
+		bodyCh := make(chan []byte, 1)
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			b, _ := io.ReadAll(r.Body)
+			bodyCh <- b
+			w.WriteHeader(http.StatusOK)
+		}))
+		return srv, bodyCh
+	}
+
+	extractAttrs := func(t *testing.T, raw []byte) map[string]interface{} {
+		t.Helper()
+		var body map[string]interface{}
+		require.NoError(t, json.Unmarshal(raw, &body))
+		data, ok := body["data"].(map[string]interface{})
+		require.True(t, ok, "missing data envelope")
+		attrs, ok := data["attributes"].(map[string]interface{})
+		require.True(t, ok, "missing data.attributes")
+		return attrs
+	}
+
+	t.Run("limited_access is propagated to recipient", func(t *testing.T) {
+		srv, bodyCh := startCaptureServer()
+		defer srv.Close()
+		u, err := url.Parse(srv.URL)
+		require.NoError(t, err)
+
+		s := newSharing(AccessModeLimitedAccess)
+		require.NoError(t, (&s.Members[0]).CreateSharingRequest(inst, s, &s.Credentials[0], u))
+
+		attrs := extractAttrs(t, <-bodyCh)
+		require.Equal(t, AccessModeLimitedAccess, attrs["access_mode"])
+	})
+
+	t.Run("empty access mode is omitted on the wire", func(t *testing.T) {
+		srv, bodyCh := startCaptureServer()
+		defer srv.Close()
+		u, err := url.Parse(srv.URL)
+		require.NoError(t, err)
+
+		s := newSharing("")
+		require.NoError(t, (&s.Members[0]).CreateSharingRequest(inst, s, &s.Credentials[0], u))
+
+		attrs := extractAttrs(t, <-bodyCh)
+		_, present := attrs["access_mode"]
+		require.False(t, present, "access_mode should be omitted when empty (default additive)")
+	})
+}

--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -45,6 +45,14 @@ const (
 	DriveRootTypeDirectory = "directory"
 	// DriveRootTypeFile means the shared drive root is a single file.
 	DriveRootTypeFile = "file"
+
+	// AccessModeAdditive is the default access mode for nested shared folders:
+	// parent access applies to children, and child scopes can add access.
+	AccessModeAdditive = "additive"
+	// AccessModeLimitedAccess is reserved for a future feature where a child
+	// folder becomes a restrictive boundary. It is stored but not activated
+	// in v1.
+	AccessModeLimitedAccess = "limited_access"
 )
 
 // Triggers keep record of which triggers are active
@@ -67,6 +75,7 @@ type Sharing struct {
 	Active        bool      `json:"active,omitempty"`
 	Owner         bool      `json:"owner,omitempty"`
 	Open          bool      `json:"open_sharing,omitempty"`
+	AccessMode    string    `json:"access_mode,omitempty"` // additive (default) | limited_access (reserved)
 	Description   string    `json:"description,omitempty"`
 	AppSlug       string    `json:"app_slug"`
 	PreviewPath   string    `json:"preview_path,omitempty"`
@@ -246,6 +255,15 @@ func (s *Sharing) ReadOnlyRules() bool {
 // forces a read-only mode.
 func (s *Sharing) ReadOnly() bool {
 	return s.ReadOnlyFlag() || s.ReadOnlyRules()
+}
+
+// EffectiveAccessMode returns the sharing's access mode, defaulting to
+// AccessModeAdditive when the field is empty for backwards compatibility.
+func (s *Sharing) EffectiveAccessMode() string {
+	if s.AccessMode == "" {
+		return AccessModeAdditive
+	}
+	return s.AccessMode
 }
 
 // BeOwner initializes a sharing on the cozy of its owner


### PR DESCRIPTION
  Add `AccessResolver` to compute the effective access to a file or
  folder from the additive sharing scopes on its path. `Resolve(targetID)`
  returns an `*EffectiveAccess` with `CanRead`/`CanWrite` aggregated
  highest-wins across all active additive scopes where the current
  instance is a member (via `Sharing.MemberFor`). The target's own
  share (for shared files) and every shared ancestor directory are
  considered. `EffectiveAccess.Can(verb)` maps `GET` to `CanRead` and
  the write verbs to `CanWrite`. `limited_access` scopes are filtered
  out in v1; `NearestRestrictiveBoundary` and `ChildSharedRootsUnder`
  are reserved as no-op stubs for that future mode.

  Fixes #4837 