### PR TITLE
feat(sharings): Allow nested folder sharings

### DIFF
--- a/model/sharing/error.go
+++ b/model/sharing/error.go
@@ -73,6 +73,10 @@ var (
 	ErrNotADirectory = errors.New("Provided ID is not a directory")
 	// ErrFileAlreadyShared is used when the file already has an existing sharing
 	ErrFileAlreadyShared = errors.New("File already has an existing sharing")
+	// ErrParentReadOnly is used when the selected folder or file is inside a
+	// shared ancestor on which the current instance has only read-only (or no
+	// write) access.
+	ErrParentReadOnly = errors.New("Parent folder is shared without write access")
 	// ErrNotAFile is used when the provided file_id is not a file
 	ErrNotAFile = errors.New("Provided ID is not a file")
 	// ErrFileInTrash is used when trying to share a trashed file

--- a/model/sharing/files.go
+++ b/model/sharing/files.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cozy/cozy-stack/client/request"
 	"github.com/cozy/cozy-stack/model/instance"
 	"github.com/cozy/cozy-stack/model/note"
+	"github.com/cozy/cozy-stack/model/permission"
 	"github.com/cozy/cozy-stack/model/vfs"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
@@ -423,10 +424,7 @@ func ValidateDriveRoot(inst *instance.Instance, rootID string) (*vfs.DirDoc, *vf
 		if err := checkRootForSharing(dir.ReferencedBy, ErrFolderAlreadyShared); err != nil {
 			return nil, nil, err
 		}
-		if err := checkParentsForSharing(fs, path.Dir(dir.Fullpath), ErrFolderAlreadyShared); err != nil {
-			return nil, nil, err
-		}
-		if err := checkDescendantsForSharing(fs, dir); err != nil {
+		if err := checkEffectiveParentAccess(inst, rootID); err != nil {
 			return nil, nil, err
 		}
 		return dir, nil, nil
@@ -437,65 +435,39 @@ func ValidateDriveRoot(inst *instance.Instance, rootID string) (*vfs.DirDoc, *vf
 	if err := checkRootForSharing(file.ReferencedBy, ErrFileAlreadyShared); err != nil {
 		return nil, nil, err
 	}
-	filePath, err := file.Path(fs)
-	if err != nil {
-		return nil, nil, err
-	}
-	if err := checkParentsForSharing(fs, path.Dir(filePath), ErrFileAlreadyShared); err != nil {
+	if err := checkEffectiveParentAccess(inst, rootID); err != nil {
 		return nil, nil, err
 	}
 	return nil, file, nil
+}
+
+// checkEffectiveParentAccess resolves the effective access on the selected
+// root via the AccessResolver. When an applicable additive ancestor scope
+// exists (the root lives inside a shared ancestor where the current instance
+// is a member), write/share is required on it; otherwise the root is rejected
+// with ErrParentReadOnly. When no applicable scope applies (no shared
+// ancestor, or the instance is not a member of any such scope), the root is
+// allowed.
+//
+// ponytail: ancestor-only gate. Drives are not replicated, so a read-only
+// recipient has no local copy of the shared root to nest under a new drive;
+// only a classic replicated sharing can sit under a new drive's tree. Add a
+// descendant pass (ChildSharedRootsUnder) if that becomes a problem.
+func checkEffectiveParentAccess(inst *instance.Instance, rootID string) error {
+	ea, err := NewAccessResolver(inst).Resolve(rootID)
+	if err != nil {
+		return err
+	}
+	if len(ea.SourceSharingIDs) > 0 && !ea.Can(permission.POST) {
+		return ErrParentReadOnly
+	}
+	return nil
 }
 
 func checkRootForSharing(refs []couchdb.DocReference, alreadySharedErr error) error {
 	for _, ref := range refs {
 		if ref.Type == consts.Sharings {
 			return alreadySharedErr
-		}
-	}
-	return nil
-}
-
-func checkParentsForSharing(fs vfs.VFS, currentPath string, alreadySharedErr error) error {
-	for currentPath != "/" && currentPath != "." && currentPath != "" {
-		parentDir, err := fs.DirByPath(currentPath)
-		if err != nil {
-			break
-		}
-		if err := checkRootForSharing(parentDir.ReferencedBy, alreadySharedErr); err != nil {
-			return err
-		}
-		currentPath = path.Dir(currentPath)
-	}
-	return nil
-}
-
-// checkDescendantsForSharing recursively checks if any descendant directory
-// has an existing sharing reference.
-func checkDescendantsForSharing(fs vfs.VFS, dir *vfs.DirDoc) error {
-	iter := fs.DirIterator(dir, nil)
-	for {
-		child, _, err := iter.Next()
-		if err == vfs.ErrIteratorDone {
-			break
-		}
-		if err != nil {
-			return err
-		}
-		if child == nil {
-			continue
-		}
-
-		// Check if this child directory has a sharing reference
-		for _, ref := range child.ReferencedBy {
-			if ref.Type == consts.Sharings {
-				return ErrFolderAlreadyShared
-			}
-		}
-
-		// Recursively check subdirectories
-		if err := checkDescendantsForSharing(fs, child); err != nil {
-			return err
 		}
 	}
 	return nil

--- a/model/sharing/files_test.go
+++ b/model/sharing/files_test.go
@@ -468,3 +468,103 @@ func createTree(t *testing.T, fs vfs.VFS, tree H, dirID string) *vfs.DirDoc {
 	}
 	return dirdoc
 }
+
+// TestValidateDriveRoot_ReadOnlyRecipientParent covers the new additive gate:
+// when the current instance is a read-only recipient of an active parent
+// sharing, creating a child sharing on a sub-folder is rejected with
+// ErrParentReadOnly.
+func TestValidateDriveRoot_ReadOnlyRecipientParent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+	config.UseTestFile(t)
+	testutils.NeedCouchdb(t)
+	setup := testutils.NewSetup(t, t.Name())
+	inst := setup.GetTestInstance()
+	fs := inst.VFS()
+
+	tree := H{"parent/": H{"child/": H{}}}
+	parent := createTree(t, fs, tree, consts.RootDirID)
+	child, err := fs.DirByPath(parent.Fullpath + "/child")
+	require.NoError(t, err)
+
+	// Active additive sharing on the parent, local instance is read-only recipient.
+	createActiveRecipientSharing(t, inst, parent.ID(), true)
+
+	_, _, err = ValidateDriveRoot(inst, child.ID())
+	assert.ErrorIs(t, err, ErrParentReadOnly)
+}
+
+// TestValidateDriveRoot_ReadOnlyRecipientParentFile is the file-root variant:
+// a file inside a read-only shared parent cannot be shared as a child.
+func TestValidateDriveRoot_ReadOnlyRecipientParentFile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+	config.UseTestFile(t)
+	testutils.NeedCouchdb(t)
+	setup := testutils.NewSetup(t, t.Name())
+	inst := setup.GetTestInstance()
+	fs := inst.VFS()
+
+	tree := H{"parent/": H{"nested.txt": H{}}}
+	parent := createTree(t, fs, tree, consts.RootDirID)
+	file, err := fs.FileByPath(parent.Fullpath + "/nested.txt")
+	require.NoError(t, err)
+
+	createActiveRecipientSharing(t, inst, parent.ID(), true)
+
+	_, _, err = ValidateDriveRoot(inst, file.ID())
+	assert.ErrorIs(t, err, ErrParentReadOnly)
+}
+
+// TestValidateDriveRoot_WriteRecipientParentAllowed is the positive
+// counterpart: a write recipient of the parent can create the child sharing.
+func TestValidateDriveRoot_WriteRecipientParentAllowed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+	config.UseTestFile(t)
+	testutils.NeedCouchdb(t)
+	setup := testutils.NewSetup(t, t.Name())
+	inst := setup.GetTestInstance()
+	fs := inst.VFS()
+
+	tree := H{"parent/": H{"child/": H{}}}
+	parent := createTree(t, fs, tree, consts.RootDirID)
+	child, err := fs.DirByPath(parent.Fullpath + "/child")
+	require.NoError(t, err)
+
+	// Active additive sharing on the parent, local instance is read-write recipient.
+	createActiveRecipientSharing(t, inst, parent.ID(), false)
+
+	dir, file, err := ValidateDriveRoot(inst, child.ID())
+	require.NoError(t, err)
+	require.NotNil(t, dir)
+	require.Nil(t, file)
+}
+
+// TestValidateDriveRoot_NestedOwnerAllowed confirms the owner of a parent
+// sharing can create a child sharing (owner is read-write on its own sharing).
+func TestValidateDriveRoot_NestedOwnerAllowed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+	config.UseTestFile(t)
+	testutils.NeedCouchdb(t)
+	setup := testutils.NewSetup(t, t.Name())
+	inst := setup.GetTestInstance()
+	fs := inst.VFS()
+
+	tree := H{"parent/": H{"child/": H{}}}
+	parent := createTree(t, fs, tree, consts.RootDirID)
+	child, err := fs.DirByPath(parent.Fullpath + "/child")
+	require.NoError(t, err)
+
+	// Owner sharing on the parent (active).
+	createActiveDirSharing(t, inst, parent.ID())
+
+	dir, _, err := ValidateDriveRoot(inst, child.ID())
+	require.NoError(t, err)
+	require.NotNil(t, dir)
+}

