### PR TITLE
fix(ai): safe assistant system-prompt injection, scoped file permission

### DIFF
--- a/docs/ai.md
+++ b/docs/ai.md
@@ -173,7 +173,10 @@ Content-Type: application/json
 - `stream` enables streaming the response via SSE deltas (defaults to `true`).
 - `websearch` enables web search for the query (defaults to `false`).
 - `assistantID` (optional) associates the conversation with an `io.cozy.ai.chat.assistants`
-  document. When set, the response includes a `relationships` block.
+  document. When set, the response includes a `relationships` block. If the assistant has a
+  non-empty `prompt` field, a `role: "system"` message carrying that prompt is prepended to
+  `messages` when the conversation is created (before the user's own message). Clients should
+  not render `system` messages as regular conversation turns.
 - `attachmentIDs` (optional) array of ids, specifying which documents should be leveraged by the RAG.
   
 

--- a/model/rag/chat.go
+++ b/model/rag/chat.go
@@ -55,6 +55,7 @@ type ChatMessage struct {
 const (
 	UserRole      = "user"
 	AssistantRole = "assistant"
+	SystemRole    = "system"
 	Temperature   = 0.3   // LLM parameter - Sampling temperature, lower is more deterministic, higher is more creative.
 	TopP          = 1     // LLM parameter - Alternative to temperature, take the tokens with the top p probability.
 	LogProbs      = false // LLM parameter - Whether to return log probabilities of the output tokens.
@@ -120,6 +121,7 @@ type chatAssistant struct {
 	DocRev        string                 `json:"_rev,omitempty"`
 	Relationships chatAssistantRelations `json:"relationships,omitempty"`
 	KnowledgeBase []knowledgeBaseEntry   `json:"knowledgeBase,omitempty"`
+	Prompt        string                 `json:"prompt,omitempty"`
 }
 
 type knowledgeBaseEntry struct {
@@ -170,6 +172,23 @@ func (a *chatAssistant) knowledgeBaseDirID(logger logger.Logger) string {
 	return dirID
 }
 
+// AssistantKnowledgeBaseDirID returns the Drive folder scoping the given
+// assistant's retrieval, or "" if the assistant has no knowledge base
+// folder or cannot be found. It is exported so the HTTP layer can check the
+// caller's permission on that specific folder before letting a conversation
+// reference it, without exposing the unexported chatAssistant type.
+func AssistantKnowledgeBaseDirID(inst *instance.Instance, assistantID string) (string, error) {
+	var assistant chatAssistant
+	if err := couchdb.GetDoc(inst, consts.ChatAssistants, assistantID, &assistant); err != nil {
+		if couchdb.IsNotFoundError(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	log := logger.WithDomain(inst.Domain).WithNamespace("ai")
+	return assistant.knowledgeBaseDirID(log), nil
+}
+
 // ErrAssistantNotFound is returned when a conversation references an
 // assistant that is gone (deleted, or never created). The query must fail:
 // answering anyway would silently widen a possibly folder-scoped
@@ -196,6 +215,16 @@ func Chat(inst *instance.Instance, payload ChatPayload) (*ChatConversation, erro
 						Type: consts.ChatAssistants,
 					},
 				},
+			}
+			var assistant chatAssistant
+			if err := couchdb.GetDoc(inst, consts.ChatAssistants, payload.AssistantID, &assistant); err == nil && assistant.Prompt != "" {
+				promptID, _ := uuid.NewV7()
+				chat.Messages = append(chat.Messages, ChatMessage{
+					ID:        promptID.String(),
+					Role:      SystemRole,
+					Content:   assistant.Prompt,
+					CreatedAt: time.Now().UTC(),
+				})
 			}
 		}
 	} else if err != nil {

--- a/web/ai/ai.go
+++ b/web/ai/ai.go
@@ -23,6 +23,30 @@ func Chat(c echo.Context) error {
 	}
 	payload.ChatConversationID = c.Param("id")
 	inst := middlewares.GetInstance(c)
+	for _, id := range payload.AttachmentIDs {
+		fileDoc, err := inst.VFS().FileByID(id)
+		if err != nil {
+			return middlewares.ErrForbidden
+		}
+		if err := middlewares.Allow(c, permission.GET, fileDoc); err != nil {
+			return middlewares.ErrForbidden
+		}
+	}
+	if payload.AssistantID != "" {
+		dirID, err := rag.AssistantKnowledgeBaseDirID(inst, payload.AssistantID)
+		if err != nil {
+			return jsonapi.InternalServerError(err)
+		}
+		if dirID != "" {
+			dirDoc, err := inst.VFS().DirByID(dirID)
+			if err != nil {
+				return middlewares.ErrForbidden
+			}
+			if err := middlewares.Allow(c, permission.GET, dirDoc); err != nil {
+				return middlewares.ErrForbidden
+			}
+		}
+	}
 	chat, err := rag.Chat(inst, payload)
 	if err != nil {
 		return jsonapi.InternalServerError(err)


### PR DESCRIPTION
Assistant custom prompt was never applied to conversations : 
When a conversation was created with an assistantID, the assistant's prompt field was silently ignored — the LLM never saw it. The fix looks up the assistant doc in Chat() and, if it has a non-empty prompt, prepends it as a role: "system" message before the user's own message, consumed as-is by OpenRAG's chat completion format.

 Missing permission checks on files referenced by a conversation : 

Previously, the chat route only checked permission on io.cozy.ai.chat.conversations — any attachment ID or assistant-scoped knowledge-base folder passed in the payload was used without any permission check at all. The fix adds explicit checks: each attachment ID is resolved to its file doc and checked with middlewares.Allow(GET, fileDoc), and when an assistant is scoped to a knowledge-base folder, that folder is checked the same way — so a client can no longer read files it has no permission on just by referencing them in a chat request.