### PR TITLE
fix(ai): check files permission on chat requests referencing files

### DIFF
--- a/web/ai/ai.go
+++ b/web/ai/ai.go
@@ -23,10 +23,8 @@ func Chat(c echo.Context) error {
 	}
 	payload.ChatConversationID = c.Param("id")
 	inst := middlewares.GetInstance(c)
-	if len(payload.AttachmentIDs) > 0 || payload.AssistantID != "" {
-		if err := middlewares.AllowWholeType(c, permission.GET, consts.Files); err != nil {
-			return middlewares.ErrForbidden
-		}
+	if err := middlewares.AllowWholeType(c, permission.GET, consts.Files); err != nil {
+		return middlewares.ErrForbidden
 	}
 	chat, err := rag.Chat(inst, payload)
 	if err != nil {

--- a/web/ai/ai.go
+++ b/web/ai/ai.go
@@ -23,6 +23,11 @@ func Chat(c echo.Context) error {
 	}
 	payload.ChatConversationID = c.Param("id")
 	inst := middlewares.GetInstance(c)
+	if len(payload.AttachmentIDs) > 0 || payload.AssistantID != "" {
+		if err := middlewares.AllowWholeType(c, permission.GET, consts.Files); err != nil {
+			return middlewares.ErrForbidden
+		}
+	}
 	chat, err := rag.Chat(inst, payload)
 	if err != nil {
 		return jsonapi.InternalServerError(err)


### PR DESCRIPTION
The chat route only checked permission on io.cozy.ai.chat.conversations; attachmentIDs and assistant-scoped knowledge base folders were used without any permission check. Now a whole-type GET check on io.cozy.files is performed whenever attachments or an assistant are referenced.