### PR TITLE
fix(sharing): keep empty organization drives active

### DIFF
--- a/model/sharing/group_test.go
+++ b/model/sharing/group_test.go
@@ -405,7 +405,7 @@ func TestGroups(t *testing.T) {
 		assert.True(t, couchdb.IsNotFoundError(err), "expected deleted sharing, got %v", err)
 	})
 
-	t.Run("RevokeLastOrgDriveGroupKeepsInactiveSharing", func(t *testing.T) {
+	t.Run("RevokeLastOrgDriveGroupKeepsActiveSharing", func(t *testing.T) {
 		team := createGroup(t, inst, "Org Drive Group")
 		_ = createContactInGroups(t, inst, "OrgDriveGroupAlice", []string{team.ID()})
 		s := createDriveSharingForGroupTest(t, inst, "Org drive group revoke")
@@ -420,12 +420,23 @@ func TestGroups(t *testing.T) {
 
 		stored := &Sharing{}
 		require.NoError(t, couchdb.GetDoc(inst, consts.Sharings, sid, stored))
-		assert.False(t, stored.Active)
+		assert.True(t, stored.Active)
 		assert.True(t, stored.OrgDrive)
 		require.Len(t, stored.Members, 2)
 		assert.Equal(t, MemberStatusRevoked, stored.Members[1].Status)
 		require.Len(t, stored.Groups, 1)
 		assert.True(t, stored.Groups[0].Revoked)
+
+		drives, err := ListDrives(inst)
+		require.NoError(t, err)
+		found := false
+		for _, drive := range drives {
+			if drive.SID == sid {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found)
 	})
 
 	t.Run("RevokeEmptyLastDriveGroupDeletesSharing", func(t *testing.T) {

--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -754,9 +754,8 @@ func (s *Sharing) RemoveInteractPermissionsForAMember(inst *instance.Instance, m
 	return nil
 }
 
-// RevokeRecipient revoke only one recipient on the sharer. After that, if the
-// sharing has still at least one active member, we keep it as is. Else, we
-// disable the sharing.
+// RevokeRecipient revokes one recipient on the sharer. Empty org drives remain
+// active, while other sharings are disabled when no active recipients remain.
 func (s *Sharing) RevokeRecipient(inst *instance.Instance, index int) error {
 	return s.revokeRecipient(inst, index, nil)
 }
@@ -963,10 +962,10 @@ func (s *Sharing) RevokeRecipientByNotification(inst *instance.Instance, m *Memb
 	return s.NoMoreRecipient(inst)
 }
 
-// NoMoreRecipient cleans up the sharing if there is no more active recipient
+// NoMoreRecipient keeps empty org drives active and cleans up other sharings.
 func (s *Sharing) NoMoreRecipient(inst *instance.Instance) error {
 	if s.Drive {
-		if s.hasRemainingRecipients() {
+		if s.hasRemainingRecipients() || s.OrgDrive {
 			return couchdb.UpdateDoc(inst, s)
 		}
 		if err := s.RemoveTriggers(inst); err != nil {

--- a/web/sharings/drives_test.go
+++ b/web/sharings/drives_test.go
@@ -3468,7 +3468,7 @@ func TestOrgDriveFlag(t *testing.T) {
 		return err == nil && recipientOrgDrive
 	}, 10*time.Second, 200*time.Millisecond, "recipient sharing should preserve org_drive")
 
-	eOwner.DELETE("/sharings/"+sharingID+"/recipients").
+	eOwner.DELETE("/sharings/"+sharingID+"/recipients/1").
 		WithHeader("Authorization", "Bearer "+env.acmeToken).
 		Expect().Status(http.StatusNoContent)
 
@@ -3477,11 +3477,55 @@ func TestOrgDriveFlag(t *testing.T) {
 		if err := couchdb.GetDoc(env.acme, consts.Sharings, sharingID, &revoked); err != nil {
 			return false
 		}
-		return revoked.OrgDrive && !revoked.Active
-	}, 5*time.Second, 100*time.Millisecond, "owner org-drive sharing should be kept inactive after revocation")
+		return revoked.OrgDrive && revoked.Active
+	}, 5*time.Second, 100*time.Millisecond, "owner org-drive sharing should remain active after revoking its last recipient")
 	require.Len(t, revoked.Members, 2)
 	assert.Equal(t, sharing.MemberStatusRevoked, revoked.Members[1].Status)
-	requireNoDirSharingReference(t, env.acme, folderID, sharingID)
+
+	listObj := eOwner.GET("/sharings/drives").
+		WithHeader("Authorization", "Bearer "+env.acmeToken).
+		Expect().Status(http.StatusOK).
+		JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+		Object()
+	found := false
+	for _, item := range listObj.Path("$.data").Array().Iter() {
+		if item.Object().Value("id").String().Raw() == sharingID {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "empty org drive should remain listed for its owner")
+
+	dir, err := env.acme.VFS().DirByID(folderID)
+	require.NoError(t, err)
+	require.Contains(t, dir.ReferencedBy, couchdb.DocReference{
+		ID:   sharingID,
+		Type: consts.Sharings,
+	})
+
+	eOwner.POST("/sharings/"+sharingID+"/recipients").
+		WithHeader("Authorization", "Bearer "+env.acmeToken).
+		WithHeader("Content-Type", jsonAPIContentType).
+		WithBytes(makeAddRecipientsPayload(t, sharingID, "recipients", recipientContact.ID())).
+		Expect().Status(http.StatusOK)
+
+	readded, err := sharing.FindSharing(env.acme, sharingID)
+	require.NoError(t, err)
+	require.Len(t, readded.Credentials, 1)
+	require.NotEmpty(t, readded.Credentials[0].State)
+
+	eRecipient := newSharingExpect(t, env.tsB.URL)
+	csrfToken := loginSharingRecipient(t, eRecipient)
+	authorizeLink := eOwner.GET("/sharings/"+sharingID+"/discovery").
+		WithQuery("state", readded.Credentials[0].State).
+		WithRedirectPolicy(httpexpect.DontFollowRedirects).
+		Expect().Status(http.StatusFound).
+		Header("Location").NotEmpty().Raw()
+	FakeOwnerInstanceForSharing(t, env.betty, env.tsA.URL, sharingID)
+	submitSharingAuthorize(t, eRecipient, authorizeLink, sharingID, csrfToken)
+
+	waitForDriveSharingReadyOnOwner(t, eOwner, env.acmeToken, sharingID)
+	waitForDriveSharingActiveOnRecipient(t, env.betty, sharingID)
 }
 
 func TestSharedDriveTrashAttribution(t *testing.T) {


### PR DESCRIPTION
## Summary

- Keep owner-side organization-drive sharings active when their last recipient or group is revoked.
- Preserve the root sharing reference so empty organization drives remain in the active drive listing.
- Cover last-recipient, last-group, and recipient re-addition behavior with regression tests.
