### PR TITLE
fix(sharing): handle contact group update events

### DIFF
--- a/model/job/trigger_share_group.go
+++ b/model/job/trigger_share_group.go
@@ -21,6 +21,7 @@ type ShareGroupMessage struct {
 	GroupsRemoved   []string         `json:"removed,omitempty"`
 	BecomeInvitable bool             `json:"invitable,omitempty"`
 	DeletedDoc      *couchdb.JSONDoc `json:"deleted_doc,omitempty"`
+	DeletedGroupID  string           `json:"deleted_group_id,omitempty"`
 	RenamedGroup    *couchdb.JSONDoc `json:"renamed_group,omitempty"`
 }
 
@@ -65,6 +66,19 @@ func (t *ShareGroupTrigger) match(e *realtime.Event) *ShareGroupMessage {
 }
 
 func (t *ShareGroupTrigger) matchGroup(e *realtime.Event) *ShareGroupMessage {
+	if e.Verb == realtime.EventDelete {
+		olddoc, ok := groupJSONDoc(e.OldDoc)
+		if !ok {
+			t.log.WithFields(logger.Fields{
+				"domain":   e.Domain,
+				"doc_type": e.Doc.DocType(),
+				"doc_id":   e.Doc.ID(),
+				"verb":     e.Verb,
+			}).Warnf("trigger share-group: unsupported old group document type %T", e.OldDoc)
+			return nil
+		}
+		return &ShareGroupMessage{DeletedGroupID: olddoc.ID()}
+	}
 	if e.Verb != realtime.EventUpdate {
 		return nil
 	}
@@ -210,6 +224,8 @@ func (t *ShareGroupTrigger) pushJob(e *realtime.Event, msg *ShareGroupMessage) {
 	})
 	if msg.RenamedGroup != nil {
 		log = log.WithField("group_id", msg.RenamedGroup.ID())
+	} else if msg.DeletedGroupID != "" {
+		log = log.WithField("group_id", msg.DeletedGroupID)
 	}
 	m, err := NewMessage(msg)
 	if err != nil {

--- a/model/job/trigger_share_group.go
+++ b/model/job/trigger_share_group.go
@@ -51,7 +51,11 @@ func (t *ShareGroupTrigger) match(e *realtime.Event) *ShareGroupMessage {
 	if e.Verb == realtime.EventNotify {
 		return nil
 	}
-	switch e.Doc.DocType() {
+	docType := e.Doc.DocType()
+	if docType == "" && e.OldDoc != nil {
+		docType = e.OldDoc.DocType()
+	}
+	switch docType {
 	case consts.Groups:
 		return t.matchGroup(e)
 	case consts.Contacts:
@@ -109,7 +113,7 @@ func (t *ShareGroupTrigger) matchContact(e *realtime.Event) *ShareGroupMessage {
 
 	var oldgroups []string
 	invitable := false
-	olddoc, ok := e.OldDoc.(*couchdb.JSONDoc)
+	olddoc, ok := contactJSONDoc(e.OldDoc)
 	if ok {
 		oldContact := &contact.Contact{JSONDoc: *olddoc}
 		oldgroups = oldContact.GroupIDs()
@@ -133,6 +137,21 @@ func (t *ShareGroupTrigger) matchContact(e *realtime.Event) *ShareGroupMessage {
 		msg.DeletedDoc = olddoc
 	}
 	return msg
+}
+
+// contactJSONDoc returns the generic document embedded in each supported
+// contact event representation. couchdb.UpdateDoc keeps the old document in
+// the caller's concrete type (*contact.Contact), while RTEvent clones the new
+// document through JSONDoc.Clone and publishes it as *couchdb.JSONDoc.
+func contactJSONDoc(doc realtime.Doc) (*couchdb.JSONDoc, bool) {
+	switch doc := doc.(type) {
+	case *couchdb.JSONDoc:
+		return doc, true
+	case *contact.Contact:
+		return &doc.JSONDoc, true
+	default:
+		return nil, false
+	}
 }
 
 func diffGroupIDs(as, bs []string) []string {

--- a/model/job/trigger_share_group.go
+++ b/model/job/trigger_share_group.go
@@ -70,10 +70,22 @@ func (t *ShareGroupTrigger) matchGroup(e *realtime.Event) *ShareGroupMessage {
 	}
 	newdoc, ok := groupJSONDoc(e.Doc)
 	if !ok {
+		t.log.WithFields(logger.Fields{
+			"domain":   e.Domain,
+			"doc_type": e.Doc.DocType(),
+			"doc_id":   e.Doc.ID(),
+			"verb":     e.Verb,
+		}).Warnf("trigger share-group: unsupported group document type %T", e.Doc)
 		return nil
 	}
 	olddoc, ok := groupJSONDoc(e.OldDoc)
 	if !ok {
+		t.log.WithFields(logger.Fields{
+			"domain":   e.Domain,
+			"doc_type": e.Doc.DocType(),
+			"doc_id":   e.Doc.ID(),
+			"verb":     e.Verb,
+		}).Warnf("trigger share-group: unsupported old group document type %T", e.OldDoc)
 		return nil
 	}
 	newGroup := &contact.Group{JSONDoc: *newdoc}
@@ -187,7 +199,18 @@ func contactIsNowInvitable(oldContact, newContact *contact.Contact) bool {
 }
 
 func (t *ShareGroupTrigger) pushJob(e *realtime.Event, msg *ShareGroupMessage) {
-	log := t.log.WithField("domain", e.Domain)
+	log := t.log.WithFields(logger.Fields{
+		"contact_id":           msg.ContactID,
+		"domain":               e.Domain,
+		"groups_added":         msg.GroupsAdded,
+		"groups_added_count":   len(msg.GroupsAdded),
+		"groups_removed":       msg.GroupsRemoved,
+		"groups_removed_count": len(msg.GroupsRemoved),
+		"verb":                 e.Verb,
+	})
+	if msg.RenamedGroup != nil {
+		log = log.WithField("group_id", msg.RenamedGroup.ID())
+	}
 	m, err := NewMessage(msg)
 	if err != nil {
 		log.Infof("trigger share-group: cannot serialize message: %s", err)
@@ -197,7 +220,7 @@ func (t *ShareGroupTrigger) pushJob(e *realtime.Event, msg *ShareGroupMessage) {
 		WorkerType: "share-group",
 		Message:    m,
 	}
-	log.Infof("trigger share-group: Pushing new job for contact %s", msg.ContactID)
+	log.Info("trigger share-group: Pushing new job")
 	if _, err := t.broker.PushJob(e, req); err != nil {
 		log.Errorf("trigger share-group: Could not schedule a new job: %s", err.Error())
 	}

--- a/model/job/trigger_share_group_test.go
+++ b/model/job/trigger_share_group_test.go
@@ -89,6 +89,27 @@ func TestShareGroupTrigger(t *testing.T) {
 		require.Same(t, updated, msg.RenamedGroup)
 	})
 
+	t.Run("The group is deleted", func(t *testing.T) {
+		group := contact.NewGroup()
+		group.SetID("id-marketing")
+		group.SetRev("1-abcdef")
+		group.M["name"] = "Marketing"
+
+		deleted := group.JSONDoc.Clone().(*couchdb.JSONDoc)
+		deleted.Type = ""
+		deleted.SetRev("2-abcdef")
+		deleted.M["_deleted"] = true
+
+		msg := trigger.match(&realtime.Event{
+			Doc:    deleted,
+			OldDoc: group,
+			Verb:   realtime.EventDelete,
+		})
+
+		require.NotNil(t, msg)
+		assert.Equal(t, "id-marketing", msg.DeletedGroupID)
+	})
+
 	t.Run("The RabbitMQ contact update has a typed old document", func(t *testing.T) {
 		oldDoc := contactDocWithGroups("contact-bob", "id-friends")
 		oldDoc.Type = ""

--- a/model/job/trigger_share_group_test.go
+++ b/model/job/trigger_share_group_test.go
@@ -71,13 +71,13 @@ func TestShareGroupTrigger(t *testing.T) {
 		oldGroup := contact.NewGroup()
 		oldGroup.SetID("id-marketing")
 		oldGroup.SetRev("1-abcdef")
-		oldGroup.Type = consts.Groups
 		oldGroup.M["name"] = "Marketing"
 		oldGroup.M["color"] = "#3367D6"
 
 		updated := oldGroup.JSONDoc.Clone().(*couchdb.JSONDoc)
 		updated.SetRev("2-abcdef")
 		updated.M["color"] = "#A142F4"
+		require.Empty(t, updated.DocType())
 
 		msg := trigger.match(&realtime.Event{
 			Doc:    updated,
@@ -87,6 +87,66 @@ func TestShareGroupTrigger(t *testing.T) {
 
 		require.NotNil(t, msg)
 		require.Same(t, updated, msg.RenamedGroup)
+	})
+
+	t.Run("The RabbitMQ contact update has a typed old document", func(t *testing.T) {
+		oldDoc := contactDocWithGroups("contact-bob", "id-friends")
+		oldDoc.Type = ""
+		oldContact := &contact.Contact{JSONDoc: *oldDoc}
+		updated := oldContact.Clone().(*couchdb.JSONDoc)
+		updated.M["relationships"] = contactDocWithGroups(
+			"contact-bob", "id-friends", "id-football",
+		).M["relationships"]
+		updated.SetRev("2-abcdef")
+		require.Empty(t, updated.DocType())
+
+		msg := trigger.match(&realtime.Event{
+			Doc:    updated,
+			OldDoc: oldContact,
+			Verb:   realtime.EventUpdate,
+		})
+
+		require.NotNil(t, msg)
+		assert.Equal(t, "contact-bob", msg.ContactID)
+		assert.Equal(t, []string{"id-football"}, msg.GroupsAdded)
+		assert.Empty(t, msg.GroupsRemoved)
+
+		oldContact = &contact.Contact{JSONDoc: *updated}
+		removed := oldContact.Clone().(*couchdb.JSONDoc)
+		removed.M["relationships"] = contactDocWithGroups(
+			"contact-bob", "id-friends",
+		).M["relationships"]
+		removed.SetRev("3-abcdef")
+		msg = trigger.match(&realtime.Event{
+			Doc:    removed,
+			OldDoc: oldContact,
+			Verb:   realtime.EventUpdate,
+		})
+
+		require.NotNil(t, msg)
+		assert.Empty(t, msg.GroupsAdded)
+		assert.Equal(t, []string{"id-football"}, msg.GroupsRemoved)
+	})
+
+	t.Run("The RabbitMQ contact becomes invitable with a typed old document", func(t *testing.T) {
+		oldDoc := contactDocWithGroups("contact-charlie", "id-friends")
+		oldContact := &contact.Contact{JSONDoc: *oldDoc}
+		updated := oldDoc.Clone().(*couchdb.JSONDoc)
+		updated.SetRev("2-abcdef")
+		updated.M["email"] = []interface{}{
+			map[string]interface{}{"address": "charlie@example.net"},
+		}
+
+		msg := trigger.match(&realtime.Event{
+			Doc:    updated,
+			OldDoc: oldContact,
+			Verb:   realtime.EventUpdate,
+		})
+
+		require.NotNil(t, msg)
+		assert.Empty(t, msg.GroupsAdded)
+		assert.Empty(t, msg.GroupsRemoved)
+		assert.True(t, msg.BecomeInvitable)
 	})
 
 	t.Run("The contact becomes invitable", func(t *testing.T) {
@@ -255,4 +315,27 @@ func TestShareGroupTrigger(t *testing.T) {
 		assert.EqualValues(t, msg.GroupsRemoved, []string{"id-friends"})
 		assert.False(t, msg.BecomeInvitable)
 	})
+}
+
+func contactDocWithGroups(id string, groupIDs ...string) *couchdb.JSONDoc {
+	refs := make([]interface{}, 0, len(groupIDs))
+	for _, groupID := range groupIDs {
+		refs = append(refs, map[string]interface{}{
+			"_id":   groupID,
+			"_type": consts.Groups,
+		})
+	}
+	return &couchdb.JSONDoc{
+		Type: consts.Contacts,
+		M: map[string]interface{}{
+			"_id":      id,
+			"_rev":     "1-abcdef",
+			"fullname": "Contact " + id,
+			"relationships": map[string]interface{}{
+				"groups": map[string]interface{}{
+					"data": refs,
+				},
+			},
+		},
+	}
 }

--- a/model/job/trigger_share_group_test.go
+++ b/model/job/trigger_share_group_test.go
@@ -90,13 +90,16 @@ func TestShareGroupTrigger(t *testing.T) {
 	})
 
 	t.Run("The group is deleted", func(t *testing.T) {
-		group := contact.NewGroup()
-		group.SetID("id-marketing")
-		group.SetRev("1-abcdef")
-		group.M["name"] = "Marketing"
+		group := &couchdb.JSONDoc{
+			Type: consts.Groups,
+			M: map[string]interface{}{
+				"_id":  "id-marketing",
+				"_rev": "1-abcdef",
+				"name": "Marketing",
+			},
+		}
 
-		deleted := group.JSONDoc.Clone().(*couchdb.JSONDoc)
-		deleted.Type = ""
+		deleted := group.Clone().(*couchdb.JSONDoc)
 		deleted.SetRev("2-abcdef")
 		deleted.M["_deleted"] = true
 

--- a/model/sharing/group.go
+++ b/model/sharing/group.go
@@ -58,11 +58,7 @@ func (s *Sharing) AddGroup(inst *instance.Instance, groupID string, readOnly boo
 		if err != nil {
 			return err
 		}
-		pos := sort.SearchInts(s.Members[idx].Groups, groupIndex)
-		if pos == len(s.Members[idx].Groups) || s.Members[idx].Groups[pos] != groupIndex {
-			s.Members[idx].Groups = append(s.Members[idx].Groups, groupIndex)
-			sort.Ints(s.Members[idx].Groups)
-		}
+		addGroupToMember(&s.Members[idx], groupIndex)
 	}
 
 	g := Group{
@@ -226,6 +222,9 @@ func updateGroupMetadata(inst *instance.Instance, doc *couchdb.JSONDoc) error {
 
 // AddMemberToGroup adds a contact to a sharing via a group (on the owner).
 func (s *Sharing) AddMemberToGroup(inst *instance.Instance, groupIndex int, contact *contact.Contact) error {
+	if s.contactIsMemberOfGroup(groupIndex, contact) {
+		return nil
+	}
 	readOnly := s.Groups[groupIndex].ReadOnly
 	m := buildMemberFromContact(contact, readOnly)
 	m.OnlyInGroups = true
@@ -233,8 +232,7 @@ func (s *Sharing) AddMemberToGroup(inst *instance.Instance, groupIndex int, cont
 	if err != nil {
 		return err
 	}
-	s.Members[idx].Groups = append(s.Members[idx].Groups, groupIndex)
-	sort.Ints(s.Members[idx].Groups)
+	addGroupToMember(&s.Members[idx], groupIndex)
 
 	// We can ignore the error as we will try again to save the sharing
 	// after sending the invitation.
@@ -255,6 +253,9 @@ func (s *Sharing) AddMemberToGroup(inst *instance.Instance, groupIndex int, cont
 
 // DelegateAddMemberToGroup adds a contact to a sharing via a group (on a recipient).
 func (s *Sharing) DelegateAddMemberToGroup(inst *instance.Instance, groupIndex int, contact *contact.Contact) error {
+	if s.contactIsMemberOfGroup(groupIndex, contact) {
+		return nil
+	}
 	readOnly := s.Groups[groupIndex].ReadOnly
 	m := buildMemberFromContact(contact, readOnly)
 	m.OnlyInGroups = true
@@ -264,6 +265,44 @@ func (s *Sharing) DelegateAddMemberToGroup(inst *instance.Instance, groupIndex i
 		members: []Member{m},
 	}
 	return s.SendDelegated(inst, api)
+}
+
+func addGroupToMember(member *Member, groupIndex int) bool {
+	for _, index := range member.Groups {
+		if index == groupIndex {
+			return false
+		}
+	}
+	member.Groups = append(member.Groups, groupIndex)
+	sort.Ints(member.Groups)
+	return true
+}
+
+func (s *Sharing) contactIsMemberOfGroup(groupIndex int, c *contact.Contact) bool {
+	var email string
+	if addr, err := c.ToMailAddress(); err == nil {
+		email = addr.Email
+	}
+	cozyURL := c.PrimaryCozyURL()
+
+	for i, member := range s.Members {
+		if i == 0 {
+			continue
+		}
+		matches := email != "" && member.Email == email
+		if email == "" && cozyURL != "" {
+			matches = member.Instance == cozyURL
+		}
+		if !matches {
+			continue
+		}
+		for _, index := range member.Groups {
+			if index == groupIndex {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // RemoveMemberFromGroup removes a member of a group.

--- a/model/sharing/group.go
+++ b/model/sharing/group.go
@@ -90,19 +90,9 @@ func (s *Sharing) RevokeGroup(inst *instance.Instance, index int) error {
 		if !inGroup {
 			continue
 		}
-		if len(m.Groups) == 1 {
-			s.Members[i].Groups = nil
-		} else {
-			var groups []int
-			for _, idx := range m.Groups {
-				if idx != index {
-					groups = append(groups, idx)
-				}
-			}
-			s.Members[i].Groups = groups
-		}
+		removeGroupFromMember(&s.Members[i], index)
 		if m.OnlyInGroups && len(s.Members[i].Groups) == 0 {
-			if err := s.RevokeRecipient(inst, i); err != nil {
+			if err := s.revokeRecipientAfterRemovingGroup(inst, i, index); err != nil {
 				errm = multierror.Append(errm, err)
 			}
 		}
@@ -304,6 +294,16 @@ func addGroupToMember(member *Member, groupIndex int) bool {
 	return true
 }
 
+func removeGroupFromMember(member *Member, groupIndex int) {
+	var groups []int
+	for _, index := range member.Groups {
+		if index != groupIndex {
+			groups = append(groups, index)
+		}
+	}
+	member.Groups = groups
+}
+
 func (s *Sharing) contactIsMemberOfGroup(groupIndex int, c *contact.Contact) bool {
 	var email string
 	if addr, err := c.ToMailAddress(); err == nil {
@@ -354,16 +354,10 @@ func (s *Sharing) RemoveMemberFromGroup(inst *instance.Instance, groupIndex int,
 			continue
 		}
 
-		var groups []int
-		for _, idx := range m.Groups {
-			if idx != groupIndex {
-				groups = append(groups, idx)
-			}
-		}
-		s.Members[i].Groups = groups
+		removeGroupFromMember(&s.Members[i], groupIndex)
 
 		if m.OnlyInGroups && len(s.Members[i].Groups) == 0 {
-			return s.RevokeRecipient(inst, i)
+			return s.revokeRecipientAfterRemovingGroup(inst, i, groupIndex)
 		} else {
 			return couchdb.UpdateDoc(inst, s)
 		}
@@ -425,16 +419,10 @@ func (s *Sharing) SendRemoveMemberFromGroup(inst *instance.Instance, groupIndex,
 }
 
 func (s *Sharing) DelegatedRemoveMemberFromGroup(inst *instance.Instance, groupIndex, memberIndex int) error {
-	var groups []int
-	for _, idx := range s.Members[memberIndex].Groups {
-		if idx != groupIndex {
-			groups = append(groups, idx)
-		}
-	}
-	s.Members[memberIndex].Groups = groups
+	removeGroupFromMember(&s.Members[memberIndex], groupIndex)
 
 	if s.Members[memberIndex].OnlyInGroups && len(s.Members[memberIndex].Groups) == 0 {
-		return s.RevokeRecipient(inst, memberIndex)
+		return s.revokeRecipientAfterRemovingGroup(inst, memberIndex, groupIndex)
 	} else {
 		return couchdb.UpdateDoc(inst, s)
 	}

--- a/model/sharing/group.go
+++ b/model/sharing/group.go
@@ -132,6 +132,9 @@ func UpdateGroups(inst *instance.Instance, msg job.ShareGroupMessage) error {
 	if msg.RenamedGroup != nil {
 		return updateGroupMetadata(inst, msg.RenamedGroup)
 	}
+	if msg.DeletedGroupID != "" {
+		return revokeDeletedGroup(inst, msg.DeletedGroupID)
+	}
 
 	var c *contact.Contact
 	if msg.DeletedDoc != nil {
@@ -189,6 +192,29 @@ func UpdateGroups(inst *instance.Instance, msg job.ShareGroupMessage) error {
 		}
 	}
 
+	return errm
+}
+
+func revokeDeletedGroup(inst *instance.Instance, groupID string) error {
+	sharings, err := FindActive(inst)
+	if err != nil {
+		return err
+	}
+
+	var errm error
+	for _, s := range sharings {
+		if !s.Owner {
+			continue
+		}
+		for idx, group := range s.Groups {
+			if group.ID != groupID || group.Revoked {
+				continue
+			}
+			if err := s.RevokeGroup(inst, idx); err != nil {
+				errm = multierror.Append(errm, err)
+			}
+		}
+	}
 	return errm
 }
 

--- a/model/sharing/group_test.go
+++ b/model/sharing/group_test.go
@@ -249,6 +249,18 @@ func TestGroups(t *testing.T) {
 		assert.True(t, s.Members[3].OnlyInGroups)
 		assert.Equal(t, s.Members[3].Groups, []int{1})
 
+		// Replaying the same group addition must not duplicate the group index,
+		// rotate credentials, resend invitations, or update the sharing.
+		revAfterFirstAddition := s.Rev()
+		credentialsAfterFirstAddition := append([]Credentials(nil), s.Credentials...)
+		require.NoError(t, UpdateGroups(inst, msg1))
+
+		s = &Sharing{}
+		require.NoError(t, couchdb.GetDoc(inst, consts.Sharings, sid, s))
+		require.Equal(t, revAfterFirstAddition, s.Rev())
+		require.Equal(t, credentialsAfterFirstAddition, s.Credentials)
+		assert.Equal(t, []int{0, 1}, s.Members[2].Groups)
+
 		// Charlie is removed of the football group
 		msg2 := job.ShareGroupMessage{
 			ContactID:     charlie.ID(),

--- a/model/sharing/group_test.go
+++ b/model/sharing/group_test.go
@@ -360,6 +360,33 @@ func TestGroups(t *testing.T) {
 		assert.False(t, s.Groups[0].Revoked)
 	})
 
+	t.Run("RemoveMemberFromGroupPreservesRemovalAfterConflict", func(t *testing.T) {
+		team := createGroup(t, inst, "Conflicting Drive Team")
+		otherTeam := createGroup(t, inst, "Remaining Drive Team")
+		alice := createContactInGroups(t, inst, "ConflictAlice", []string{team.ID()})
+
+		s := createDriveSharingForGroupTest(t, inst, "Conflicting group removal")
+		s.OrgDrive = true
+		sid := s.SID
+		require.NoError(t, s.AddGroup(inst, team.ID(), false))
+		require.NoError(t, s.AddGroup(inst, otherTeam.ID(), false))
+		require.NoError(t, couchdb.UpdateDoc(inst, s))
+
+		concurrent := &Sharing{}
+		require.NoError(t, couchdb.GetDoc(inst, consts.Sharings, sid, concurrent))
+		concurrent.Description = "Updated concurrently"
+		require.NoError(t, couchdb.UpdateDoc(inst, concurrent))
+
+		require.NoError(t, s.RemoveMemberFromGroup(inst, 0, alice))
+
+		stored := &Sharing{}
+		require.NoError(t, couchdb.GetDoc(inst, consts.Sharings, sid, stored))
+		require.Len(t, stored.Members, 2)
+		assert.Equal(t, MemberStatusRevoked, stored.Members[1].Status)
+		assert.Empty(t, stored.Members[1].Groups)
+		assert.Equal(t, "Updated concurrently", stored.Description)
+	})
+
 	t.Run("RevokeLastDriveGroupDeletesSharing", func(t *testing.T) {
 		team := createGroup(t, inst, "Drive Group")
 		_ = createContactInGroups(t, inst, "DriveGroupAlice", []string{team.ID()})

--- a/model/sharing/group_test.go
+++ b/model/sharing/group_test.go
@@ -438,6 +438,32 @@ func TestGroups(t *testing.T) {
 		assert.True(t, stored.Groups[0].Revoked)
 		assert.False(t, stored.Groups[1].Revoked)
 	})
+
+	t.Run("DeleteGroupRevokesMatchingSharingGroup", func(t *testing.T) {
+		team := createGroup(t, inst, "Deleted Drive Group")
+		otherTeam := createGroup(t, inst, "Active Drive Group")
+		_ = createContactInGroups(t, inst, "DeletedGroupAlice", []string{team.ID()})
+		s := createDriveSharingForGroupTest(t, inst, "Deleted sharing group")
+		s.OrgDrive = true
+		sid := s.SID
+		require.NoError(t, s.AddGroup(inst, team.ID(), false))
+		require.NoError(t, s.AddGroup(inst, otherTeam.ID(), false))
+		require.NoError(t, couchdb.UpdateDoc(inst, s))
+
+		require.NoError(t, UpdateGroups(inst, job.ShareGroupMessage{
+			DeletedGroupID: team.ID(),
+		}))
+
+		stored := &Sharing{}
+		require.NoError(t, couchdb.GetDoc(inst, consts.Sharings, sid, stored))
+		assert.True(t, stored.Active)
+		require.Len(t, stored.Members, 2)
+		assert.Equal(t, MemberStatusRevoked, stored.Members[1].Status)
+		assert.Empty(t, stored.Members[1].Groups)
+		require.Len(t, stored.Groups, 2)
+		assert.True(t, stored.Groups[0].Revoked)
+		assert.False(t, stored.Groups[1].Revoked)
+	})
 }
 
 func createDriveSharingForGroupTest(t *testing.T, inst *instance.Instance, description string) *Sharing {

--- a/model/sharing/member.go
+++ b/model/sharing/member.go
@@ -1188,6 +1188,10 @@ func (s *Sharing) DelegateRevokeRecipient(inst *instance.Instance, index int) er
 
 // RevokeMember revoke the access granted to a member and contact it
 func (s *Sharing) RevokeMember(inst *instance.Instance, index int) error {
+	return s.revokeMember(inst, index, nil)
+}
+
+func (s *Sharing) revokeMember(inst *instance.Instance, index int, removedGroupIndex *int) error {
 	m := &s.Members[index]
 
 	// skip if member is already revoked
@@ -1220,6 +1224,9 @@ func (s *Sharing) RevokeMember(inst *instance.Instance, index int) error {
 	// operation several times.
 	leftRetries := 3
 	for {
+		if removedGroupIndex != nil {
+			removeGroupFromMember(m, *removedGroupIndex)
+		}
 		m.Status = MemberStatusRevoked
 		// Do not remove the credentials from the array to preserve the members /
 		// credentials order, just empty them

--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -758,10 +758,18 @@ func (s *Sharing) RemoveInteractPermissionsForAMember(inst *instance.Instance, m
 // sharing has still at least one active member, we keep it as is. Else, we
 // disable the sharing.
 func (s *Sharing) RevokeRecipient(inst *instance.Instance, index int) error {
+	return s.revokeRecipient(inst, index, nil)
+}
+
+func (s *Sharing) revokeRecipientAfterRemovingGroup(inst *instance.Instance, index, groupIndex int) error {
+	return s.revokeRecipient(inst, index, &groupIndex)
+}
+
+func (s *Sharing) revokeRecipient(inst *instance.Instance, index int, removedGroupIndex *int) error {
 	if !s.Owner {
 		return ErrInvalidSharing
 	}
-	if err := s.RevokeMember(inst, index); err != nil {
+	if err := s.revokeMember(inst, index, removedGroupIndex); err != nil {
 		return err
 	}
 	m := &s.Members[index]

--- a/pkg/couchdb/couchdb.go
+++ b/pkg/couchdb/couchdb.go
@@ -48,8 +48,16 @@ func RTEvent(db prefixer.Prefixer, verb string, doc, oldDoc Doc) {
 		logger.WithDomain(db.DomainName()).WithNamespace("couchdb").
 			Errorf("error in hooks on %s %s %v\n", verb, doc.DocType(), err)
 	}
-	docClone := doc.Clone()
+	docClone := cloneDoc(doc)
 	go realtime.GetHub().Publish(db, verb, docClone, oldDoc)
+}
+
+func cloneDoc(doc Doc) Doc {
+	cloned := doc.Clone()
+	if jsonDoc, ok := cloned.(*JSONDoc); ok {
+		jsonDoc.Type = doc.DocType()
+	}
+	return cloned
 }
 
 // JSONDoc is a map representing a simple json object that implements
@@ -528,7 +536,7 @@ func DeleteDoc(db prefixer.Prefixer, doc Doc) error {
 	if id == "" {
 		return fmt.Errorf("Missing ID for DeleteDoc")
 	}
-	old := doc.Clone()
+	old := cloneDoc(doc)
 
 	// XXX Specific log for the deletion of an account, to help monitor this
 	// metric.

--- a/pkg/couchdb/couchdb_test.go
+++ b/pkg/couchdb/couchdb_test.go
@@ -33,6 +33,22 @@ type testDoc struct {
 	FieldB  int    `json:"fieldB,omitempty"`
 }
 
+type testJSONDoc struct {
+	JSONDoc
+}
+
+func (t *testJSONDoc) DocType() string {
+	return TestDoctype
+}
+
+func TestCloneDocPreservesDocType(t *testing.T) {
+	doc := &testJSONDoc{JSONDoc: JSONDoc{M: map[string]interface{}{}}}
+
+	cloned := cloneDoc(doc)
+
+	assert.Equal(t, TestDoctype, cloned.DocType())
+}
+
 func TestCouchdb(t *testing.T) {
 	if testing.Short() {
 		t.Skip("a couchdb is required for this test: test skipped due to the use of --short flag")
@@ -113,7 +129,9 @@ func TestCouchdb(t *testing.T) {
 		// Delete it
 		err = DeleteDoc(TestPrefix, updated)
 		assert.NoError(t, err)
-		assertGotEvent(t, realtime.EventDelete, doc.ID())
+		evt = assertGotEvent(t, realtime.EventDelete, doc.ID())
+		assert.Equal(t, TestDoctype, evt.Doc.DocType())
+		assert.Equal(t, TestDoctype, evt.OldDoc.DocType())
 
 		fetched3 := &testDoc{}
 		err = GetDoc(TestPrefix, docType, id, fetched3)
@@ -122,6 +140,20 @@ func TestCouchdb(t *testing.T) {
 		if assert.True(t, iscoucherr) {
 			assert.Equal(t, coucherr.Reason, "deleted")
 		}
+	})
+
+	t.Run("DeleteDoc preserves an embedded JSONDoc type", func(t *testing.T) {
+		doc := &testJSONDoc{JSONDoc: JSONDoc{M: map[string]interface{}{
+			"_id":  "embedded-json-doc",
+			"test": "value",
+		}}}
+		require.NoError(t, CreateNamedDoc(TestPrefix, doc))
+		assertGotEvent(t, realtime.EventCreate, doc.ID())
+
+		require.NoError(t, DeleteDoc(TestPrefix, doc))
+		evt := assertGotEvent(t, realtime.EventDelete, doc.ID())
+		assert.Equal(t, TestDoctype, evt.Doc.DocType())
+		assert.Equal(t, TestDoctype, evt.OldDoc.DocType())
 	})
 
 	t.Run("GetAllDocs", func(t *testing.T) {

--- a/pkg/rabbitmq/handlers.go
+++ b/pkg/rabbitmq/handlers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cozy/cozy-stack/model/orgdirectory"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/crypto"
+	"github.com/cozy/cozy-stack/pkg/logger"
 )
 
 const DefaultDomain = "twake.app"
@@ -319,34 +320,48 @@ func (h *B2BGroupLifecycleHandler) Handle(ctx context.Context, d amqp.Delivery) 
 		if err := json.Unmarshal(d.Body, &msg); err != nil {
 			return fmt.Errorf("b2b.group.created: failed to unmarshal message: %w", err)
 		}
+		logB2BGroupMessage(d.RoutingKey, msg.OrganizationID, msg.ID, len(msg.Members))
 		return orgdirectory.SyncGroupCreated(ctx, msg)
 	case RoutingKeyB2BGroupUpdated:
 		var msg orgdirectory.GroupUpdatedMessage
 		if err := json.Unmarshal(d.Body, &msg); err != nil {
 			return fmt.Errorf("b2b.group.updated: failed to unmarshal message: %w", err)
 		}
+		logB2BGroupMessage(d.RoutingKey, msg.OrganizationID, msg.ID, 0)
 		return orgdirectory.SyncGroupUpdated(ctx, msg)
 	case RoutingKeyB2BGroupDeleted:
 		var msg orgdirectory.GroupDeletedMessage
 		if err := json.Unmarshal(d.Body, &msg); err != nil {
 			return fmt.Errorf("b2b.group.deleted: failed to unmarshal message: %w", err)
 		}
+		logB2BGroupMessage(d.RoutingKey, msg.OrganizationID, msg.ID, 0)
 		return orgdirectory.SyncGroupDeleted(ctx, msg)
 	case RoutingKeyB2BGroupMemberAdded:
 		var msg orgdirectory.GroupMembersMessage
 		if err := json.Unmarshal(d.Body, &msg); err != nil {
 			return fmt.Errorf("b2b.group.member.added: failed to unmarshal message: %w", err)
 		}
+		logB2BGroupMessage(d.RoutingKey, msg.OrganizationID, msg.ID, len(msg.Members))
 		return orgdirectory.SyncGroupMembersAdded(ctx, msg)
 	case RoutingKeyB2BGroupMemberRemoved:
 		var msg orgdirectory.GroupMembersMessage
 		if err := json.Unmarshal(d.Body, &msg); err != nil {
 			return fmt.Errorf("b2b.group.member.removed: failed to unmarshal message: %w", err)
 		}
+		logB2BGroupMessage(d.RoutingKey, msg.OrganizationID, msg.ID, len(msg.Members))
 		return orgdirectory.SyncGroupMembersRemoved(ctx, msg)
 	default:
 		return fmt.Errorf("b2b.group: unsupported routing key %s", d.RoutingKey)
 	}
+}
+
+func logB2BGroupMessage(routingKey, organizationID, groupID string, memberCount int) {
+	log.WithFields(logger.Fields{
+		"group_id":        groupID,
+		"member_count":    memberCount,
+		"organization_id": organizationID,
+		"routing_key":     routingKey,
+	}).Info("b2b.group: processing message")
 }
 
 // UserPhoneUpdatedHandler handles user phone update messages.


### PR DESCRIPTION
## Summary

- Normalize typed and generic contact snapshots before computing sharing group membership and invitation deltas.
- Ignore contact updates without an old snapshot and cover additions, removals, and invitable contacts with regression tests.
- Make repeated owner and delegated group additions idempotent.
- Add structured group event context to RabbitMQ and share-group scheduler logs.
