### PR TITLE
feat: add forced session codes to intent hrefs

### DIFF
--- a/web/auth/flagship.go
+++ b/web/auth/flagship.go
@@ -30,6 +30,12 @@ const (
 	SessionCodeSourcePassword = "password"
 )
 
+// SessionCodeGrant authorizes a token caller to mint a session code.
+type SessionCodeGrant struct {
+	Permission *permission.Permission
+	Source     string
+}
+
 // CreateSessionCode is the handler for creating a session code by the flagship
 // app.
 func CreateSessionCode(c echo.Context) error {
@@ -55,11 +61,23 @@ func CreateSessionCode(c echo.Context) error {
 }
 
 func ReturnSessionCode(c echo.Context, statusCode int, inst *instance.Instance, source string) error {
-	code, err := inst.CreateSessionCode()
+	code, err := MintSessionCode(c, inst, source)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{
 			"error": err,
 		})
+	}
+
+	return c.JSON(statusCode, echo.Map{
+		"session_code": code,
+	})
+}
+
+// MintSessionCode mints a session code and logs its audit source.
+func MintSessionCode(c echo.Context, inst *instance.Instance, source string) (string, error) {
+	code, err := inst.CreateSessionCode()
+	if err != nil {
+		return "", err
 	}
 
 	req := c.Request()
@@ -74,9 +92,7 @@ func ReturnSessionCode(c echo.Context, statusCode int, inst *instance.Instance, 
 		WithField("source", source).
 		Infof("New session_code created from %s at %s", ip, time.Now())
 
-	return c.JSON(statusCode, echo.Map{
-		"session_code": code,
-	})
+	return code, nil
 }
 
 type sessionCodeParameters struct {
@@ -94,14 +110,8 @@ const (
 )
 
 func canCreateSessionCode(c echo.Context, inst *instance.Instance) (canCreateSessionCodeResult, string) {
-	pdoc, err := middlewares.GetPermission(c)
-	if err == nil {
-		if pdoc.Permissions.IsMaximal() {
-			return allowedToCreateSessionCode, SessionCodeSourceFlagship
-		}
-		if claims, ok := c.Get("claims").(permission.Claims); ok && isAppTokenExchangeToken(inst, pdoc, claims) {
-			return allowedToCreateSessionCode, SessionCodeSourceAppTokenExchange
-		}
+	if grant, ok := AuthorizeSessionCodeToken(c, inst); ok {
+		return allowedToCreateSessionCode, grant.Source
 	}
 
 	var args sessionCodeParameters
@@ -119,6 +129,23 @@ func canCreateSessionCode(c echo.Context, inst *instance.Instance) (canCreateSes
 		}
 	}
 	return allowedToCreateSessionCode, SessionCodeSourcePassword
+}
+
+// AuthorizeSessionCodeToken returns a grant for token flows allowed to mint a
+// session code. It intentionally does not use the passphrase fallback accepted
+// by the /auth/session_code endpoint.
+func AuthorizeSessionCodeToken(c echo.Context, inst *instance.Instance) (SessionCodeGrant, bool) {
+	pdoc, err := middlewares.GetPermission(c)
+	if err != nil {
+		return SessionCodeGrant{}, false
+	}
+	if pdoc.Permissions.IsMaximal() {
+		return SessionCodeGrant{Permission: pdoc, Source: SessionCodeSourceFlagship}, true
+	}
+	if claims, ok := c.Get("claims").(permission.Claims); ok && isAppTokenExchangeToken(inst, pdoc, claims) {
+		return SessionCodeGrant{Permission: pdoc, Source: SessionCodeSourceAppTokenExchange}, true
+	}
+	return SessionCodeGrant{Permission: pdoc}, false
 }
 
 func isAppTokenExchangeToken(inst *instance.Instance, pdoc *permission.Permission, claims permission.Claims) bool {

--- a/web/intents/intents.go
+++ b/web/intents/intents.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/cozy/cozy-stack/model/app"
@@ -14,13 +15,15 @@ import (
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/jsonapi"
+	"github.com/cozy/cozy-stack/web/auth"
 	"github.com/cozy/cozy-stack/web/middlewares"
 	"github.com/labstack/echo/v4"
 )
 
 type apiIntent struct {
-	doc *intent.Intent
-	ins *instance.Instance
+	doc         *intent.Intent
+	ins         *instance.Instance
+	sessionCode string
 }
 
 func (i *apiIntent) ID() string                             { return i.doc.ID() }
@@ -49,16 +52,19 @@ func (i *apiIntent) Links() *jsonapi.LinksList {
 // In the JSON-API, the client is the domain of the client-side app that
 // asked the intent (it is used for postMessage)
 func (i *apiIntent) MarshalJSON() ([]byte, error) {
-	was := i.doc.Client
-	parts := strings.SplitN(i.doc.Client, "/", 2)
+	output := i.doc.Clone().(*intent.Intent)
+	parts := strings.SplitN(output.Client, "/", 2)
 	if len(parts) < 2 {
-		i.doc.Client = ""
+		output.Client = ""
 	} else {
-		i.doc.Client = i.resolveClientURL(parts[1])
+		output.Client = i.resolveClientURL(parts[1])
 	}
-	res, err := json.Marshal(i.doc)
-	i.doc.Client = was
-	return res, err
+	if i.sessionCode != "" {
+		if err := addSessionCodeToServices(output.Services, i.sessionCode); err != nil {
+			return nil, err
+		}
+	}
+	return json.Marshal(output)
 }
 
 func (i *apiIntent) resolveClientURL(slug string) string {
@@ -83,11 +89,11 @@ func RequestAppSourceID(pdoc *permission.Permission) string {
 }
 
 func createIntent(c echo.Context) error {
-	pdoc, err := middlewares.GetPermission(c)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusForbidden)
-	}
 	instance := middlewares.GetInstance(c)
+	grant, err := createIntentSessionCodeGrant(c, instance)
+	if err != nil {
+		return err
+	}
 	intent := &intent.Intent{}
 	if _, err = jsonapi.Bind(c.Request().Body, intent); err != nil {
 		return jsonapi.BadRequest(err)
@@ -98,7 +104,7 @@ func createIntent(c echo.Context) error {
 	if intent.Type == "" {
 		return jsonapi.InvalidParameter("type", errors.New("Type is missing"))
 	}
-	intent.Client = RequestAppSourceID(pdoc)
+	intent.Client = RequestAppSourceID(grant.Permission)
 	intent.SetID("")
 	intent.SetRev("")
 	intent.Services = nil
@@ -117,8 +123,53 @@ func createIntent(c echo.Context) error {
 	if err = intent.Save(instance); err != nil {
 		return wrapIntentsError(err)
 	}
-	api := &apiIntent{intent, instance}
+	sessionCode := ""
+	if grant.Source != "" && len(intent.Services) > 0 {
+		sessionCode, err = auth.MintSessionCode(c, instance, grant.Source)
+		if err != nil {
+			return jsonapi.InternalServerError(err)
+		}
+	}
+	api := &apiIntent{doc: intent, ins: instance, sessionCode: sessionCode}
 	return jsonapi.Data(c, http.StatusOK, api, nil)
+}
+
+func createIntentSessionCodeGrant(c echo.Context, inst *instance.Instance) (auth.SessionCodeGrant, error) {
+	if c.QueryParam("force_session_id") != "true" {
+		pdoc, err := middlewares.GetPermission(c)
+		if err != nil {
+			return auth.SessionCodeGrant{}, echo.NewHTTPError(http.StatusForbidden)
+		}
+		return auth.SessionCodeGrant{Permission: pdoc}, nil
+	}
+
+	grant, ok := auth.AuthorizeSessionCodeToken(c, inst)
+	if !ok {
+		return auth.SessionCodeGrant{}, echo.NewHTTPError(http.StatusForbidden)
+	}
+	return grant, nil
+}
+
+func addSessionCodeToServices(services []intent.Service, sessionCode string) error {
+	for idx := range services {
+		href, err := serviceHrefWithSessionCode(services[idx].Href, sessionCode)
+		if err != nil {
+			return err
+		}
+		services[idx].Href = href
+	}
+	return nil
+}
+
+func serviceHrefWithSessionCode(href, sessionCode string) (string, error) {
+	u, err := url.Parse(href)
+	if err != nil {
+		return "", err
+	}
+	query := u.Query()
+	query.Set("session_code", sessionCode)
+	u.RawQuery = query.Encode()
+	return u.String(), nil
 }
 
 func getIntent(c echo.Context) error {
@@ -141,7 +192,7 @@ func getIntent(c echo.Context) error {
 	if !allowed {
 		return echo.NewHTTPError(http.StatusForbidden)
 	}
-	api := &apiIntent{intent, instance}
+	api := &apiIntent{doc: intent, ins: instance}
 	return jsonapi.Data(c, http.StatusOK, api, nil)
 }
 

--- a/web/intents/intents_test.go
+++ b/web/intents/intents_test.go
@@ -2,6 +2,7 @@ package intents
 
 import (
 	"encoding/json"
+	"net/url"
 	"testing"
 	"time"
 
@@ -13,10 +14,12 @@ import (
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/crypto"
 	"github.com/cozy/cozy-stack/pkg/jsonapi"
 	"github.com/cozy/cozy-stack/tests/testutils"
 	"github.com/cozy/cozy-stack/web/errors"
 	"github.com/gavv/httpexpect/v2"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/require"
 )
@@ -30,10 +33,30 @@ func TestIntents(t *testing.T) {
 	var intentID string
 
 	config.UseTestFile(t)
+	const (
+		contextName         = "intents-session-code-test"
+		linkedAppSlug       = "drive"
+		linkedAppSoftwareID = "registry://drive/stable"
+	)
+	conf := config.GetConfig()
+	if conf.Authentication == nil {
+		conf.Authentication = map[string]interface{}{}
+	}
+	conf.Authentication[contextName] = map[string]interface{}{
+		"oidc": map[string]interface{}{
+			"allow_app_token_exchange": true,
+			"app_token_exchange": map[string]interface{}{
+				"drive-web": map[string]interface{}{
+					"software_id": linkedAppSoftwareID,
+				},
+			},
+		},
+	}
 	testutils.NeedCouchdb(t)
 	setup := testutils.NewSetup(t, t.Name())
 	ins := setup.GetTestInstance(&lifecycle.Options{
-		Domain: "cozy.example.net",
+		Domain:      "cozy.example.net",
+		ContextName: contextName,
 	})
 	_, _ = setup.GetTestClient(consts.Settings)
 
@@ -102,6 +125,27 @@ func TestIntents(t *testing.T) {
 	ts.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler
 	t.Cleanup(ts.Close)
 
+	createEligibleSessionCodeClient := func(t *testing.T, clientName string) *oauth.Client {
+		t.Helper()
+
+		oauthClient := &oauth.Client{
+			ClientName:   clientName,
+			RedirectURIs: []string{"https://foobar"},
+			SoftwareID:   linkedAppSoftwareID,
+		}
+		require.Nil(t, oauthClient.Create(ins, oauth.SoftwareIDPrevalidated))
+		return oauthClient
+	}
+	createEligibleSessionCodeToken := func(t *testing.T, clientName string) string {
+		t.Helper()
+
+		oauthClient := createEligibleSessionCodeClient(t, clientName)
+		tok, err := ins.MakeJWT(consts.AccessTokenAudience,
+			oauthClient.ClientID, oauth.BuildLinkedAppScope(linkedAppSlug), "", time.Now())
+		require.NoError(t, err)
+		return tok
+	}
+
 	t.Run("CreateIntent", func(t *testing.T) {
 		e := testutils.CreateTestClient(t, ts.URL)
 
@@ -124,6 +168,11 @@ func TestIntents(t *testing.T) {
 			Object()
 
 		intentID = checkIntentResult(obj, appPerms, true, "https://app.cozy.example.net")
+		href := firstServiceHref(t, obj)
+		u, err := url.Parse(href)
+		require.NoError(t, err)
+		require.Equal(t, intentID, u.Query().Get("intent"))
+		require.Empty(t, u.Query().Get("session_code"))
 	})
 
 	t.Run("NewAPIIntentMatchesGetEndpoint", func(t *testing.T) {
@@ -235,6 +284,85 @@ func TestIntents(t *testing.T) {
 		attrs.ValueEqual("client", "https://drive.cozy.example.net")
 	})
 
+	t.Run("CreateIntentWithForcedSessionCode", func(t *testing.T) {
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		tok := createEligibleSessionCodeToken(t, "test-forced-session-linked-app")
+
+		obj := expectPickIntentCreated(newPickIntentRequest(e, tok).
+			WithQuery("force_session_id", "true"))
+
+		data := obj.Value("data").Object()
+		forcedIntentID := data.Value("id").String().NotEmpty().Raw()
+
+		href := firstServiceHref(t, obj)
+		u, err := url.Parse(href)
+		require.NoError(t, err)
+		require.Equal(t, forcedIntentID, u.Query().Get("intent"))
+		sessionCode := u.Query().Get("session_code")
+		require.NotEmpty(t, sessionCode)
+		require.True(t, ins.CheckAndClearSessionCode(sessionCode))
+
+		stored := &intent.Intent{}
+		require.NoError(t, couchdb.GetDoc(ins, consts.Intents, forcedIntentID, stored))
+		require.Len(t, stored.Services, 1)
+		require.NotContains(t, stored.Services[0].Href, "session_code")
+	})
+
+	t.Run("CreateIntentWithForcedSessionCodeRejectsInvalidRequest", func(t *testing.T) {
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		tok := createEligibleSessionCodeToken(t, "test-forced-session-invalid-intent")
+
+		e.POST("/intents").
+			WithQuery("force_session_id", "true").
+			WithHeader("Authorization", "Bearer "+tok).
+			WithHeader("Content-Type", "application/vnd.api+json").
+			WithHeader("Accept", "application/vnd.api+json").
+			WithBytes([]byte(`{
+        "data": {
+          "type": "io.cozy.settings",
+          "attributes": {
+            "type": "io.cozy.files",
+            "permissions": ["GET"]
+          }
+        }
+      }`)).
+			Expect().Status(422)
+	})
+
+	t.Run("CreateIntentWithForcedSessionCodeRejectsWebappToken", func(t *testing.T) {
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		newPickIntentRequest(e, appToken).
+			WithQuery("force_session_id", "true").
+			Expect().Status(403)
+	})
+
+	t.Run("CreateIntentWithForcedSessionCodeRejectsForgedToken", func(t *testing.T) {
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		oauthClient := createEligibleSessionCodeClient(t, "test-forged-session-linked-app")
+
+		claims := permission.Claims{
+			RegisteredClaims: jwt.RegisteredClaims{
+				Audience:  jwt.ClaimStrings{consts.AccessTokenAudience},
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+				IssuedAt:  jwt.NewNumericDate(time.Now()),
+				Issuer:    ins.Domain,
+				Subject:   oauthClient.ClientID,
+			},
+			Scope: oauth.BuildLinkedAppScope(linkedAppSlug),
+		}
+		token := jwt.NewWithClaims(crypto.SigningMethod, claims)
+		forgedAccessToken, err := token.SignedString([]byte("wrong-secret"))
+		require.NoError(t, err)
+
+		newPickIntentRequest(e, forgedAccessToken).
+			WithQuery("force_session_id", "true").
+			Expect().Status(403)
+	})
+
 	t.Run("CreateIntentWithClientURLMatchingFlag", func(t *testing.T) {
 		ins.FeatureFlags = map[string]interface{}{"custom_url_flag": "https://flag.example.com"}
 		e := testutils.CreateTestClient(t, ts.URL)
@@ -309,6 +437,40 @@ func TestIntents(t *testing.T) {
 
 		checkIntentResult(obj, customAppPerms, true, "https://custom.cozy.example.net")
 	})
+}
+
+const pickIntentPayload = `{
+  "data": {
+    "type": "io.cozy.settings",
+    "attributes": {
+      "action": "PICK",
+      "type": "io.cozy.files",
+      "permissions": ["GET"]
+    }
+  }
+}`
+
+func newPickIntentRequest(e *httpexpect.Expect, token string) *httpexpect.Request {
+	return e.POST("/intents").
+		WithHeader("Authorization", "Bearer "+token).
+		WithHeader("Content-Type", "application/vnd.api+json").
+		WithHeader("Accept", "application/vnd.api+json").
+		WithBytes([]byte(pickIntentPayload))
+}
+
+func expectPickIntentCreated(req *httpexpect.Request) *httpexpect.Object {
+	return req.Expect().Status(200).
+		JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+		Object()
+}
+
+func firstServiceHref(t *testing.T, obj *httpexpect.Object) string {
+	t.Helper()
+
+	attrs := obj.Value("data").Object().Value("attributes").Object()
+	services := attrs.Value("services").Array()
+	services.Length().Equal(1)
+	return services.First().Object().Value("href").String().NotEmpty().Raw()
 }
 
 func checkIntentResult(obj *httpexpect.Object, appPerms *permission.Permission, fromWeb bool, expectedClient string) string {


### PR DESCRIPTION
## Summary

- Add `force_session_id=true` handling on `/intents` to return service hrefs with a session code.
- Reuse token authorization and session-code minting helpers for eligible callers.
- Keep session codes out of stored intent documents.
- Closes #4877.