--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -592,6 +592,11 @@ func CreateDrive(inst *instance.Instance, rootID, description, appSlug string) (
 		s.Description = rootName
 	}
 
+	// All drives are additive by default (EffectiveAccessMode returns
+	// additive when empty, but set it explicitly so the intent is visible
+	// and the field is testable in API responses).
+	s.AccessMode = AccessModeAdditive
+
 	// Initialize as owner
 	if err := s.BeOwner(inst, appSlug); err != nil {
 		return nil, err

--- a/web/sharings/drives.go
+++ b/web/sharings/drives.go
@@ -167,6 +167,8 @@ func wrapDriveRootErrors(err error) error {
 		return jsonapi.NotFound(err)
 	case sharing.ErrFolderAlreadyShared, sharing.ErrFileAlreadyShared:
 		return jsonapi.Conflict(err)
+	case sharing.ErrParentReadOnly:
+		return jsonapi.Forbidden(err)
 	case sharing.ErrSystemFolder, sharing.ErrFileInTrash:
 		return jsonapi.BadRequest(err)
 	default:

--- a/web/sharings/drives_test.go
+++ b/web/sharings/drives_test.go
@@ -1776,7 +1776,7 @@ func TestCreateDriveFromFolder(t *testing.T) {
 			Contains("already has an existing sharing")
 	})
 
-	t.Run("FailOnFolderInsideSharing", func(t *testing.T) {
+	t.Run("SucceedOnFolderInsideSharing", func(t *testing.T) {
 		// Create a parent directory and share it
 		parentID := createRootDirectory(t, eOwner, "ParentShared", ownerAppToken)
 
@@ -1804,8 +1804,8 @@ func TestCreateDriveFromFolder(t *testing.T) {
 			}`, consts.Sharings, parentID, recipientContact.ID(), recipientContact.DocType()))).
 			Expect().Status(201)
 
-		// Try to share the child folder (should fail because it's inside a shared folder)
-		resp := eOwner.POST("/sharings/drives").
+		// Share the child folder as an additive nested sharing
+		obj := eOwner.POST("/sharings/drives").
 			WithHeader("Authorization", "Bearer "+ownerAppToken).
 			WithHeader("Content-Type", "application/vnd.api+json").
 			WithBytes([]byte(fmt.Sprintf(`{
@@ -1816,12 +1816,32 @@ func TestCreateDriveFromFolder(t *testing.T) {
 					}
 				}
 			}`, consts.Sharings, childID))).
-			Expect().Status(409)
+			Expect().Status(201).
+			JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+			Object()
 
-		// Verify error message
-		resp.JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
-			Object().Path("$.errors[0].detail").String().
-			Contains("already has an existing sharing")
+		data := obj.Value("data").Object()
+		data.Value("id").String().NotEmpty()
+		attrs := data.Value("attributes").Object()
+		attrs.Value("drive").Boolean().IsTrue()
+		// The child sharing is created as an additive sharing
+		attrs.Value("access_mode").String().IsEqual("additive")
+
+		// No inherited parent members: only the owner
+		attrs.Value("members").Array().Length().IsEqual(1)
+
+		// referenced_by is added to the child folder root
+		dir, _, err := ownerInstance.VFS().DirOrFileByID(childID)
+		require.NoError(t, err)
+		require.NotNil(t, dir)
+		var hasSharingRef bool
+		for _, ref := range dir.ReferencedBy {
+			if ref.Type == consts.Sharings {
+				hasSharingRef = true
+				break
+			}
+		}
+		require.True(t, hasSharingRef, "child folder root must be referenced by the new sharing")
 	})
 
 	t.Run("FailOnAlreadySharedFile", func(t *testing.T) {
@@ -1858,7 +1878,7 @@ func TestCreateDriveFromFolder(t *testing.T) {
 			Contains("already has an existing sharing")
 	})
 
-	t.Run("FailOnFileInsideSharedFolder", func(t *testing.T) {
+	t.Run("SucceedOnFileInsideSharedFolder", func(t *testing.T) {
 		parentID := createRootDirectory(t, eOwner, "ParentSharedForFile", ownerAppToken)
 		fileID := createFile(t, eOwner, parentID, "NestedDriveFile.txt", ownerAppToken)
 
@@ -1882,7 +1902,7 @@ func TestCreateDriveFromFolder(t *testing.T) {
 			}`, consts.Sharings, parentID, recipientContact.ID(), recipientContact.DocType()))).
 			Expect().Status(201)
 
-		resp := eOwner.POST("/sharings/drives").
+		obj := eOwner.POST("/sharings/drives").
 			WithHeader("Authorization", "Bearer "+ownerAppToken).
 			WithHeader("Content-Type", "application/vnd.api+json").
 			WithBytes([]byte(fmt.Sprintf(`{
@@ -1893,14 +1913,31 @@ func TestCreateDriveFromFolder(t *testing.T) {
 					}
 				}
 			}`, consts.Sharings, fileID))).
-			Expect().Status(409)
+			Expect().Status(201).
+			JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+			Object()
 
-		resp.JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
-			Object().Path("$.errors[0].detail").String().
-			Contains("already has an existing sharing")
+		attrs := obj.Value("data").Object().Value("attributes").Object()
+		attrs.Value("drive").Boolean().IsTrue()
+		attrs.Value("access_mode").String().IsEqual("additive")
+		// No inherited parent members: only the owner
+		attrs.Value("members").Array().Length().IsEqual(1)
+
+		// referenced_by is added to the file root
+		_, file, err := ownerInstance.VFS().DirOrFileByID(fileID)
+		require.NoError(t, err)
+		require.NotNil(t, file)
+		var hasSharingRef bool
+		for _, ref := range file.ReferencedBy {
+			if ref.Type == consts.Sharings {
+				hasSharingRef = true
+				break
+			}
+		}
+		require.True(t, hasSharingRef, "file root must be referenced by the new sharing")
 	})
 
