### PR TITLE
fix(common): build matrix id from email localpart

### DIFF
--- a/model/settings/common/common.go
+++ b/model/settings/common/common.go
@@ -308,7 +308,15 @@ func buildRequest(inst *instance.Instance, settings *couchdb.JSONDoc) UserSettin
 		request.Payload.Phone = phone
 	}
 	if len(parts) > 1 {
-		id := fmt.Sprintf("@%s:%s", nickname, strings.Join(parts[1:], "."))
+		// The Matrix localpart comes from the email local part, which preserves
+		// dots and can differ from the domain slug. Fall back to the slug when
+		// no email is available. The homeserver part stays domain-derived.
+		localpart := nickname
+		email, _ := settings.M["email"].(string)
+		if local, _, found := strings.Cut(email, "@"); found && local != "" {
+			localpart = strings.ToLower(local)
+		}
+		id := fmt.Sprintf("@%s:%s", localpart, strings.Join(parts[1:], "."))
 		request.Payload.MatrixID = id
 	}
 

--- a/model/settings/common/common_test.go
+++ b/model/settings/common/common_test.go
@@ -10,6 +10,41 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestBuildRequest_MatrixIDFromEmail(t *testing.T) {
+	inst := &instance.Instance{Domain: "alicewonderland.stg.lin-saas.com"}
+
+	t.Run("email localpart preserves dots and drives the matrix id", func(t *testing.T) {
+		settings := &couchdb.JSONDoc{M: map[string]interface{}{
+			"email": "al.ice.wonder.land@stg.lin-saas.com",
+		}}
+		req := buildRequest(inst, settings)
+		require.Equal(t, "@al.ice.wonder.land:stg.lin-saas.com", req.Payload.MatrixID)
+	})
+
+	t.Run("email localpart is lowercased", func(t *testing.T) {
+		settings := &couchdb.JSONDoc{M: map[string]interface{}{
+			"email": "Al.Ice@stg.lin-saas.com",
+		}}
+		req := buildRequest(inst, settings)
+		require.Equal(t, "@al.ice:stg.lin-saas.com", req.Payload.MatrixID)
+	})
+
+	t.Run("falls back to the domain slug when no email is present", func(t *testing.T) {
+		settings := &couchdb.JSONDoc{M: map[string]interface{}{}}
+		req := buildRequest(inst, settings)
+		require.Equal(t, "@alicewonderland:stg.lin-saas.com", req.Payload.MatrixID)
+	})
+
+	t.Run("single-label domain yields no matrix id", func(t *testing.T) {
+		local := &instance.Instance{Domain: "localhost"}
+		settings := &couchdb.JSONDoc{M: map[string]interface{}{
+			"email": "al.ice@example.org",
+		}}
+		req := buildRequest(local, settings)
+		require.Empty(t, req.Payload.MatrixID)
+	})
+}
+
 func TestUpdateCommonSettings_VersionMismatchReturnsTypedError(t *testing.T) {
 	// Initialize test configuration
 	config.UseTestFile(t)


### PR DESCRIPTION
## Problem

The common-settings payload built the Matrix ID localpart from the instance domain slug. The slug is dot-stripped and can differ from the real localpart, so a user with email localpart `al.ice.wonder.land` was sent as `@alicewonderland:...` instead of `@al.ice.wonder.land:...`, and the bridge provisioned a new, unrelated Matrix user.

## Solution

Build the localpart from the email local part (the segment before `@`), lowercased, which preserves dots. The homeserver part stays domain-derived, and the slug is used only as a fallback when no email is set.

Closes #4870
