### PR TITLE
fix(sharing): refresh delegated recipient removal tokens

### DIFF
--- a/web/sharings/drives_test.go
+++ b/web/sharings/drives_test.go
@@ -627,6 +627,10 @@ func newDriveOwnerTestServerWithOptions(
 	token := generateAppToken(inst, "drive", consts.Files)
 
 	routes := mergeRouteHandlers(map[string]func(*echo.Group){
+		"/auth": func(g *echo.Group) {
+			g.Use(middlewares.LoadSession)
+			auth.Routes(g)
+		},
 		"/files":    files.Routes,
 		"/sharings": sharings.Routes,
 	}, extraRoutes)
@@ -2632,6 +2636,65 @@ func TestSharedDriveDelegatedRecipientRemoval(t *testing.T) {
 		eDave.GET("/sharings/drives/"+sharingID+"/"+fileID).
 			WithHeader("Authorization", "Bearer "+env.daveToken).
 			Expect().Status(http.StatusForbidden)
+	})
+
+	t.Run("ExpiredAccessTokenIsRefreshedForLocalOwner", func(t *testing.T) {
+		sharingID, _, _ := createSharedDrive(
+			t,
+			DriveCreationMethodLegacy,
+			env.acme,
+			env.acmeToken,
+			env.tsA.URL,
+			"Delegated Recipient Removal Expired Token Drive",
+			"Drive for expired delegated recipient token tests",
+			nil,
+		)
+		acceptSharedDriveForBetty(t, env.acme, env.betty, env.tsA.URL, env.tsB.URL, sharingID)
+		acceptSharedDrive(t, env.acme, env.dave, "Dave", env.tsA.URL, env.tsD.URL, sharingID)
+
+		previousLocalInstanceFromURL := sharings.LocalInstanceFromURL
+		sharings.LocalInstanceFromURL = func(rawURL string) *instance.Instance {
+			if rawURL == env.tsA.URL {
+				return env.acme
+			}
+			return previousLocalInstanceFromURL(rawURL)
+		}
+		t.Cleanup(func() {
+			sharings.LocalInstanceFromURL = previousLocalInstanceFromURL
+		})
+
+		recipientSharing, err := sharing.FindSharing(env.betty, sharingID)
+		require.NoError(t, err)
+		require.NotEmpty(t, recipientSharing.Credentials)
+		credentials := &recipientSharing.Credentials[0]
+		require.NotNil(t, credentials.Client)
+		require.NotNil(t, credentials.AccessToken)
+		require.NotEmpty(t, credentials.AccessToken.RefreshToken)
+
+		expiredToken, err := env.acme.MakeJWT(
+			consts.AccessTokenAudience,
+			credentials.Client.ClientID,
+			credentials.AccessToken.Scope,
+			"",
+			time.Now().Add(-consts.AccessTokenValidityDuration-time.Minute),
+		)
+		require.NoError(t, err)
+		credentials.AccessToken.AccessToken = expiredToken
+		require.NoError(t, couchdb.UpdateDoc(env.betty, recipientSharing))
+
+		eBetty.DELETE("/sharings/"+sharingID+"/recipients/2").
+			WithHeader("Authorization", "Bearer "+env.bettyToken).
+			Expect().Status(http.StatusNoContent).
+			Header(echo.HeaderWWWAuthenticate).Empty()
+
+		removed := findSharingMemberByEmail(t, env.acme, sharingID, "dave@example.net")
+		require.Equal(t, sharing.MemberStatusRevoked, removed.Status)
+
+		refreshedSharing, err := sharing.FindSharing(env.betty, sharingID)
+		require.NoError(t, err)
+		require.NotEmpty(t, refreshedSharing.Credentials)
+		require.NotNil(t, refreshedSharing.Credentials[0].AccessToken)
+		require.NotEqual(t, expiredToken, refreshedSharing.Credentials[0].AccessToken.AccessToken)
 	})
 
 	t.Run("ReadOnlyRecipientCannotRemoveAnotherRecipient", func(t *testing.T) {

--- a/web/sharings/revoke.go
+++ b/web/sharings/revoke.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/cozy/cozy-stack/model/instance"
+	"github.com/cozy/cozy-stack/model/permission"
 	"github.com/cozy/cozy-stack/model/sharing"
 	"github.com/cozy/cozy-stack/pkg/jsonapi"
 	"github.com/cozy/cozy-stack/web/middlewares"
@@ -55,21 +57,46 @@ func RevokeRecipient(c echo.Context) error {
 		go s.NotifyRecipients(inst, nil)
 		return c.NoContent(http.StatusNoContent)
 	}
-	if owner := sharing.LocalInstanceFromURL(s.Members[0].Instance); owner != nil && owner.Domain != inst.Domain {
+	if owner := LocalInstanceFromURL(s.Members[0].Instance); owner != nil && owner.Domain != inst.Domain {
 		if len(s.Credentials) == 0 || s.Credentials[0].AccessToken == nil {
 			return wrapErrors(sharing.ErrInvalidSharing)
 		}
-		// Re-enter the owner-side handler so delegated calls keep the same authorization path.
-		c.Request().Header.Set(echo.HeaderAuthorization, "Bearer "+s.Credentials[0].AccessToken.AccessToken)
-		middlewares.ForcePermission(c, nil)
-		c.Set("claims", nil)
-		middlewares.SetInstance(c, owner)
-		return RevokeRecipient(c)
+		return delegateRevokeRecipientLocally(c, inst, owner, s)
 	}
 	if err = s.DelegateRevokeRecipient(inst, index); err != nil {
 		return wrapErrors(err)
 	}
 	return c.NoContent(http.StatusNoContent)
+}
+
+func delegateRevokeRecipientLocally(
+	c echo.Context,
+	recipient, owner *instance.Instance,
+	s *sharing.Sharing,
+) error {
+	credentials := &s.Credentials[0]
+	err := callRevokeRecipientOnOwner(c, owner, credentials.AccessToken.AccessToken)
+	if !errors.Is(err, permission.ErrExpiredToken) {
+		return err
+	}
+
+	if err = credentials.Refresh(recipient, s, &s.Members[0]); err != nil {
+		return wrapErrors(err)
+	}
+	if credentials.AccessToken == nil {
+		return wrapErrors(sharing.ErrNoOAuthClient)
+	}
+	return callRevokeRecipientOnOwner(c, owner, credentials.AccessToken.AccessToken)
+}
+
+func callRevokeRecipientOnOwner(c echo.Context, owner *instance.Instance, accessToken string) error {
+	// Re-enter the owner-side handler so delegated calls keep the same authorization path.
+	c.Response().Header().Del(echo.HeaderWWWAuthenticate)
+	c.Request().Header.Set(echo.HeaderAuthorization, "Bearer "+accessToken)
+	middlewares.ForcePermission(c, nil)
+	c.Set("claims", nil)
+	middlewares.SetInstance(c, owner)
+	return RevokeRecipient(c)
 }
 
 func authorizeRevokeRecipient(c echo.Context, s *sharing.Sharing) error {


### PR DESCRIPTION
## Summary

- Refresh an expired sharing OAuth token before retrying same-stack delegated recipient removal.
- Clear cached authorization state and stale authentication response headers between attempts.
- Cover local-owner removal with an expired token and persisted refreshed credentials.