-	t.Run("FailOnFolderContainingSharedChild", func(t *testing.T) {
+	t.Run("SucceedOnFolderContainingSharedChild", func(t *testing.T) {
 		// Create a parent directory
 		parentID := createRootDirectory(t, eOwner, "ParentWithSharedChild", ownerAppToken)
 
@@ -1928,8 +1965,8 @@ func TestCreateDriveFromFolder(t *testing.T) {
 			}`, consts.Sharings, childID, recipientContact.ID(), recipientContact.DocType()))).
 			Expect().Status(201)
 
-		// Try to share the parent folder (should fail because it contains a shared folder)
-		resp := eOwner.POST("/sharings/drives").
+		// Share the parent folder as an additive nested sharing
+		obj := eOwner.POST("/sharings/drives").
 			WithHeader("Authorization", "Bearer "+ownerAppToken).
 			WithHeader("Content-Type", "application/vnd.api+json").
 			WithBytes([]byte(fmt.Sprintf(`{
@@ -1940,12 +1977,128 @@ func TestCreateDriveFromFolder(t *testing.T) {
 					}
 				}
 			}`, consts.Sharings, parentID))).
-			Expect().Status(409)
+			Expect().Status(201).
+			JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+			Object()
 
-		// Verify error message
+		attrs := obj.Value("data").Object().Value("attributes").Object()
+		attrs.Value("drive").Boolean().IsTrue()
+		attrs.Value("access_mode").String().IsEqual("additive")
+		// No inherited child members: only the owner
+		attrs.Value("members").Array().Length().IsEqual(1)
+
+		// The pre-existing child sharing's referenced_by on the child folder
+		// remains intact.
+		dir, _, err := ownerInstance.VFS().DirOrFileByID(childID)
+		require.NoError(t, err)
+		require.NotNil(t, dir)
+		var hasSharingRef bool
+		for _, ref := range dir.ReferencedBy {
+			if ref.Type == consts.Sharings {
+				hasSharingRef = true
+				break
+			}
+		}
+		require.True(t, hasSharingRef, "child folder must keep its sharing reference")
+	})
+
+	// In the two FailOn*ReadOnlyShared subtests, the local instance is the
+	// read-only *recipient* of the parent sharing; the sharing's owner is a
+	// fictional external instance (Alice) that never serves requests. The
+	// aliases below name that role explicitly.
+	// TODO: when the shared sub-folder features land, switch these tests to
+	// the multi-instance env of drives_permissions_test.go (real recipient
+	// instance, real invitation flow).
+	eRecipient := eOwner
+	recipientInstance := ownerInstance
+	recipientAppToken := ownerAppToken
+
+	// makeReadOnlyParentSharing builds an active additive sharing on parentID
+	// where the local instance is a read-only recipient (not the owner).
+	makeReadOnlyParentSharing := func(parentID string) {
+		t.Helper()
+		now := time.Now()
+		s := &sharing.Sharing{
+			Active:        true,
+			Owner:         false,
+			Drive:         true,
+			DriveRootType: sharing.DriveRootTypeDirectory,
+			AppSlug:       "test",
+			AccessMode:    sharing.AccessModeAdditive,
+			Members: []sharing.Member{
+				{
+					Status:   sharing.MemberStatusOwner,
+					Name:     "Alice",
+					Email:    "alice@cozy.tools",
+					Instance: "https://owner.cozy.tools",
+				},
+				{
+					Status:   sharing.MemberStatusReady,
+					Name:     recipientInstance.Domain,
+					Instance: "https://" + recipientInstance.Domain,
+					ReadOnly: true,
+				},
+			},
+			Rules: []sharing.Rule{
+				{
+					Title:   "test",
+					DocType: consts.Files,
+					Values:  []string{parentID},
+				},
+			},
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+		require.NoError(t, couchdb.CreateDoc(recipientInstance, s))
+		require.NoError(t, s.AddReferenceForSharing(recipientInstance, &s.Rules[0]))
+	}
+
+	t.Run("FailOnFolderInsideReadOnlyShared", func(t *testing.T) {
+		parentID := createRootDirectory(t, eRecipient, "ReadOnlySharedParent", recipientAppToken)
+		childID := createDirectory(t, eRecipient, parentID, "ChildFolder", recipientAppToken)
+
+		makeReadOnlyParentSharing(parentID)
+
+		resp := eRecipient.POST("/sharings/drives").
+			WithHeader("Authorization", "Bearer "+recipientAppToken).
+			WithHeader("Content-Type", "application/vnd.api+json").
+			WithBytes([]byte(fmt.Sprintf(`{
+				"data": {
+					"type": "%s",
+					"attributes": {
+						"folder_id": "%s"
+					}
+				}
+			}`, consts.Sharings, childID))).
+			Expect().Status(403)
+
 		resp.JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
 			Object().Path("$.errors[0].detail").String().
-			Contains("already has an existing sharing")
+			Contains("without write access")
+	})
+
+	t.Run("FailOnFileInsideReadOnlyShared", func(t *testing.T) {
+		parentID := createRootDirectory(t, eRecipient, "ReadOnlySharedParentForFile", recipientAppToken)
+		fileID := createFile(t, eRecipient, parentID, "NestedFile.txt", recipientAppToken)
+
+		makeReadOnlyParentSharing(parentID)
+
+		resp := eRecipient.POST("/sharings/drives").
+			WithHeader("Authorization", "Bearer "+recipientAppToken).
+			WithHeader("Content-Type", "application/vnd.api+json").
+			WithBytes([]byte(fmt.Sprintf(`{
+				"data": {
+					"type": "%s",
+					"attributes": {
+						"folder_id": "%s"
+					}
+				}
+			}`, consts.Sharings, fileID))).
+			Expect().Status(403)
+
+		resp.JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+			Object().Path("$.errors[0].detail").String().
+			Contains("without write access")
 	})
 }
 


### PR DESCRIPTION
  Drive roots can now live inside an existing sharing: the blanket
  parent/descendant rejections in ValidateDriveRoot are replaced by a
  single effective-access gate. When the AccessResolver finds an
  applicable additive ancestor scope, write access (POST) is required
  on it, otherwise the root is rejected with the new ErrParentReadOnly,
  mapped to 403 in the drives API. Roots without an applicable scope
  are allowed. New drives are explicitly created with access_mode
  additive.

  Closes #4838 