### PR TITLE
fix(bitwarden): find the org member by the old domain of the instance

### DIFF
--- a/model/bitwarden/organization.go
+++ b/model/bitwarden/organization.go
@@ -87,23 +87,34 @@ func (o *Organization) Clone() couchdb.Doc {
 // organization. The members are keyed by the instances domains, and an
 // instance that has been migrated to a new domain still has its entry stored
 // under its former domain: the old domain and the domain aliases are used as
-// fallbacks so that such an instance keeps its access to the organization. It
-// returns a zero value when the instance is not a member.
+// fallbacks so that such an instance keeps its access to the organization.
+// An entry with the organization key has the precedence, as a keyless entry
+// can have been created under the new domain while the key stayed on the
+// entry of the former domain. It returns a zero value when the instance is
+// not a member.
 func (o *Organization) Member(inst *instance.Instance) OrgMember {
-	if m, ok := o.Members[inst.Domain]; ok {
-		return m
-	}
+	domains := make([]string, 0, 2+len(inst.DomainAliases))
+	domains = append(domains, inst.Domain)
 	if inst.OldDomain != "" {
-		if m, ok := o.Members[inst.OldDomain]; ok {
+		domains = append(domains, inst.OldDomain)
+	}
+	domains = append(domains, inst.DomainAliases...)
+
+	var keyless OrgMember
+	var found bool
+	for _, domain := range domains {
+		m, ok := o.Members[domain]
+		if !ok {
+			continue
+		}
+		if m.OrgKey != "" {
 			return m
 		}
-	}
-	for _, alias := range inst.DomainAliases {
-		if m, ok := o.Members[alias]; ok {
-			return m
+		if !found {
+			keyless, found = m, true
 		}
 	}
-	return OrgMember{}
+	return keyless
 }
 
 // FindCiphers returns the ciphers for this organization.

--- a/model/bitwarden/organization.go
+++ b/model/bitwarden/organization.go
@@ -83,6 +83,29 @@ func (o *Organization) Clone() couchdb.Doc {
 	return &cloned
 }
 
+// Member returns the entry of the given instance in the members of this
+// organization. The members are keyed by the instances domains, and an
+// instance that has been migrated to a new domain still has its entry stored
+// under its former domain: the old domain and the domain aliases are used as
+// fallbacks so that such an instance keeps its access to the organization. It
+// returns a zero value when the instance is not a member.
+func (o *Organization) Member(inst *instance.Instance) OrgMember {
+	if m, ok := o.Members[inst.Domain]; ok {
+		return m
+	}
+	if inst.OldDomain != "" {
+		if m, ok := o.Members[inst.OldDomain]; ok {
+			return m
+		}
+	}
+	for _, alias := range inst.DomainAliases {
+		if m, ok := o.Members[alias]; ok {
+			return m
+		}
+	}
+	return OrgMember{}
+}
+
 // FindCiphers returns the ciphers for this organization.
 func (o *Organization) FindCiphers(inst *instance.Instance) ([]*Cipher, error) {
 	var ciphers []*Cipher

--- a/model/bitwarden/organization_test.go
+++ b/model/bitwarden/organization_test.go
@@ -1,0 +1,74 @@
+package bitwarden
+
+import (
+	"testing"
+
+	"github.com/cozy/cozy-stack/model/instance"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOrganizationMember(t *testing.T) {
+	org := &Organization{
+		Members: map[string]OrgMember{
+			"alice.mycozy.cloud": {
+				UserID: "alice",
+				OrgKey: "alice-key",
+				Status: OrgMemberConfirmed,
+				Owner:  true,
+			},
+			"bob.twake.app": {
+				UserID: "bob",
+				OrgKey: "bob-key",
+				Status: OrgMemberConfirmed,
+			},
+		},
+	}
+
+	t.Run("the member is found by the domain", func(t *testing.T) {
+		inst := &instance.Instance{Domain: "bob.twake.app"}
+		m := org.Member(inst)
+		assert.Equal(t, "bob", m.UserID)
+		assert.Equal(t, "bob-key", m.OrgKey)
+	})
+
+	t.Run("the member is found by the old domain", func(t *testing.T) {
+		inst := &instance.Instance{
+			Domain:    "alice.twake.app",
+			OldDomain: "alice.mycozy.cloud",
+		}
+		m := org.Member(inst)
+		assert.Equal(t, "alice", m.UserID)
+		assert.Equal(t, "alice-key", m.OrgKey)
+		assert.True(t, m.Owner)
+	})
+
+	t.Run("the domain has the precedence over the old domain", func(t *testing.T) {
+		inst := &instance.Instance{
+			Domain:    "bob.twake.app",
+			OldDomain: "alice.mycozy.cloud",
+		}
+		m := org.Member(inst)
+		assert.Equal(t, "bob", m.UserID)
+	})
+
+	t.Run("the member is found by a domain alias", func(t *testing.T) {
+		inst := &instance.Instance{
+			Domain:        "alice.twake.app",
+			DomainAliases: []string{"other.example.org", "alice.mycozy.cloud"},
+		}
+		m := org.Member(inst)
+		assert.Equal(t, "alice", m.UserID)
+	})
+
+	t.Run("a zero value is returned for a non member", func(t *testing.T) {
+		inst := &instance.Instance{
+			Domain:    "charlie.twake.app",
+			OldDomain: "charlie.mycozy.cloud",
+		}
+		m := org.Member(inst)
+		assert.Empty(t, m.UserID)
+		assert.Empty(t, m.OrgKey)
+		assert.False(t, m.Owner)
+		assert.Equal(t, OrgMemberInvited, m.Status)
+	})
+}

--- a/model/bitwarden/organization_test.go
+++ b/model/bitwarden/organization_test.go
@@ -60,6 +60,47 @@ func TestOrganizationMember(t *testing.T) {
 		assert.Equal(t, "alice", m.UserID)
 	})
 
+	t.Run("an entry with a key has the precedence over a keyless entry", func(t *testing.T) {
+		migrated := &Organization{
+			Members: map[string]OrgMember{
+				"alice.mycozy.cloud": {
+					UserID: "alice",
+					OrgKey: "alice-key",
+					Status: OrgMemberConfirmed,
+				},
+				"alice.twake.app": {
+					UserID: "alice",
+					Status: OrgMemberAccepted,
+				},
+			},
+		}
+		inst := &instance.Instance{
+			Domain:    "alice.twake.app",
+			OldDomain: "alice.mycozy.cloud",
+		}
+		m := migrated.Member(inst)
+		assert.Equal(t, "alice-key", m.OrgKey)
+		assert.Equal(t, OrgMemberConfirmed, m.Status)
+	})
+
+	t.Run("the keyless entry is returned when no entry has a key", func(t *testing.T) {
+		pending := &Organization{
+			Members: map[string]OrgMember{
+				"alice.twake.app": {
+					UserID: "alice",
+					Status: OrgMemberAccepted,
+				},
+			},
+		}
+		inst := &instance.Instance{
+			Domain:    "alice.twake.app",
+			OldDomain: "alice.mycozy.cloud",
+		}
+		m := pending.Member(inst)
+		assert.Equal(t, "alice", m.UserID)
+		assert.Equal(t, OrgMemberAccepted, m.Status)
+	})
+
 	t.Run("a zero value is returned for a non member", func(t *testing.T) {
 		inst := &instance.Instance{
 			Domain:    "charlie.twake.app",

--- a/model/sharing/member.go
+++ b/model/sharing/member.go
@@ -1487,12 +1487,12 @@ func (s *Sharing) SaveBitwarden(inst *instance.Instance, m *Member, bw *APIBitwa
 	if orgKey == "" && bw.UserID != "" {
 		// The member can have been migrated to a new domain: its entry is
 		// still stored under its former domain. The user keeps the same RSA
-		// key pair, so the organization key can be reused, and the stale
-		// entry is removed to avoid keeping a keyless duplicate.
+		// key pair, so the organization key can be reused. The entry of the
+		// former domain is left as is, and Organization.Member gives the
+		// precedence to the entry that has the key.
 		for former, member := range org.Members {
 			if former != domain && member.UserID == bw.UserID {
 				orgKey = member.OrgKey
-				delete(org.Members, former)
 				break
 			}
 		}

--- a/model/sharing/member.go
+++ b/model/sharing/member.go
@@ -1484,6 +1484,19 @@ func (s *Sharing) SaveBitwarden(inst *instance.Instance, m *Member, bw *APIBitwa
 		domain = u.Host
 	}
 	orgKey := org.Members[domain].OrgKey
+	if orgKey == "" && bw.UserID != "" {
+		// The member can have been migrated to a new domain: its entry is
+		// still stored under its former domain. The user keeps the same RSA
+		// key pair, so the organization key can be reused, and the stale
+		// entry is removed to avoid keeping a keyless duplicate.
+		for former, member := range org.Members {
+			if former != domain && member.UserID == bw.UserID {
+				orgKey = member.OrgKey
+				delete(org.Members, former)
+				break
+			}
+		}
+	}
 
 	if bw.PublicKey != "" {
 		contact := &bitwarden.Contact{}

--- a/web/bitwarden/organization.go
+++ b/web/bitwarden/organization.go
@@ -86,7 +86,7 @@ type organizationResponse struct {
 }
 
 func newOrganizationResponse(inst *instance.Instance, org *bitwarden.Organization) *organizationResponse {
-	m := org.Members[inst.Domain]
+	m := org.Member(inst)
 	typ := 2 // User
 	if m.Owner {
 		typ = 0 // Owner
@@ -138,7 +138,7 @@ type collectionResponse struct {
 }
 
 func newCollectionResponse(inst *instance.Instance, org *bitwarden.Organization, coll *bitwarden.Collection) *collectionResponse {
-	m := org.Members[inst.Domain]
+	m := org.Member(inst)
 
 	return &collectionResponse{
 		ID:             coll.ID(),
@@ -309,7 +309,7 @@ func DeleteOrganization(c echo.Context) error {
 		})
 	}
 
-	if m := org.Members[inst.Domain]; !m.Owner {
+	if m := org.Member(inst); !m.Owner {
 		return c.JSON(http.StatusUnauthorized, echo.Map{
 			"error": "only the Owner can call this endpoint",
 		})
@@ -426,7 +426,7 @@ func ConfirmUser(c echo.Context) error {
 			"error": err.Error(),
 		})
 	}
-	if m := org.Members[inst.Domain]; !m.Owner {
+	if m := org.Member(inst); !m.Owner {
 		return c.JSON(http.StatusUnauthorized, echo.Map{
 			"error": "only the Owner can call this endpoint",
 		})


### PR DESCRIPTION
## Summary

- Add `Organization.Member(inst)` which looks up the member entry by the instance domain, then falls back on `OldDomain` and on the domain aliases.
- Use it in `newOrganizationResponse`, `newCollectionResponse` and the two owner checks of `web/bitwarden/organization.go`, which read the map with `Members[inst.Domain]`.
- The members of an organization are keyed by the domains of their instances, so an instance migrated to a new domain no longer matches its own entry: the organization is returned with an empty key and an Invited status, and the shared ciphers cannot be decrypted.
- `PassphraseSalt` already uses the same `OldDomain` fallback for the master password salt.
- Add unit tests for the lookup.